### PR TITLE
fix(web): drop noopener from ChatGPT OAuth popup

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -31,6 +31,8 @@ export { toKebabCaseImpl as toKebabCase };
 const ALL_PROVIDERS = Object.keys(MODELS_BY_PROVIDER) as (keyof typeof MODELS_BY_PROVIDER)[];
 const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
 
+const CODEX_SUBSCRIPTION_MODEL_IDS = new Set(["gpt-5.4", "gpt-5.3-codex"]);
+
 const EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh", "max"] as const;
 const SPEED_OPTIONS = ["standard", "fast"] as const;
 const VERBOSITY_OPTIONS = ["low", "medium", "high"] as const;
@@ -569,7 +571,15 @@ function ProfileEditorModalInner({
       return [];
     }
     const catalogModels = getModelsForProvider(provider);
-    if (catalogModels.length > 0) return catalogModels;
+    if (catalogModels.length > 0) {
+      const selectedConn = resolvedProviderConnection
+        ? availableConnectionsForProvider.find((c) => c.name === resolvedProviderConnection)
+        : undefined;
+      if (selectedConn?.auth.type === "oauth_subscription") {
+        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
+      }
+      return catalogModels;
+    }
     // Static catalog is empty (openai-compatible) — derive from connections.
     const connectionModelsToCatalog = (models: ConnectionModel[] | null | undefined) =>
       (models ?? []).map((m) => ({

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -191,9 +191,10 @@ export function ProviderEditorContent({
         await startChatgptSubscriptionAuth(assistantId);
       chatgptStateRef.current = state;
       if (popup) {
+        popup.opener = null;
         popup.location.href = authorize_url;
       } else {
-        window.open(authorize_url, "_blank");
+        window.open(authorize_url, "_blank", "noopener");
       }
       setChatgptOAuthState("paste_url");
     } catch {

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -185,7 +185,7 @@ export function ProviderEditorContent({
   async function handleChatgptSignIn() {
     setChatgptOAuthState("starting");
     setChatgptOAuthError(null);
-    const popup = window.open("about:blank", "_blank", "noopener");
+    const popup = window.open("about:blank", "_blank");
     try {
       const { authorize_url, state } =
         await startChatgptSubscriptionAuth(assistantId);
@@ -193,7 +193,7 @@ export function ProviderEditorContent({
       if (popup) {
         popup.location.href = authorize_url;
       } else {
-        window.open(authorize_url, "_blank", "noopener");
+        window.open(authorize_url, "_blank");
       }
       setChatgptOAuthState("paste_url");
     } catch {


### PR DESCRIPTION
## Summary
- Remove `noopener` from the ChatGPT OAuth `window.open` call — it causes the return value to be `null`, so the popup stays stuck on `about:blank` and never navigates to the OAuth URL
- Filter the model dropdown in the profile editor when the selected connection uses `oauth_subscription` auth — only show models supported by the Codex endpoint (GPT-5.4, GPT-5.3 Codex) instead of all OpenAI models

Follow-up to #31612.

## Test plan
- [ ] Click "Sign in with ChatGPT" — popup should open and navigate to the ChatGPT OAuth page (not stay on about:blank)
- [ ] In the profile editor, select a ChatGPT subscription connection — model dropdown should only show GPT-5.4 and GPT-5.3 Codex
- [ ] Select a regular OpenAI API key connection — all models should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)