### PR TITLE
[codex] Update Slack loading statuses

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -306,7 +306,7 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 });
 
 describe("Slack thinking status timing", () => {
-  const slackStatusLabels = ["is grinding", "is working", "is touching grass"];
+  const slackStatusLabels = ["is on it", "is working hard"];
 
   const trustCtx: TrustContext = {
     trustClass: "guardian",

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -306,7 +306,7 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 });
 
 describe("Slack thinking status timing", () => {
-  const slackStatusLabels = ["is on it", "is working hard"];
+  const slackStatusLabels = ["is on it", "is working hard", "is touching grass"];
 
   const trustCtx: TrustContext = {
     trustClass: "guardian",

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -552,11 +552,7 @@ function createSlackThinkingStatusController(params: {
 
 const SLACK_THINKING_MAX_DURATION_MS = 120_000;
 const SLACK_GENERIC_LOADING_MESSAGES = ["Working on it..."] as const;
-const SLACK_THINKING_STATUSES = [
-  "is grinding",
-  "is working",
-  "is touching grass",
-] as const;
+const SLACK_THINKING_STATUSES = ["is on it", "is working hard"] as const;
 
 function getRandomSlackThinkingStatus(): string {
   return SLACK_THINKING_STATUSES[


### PR DESCRIPTION
## Summary

Set the Slack thinking-status label pool to `is on it` and `is working hard`, removing the previous `is grinding` copy.

## Impact

Slack users see kinder, still-light status text while the assistant is working.

## Validation

- `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts`
- Pre-push hook: assistant typecheck and lint for the changed files