### PR TITLE
feat(cli): assistant memory v2 ema — inspect EMA scores

### DIFF
--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -22,6 +22,7 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import type {
   MemoryV2BackfillOp,
   MemoryV2BackfillResult,
+  MemoryV2EmaScoresResult,
   MemoryV2ReembedSkillsResult,
   MemoryV2ValidateResult,
 } from "../../runtime/routes/memory-v2-routes.js";
@@ -252,6 +253,121 @@ Examples:
             process.exitCode = 1;
           }
         });
+
+      // ── ema ───────────────────────────────────────────────────────────────
+
+      v2.command("ema")
+        .description(
+          "List concept pages by injection-frequency EMA score (read-only)",
+        )
+        .option(
+          "-n, --limit <count>",
+          "Maximum rows to print (default 25; ignored with --all)",
+          "25",
+        )
+        .option("--all", "Print every page, including zero-score pages")
+        .option(
+          "--include-zeros",
+          "Include pages with score 0 in the default-limited view",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted table")
+        .addHelpText(
+          "after",
+          `
+EMA score is the time-decayed sum Σ exp(-λ × (now - tᵢ)) with a 3-day
+half-life, computed from memory_v2_injection_events. A score of 1.0 means
+roughly one router selection in the last few minutes; 0.5 means a single
+selection ~3 days ago. Pages that have never been router-selected since
+EMA tracking began report 0.
+
+Examples:
+  $ assistant memory v2 ema
+  $ assistant memory v2 ema -n 100
+  $ assistant memory v2 ema --all --json | jq '.entries | length'`,
+        )
+        .action(
+          async (opts: {
+            limit: string;
+            all?: boolean;
+            includeZeros?: boolean;
+            json?: boolean;
+          }) => {
+            const result = await cliIpcCall<MemoryV2EmaScoresResult>(
+              "memory_v2_ema_scores",
+              { body: {} },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to fetch EMA scores");
+              process.exitCode = 1;
+              return;
+            }
+
+            const allEntries = result.result!.entries;
+            const includeZeros =
+              opts.all === true || opts.includeZeros === true;
+            const visible = includeZeros
+              ? allEntries
+              : allEntries.filter((e) => e.score > 0);
+
+            const limit =
+              opts.all === true ? visible.length : Number(opts.limit);
+            if (!opts.all && (!Number.isFinite(limit) || limit < 1)) {
+              log.error(
+                `--limit must be a positive integer (got "${opts.limit}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const rows = visible.slice(0, limit);
+
+            if (opts.json === true) {
+              log.info(
+                JSON.stringify(
+                  {
+                    entries: rows,
+                    totalScored: allEntries.filter((e) => e.score > 0).length,
+                    totalPages: allEntries.length,
+                  },
+                  null,
+                  2,
+                ),
+              );
+              return;
+            }
+
+            if (rows.length === 0) {
+              log.info(
+                "No concept pages have any EMA signal yet. Send a few turns through the router and try again.",
+              );
+              return;
+            }
+
+            const slugWidth = Math.min(
+              60,
+              Math.max(...rows.map((r) => r.slug.length)),
+            );
+            const header = `${"slug".padEnd(slugWidth)}  ${"score".padStart(8)}  modified`;
+            log.info(header);
+            log.info("-".repeat(header.length));
+            for (const row of rows) {
+              const slug =
+                row.slug.length > slugWidth
+                  ? row.slug.slice(0, slugWidth - 1) + "…"
+                  : row.slug.padEnd(slugWidth);
+              const score = row.score.toFixed(3).padStart(8);
+              const modified =
+                row.modifiedAt > 0
+                  ? new Date(row.modifiedAt).toISOString().slice(0, 10)
+                  : "—";
+              log.info(`${slug}  ${score}  ${modified}`);
+            }
+            const totalScored = allEntries.filter((e) => e.score > 0).length;
+            log.info(
+              `\n${rows.length} of ${visible.length} shown (${totalScored} total with score > 0, ${allEntries.length} pages indexed).`,
+            );
+          },
+        );
     },
   });
 }

--- a/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
@@ -145,3 +145,17 @@ describe("memory_v2_list_concept_pages handler", () => {
     expect(result.pages.map((p) => p.slug)).toEqual(["valid-page"]);
   });
 });
+
+describe("memory_v2_ema_scores route registration", () => {
+  test("route is registered with the expected operationId and POST endpoint", () => {
+    const route = ROUTES.find((r) => r.operationId === "memory_v2_ema_scores");
+    expect(route).toBeDefined();
+    expect(route!.method).toBe("POST");
+    expect(route!.endpoint).toBe("memory/v2/ema-scores");
+    expect(route!.tags).toContain("memory");
+    // Schema rejects unknown keys so accidental request-body fields fail
+    // loudly during route adapter parsing rather than silently propagating.
+    expect(() => route!.requestBody!.parse({ extra: true })).toThrow();
+    expect(() => route!.requestBody!.parse({})).not.toThrow();
+  });
+});

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { z } from "zod";
 
 import { loadConfig } from "../../config/loader.js";
+import { getDb } from "../../memory/db-connection.js";
 import {
   enqueueMemoryJob,
   type MemoryJobType,
@@ -21,6 +22,8 @@ import {
   totalEdgeCount,
   validateEdgeTargets,
 } from "../../memory/v2/edge-index.js";
+import { computeInjectionScores } from "../../memory/v2/injection-events.js";
+import { getPageIndex } from "../../memory/v2/page-index.js";
 import {
   getConceptsDir,
   listPages,
@@ -290,6 +293,47 @@ async function handleConceptFrequency({
   return getConceptFrequencySummary(workspaceDir, { conversationId, sinceMs });
 }
 
+// ── EMA scores ──────────────────────────────────────────────────────────
+
+const MemoryV2EmaScoresParams = z.object({}).strict();
+
+export interface MemoryV2EmaScoresEntry {
+  slug: string;
+  /** Time-decayed injection frequency; 0 when no events in the read window. */
+  score: number;
+  /** File mtime in epoch ms; 0 for synthetic entries (skills, CLI commands). */
+  modifiedAt: number;
+}
+
+export interface MemoryV2EmaScoresResult {
+  /** Every page index entry, sorted by score descending then slug ASCII. */
+  entries: MemoryV2EmaScoresEntry[];
+}
+
+async function handleEmaScores({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2EmaScoresResult> {
+  // Intentionally NOT gated on `memory.v2.enabled` — operators inspecting
+  // EMA data before flipping tier-2 routing on is a legitimate dry-run
+  // use case, mirroring `memory_v2_validate`.
+  MemoryV2EmaScoresParams.parse(body);
+
+  const pageIndex = await getPageIndex(getWorkspaceDir());
+  const slugs = pageIndex.entries.map((e) => e.slug);
+  const scores = computeInjectionScores(getDb(), slugs, Date.now());
+
+  const entries: MemoryV2EmaScoresEntry[] = pageIndex.entries.map((entry) => ({
+    slug: entry.slug,
+    score: scores.get(entry.slug) ?? 0,
+    modifiedAt: entry.modifiedAt,
+  }));
+  entries.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+  });
+  return { entries };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -358,5 +402,16 @@ export const ROUTES: RouteDefinition[] = [
       "Debug-only. Aggregates the existing memory_v2_activation_logs table by (slug, status) and cross-references on-disk concept pages so an operator can see which concepts get injected often, which get scored but rejected, and which on-disk pages never even surface as candidates. Optional filters: conversationId narrows to a single conversation; sinceMs restricts to logs created at-or-after the given epoch ms timestamp.",
     tags: ["memory"],
     requestBody: MemoryV2ConceptFrequencyParams,
+  },
+  {
+    operationId: "memory_v2_ema_scores",
+    method: "POST",
+    endpoint: "memory/v2/ema-scores",
+    handler: handleEmaScores,
+    summary: "List every concept page with its injection-frequency EMA score",
+    description:
+      "Computes the time-decayed injection frequency (3-day half-life) for every entry in the current page index by reading memory_v2_injection_events. Returns entries sorted by score descending then slug ASCII, including zero-score pages so callers can decide whether to filter. Read-only; tier 2 of the v4 router uses the same computation to pick its top-M.",
+    tags: ["memory"],
+    requestBody: MemoryV2EmaScoresParams,
   },
 ];


### PR DESCRIPTION
## Summary
- New IPC route \`memory_v2_ema_scores\` returns every page index entry with its EMA score and mtime, sorted by score desc then slug ASCII.
- New CLI subcommand \`assistant memory v2 ema\` formats a table with slug, score, last-modified date.
- Flags: \`-n/--limit N\` (default 25), \`--all\`, \`--include-zeros\`, \`--json\`.
- Read-only and not gated on \`memory.v2.enabled\`.

## Original prompt
Sidd asked for a command to inspect EMAs of all concept pages before twiddling the tier-2 config. The data has been accumulating in \`memory_v2_injection_events\` since the EMA-backfill PR; this makes it visible.

## Test plan
- [x] \`bun test src/runtime/routes/__tests__/memory-v2-routes.test.ts\` — 4 tests pass.
- [x] Existing injection-events + router tests unchanged.
- [x] \`bunx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)