### PR TITLE
fix(messages): hidden-message filter is pagination-aware

### DIFF
--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -110,4 +110,108 @@ describe("handleListMessages metadata.hidden filtering", () => {
 
     expect(body.messages).toHaveLength(2);
   });
+
+  test("pagination skips hidden rows so hasMore and oldest cursor reflect visible rows", async () => {
+    const conv = createConversation();
+    // 4 visible older rows, then a block of 3 hidden rows, then 2 visible newer.
+    // With limit=2 and page=latest we should get the 2 newest visible rows,
+    // hasMore=true (older visible rows exist), and a cursor pointing at the
+    // oldest visible row in the page rather than null.
+    for (let i = 0; i < 4; i++) {
+      await addMessage(
+        conv.id,
+        "user",
+        JSON.stringify([{ type: "text", text: `old visible ${i}` }]),
+      );
+    }
+    for (let i = 0; i < 3; i++) {
+      await addMessage(
+        conv.id,
+        "assistant",
+        JSON.stringify([{ type: "text", text: `hidden ${i}` }]),
+        { hidden: true },
+      );
+    }
+    for (let i = 0; i < 2; i++) {
+      await addMessage(
+        conv.id,
+        "user",
+        JSON.stringify([{ type: "text", text: `new visible ${i}` }]),
+      );
+    }
+
+    const latest = handleListMessages({
+      queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
+    }) as {
+      messages: MessagePayload[];
+      hasMore: boolean;
+      oldestTimestamp: number | null;
+      oldestMessageId: string | null;
+    };
+
+    expect(latest.messages.map((m) => m.content)).toEqual([
+      "new visible 0",
+      "new visible 1",
+    ]);
+    expect(latest.hasMore).toBe(true);
+    expect(latest.oldestTimestamp).not.toBeNull();
+    expect(latest.oldestMessageId).not.toBeNull();
+
+    // Older page request — anchored before the latest page's oldest row —
+    // should skip the hidden block entirely and return the next 2 visible rows.
+    const older = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        beforeTimestamp: String(latest.oldestTimestamp),
+        limit: "2",
+      },
+    }) as {
+      messages: MessagePayload[];
+      hasMore: boolean;
+    };
+
+    expect(older.messages.map((m) => m.content)).toEqual([
+      "old visible 2",
+      "old visible 3",
+    ]);
+    expect(older.hasMore).toBe(true);
+  });
+
+  test("pagination drains DB when every row in a page is hidden", async () => {
+    const conv = createConversation();
+    // 5 hidden rows then 2 visible older rows. With limit=2, the naive
+    // implementation fetches 3 newest (all hidden), filters to 0 visible, and
+    // returns hasMore=true with no cursor. We expect the loop to keep going
+    // and surface the visible rows instead.
+    for (let i = 0; i < 2; i++) {
+      await addMessage(
+        conv.id,
+        "user",
+        JSON.stringify([{ type: "text", text: `old visible ${i}` }]),
+      );
+    }
+    for (let i = 0; i < 5; i++) {
+      await addMessage(
+        conv.id,
+        "assistant",
+        JSON.stringify([{ type: "text", text: `hidden ${i}` }]),
+        { hidden: true },
+      );
+    }
+
+    const latest = handleListMessages({
+      queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
+    }) as {
+      messages: MessagePayload[];
+      hasMore: boolean;
+      oldestTimestamp: number | null;
+    };
+
+    expect(latest.messages.map((m) => m.content)).toEqual([
+      "old visible 0",
+      "old visible 1",
+    ]);
+    expect(latest.hasMore).toBe(false);
+    expect(latest.oldestTimestamp).not.toBeNull();
+  });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1259,10 +1259,14 @@ interface PaginatedMessagesResult {
   hasMore: boolean;
 }
 
+const PAGINATION_CHUNK_MIN = 50;
+const PAGINATION_SCAN_CAP = 10_000;
+
 export function getMessagesPaginated(
   conversationId: string,
   limit: number | undefined,
   beforeTimestamp?: number,
+  filter?: (row: MessageRow) => boolean,
 ): PaginatedMessagesResult {
   const db = getDb();
 
@@ -1278,30 +1282,69 @@ export function getMessagesPaginated(
       .orderBy(asc(messages.createdAt))
       .all()
       .map(parseMessage);
-    return { messages: rows, hasMore: false };
+    return {
+      messages: filter ? rows.filter(filter) : rows,
+      hasMore: false,
+    };
   }
 
-  const conditions = [eq(messages.conversationId, conversationId)];
-  if (beforeTimestamp !== undefined) {
-    conditions.push(lt(messages.createdAt, beforeTimestamp));
+  // Walk pages newest→oldest, applying `filter` in TS (metadata parsing is
+  // JSON, not a structured column). Keep fetching until we have `limit + 1`
+  // visible rows or the DB is exhausted, so `hasMore` and the cursor reflect
+  // the visible page rather than the unfiltered row count. Without this loop,
+  // a fully-hidden page returns `{ messages: [], hasMore: true }` with no
+  // cursor, which stalls the web client's older-page fetch.
+  let cursorCreatedAt = beforeTimestamp;
+  let cursorMessageId: string | undefined;
+  const visible: MessageRow[] = [];
+  const chunkSize = Math.max(limit + 1, PAGINATION_CHUNK_MIN);
+  // Bound the work a single request can do when `filter` rejects nearly every
+  // row — otherwise a pathological filter against a huge conversation would
+  // tie up a connection for thousands of roundtrips.
+  let rowsScanned = 0;
+
+  while (visible.length < limit + 1 && rowsScanned < PAGINATION_SCAN_CAP) {
+    const cursorPredicate =
+      cursorCreatedAt === undefined
+        ? undefined
+        : cursorMessageId === undefined
+          ? lt(messages.createdAt, cursorCreatedAt)
+          : or(
+              lt(messages.createdAt, cursorCreatedAt),
+              and(
+                eq(messages.createdAt, cursorCreatedAt),
+                lt(messages.id, cursorMessageId),
+              ),
+            );
+
+    const chunk = db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.conversationId, conversationId), cursorPredicate))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
+      .limit(chunkSize)
+      .all()
+      .map(parseMessage);
+
+    if (chunk.length === 0) break;
+    rowsScanned += chunk.length;
+
+    for (const row of chunk) {
+      if (!filter || filter(row)) visible.push(row);
+      if (visible.length >= limit + 1) break;
+    }
+
+    if (chunk.length < chunkSize) break;
+    const lastRow = chunk[chunk.length - 1];
+    cursorCreatedAt = lastRow.createdAt;
+    cursorMessageId = lastRow.id;
   }
 
-  const rows = db
-    .select()
-    .from(messages)
-    .where(and(...conditions))
-    .orderBy(desc(messages.createdAt))
-    .limit(limit + 1)
-    .all()
-    .map(parseMessage);
+  const hasMore = visible.length > limit;
+  if (hasMore) visible.splice(limit);
+  visible.reverse();
 
-  const hasMore = rows.length > limit;
-  if (hasMore) {
-    rows.splice(limit);
-  }
-  rows.reverse();
-
-  return { messages: rows, hasMore };
+  return { messages: visible, hasMore };
 }
 
 export function getLastUserTimestampBefore(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -494,24 +494,31 @@ export function handleListMessages({
   let rawMessages: MessageRow[];
   let hasMore = false;
 
+  // Drop messages flagged as hidden in metadata (e.g. internal scaffolding
+  // like retrospective instructions). The LLM-side history loader
+  // (`getMessages` in memory/conversation-crud.ts) intentionally does not
+  // filter — hidden messages remain in agent context but are suppressed from
+  // the UI list. Filtering is pushed into the paginated query so `hasMore`
+  // and the cursor reflect visible rows; otherwise a fully-hidden page would
+  // return `hasMore: true` with no cursor and stall the web client.
+  // Hidden tool_use/tool_result pairs must be hidden together — if a hidden
+  // assistant message has tool_use blocks but its matching user tool_result
+  // is left visible, the result will render as a standalone orphan because
+  // `mergeToolResultsIntoAssistantMessages` has nothing to merge it into.
+  const visibleFilter = (m: MessageRow) => !isHiddenMessage(m.metadata);
+
   if (isPaginated) {
     const result = getMessagesPaginated(
       resolvedConversationId,
       limit,
       beforeTimestamp,
+      visibleFilter,
     );
     rawMessages = result.messages;
     hasMore = result.hasMore;
   } else {
-    rawMessages = getMessages(resolvedConversationId);
+    rawMessages = getMessages(resolvedConversationId).filter(visibleFilter);
   }
-
-  // Drop messages flagged as hidden in metadata (e.g. internal scaffolding
-  // like retrospective instructions). The LLM-side history loader
-  // (`getMessages` in memory/conversation-crud.ts) intentionally does not
-  // filter — hidden messages remain in agent context but are suppressed from
-  // the UI list.
-  rawMessages = rawMessages.filter((m) => !isHiddenMessage(m.metadata));
 
   // During streaming, tool_use (assistant) and tool_result (user) events are
   // assembled client-side into a single assistant ChatMessage. On reload, they


### PR DESCRIPTION
Addresses feedback on #31366. Push hidden-message filtering into the DB pagination layer so hasMore and oldest cursors reflect visible-only rows. Previously a fully-hidden page returned hasMore: true with null cursors, stalling the web client's older-page fetches.