### PR TITLE
Recover BYOK provider connections on upgrade

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -18,6 +18,7 @@ import {
   test,
 } from "bun:test";
 
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 // ---------------------------------------------------------------------------
@@ -81,8 +82,15 @@ import { migrateCreateProviderConnections } from "../memory/migrations/243-provi
 import { migrateProviderConnectionStatusLabel } from "../memory/migrations/244-provider-connection-status-label.js";
 import { migrateProviderConnectionBaseUrlAndModels } from "../memory/migrations/250-provider-connection-base-url-and-models.js";
 import * as schema from "../memory/schema.js";
+import {
+  readLegacyInferenceModeSnapshot,
+  runProviderConnectionsBackfill,
+} from "../providers/inference/backfill.js";
 import { getConnection } from "../providers/inference/connections.js";
+import { credentialKey } from "../security/credential-key.js";
 import { _setStorePath } from "../security/encrypted-store.js";
+import { _resetBackend, setSecureKeyAsync } from "../security/secure-keys.js";
+import { dropServicesInferenceModeMigration } from "../workspace/migrations/076-drop-services-inference-mode.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -92,13 +100,17 @@ function writeConfig(obj: unknown): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
 }
 
-function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
+function mergeDefaultConfigAndSeedInferenceProfiles(
+  db?: DrizzleDb,
+  options: { legacyInferenceMode?: "managed" | "your-own" } = {},
+): void {
   const defaultConfigMerge = mergeDefaultWorkspaceConfig();
   seedInferenceProfiles({
     preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
     preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
     isHatch: defaultConfigMerge.hadOverlay,
     db,
+    legacyInferenceMode: options.legacyInferenceMode,
   });
 }
 
@@ -329,6 +341,7 @@ describe("loadConfig startup behavior", () => {
     if (existsSync(updatesPath)) rmSync(updatesPath, { force: true });
     ensureTestDir();
     _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    _resetBackend();
     delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     delete process.env.IS_PLATFORM;
     invalidateConfigCache();
@@ -336,6 +349,7 @@ describe("loadConfig startup behavior", () => {
 
   afterEach(() => {
     _setStorePath(null);
+    _resetBackend();
     delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     delete process.env.IS_PLATFORM;
     invalidateConfigCache();
@@ -505,6 +519,92 @@ describe("loadConfig startup behavior", () => {
     );
     // No user profiles created on platform.
     expect(config.llm.profiles["custom-balanced"]).toBeUndefined();
+  });
+
+  test("on-platform upgrade preserves legacy BYOK inference mode", async () => {
+    process.env.IS_PLATFORM = "true";
+
+    writeConfig({
+      services: { inference: { mode: "your-own" } },
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      },
+    });
+
+    const legacyInferenceMode = readLegacyInferenceModeSnapshot();
+    expect(legacyInferenceMode).toBe("your-own");
+
+    const db = createProviderConnectionsDb();
+    dropServicesInferenceModeMigration.run(WORKSPACE_DIR);
+    await runProviderConnectionsBackfill(db, { legacyInferenceMode });
+    mergeDefaultConfigAndSeedInferenceProfiles(db, { legacyInferenceMode });
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.services.inference).toEqual({});
+    expect(raw.llm.default.provider_connection).toBe("anthropic-personal");
+    expect(raw.llm.activeProfile).toBe("custom-balanced");
+    expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
+    expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
+      "anthropic-personal",
+    );
+    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+      "anthropic-managed",
+    );
+
+    expect(getConnection(db, "anthropic-personal")?.auth).toEqual({
+      type: "api_key",
+      credential: credentialKey("anthropic", "api_key"),
+    });
+  });
+
+  test("already-upgraded platform configs recover personal connections from stored keys once", async () => {
+    process.env.IS_PLATFORM = "true";
+
+    await setSecureKeyAsync(
+      credentialKey("anthropic", "api_key"),
+      "sk-ant-test",
+    );
+    writeConfig({
+      services: { inference: {} },
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          provider_connection: "anthropic-managed",
+        },
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            provider_connection: "anthropic-managed",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const db = createProviderConnectionsDb();
+    expect(getConnection(db, "anthropic-personal")).toBeNull();
+
+    await runProviderConnectionsBackfill(db);
+
+    expect(getConnection(db, "anthropic-personal")?.auth).toEqual({
+      type: "api_key",
+      credential: credentialKey("anthropic", "api_key"),
+    });
+
+    // Recovery is a one-time upgrade repair. If a user later deletes the
+    // personal connection while leaving the secret in place, the next boot must
+    // not resurrect it.
+    db.delete(schema.providerConnections)
+      .where(eq(schema.providerConnections.name, "anthropic-personal"))
+      .run();
+    await runProviderConnectionsBackfill(db);
+    expect(getConnection(db, "anthropic-personal")).toBeNull();
   });
 
   test("re-hatch from openai to anthropic creates user anthropic profiles off-platform", () => {
@@ -944,6 +1044,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     }
     ensureTestDir();
     _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    _resetBackend();
     delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     delete process.env.IS_PLATFORM;
     invalidateConfigCache();
@@ -951,6 +1052,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
   afterEach(() => {
     _setStorePath(null);
+    _resetBackend();
     delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     delete process.env.IS_PLATFORM;
     invalidateConfigCache();

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -89,7 +89,11 @@ import {
 import { getConnection } from "../providers/inference/connections.js";
 import { credentialKey } from "../security/credential-key.js";
 import { _setStorePath } from "../security/encrypted-store.js";
-import { _resetBackend, setSecureKeyAsync } from "../security/secure-keys.js";
+import {
+  _resetBackend,
+  listSecureKeysAsync,
+  setSecureKeyAsync,
+} from "../security/secure-keys.js";
 import { dropServicesInferenceModeMigration } from "../workspace/migrations/076-drop-services-inference-mode.js";
 
 // ---------------------------------------------------------------------------
@@ -590,7 +594,9 @@ describe("loadConfig startup behavior", () => {
     const db = createProviderConnectionsDb();
     expect(getConnection(db, "anthropic-personal")).toBeNull();
 
-    await runProviderConnectionsBackfill(db);
+    await runProviderConnectionsBackfill(db, {
+      listStoredCredentialAccounts: listSecureKeysAsync,
+    });
 
     expect(getConnection(db, "anthropic-personal")?.auth).toEqual({
       type: "api_key",
@@ -603,7 +609,9 @@ describe("loadConfig startup behavior", () => {
     db.delete(schema.providerConnections)
       .where(eq(schema.providerConnections.name, "anthropic-personal"))
       .run();
-    await runProviderConnectionsBackfill(db);
+    await runProviderConnectionsBackfill(db, {
+      listStoredCredentialAccounts: listSecureKeysAsync,
+    });
     expect(getConnection(db, "anthropic-personal")).toBeNull();
   });
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -138,6 +138,12 @@ export type SeedInferenceProfilesOptions = {
   isHatch?: boolean;
   /** DB handle for creating user provider connections at hatch time. */
   db?: DrizzleDb;
+  /**
+   * Snapshot of the removed `services.inference.mode` value captured before
+   * workspace migration 076 strips it. Platform upgrades from legacy BYOK need
+   * this because IS_PLATFORM alone would otherwise seed managed profiles.
+   */
+  legacyInferenceMode?: "managed" | "your-own";
 };
 
 /**
@@ -151,9 +157,10 @@ export type SeedInferenceProfilesOptions = {
  *    Platform overlays (`preserveProfileNames`) take precedence.
  *
  * 2. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
- *    `custom-cost-optimized`): materialized once at hatch time for
- *    off-platform installations. Each points at a personal provider
- *    connection backed by the user's API key in CES. Subsequent boots
+ *    `custom-cost-optimized`): materialized at hatch time for off-platform
+ *    installations, and during platform upgrades when the removed legacy
+ *    inference mode explicitly selected BYOK. Each points at a personal
+ *    provider connection backed by the user's API key in CES. Subsequent boots
  *    leave these untouched — the user owns them.
  */
 export function seedInferenceProfiles(
@@ -263,16 +270,21 @@ export function seedInferenceProfiles(
     profiles[name] = next as ProfileEntry;
   }
 
-  // 2. User profiles — only at hatch time for off-platform installations.
+  // 2. User profiles — at hatch time for off-platform installations, and on
+  // platform upgrades where the removed legacy inference mode explicitly said
+  // "your-own".
   let userConnectionName: string | undefined;
-  if (options.isHatch && !isPlatform) {
+  const shouldSeedUserProfiles =
+    (options.isHatch && !isPlatform) ||
+    options.legacyInferenceMode === "your-own";
+  if (shouldSeedUserProfiles) {
     // BYOK hatch: disable canonical managed connections so the picker doesn't
     // surface unusable platform-auth options on day one. If the hatch overlay
     // selected a managed profile, leave that connection active; the user has
     // already chosen managed inference. Runs only here, only at hatch —
     // `seedCanonicalConnections` leaves `status` alone on subsequent boots so
     // a post-hatch user re-enable persists.
-    if (options.db) {
+    if (options.isHatch && !isPlatform && options.db) {
       disableManagedConnectionsForByokHatch(options.db, {
         excludeConnection: hatchSelectedManagedConnection,
       });
@@ -330,6 +342,12 @@ export function seedInferenceProfiles(
     if (options.isHatch) {
       // Hatch = fresh setup. Pick the right default based on platform mode.
       llm.activeProfile = userConnectionName ? "custom-balanced" : "balanced";
+    } else if (
+      options.legacyInferenceMode === "your-own" &&
+      userConnectionName &&
+      !requestedActiveExists
+    ) {
+      llm.activeProfile = "custom-balanced";
     } else if (!requestedActiveExists) {
       llm.activeProfile = "balanced";
     }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -77,6 +77,7 @@ import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {
+  listSecureKeysAsync,
   onCesClientChanged,
   setCesClient,
   setCesReconnect,
@@ -409,7 +410,10 @@ export async function runDaemon(): Promise<void> {
       // Idempotent — runs every boot so new canonicals propagate and manual
       // config.json edits self-heal.
       try {
-        await runProviderConnectionsBackfill(getDb(), { legacyInferenceMode });
+        await runProviderConnectionsBackfill(getDb(), {
+          legacyInferenceMode,
+          listStoredCredentialAccounts: listSecureKeysAsync,
+        });
       } catch (err) {
         log.warn(
           { err },

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -61,7 +61,10 @@ import { installPluginRuntime } from "../plugins/external-api.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
 import { backfillGuardIfNeeded } from "../proactive-artifact/index.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
-import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
+import {
+  readLegacyInferenceModeSnapshot,
+  runProviderConnectionsBackfill,
+} from "../providers/inference/backfill.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import {
@@ -393,17 +396,20 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
+    let legacyInferenceMode: "managed" | "your-own" | undefined;
     if (dbReady) {
+      legacyInferenceMode = readLegacyInferenceModeSnapshot();
       await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
       log.info("Daemon startup: workspace migrations complete");
 
       // Seed canonical inference provider_connections and backfill any legacy
       // profiles that pre-date the connection field. Runs after workspace
-      // migrations so migration 076 has already stripped services.inference.mode
-      // before backfill reads config. Idempotent — runs every boot so new
-      // canonicals propagate and manual config.json edits self-heal.
+      // migrations, using the pre-migration mode snapshot so migration 076
+      // can strip services.inference.mode without losing BYOK intent.
+      // Idempotent — runs every boot so new canonicals propagate and manual
+      // config.json edits self-heal.
       try {
-        runProviderConnectionsBackfill(getDb());
+        await runProviderConnectionsBackfill(getDb(), { legacyInferenceMode });
       } catch (err) {
         log.warn(
           { err },
@@ -574,6 +580,7 @@ export async function runDaemon(): Promise<void> {
         preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
         isHatch: defaultConfigMerge.hadOverlay,
         db: dbReady ? getDb() : undefined,
+        legacyInferenceMode,
       });
       log.info("Inference profile seeding complete");
     } catch (err) {

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -24,10 +24,6 @@ import { dirname, join } from "node:path";
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { DrizzleDb } from "../../memory/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
-import {
-  type CredentialListResult,
-  listSecureKeysAsync,
-} from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
@@ -49,6 +45,7 @@ const CREDENTIAL_RECOVERY_MARKER =
 const CREDENTIAL_RECOVERY_TIMEOUT_MS = 2_000;
 
 export type LegacyInferenceMode = "managed" | "your-own";
+type CredentialListResult = { accounts: string[]; unreachable: boolean };
 
 export type ProviderConnectionsBackfillOptions = {
   /**
@@ -58,6 +55,12 @@ export type ProviderConnectionsBackfillOptions = {
    * `*-managed`.
    */
   legacyInferenceMode?: LegacyInferenceMode;
+  /**
+   * Supplied by the daemon startup boundary so this backfill can recover
+   * connection rows from credential names without importing secure-keys
+   * directly.
+   */
+  listStoredCredentialAccounts?: () => Promise<CredentialListResult>;
 };
 
 export function readLegacyInferenceModeSnapshot():
@@ -97,7 +100,7 @@ export async function runProviderConnectionsBackfill(
   try {
     seedCanonicalConnections(db);
     backfillConfigProfiles(db, options);
-    await recoverPersonalConnectionsFromStoredCredentials(db);
+    await recoverPersonalConnectionsFromStoredCredentials(db, options);
   } catch (err) {
     log.error(
       { err },
@@ -289,10 +292,14 @@ function ensurePersonalConnection(
 
 async function recoverPersonalConnectionsFromStoredCredentials(
   db: DrizzleDb,
+  options: ProviderConnectionsBackfillOptions,
 ): Promise<void> {
+  if (!options.listStoredCredentialAccounts) return;
   if (credentialRecoveryMarkerExists()) return;
 
-  const listResult = await listSecureKeysForRecovery();
+  const listResult = await listSecureKeysForRecovery(
+    options.listStoredCredentialAccounts,
+  );
   if (listResult.unreachable) {
     log.warn(
       "Credential store unreachable during provider connection recovery; will retry on next boot",
@@ -311,11 +318,13 @@ async function recoverPersonalConnectionsFromStoredCredentials(
   writeCredentialRecoveryMarker(recoveredProviders);
 }
 
-async function listSecureKeysForRecovery(): Promise<CredentialListResult> {
+async function listSecureKeysForRecovery(
+  listStoredCredentialAccounts: () => Promise<CredentialListResult>,
+): Promise<CredentialListResult> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      listSecureKeysAsync(),
+      listStoredCredentialAccounts(),
       new Promise<CredentialListResult>((resolve) => {
         timeout = setTimeout(
           () => resolve({ accounts: [], unreachable: true }),

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -7,8 +7,9 @@
  *   - `llm.profiles.*`        — named alternate profiles (fast/balanced/...)
  *   - `llm.callSites.*`       — per-call-site overrides with bare `provider`
  *
- * Idempotent: any object that already has `provider_connection` is skipped.
- * Only modifies config.json when at least one location needs updating.
+ * Idempotent: any object that already has `provider_connection` is skipped
+ * after ensuring its personal connection row exists. Only modifies config.json
+ * when at least one location needs updating.
  *
  * The `default` and `callSites` walks were added alongside Phase 1.1 of the
  * post-v1 inference-providers cleanup: dispatch now throws on missing
@@ -17,10 +18,19 @@
  * default profile and on any legacy bare-`provider` callsite override.
  */
 
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { DrizzleDb } from "../../memory/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
+import {
+  type CredentialListResult,
+  listSecureKeysAsync,
+} from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { PROVIDER_CATALOG } from "../model-catalog.js";
 import {
   createConnection,
   getConnection,
@@ -32,13 +42,41 @@ const log = getLogger("provider-connections-backfill");
 
 // Providers that support the managed (platform) auth type.
 const MANAGED_PROVIDERS = new Set(["anthropic", "openai", "gemini"]);
+const VALID_INFERENCE_PROVIDERS = new Set(PROVIDER_CATALOG.map((p) => p.id));
+const CREDENTIAL_KEY_PREFIX = "credential/";
+const CREDENTIAL_RECOVERY_MARKER =
+  "provider-connection-credential-recovery-v1.json";
+const CREDENTIAL_RECOVERY_TIMEOUT_MS = 2_000;
+
+export type LegacyInferenceMode = "managed" | "your-own";
+
+export type ProviderConnectionsBackfillOptions = {
+  /**
+   * Snapshot of the removed `services.inference.mode` field, captured before
+   * workspace migration 076 strips it. This preserves BYOK intent on platform
+   * upgrades where IS_PLATFORM would otherwise make the backfill choose
+   * `*-managed`.
+   */
+  legacyInferenceMode?: LegacyInferenceMode;
+};
+
+export function readLegacyInferenceModeSnapshot():
+  | LegacyInferenceMode
+  | undefined {
+  const raw = loadRawConfig();
+  const services = readObject(raw.services);
+  const inference = readObject(services?.inference);
+  const mode = inference?.mode;
+  return mode === "managed" || mode === "your-own" ? mode : undefined;
+}
 
 /**
  * Seed canonical provider_connections and backfill any legacy config locations
  * that pre-date the connection field.
  *
- * Runs on every daemon boot — both halves are idempotent and cheap
- * (O(profiles + callSites), typically ≤20 entries total). Designed to:
+ * Runs on every daemon boot — config backfill is cheap
+ * (O(profiles + callSites), typically ≤20 entries total), and stored-key
+ * recovery is one-shot after the credential store is reachable. Designed to:
  *   - propagate new canonical connections as they're added in future versions
  *   - self-heal manual config.json edits that drop the connection field
  *
@@ -48,31 +86,47 @@ const MANAGED_PROVIDERS = new Set(["anthropic", "openai", "gemini"]);
  *   3. For each entry without `provider_connection`, derive one from the
  *      entry's `provider` field + the global inference mode and write it back.
  *   4. Save config.json if any entry was updated.
+ *   5. Once per workspace, recreate missing personal connections for existing
+ *      stored API keys so already-upgraded v0.8.1 installs do not require
+ *      re-adding keys.
  */
-export function runProviderConnectionsBackfill(db: DrizzleDb): void {
+export async function runProviderConnectionsBackfill(
+  db: DrizzleDb,
+  options: ProviderConnectionsBackfillOptions = {},
+): Promise<void> {
   try {
     seedCanonicalConnections(db);
-    backfillConfigProfiles(db);
+    backfillConfigProfiles(db, options);
+    await recoverPersonalConnectionsFromStoredCredentials(db);
   } catch (err) {
-    log.error({ err }, "provider_connections backfill failed — will retry on next boot");
+    log.error(
+      { err },
+      "provider_connections backfill failed — will retry on next boot",
+    );
   }
 }
 
-function backfillConfigProfiles(db: DrizzleDb): void {
+function backfillConfigProfiles(
+  db: DrizzleDb,
+  options: ProviderConnectionsBackfillOptions,
+): void {
   const raw = loadRawConfig();
   const llm = raw.llm as Record<string, unknown> | undefined;
   if (!llm) return;
 
   const isPlatform =
     process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
-  const globalMode = isPlatform ? "managed" : "your-own";
+  const globalMode =
+    options.legacyInferenceMode ?? (isPlatform ? "managed" : "your-own");
 
   let changed = false;
 
   // 1. The default profile — every dispatch path's terminal fallback.
   const defaultProfile = llm.default as Record<string, unknown> | undefined;
   if (defaultProfile && typeof defaultProfile === "object") {
-    if (ensureProviderConnection(defaultProfile, "<llm.default>", db, globalMode)) {
+    if (
+      ensureProviderConnection(defaultProfile, "<llm.default>", db, globalMode)
+    ) {
       llm.default = defaultProfile;
       changed = true;
     }
@@ -134,7 +188,9 @@ function backfillConfigProfiles(db: DrizzleDb): void {
  * `*-personal` connection is needed and doesn't yet exist in the DB, this
  * also creates it (lazy bootstrap of user-mode credential rows).
  *
- * Returns `true` if the entry was changed, `false` otherwise.
+ * Returns `true` if the entry was changed, `false` otherwise. Existing
+ * `*-personal` references still ensure the DB row exists, but do not count as
+ * config changes.
  */
 function ensureProviderConnection(
   entry: Record<string, unknown>,
@@ -147,12 +203,14 @@ function ensureProviderConnection(
   // `provider_connection: ""` would otherwise skip backfill and then hard-throw
   // at runtime. Self-heal those alongside null/undefined.
   const existing = entry.provider_connection;
-  const hasValid =
-    typeof existing === "string" && existing.trim() !== "";
-  if (hasValid) return false;
-
+  const hasValid = typeof existing === "string" && existing.trim() !== "";
   const provider = entry.provider as string | undefined;
   if (!provider) return false;
+
+  if (hasValid) {
+    ensurePersonalConnectionForName(db, provider, existing.trim(), entryLabel);
+    return false;
+  }
 
   if (PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
     log.warn(
@@ -172,32 +230,7 @@ function ensureProviderConnection(
     // `auth: { type: "none" }`; everything else gets an api_key
     // pointing at the conventional credential slot.
     connectionName = `${provider}-personal`;
-    if (!getConnection(db, connectionName)) {
-      const isKeyless = provider === "ollama";
-      const credName = credentialKey(provider, "api_key");
-      const result = createConnection(db, {
-        name: connectionName,
-        provider,
-        auth: isKeyless
-          ? { type: "none" }
-          : { type: "api_key", credential: credName },
-      });
-      if (!result.ok) {
-        log.warn(
-          { entry: entryLabel, provider, error: result.error },
-          "Failed to create personal connection during backfill; skipping entry",
-        );
-        return false;
-      }
-      log.info(
-        {
-          connectionName,
-          provider,
-          credential: isKeyless ? null : credName,
-        },
-        "Created personal connection during backfill",
-      );
-    }
+    if (!ensurePersonalConnection(db, provider, entryLabel)) return false;
   }
 
   entry.provider_connection = connectionName;
@@ -206,4 +239,166 @@ function ensureProviderConnection(
     "Backfilled provider_connection",
   );
   return true;
+}
+
+function ensurePersonalConnectionForName(
+  db: DrizzleDb,
+  provider: string,
+  connectionName: string,
+  entryLabel: string,
+): boolean {
+  if (connectionName !== `${provider}-personal`) return true;
+  return ensurePersonalConnection(db, provider, entryLabel);
+}
+
+function ensurePersonalConnection(
+  db: DrizzleDb,
+  provider: string,
+  entryLabel: string,
+): boolean {
+  const connectionName = `${provider}-personal`;
+  if (getConnection(db, connectionName)) return true;
+
+  const isKeyless = provider === "ollama";
+  const credName = credentialKey(provider, "api_key");
+  const result = createConnection(db, {
+    name: connectionName,
+    provider,
+    auth: isKeyless
+      ? { type: "none" }
+      : { type: "api_key", credential: credName },
+    label: personalConnectionLabel(provider),
+  });
+  if (!result.ok) {
+    log.warn(
+      { entry: entryLabel, provider, error: result.error },
+      "Failed to create personal connection during backfill; skipping entry",
+    );
+    return false;
+  }
+  log.info(
+    {
+      connectionName,
+      provider,
+      credential: isKeyless ? null : credName,
+    },
+    "Created personal connection during backfill",
+  );
+  return true;
+}
+
+async function recoverPersonalConnectionsFromStoredCredentials(
+  db: DrizzleDb,
+): Promise<void> {
+  if (credentialRecoveryMarkerExists()) return;
+
+  const listResult = await listSecureKeysForRecovery();
+  if (listResult.unreachable) {
+    log.warn(
+      "Credential store unreachable during provider connection recovery; will retry on next boot",
+    );
+    return;
+  }
+
+  const recoveredProviders: string[] = [];
+  for (const provider of providersFromStoredCredentials(listResult.accounts)) {
+    if (getConnection(db, `${provider}-personal`)) continue;
+    if (ensurePersonalConnection(db, provider, "<credential-store-recovery>")) {
+      recoveredProviders.push(provider);
+    }
+  }
+
+  writeCredentialRecoveryMarker(recoveredProviders);
+}
+
+async function listSecureKeysForRecovery(): Promise<CredentialListResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      listSecureKeysAsync(),
+      new Promise<CredentialListResult>((resolve) => {
+        timeout = setTimeout(
+          () => resolve({ accounts: [], unreachable: true }),
+          CREDENTIAL_RECOVERY_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function providersFromStoredCredentials(accounts: string[]): string[] {
+  const providers = new Set<string>();
+  for (const account of accounts) {
+    const provider = providerFromStoredCredential(account);
+    if (provider) providers.add(provider);
+  }
+  return [...providers].sort();
+}
+
+function providerFromStoredCredential(account: string): string | undefined {
+  if (account.startsWith(CREDENTIAL_KEY_PREFIX)) {
+    const rest = account.slice(CREDENTIAL_KEY_PREFIX.length);
+    const slashIdx = rest.indexOf("/");
+    if (slashIdx < 1 || slashIdx >= rest.length - 1) return undefined;
+    const service = rest.slice(0, slashIdx);
+    const field = rest.slice(slashIdx + 1);
+    if (field !== "api_key") return undefined;
+    return isRecoverableInferenceProvider(service) ? service : undefined;
+  }
+
+  return isRecoverableInferenceProvider(account) ? account : undefined;
+}
+
+function isRecoverableInferenceProvider(provider: string): boolean {
+  return (
+    provider !== "ollama" &&
+    VALID_INFERENCE_PROVIDERS.has(provider) &&
+    !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)
+  );
+}
+
+function credentialRecoveryMarkerPath(): string {
+  return join(getWorkspaceDir(), "data", CREDENTIAL_RECOVERY_MARKER);
+}
+
+function credentialRecoveryMarkerExists(): boolean {
+  return existsSync(credentialRecoveryMarkerPath());
+}
+
+function writeCredentialRecoveryMarker(recoveredProviders: string[]): void {
+  const path = credentialRecoveryMarkerPath();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify(
+        {
+          completedAt: new Date().toISOString(),
+          recoveredProviders,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to write provider connection credential recovery marker",
+    );
+  }
+}
+
+function personalConnectionLabel(providerId: string): string {
+  const displayName =
+    PROVIDER_CATALOG.find((p) => p.id === providerId)?.displayName ??
+    providerId;
+  return `${displayName} (Personal)`;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }


### PR DESCRIPTION
## Summary
- preserve legacy `services.inference.mode` before migration 076 strips it so platform BYOK upgrades seed `*-personal` connections/profiles instead of defaulting to managed
- add one-time stored-key recovery that recreates missing personal provider connections for already-upgraded v0.8.1 installs without re-creating them after a user deletes them
- cover fresh platform BYOK upgrade and already-upgraded recovery in config/backfill tests

## Original prompt
A v0.8.1 platform user reported that BYOK API keys disappeared from Settings after upgrade. Investigation showed the keys were likely still in `/ces-security/keys.enc`, but provider_connections/profile backfill lost the old BYOK mode and pointed settings at managed connections.