### PR TITLE
Resolve and persist Slack sender timezones during history backfill

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -289,6 +289,12 @@ interface PersistedRow {
   threadTs: string | undefined;
   displayName: string | undefined;
   actorExternalUserId: string | undefined;
+  actorTimezone: string | undefined;
+  actorTimezoneLabel: string | undefined;
+  actorTimezoneOffsetSeconds: number | undefined;
+  timestampTimezone: string | undefined;
+  timestampTimezoneLabel: string | undefined;
+  speakerTimezoneLabel: string | undefined;
   slackFiles: Array<{ name: string; mimetype?: string }> | undefined;
   provenanceTrustClass: string | undefined;
   provenanceSourceChannel: string | undefined;
@@ -316,6 +322,12 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       threadTs: undefined,
       displayName: undefined,
       actorExternalUserId: undefined,
+      actorTimezone: undefined,
+      actorTimezoneLabel: undefined,
+      actorTimezoneOffsetSeconds: undefined,
+      timestampTimezone: undefined,
+      timestampTimezoneLabel: undefined,
+      speakerTimezoneLabel: undefined,
       slackFiles: undefined,
       provenanceTrustClass: undefined,
       provenanceSourceChannel: undefined,
@@ -356,6 +368,12 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       threadTs: slackMeta?.threadTs,
       displayName: slackMeta?.displayName,
       actorExternalUserId: slackMeta?.actorExternalUserId,
+      actorTimezone: slackMeta?.actorTimezone,
+      actorTimezoneLabel: slackMeta?.actorTimezoneLabel,
+      actorTimezoneOffsetSeconds: slackMeta?.actorTimezoneOffsetSeconds,
+      timestampTimezone: slackMeta?.timestampTimezone,
+      timestampTimezoneLabel: slackMeta?.timestampTimezoneLabel,
+      speakerTimezoneLabel: slackMeta?.speakerTimezoneLabel,
       slackFiles: slackMeta?.slackFiles?.map((file) => ({
         name: file.name,
         ...(file.mimetype ? { mimetype: file.mimetype } : {}),
@@ -1121,6 +1139,61 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.provenanceSourceChannel).toBe("slack");
     expect(persisted.provenanceGuardianExternalUserId).toBe("U_GUARDIAN");
     expect(persisted.provenanceRequesterIdentifier).toBe("U_ANITA");
+  });
+
+  test("backfilled Slack timezone metadata derives timestamp and speaker fields", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "non-guardian context",
+        threadId: undefined,
+        sender: { id: "U_ANITA", name: "Anita" },
+        metadata: {
+          actorTimezone: "America/New_York",
+          actorTimezoneLabel: "ET",
+          actorTimezoneOffsetSeconds: -18000,
+        },
+      }),
+      makeBackfillMessage({
+        id: "1234.1",
+        text: "trusted context",
+        threadId: "1234.0",
+        sender: { id: "U_GUARDIAN", name: "Guardian User" },
+        metadata: {
+          actorTimezone: "America/Denver",
+          actorTimezoneLabel: "MT",
+          actorTimezoneOffsetSeconds: -25200,
+        },
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+      guardianExternalUserId: "U_GUARDIAN",
+    });
+
+    const persisted = readPersistedSlackRows(conv.id);
+    const nonGuardian = persisted.find((p) => p.channelTs === "1234.0");
+    expect(nonGuardian).toBeDefined();
+    expect(nonGuardian?.actorTimezone).toBe("America/New_York");
+    expect(nonGuardian?.actorTimezoneLabel).toBe("ET");
+    expect(nonGuardian?.actorTimezoneOffsetSeconds).toBe(-18000);
+    expect(nonGuardian?.timestampTimezone).toBe("America/New_York");
+    expect(nonGuardian?.timestampTimezoneLabel).toBe("ET");
+    expect(nonGuardian?.speakerTimezoneLabel).toBe("ET");
+
+    const guardian = persisted.find((p) => p.channelTs === "1234.1");
+    expect(guardian).toBeDefined();
+    expect(guardian?.actorTimezone).toBe("America/Denver");
+    expect(guardian?.actorTimezoneLabel).toBe("MT");
+    expect(guardian?.actorTimezoneOffsetSeconds).toBe(-25200);
+    expect(guardian?.timestampTimezone).toBe("America/Denver");
+    expect(guardian?.timestampTimezoneLabel).toBe("MT");
+    expect(guardian?.speakerTimezoneLabel).toBeUndefined();
   });
 
   test("backfilled guardian-authored text is persisted raw with guardian provenance", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -21,7 +21,7 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   isProviderConnected: async () => false,
 }));
 
-const findContactChannelMock = mock(() => undefined);
+const findContactChannelMock = mock((): unknown => undefined);
 const upsertContactChannelMock = mock(() => {});
 mock.module("../../../../contacts/contact-store.js", () => ({
   findContactChannel: findContactChannelMock,
@@ -30,9 +30,13 @@ mock.module("../../../../contacts/contacts-write.js", () => ({
   upsertContactChannel: upsertContactChannelMock,
 }));
 
-import { slackProvider } from "../adapter.js";
+import {
+  __resetSlackUserInfoCacheForTests,
+  slackProvider,
+} from "../adapter.js";
 
 const originalFetch = globalThis.fetch;
+let userInfoCalls: string[] = [];
 
 function installFetchStub() {
   globalThis.fetch = (async (
@@ -60,6 +64,42 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   const method = parsed.pathname.split("/").at(-1);
 
   if (method === "conversations.history") {
+    if (parsed.searchParams.get("channel") === "C_USERINFO_FAIL") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            ts: "1700000006.000700",
+            user: "UMISSING",
+            text: "Fallback sender message",
+          },
+        ],
+      };
+    }
+
+    if (parsed.searchParams.get("channel") === "C_TIMEZONE_CACHE") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            ts: "1700000004.000500",
+            user: "USENDER",
+            text: "First timezone-bearing message",
+          },
+          {
+            type: "message",
+            ts: "1700000005.000600",
+            user: "USENDER",
+            text: "Second timezone-bearing message",
+          },
+        ],
+      };
+    }
+
     if (parsed.searchParams.get("channel") === "C_BOT_HISTORY") {
       return {
         ok: true,
@@ -133,7 +173,9 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   }
 
   if (method === "users.info") {
-    return fakeUserInfoResponse(parsed.searchParams.get("user") ?? "");
+    const userId = parsed.searchParams.get("user") ?? "";
+    userInfoCalls.push(userId);
+    return fakeUserInfoResponse(userId);
   }
 
   return { ok: true };
@@ -157,6 +199,9 @@ function fakeUserInfoResponse(userId: string): Record<string, unknown> {
       user: {
         id: "USENDER",
         name: "sender",
+        tz: "America/New_York",
+        tz_label: "Eastern Time",
+        tz_offset: -18000,
         profile: { display_name: "Sender" },
       },
     };
@@ -178,6 +223,8 @@ function fakeUserInfoResponse(userId: string): Record<string, unknown> {
 
 describe("Slack adapter mention rendering", () => {
   beforeEach(async () => {
+    __resetSlackUserInfoCacheForTests();
+    userInfoCalls = [];
     getSecureKeyAsyncMock.mockReset();
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
       if (key === credentialKey("slack_channel", "bot_token")) {
@@ -215,6 +262,72 @@ describe("Slack adapter mention rendering", () => {
       isBot: true,
       slackBotId: "B_ASSISTANT",
     });
+  });
+
+  test("getHistory caches Slack user info and maps timezone metadata", async () => {
+    const messages = await slackProvider.getHistory(
+      undefined,
+      "C_TIMEZONE_CACHE",
+    );
+
+    expect(messages).toHaveLength(2);
+    expect(userInfoCalls.filter((userId) => userId === "USENDER")).toHaveLength(
+      1,
+    );
+    expect(messages.map((message) => message.sender)).toEqual([
+      { id: "USENDER", name: "Sender" },
+      { id: "USENDER", name: "Sender" },
+    ]);
+    expect(messages.map((message) => message.metadata)).toEqual([
+      {
+        actorTimezone: "America/New_York",
+        actorTimezoneLabel: "Eastern Time",
+        actorTimezoneOffsetSeconds: -18000,
+      },
+      {
+        actorTimezone: "America/New_York",
+        actorTimezoneLabel: "Eastern Time",
+        actorTimezoneOffsetSeconds: -18000,
+      },
+    ]);
+  });
+
+  test("getHistory prefers contact display names while still fetching Slack timezone facts", async () => {
+    findContactChannelMock.mockImplementationOnce(() => ({
+      contact: { displayName: "Saved Sender" },
+    }));
+
+    const messages = await slackProvider.getHistory(
+      undefined,
+      "C_TIMEZONE_CACHE",
+    );
+
+    expect(userInfoCalls.filter((userId) => userId === "USENDER")).toHaveLength(
+      1,
+    );
+    expect(messages[0].sender).toEqual({
+      id: "USENDER",
+      name: "Saved Sender",
+    });
+    expect(messages[0].metadata).toEqual({
+      actorTimezone: "America/New_York",
+      actorTimezoneLabel: "Eastern Time",
+      actorTimezoneOffsetSeconds: -18000,
+    });
+  });
+
+  test("getHistory falls back when Slack user info lookup fails", async () => {
+    const messages = await slackProvider.getHistory(
+      undefined,
+      "C_USERINFO_FAIL",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(
+      userInfoCalls.filter((userId) => userId === "UMISSING"),
+    ).toHaveLength(1);
+    expect(messages[0].sender).toEqual({ id: "UMISSING", name: "UMISSING" });
+    expect(messages[0].metadata).toBeUndefined();
   });
 
   test("getThreadReplies renders Slack user mentions for model-facing text without changing sender identity", async () => {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -35,10 +35,18 @@ import type {
   SlackConversation,
   SlackMessage,
   SlackSearchMatch,
+  SlackUser,
 } from "./types.js";
 
-// Cache user display names to avoid repeated API calls within a session
-const userNameCache = new Map<string, string>();
+interface NormalizedSlackUserInfo {
+  displayName: string;
+  timezone?: string;
+  timezoneLabel?: string;
+  timezoneOffsetSeconds?: number;
+}
+
+// Cache normalized Slack user facts to avoid repeated API calls within a session.
+const userInfoCache = new Map<string, Promise<NormalizedSlackUserInfo>>();
 
 /**
  * Cached auth resolved during resolveConnection(), split by direction.
@@ -186,20 +194,34 @@ async function resolveUserName(
   auth: OAuthConnection | string,
   userId: string,
 ): Promise<string> {
-  if (!userId) return "unknown";
-  const cached = userNameCache.get(userId);
+  return (await resolveUserInfo(auth, userId)).displayName;
+}
+
+async function resolveUserInfo(
+  auth: OAuthConnection | string,
+  userId: string,
+): Promise<NormalizedSlackUserInfo> {
+  if (!userId) return { displayName: "unknown" };
+  const cached = userInfoCache.get(userId);
   if (cached) return cached;
 
-  // Check contacts DB for a persistent cache hit
+  const resolved = resolveUserInfoUncached(auth, userId);
+  userInfoCache.set(userId, resolved);
+  return resolved;
+}
+
+async function resolveUserInfoUncached(
+  auth: OAuthConnection | string,
+  userId: string,
+): Promise<NormalizedSlackUserInfo> {
+  let contactDisplayName: string | undefined;
   try {
     const result = findContactChannel({
       channelType: "slack",
       externalUserId: userId,
     });
     if (result) {
-      const name = result.contact.displayName;
-      userNameCache.set(userId, name);
-      return name;
+      contactDisplayName = result.contact.displayName;
     }
   } catch {
     // Contact lookup failures are non-fatal — fall through to API
@@ -207,16 +229,60 @@ async function resolveUserName(
 
   try {
     const resp = await slack.userInfo(auth, userId);
-    const name =
-      resp.user.profile?.display_name ||
-      resp.user.profile?.real_name ||
-      resp.user.real_name ||
-      resp.user.name;
-    userNameCache.set(userId, name);
-    return name;
+    return normalizeSlackUserInfo(resp.user, contactDisplayName);
   } catch {
-    return userId;
+    return { displayName: contactDisplayName ?? userId };
   }
+}
+
+function normalizeSlackUserInfo(
+  user: SlackUser,
+  contactDisplayName: string | undefined,
+): NormalizedSlackUserInfo {
+  const displayName =
+    contactDisplayName ||
+    user.profile?.display_name ||
+    user.profile?.real_name ||
+    user.real_name ||
+    user.name ||
+    user.id;
+  const timezone = trimNonEmpty(user.tz);
+  const timezoneLabel = trimNonEmpty(user.tz_label);
+  const timezoneOffsetSeconds =
+    typeof user.tz_offset === "number" && Number.isFinite(user.tz_offset)
+      ? user.tz_offset
+      : undefined;
+  return {
+    displayName,
+    ...(timezone ? { timezone } : {}),
+    ...(timezoneLabel ? { timezoneLabel } : {}),
+    ...(timezoneOffsetSeconds !== undefined ? { timezoneOffsetSeconds } : {}),
+  };
+}
+
+function trimNonEmpty(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function __resetSlackUserInfoCacheForTests(): void {
+  userInfoCache.clear();
+}
+
+function slackUserInfoMetadata(
+  userInfo: NormalizedSlackUserInfo | undefined,
+): Record<string, unknown> {
+  if (!userInfo) return {};
+  return {
+    ...(userInfo.timezone ? { actorTimezone: userInfo.timezone } : {}),
+    ...(userInfo.timezoneLabel
+      ? { actorTimezoneLabel: userInfo.timezoneLabel }
+      : {}),
+    ...(userInfo.timezoneOffsetSeconds !== undefined
+      ? { actorTimezoneOffsetSeconds: userInfo.timezoneOffsetSeconds }
+      : {}),
+  };
 }
 
 function mapConversationType(conv: SlackConversation): Conversation["type"] {
@@ -276,7 +342,7 @@ function mapSlackFiles(files: SlackMessage["files"]):
 function mapMessage(
   msg: SlackMessage,
   channelId: string,
-  senderName: string,
+  senderInfo: NormalizedSlackUserInfo,
   renderedText: string,
 ): Message {
   // Bot-authored when Slack sets `subtype: "bot_message"` or attributes the
@@ -286,10 +352,15 @@ function mapMessage(
     msg.subtype === "bot_message" || (msg.bot_id != null && !msg.user);
   const slackFiles = mapSlackFiles(msg.files);
   const slackBotId = msg.bot_id?.trim();
+  const userMetadata = slackUserInfoMetadata(msg.user ? senderInfo : undefined);
+  const hasUserMetadata = Object.keys(userMetadata).length > 0;
   return {
     id: msg.ts,
     conversationId: channelId,
-    sender: { id: msg.user ?? msg.bot_id ?? "unknown", name: senderName },
+    sender: {
+      id: msg.user ?? msg.bot_id ?? "unknown",
+      name: senderInfo.displayName,
+    },
     text: renderedText,
     timestamp: parseFloat(msg.ts) * 1000,
     threadId: msg.thread_ts,
@@ -297,12 +368,13 @@ function mapMessage(
     platform: "slack",
     reactions: msg.reactions?.map((r) => ({ name: r.name, count: r.count })),
     hasAttachments: (msg.files?.length ?? 0) > 0,
-    ...(isBot || slackFiles
+    ...(isBot || slackFiles || hasUserMetadata
       ? {
           metadata: {
             ...(isBot ? { isBot: true } : {}),
             ...(slackBotId ? { slackBotId } : {}),
             ...(slackFiles ? { slackFiles } : {}),
+            ...userMetadata,
           },
         }
       : {}),
@@ -336,12 +408,12 @@ async function mapSlackMessages(
   );
   const messages: Message[] = [];
   for (const msg of slackMessages) {
-    const name = await resolveUserName(auth, msg.user ?? "");
+    const senderInfo = await resolveUserInfo(auth, msg.user ?? "");
     messages.push(
       mapMessage(
         msg,
         channelId,
-        name,
+        senderInfo,
         renderSlackTextForModel(msg.text, { userLabels }),
       ),
     );

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -89,6 +89,9 @@ export interface SlackUser {
   id: string;
   name: string;
   real_name?: string;
+  tz?: string;
+  tz_label?: string;
+  tz_offset?: number;
   profile?: {
     display_name?: string;
     real_name?: string;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1579,6 +1579,22 @@ async function persistBackfilledSlackMessage(params: {
     ...(f.mimetype ? { mimetype: f.mimetype } : {}),
   }));
   const actorExternalUserId = message.sender?.id?.trim();
+  const actorTimezone = trimMetadataString(message.metadata, "actorTimezone");
+  const actorTimezoneLabel = trimMetadataString(
+    message.metadata,
+    "actorTimezoneLabel",
+  );
+  const rawActorTimezoneOffsetSeconds =
+    message.metadata?.actorTimezoneOffsetSeconds;
+  const actorTimezoneOffsetSeconds =
+    typeof rawActorTimezoneOffsetSeconds === "number" &&
+    Number.isFinite(rawActorTimezoneOffsetSeconds)
+      ? rawActorTimezoneOffsetSeconds
+      : undefined;
+  const isGuardian = isBackfilledSlackGuardianMessage(
+    message,
+    params.guardianExternalUserId,
+  );
   const slackMeta: SlackMessageMetadata = {
     source: "slack",
     channelId: params.channelId,
@@ -1587,13 +1603,21 @@ async function persistBackfilledSlackMessage(params: {
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
     ...(actorExternalUserId ? { actorExternalUserId } : {}),
+    ...(actorTimezone ? { actorTimezone } : {}),
+    ...(actorTimezoneLabel ? { actorTimezoneLabel } : {}),
+    ...(actorTimezoneOffsetSeconds !== undefined
+      ? { actorTimezoneOffsetSeconds }
+      : {}),
+    ...(actorTimezone ? { timestampTimezone: actorTimezone } : {}),
+    ...(actorTimezoneLabel
+      ? { timestampTimezoneLabel: actorTimezoneLabel }
+      : {}),
+    ...(!isGuardian && actorTimezoneLabel
+      ? { speakerTimezoneLabel: actorTimezoneLabel }
+      : {}),
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
 
-  const isGuardian = isBackfilledSlackGuardianMessage(
-    message,
-    params.guardianExternalUserId,
-  );
   const role = (await isBackfilledSlackAssistantMessage(
     message,
     params.account,


### PR DESCRIPTION
## Summary
- Resolves cached Slack user timezone facts during history backfill.
- Persists backfilled Slack timezone metadata for later local-time rendering.

Part of plan: slack-message-timezones.md (PR 3 of 5)