### PR TITLE
feat(web): expose /clean in chat composer slash command catalog

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts
+++ b/apps/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts
@@ -11,6 +11,7 @@ export interface SlashCommand {
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "commands", description: "List all available commands", selectionBehavior: "autoSend" },
   { name: "compact", description: "Force context compaction immediately", selectionBehavior: "autoSend" },
+  { name: "clean", description: "Strip injected runtime context and reset memory injection state", selectionBehavior: "autoSend" },
   { name: "models", description: "List all available models", selectionBehavior: "autoSend" },
   { name: "status", description: "Show conversation status and context usage", selectionBehavior: "autoSend" },
   { name: "btw", description: "Ask a side question while the assistant is working", selectionBehavior: "insertTrailingSpace" },

--- a/apps/web/src/domains/chat/components/chat-composer/use-composer-controller.test.ts
+++ b/apps/web/src/domains/chat/components/chat-composer/use-composer-controller.test.ts
@@ -29,9 +29,9 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("filteredCommands", () => {
-  test("empty filter returns all 5 commands", () => {
+  test("empty filter returns all 6 commands", () => {
     const result = filteredCommands("");
-    expect(result).toHaveLength(5);
+    expect(result).toHaveLength(6);
     expect(result).toBe(SLASH_COMMANDS);
   });
 
@@ -41,10 +41,10 @@ describe("filteredCommands", () => {
     expect(result[0]!.name).toBe("models");
   });
 
-  test('filter "c" returns commands and compact', () => {
+  test('filter "c" returns commands, compact, and clean', () => {
     const result = filteredCommands("c");
-    expect(result).toHaveLength(2);
-    expect(result.map((c) => c.name)).toEqual(["commands", "compact"]);
+    expect(result).toHaveLength(3);
+    expect(result.map((c) => c.name)).toEqual(["commands", "compact", "clean"]);
   });
 
   test('filter "xyz" returns empty list', () => {
@@ -79,7 +79,7 @@ describe("computeSlashState", () => {
     const [state] = computeSlashState("/", false);
     expect(state.showSlashMenu).toBe(true);
     expect(state.slashFilter).toBe("");
-    expect(state.slashCommands).toHaveLength(5);
+    expect(state.slashCommands).toHaveLength(6);
     expect(state.slashSelectedIndex).toBe(0);
   });
 
@@ -91,10 +91,10 @@ describe("computeSlashState", () => {
     expect(state.slashCommands[0]!.name).toBe("models");
   });
 
-  test('typing "/c" shows commands and compact', () => {
+  test('typing "/c" shows commands, compact, and clean', () => {
     const [state] = computeSlashState("/c", false);
     expect(state.showSlashMenu).toBe(true);
-    expect(state.slashCommands.map((c) => c.name)).toEqual(["commands", "compact"]);
+    expect(state.slashCommands.map((c) => c.name)).toEqual(["commands", "compact", "clean"]);
   });
 
   test('typing "/xyz" closes popup (no matching commands)', () => {
@@ -146,7 +146,7 @@ describe("computeSlashState — suppress reopen", () => {
     const [state, consumed] = computeSlashState("/", true);
     expect(state.showSlashMenu).toBe(false);
     expect(state.slashFilter).toBe("");
-    expect(state.slashCommands).toHaveLength(5);
+    expect(state.slashCommands).toHaveLength(6);
     expect(consumed).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Add `/clean` to the web chat composer's hardcoded `SLASH_COMMANDS` catalog so it appears in autocomplete (was already implemented end-to-end on the daemon — only the client-side subset was missing it).
- Update the four assertions in `use-composer-controller.test.ts` that pinned the catalog to 5 commands and to the old `["commands", "compact"]` `/c` filter result.

## Original prompt
Sidd noticed `/clean` doesn't surface in the Vellum web app chat composer's slash-command autocomplete. The web catalog at `apps/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts` is a hardcoded subset of `ChatSlashCommandCatalog.allCommands` and is the sole source the composer filters from — it doesn't fetch from the daemon. `/clean` is fully wired up server-side (`assistant/src/daemon/conversation-slash.ts`), so the fix is just to add the entry to the client catalog. `autoSend` selection behavior matches the backend's no-argument contract.