### PR TITLE
Add Slack thread detach IPC

### DIFF
--- a/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
+++ b/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
@@ -1,0 +1,157 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { randomBytes } from "node:crypto";
+import { createConnection, type Socket } from "node:net";
+
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { SlackStore } from "../db/slack-store.js";
+import { slackActiveThreads } from "../db/schema.js";
+import { GatewayIpcServer } from "../ipc/server.js";
+import { slackThreadRoutes } from "../ipc/slack-thread-handlers.js";
+
+const CHANNEL_ID = "CFAKE00001";
+const OTHER_CHANNEL_ID = "COTHER0001";
+const THREAD_TS = "1700000000.000000";
+const OTHER_THREAD_TS = "1700000001.000000";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(slackActiveThreads).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function connectClient(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(path, () => resolve(client));
+    client.on("error", reject);
+  });
+}
+
+function sendRequest(
+  client: Socket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ id: string; result?: unknown; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const id = randomBytes(4).toString("hex");
+    let buffer = "";
+
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        client.off("data", onData);
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+
+    client.on("data", onData);
+    client.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+}
+
+function activeThreadRows(): Array<{ threadTs: string; channelId: string }> {
+  return new SlackStore(getGatewayDb()).listActiveThreadsWithChannel();
+}
+
+function trackThread(): void {
+  new SlackStore(getGatewayDb()).trackThread(THREAD_TS, CHANNEL_ID, 60_000);
+}
+
+describe("IPC Slack thread routes", () => {
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let client: Socket;
+
+  afterEach(() => {
+    client?.destroy();
+    server?.stop();
+  });
+
+  async function startServerAndConnect(): Promise<void> {
+    server = new GatewayIpcServer([...slackThreadRoutes]);
+    server.start();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client = await connectClient(server.getSocketPath());
+  }
+
+  test("detach_slack_active_thread removes a matching active thread", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: true,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([]);
+  });
+
+  test("detach_slack_active_thread is idempotent for an unknown thread", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: CHANNEL_ID,
+      threadTs: OTHER_THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: false,
+      channelId: CHANNEL_ID,
+      threadTs: OTHER_THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([
+      { threadTs: THREAD_TS, channelId: CHANNEL_ID },
+    ]);
+  });
+
+  test("detach_slack_active_thread does not remove channel mismatches", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: OTHER_CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: false,
+      channelId: OTHER_CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([
+      { threadTs: THREAD_TS, channelId: CHANNEL_ID },
+    ]);
+  });
+});

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -67,6 +67,16 @@ export class SlackStore {
     return row !== undefined;
   }
 
+  detachThread(threadTs: string, channelId: string): boolean {
+    const raw = (this.db as unknown as { $client: Database }).$client;
+    const changes = raw
+      .prepare(
+        "DELETE FROM slack_active_threads WHERE thread_ts = ? AND channel_id = ?",
+      )
+      .run(threadTs, channelId).changes;
+    return changes > 0;
+  }
+
   /**
    * Returns all unexpired active threads with a known channel for reconnect
    * catch-up. Rows with a NULL `channel_id` (legacy rows from before the

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -176,6 +176,7 @@ import {
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
+import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
 
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
@@ -2205,6 +2206,7 @@ async function main() {
   const ipcServer = new GatewayIpcServer([
     ...featureFlagRoutes,
     ...contactRoutes,
+    ...slackThreadRoutes,
     ...thresholdRoutes,
     ...riskClassificationRoutes,
     ...createVelayRoutes(velayTunnelClient),

--- a/gateway/src/ipc/slack-thread-handlers.ts
+++ b/gateway/src/ipc/slack-thread-handlers.ts
@@ -1,0 +1,39 @@
+/**
+ * IPC route definitions for Slack active-thread listener control.
+ *
+ * The gateway owns Slack Socket Mode listener state, so assistant-side
+ * controls call here instead of writing gateway storage directly.
+ */
+
+import { z } from "zod";
+
+import { SlackStore } from "../db/slack-store.js";
+import type { IpcRoute } from "./server.js";
+
+let store: SlackStore | null = null;
+
+function getStore(): SlackStore {
+  if (!store) {
+    store = new SlackStore();
+  }
+  return store;
+}
+
+const DetachSlackActiveThreadParamsSchema = z.object({
+  channelId: z.string().trim().min(1),
+  threadTs: z.string().trim().min(1),
+});
+
+export const slackThreadRoutes: IpcRoute[] = [
+  {
+    method: "detach_slack_active_thread",
+    schema: DetachSlackActiveThreadParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channelId, threadTs } = DetachSlackActiveThreadParamsSchema.parse(
+        params ?? {},
+      );
+      const detached = getStore().detachThread(threadTs, channelId);
+      return { detached, channelId, threadTs };
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add a gateway IPC route for detaching active Slack thread listeners.
- Remove active-thread rows by channel/thread and cover the behavior with focused tests.

Part of #31626
Closes #31627

## Test plan
- cd gateway && bun test src/__tests__/ipc-slack-thread-routes.test.ts