### PR TITLE
fix: simplify Slack timezone rendering helpers

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -32,6 +32,7 @@ import { backfillMemoryRecallLogMessageId } from "../memory/memory-recall-log-st
 import { backfillMemoryV2ActivationMessageId } from "../memory/memory-v2-activation-log-store.js";
 import { getThreadTs } from "../memory/slack-thread-store.js";
 import {
+  formatSlackTimezoneLabel,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
@@ -63,10 +64,7 @@ import {
   isContextTooLarge,
 } from "./conversation-error.js";
 import { isProviderOrderingError } from "./conversation-slash.js";
-import {
-  formatTimeZoneLabel,
-  resolveTurnTimezoneContext,
-} from "./date-context.js";
+import { resolveTurnTimezoneContext } from "./date-context.js";
 import type { ServerMessage } from "./message-protocol.js";
 import type {
   WebSearchMetadata,
@@ -1063,9 +1061,9 @@ export async function handleMessageComplete(
       const timestampTimezone = resolveAssistantReplyTimestampTimezone(
         deps.ctx,
       );
-      const timestampTimezoneLabel = formatTimeZoneLabel(
+      const timestampTimezoneLabel = formatSlackTimezoneLabel(
         timestampTimezone,
-        state.turnStartedAt,
+        { nowMs: state.turnStartedAt },
       );
       const requesterTimezoneLabel =
         deps.ctx.trustContext?.requesterTimezoneLabel?.trim();

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -36,6 +36,7 @@ import {
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
 import {
+  buildSlackTimezoneMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
@@ -267,11 +268,6 @@ export function buildSlackMetaForPersistence(params: {
   ) {
     return null;
   }
-  const actorTimezoneOffsetSeconds =
-    typeof candidate.actorTimezoneOffsetSeconds === "number" &&
-    Number.isFinite(candidate.actorTimezoneOffsetSeconds)
-      ? candidate.actorTimezoneOffsetSeconds
-      : undefined;
   const slackMeta: SlackMessageMetadata = {
     source: "slack",
     channelId: candidate.channelId,
@@ -283,24 +279,7 @@ export function buildSlackMetaForPersistence(params: {
     ...(candidate.actorExternalUserId
       ? { actorExternalUserId: candidate.actorExternalUserId }
       : {}),
-    ...(candidate.actorTimezone
-      ? { actorTimezone: candidate.actorTimezone }
-      : {}),
-    ...(candidate.actorTimezoneLabel
-      ? { actorTimezoneLabel: candidate.actorTimezoneLabel }
-      : {}),
-    ...(actorTimezoneOffsetSeconds !== undefined
-      ? { actorTimezoneOffsetSeconds }
-      : {}),
-    ...(candidate.timestampTimezone
-      ? { timestampTimezone: candidate.timestampTimezone }
-      : {}),
-    ...(candidate.timestampTimezoneLabel
-      ? { timestampTimezoneLabel: candidate.timestampTimezoneLabel }
-      : {}),
-    ...(candidate.speakerTimezoneLabel
-      ? { speakerTimezoneLabel: candidate.speakerTimezoneLabel }
-      : {}),
+    ...buildSlackTimezoneMetadata(candidate),
   };
   return writeSlackMetadata(slackMeta);
 }

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -366,38 +366,6 @@ export function formatLocalTimestamp(ms: number, timeZone?: string): string {
   return `${v.year}-${v.month}-${v.day} ${v.hour}:${v.minute}:${v.second}`;
 }
 
-function readTimeZoneName(
-  timeZone: string,
-  timeZoneName: "short" | "shortGeneric",
-  nowMs: number,
-): string | null {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour: "numeric",
-      timeZoneName,
-    }).formatToParts(new Date(nowMs));
-    const label = parts.find((part) => part.type === "timeZoneName")?.value;
-    return label && label.trim().length > 0 ? label.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
-export function formatTimeZoneLabel(
-  timeZone: string | null | undefined,
-  nowMs: number = Date.now(),
-): string | null {
-  const canonical = canonicalizeTimeZone(timeZone);
-  if (!canonical) return null;
-  if (canonical === "UTC") return "UTC";
-
-  const generic = readTimeZoneName(canonical, "shortGeneric", nowMs);
-  if (generic && !/\s/u.test(generic)) return generic;
-
-  return readTimeZoneName(canonical, "short", nowMs);
-}
-
 export function resolveTurnTimezoneContext(
   options: TemporalContextOptions = {},
 ): TurnTimezoneContext {

--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -1,12 +1,50 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSlackTimezoneMetadata,
+  formatSlackTimezoneLabel,
   mergeSlackMetadata,
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "./message-metadata.js";
+
+describe("formatSlackTimezoneLabel", () => {
+  test("uses compact common labels for IANA timezones", () => {
+    expect(formatSlackTimezoneLabel("America/Denver")).toBe("MT");
+    expect(formatSlackTimezoneLabel("America/New_York")).toBe("ET");
+  });
+
+  test("compacts persisted Slack profile labels before falling back to timezone", () => {
+    expect(
+      formatSlackTimezoneLabel("America/New_York", {
+        persistedLabel: "Eastern Time",
+      }),
+    ).toBe("ET");
+  });
+});
+
+describe("buildSlackTimezoneMetadata", () => {
+  test("copies only populated Slack timezone fields", () => {
+    expect(
+      buildSlackTimezoneMetadata({
+        actorTimezone: " America/New_York ",
+        actorTimezoneLabel: " ET ",
+        actorTimezoneOffsetSeconds: -18_000,
+        timestampTimezone: "America/New_York",
+        timestampTimezoneLabel: "",
+        speakerTimezoneLabel: " Eastern Time ",
+      }),
+    ).toEqual({
+      actorTimezone: "America/New_York",
+      actorTimezoneLabel: "ET",
+      actorTimezoneOffsetSeconds: -18_000,
+      timestampTimezone: "America/New_York",
+      speakerTimezoneLabel: "Eastern Time",
+    });
+  });
+});
 
 describe("readSlackMetadata", () => {
   test("tolerates null and undefined", () => {

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -57,6 +57,155 @@ export type SlackReactionMetadata = z.infer<typeof slackReactionMetadataSchema>;
 export type SlackFileMetadata = z.infer<typeof slackFileMetadataSchema>;
 export type SlackMessageMetadata = z.infer<typeof slackMessageMetadataSchema>;
 
+type SlackTimezoneMetadata = Pick<
+  SlackMessageMetadata,
+  | "actorTimezone"
+  | "actorTimezoneLabel"
+  | "actorTimezoneOffsetSeconds"
+  | "timestampTimezone"
+  | "timestampTimezoneLabel"
+  | "speakerTimezoneLabel"
+>;
+type SlackTimezoneMetadataInput = Omit<
+  Partial<SlackTimezoneMetadata>,
+  "actorTimezoneOffsetSeconds"
+> & {
+  actorTimezoneOffsetSeconds?: unknown;
+};
+
+const COMMON_SLACK_TIMEZONE_LABEL_BY_IANA = new Map<string, string>([
+  ["America/New_York", "ET"],
+  ["America/Detroit", "ET"],
+  ["America/Indiana/Indianapolis", "ET"],
+  ["America/Kentucky/Louisville", "ET"],
+  ["America/Toronto", "ET"],
+  ["America/Montreal", "ET"],
+  ["America/Chicago", "CT"],
+  ["America/Winnipeg", "CT"],
+  ["America/Mexico_City", "CT"],
+  ["America/Denver", "MT"],
+  ["America/Boise", "MT"],
+  ["America/Phoenix", "MT"],
+  ["America/Edmonton", "MT"],
+  ["America/Los_Angeles", "PT"],
+  ["America/Vancouver", "PT"],
+  ["America/Tijuana", "PT"],
+]);
+
+const COMPACT_SLACK_TIMEZONE_LABEL_BY_NAME = new Map<string, string>([
+  ["EASTERN TIME", "ET"],
+  ["EASTERN STANDARD TIME", "ET"],
+  ["EASTERN DAYLIGHT TIME", "ET"],
+  ["EST", "ET"],
+  ["EDT", "ET"],
+  ["CENTRAL TIME", "CT"],
+  ["CENTRAL STANDARD TIME", "CT"],
+  ["CENTRAL DAYLIGHT TIME", "CT"],
+  ["CST", "CT"],
+  ["CDT", "CT"],
+  ["MOUNTAIN TIME", "MT"],
+  ["MOUNTAIN STANDARD TIME", "MT"],
+  ["MOUNTAIN DAYLIGHT TIME", "MT"],
+  ["MST", "MT"],
+  ["MDT", "MT"],
+  ["PACIFIC TIME", "PT"],
+  ["PACIFIC STANDARD TIME", "PT"],
+  ["PACIFIC DAYLIGHT TIME", "PT"],
+  ["PST", "PT"],
+  ["PDT", "PT"],
+]);
+
+const slackShortTimeZoneFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function compactStoredSlackTimezoneLabel(
+  label: string | null | undefined,
+): string | null {
+  const trimmed = label?.trim();
+  if (!trimmed) return null;
+  return (
+    COMPACT_SLACK_TIMEZONE_LABEL_BY_NAME.get(trimmed.toUpperCase()) ?? trimmed
+  );
+}
+
+function getSlackShortTimeZoneFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = slackShortTimeZoneFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "short",
+    });
+    slackShortTimeZoneFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function extractSlackShortTimeZoneName(
+  timeZone: string,
+  nowMs: number,
+): string | null {
+  try {
+    const part = getSlackShortTimeZoneFormatter(timeZone)
+      .formatToParts(new Date(nowMs))
+      .find((p) => p.type === "timeZoneName");
+    return part?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatSlackTimezoneLabel(
+  timeZone: string | null | undefined,
+  opts: { persistedLabel?: string | null; nowMs?: number } = {},
+): string | null {
+  const persisted = compactStoredSlackTimezoneLabel(opts.persistedLabel);
+  if (persisted) return persisted;
+
+  const trimmedTimezone = timeZone?.trim();
+  if (!trimmedTimezone) return null;
+  const mapped = COMMON_SLACK_TIMEZONE_LABEL_BY_IANA.get(trimmedTimezone);
+  if (mapped) return mapped;
+  return (
+    extractSlackShortTimeZoneName(trimmedTimezone, opts.nowMs ?? Date.now()) ??
+    trimmedTimezone
+  );
+}
+
+function trimmedOptionalString(
+  value: string | null | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function buildSlackTimezoneMetadata(
+  input: SlackTimezoneMetadataInput,
+): Partial<SlackTimezoneMetadata> {
+  const actorTimezone = trimmedOptionalString(input.actorTimezone);
+  const actorTimezoneLabel = trimmedOptionalString(input.actorTimezoneLabel);
+  const timestampTimezone = trimmedOptionalString(input.timestampTimezone);
+  const timestampTimezoneLabel = trimmedOptionalString(
+    input.timestampTimezoneLabel,
+  );
+  const speakerTimezoneLabel = trimmedOptionalString(
+    input.speakerTimezoneLabel,
+  );
+  const actorTimezoneOffsetSeconds =
+    typeof input.actorTimezoneOffsetSeconds === "number" &&
+    Number.isFinite(input.actorTimezoneOffsetSeconds)
+      ? input.actorTimezoneOffsetSeconds
+      : undefined;
+  return {
+    ...(actorTimezone ? { actorTimezone } : {}),
+    ...(actorTimezoneLabel ? { actorTimezoneLabel } : {}),
+    ...(actorTimezoneOffsetSeconds !== undefined
+      ? { actorTimezoneOffsetSeconds }
+      : {}),
+    ...(timestampTimezone ? { timestampTimezone } : {}),
+    ...(timestampTimezoneLabel ? { timestampTimezoneLabel } : {}),
+    ...(speakerTimezoneLabel ? { speakerTimezoneLabel } : {}),
+  };
+}
+
 /**
  * Parse a JSON string into `SlackMessageMetadata`. Returns `null` on parse
  * error, on non-object payloads, when `source !== "slack"`, or when any

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, test } from "bun:test";
 import type { Message } from "../../../providers/types.js";
 import {
   extractTagLineTexts,
-  isReactionTagLine,
   parentAlias,
   type RenderableSlackMessage,
   renderSlackTranscript,
@@ -663,50 +662,6 @@ describe("parentAlias", () => {
   test("starts with M and is 7 chars long (M + 6 hex)", () => {
     const a = parentAlias("1700000000.000100");
     expect(a).toMatch(/^M[0-9a-f]{6}$/);
-  });
-});
-
-// ── isReactionTagLine ────────────────────────────────────────────────────────
-
-describe("isReactionTagLine", () => {
-  // Pinned to the exact shapes `renderReaction` and the overflow trailer
-  // produce. The helper is the public contract that lets consumers
-  // re-label the transcript without double-attributing reaction lines,
-  // so drift here silently breaks `buildActiveThreadBlockFromRenderable`.
-  const alias = parentAlias("1700000000.000100");
-
-  test("matches reaction-add line", () => {
-    expect(
-      isReactionTagLine(`[11/14/23 14:28 @bob reacted 👍 to ${alias}]`),
-    ).toBe(true);
-  });
-
-  test("matches reaction-remove line", () => {
-    expect(
-      isReactionTagLine(`[11/14/23 14:28 @bob removed 👍 from ${alias}]`),
-    ).toBe(true);
-  });
-
-  test("matches overflow trailer line", () => {
-    expect(isReactionTagLine(`[…and 2 more reactions to ${alias}]`)).toBe(true);
-  });
-
-  test("does not match a regular message tag line", () => {
-    expect(isReactionTagLine("[11/14/23 14:25 @alice]: hi")).toBe(false);
-  });
-
-  test("does not match content-only assistant output", () => {
-    expect(isReactionTagLine("on it. here's the answer")).toBe(false);
-  });
-
-  test("does not match the `[deleted]` sentinel", () => {
-    expect(isReactionTagLine("[deleted]")).toBe(false);
-  });
-
-  test("does not match a user-deleted marker", () => {
-    expect(
-      isReactionTagLine("[11/14/23 14:25 @alice — deleted 11/14/23 14:32]"),
-    ).toBe(false);
   });
 });
 

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -21,7 +21,10 @@ import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,
 } from "../../../security/untrusted-content.js";
-import type { SlackMessageMetadata } from "./message-metadata.js";
+import {
+  formatSlackTimezoneLabel,
+  type SlackMessageMetadata,
+} from "./message-metadata.js";
 
 export interface RenderableSlackMessage {
   role: "user" | "assistant";
@@ -125,31 +128,6 @@ export function parentAlias(channelTs: string): string {
 }
 
 /**
- * Trailing signature of a reaction or reaction-overflow line, both of
- * which end with a `parentAlias` target and a closing bracket:
- * `[... reacted 👍 to M1a2b3c]`, `[... removed 👍 from M1a2b3c]`,
- * `[…and N more reactions to M1a2b3c]`. Regular message tag lines end
- * with the message body, not with `]`, so they never match.
- */
-const REACTION_TAG_LINE_SUFFIX = /M[0-9a-f]{6}\]$/;
-
-/**
- * Whether a rendered tag-line string was produced by the reaction or
- * reaction-overflow code paths (`renderReaction` / the overflow trailer).
- *
- * Reaction lines already embed the actor attribution inline
- * (`[11/14/23 14:28 @assistant reacted 👍 to M1a2b3c]`), so consumers
- * that flatten the rendered transcript and re-apply role labels should
- * skip these lines to avoid double-attribution.
- *
- * Co-located with `renderReaction` and `parentAlias` so the format
- * knowledge lives with the functions that own the line shape.
- */
-export function isReactionTagLine(text: string): boolean {
-  return REACTION_TAG_LINE_SUFFIX.test(text);
-}
-
-/**
  * Format a Slack ts (`"1700000000.000100"`) as `MM/DD/YY HH:MM` (UTC).
  *
  * Slack ts is `<unix-seconds>.<microseconds>`; we treat it as a unix epoch
@@ -175,70 +153,7 @@ function formatEpochMs(ms: number): string {
   return `${mo}/${da}/${yy} ${hh}:${mm}`;
 }
 
-const COMMON_TIMEZONE_LABEL_BY_IANA = new Map<string, string>([
-  ["America/New_York", "ET"],
-  ["America/Detroit", "ET"],
-  ["America/Indiana/Indianapolis", "ET"],
-  ["America/Kentucky/Louisville", "ET"],
-  ["America/Toronto", "ET"],
-  ["America/Montreal", "ET"],
-  ["America/Chicago", "CT"],
-  ["America/Winnipeg", "CT"],
-  ["America/Mexico_City", "CT"],
-  ["America/Denver", "MT"],
-  ["America/Boise", "MT"],
-  ["America/Phoenix", "MT"],
-  ["America/Edmonton", "MT"],
-  ["America/Los_Angeles", "PT"],
-  ["America/Vancouver", "PT"],
-  ["America/Tijuana", "PT"],
-]);
-
-const COMPACT_TIMEZONE_LABEL_BY_NAME = new Map<string, string>([
-  ["EASTERN TIME", "ET"],
-  ["EASTERN STANDARD TIME", "ET"],
-  ["EASTERN DAYLIGHT TIME", "ET"],
-  ["EST", "ET"],
-  ["EDT", "ET"],
-  ["CENTRAL TIME", "CT"],
-  ["CENTRAL STANDARD TIME", "CT"],
-  ["CENTRAL DAYLIGHT TIME", "CT"],
-  ["CST", "CT"],
-  ["CDT", "CT"],
-  ["MOUNTAIN TIME", "MT"],
-  ["MOUNTAIN STANDARD TIME", "MT"],
-  ["MOUNTAIN DAYLIGHT TIME", "MT"],
-  ["MST", "MT"],
-  ["MDT", "MT"],
-  ["PACIFIC TIME", "PT"],
-  ["PACIFIC STANDARD TIME", "PT"],
-  ["PACIFIC DAYLIGHT TIME", "PT"],
-  ["PST", "PT"],
-  ["PDT", "PT"],
-]);
-
-const shortTimeZoneFormatters = new Map<string, Intl.DateTimeFormat>();
 const compactDateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function compactPersistedTimezoneLabel(
-  label: string | undefined,
-): string | null {
-  const trimmed = label?.trim();
-  if (!trimmed) return null;
-  return COMPACT_TIMEZONE_LABEL_BY_NAME.get(trimmed.toUpperCase()) ?? trimmed;
-}
-
-function getShortTimeZoneFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = shortTimeZoneFormatters.get(timeZone);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      timeZoneName: "short",
-    });
-    shortTimeZoneFormatters.set(timeZone, formatter);
-  }
-  return formatter;
-}
 
 function getCompactDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
   let formatter = compactDateTimeFormatters.get(timeZone);
@@ -255,29 +170,6 @@ function getCompactDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
     compactDateTimeFormatters.set(timeZone, formatter);
   }
   return formatter;
-}
-
-function extractShortTimeZoneName(ms: number, timeZone: string): string | null {
-  try {
-    const part = getShortTimeZoneFormatter(timeZone)
-      .formatToParts(new Date(ms))
-      .find((p) => p.type === "timeZoneName");
-    return part?.value ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function compactTimezoneLabel(
-  timeZone: string,
-  persistedLabel: string | undefined,
-  ms: number,
-): string {
-  const persisted = compactPersistedTimezoneLabel(persistedLabel);
-  if (persisted) return persisted;
-  const mapped = COMMON_TIMEZONE_LABEL_BY_IANA.get(timeZone);
-  if (mapped) return mapped;
-  return extractShortTimeZoneName(ms, timeZone) ?? timeZone;
 }
 
 function compactDateTimeParts(ms: number, timeZone: string) {
@@ -308,11 +200,20 @@ function formatCompactEpochMs(
   timezoneLabel: string | undefined,
 ): string {
   if (!Number.isFinite(ms)) {
-    return `??? ?? ???? ??:?? ${compactTimezoneLabel(timeZone, timezoneLabel, ms)}`;
+    return `??? ?? ???? ??:?? ${
+      formatSlackTimezoneLabel(timeZone, {
+        persistedLabel: timezoneLabel,
+        nowMs: ms,
+      }) ?? timeZone
+    }`;
   }
   const parts = compactDateTimeParts(ms, timeZone);
   if (!parts) return formatEpochMs(ms);
-  const label = compactTimezoneLabel(timeZone, timezoneLabel, ms);
+  const label =
+    formatSlackTimezoneLabel(timeZone, {
+      persistedLabel: timezoneLabel,
+      nowMs: ms,
+    }) ?? timeZone;
   return `${parts.month} ${parts.day} ${parts.year} ${parts.hour}:${parts.minute} ${parts.dayPeriod} ${label}`;
 }
 
@@ -323,7 +224,12 @@ function formatCompactSlackTs(
 ): string {
   const seconds = Number.parseFloat(channelTs);
   if (!Number.isFinite(seconds)) {
-    return `??? ?? ???? ??:?? ${compactTimezoneLabel(timeZone, timezoneLabel, Number.NaN)}`;
+    return `??? ?? ???? ??:?? ${
+      formatSlackTimezoneLabel(timeZone, {
+        persistedLabel: timezoneLabel,
+        nowMs: Number.NaN,
+      }) ?? timeZone
+    }`;
   }
   return formatCompactEpochMs(seconds * 1000, timeZone, timezoneLabel);
 }
@@ -343,7 +249,9 @@ function speakerLabel(
 ): string {
   const speaker =
     msg.senderLabel ?? (msg.role === "assistant" ? "assistant" : "");
-  const suffix = compactPersistedTimezoneLabel(meta.speakerTimezoneLabel);
+  const suffix = formatSlackTimezoneLabel(undefined, {
+    persistedLabel: meta.speakerTimezoneLabel,
+  });
   if (!speaker) return "";
   return suffix ? `${speaker} (${suffix})` : speaker;
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -67,6 +67,7 @@ import {
 } from "../../messaging/providers/slack/backfill.js";
 import { downloadSlackFile } from "../../messaging/providers/slack/download.js";
 import {
+  buildSlackTimezoneMetadata,
   mergeSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackFileMetadata,
@@ -1142,27 +1143,15 @@ export async function handleChannelInbound({
               ...(trustCtx.requesterExternalUserId
                 ? { actorExternalUserId: trustCtx.requesterExternalUserId }
                 : {}),
-              ...(slackActorTimezone?.timezone
-                ? { actorTimezone: slackActorTimezone.timezone }
-                : {}),
-              ...(slackActorTimezone?.timezoneLabel
-                ? { actorTimezoneLabel: slackActorTimezone.timezoneLabel }
-                : {}),
-              ...(slackActorTimezone?.timezoneOffsetSeconds !== undefined
-                ? {
-                    actorTimezoneOffsetSeconds:
-                      slackActorTimezone.timezoneOffsetSeconds,
-                  }
-                : {}),
-              ...(slackActorTimezone?.timezone
-                ? { timestampTimezone: slackActorTimezone.timezone }
-                : {}),
-              ...(slackActorTimezone?.timezoneLabel
-                ? { timestampTimezoneLabel: slackActorTimezone.timezoneLabel }
-                : {}),
-              ...(slackSpeakerTimezoneLabel
-                ? { speakerTimezoneLabel: slackSpeakerTimezoneLabel }
-                : {}),
+              ...buildSlackTimezoneMetadata({
+                actorTimezone: slackActorTimezone?.timezone,
+                actorTimezoneLabel: slackActorTimezone?.timezoneLabel,
+                actorTimezoneOffsetSeconds:
+                  slackActorTimezone?.timezoneOffsetSeconds,
+                timestampTimezone: slackActorTimezone?.timezone,
+                timestampTimezoneLabel: slackActorTimezone?.timezoneLabel,
+                speakerTimezoneLabel: slackSpeakerTimezoneLabel,
+              }),
             }
           : undefined;
 
@@ -1584,13 +1573,6 @@ async function persistBackfilledSlackMessage(params: {
     message.metadata,
     "actorTimezoneLabel",
   );
-  const rawActorTimezoneOffsetSeconds =
-    message.metadata?.actorTimezoneOffsetSeconds;
-  const actorTimezoneOffsetSeconds =
-    typeof rawActorTimezoneOffsetSeconds === "number" &&
-    Number.isFinite(rawActorTimezoneOffsetSeconds)
-      ? rawActorTimezoneOffsetSeconds
-      : undefined;
   const isGuardian = isBackfilledSlackGuardianMessage(
     message,
     params.guardianExternalUserId,
@@ -1603,18 +1585,14 @@ async function persistBackfilledSlackMessage(params: {
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
     ...(actorExternalUserId ? { actorExternalUserId } : {}),
-    ...(actorTimezone ? { actorTimezone } : {}),
-    ...(actorTimezoneLabel ? { actorTimezoneLabel } : {}),
-    ...(actorTimezoneOffsetSeconds !== undefined
-      ? { actorTimezoneOffsetSeconds }
-      : {}),
-    ...(actorTimezone ? { timestampTimezone: actorTimezone } : {}),
-    ...(actorTimezoneLabel
-      ? { timestampTimezoneLabel: actorTimezoneLabel }
-      : {}),
-    ...(!isGuardian && actorTimezoneLabel
-      ? { speakerTimezoneLabel: actorTimezoneLabel }
-      : {}),
+    ...buildSlackTimezoneMetadata({
+      actorTimezone,
+      actorTimezoneLabel,
+      actorTimezoneOffsetSeconds: message.metadata?.actorTimezoneOffsetSeconds,
+      timestampTimezone: actorTimezone,
+      timestampTimezoneLabel: actorTimezoneLabel,
+      speakerTimezoneLabel: isGuardian ? undefined : actorTimezoneLabel,
+    }),
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Consolidates Slack timezone label formatting used by persistence and rendering.
- Removes dead text-based reaction tag detection after provenance migration.

Fixes cleanup gaps identified during plan review for slack-message-timezones.md.