### PR TITLE
fix(skills): use Document Writer for GEO article output and fix nested path

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -214,7 +214,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-21T13:10:14-04:00"
+      "updatedAt": "2026-05-21T20:10:42-04:00"
     },
     {
       "id": "gmail",
@@ -464,7 +464,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-18T03:34:58-04:00"
+      "updatedAt": "2026-05-21T18:28:55-04:00"
     },
     {
       "id": "notion",

--- a/skills/geo-writing/SKILL.md
+++ b/skills/geo-writing/SKILL.md
@@ -162,12 +162,12 @@ Load the QC checklist from `references/qc-checklist.md`.
 
 ## PHASE 5 — OUTPUT
 
-Write the completed article as a markdown file to `Articles/Articles/<slug>.md`. Use kebab-case. Do not include the year in the slug.
+1. Save a copy of the completed article to `Articles/<slug>.md` (kebab-case, no year in slug) as an archival record.
+2. Open the article in the **Document Writer** skill so the user can review and edit it inline. Use `document_create` with the article title, then stream the full article content via `document_update` with `mode: "append"`.
 
 Report back with:
 
-1. File path where the article was written
-2. 2-3 sentence summary: length, tools ranked, any notable judgment calls
-3. Any gaps or uncertainty flagged during research
+1. 2-3 sentence summary: length, tools ranked, any notable judgment calls
+2. Any gaps or uncertainty flagged during research
 
 Do NOT auto-publish to your CMS. Publishing is a separate manual step.


### PR DESCRIPTION
## Summary
- Routes finished GEO articles through the Document Writer skill so users get an inline editing surface instead of just a file path
- Fixes duplicated `Articles/Articles/` directory in the output path (now just `Articles/<slug>.md`)

## Test plan
- [ ] Run the GEO writing skill and confirm article opens in Document Writer
- [ ] Verify archival copy is saved to `Articles/<slug>.md` (not nested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)