### PR TITLE
feat(daemon): add /clean slash command (strip injections, preserve history)

### DIFF
--- a/assistant/src/__tests__/conversation-clean-command.test.ts
+++ b/assistant/src/__tests__/conversation-clean-command.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the `/clean` slash command primitives.
+ *
+ * `/clean` is wired up so that:
+ *   1. Runtime injection prefixes are stripped from user-message text blocks
+ *      (same allowlist `/compact` uses).
+ *   2. Assistant turns, tool_use blocks, and tool_result blocks are preserved
+ *      verbatim — `/clean` never alters history shape.
+ *   3. The user-facing result message reports tokens reclaimed and the
+ *      number of messages preserved.
+ *
+ * The slash-routing layer is covered by `conversation-slash-commands.test.ts`;
+ * the graph-memory eviction hook is covered by the v2 routing tests. This
+ * file focuses on the formatter and the strip behavior that defines the
+ * "no history loss" contract.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { formatCleanResult } from "../daemon/conversation-process.js";
+import { stripInjectionsForCompaction } from "../daemon/conversation-runtime-assembly.js";
+import type { Message } from "../providers/types.js";
+
+describe("formatCleanResult", () => {
+  test("formats token reclamation and preserved-message count", () => {
+    const out = formatCleanResult({
+      previousEstimatedInputTokens: 100_000,
+      estimatedInputTokens: 95_000,
+      maxInputTokens: 200_000,
+      preservedMessages: 250,
+    });
+    expect(out).toContain("Context Cleaned");
+    expect(out).toContain("100,000 → 95,000 (5,000 reclaimed)");
+    expect(out).toContain("95,000 / 200,000 tokens");
+    expect(out).toContain("250 preserved");
+  });
+
+  test("renders zero reclaimed when nothing was stripped", () => {
+    const out = formatCleanResult({
+      previousEstimatedInputTokens: 12_345,
+      estimatedInputTokens: 12_345,
+      maxInputTokens: 200_000,
+      preservedMessages: 10,
+    });
+    expect(out).toContain("12,345 → 12,345 (0 reclaimed)");
+    expect(out).toContain("10 preserved");
+  });
+});
+
+describe("stripInjectionsForCompaction preserves history shape", () => {
+  test("strips known injection prefixes from user text blocks", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<NOW.md Always keep this up to date>\nfoo\n</NOW.md>",
+          },
+          { type: "text", text: "Hello, please help with X." },
+        ],
+      },
+    ];
+    const out = stripInjectionsForCompaction(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0].content).toHaveLength(1);
+    expect(out[0].content[0]).toEqual({
+      type: "text",
+      text: "Hello, please help with X.",
+    });
+  });
+
+  test("preserves assistant turns and tool_use/tool_result blocks verbatim", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<knowledge_base>\nstale kb\n</knowledge_base>",
+          },
+          { type: "text", text: "Run the calculator." },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Using the calculator." },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "calculator",
+            input: { expr: "1 + 2" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-1",
+            content: "3",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The answer is 3." }],
+      },
+    ];
+
+    const out = stripInjectionsForCompaction(messages);
+
+    expect(out).toHaveLength(4);
+    expect(out[0].content).toEqual([
+      { type: "text", text: "Run the calculator." },
+    ]);
+    expect(out[1]).toEqual(messages[1]);
+    expect(out[2]).toEqual(messages[2]);
+    expect(out[3]).toEqual(messages[3]);
+  });
+
+  test("leaves <turn_context>, <workspace>, and <memory __injected> alone", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<turn_context>\nnow\n</turn_context>" },
+          { type: "text", text: "<workspace>\nfiles\n</workspace>" },
+          { type: "text", text: "<memory __injected>\nrecent\n</memory>" },
+        ],
+      },
+    ];
+    const out = stripInjectionsForCompaction(messages);
+    expect(out[0].content).toEqual(messages[0].content);
+  });
+});

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -1,10 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import {
-  invalidateConfigCache,
-  loadRawConfig,
-} from "../config/loader.js";
+import { invalidateConfigCache, loadRawConfig } from "../config/loader.js";
 import {
   classifySlash,
   resolveSlash,
@@ -42,6 +39,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/clean — Strip injected runtime context and reset memory injection state (no summarization)",
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -58,6 +56,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/clean — Strip injected runtime context and reset memory injection state (no summarization)",
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -74,6 +73,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/clean — Strip injected runtime context and reset memory injection state (no summarization)",
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -87,6 +87,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/clean — Strip injected runtime context and reset memory injection state (no summarization)",
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -99,6 +100,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/clean — Strip injected runtime context and reset memory injection state (no summarization)",
       "/model — List or switch inference profile",
       "/models — List all available models",
     ]);
@@ -187,13 +189,38 @@ describe("resolveSlash /compact target override", () => {
   });
 });
 
+describe("resolveSlash /clean", () => {
+  test("plain /clean resolves to kind=clean", async () => {
+    const result = await resolveSlash("/clean");
+    expect(result).toEqual({ kind: "clean" });
+  });
+
+  test("/clean tolerates surrounding whitespace", async () => {
+    const result = await resolveSlash("  /clean  ");
+    expect(result).toEqual({ kind: "clean" });
+  });
+
+  test("/clean is case-insensitive", async () => {
+    const result = await resolveSlash("/CLEAN");
+    expect(result).toEqual({ kind: "clean" });
+  });
+
+  test("/clean rejects arguments with usage hint", async () => {
+    const result = await resolveSlash("/clean now");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown");
+    expect(result.message).toContain("/clean");
+    expect(result.message).toContain("does not take arguments");
+  });
+});
+
 describe("classifySlash is a pure classifier matching resolveSlash kinds", () => {
   // Lookahead in `buildPassthroughBatch` must not run `resolveSlash`'s side
   // effects. The pure classifier is synchronous, takes no side-effecting
   // dependencies, and must agree with resolveSlash's `kind`.
   const cases: Array<{
     input: string;
-    kind: "passthrough" | "compact" | "unknown";
+    kind: "passthrough" | "compact" | "clean" | "unknown";
   }> = [
     { input: "/models", kind: "unknown" },
     { input: "/context", kind: "unknown" },
@@ -204,6 +231,9 @@ describe("classifySlash is a pure classifier matching resolveSlash kinds", () =>
     { input: "/compact 30k", kind: "compact" },
     { input: "/compact 1.5M", kind: "compact" },
     { input: "/compact bogus", kind: "unknown" },
+    { input: "/clean", kind: "clean" },
+    { input: "  /clean  ", kind: "clean" },
+    { input: "/clean foo", kind: "unknown" },
     { input: "/model", kind: "unknown" },
     { input: "/model foo", kind: "unknown" },
     { input: "/opus", kind: "unknown" },
@@ -318,9 +348,7 @@ describe("resolveSlash /model — inference profile switcher", () => {
     const result = await resolveSlash("/model balanced");
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") throw new Error("expected unknown kind");
-    expect(result.message).toBe(
-      "Already using profile `balanced` (Balanced).",
-    );
+    expect(result.message).toBe("Already using profile `balanced` (Balanced).");
   });
 
   test("`/model` with no profiles defined points at Settings", async () => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -221,6 +221,26 @@ export class ContextWindowManager {
     return getConfig().compaction;
   }
 
+  get maxInputTokens(): number {
+    return this.config.maxInputTokens;
+  }
+
+  /**
+   * Estimate the prompt-token cost of `messages` using the same path as the
+   * auto-compaction pre-check. Clears the system-prompt cache so the next
+   * turn re-resolves it (the system prompt is lazy and may have changed).
+   */
+  estimateInputTokens(messages: Message[]): number {
+    try {
+      return estimatePromptTokens(messages, this.systemPrompt, {
+        providerName: this.estimationProviderName,
+        toolTokenBudget: this.toolTokenBudget,
+      });
+    } finally {
+      this.clearSystemPromptCache();
+    }
+  }
+
   /**
    * Cheap pre-check — estimate the current token count and compare against
    * `compaction.autoThreshold`. Callers pass the estimate back through

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -33,6 +33,7 @@ import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
+import type { CleanResult } from "./conversation.js";
 import {
   persistQueuedMessageBody,
   serializePersistedUserMessageContent,
@@ -85,6 +86,21 @@ export function formatCompactResult(result: ContextWindowResult): string {
     )} tokens`,
     `Messages: ${fmt(result.compactedMessages)} compacted`,
     `Tail:     ${fmt(result.preservedTailMessages)} preserved`,
+  ].join("\n");
+}
+
+/** Format the result of a forced clean into a user-facing message. */
+export function formatCleanResult(result: CleanResult): string {
+  const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");
+  const reclaimed =
+    result.previousEstimatedInputTokens - result.estimatedInputTokens;
+  return [
+    "Context Cleaned\n",
+    `Tokens:   ${fmt(result.previousEstimatedInputTokens)} → ${fmt(result.estimatedInputTokens)} (${fmt(reclaimed)} reclaimed)`,
+    `Context:  ${fmt(result.estimatedInputTokens)} / ${fmt(
+      result.maxInputTokens,
+    )} tokens`,
+    `Messages: ${fmt(result.preservedMessages)} preserved`,
   ].join("\n");
 }
 
@@ -191,6 +207,8 @@ export interface ProcessConversationContext {
   forceCompact(options?: {
     targetInputTokensOverride?: number;
   }): Promise<ContextWindowResult>;
+  /** Strip runtime injections and reset memory-injection state. */
+  forceClean(): Promise<CleanResult>;
   /** Set transport-derived hints for the conversation. */
   setTransportHints(hints: string[] | undefined): void;
   /** IANA timezone reported by the active client for the current turn. */
@@ -378,7 +396,10 @@ function repairPendingToolUseBlocks(
     const msg = messages[i];
     if (msg.role === "user") {
       for (const block of msg.content) {
-        if (block.type === "tool_result" || block.type === "web_search_tool_result") {
+        if (
+          block.type === "tool_result" ||
+          block.type === "web_search_tool_result"
+        ) {
           resolvedToolUseIds.add(block.tool_use_id);
         }
       }
@@ -765,6 +786,94 @@ async function drainSingleMessage(
           requestId: next.requestId,
         },
         "Failed to execute /compact",
+      );
+      next.onEvent({
+        type: "error",
+        conversationId: conversation.conversationId,
+        message,
+      });
+    }
+    await drainQueue(conversation);
+    return;
+  }
+
+  // /clean — strip runtime injections and reset memory state, no LLM call.
+  if (slashResult.kind === "clean") {
+    let persistedCleanMessage = false;
+    try {
+      const drainProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
+      const drainChannelMeta = {
+        ...drainProvenance,
+        ...(queuedTurnCtx
+          ? {
+              userMessageChannel: queuedTurnCtx.userMessageChannel,
+              assistantMessageChannel: queuedTurnCtx.assistantMessageChannel,
+            }
+          : {}),
+        ...(queuedInterfaceCtx
+          ? {
+              userMessageInterface: queuedInterfaceCtx.userMessageInterface,
+              assistantMessageInterface:
+                queuedInterfaceCtx.assistantMessageInterface,
+            }
+          : {}),
+        sentAt: next.sentAt,
+      };
+      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      await addMessage(
+        conversation.conversationId,
+        "user",
+        serializePersistedUserMessageContent(
+          next.content,
+          next.attachments,
+          next.displayContent,
+        ),
+        drainChannelMeta,
+      );
+      persistedCleanMessage = true;
+      conversation.messages.push(cleanUserMsg);
+
+      const result = await conversation.forceClean();
+      const responseText = formatCleanResult(result);
+
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversation.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        { ...drainChannelMeta, sentAt: Date.now() },
+      );
+      conversation.messages.push(assistantMsg);
+
+      next.onEvent({
+        type: "assistant_text_delta",
+        text: responseText,
+        conversationId: conversation.conversationId,
+      });
+      conversation.traceEmitter.emit(
+        "message_complete",
+        "Clean slash command handled",
+        { requestId: next.requestId, status: "success" },
+      );
+      next.onEvent({
+        type: "message_complete",
+        conversationId: conversation.conversationId,
+      });
+      publishConversationMessagesChanged(conversation.conversationId);
+    } catch (err) {
+      if (persistedCleanMessage) {
+        publishConversationMessagesChanged(conversation.conversationId);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        {
+          err,
+          conversationId: conversation.conversationId,
+          requestId: next.requestId,
+        },
+        "Failed to execute /clean",
       );
       next.onEvent({
         type: "error",
@@ -1626,6 +1735,85 @@ export async function processMessage(
       return persisted.id;
     } catch (err) {
       if (persistedCompactMessage) {
+        publishConversationMessagesChanged(conversation.conversationId);
+      }
+      throw err;
+    } finally {
+      conversation.processing = false;
+      await drainQueue(conversation);
+    }
+  }
+
+  // /clean — strip runtime injections, return message ID. No LLM call.
+  if (slashResult.kind === "clean") {
+    conversation.processing = true;
+    let persistedCleanMessage = false;
+    try {
+      const pmTurnCtx = conversation.getTurnChannelContext();
+      const pmInterfaceCtx = conversation.getTurnInterfaceContext();
+      const pmProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
+      const pmChannelMeta = {
+        ...pmProvenance,
+        ...(pmTurnCtx
+          ? {
+              userMessageChannel: pmTurnCtx.userMessageChannel,
+              assistantMessageChannel: pmTurnCtx.assistantMessageChannel,
+            }
+          : {}),
+        ...(pmInterfaceCtx
+          ? {
+              userMessageInterface: pmInterfaceCtx.userMessageInterface,
+              assistantMessageInterface:
+                pmInterfaceCtx.assistantMessageInterface,
+            }
+          : {}),
+      };
+      const cleanUserMsg = createUserMessage(content, attachments);
+      const persisted = await addMessage(
+        conversation.conversationId,
+        "user",
+        serializePersistedUserMessageContent(
+          content,
+          attachments,
+          displayContent,
+        ),
+        pmChannelMeta,
+      );
+      persistedCleanMessage = true;
+      conversation.messages.push(cleanUserMsg);
+
+      const result = await conversation.forceClean();
+      const responseText = formatCleanResult(result);
+
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversation.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        pmChannelMeta,
+      );
+      conversation.messages.push(assistantMsg);
+
+      onEvent({
+        type: "assistant_text_delta",
+        text: responseText,
+        conversationId: conversation.conversationId,
+      });
+      conversation.traceEmitter.emit(
+        "message_complete",
+        "Clean slash command handled",
+        { requestId, status: "success" },
+      );
+      onEvent({
+        type: "message_complete",
+        conversationId: conversation.conversationId,
+      });
+      publishConversationMessagesChanged(conversation.conversationId);
+      return persisted.id;
+    } catch (err) {
+      if (persistedCleanMessage) {
         publishConversationMessagesChanged(conversation.conversationId);
       }
       throw err;

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -14,7 +14,8 @@ import { getVisibleProviderCatalog } from "../providers/provider-catalog-visibil
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
   | { kind: "unknown"; message: string }
-  | { kind: "compact"; targetInputTokensOverride?: number };
+  | { kind: "compact"; targetInputTokensOverride?: number }
+  | { kind: "clean" };
 
 const COMPACT_USAGE_HINT =
   "Usage: `/compact [<tokens>]` (e.g. `/compact 30000`, `/compact 30k`, `/compact 1m`).";
@@ -50,6 +51,23 @@ function parseCompactCommand(trimmed: string): CompactParse | null {
     };
   }
   return { kind: "compact", targetInputTokensOverride: tokens };
+}
+
+type CleanParse = { kind: "clean" } | { kind: "unknown"; message: string };
+
+const CLEAN_COMMAND_PATTERN = /^\/clean(?:\s+(.+?))?\s*$/i;
+
+function parseCleanCommand(trimmed: string): CleanParse | null {
+  const match = trimmed.match(CLEAN_COMMAND_PATTERN);
+  if (!match) return null;
+  const rest = match[1]?.trim();
+  if (rest) {
+    return {
+      kind: "unknown",
+      message: `\`/clean\` does not take arguments. Usage: \`/clean\`.`,
+    };
+  }
+  return { kind: "clean" };
 }
 
 // ── /context and /status commands ────────────────────────────────────
@@ -302,10 +320,14 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
   return { kind: "unknown", message: lines.join("\n") };
 }
 
+const CLEAN_HELP_LINE =
+  "/clean — Strip injected runtime context and reset memory injection state (no summarization)";
+
 function resolveCommandsList(context?: SlashContext): string[] {
   const fallbackLines = [
     "/commands — List all available commands",
     "/compact — Force context compaction immediately",
+    CLEAN_HELP_LINE,
   ];
   if (context) {
     fallbackLines.push("/context — Show conversation context usage");
@@ -322,6 +344,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
     return [
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      CLEAN_HELP_LINE,
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -335,6 +358,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
     return [
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      CLEAN_HELP_LINE,
       "/context — Show conversation context usage",
       "/model — List or switch inference profile",
       "/models — List all available models",
@@ -347,6 +371,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
   return [
     "/commands — List all available commands",
     "/compact — Force context compaction immediately",
+    CLEAN_HELP_LINE,
     "/context — Show conversation context usage",
     "/model — List or switch inference profile",
     "/models — List all available models",
@@ -366,7 +391,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
  */
 export function classifySlash(
   content: string,
-): "passthrough" | "compact" | "unknown" {
+): "passthrough" | "compact" | "clean" | "unknown" {
   const trimmed = content.trim();
   if (parseModelCommand(trimmed) != null) {
     return "unknown";
@@ -381,6 +406,8 @@ export function classifySlash(
   if (trimmed === "/models") return "unknown";
   const compactParse = parseCompactCommand(trimmed);
   if (compactParse) return compactParse.kind;
+  const cleanParse = parseCleanCommand(trimmed);
+  if (cleanParse) return cleanParse.kind;
   if (trimmed === "/context") return "unknown";
   if (trimmed === "/status") return "unknown";
   if (trimmed === "/commands") return "unknown";
@@ -388,9 +415,10 @@ export function classifySlash(
 }
 
 /**
- * Resolve built-in slash commands (/models, /context, /status, /commands, /compact).
- * Returns `unknown` with a deterministic message, `compact` for forced compaction,
- * or the (possibly rewritten) content as `passthrough`.
+ * Resolve built-in slash commands (/models, /context, /status, /commands,
+ * /compact, /clean). Returns `unknown` with a deterministic message,
+ * `compact` for forced compaction, `clean` for injection stripping, or the
+ * (possibly rewritten) content as `passthrough`.
  */
 export async function resolveSlash(
   content: string,
@@ -423,6 +451,10 @@ export async function resolveSlash(
   // Handle /compact command (with optional `<tokens>` override).
   const compactParse = parseCompactCommand(trimmed);
   if (compactParse) return compactParse;
+
+  // Handle /clean command (strip injections, no summarization).
+  const cleanParse = parseCleanCommand(trimmed);
+  if (cleanParse) return cleanParse;
 
   // Handle /context and legacy /status commands
   if (trimmed === "/context" || trimmed === "/status") {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -104,6 +104,7 @@ import {
   type ChannelCapabilities,
   getSlackCompactionWatermarkForPrefix,
   loadSlackChronologicalContext,
+  stripInjectionsForCompaction,
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import {
@@ -141,6 +142,13 @@ import type {
 import { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("conversation");
+
+export interface CleanResult {
+  previousEstimatedInputTokens: number;
+  estimatedInputTokens: number;
+  maxInputTokens: number;
+  preservedMessages: number;
+}
 
 export { findLastUndoableUserMessageIndex } from "./conversation-history.js";
 export type {
@@ -1130,6 +1138,31 @@ export class Conversation {
       });
     }
     return result;
+  }
+
+  /**
+   * Strip stale runtime injections from the message history and reset the
+   * memory-injection ledger without summarizing any history. Mirrors the
+   * non-LLM side effects of `forceCompact`: the next turn re-injects fresh
+   * NOW.md / knowledge-base / memory-v2 static blocks, and per-turn memory
+   * activations are no longer deduped against the prior session.
+   */
+  async forceClean(): Promise<CleanResult> {
+    const previousEstimatedInputTokens =
+      this.contextWindowManager.estimateInputTokens(this.messages);
+    const stripped = stripInjectionsForCompaction(this.messages);
+    this.messages = stripped;
+    await this.graphMemory.onCompacted(0);
+    this.pendingPostCompactReinject = true;
+    const estimatedInputTokens = this.contextWindowManager.estimateInputTokens(
+      this.messages,
+    );
+    return {
+      previousEstimatedInputTokens,
+      estimatedInputTokens,
+      maxInputTokens: this.contextWindowManager.maxInputTokens,
+      preservedMessages: this.messages.length,
+    };
   }
 
   setChannelCapabilities(caps: ChannelCapabilities | null): void {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -38,7 +38,10 @@ import {
   buildSlackMetaForPersistence,
   serializePersistedUserMessageContent,
 } from "./conversation-messaging.js";
-import { formatCompactResult } from "./conversation-process.js";
+import {
+  formatCleanResult,
+  formatCompactResult,
+} from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import {
   buildSlashContextForContent,
@@ -436,6 +439,60 @@ export async function processMessage(
       "assistant",
       JSON.stringify(assistantMsg.content),
       compactChannelMeta,
+    );
+    conversation.getMessages().push(assistantMsg);
+    publishConversationMessagesChanged(conversationId);
+    return {
+      messageId: persisted.id,
+      assistantMessageId: persistedAssistant.id,
+    };
+  }
+
+  if (slashResult.kind === "clean") {
+    const serverTurnCtx = conversation.getTurnChannelContext();
+    const serverProvenance = provenanceFromTrustContext(
+      conversation.trustContext,
+    );
+    const cleanChannelMeta = {
+      ...serverProvenance,
+      ...(serverTurnCtx
+        ? {
+            userMessageChannel: serverTurnCtx.userMessageChannel,
+            assistantMessageChannel: serverTurnCtx.assistantMessageChannel,
+          }
+        : {}),
+      ...(serverInterfaceCtx
+        ? {
+            userMessageInterface: serverInterfaceCtx.userMessageInterface,
+            assistantMessageInterface:
+              serverInterfaceCtx.assistantMessageInterface,
+          }
+        : {}),
+    };
+    const cleanUserMeta = slackMeta
+      ? { ...cleanChannelMeta, slackMeta }
+      : cleanChannelMeta;
+    const cleanMsg = createUserMessage(content, attachments);
+    const persisted = await addMessage(
+      conversationId,
+      "user",
+      serializePersistedUserMessageContent(
+        content,
+        attachments,
+        options?.displayContent,
+      ),
+      cleanUserMeta,
+    );
+    conversation.getMessages().push(cleanMsg);
+
+    const result = await conversation.forceClean();
+    const responseText = formatCleanResult(result);
+    const assistantMsg = createAssistantMessage(responseText);
+    const persistedAssistant = await addMessage(
+      conversationId,
+      "assistant",
+      JSON.stringify(assistantMsg.content),
+      cleanChannelMeta,
     );
     conversation.getMessages().push(assistantMsg);
     publishConversationMessagesChanged(conversationId);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -24,6 +24,7 @@ import { createApprovalConversationGenerator } from "../../daemon/approval-gener
 import type { Conversation } from "../../daemon/conversation.js";
 import {
   buildModelInfoEvent,
+  formatCleanResult,
   formatCompactResult,
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
@@ -2132,6 +2133,82 @@ export async function handleSendMessage(
         );
       }
     })();
+
+    return {
+      accepted: true,
+      messageId: persisted.id,
+      conversationId,
+    };
+  }
+
+  if (slashResult.kind === "clean") {
+    conversation.processing = true;
+    const provenance = provenanceFromTrustContext(conversation.trustContext);
+    const channelMeta = {
+      ...provenance,
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+      userMessageInterface: sourceInterface,
+      assistantMessageInterface: sourceInterface,
+    };
+    const cleanMsg = createUserMessage(rawContent, attachments);
+    const persisted = await addMessage(
+      mapping.conversationId,
+      "user",
+      JSON.stringify(cleanMsg.content),
+      channelMeta,
+    );
+    conversation.getMessages().push(cleanMsg);
+
+    const conversationId = mapping.conversationId;
+
+    let assistantMessagePersisted = false;
+    try {
+      broadcastMessage({
+        type: "user_message_echo",
+        text: rawContent,
+        conversationId,
+        messageId: persisted.id,
+        clientMessageId,
+      });
+      publishConversationMessagesChanged(conversationId);
+
+      const result = await conversation.forceClean();
+      const responseText = formatCleanResult(result);
+
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        channelMeta,
+      );
+      assistantMessagePersisted = true;
+      conversation.getMessages().push(assistantMsg);
+
+      broadcastMessage({
+        type: "assistant_text_delta",
+        text: responseText,
+        conversationId,
+      });
+      broadcastMessage({ type: "message_complete", conversationId });
+      publishConversationMessagesChanged(conversationId);
+    } catch (err) {
+      if (assistantMessagePersisted) {
+        publishConversationMessagesChanged(conversationId);
+      }
+      log.error({ err, conversationId }, "Clean command failed");
+      broadcastMessage({
+        type: "conversation_error",
+        conversationId,
+        code: "UNKNOWN",
+        userMessage: `Clean failed: ${err instanceof Error ? err.message : String(err)}`,
+        retryable: true,
+      });
+    } finally {
+      conversation.processing = false;
+      silentlyWithLog(conversation.drainQueue(), "clean-command queue drain");
+    }
 
     return {
       accepted: true,


### PR DESCRIPTION
## Summary

- Add `/clean` slash command that strips runtime injection blocks from the message history and clears the memory injection ledger, without an LLM summarization call.
- Mirrors `/compact`'s non-LLM side effects: re-injects NOW.md / knowledge base / memory v2 static blocks on the next turn, and resets per-turn memory activation dedup.
- Preserves the entire user / assistant / tool_use / tool_result history verbatim — useful when accumulated injections (not conversation length) have pushed context into pressure.

## Original prompt

Add a `/clean` command that does everything `/compact` does (strip the same injections from messages, allow them to be re-injected on the next turn, clear the list of injected memories) but leaves the user / assistant / tool_call / tool_response history completely intact, as if the compaction process had decided to keep the whole conversation and summarize nothing.

## Test plan

- [x] \`bun test src/__tests__/conversation-slash-commands.test.ts\` — 45 pass (existing + new \`/clean\` parsing tests + updated \`/commands\` help listings)
- [x] \`bun test src/__tests__/conversation-clean-command.test.ts\` — 5 pass (formatCleanResult + strip preserves assistant + tool blocks)
- [ ] End-to-end smoke: in a conversation with accumulated injections, run \`/context\`, then \`/clean\`, then \`/context\` again — token count should drop and the next user turn should see fresh NOW.md / memory re-injections.