### PR TITLE
fix(settings): use SideMenu.Item in settings sidebar for visual parity with chat side menu

### DIFF
--- a/apps/web/src/domains/settings/components/settings-sidebar-tree.tsx
+++ b/apps/web/src/domains/settings/components/settings-sidebar-tree.tsx
@@ -34,7 +34,24 @@ export function SettingsSidebarTree({
           active={isActive}
           trailingIcon={ChevronRight}
           trailingIconClassName="md:hidden"
-          onSelect={() => navigate(item.href)}
+          href={item.href}
+          onClick={(e) => {
+            // Modifier and middle clicks fall through to the native <a> so
+            // Cmd/Ctrl-click opens a new tab, Shift-click opens a window,
+            // and "Copy link address" works. Plain left-clicks become SPA
+            // navigation via react-router.
+            if (
+              e.metaKey ||
+              e.ctrlKey ||
+              e.shiftKey ||
+              e.altKey ||
+              e.button !== 0
+            ) {
+              return;
+            }
+            e.preventDefault();
+            navigate(item.href);
+          }}
         />
         {!isLast && (
           <div

--- a/apps/web/src/domains/settings/components/settings-sidebar-tree.tsx
+++ b/apps/web/src/domains/settings/components/settings-sidebar-tree.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight, type LucideIcon } from "lucide-react";
 import { Fragment } from "react";
-import { NavLink } from "react-router";
+import { useLocation, useNavigate } from "react-router";
+
+import { SideMenu } from "@vellum/design-library";
 
 export interface SettingsSidebarItem {
   id: string;
@@ -14,65 +16,45 @@ interface SettingsSidebarTreeProps {
   bottomItems?: SettingsSidebarItem[];
 }
 
-function SidebarNavItem({
-  item,
-  isLast,
-}: {
-  item: SettingsSidebarItem;
-  isLast: boolean;
-}) {
-  const Icon = item.icon;
-
-  return (
-    <Fragment>
-      <NavLink
-        to={item.href}
-        end={false}
-        className={({ isActive }) =>
-          [
-            "flex items-center gap-3 rounded-lg px-3 py-2 text-body-small-default transition-colors",
-            isActive
-              ? "bg-[var(--surface-active)]"
-              : "hover:bg-[var(--surface-lift)]",
-          ].join(" ")
-        }
-        style={{ color: "var(--content-default)" }}
-      >
-        <Icon size={18} className="shrink-0" aria-hidden />
-        <span className="min-w-0 flex-1 truncate">{item.label}</span>
-        <ChevronRight
-          size={16}
-          className="shrink-0 text-[var(--content-tertiary)] md:hidden"
-          aria-hidden
-        />
-      </NavLink>
-      {!isLast && (
-        <div
-          role="presentation"
-          aria-hidden
-          className="my-2 h-px w-full bg-[var(--border-base)] md:hidden"
-        />
-      )}
-    </Fragment>
-  );
-}
-
 export function SettingsSidebarTree({
   items,
   bottomItems,
 }: SettingsSidebarTreeProps) {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  const renderItem = (item: SettingsSidebarItem, isLast: boolean) => {
+    const isActive =
+      pathname === item.href || pathname.startsWith(item.href + "/");
+    return (
+      <Fragment key={item.id}>
+        <SideMenu.Item
+          icon={item.icon}
+          label={item.label}
+          active={isActive}
+          trailingIcon={ChevronRight}
+          trailingIconClassName="md:hidden"
+          onSelect={() => navigate(item.href)}
+        />
+        {!isLast && (
+          <div
+            role="presentation"
+            aria-hidden
+            className="my-2 h-px w-full bg-[var(--border-base)] md:hidden"
+          />
+        )}
+      </Fragment>
+    );
+  };
+
   return (
     <nav
       aria-label="Settings navigation"
       className="flex min-h-full flex-col md:gap-2 md:px-6 md:pb-4"
     >
-      {items.map((item, index) => (
-        <SidebarNavItem
-          key={item.id}
-          item={item}
-          isLast={index === items.length - 1 && !bottomItems?.length}
-        />
-      ))}
+      {items.map((item, index) =>
+        renderItem(item, index === items.length - 1 && !bottomItems?.length),
+      )}
 
       {bottomItems && bottomItems.length > 0 && (
         <>
@@ -82,13 +64,9 @@ export function SettingsSidebarTree({
             aria-hidden
             className="mx-0 my-2 h-px w-full bg-[var(--border-base)] md:mx-0"
           />
-          {bottomItems.map((item, index) => (
-            <SidebarNavItem
-              key={item.id}
-              item={item}
-              isLast={index === bottomItems.length - 1}
-            />
-          ))}
+          {bottomItems.map((item, index) =>
+            renderItem(item, index === bottomItems.length - 1),
+          )}
         </>
       )}
     </nav>


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `NavLink` rows in `settings-sidebar-tree.tsx` with `SideMenu.Item` from `@vellum/design-library`, so the settings sidebar matches the chat side menu pixel-for-pixel.
- Active state is now computed from `useLocation().pathname` (`pathname === href || pathname.startsWith(href + "/")`), navigation goes through `useNavigate()`. No public API change — `SettingsSidebarItem` shape is unchanged.
- Net: -22 lines, no new components, no new tokens. Just reuses the existing primitive that the chat side menu already uses.

### Before / after

| | Before (hand-rolled) | After (SideMenu.Item) |
|---|---|---|
| Font | `text-body-small-default` (~12px) | `text-body-medium-lighter` (14/400) desktop, `text-body-large-default` mobile |
| Icon size | 18px | 14px |
| Gap | `gap-3` (12px) | `gap-[8px]` |
| Padding | `px-3 py-2` | `p-2`, `max-md:py-3` |
| Radius | `rounded-lg` (8px) | `rounded-[6px]` |
| Text color | `--content-default` | `--content-secondary` (default) / `--content-emphasised` (active) |
| Hover | `--surface-lift` | `--surface-hover` |
| Active | `--surface-active` only | `--surface-active` + brighter text |

This is the same primitive `apps/web/src/domains/chat/components/assistant-side-menu.tsx` already uses, and the same approach `vellum-assistant-platform`'s `SettingsSidebarTree` takes — so the settings and chat sidebars become byte-for-byte identical.

## Original prompt

The user noticed the settings sidebar felt off in font size, spacing, and icons compared to the chat side menu in the screenshot they shared. After comparing with `vellum-assistant-platform`'s settings sidebar, the root cause was that this file hand-rolls a `NavLink` row instead of reusing the shared `SideMenu.Item` primitive. The fix is a one-file refactor to swap in the existing design-library primitive so the two sidebars match.