### PR TITLE
fix(web): drop stale-conversation SSE deltas on chat switch

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { useRef, type MutableRefObject } from "react";
+
+import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
+import type { ChatEventStream } from "@/domains/chat/api/stream.js";
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store.js";
+
+import { useEventStream } from "@/domains/chat/hooks/use-event-stream.js";
+
+type StreamContext = { assistantId: string; conversationKey: string };
+
+function renderEventStream(
+  activeConversationKey: string,
+  handleStreamEvent: (event: AssistantEvent, epoch: number) => void,
+) {
+  return renderHook(
+    ({ key }: { key: string }) => {
+      const streamRef = useRef<ChatEventStream | null>(null);
+      const streamEpochRef = useRef(0);
+      const reconcileAfterNextStreamOpenRef = useRef(false);
+      const streamContextRef = useRef<StreamContext | null>(null);
+      const syncRouterRef = useRef(null) as MutableRefObject<
+        null
+      > as never;
+      const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+      useEventStream({
+        assistantStateKind: "active",
+        assistantId: "asst-1",
+        activeConversationKey: key,
+        conversationExistsOnServer: true,
+        streamRef,
+        streamEpochRef,
+        reconcileAfterNextStreamOpenRef,
+        streamContextRef,
+        handleStreamEvent,
+        reconcileActiveConversation: async () =>
+          ({
+            changed: false,
+            messagesAdded: 0,
+            assistantProgress: 0,
+          }) as never,
+        startReconciliationLoop: () => {},
+        cancelReconciliation: () => {},
+        reachabilityProbe: () => {},
+        reachabilityPhase: "ready",
+        reachabilityReset: () => {},
+        setMessages: () => {},
+        setError: () => {},
+        syncRouterRef,
+        conversationListInvalidatedTimerRef: timerRef,
+      });
+    },
+    { initialProps: { key: activeConversationKey } },
+  );
+}
+
+function publishDelta(conversationKey: string): void {
+  useEventBusStore.getState().publish("sse.event", {
+    type: "assistant_text_delta",
+    conversationKey,
+    delta: "hi",
+  } as unknown as AssistantEvent);
+}
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+});
+
+describe("useEventStream — conversation-switch filtering", () => {
+  test("forwards events whose conversationKey matches the active key", () => {
+    const handler = mock(() => {});
+    renderEventStream("conv-A", handler);
+    publishDelta("conv-A");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("drops events for a non-active conversation", () => {
+    const handler = mock(() => {});
+    renderEventStream("conv-A", handler);
+    publishDelta("conv-B");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("rejects in-flight events for the previous conversation as soon as the active key changes", () => {
+    const handler = mock(() => {});
+    const { rerender } = renderEventStream("conv-A", handler);
+    publishDelta("conv-A");
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Conversation switch: re-render with the new active key. The
+    // effect cleanup + re-subscribe has not necessarily run yet on
+    // the bus side, but the latest-key ref must already gate further
+    // deliveries for the previous conversation.
+    rerender({ key: "conv-B" });
+    publishDelta("conv-A");
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Events for the new active key still flow through.
+    publishDelta("conv-B");
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  test("forwards assistant-broadcast events that omit conversationKey", () => {
+    const handler = mock(() => {});
+    renderEventStream("conv-A", handler);
+    useEventBusStore.getState().publish("sse.event", {
+      type: "sync_changed",
+      tags: ["assistant:self:identity"],
+    } as unknown as AssistantEvent);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-event-stream.ts
@@ -156,6 +156,16 @@ export function useEventStream({
   const reachabilityResetRef = useRef(reachabilityReset);
   reachabilityResetRef.current = reachabilityReset;
 
+  // Track the latest active conversation key in a ref updated during
+  // render. The bus subscriber filters against this ref instead of the
+  // closure-captured value so an `assistant_text_delta` published in
+  // the gap between a conversation switch and the effect cleanup is
+  // rejected as soon as React commits the new active key — without
+  // this, in-flight deltas for the previous conversation can merge
+  // into the new conversation's messages.
+  const activeConversationKeyLatestRef = useRef(activeConversationKey);
+  activeConversationKeyLatestRef.current = activeConversationKey;
+
   // --------------------------------------------------------------------------
   // Effect 1: Subscribe to the bus-owned SSE for the active conversation.
   // --------------------------------------------------------------------------
@@ -191,11 +201,18 @@ export function useEventStream({
         .conversationKey;
       // Assistant-broadcast events (no conversationKey) are routed to
       // every conversation-scoped consumer; the handler decides what
-      // to do with them. Per-conversation events are filtered here.
+      // to do with them. Per-conversation events are filtered against
+      // the LATEST active conversation key, not the closure-captured
+      // value — see comment on `activeConversationKeyLatestRef`.
       if (
         eventConversationKey !== undefined &&
-        eventConversationKey !== capturedConversationKey
+        eventConversationKey !== activeConversationKeyLatestRef.current
       ) {
+        recordChatDiagnostic("sse_event_wrong_conversation_filtered", {
+          eventConversationKey,
+          activeConversationKey: activeConversationKeyLatestRef.current,
+          eventType: event.type,
+        });
         return;
       }
       handleStreamEventRef.current(event, streamEpochRef.current);


### PR DESCRIPTION
## Summary

Hotfix for the user-reported bug: "switching chats during streaming can show stream outputs in the wrong chat."

## Root cause

The bus-owned SSE connection (LUM-1812) never closes on a conversation switch. Between the user clicking a sibling conversation and React running the `useEventStream` effect cleanup, the **old** bus subscription is still active with a closure-captured `capturedConversationKey` equal to the previous conversation key. In-flight `assistant_text_delta` events for the previous conversation pass that filter (`A === A`), call `handleStreamEvent`, and merge into `messages` — which the UI now displays as the new conversation's transcript.

The pre-LUM-1812 architecture didn't have this race because each conversation owned its own SSE connection; switching cancelled the daemon-side stream, so the window for in-flight events was a single network roundtrip. The bus-owned SSE keeps flowing regardless of the active conversation.

## Fix

Compare `event.conversationKey` against a `useRef` whose `.current` is assigned during the render body (`activeConversationKeyLatestRef.current = activeConversationKey`). This ref reflects the new active key as soon as React commits, rather than waiting for the effect cleanup microtask. Cross-conversation deltas are dropped at the subscriber level and logged via a new `sse_event_wrong_conversation_filtered` diagnostic so the rate is observable in Sentry.

## Test plan

- [x] `bun test src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx` — 4 pass, including the critical regression test that publishes deltas, rerenders with a new active key, and asserts no further deltas for the previous conversation reach the handler.
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (pre-existing unrelated warning)
- [ ] Manual: open two conversations side-by-side, send a message in A, switch to B mid-stream, verify A's deltas do NOT appear in B's transcript.

## Why not revert LUM-1812 instead

Reverting would cascade through #31531 / #31537 / #31547 / #31548 / #31549 / #31550 / #31551 (≈3-4k LoC moving backward) and re-introduce the daemon `clientId` eviction bug that broke chat send. This hotfix is 15 LoC + a regression test.


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_