### PR TITLE
chore(assistant): pass explicit state to pendingInteractions.resolve()

### DIFF
--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -193,6 +193,6 @@ describe("handleConfirmationResponse canonical status sync", () => {
     // Canonical status sync is now handled inside Conversation.handleConfirmationResponse,
     // which this test mocks out — so the handler itself no longer calls resolveCanonicalGuardianRequest.
     expect(resolveCanonicalGuardianRequestMock).not.toHaveBeenCalled();
-    expect(resolveMock).toHaveBeenCalledWith("req-confirm-allow");
+    expect(resolveMock).toHaveBeenCalledWith("req-confirm-allow", "approved");
   });
 });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -306,7 +306,7 @@ export class AcpSessionManager {
    */
   private teardownSession(acpSessionId: string, entry: SessionEntry): void {
     for (const requestId of entry.clientHandler.pendingRequestIds) {
-      const interaction = pendingInteractions.resolve(requestId);
+      const interaction = pendingInteractions.resolve(requestId, "cancelled");
       if (interaction?.directResolve) {
         interaction.directResolve("deny");
       }

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -36,7 +36,15 @@ export function handleConfirmationResponse(msg: ConfirmationResponse): void {
         undefined,
         { source: "button" },
       );
-      pendingInteractions.resolve(msg.requestId);
+      // Idempotent cleanup: the prompter's `resolveConfirmation` already
+      // resolved the interaction with the correct approved/rejected state
+      // before we reach here, so the entry is typically gone. This call is
+      // a safety net for paths where the prompter no-ops; map decision to
+      // state to keep the emitted event accurate when it does fire.
+      pendingInteractions.resolve(
+        msg.requestId,
+        decision === "allow" ? "approved" : "rejected",
+      );
       return;
     }
   }

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -185,7 +185,7 @@ export class HostBrowserProxy {
       let detachAbort: () => void = () => {};
 
       const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, cdpMethod: input.cdpMethod },
           "Host browser proxy request timed out",
@@ -200,7 +200,7 @@ export class HostBrowserProxy {
       if (signal) {
         const onAbort = () => {
           if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             try {
               broadcastMessage({
                 type: "host_browser_cancel",
@@ -229,7 +229,7 @@ export class HostBrowserProxy {
 
       try {
         if (!preferredClient) {
-          pendingInteractions.resolve(requestId);
+          pendingInteractions.resolve(requestId, "cancelled");
           reject(
             new Error(
               "host_browser send failed: no active extension connection",
@@ -244,7 +244,7 @@ export class HostBrowserProxy {
           { targetClientId: preferredClient.clientId },
         );
       } catch (err) {
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, cdpMethod: input.cdpMethod, err },
           "Host browser proxy send failed",
@@ -256,7 +256,7 @@ export class HostBrowserProxy {
 
   dispose(): void {
     for (const entry of pendingInteractions.getByKind("host_browser")) {
-      pendingInteractions.resolve(entry.requestId);
+      pendingInteractions.resolve(entry.requestId, "cancelled");
       try {
         broadcastMessage({
           type: "host_browser_cancel",

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -195,7 +195,7 @@ export class HostCuProxy {
 
       const timer = setTimeout(() => {
         this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn({ requestId, toolName }, "Host CU proxy request timed out");
         resolve({
           content: "Host CU proxy timed out waiting for client response",
@@ -207,7 +207,7 @@ export class HostCuProxy {
         const onAbort = () => {
           if (pendingInteractions.get(requestId)) {
             this._ownedRequests.delete(requestId);
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             try {
               broadcastMessage(
                 {
@@ -263,7 +263,7 @@ export class HostCuProxy {
         );
       } catch (err) {
         this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn({ requestId, toolName, err }, "Host CU proxy send failed");
         reject(err instanceof Error ? err : new Error(String(err)));
       }
@@ -447,7 +447,7 @@ export class HostCuProxy {
 
   dispose(): void {
     for (const requestId of this._ownedRequests) {
-      const entry = pendingInteractions.resolve(requestId);
+      const entry = pendingInteractions.resolve(requestId, "cancelled");
       if (!entry) continue;
       try {
         broadcastMessage(

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -136,7 +136,7 @@ export class HostFileProxy {
       let detachAbort: () => void = () => {};
 
       const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, operation: input.operation },
           "Host file proxy request timed out",
@@ -152,7 +152,7 @@ export class HostFileProxy {
       if (signal) {
         const onAbort = () => {
           if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             try {
               broadcastMessage(
                 {
@@ -210,7 +210,7 @@ export class HostFileProxy {
           { targetClientId: resolvedTargetClientId },
         );
       } catch (err) {
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, operation: input.operation, err },
           "Host file proxy send failed",
@@ -252,7 +252,7 @@ export class HostFileProxy {
 
   dispose(): void {
     for (const entry of pendingInteractions.getByKind("host_file")) {
-      pendingInteractions.resolve(entry.requestId);
+      pendingInteractions.resolve(entry.requestId, "cancelled");
       try {
         broadcastMessage(
           {

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -154,7 +154,7 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
         detachAbort();
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, toolName, kind: this.resultPendingKind },
           "Host proxy request timed out",
@@ -168,7 +168,7 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
             clearTimeout(timer);
             this.pending.delete(requestId);
             detachAbort();
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             try {
               broadcastDynamic(
                 {
@@ -239,7 +239,7 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
         clearTimeout(timer);
         this.pending.delete(requestId);
         detachAbort();
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, toolName, kind: this.resultPendingKind, err },
           "Host proxy send failed",
@@ -285,7 +285,7 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       entry.detachAbort();
-      pendingInteractions.resolve(requestId);
+      pendingInteractions.resolve(requestId, "cancelled");
       try {
         broadcastDynamic(
           {

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -205,7 +205,7 @@ export class HostTransferProxy {
 
           const timer = setTimeout(() => {
             this.transfers.delete(transferId);
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             log.warn(
               { requestId, transferId, direction: "to_host" },
               "Host transfer proxy request timed out",
@@ -222,7 +222,7 @@ export class HostTransferProxy {
             const onAbort = () => {
               if (pendingInteractions.get(requestId)) {
                 this.transfers.delete(transferId);
-                pendingInteractions.resolve(requestId);
+                pendingInteractions.resolve(requestId, "cancelled");
                 try {
                   broadcastMessage(
                     {
@@ -301,7 +301,7 @@ export class HostTransferProxy {
             );
           } catch (err) {
             this.transfers.delete(transferId);
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             log.warn(
               { requestId, transferId, err },
               "Host transfer proxy send failed",
@@ -396,7 +396,7 @@ export class HostTransferProxy {
 
       const timer = setTimeout(() => {
         this.transfers.delete(transferId);
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, transferId, direction: "to_sandbox" },
           "Host transfer proxy request timed out",
@@ -413,7 +413,7 @@ export class HostTransferProxy {
         const onAbort = () => {
           if (pendingInteractions.get(requestId)) {
             this.transfers.delete(transferId);
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             try {
               broadcastMessage(
                 {
@@ -487,7 +487,7 @@ export class HostTransferProxy {
         );
       } catch (err) {
         this.transfers.delete(transferId);
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         log.warn(
           { requestId, transferId, err },
           "Host transfer proxy send failed",
@@ -622,14 +622,14 @@ export class HostTransferProxy {
 
     if (entry.overwrite !== true && existsSync(entry.filePath)) {
       const errorMsg = `Destination file already exists: ${entry.filePath}. Set overwrite to true to replace it.`;
-      const interaction = pendingInteractions.resolve(requestId);
+      const interaction = pendingInteractions.resolve(requestId, "answered");
       this.transfers.delete(transferId);
       interaction?.rpcResolve?.({ content: errorMsg, isError: true });
       return { accepted: false, error: errorMsg };
     }
 
     const cleanup = () => {
-      pendingInteractions.resolve(requestId);
+      pendingInteractions.resolve(requestId, "answered");
       this.transfers.delete(transferId);
     };
 
@@ -662,7 +662,7 @@ export class HostTransferProxy {
     if (!interaction) return;
     const transferId = interaction.metadata?.transferId as string | undefined;
     if (transferId) this.transfers.delete(transferId);
-    pendingInteractions.resolve(requestId);
+    pendingInteractions.resolve(requestId, "cancelled");
     try {
       broadcastMessage(
         {
@@ -718,7 +718,7 @@ export class HostTransferProxy {
     for (const entry of pendingInteractions.getByKind("host_transfer")) {
       const transferId = entry.metadata?.transferId as string | undefined;
       if (transferId) this.transfers.delete(transferId);
-      pendingInteractions.resolve(entry.requestId);
+      pendingInteractions.resolve(entry.requestId, "cancelled");
       try {
         broadcastMessage(
           {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -79,7 +79,7 @@ export class PermissionPrompter {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
 
       const timer = setTimeout(() => {
-        const interaction = pendingInteractions.resolve(requestId);
+        const interaction = pendingInteractions.resolve(requestId, "cancelled");
         this.ownedIds.delete(requestId);
         log.warn(
           { requestId, toolName },
@@ -130,7 +130,7 @@ export class PermissionPrompter {
       if (signal) {
         const onAbort = () => {
           if (this.ownedIds.has(requestId)) {
-            pendingInteractions.resolve(requestId);
+            pendingInteractions.resolve(requestId, "cancelled");
             this.ownedIds.delete(requestId);
             resolve({ decision: "deny", wasAbort: true });
           }
@@ -232,7 +232,7 @@ export class PermissionPrompter {
 
   dispose(): void {
     for (const requestId of [...this.ownedIds]) {
-      const interaction = pendingInteractions.resolve(requestId);
+      const interaction = pendingInteractions.resolve(requestId, "cancelled");
       this.ownedIds.delete(requestId);
       interaction?.rpcReject?.(
         new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -223,8 +223,11 @@ export class QuestionPrompter {
           signal.removeEventListener("abort", onAbort);
         }
         // Idempotent: a no-op if the entry was already removed (e.g. by
-        // `removeByConversation`) or by an earlier path.
-        pendingInteractions.resolve(requestId);
+        // `removeByConversation`) or by an earlier path. The route's
+        // success path resolves with "answered" before invoking rpcResolve,
+        // so this fallback only fires for timeout / abort / removeByConversation —
+        // all cancellation-shaped outcomes.
+        pendingInteractions.resolve(requestId, "cancelled");
         fn();
       };
 

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -71,7 +71,7 @@ export class SecretPrompter {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
 
       const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
+        pendingInteractions.resolve(requestId, "cancelled");
         this.ownedIds.delete(requestId);
         log.warn({ requestId, service, field }, "Secret prompt timed out");
         resolve({ value: null, delivery: "store" });
@@ -142,7 +142,7 @@ export class SecretPrompter {
 
   dispose(): void {
     for (const requestId of [...this.ownedIds]) {
-      const interaction = pendingInteractions.resolve(requestId);
+      const interaction = pendingInteractions.resolve(requestId, "cancelled");
       this.ownedIds.delete(requestId);
       interaction?.rpcReject?.(
         new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -107,12 +107,12 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
 
   const conversation = findConversation(peeked.conversationId);
   if (!conversation) {
-    pendingInteractions.resolve(requestId);
+    pendingInteractions.resolve(requestId, "cancelled");
     throw new NotFoundError("Conversation not found for host CU result");
   }
 
   if (!conversation.hostCuProxy) {
-    pendingInteractions.resolve(requestId);
+    pendingInteractions.resolve(requestId, "cancelled");
     throw new NotFoundError("No host CU proxy for conversation");
   }
 


### PR DESCRIPTION
## Why

`pendingInteractions.resolve()` emits `interaction_resolved` on the SSE event hub with a `state` field. The signature is `resolve(requestId, state?)` where `state` defaults to `"cancelled"`. About 20 callers omit the state argument, mislabeling answered / approved / rejected resolutions as `"cancelled"` in daemon logs.

No client impact today (web client ignores `state`), but daemon logs misreport every interaction's terminal state — a real debugging burden the moment anyone needs it. This PR makes every site explicit.

The `resolve()` signature still defaults to `"cancelled"` so anything I missed continues to compile.

## States added

| File | Line(s) | State | Reason |
| --- | --- | --- | --- |
| `assistant/src/permissions/secret-prompter.ts` | 74 | `cancelled` | timeout |
| `assistant/src/permissions/secret-prompter.ts` | 145 | `cancelled` | dispose |
| `assistant/src/permissions/prompter.ts` | 82 | `cancelled` | timeout |
| `assistant/src/permissions/prompter.ts` | 133 | `cancelled` | abort |
| `assistant/src/permissions/prompter.ts` | 235 | `cancelled` | dispose |
| `assistant/src/permissions/question-prompter.ts` | 227 | `cancelled` | `finish()` teardown — only runs for timeout / abort / `removeByConversation`; route success path resolves with `answered` first |
| `assistant/src/runtime/routes/host-cu-routes.ts` | 110, 115 | `cancelled` | late result dropped (conversation or proxy gone) |
| `assistant/src/daemon/host-cu-proxy.ts` | 198, 210, 266, 450 | `cancelled` | timeout / abort / send-failure / dispose |
| `assistant/src/daemon/host-transfer-proxy.ts` | 208, 225, 304, 399, 416, 490, 665, 721 | `cancelled` | timeout / abort / send-failure / cancel() / dispose |
| `assistant/src/daemon/host-transfer-proxy.ts` | 625, 632 | `answered` | `receiveTransferContent` — host did deliver content; dest-exists rejection and post-write cleanup are both responses |
| `assistant/src/daemon/host-file-proxy.ts` | 139, 155, 213, 255 | `cancelled` | timeout / abort / send-failure / dispose |
| `assistant/src/daemon/host-browser-proxy.ts` | 188, 203, 232, 247, 259 | `cancelled` | timeout / abort / no-client / send-failure / dispose |
| `assistant/src/daemon/host-proxy-base.ts` | 157, 171, 242, 288 | `cancelled` | timeout / abort / send-failure / dispose |
| `assistant/src/daemon/handlers/conversations.ts` | 39 | `approved` / `rejected` (mapped from decision) | idempotent post-prompter cleanup; matches what the prompter would have emitted |
| `assistant/src/acp/session-manager.ts` | 309 | `cancelled` | teardown denies pending permissions with no real user answer |

## Sites I'm least sure about (please double-check)

- **`host-transfer-proxy.ts:625, 632`** — flagged as `answered`. The reasoning: `receiveTransferContent` is the client's content-delivery path, so even the "destination already exists" rejection is a response (the host did successfully push bytes), not a cancellation. If you'd rather treat the existence rejection as `cancelled` (closer to "we never wrote anything"), happy to flip it.
- **`daemon/handlers/conversations.ts:39`** — this `pendingInteractions.resolve(msg.requestId, ...)` runs *after* the prompter's own `resolveConfirmation` already deregistered the entry with the correct `approved`/`rejected` state. It's a defensive cleanup that almost always no-ops. I mapped decision → state so that on the rare path where the prompter no-ops (e.g. ACP direct flows that wouldn't normally route here, or stale state), the emitted event is still accurate. Could equally be argued to be `"superseded"` since the message wasn't owned by a tracked prompter.
- **`acp/session-manager.ts:309`** — chose `cancelled` because session teardown isn't a user decision. The `directResolve("deny")` call below it still routes "deny" to the agent; I'm only labeling the lifecycle event. `"superseded"` would also be defensible if you read teardown as the session itself superseding pending permissions.

## Test plan

- [x] `bunx tsc --noEmit` clean (pre-existing errors in `packages/service-contracts`, `packages/ces-client` are unrelated)
- [x] `bun run lint` clean
- [x] Per-file unit tests pass when run alone: `host-cu-proxy`, `host-transfer-proxy`, `host-file-proxy`, `host-browser-proxy`, `host-proxy-base`, `pending-interactions-resolved-event`, `secret-prompter-channel-fallback`, `host-app-control-proxy`, `host-transfer-pending-interactions`, `approval-routes-http`, `host-cu-routes-targeted`, `host-browser-routes`, `question-routes`, `session-manager-persistence`.

## Branch note

Intended branch name `claude/daemon-resolve-explicit-state` was already checked out by another worktree; pushed as `-v2` so this PR can land in parallel.

## Follow-up to

- LUM-1813 (#31551) — push-based interaction resolution.

https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg

---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_