### PR TITLE
refactor(web): user-facing-kinds allowlist + reconnect-sweep regression test

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -19,6 +19,7 @@ import type {
   AssistantOutboundAttachment,
   ConversationListInvalidatedReason,
   DirectoryScopeOption,
+  InteractionKind,
   QuestionEntry,
   QuestionOption,
   ScopeOption,
@@ -719,7 +720,7 @@ export function parseAssistantEvent(
           | "answered"
           | "cancelled"
           | "superseded",
-        kind,
+        kind: kind as InteractionKind,
       };
     }
 

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -702,6 +702,48 @@ export type InteractionResolutionState =
   | "superseded";
 
 /**
+ * Mirrors the daemon's `PendingInteraction["kind"]` union
+ * (`assistant/src/runtime/pending-interactions.ts`). Split into user-facing
+ * kinds (prompts that block the conversation waiting for a person) and
+ * host-proxy kinds (intermediate tool steps that resolve mid-turn).
+ *
+ * Keep in sync with the daemon enum — adding a kind on one side without the
+ * other causes the attention-tracking allowlist to silently miss or
+ * incorrectly clear processing indicators.
+ */
+export type UserFacingInteractionKind =
+  | "confirmation"
+  | "secret"
+  | "question"
+  | "acp_confirmation";
+
+export type HostProxyInteractionKind =
+  | "host_bash"
+  | "host_file"
+  | "host_cu"
+  | "host_browser"
+  | "host_app_control"
+  | "host_transfer";
+
+export type InteractionKind =
+  | UserFacingInteractionKind
+  | HostProxyInteractionKind;
+
+/**
+ * Allowlist of interaction kinds that signal the daemon has handed control
+ * back to a person (vs intermediate host-proxy tool steps). Attention
+ * tracking uses this to decide whether to clear processing/attention state
+ * on `interaction_resolved`.
+ */
+export const USER_FACING_INTERACTION_KINDS: ReadonlySet<string> =
+  new Set<UserFacingInteractionKind>([
+    "confirmation",
+    "secret",
+    "question",
+    "acp_confirmation",
+  ]);
+
+/**
  * Emitted when a daemon-side pending interaction (confirmation, secret,
  * question, host-proxy request) transitions to a resolved state. Drives
  * push-based attention reconciliation in the sidebar.
@@ -713,7 +755,7 @@ export interface InteractionResolvedEvent {
   conversationKey: string;
   state: InteractionResolutionState;
   /** Kind of the resolved interaction (e.g. `"confirmation"`, `"secret"`). */
-  kind: string;
+  kind: InteractionKind;
 }
 
 export type AssistantEvent =

--- a/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
+++ b/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
@@ -56,7 +56,19 @@ function publishInteractionResolved(payload: {
       requestId: payload.requestId,
       conversationKey: payload.conversationKey,
       state: payload.state,
-      kind: payload.kind ?? "confirmation",
+      // Cast through the daemon-mirrored union; tests intentionally feed
+      // both user-facing and host-proxy kinds.
+      kind: (payload.kind ?? "confirmation") as
+        | "confirmation"
+        | "secret"
+        | "question"
+        | "acp_confirmation"
+        | "host_bash"
+        | "host_file"
+        | "host_cu"
+        | "host_browser"
+        | "host_app_control"
+        | "host_transfer",
     });
   });
 }
@@ -192,7 +204,7 @@ describe("useAttentionTracking — interaction_resolved subscriber", () => {
     ).toBe(false);
   });
 
-  test("ignores host-proxy resolutions so in-progress tool steps don't clear the processing indicator", () => {
+  test("only clears state for kinds in the user-facing allowlist (host-proxy and unknown future kinds are ignored)", () => {
     useConversationStore.getState().addProcessingKey("conv-host");
     expect(
       useConversationStore.getState().processingKeys.has("conv-host"),
@@ -207,6 +219,10 @@ describe("useAttentionTracking — interaction_resolved subscriber", () => {
       { wrapper },
     );
 
+    // Host-proxy kinds resolve as intermediate tool steps mid-turn and
+    // must not clear the processing indicator. A hypothetical future
+    // intermediate kind without a `host_` prefix must also be ignored —
+    // the subscriber filters by an explicit allowlist, not by name shape.
     for (const kind of [
       "host_bash",
       "host_file",
@@ -214,6 +230,7 @@ describe("useAttentionTracking — interaction_resolved subscriber", () => {
       "host_browser",
       "host_app_control",
       "host_transfer",
+      "future_intermediate_step",
     ]) {
       publishInteractionResolved({
         requestId: `req-${kind}`,

--- a/apps/web/src/domains/conversations/use-attention-tracking-reconnect-sweep.test.tsx
+++ b/apps/web/src/domains/conversations/use-attention-tracking-reconnect-sweep.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Post-reconnect attention sweep: when the bus-owned SSE connection
+ * reopens after a transport hiccup (watchdog / error / resume), refetch
+ * the bulk pending-interactions snapshot and reconcile sidebar state.
+ *
+ * A fresh first-open is owned by the initial-sweep effect — the
+ * reconnect handler must not double-fire on `cause === "fresh"`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store.js";
+
+// Stub the conversation-list query and the mark-seen endpoint so the
+// hook does not try to hit a real backend during renderHook.
+mock.module("@/domains/conversations/conversation-queries.js", () => ({
+  useConversationListQuery: () => ({ conversations: [] }),
+  getConversations: () => [],
+  findConversation: () => undefined,
+  markConversationSeenLocal: () => {},
+}));
+
+mock.module("@/domains/chat/api/conversations.js", () => ({
+  markConversationSeen: async () => {},
+}));
+
+// Per-test override slot for the bulk fetch. `mock.module` calls in bun
+// pollute every other test file that imports the same module, so we must
+// re-declare every export from `@/domains/chat/api/interactions.js`
+// (not just the one we drive). The non-driven exports throw a pointer
+// back to this file so cross-suite leakage is loud and easy to diagnose.
+type BulkFetchImpl = (assistantId: string) => Promise<Set<string>>;
+const bulkFetch: { current: BulkFetchImpl } = {
+  current: async () => new Set<string>(),
+};
+
+const stubFromOtherTest = (name: string) => () => {
+  throw new Error(
+    `[reconnect-sweep test] ${name} called via a leaked mock.module — ` +
+      "another test file is sharing this stub. Re-mock it in the test " +
+      "that needs it (see apps/web/src/domains/conversations/" +
+      "use-attention-tracking-reconnect-sweep.test.tsx).",
+  );
+};
+
+mock.module("@/domains/chat/api/interactions.js", () => ({
+  listConversationKeysWithPendingInteractions: (assistantId: string) =>
+    bulkFetch.current(assistantId),
+  // Other exports of the module — stubbed loudly so a stale leak surfaces.
+  getPendingInteractions: stubFromOtherTest("getPendingInteractions"),
+  submitSecretResponse: stubFromOtherTest("submitSecretResponse"),
+  submitConfirmation: stubFromOtherTest("submitConfirmation"),
+  submitContactPrompt: stubFromOtherTest("submitContactPrompt"),
+  submitQuestionResponse: stubFromOtherTest("submitQuestionResponse"),
+  submitTrustRule: stubFromOtherTest("submitTrustRule"),
+}));
+
+const { useAttentionTracking } = await import(
+  "@/domains/conversations/use-attention-tracking.js"
+);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function publishOpened(cause: "fresh" | "error" | "watchdog" | "resume") {
+  useEventBusStore.getState().publish("sse.opened", {
+    assistantId: "asst-1",
+    cause,
+  });
+}
+
+function mountHook() {
+  return renderHook(
+    () =>
+      useAttentionTracking({
+        assistantId: "asst-1",
+        assistantStateKind: "active",
+      }),
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+  useConversationStore.getState().reset();
+  bulkFetch.current = async () => new Set<string>();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+  useConversationStore.getState().reset();
+});
+
+describe("useAttentionTracking — post-reconnect sweep", () => {
+  test("does NOT run when cause is 'fresh' (initial-sweep effect handles it)", async () => {
+    let calls = 0;
+    bulkFetch.current = async () => {
+      calls += 1;
+      return new Set<string>();
+    };
+
+    useConversationStore.getState().addAttentionKey("conv-stale");
+    mountHook();
+
+    // The initial-sweep effect fires once on mount with an empty
+    // conversation list (see the stubbed `useConversationListQuery`)
+    // and therefore short-circuits before invoking the fetch. Reset
+    // the counter to isolate what the `sse.opened` handler does.
+    await waitFor(() => {
+      // Allow any mount microtasks to settle.
+      expect(true).toBe(true);
+    });
+    calls = 0;
+
+    publishOpened("fresh");
+
+    // Yield twice — once for the publish microtask, once for any
+    // awaited fetch that could have been scheduled.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toBe(0);
+    // And attentionKeys are untouched (no reconciliation ran).
+    expect(
+      useConversationStore.getState().attentionKeys.has("conv-stale"),
+    ).toBe(true);
+  });
+
+  for (const cause of ["watchdog", "error", "resume"] as const) {
+    test(`runs the sweep when cause is '${cause}' and reconciles attention/processing keys`, async () => {
+      // Pre-populate sidebar state:
+      //  - conv-stale: in attentionKeys but no longer pending → must be removed
+      //  - conv-promote: in processingKeys AND still pending → must be promoted to attentionKeys
+      //  - conv-new: not tracked at all but pending → must be added to attentionKeys
+      //  - conv-active: active key — must NEVER be mutated by the sweep
+      useConversationStore.getState().setActiveKey("conv-active");
+      useConversationStore.getState().addAttentionKey("conv-stale");
+      useConversationStore.getState().addAttentionKey("conv-active");
+      useConversationStore.getState().addProcessingKey("conv-promote");
+      useConversationStore.getState().addProcessingKey("conv-active");
+
+      bulkFetch.current = async () =>
+        new Set(["conv-promote", "conv-new", "conv-active"]);
+
+      mountHook();
+      publishOpened(cause);
+
+      await waitFor(() => {
+        expect(
+          useConversationStore.getState().attentionKeys.has("conv-new"),
+        ).toBe(true);
+      });
+
+      const state = useConversationStore.getState();
+      // Stale attention removed.
+      expect(state.attentionKeys.has("conv-stale")).toBe(false);
+      // Promoted: now in attention, removed from processing.
+      expect(state.attentionKeys.has("conv-promote")).toBe(true);
+      expect(state.processingKeys.has("conv-promote")).toBe(false);
+      // Newly-pending conversation added to attention.
+      expect(state.attentionKeys.has("conv-new")).toBe(true);
+      // Active conversation untouched in both sets, regardless of the
+      // fetch payload — the sweep must skip it.
+      expect(state.attentionKeys.has("conv-active")).toBe(true);
+      expect(state.processingKeys.has("conv-active")).toBe(true);
+    });
+  }
+
+  test("silently no-ops when the bulk fetch throws", async () => {
+    useConversationStore.getState().addAttentionKey("conv-stale");
+    useConversationStore.getState().addProcessingKey("conv-promote");
+
+    let invoked = 0;
+    bulkFetch.current = async () => {
+      invoked += 1;
+      throw new Error("network down");
+    };
+
+    mountHook();
+    publishOpened("watchdog");
+
+    await waitFor(() => {
+      expect(invoked).toBe(1);
+    });
+
+    // Yield one more tick so any (incorrect) follow-up dispatches would
+    // have landed before we assert.
+    await Promise.resolve();
+
+    // Sidebar state untouched — keys stay until the next successful sweep.
+    const state = useConversationStore.getState();
+    expect(state.attentionKeys.has("conv-stale")).toBe(true);
+    expect(state.processingKeys.has("conv-promote")).toBe(true);
+  });
+});

--- a/apps/web/src/domains/conversations/use-attention-tracking.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking.ts
@@ -10,6 +10,7 @@ import {
 } from "@/domains/conversations/conversation-queries.js";
 import { markConversationSeen } from "@/domains/chat/api/conversations.js";
 import { listConversationKeysWithPendingInteractions } from "@/domains/chat/api/interactions.js";
+import { USER_FACING_INTERACTION_KINDS } from "@/domains/chat/api/event-types.js";
 import type { AssistantState } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
 import { useBusSubscription } from "@/hooks/use-bus-subscription.js";
 
@@ -185,17 +186,23 @@ export function useAttentionTracking({
   // `attentionKeys` and `processingKeys` — the user has either responded
   // elsewhere or the daemon discarded the prompt.
   //
-  // Host-proxy kinds (`host_bash`, `host_file`, `host_cu`,
-  // `host_browser`, `host_app_control`, `host_transfer`) resolve as
-  // intermediate tool steps during a turn that is still running, so
-  // they must not clear the processing indicator. Only the
-  // user-facing kinds (confirmation, secret, question,
-  // acp_confirmation) signal that the turn has handed control back.
+  // Only the user-facing interaction kinds (confirmation, secret,
+  // question, acp_confirmation — see `USER_FACING_INTERACTION_KINDS`)
+  // signal that the daemon has handed control back to a person and the
+  // attention indicator should clear. Every other kind (today, the
+  // host-proxy family: `host_bash`, `host_file`, `host_cu`,
+  // `host_browser`, `host_app_control`, `host_transfer`) resolves as
+  // an intermediate tool step during a turn that is still running, so
+  // those must not clear the processing indicator. Filtering by an
+  // explicit allowlist — rather than denylisting `host_*` — means
+  // future intermediate-step kinds without that prefix stay
+  // silently-ignored by default instead of accidentally clearing
+  // processing state.
   // -------------------------------------------------------------------------
   useBusSubscription("sse.event", (event) => {
     if (!assistantId) return;
     if (event.type !== "interaction_resolved") return;
-    if (event.kind.startsWith("host_")) return;
+    if (!USER_FACING_INTERACTION_KINDS.has(event.kind)) return;
     const key = event.conversationKey;
     if (!key) return;
     const state = useConversationStore.getState();


### PR DESCRIPTION
## Summary

Follow-up B to LUM-1813. Two independent changes to attention tracking:

1. **Allowlist instead of denylist.** The `interaction_resolved` subscriber in `use-attention-tracking.ts` previously filtered host-proxy resolutions with `event.kind.startsWith("host_")`. That works for today's six host-proxy kinds (`host_bash`, `host_file`, `host_cu`, `host_browser`, `host_app_control`, `host_transfer`) but would silently misbehave if a future intermediate-step kind were added without the `host_` prefix. Replaced with an explicit `USER_FACING_INTERACTION_KINDS` allowlist (`confirmation`, `secret`, `question`, `acp_confirmation`) so unknown kinds default to ignore. Also exposes a typed `InteractionKind` union mirroring the daemon's `PendingInteraction["kind"]` and narrows `InteractionResolvedEvent.kind` from `string` to that union.

2. **Regression coverage for the post-reconnect sweep.** New sibling file `use-attention-tracking-reconnect-sweep.test.tsx` drives the `sse.opened` subscriber end-to-end: confirms `cause === "fresh"` is skipped (initial-sweep owns that), confirms `watchdog` / `error` / `resume` reconcile attention/processing keys correctly (stale removed, still-pending promoted, newly-pending added, active conversation never touched), and confirms a throwing bulk fetch silently no-ops.

The new test stubs every export of `@/domains/chat/api/interactions.js` because bun's `mock.module` is process-global; the non-driven exports throw with a pointer back to the test file so any future cross-suite leakage surfaces loudly.

## Test plan

- [x] `bun test src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx` — 7 pass (existing host-proxy assertion rewritten to allowlist semantics, now also covers an unknown future kind)
- [x] `bun test src/domains/conversations/use-attention-tracking-reconnect-sweep.test.tsx` — 5 pass
- [x] `bun test src/domains/conversations/` — 57 pass across 6 files (no cross-file mock leakage)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (one pre-existing unrelated warning in `lib/errors/report.ts`)

Daemon untouched.

https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg

---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_