### PR TITLE
fix(home): emit home_feed_updated event on OAuth connect/disconnect

### DIFF
--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -19,6 +19,8 @@ import { listProviders } from "../oauth/oauth-store.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { isOAuthProviderConnected } from "../schedule/integration-status.js";
 import { getLogger } from "../util/logger.js";
@@ -128,6 +130,20 @@ export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
 export function invalidateAssistantSuggestedPromptsCache(): void {
   cachedLLMPrompts = [];
   cachedLLMPromptsAt = 0;
+  assistantEventHub
+    .publish(
+      buildAssistantEvent({
+        type: "home_feed_updated",
+        updatedAt: new Date().toISOString(),
+        newItemCount: 0,
+      }),
+    )
+    .catch((err) => {
+      log.warn(
+        { err },
+        "Failed to publish home_feed_updated after prompt cache invalidation",
+      );
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Emit a `home_feed_updated` SSE event when `invalidateAssistantSuggestedPromptsCache()` is called during OAuth connect/disconnect
- Both apps/web and platform web clients listen for this event to invalidate their React Query cache and refetch the home feed
- Without this event, suggestion pills (e.g. "Connect Gmail" -> "Triage my inbox") stay stale until the 30s query TTL expires

## Changes

- `assistant/src/home/suggested-prompts.ts`: Added `buildAssistantEvent` and `assistantEventHub` imports; emit `home_feed_updated` event after clearing the in-memory cache, following the same fire-and-forget pattern used in `feed-writer.ts`

## Test plan

- [ ] Connect a new OAuth provider (e.g. Gmail) and verify the home feed suggestion pills update immediately without manual refresh
- [ ] Disconnect an OAuth provider and verify the "Connect X" pill reappears immediately
- [ ] Verify no regressions in the existing home feed update flow (new feed items still trigger the event via feed-writer.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)