### PR TITLE
fix(memory): register ema subcommand and ema-scores route policy

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -143,6 +143,7 @@ describe("subcommand registration", () => {
     const subcommandNames = v2!.commands.map((c) => c.name()).sort();
     expect(subcommandNames).toEqual([
       "activation",
+      "ema",
       "reembed",
       "reembed-skills",
       "validate",
@@ -307,9 +308,7 @@ describe("memory v2 validate", () => {
     expect(logOutput.some((line) => line.includes("Pages: 49"))).toBe(true);
     expect(logOutput.some((line) => line.includes("Edges: 166"))).toBe(true);
     expect(
-      logOutput.some((line) =>
-        line.includes("Missing edge endpoints: none"),
-      ),
+      logOutput.some((line) => line.includes("Missing edge endpoints: none")),
     ).toBe(true);
     expect(
       logOutput.some((line) => line.includes("Oversized pages: none")),
@@ -325,9 +324,7 @@ describe("memory v2 validate", () => {
       result: {
         pageCount: 10,
         edgeCount: 20,
-        missingEdgeEndpoints: [
-          { from: "people/alice", to: "people/missing" },
-        ],
+        missingEdgeEndpoints: [{ from: "people/alice", to: "people/missing" }],
         oversizedPages: [{ slug: "arcs/big-day", chars: 12345 }],
         parseFailures: [
           { slug: "people/broken", error: "missing frontmatter" },
@@ -342,9 +339,7 @@ describe("memory v2 validate", () => {
       true,
     );
     expect(logOutput.some((line) => line.includes("arcs/big-day"))).toBe(true);
-    expect(logOutput.some((line) => line.includes("people/broken"))).toBe(
-      true,
-    );
+    expect(logOutput.some((line) => line.includes("people/broken"))).toBe(true);
   });
 
   test("exits with code 1 on IPC failure", async () => {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -469,6 +469,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/list-concept-pages:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/concept-frequency:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v2/ema-scores:POST", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Add `ema` to the expected memory v2 subcommands list in `memory-v2.test.ts` (CI was failing because the test wasn't updated when the new `assistant memory v2 ema` command landed in #31614).
- Add `memory/v2/ema-scores:POST` to `route-policy.ts` so the route-policy coverage guard test passes. Uses `settings.read` (read-only operation, matching the sibling `concept-frequency` route).

## Original prompt
Fix the specific CI issue in the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/26262081704/job/77297515583. Two tests broke after #31614 landed the new `assistant memory v2 ema` command: the subcommand-registration test needs the new entry, and the route-policy coverage guard needs a policy entry for the corresponding `memory/v2/ema-scores` endpoint.