### PR TITLE
feat(skills): add activation hints to media-processing skill

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -6,6 +6,14 @@ metadata:
   emoji: "🎬"
   vellum:
     display-name: "Media Processing"
+    activation-hints:
+      - "User wants to ingest, process, or analyze a local video, audio, or image file"
+      - "User wants to ask natural-language questions about a video's content (e.g. 'what happens at 3:14', 'find all the goals', 'who appears in this footage')"
+      - "User wants to extract a clip or short segment from a video"
+      - "User wants to run keyframe extraction, segmentation, or frame-by-frame analysis on a video"
+    avoid-when:
+      - "User only wants a plain audio transcript — use the transcribe skill instead"
+      - "User just wants to play or open a media file in their default system player — that does not need this pipeline"
 ---
 
 Ingest and track processing of media files (video, audio, images) through a configurable 3-phase pipeline.


### PR DESCRIPTION
## Summary
- Add `activation-hints` and `avoid-when` to the `media-processing` skill's SKILL.md frontmatter
- Hints route natural-language media-analysis requests (e.g. "analyze this video", "find the goals in this footage", "extract a clip") to the media-processing pipeline via the `<available_skills>` section of the system prompt
- `avoid-when` steers transcription-only requests to the `transcribe` skill

## Original prompt
Follow-up to the parallel schedule-activation-hints PR. The `media-processing` skill was one of five bundled skills missing `activation-hints` in their SKILL.md frontmatter — the routing cues projected into `<available_skills>` to guide skill selection. This PR adds those hints so natural-language media-analysis requests reach the right pipeline.