### PR TITLE
feat(web): add queue steering Push to agent button (JARVIS-845)

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -332,6 +332,7 @@ export type PostMessageResult =
     assistantId: string;
     conversationKey: string;
     resolvedConversationId?: string;
+    requestId?: string;
   }
   | { ok: false; status: number; error: { code?: string; detail?: string } };
 
@@ -524,6 +525,7 @@ export async function postChatMessage(
       assistantId,
       conversationKey,
       resolvedConversationId,
+      requestId: typeof sendData.requestId === "string" ? sendData.requestId : undefined,
     };
   }
 
@@ -542,6 +544,30 @@ export async function postChatMessage(
     messageId: sendData.messageId,
     resolvedConversationId,
   };
+}
+
+/**
+ * Steer the assistant to a queued message by aborting the current
+ * generation and promoting the message to the head of the queue.
+ */
+export async function steerToMessage(
+  assistantId: string,
+  conversationKey: string,
+  requestId: string,
+): Promise<boolean> {
+  try {
+    const encoded = encodeURIComponent(requestId);
+    const { response } = await client.post<unknown, unknown>({
+      ...SDK_BASE_OPTIONS,
+      url: `/v1/assistants/{assistant_id}/messages/queued/${encoded}/steer`,
+      path: { assistant_id: assistantId },
+      query: { conversationId: conversationKey },
+      throwOnError: false,
+    });
+    return response?.ok ?? false;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -606,6 +606,7 @@ export function ChatPage() {
     queuedMessages,
     handleCancelQueuedMessage,
     handleCancelAllQueued,
+    handleSteerMessage,
     handleEditQueueTail,
   } = useSendMessage({
     assistantId,
@@ -1242,6 +1243,7 @@ export function ChatPage() {
       queuedMessages,
       handleCancelQueuedMessage,
       handleCancelAllQueued,
+      handleSteerMessage,
       handleEditQueueTail,
     },
     interactionActions: {

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -66,6 +66,7 @@ import { pickRandomPlaceholder } from "@/domains/chat/utils/empty-state-constant
 import { useEmptyStateGreeting } from "@/domains/chat/hooks/use-empty-state-greeting.js";
 import { getChatBillingBannerDecision, shouldShowGenericChatErrorNotice } from "@/domains/chat/utils/error-classification.js";
 
+import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store.js";
 import { useDeployStore } from "@/domains/chat/deploy-store.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import type { SubagentEntry, SubagentState } from "@/domains/subagents/subagent-store.js";
@@ -167,6 +168,7 @@ export interface SendMessageHandlers {
   queuedMessages: DisplayMessage[];
   handleCancelQueuedMessage: (stableId: string) => void;
   handleCancelAllQueued: () => void;
+  handleSteerMessage: (stableId: string) => void;
   handleEditQueueTail: () => void;
 }
 
@@ -470,6 +472,7 @@ export function ChatRouteContent({
     queuedMessages,
     handleCancelQueuedMessage,
     handleCancelAllQueued,
+    handleSteerMessage,
     handleEditQueueTail,
   } = send;
   const {
@@ -522,6 +525,12 @@ export function ChatRouteContent({
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
+
+  // -------------------------------------------------------------------------
+  // Feature flags
+  // -------------------------------------------------------------------------
+
+  const queueSteering = useAssistantFeatureFlagStore.use.queueSteering();
 
   // -------------------------------------------------------------------------
   // Interaction state (from Zustand store)
@@ -1238,6 +1247,8 @@ export function ChatRouteContent({
       queuedMessages={queuedMessages}
       onCancelMessage={handleCancelQueuedMessage}
       onCancelAll={handleCancelAllQueued}
+      onSteer={handleSteerMessage}
+      showSteer={queueSteering}
       onEditTail={handleEditQueueTail}
     />
   );

--- a/apps/web/src/domains/chat/components/queued-messages-drawer.tsx
+++ b/apps/web/src/domains/chat/components/queued-messages-drawer.tsx
@@ -1,5 +1,5 @@
 
-import { Pencil, X } from "lucide-react";
+import { ArrowUp, Pencil, X } from "lucide-react";
 import { useCallback, type ReactNode } from "react";
 
 import { Button } from "@vellum/design-library";
@@ -13,6 +13,8 @@ export interface QueuedMessagesDrawerProps {
   queuedMessages: DisplayMessage[];
   onCancelMessage: (stableId: string) => void;
   onCancelAll: () => void;
+  onSteer: (stableId: string) => void;
+  showSteer: boolean;
   onEditTail: () => void;
 }
 
@@ -25,6 +27,8 @@ interface QueuedMessageRowProps {
   position: number;
   isTail: boolean;
   onCancel: () => void;
+  onSteer: () => void;
+  showSteer: boolean;
   onEdit: () => void;
 }
 
@@ -33,6 +37,8 @@ function QueuedMessageRow({
   position,
   isTail,
   onCancel,
+  onSteer,
+  showSteer,
   onEdit,
 }: QueuedMessageRowProps) {
   return (
@@ -52,6 +58,16 @@ function QueuedMessageRow({
 
       {/* Action icons */}
       <div className="flex shrink-0 items-center gap-0.5">
+        {showSteer && (
+          <Button
+            variant="ghost"
+            size="compact"
+            className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+            iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
+            onClick={onSteer}
+            aria-label="Push to agent"
+          />
+        )}
         {isTail && (
           <Button
             variant="ghost"
@@ -83,6 +99,8 @@ export function QueuedMessagesDrawer({
   queuedMessages,
   onCancelMessage,
   onCancelAll,
+  onSteer,
+  showSteer,
   onEditTail,
 }: QueuedMessagesDrawerProps): ReactNode {
   const handleCancelMessage = useCallback(
@@ -123,6 +141,8 @@ export function QueuedMessagesDrawer({
               position={idx + 1}
               isTail={idx === queuedMessages.length - 1}
               onCancel={() => handleCancelMessage(msg.stableId)}
+              onSteer={() => onSteer(msg.stableId)}
+              showSteer={showSteer}
               onEdit={onEditTail}
             />
           ))}

--- a/apps/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/apps/web/src/domains/chat/hooks/use-message-queue.ts
@@ -19,7 +19,7 @@ import {
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { useTurnStore } from "@/domains/messaging/turn-store.js";
-import { deleteQueuedMessage } from "@/domains/chat/api/messages.js";
+import { deleteQueuedMessage, steerToMessage } from "@/domains/chat/api/messages.js";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -103,6 +103,25 @@ export function useMessageQueue({
     }
   }, [queuedMessages, handleCancelQueuedMessage]);
 
+  const handleSteerMessage = useCallback(
+    (stableId: string) => {
+      if (!assistantId || !activeConversationKey) {
+        return;
+      }
+      let targetRequestId: string | undefined;
+      for (const [reqId, sId] of requestIdToStableIdRef.current.entries()) {
+        if (sId === stableId) {
+          targetRequestId = reqId;
+          break;
+        }
+      }
+      if (targetRequestId) {
+        void steerToMessage(assistantId, activeConversationKey, targetRequestId);
+      }
+    },
+    [assistantId, activeConversationKey],
+  );
+
   const handleEditQueueTail = useCallback(() => {
     if (queuedMessages.length === 0) {
       return;
@@ -120,6 +139,7 @@ export function useMessageQueue({
     queuedMessages,
     handleCancelQueuedMessage,
     handleCancelAllQueued,
+    handleSteerMessage,
     handleEditQueueTail,
   };
 }

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -166,6 +166,7 @@ export function useSendMessage({
     queuedMessages,
     handleCancelQueuedMessage,
     handleCancelAllQueued,
+    handleSteerMessage,
     handleEditQueueTail,
   } = useMessageQueue({
     assistantId,
@@ -508,6 +509,9 @@ export function useSendMessage({
             }
             return;
           }
+          if (postResult.requestId) {
+            requestIdToStableIdRef.current.set(postResult.requestId, userMessage.stableId);
+          }
         } catch {
           revertQueuedMessage(userMessage.stableId);
           setError({ message: "Failed to queue message. Please try again." });
@@ -622,6 +626,7 @@ export function useSendMessage({
     queuedMessages,
     handleCancelQueuedMessage,
     handleCancelAllQueued,
+    handleSteerMessage,
     handleEditQueueTail,
   };
 }


### PR DESCRIPTION
## Summary

- Add "Push to agent" (arrow-up) button on each queued message in the `QueuedMessagesDrawer`, gated behind the `queue-steering` assistant feature flag
- Add `steerToMessage()` API function that calls `POST /v1/assistants/{id}/messages/queued/{requestId}/steer`
- Capture `requestId` from the daemon's queued POST response and map it to the optimistic `stableId` so steer/cancel operations can resolve the correct daemon request
- Thread `handleSteerMessage` callback through `useMessageQueue` → `useSendMessage` → `ChatPage` → `ChatRouteContent` → `QueuedMessagesDrawer`

## Test plan

- [ ] Enable `queue-steering` feature flag on an assistant
- [ ] Send a message while the assistant is already processing → message appears in queue drawer
- [ ] Verify the arrow-up (steer) button appears on each queued message
- [ ] Click steer → current generation aborts, steered message is processed next
- [ ] With flag disabled, verify the steer button does not appear
- [ ] Cancel and edit-tail still work as before

Part of JARVIS-845

🤖 Generated with [Claude Code](https://claude.com/claude-code)