### PR TITLE
chore(openapi): regenerate spec for memory/v2/ema-scores endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -10985,6 +10985,28 @@ paths:
               required:
                 - slug
               additionalProperties: false
+  /v1/memory/v2/ema-scores:
+    post:
+      operationId: memory_v2_emascores_post
+      summary: List every concept page with its injection-frequency EMA score
+      description:
+        Computes the time-decayed injection frequency (3-day half-life) for every entry in the current page index
+        by reading memory_v2_injection_events. Returns entries sorted by score descending then slug ASCII, including
+        zero-score pages so callers can decide whether to filter. Read-only; tier 2 of the v4 router uses the same
+        computation to pick its top-M.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
   /v1/memory/v2/list-concept-pages:
     post:
       operationId: memory_v2_listconceptpages_post


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to include the `/v1/memory/v2/ema-scores` endpoint added in #31614
- Fixes the OpenAPI Spec Check CI job on main

## Original prompt
Fix the failing OpenAPI Spec Check job on main (run 26262081704, job 77297515594). The committed `assistant/openapi.yaml` is missing the `/v1/memory/v2/ema-scores` route that was introduced when the `assistant memory v2 ema` command landed, so `bun run generate:openapi -- --check` exits non-zero. Regenerate the spec so CI passes.