### PR TITLE
fix(web): recover pre-chat onboarding context lost on ChatPage remount

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -42,7 +42,10 @@ import {
   resolveDraftKey,
 } from "@/domains/conversations/conversation-queries.js";
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
-import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
+import {
+  consumePendingPreChatContext,
+  type PreChatOnboardingContext,
+} from "@/domains/onboarding/prechat.js";
 
 import { clearQueueStatus } from "@/domains/chat/hooks/stream-message-updaters.js";
 import { attachConfirmationToToolCall } from "@/domains/chat/utils/chat-utils.js";
@@ -221,7 +224,8 @@ export function useSendMessage({
           resolvedConversationKey,
         });
 
-      const onboardingContext = pendingOnboardingContextRef.current;
+      const onboardingContext =
+        pendingOnboardingContextRef.current ?? consumePendingPreChatContext();
       const postResult = await postChatMessage(
         requestAssistantId,
         requestConversationKey,

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -226,6 +226,9 @@ export function useSendMessage({
 
       const onboardingContext =
         pendingOnboardingContextRef.current ?? consumePendingPreChatContext();
+      if (onboardingContext && !pendingOnboardingContextRef.current) {
+        pendingOnboardingContextRef.current = onboardingContext;
+      }
       const postResult = await postChatMessage(
         requestAssistantId,
         requestConversationKey,


### PR DESCRIPTION
## Summary
- The `?onboarding=1` effect in ChatPage consumes the prechat context from sessionStorage into a ref, then navigates to a conversation URL — which remounts ChatPage and resets the ref to null. The sessionStorage was already drained, so the first message sends without onboarding context.
- Fix: fall back to `consumePendingPreChatContext()` from sessionStorage at send time in `useSendMessage` if the ref is null, so the context survives the component remount.
- This fixes First-Run User Context being absent from the system prompt on the web app, and ensures the content-automation cohort field reaches the daemon.

Closes JARVIS-932

## Test plan
- [ ] Complete web pre-chat onboarding (name, tasks, tone, tools) → send first message → verify First-Run User Context appears in system prompt via LLM inspector
- [ ] Verify onboarding context fields (tools, tasks, tone, cohort) are present in the daemon's `POST /v1/messages` request body
- [ ] Verify subsequent messages do NOT include onboarding context (consume-once semantics)
- [ ] Verify standard flow still works on macOS/native (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)