### PR TITLE
feat(web): port ChatGPT subscription OAuth UI to apps/web

### DIFF
--- a/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -25,6 +25,8 @@ function formatAuthSummary(auth: ProviderConnection["auth"]): string {
   switch (auth.type) {
     case "api_key":
       return `API key · ${auth.credential}`;
+    case "oauth_subscription":
+      return "ChatGPT Subscription";
     case "platform":
       return "Managed proxy";
     case "none":
@@ -58,6 +60,7 @@ export function ManageProvidersModal({
   onClose,
 }: ManageProvidersModalProps) {
   const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
+  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [connections, setConnections] = useState<ProviderConnection[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -157,6 +160,7 @@ export function ManageProvidersModal({
             assistantId={assistantId}
             existingNames={existingNames}
             openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
+            chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
             onSave={handleEditorSave}
             onCancel={cancelEditor}
           />

--- a/apps/web/src/domains/settings/ai/provider-connections-client.ts
+++ b/apps/web/src/domains/settings/ai/provider-connections-client.ts
@@ -23,6 +23,7 @@ export interface ConnectionModel {
 
 export type Auth =
   | { type: "api_key"; credential: string }
+  | { type: "oauth_subscription" }
   | { type: "platform" }
   | { type: "none" };
 
@@ -234,6 +235,41 @@ export async function writeSecret(
     url: `/v1/assistants/{assistant_id}/secrets/`,
     path: { assistant_id: assistantId },
     body: { type, name, value },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!result.response?.ok) throwHttpError(result.response);
+}
+
+// ---------------------------------------------------------------------------
+// ChatGPT Subscription OAuth — manual copy-paste flow
+// ---------------------------------------------------------------------------
+
+export interface ChatgptAuthStartResult {
+  authorize_url: string;
+  state: string;
+}
+
+export async function startChatgptSubscriptionAuth(
+  assistantId: string,
+): Promise<ChatgptAuthStartResult> {
+  const result = await client.post({
+    url: `/v1/assistants/{assistant_id}/inference/chatgpt-subscription/auth`,
+    path: { assistant_id: assistantId },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!result.response?.ok) throwHttpError(result.response);
+  return result.data as ChatgptAuthStartResult;
+}
+
+export async function exchangeChatgptAuthCode(
+  assistantId: string,
+  code: string,
+  state: string,
+): Promise<void> {
+  const result = await client.post({
+    url: `/v1/assistants/{assistant_id}/inference/chatgpt-subscription/auth/exchange`,
+    path: { assistant_id: assistantId },
+    body: { code, state },
     headers: { "Content-Type": "application/json" },
   });
   if (!result.response?.ok) throwHttpError(result.response);

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -18,8 +18,11 @@ import {
   type ProviderConnection,
   type UpdateConnectionInput,
   createConnection,
+  exchangeChatgptAuthCode,
+  listConnections,
   listCredentials,
   readSecret,
+  startChatgptSubscriptionAuth,
   updateConnection,
   writeSecret,
 } from "@/domains/settings/ai/provider-connections-client.js";
@@ -74,6 +77,7 @@ export interface ProviderEditorContentProps {
   assistantId: string;
   existingNames: string[];
   openAICompatibleEndpointsEnabled?: boolean;
+  chatgptSubscriptionEnabled?: boolean;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
 }
@@ -84,6 +88,7 @@ export function ProviderEditorContent({
   assistantId,
   existingNames,
   openAICompatibleEndpointsEnabled = false,
+  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProviderEditorContentProps) {
@@ -158,6 +163,94 @@ export function ProviderEditorContent({
   const [newCredentialName, setNewCredentialName] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
 
+  // -- ChatGPT Subscription OAuth state -------------------------------------
+  type ChatgptOAuthState =
+    | "idle"
+    | "starting"
+    | "paste_url"
+    | "exchanging"
+    | "completed"
+    | "failed";
+  const [chatgptOAuthState, setChatgptOAuthState] =
+    useState<ChatgptOAuthState>("idle");
+  const [chatgptPastedUrl, setChatgptPastedUrl] = useState("");
+  const [chatgptOAuthError, setChatgptOAuthError] = useState<string | null>(
+    null,
+  );
+  const chatgptStateRef = useRef<string>("");
+
+  const chatgptFlagEnabled =
+    chatgptSubscriptionEnabled && provider === "openai" && effectiveMode === "create";
+
+  async function handleChatgptSignIn() {
+    setChatgptOAuthState("starting");
+    setChatgptOAuthError(null);
+    try {
+      const { authorize_url, state } =
+        await startChatgptSubscriptionAuth(assistantId);
+      chatgptStateRef.current = state;
+      window.open(authorize_url, "_blank", "noopener");
+      setChatgptOAuthState("paste_url");
+    } catch {
+      setChatgptOAuthState("failed");
+      setChatgptOAuthError("Failed to start ChatGPT sign-in. Please try again.");
+    }
+  }
+
+  async function handleChatgptUrlSubmit() {
+    setChatgptOAuthError(null);
+    const trimmed = chatgptPastedUrl.trim();
+    if (!trimmed) {
+      setChatgptOAuthError("Please paste the URL from the error page.");
+      return;
+    }
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(trimmed);
+    } catch {
+      setChatgptOAuthError("Invalid URL. Please paste the full URL from the address bar.");
+      return;
+    }
+    const code = parsedUrl.searchParams.get("code");
+    const state = parsedUrl.searchParams.get("state");
+    if (!code) {
+      setChatgptOAuthError("The URL is missing the authorization code. Make sure you copied the full URL.");
+      return;
+    }
+    if (!state) {
+      setChatgptOAuthError("The URL is missing the state parameter. Make sure you copied the full URL.");
+      return;
+    }
+    setChatgptOAuthState("exchanging");
+    try {
+      await exchangeChatgptAuthCode(assistantId, code, state);
+      setChatgptOAuthState("completed");
+      const conns = await listConnections(assistantId, "openai");
+      const chatgptConn = conns.find(
+        (c) =>
+          c.name === "chatgpt-subscription" || c.name === "openai-chatgpt",
+      );
+      if (chatgptConn) {
+        onSave(chatgptConn);
+      } else {
+        onSave({
+          name: "chatgpt-subscription",
+          provider: "openai",
+          auth: { type: "oauth_subscription" },
+          status: "active",
+          label: "ChatGPT Subscription",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          baseUrl: null,
+          models: null,
+        });
+      }
+    } catch {
+      setChatgptOAuthState("failed");
+      setChatgptOAuthError("Failed to complete sign-in. Please try again.");
+    }
+  }
+
   const loadMaskedValue = useCallback(
     async (credRef: string) => {
       const parts = credRef.split("/");
@@ -225,6 +318,12 @@ export function ProviderEditorContent({
     setNewCredentialName("");
     setIsSavingKey(false);
     setIsAdvancedExpanded(false);
+
+    // Reset ChatGPT OAuth state
+    setChatgptOAuthState("idle");
+    setChatgptPastedUrl("");
+    setChatgptOAuthError(null);
+    chatgptStateRef.current = "";
 
     // Load credential data for edit mode with api_key auth
     if (connection?.auth.type === "api_key") {
@@ -772,6 +871,142 @@ export function ProviderEditorContent({
           onChange={(v) => setStatus(v ? "active" : "disabled")}
           label="Active"
         />
+
+        {/* ChatGPT Subscription OAuth — manual copy-paste flow */}
+        {chatgptFlagEnabled ? (
+          <div className="space-y-3 rounded-lg border border-[var(--border-default)] p-4">
+            <Typography
+              variant="body-medium-default"
+              as="p"
+              className="text-[var(--content-default)]"
+            >
+              ChatGPT Subscription
+            </Typography>
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              Connect your ChatGPT subscription to use OpenAI models without an
+              API key.
+            </Typography>
+
+            {chatgptOAuthState === "idle" ? (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={() => void handleChatgptSignIn()}
+              >
+                Sign in with ChatGPT
+              </Button>
+            ) : null}
+
+            {chatgptOAuthState === "starting" ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+                <Typography
+                  variant="body-small-default"
+                  className="text-[var(--content-tertiary)]"
+                >
+                  Starting sign-in...
+                </Typography>
+              </div>
+            ) : null}
+
+            {chatgptOAuthState === "paste_url" ? (
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    1. Sign in with ChatGPT in the popup
+                  </Typography>
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    2. After sign-in, you&apos;ll see an error page
+                  </Typography>
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    3. Copy the URL from the address bar and paste it below
+                  </Typography>
+                </div>
+                <Input
+                  value={chatgptPastedUrl}
+                  onChange={(e) => {
+                    setChatgptPastedUrl(e.target.value);
+                    setChatgptOAuthError(null);
+                  }}
+                  placeholder="Paste callback URL here..."
+                  fullWidth
+                />
+                <div className="flex justify-end">
+                  <Button
+                    variant="primary"
+                    size="compact"
+                    disabled={!chatgptPastedUrl.trim()}
+                    onClick={() => void handleChatgptUrlSubmit()}
+                  >
+                    Complete Sign In
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {chatgptOAuthState === "exchanging" ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+                <Typography
+                  variant="body-small-default"
+                  className="text-[var(--content-tertiary)]"
+                >
+                  Completing sign-in...
+                </Typography>
+              </div>
+            ) : null}
+
+            {chatgptOAuthState === "completed" ? (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-[var(--system-positive-strong)]"
+              >
+                ChatGPT subscription connected successfully.
+              </Typography>
+            ) : null}
+
+            {chatgptOAuthError ? (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-(--system-negative-strong)"
+              >
+                {chatgptOAuthError}
+              </Typography>
+            ) : null}
+
+            {chatgptOAuthState === "failed" ? (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={() => {
+                  setChatgptOAuthState("idle");
+                  setChatgptPastedUrl("");
+                  setChatgptOAuthError(null);
+                }}
+              >
+                Try Again
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
 
         {error && (
           <Typography


### PR DESCRIPTION
## Summary
- Ports the ChatGPT subscription OAuth copy-paste flow from the platform repo (`web/`) to `apps/web/` in vellum-assistant, which is now the active web UI codebase
- Adds `oauth_subscription` auth type and `startChatgptSubscriptionAuth` / `exchangeChatgptAuthCode` API client functions to `provider-connections-client.ts`
- Adds ChatGPT subscription OAuth state machine UI (sign-in → paste URL → exchange → completed/failed) to `provider-editor-modal.tsx`, gated behind the `chatgpt-subscription-auth` feature flag
- Wires `chatgptSubscriptionAuth` flag from the zustand feature flag store through `manage-providers-modal.tsx` to the editor component

## Context
The web UI has migrated from `vellum-assistant-platform/web/` to `vellum-assistant/apps/web/`. The ChatGPT subscription OAuth changes were previously merged to the platform repo but need to live in the new location. The daemon-side implementation (PKCE flow, token exchange, token refresh) was already merged in PR #30893.

Related: JARVIS-865

## Test plan
- [ ] Enable `chatgpt-subscription-auth` feature flag in developer settings
- [ ] Navigate to Settings → AI → Provider Connections → New Connection
- [ ] Select OpenAI as provider — ChatGPT Subscription section should appear
- [ ] Click "Sign in with ChatGPT" — popup should open
- [ ] After OAuth redirect, paste the callback URL and click "Complete Sign In"
- [ ] Verify the connection appears in the provider list

🤖 Generated with [Claude Code](https://claude.com/claude-code)