### PR TITLE
fix(web): fix ChatGPT subscription popup blocking and auth shape

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-connections-client.ts
+++ b/apps/web/src/domains/settings/ai/provider-connections-client.ts
@@ -23,7 +23,7 @@ export interface ConnectionModel {
 
 export type Auth =
   | { type: "api_key"; credential: string }
-  | { type: "oauth_subscription" }
+  | { type: "oauth_subscription"; credential: string }
   | { type: "platform" }
   | { type: "none" };
 

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -185,13 +185,19 @@ export function ProviderEditorContent({
   async function handleChatgptSignIn() {
     setChatgptOAuthState("starting");
     setChatgptOAuthError(null);
+    const popup = window.open("about:blank", "_blank", "noopener");
     try {
       const { authorize_url, state } =
         await startChatgptSubscriptionAuth(assistantId);
       chatgptStateRef.current = state;
-      window.open(authorize_url, "_blank", "noopener");
+      if (popup) {
+        popup.location.href = authorize_url;
+      } else {
+        window.open(authorize_url, "_blank", "noopener");
+      }
       setChatgptOAuthState("paste_url");
     } catch {
+      popup?.close();
       setChatgptOAuthState("failed");
       setChatgptOAuthError("Failed to start ChatGPT sign-in. Please try again.");
     }
@@ -236,7 +242,7 @@ export function ProviderEditorContent({
         onSave({
           name: "chatgpt-subscription",
           provider: "openai",
-          auth: { type: "oauth_subscription" },
+          auth: { type: "oauth_subscription", credential: "credential/openai/chatgpt-subscription" },
           status: "active",
           label: "ChatGPT Subscription",
           createdAt: Date.now(),


### PR DESCRIPTION
## Summary
- Open the OAuth popup synchronously in the click handler (`about:blank`) then navigate it after the API responds, preventing browser popup blockers from intercepting it
- Add the required `credential` field to the `oauth_subscription` auth type to match the daemon's Zod schema (`z.string().min(1)`)

Follow-up to #31603 addressing automated review comments.

## Test plan
- [ ] Click "Sign in with ChatGPT" — popup should open immediately (not blocked)
- [ ] If API call fails, popup should close automatically
- [ ] Verify fallback `onSave` path includes valid auth shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)