### PR TITLE
feat(memory): default buffer-size trigger to 100 lines

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -23,7 +23,7 @@ describe("MemoryV2ConfigSchema", () => {
       bm25_k1: 1.2,
       bm25_b: 0.4,
       consolidation_interval_hours: 4,
-      consolidation_max_buffer_lines: null,
+      consolidation_max_buffer_lines: 100,
       max_page_chars: 5000,
       consolidation_prompt_path: null,
       rerank: {

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -203,9 +203,9 @@ export const MemoryV2ConfigSchema = z
         "memory.v2.consolidation_max_buffer_lines must be a positive integer",
       )
       .nullable()
-      .default(null)
+      .default(100)
       .describe(
-        "Optional size-based trigger. When set, consolidation also runs once `memory/buffer.md` reaches this many non-empty lines, in addition to the time-based interval. `null` (default) disables the size trigger.",
+        "Size-based trigger for consolidation. When `memory/buffer.md` reaches this many non-empty lines, consolidation runs even if the time-based interval hasn't elapsed. Defaults to 100. Set to `null` to disable the size trigger and rely solely on `consolidation_interval_hours`.",
       ),
     max_page_chars: z
       .number({ error: "memory.v2.max_page_chars must be a number" })

--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -236,13 +236,29 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
 });
 
 describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
-  test("default null leaves size trigger disabled", () => {
+  test("default threshold (100 lines) fires once the buffer reaches it", () => {
     const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
 
     const now = Date.now();
     // Recent checkpoint so the time-based trigger does not fire.
     setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
     writeBuffer(100);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("explicit null disables the size trigger", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: null,
+    });
+
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    writeBuffer(500);
 
     maybeEnqueueGraphMaintenanceJobs(config, now);
 


### PR DESCRIPTION
## Summary
- Changes `memory.v2.consolidation_max_buffer_lines` default from `null` to `100` so consolidation kicks in once the buffer has 100+ non-empty entries, regardless of the time-based interval.
- `null` is still accepted to opt out and fall back to the time-based trigger only.
- Updates the schema describe text and the schedule test that previously asserted the null-default behavior; adds a test covering the explicit-null opt-out.

## Original prompt
Follow-up to #31578, which introduced an optional size-based consolidation trigger defaulting to `null` (disabled). The user asked to flip the default to 100 lines so the trigger is on by default. The opt-out path via `null` is preserved for users who want time-based-only consolidation.