### PR TITLE
Gate hatch version selector to staff nonprod

### DIFF
--- a/apps/web/src/domains/chat/components/version-selection-screen.tsx
+++ b/apps/web/src/domains/chat/components/version-selection-screen.tsx
@@ -55,6 +55,8 @@ export function VersionSelectionScreen({ onHatch }: VersionSelectionScreenProps)
           </div>
         ) : (
           <Dropdown
+            className="w-64 max-w-full"
+            aria-label="Assistant version"
             value={selectedVersion}
             onChange={setSelectedVersion}
             options={[

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -47,7 +47,7 @@ interface UseAssistantLifecycleOptions {
   isLoggedIn: boolean;
   isLoading: boolean;
   isRetired: boolean;
-  isNonProduction: boolean;
+  canSelectHatchVersion: boolean;
   /** Framework-agnostic redirect — called instead of router.replace(). */
   onRedirect: (url: string) => void;
 }
@@ -82,7 +82,7 @@ export function useAssistantLifecycle({
   isLoggedIn,
   isLoading,
   isRetired,
-  isNonProduction,
+  canSelectHatchVersion,
   onRedirect,
 }: UseAssistantLifecycleOptions): UseAssistantLifecycleReturn {
   const [assistantState, setAssistantState] = useState<AssistantState>({
@@ -106,8 +106,8 @@ export function useAssistantLifecycle({
   // Stabilize external values with refs so useCallback identities stay stable.
   const isRetiredRef = useRef(isRetired);
   isRetiredRef.current = isRetired;
-  const isNonProductionRef = useRef(isNonProduction);
-  isNonProductionRef.current = isNonProduction;
+  const canSelectHatchVersionRef = useRef(canSelectHatchVersion);
+  canSelectHatchVersionRef.current = canSelectHatchVersion;
   const onRedirectRef = useRef(onRedirect);
   onRedirectRef.current = onRedirect;
 
@@ -210,8 +210,8 @@ export function useAssistantLifecycle({
           onRedirectRef.current(onboardingRedirect);
           return;
         }
-        // In nonprod, let the user pick a release version before hatching.
-        if (isNonProductionRef.current) {
+        // In dev/staging, Vellum staff can pick a release version before hatching.
+        if (canSelectHatchVersionRef.current) {
           setAssistantState({ kind: "awaiting_version_selection" });
           return;
         }

--- a/apps/web/src/domains/chat/lib/hatch-version-selection.test.ts
+++ b/apps/web/src/domains/chat/lib/hatch-version-selection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isVellumStaffUser,
+  shouldShowHatchVersionSelector,
+} from "./hatch-version-selection.js";
+
+const VELLUM_EMAIL_DOMAIN = "vellum.ai";
+
+describe("shouldShowHatchVersionSelector", () => {
+  test("allows Vellum staff in dev or staging", () => {
+    expect(
+      shouldShowHatchVersionSelector({
+        isDevOrStaging: true,
+        isVellumStaff: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("blocks non-staff users in dev or staging", () => {
+    expect(
+      shouldShowHatchVersionSelector({
+        isDevOrStaging: true,
+        isVellumStaff: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("blocks staff users in production", () => {
+    expect(
+      shouldShowHatchVersionSelector({
+        isDevOrStaging: false,
+        isVellumStaff: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isVellumStaffUser", () => {
+  test("allows users marked as staff", () => {
+    expect(isVellumStaffUser(null, true)).toBe(true);
+  });
+
+  test("allows users with a Vellum email domain", () => {
+    expect(isVellumStaffUser(`user@${VELLUM_EMAIL_DOMAIN}`, false)).toBe(true);
+  });
+
+  test("blocks users without a Vellum email domain or staff flag", () => {
+    expect(isVellumStaffUser("user@example.com", false)).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/lib/hatch-version-selection.ts
+++ b/apps/web/src/domains/chat/lib/hatch-version-selection.ts
@@ -1,0 +1,22 @@
+export interface HatchVersionSelectorAccess {
+  isDevOrStaging: boolean;
+  isVellumStaff: boolean;
+}
+
+export function isVellumStaffUser(
+  email: string | null,
+  isStaff: boolean,
+): boolean {
+  if (isStaff) {
+    return true;
+  }
+
+  return !!email && email.trim().toLowerCase().endsWith("@vellum.ai");
+}
+
+export function shouldShowHatchVersionSelector({
+  isDevOrStaging,
+  isVellumStaff,
+}: HatchVersionSelectorAccess): boolean {
+  return isDevOrStaging && isVellumStaff;
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -8,6 +8,10 @@ import {
   useAssistantLifecycle,
   type UseAssistantLifecycleReturn,
 } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+import {
+  isVellumStaffUser,
+  shouldShowHatchVersionSelector,
+} from "@/domains/chat/lib/hatch-version-selection.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 import { useClientFeatureFlagSync } from "@/lib/feature-flags/use-client-feature-flag-sync.js";
@@ -66,14 +70,22 @@ export function RootLayout() {
 
   const navigate = useNavigate();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
+  const authUser = useAuthStore.use.user();
   const authLoading = useAuthStore.use.isLoading();
   const isNonProduction = useEnvironmentStore.use.isNonProduction();
+  const canSelectHatchVersion = shouldShowHatchVersionSelector({
+    isDevOrStaging: isNonProduction,
+    isVellumStaff: isVellumStaffUser(
+      authUser?.email ?? null,
+      authUser?.isStaff ?? false,
+    ),
+  });
   useClientFeatureFlagSync(isLoggedIn && !authLoading);
   const lifecycle = useAssistantLifecycle({
     isLoggedIn,
     isLoading: authLoading,
     isRetired: false,
-    isNonProduction,
+    canSelectHatchVersion,
     onRedirect: navigate,
   });
 


### PR DESCRIPTION
## Summary
- add a staff/non-production gate for the hatch version selector
- use that gate in the root assistant lifecycle before entering version selection
- keep the hatch selector accessible with a fixed dropdown width and label

## Why
- dev/staging Vellum staff can select a managed assistant release before hatching
- non-staff users and production users continue to hatch the default latest version

## Tests
- `bun test src/domains/chat/lib/hatch-version-selection.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
