### PR TITLE
Render Slack context with compact local timestamps and timezone suffixes

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -283,6 +283,7 @@ let mockSlackChronologicalContext: {
   renderedMessages: Array<{
     message: Message;
     sourceChannelTs: string | null;
+    tagLineProvenance: "none" | "slack-reaction" | "slack-timezone-message";
   }>;
   messages: Message[];
   compactableStartIndex: number;
@@ -2914,11 +2915,8 @@ describe("session-agent-loop", () => {
       // (from the mocked `addMessage` -> `{ id: "mock-msg-id" }`) into the
       // backfill primitive, scoped to this conversation.
       expect(backfillMessageIdOnLogsMock).toHaveBeenCalledTimes(1);
-      const backfillCall =
-        backfillMessageIdOnLogsMock.mock.calls[0] as unknown as [
-          string,
-          string,
-        ];
+      const backfillCall = backfillMessageIdOnLogsMock.mock
+        .calls[0] as unknown as [string, string];
       expect(backfillCall[0]).toBe("test-conv");
       expect(backfillCall[1]).toBe("mock-msg-id");
     });
@@ -3034,6 +3032,7 @@ describe("session-agent-loop", () => {
             "1700000020.000000",
             "1700000030.000000",
           ][index]!,
+          tagLineProvenance: "none",
         })),
         compactableStartIndex: 0,
       };
@@ -3133,6 +3132,7 @@ describe("session-agent-loop", () => {
             "1700000020.000000",
             "1700000030.000000",
           ][index]!,
+          tagLineProvenance: "none",
         })),
         compactableStartIndex: 0,
       };
@@ -3249,6 +3249,7 @@ describe("session-agent-loop", () => {
             "1700000030.000000",
             "1700000040.000000",
           ][index]!,
+          tagLineProvenance: "none",
         })),
         compactableStartIndex: 0,
       };
@@ -3354,9 +3355,10 @@ describe("session-agent-loop", () => {
               {
                 message: firstSummaryMessage,
                 sourceChannelTs: null,
+                tagLineProvenance: "none",
               },
-              mockSlackChronologicalContext.renderedMessages[2],
-              mockSlackChronologicalContext.renderedMessages[3],
+              mockSlackChronologicalContext!.renderedMessages[2],
+              mockSlackChronologicalContext!.renderedMessages[3],
             ],
             messages: firstCompactedMessages,
             compactableStartIndex: 1,
@@ -3395,6 +3397,7 @@ describe("session-agent-loop", () => {
             "1700000020.000000",
             "1700000030.000000",
           ][index]!,
+          tagLineProvenance: "none",
         })),
         compactableStartIndex: 0,
       };
@@ -3552,6 +3555,7 @@ describe("session-agent-loop", () => {
               ],
             },
             sourceChannelTs: null,
+            tagLineProvenance: "none",
           },
           {
             message: {
@@ -3559,6 +3563,7 @@ describe("session-agent-loop", () => {
               content: [{ type: "text", text: "after watermark reply" }],
             },
             sourceChannelTs: "1700000020.000000",
+            tagLineProvenance: "none",
           },
         ],
         compactableStartIndex: 1,
@@ -3653,6 +3658,7 @@ describe("session-agent-loop", () => {
               ],
             },
             sourceChannelTs: null,
+            tagLineProvenance: "none",
           },
           {
             message: {
@@ -3665,6 +3671,7 @@ describe("session-agent-loop", () => {
               ],
             },
             sourceChannelTs: "1700000121.000000",
+            tagLineProvenance: "none",
           },
         ],
         compactableStartIndex: 1,

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -4047,13 +4047,48 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     );
   });
 
+  test("assistant content that only looks like a compact tag still gets active-thread attribution", () => {
+    const compactLookingContent =
+      "[nov 14 2023 3:13 PM MT assistant (ET)] Assistant reply";
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "Parent",
+        1_000,
+        buildMeta({ channelTs: PARENT_TS, displayName: "@alice" }),
+      ),
+      buildRow(
+        "assistant",
+        compactLookingContent,
+        2_000,
+        buildMeta({
+          channelTs: "1700000005.000001",
+          threadTs: PARENT_TS,
+        }),
+      ),
+      buildRow(
+        "user",
+        "Follow-up",
+        3_000,
+        buildMeta({
+          channelTs: REPLY_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+    ];
+
+    const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
+    expect(result).not.toBeNull();
+    expect(result!).toContain(`@assistant: ${compactLookingContent}`);
+  });
+
   test("assistant reaction overflow trailer is not double-attributed", () => {
     // When assistant reactions overflow the per-target cap, `renderSlackTranscript`
     // emits a trailer line (`[…and N more reactions to Mxxxxxx]`) whose role
-    // is inherited from the first overflowing reaction — i.e. `assistant`. The
-    // trailer embeds no actor attribution but ends with the parent alias and
-    // shares the same `M<hex>]` signature as a real reaction line, so it must
-    // be detected by `isReactionTagLine` and skipped by the prefix step.
+    // is inherited from the first overflowing reaction — i.e. `assistant`.
+    // Renderer provenance marks it as a Slack reaction line so the flattened
+    // active-thread block does not add a content-message prefix.
     const PARENT_ALIAS_TS = PARENT_TS;
     const buildAssistantReaction = (ts: string, emoji: string) =>
       buildRow(

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3998,6 +3998,55 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     expect(result!).toContain("@assistant: Assistant reply");
   });
 
+  test("timezone-aware assistant rows keep renderer attribution in active-thread focus block", () => {
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "Parent",
+        1_000,
+        buildMeta({
+          channelTs: PARENT_TS,
+          displayName: "aaron",
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "MT",
+        }),
+      ),
+      buildRow(
+        "assistant",
+        "Assistant reply",
+        2_000,
+        buildMeta({
+          channelTs: "1700000005.000001",
+          threadTs: PARENT_TS,
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "MT",
+          speakerTimezoneLabel: "ET",
+        }),
+      ),
+      buildRow(
+        "user",
+        "Follow-up",
+        3_000,
+        buildMeta({
+          channelTs: REPLY_TS,
+          threadTs: PARENT_TS,
+          displayName: "aaron",
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "MT",
+        }),
+      ),
+    ];
+
+    const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
+    expect(result).not.toBeNull();
+    expect(result!).toContain(
+      "[nov 14 2023 3:13 PM MT assistant (ET)] Assistant reply",
+    );
+    expect(result!).not.toContain(
+      "@assistant: [nov 14 2023 3:13 PM MT assistant (ET)]",
+    );
+  });
+
   test("assistant reaction overflow trailer is not double-attributed", () => {
     // When assistant reactions overflow the per-target cap, `renderSlackTranscript`
     // emits a trailer line (`[…and N more reactions to Mxxxxxx]`) whose role
@@ -4271,7 +4320,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).not.toBeNull();
     expect(result!.map((m) => (m.content[0] as { text: string }).text)).toEqual(
       [
-        `[11/14/23 14:25 @alice]: ${slackExternal(
+        `[nov 14 2023 9:25 AM ET @alice (ET)] ${slackExternal(
           "timezone-aware hello",
           "@alice",
         )}`,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1146,6 +1146,7 @@ export async function runAgentLoopImpl(
           {
             message: result.messages[0]!,
             sourceChannelTs: null,
+            tagLineProvenance: "none",
           },
           ...retainedRenderedMessages,
         ],

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -25,6 +25,7 @@ import {
   compareSlackTs,
   extractTagLineTexts,
   isReactionTagLine,
+  isSlackMessageTagLine,
   isSlackTsAfter,
   type RenderableSlackMessage,
   type RenderedSlackTranscriptMessage,
@@ -1554,13 +1555,12 @@ function buildActiveThreadBlockFromRenderable(
   if (members.length === 0) return null;
 
   // The active-thread block is flattened to plain text below, which discards
-  // `Message.role`. Assistant rows are relabeled in the post-render step:
-  // `renderSlackTranscript` emits assistant content with no tag-line wrapper
-  // (to prevent the model mimicking `[MM/DD/YY HH:MM]:` prefixes in outbound
-  // replies), so we prepend an explicit `@assistant:` label to the flattened
-  // line. Unnamed user rows (no real Slack displayName) get a `@user`
-  // senderLabel here so their tag line carries attribution through the
-  // renderer. Labeled user rows and assistant rows pass through unchanged.
+  // `Message.role`. Assistant rows that render content-only are relabeled in
+  // the post-render step. Timezone-aware assistant rows are already
+  // bracket-tagged by the renderer and must not receive another prefix.
+  // Unnamed user rows (no real Slack displayName) get a `@user` senderLabel
+  // here so their tag line carries attribution through the renderer. Labeled
+  // user rows and assistant rows pass through unchanged.
   const labeledMembers = members.map((m) => {
     if (m.role === "assistant") return m;
     if (m.senderLabel !== null) return m;
@@ -1569,14 +1569,16 @@ function buildActiveThreadBlockFromRenderable(
 
   const rendered = renderSlackTranscript(labeledMembers);
   if (rendered.length === 0) return null;
-  // Reaction / overflow-trailer lines already embed `@assistant` inline, so
-  // `isReactionTagLine` is used to skip those and avoid double-attribution
-  // (`@assistant: [... @assistant reacted ...]`). Regular content and the
-  // `[deleted]` sentinel get the prefix so attribution survives flattening.
+  // Reaction / overflow-trailer lines already embed `@assistant` inline, and
+  // timezone-aware assistant rows already carry compact bracket attribution.
+  // Regular content and the `[deleted]` sentinel get the prefix so attribution
+  // survives flattening.
   const lines = rendered
     .map((msg) => {
       const text = extractTagLineTexts([msg])[0] ?? "";
-      return msg.role === "assistant" && !isReactionTagLine(text)
+      return msg.role === "assistant" &&
+        !isReactionTagLine(text) &&
+        !isSlackMessageTagLine(text)
         ? `@assistant: ${text}`
         : text;
     })

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -24,12 +24,9 @@ import { readSlackMetadata } from "../messaging/providers/slack/message-metadata
 import {
   compareSlackTs,
   extractTagLineTexts,
-  isReactionTagLine,
-  isSlackMessageTagLine,
   isSlackTsAfter,
   type RenderableSlackMessage,
   type RenderedSlackTranscriptMessage,
-  renderSlackTranscript,
   renderSlackTranscriptWithProvenance,
 } from "../messaging/providers/slack/render-transcript.js";
 import { getInjectors } from "../plugins/registry.js";
@@ -1372,6 +1369,7 @@ function assembleSlackChronologicalContext(
       {
         message: createContextSummaryMessage(contextSummary),
         sourceChannelTs: null,
+        tagLineProvenance: "none",
       },
       ...renderedMessages,
     ];
@@ -1567,18 +1565,17 @@ function buildActiveThreadBlockFromRenderable(
     return { ...m, senderLabel: "@user" };
   });
 
-  const rendered = renderSlackTranscript(labeledMembers);
-  if (rendered.length === 0) return null;
-  // Reaction / overflow-trailer lines already embed `@assistant` inline, and
-  // timezone-aware assistant rows already carry compact bracket attribution.
-  // Regular content and the `[deleted]` sentinel get the prefix so attribution
-  // survives flattening.
-  const lines = rendered
-    .map((msg) => {
-      const text = extractTagLineTexts([msg])[0] ?? "";
-      return msg.role === "assistant" &&
-        !isReactionTagLine(text) &&
-        !isSlackMessageTagLine(text)
+  const rendered = renderSlackTranscriptWithProvenance(labeledMembers);
+  if (rendered.renderedMessages.length === 0) return null;
+  // Reaction / overflow-trailer lines are renderer-owned Slack event lines,
+  // and timezone-aware assistant rows already carry metadata-backed compact
+  // attribution. Regular assistant content and the `[deleted]` sentinel get
+  // the prefix so attribution survives flattening.
+  const lines = rendered.renderedMessages
+    .map((entry) => {
+      const text = extractTagLineTexts([entry.message])[0] ?? "";
+      return entry.message.role === "assistant" &&
+        entry.tagLineProvenance === "none"
         ? `@assistant: ${text}`
         : text;
     })

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -114,6 +114,98 @@ describe("renderSlackTranscript — basics", () => {
     expect(renderSlackTranscript([])).toEqual([]);
   });
 
+  test("renders timezone-aware rows with compact local timestamps and speaker suffixes", () => {
+    const out = renderSlackTranscript([
+      {
+        ...userMsg("1772681640.000001", "aaron", "hey there"),
+        metadata: {
+          source: "slack",
+          channelId: CHANNEL,
+          channelTs: "1772681640.000001",
+          eventKind: "message",
+          displayName: "aaron",
+          actorTimezone: "America/Denver",
+          actorTimezoneLabel: "MT",
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "MT",
+        },
+      },
+      {
+        ...userMsg("1772681760.000002", "jordan", "whatsup"),
+        metadata: {
+          source: "slack",
+          channelId: CHANNEL,
+          channelTs: "1772681760.000002",
+          eventKind: "message",
+          displayName: "jordan",
+          actorTimezone: "America/New_York",
+          actorTimezoneLabel: "Eastern Time",
+          timestampTimezone: "America/New_York",
+          timestampTimezoneLabel: "Eastern Time",
+          speakerTimezoneLabel: "Eastern Time",
+        },
+      },
+      {
+        ...userMsg(
+          "1772681820.000003",
+          "aaron",
+          "nm, i wonder how my assistant is doing",
+        ),
+        metadata: {
+          source: "slack",
+          channelId: CHANNEL,
+          channelTs: "1772681820.000003",
+          eventKind: "message",
+          displayName: "aaron",
+          actorTimezone: "America/Denver",
+          actorTimezoneLabel: "MT",
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "MT",
+        },
+      },
+      {
+        ...userMsg("1772681880.000004", null, "i'm good", {
+          role: "assistant",
+        }),
+        metadata: {
+          source: "slack",
+          channelId: CHANNEL,
+          channelTs: "1772681880.000004",
+          eventKind: "message",
+          timestampTimezone: "America/Denver",
+          timestampTimezoneLabel: "Mountain Time",
+          speakerTimezoneLabel: "ET",
+        },
+      },
+      {
+        ...userMsg("1772681940.000005", "jordan", "ayeeeee"),
+        metadata: {
+          source: "slack",
+          channelId: CHANNEL,
+          channelTs: "1772681940.000005",
+          eventKind: "message",
+          displayName: "jordan",
+          actorTimezone: "America/New_York",
+          actorTimezoneLabel: "ET",
+          timestampTimezone: "America/New_York",
+          timestampTimezoneLabel: "ET",
+          speakerTimezoneLabel: "ET",
+        },
+      },
+    ]);
+
+    expect(out).toEqual([
+      textMsg("user", "[mar 4 2026 8:34 PM MT aaron] hey there"),
+      textMsg("user", "[mar 4 2026 10:36 PM ET jordan (ET)] whatsup"),
+      textMsg(
+        "user",
+        "[mar 4 2026 8:37 PM MT aaron] nm, i wonder how my assistant is doing",
+      ),
+      textMsg("assistant", "[mar 4 2026 8:38 PM MT assistant (ET)] i'm good"),
+      textMsg("user", "[mar 4 2026 10:39 PM ET jordan (ET)] ayeeeee"),
+    ]);
+  });
+
   test("renders top-level message with MM/DD/YY HH:MM tag", () => {
     const out = renderSlackTranscript([userMsg(TS_14_25, "@alice", "hi")]);
     expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice]: hi")]);

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -384,6 +384,9 @@ describe("renderSlackTranscript — basics", () => {
       TS_14_25,
       TS_14_28,
     ]);
+    expect(
+      out.renderedMessages.map((entry) => entry.tagLineProvenance),
+    ).toEqual(["none", "none"]);
   });
 
   test("omits sender label for user-role message with null senderLabel (no displayName)", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -125,6 +125,8 @@ export function parentAlias(channelTs: string): string {
  * with the message body, not with `]`, so they never match.
  */
 const REACTION_TAG_LINE_SUFFIX = /M[0-9a-f]{6}\]$/;
+const COMPACT_MESSAGE_TAG_LINE_PREFIX =
+  /^\[[a-z]{3} \d{1,2} \d{4} \d{1,2}:\d{2} (?:AM|PM) [^\]\s]+(?: [^\]]+)?\](?:\s|$)/;
 
 /**
  * Whether a rendered tag-line string was produced by the reaction or
@@ -140,6 +142,15 @@ const REACTION_TAG_LINE_SUFFIX = /M[0-9a-f]{6}\]$/;
  */
 export function isReactionTagLine(text: string): boolean {
   return REACTION_TAG_LINE_SUFFIX.test(text);
+}
+
+/**
+ * Whether a rendered line already carries the compact Slack message
+ * attribution tag. Used by flattened active-thread context so assistant rows
+ * that the renderer has already bracket-tagged do not get relabeled again.
+ */
+export function isSlackMessageTagLine(text: string): boolean {
+  return COMPACT_MESSAGE_TAG_LINE_PREFIX.test(text);
 }
 
 /**
@@ -166,6 +177,179 @@ function formatEpochMs(ms: number): string {
   const hh = String(d.getUTCHours()).padStart(2, "0");
   const mm = String(d.getUTCMinutes()).padStart(2, "0");
   return `${mo}/${da}/${yy} ${hh}:${mm}`;
+}
+
+const COMMON_TIMEZONE_LABEL_BY_IANA = new Map<string, string>([
+  ["America/New_York", "ET"],
+  ["America/Detroit", "ET"],
+  ["America/Indiana/Indianapolis", "ET"],
+  ["America/Kentucky/Louisville", "ET"],
+  ["America/Toronto", "ET"],
+  ["America/Montreal", "ET"],
+  ["America/Chicago", "CT"],
+  ["America/Winnipeg", "CT"],
+  ["America/Mexico_City", "CT"],
+  ["America/Denver", "MT"],
+  ["America/Boise", "MT"],
+  ["America/Phoenix", "MT"],
+  ["America/Edmonton", "MT"],
+  ["America/Los_Angeles", "PT"],
+  ["America/Vancouver", "PT"],
+  ["America/Tijuana", "PT"],
+]);
+
+const COMPACT_TIMEZONE_LABEL_BY_NAME = new Map<string, string>([
+  ["EASTERN TIME", "ET"],
+  ["EASTERN STANDARD TIME", "ET"],
+  ["EASTERN DAYLIGHT TIME", "ET"],
+  ["EST", "ET"],
+  ["EDT", "ET"],
+  ["CENTRAL TIME", "CT"],
+  ["CENTRAL STANDARD TIME", "CT"],
+  ["CENTRAL DAYLIGHT TIME", "CT"],
+  ["CST", "CT"],
+  ["CDT", "CT"],
+  ["MOUNTAIN TIME", "MT"],
+  ["MOUNTAIN STANDARD TIME", "MT"],
+  ["MOUNTAIN DAYLIGHT TIME", "MT"],
+  ["MST", "MT"],
+  ["MDT", "MT"],
+  ["PACIFIC TIME", "PT"],
+  ["PACIFIC STANDARD TIME", "PT"],
+  ["PACIFIC DAYLIGHT TIME", "PT"],
+  ["PST", "PT"],
+  ["PDT", "PT"],
+]);
+
+const shortTimeZoneFormatters = new Map<string, Intl.DateTimeFormat>();
+const compactDateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function compactPersistedTimezoneLabel(
+  label: string | undefined,
+): string | null {
+  const trimmed = label?.trim();
+  if (!trimmed) return null;
+  return COMPACT_TIMEZONE_LABEL_BY_NAME.get(trimmed.toUpperCase()) ?? trimmed;
+}
+
+function getShortTimeZoneFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = shortTimeZoneFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "short",
+    });
+    shortTimeZoneFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function getCompactDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = compactDateTimeFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    compactDateTimeFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function extractShortTimeZoneName(ms: number, timeZone: string): string | null {
+  try {
+    const part = getShortTimeZoneFormatter(timeZone)
+      .formatToParts(new Date(ms))
+      .find((p) => p.type === "timeZoneName");
+    return part?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function compactTimezoneLabel(
+  timeZone: string,
+  persistedLabel: string | undefined,
+  ms: number,
+): string {
+  const persisted = compactPersistedTimezoneLabel(persistedLabel);
+  if (persisted) return persisted;
+  const mapped = COMMON_TIMEZONE_LABEL_BY_IANA.get(timeZone);
+  if (mapped) return mapped;
+  return extractShortTimeZoneName(ms, timeZone) ?? timeZone;
+}
+
+function compactDateTimeParts(ms: number, timeZone: string) {
+  try {
+    const parts = getCompactDateTimeFormatter(timeZone).formatToParts(
+      new Date(ms),
+    );
+    const get = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((part) => part.type === type)?.value;
+    const month = get("month")?.toLowerCase();
+    const day = get("day");
+    const year = get("year");
+    const hour = get("hour");
+    const minute = get("minute");
+    const dayPeriod = get("dayPeriod");
+    if (!month || !day || !year || !hour || !minute || !dayPeriod) {
+      return null;
+    }
+    return { month, day, year, hour, minute, dayPeriod };
+  } catch {
+    return null;
+  }
+}
+
+function formatCompactEpochMs(
+  ms: number,
+  timeZone: string,
+  timezoneLabel: string | undefined,
+): string {
+  if (!Number.isFinite(ms)) {
+    return `??? ?? ???? ??:?? ${compactTimezoneLabel(timeZone, timezoneLabel, ms)}`;
+  }
+  const parts = compactDateTimeParts(ms, timeZone);
+  if (!parts) return formatEpochMs(ms);
+  const label = compactTimezoneLabel(timeZone, timezoneLabel, ms);
+  return `${parts.month} ${parts.day} ${parts.year} ${parts.hour}:${parts.minute} ${parts.dayPeriod} ${label}`;
+}
+
+function formatCompactSlackTs(
+  channelTs: string,
+  timeZone: string,
+  timezoneLabel: string | undefined,
+): string {
+  const seconds = Number.parseFloat(channelTs);
+  if (!Number.isFinite(seconds)) {
+    return `??? ?? ???? ??:?? ${compactTimezoneLabel(timeZone, timezoneLabel, Number.NaN)}`;
+  }
+  return formatCompactEpochMs(seconds * 1000, timeZone, timezoneLabel);
+}
+
+function hasTimestampTimezone(
+  meta: SlackMessageMetadata | null,
+): meta is SlackMessageMetadata & { timestampTimezone: string } {
+  return (
+    typeof meta?.timestampTimezone === "string" &&
+    meta.timestampTimezone.trim().length > 0
+  );
+}
+
+function speakerLabel(
+  msg: RenderableSlackMessage,
+  meta: SlackMessageMetadata,
+): string {
+  const speaker =
+    msg.senderLabel ?? (msg.role === "assistant" ? "assistant" : "");
+  const suffix = compactPersistedTimezoneLabel(meta.speakerTimezoneLabel);
+  if (!speaker) return "";
+  return suffix ? `${speaker} (${suffix})` : speaker;
 }
 
 function renderSlackFileMarkers(
@@ -255,17 +439,47 @@ function maxNullableSlackTs(a: string | null, b: string | null): string | null {
  * avoid — so we keep the content-only form.
  */
 function renderMessage(msg: RenderableSlackMessage): string {
-  if (msg.role === "assistant") {
+  const meta = msg.metadata;
+
+  if (msg.role === "assistant" && !hasTimestampTimezone(meta)) {
     if (msg.metadata?.deletedAt !== undefined) return "[deleted]";
     return appendSlackFileMarkers(msg.content, msg.metadata?.slackFiles);
   }
 
-  const meta = msg.metadata;
   const senderPart = msg.senderLabel ? ` ${msg.senderLabel}` : "";
   if (!meta) {
     // Legacy pre-upgrade row: flat render, no Slack metadata-derived fields.
     const time = formatEpochMs(msg.createdAt);
     return `[${time}${senderPart}]: ${renderModelBodyWithSlackFiles(msg, undefined)}`;
+  }
+
+  if (hasTimestampTimezone(meta)) {
+    const time = formatCompactSlackTs(
+      meta.channelTs,
+      meta.timestampTimezone,
+      meta.timestampTimezoneLabel,
+    );
+    const speaker = speakerLabel(msg, meta);
+    const speakerPart = speaker ? ` ${speaker}` : "";
+    if (meta.deletedAt !== undefined) {
+      const dtime = formatCompactEpochMs(
+        meta.deletedAt,
+        meta.timestampTimezone,
+        meta.timestampTimezoneLabel,
+      );
+      return `[${time}${speakerPart} - deleted ${dtime}]`;
+    }
+
+    let head = `[${time}${speakerPart}`;
+    if (meta.editedAt !== undefined) {
+      head += `, edited ${formatCompactEpochMs(
+        meta.editedAt,
+        meta.timestampTimezone,
+        meta.timestampTimezoneLabel,
+      )}`;
+    }
+    head += `] ${renderModelBodyWithSlackFiles(msg, meta.slackFiles)}`;
+    return head;
   }
 
   const time = formatSlackTs(meta.channelTs);
@@ -335,7 +549,13 @@ function renderModelBody(msg: RenderableSlackMessage, body: string): string {
 function renderReaction(msg: RenderableSlackMessage): string | null {
   const meta = msg.metadata;
   if (!meta || meta.eventKind !== "reaction" || !meta.reaction) return null;
-  const time = formatSlackTs(meta.channelTs);
+  const time = hasTimestampTimezone(meta)
+    ? formatCompactSlackTs(
+        meta.channelTs,
+        meta.timestampTimezone,
+        meta.timestampTimezoneLabel,
+      )
+    : formatSlackTs(meta.channelTs);
   const actor =
     msg.senderLabel ?? (msg.role === "assistant" ? "@assistant" : "@user");
   const verb = meta.reaction.op === "added" ? "reacted" : "removed";

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -78,7 +78,14 @@ export interface RenderedSlackTranscript {
 export interface RenderedSlackTranscriptMessage {
   readonly message: Message;
   readonly sourceChannelTs: string | null;
+  /** How the first rendered text line got its Slack attribution, if any. */
+  readonly tagLineProvenance: RenderedSlackTranscriptTagLineProvenance;
 }
+
+export type RenderedSlackTranscriptTagLineProvenance =
+  | "none"
+  | "slack-reaction"
+  | "slack-timezone-message";
 
 /**
  * Replayable Anthropic content-block types that we preserve verbatim from a
@@ -125,8 +132,6 @@ export function parentAlias(channelTs: string): string {
  * with the message body, not with `]`, so they never match.
  */
 const REACTION_TAG_LINE_SUFFIX = /M[0-9a-f]{6}\]$/;
-const COMPACT_MESSAGE_TAG_LINE_PREFIX =
-  /^\[[a-z]{3} \d{1,2} \d{4} \d{1,2}:\d{2} (?:AM|PM) [^\]\s]+(?: [^\]]+)?\](?:\s|$)/;
 
 /**
  * Whether a rendered tag-line string was produced by the reaction or
@@ -142,15 +147,6 @@ const COMPACT_MESSAGE_TAG_LINE_PREFIX =
  */
 export function isReactionTagLine(text: string): boolean {
   return REACTION_TAG_LINE_SUFFIX.test(text);
-}
-
-/**
- * Whether a rendered line already carries the compact Slack message
- * attribution tag. Used by flattened active-thread context so assistant rows
- * that the renderer has already bracket-tagged do not get relabeled again.
- */
-export function isSlackMessageTagLine(text: string): boolean {
-  return COMPACT_MESSAGE_TAG_LINE_PREFIX.test(text);
 }
 
 /**
@@ -729,6 +725,7 @@ export function renderSlackTranscriptWithProvenance(
       ],
     },
     sourceChannelTs: acc.sourceChannelTs,
+    tagLineProvenance: "slack-reaction",
   });
 
   const flushOverflowExcept = (
@@ -762,6 +759,7 @@ export function renderSlackTranscriptWithProvenance(
               content: [{ type: "text" as const, text: line }],
             },
             sourceChannelTs: meta.channelTs,
+            tagLineProvenance: "slack-reaction",
           });
         }
       } else {
@@ -787,12 +785,17 @@ export function renderSlackTranscriptWithProvenance(
     const tagLine = renderMessage(m);
     const blocks = buildMessageContentBlocks(m, tagLine);
     if (blocks.length === 0) continue;
+    const hasRenderedText = blocks.some((block) => block.type === "text");
     out.push({
       message: {
         role: m.role,
         content: blocks,
       },
       sourceChannelTs: meta?.channelTs ?? null,
+      tagLineProvenance:
+        hasRenderedText && hasTimestampTimezone(meta)
+          ? "slack-timezone-message"
+          : "none",
     });
   }
 
@@ -857,6 +860,7 @@ function filterOrphanToolPairs(
       out.push({
         message: { role: msg.role, content: kept },
         sourceChannelTs: entry.sourceChannelTs,
+        tagLineProvenance: entry.tagLineProvenance,
       });
     }
   }


### PR DESCRIPTION
## Summary
- Renders timezone-aware Slack context rows with compact local timestamps.
- Adds per-speaker timezone suffixes while preserving legacy rows without timezone metadata.

Part of plan: slack-message-timezones.md (PR 5 of 5)