### PR TITLE
fix: remove duplicate Slack provenance assertion

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -379,10 +379,6 @@ describe("renderSlackTranscript — basics", () => {
       TS_14_25,
       TS_14_28,
     ]);
-    expect(out.renderedMessages.map((entry) => entry.sourceChannelTs)).toEqual([
-      TS_14_25,
-      TS_14_28,
-    ]);
     expect(
       out.renderedMessages.map((entry) => entry.tagLineProvenance),
     ).toEqual(["none", "none"]);


### PR DESCRIPTION
## Summary
- Removes a duplicate Slack transcript provenance test assertion.

Fixes a cleanup gap identified during slack-message-timezones.md.