### PR TITLE
fix: cache permanent Slack user lookup fallbacks

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -411,21 +411,34 @@ describe("Slack adapter mention rendering", () => {
     });
   });
 
-  test("getHistory falls back when Slack user info lookup fails", async () => {
-    const messages = await slackProvider.getHistory(
+  test("getHistory caches fallback user info for permanent users.info failures", async () => {
+    const firstMessages = await slackProvider.getHistory(
+      undefined,
+      "C_USERINFO_FAIL",
+    );
+    const secondMessages = await slackProvider.getHistory(
       undefined,
       "C_USERINFO_FAIL",
     );
 
-    expect(messages).toHaveLength(1);
+    expect(firstMessages).toHaveLength(1);
+    expect(secondMessages).toHaveLength(1);
     expect(
       userInfoCalls.filter((userId) => userId === "UMISSING"),
     ).toHaveLength(1);
-    expect(messages[0].sender).toEqual({ id: "UMISSING", name: "UMISSING" });
-    expect(messages[0].metadata).toBeUndefined();
+    expect(firstMessages[0].sender).toEqual({
+      id: "UMISSING",
+      name: "UMISSING",
+    });
+    expect(secondMessages[0].sender).toEqual({
+      id: "UMISSING",
+      name: "UMISSING",
+    });
+    expect(firstMessages[0].metadata).toBeUndefined();
+    expect(secondMessages[0].metadata).toBeUndefined();
   });
 
-  test("getHistory does not permanently cache fallback user info after users.info fails", async () => {
+  test("getHistory does not cache fallback user info after transient users.info failures", async () => {
     const firstMessages = await slackProvider.getHistory(
       undefined,
       "C_USERINFO_RETRY",

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -50,6 +50,15 @@ interface SlackUserInfoLookupResult {
   cacheable: boolean;
 }
 
+const PERMANENT_USER_INFO_SLACK_ERRORS = new Set([
+  "account_inactive",
+  "ekm_access_denied",
+  "missing_scope",
+  "not_allowed_token_type",
+  "user_not_found",
+  "user_not_visible",
+]);
+
 // Cache normalized Slack user facts to avoid repeated API calls within a session.
 const userInfoCache = new Map<string, Promise<SlackUserInfoLookupResult>>();
 
@@ -250,12 +259,19 @@ async function resolveUserInfoUncached(
       info: normalizeSlackUserInfo(resp.user, contactDisplayName),
       cacheable: true,
     };
-  } catch {
+  } catch (err) {
     return {
       info: { displayName: contactDisplayName ?? userId },
-      cacheable: false,
+      cacheable: isPermanentSlackUserInfoFailure(err),
     };
   }
+}
+
+function isPermanentSlackUserInfoFailure(err: unknown): boolean {
+  return (
+    err instanceof SlackApiError &&
+    PERMANENT_USER_INFO_SLACK_ERRORS.has(err.slackError)
+  );
 }
 
 function slackUserInfoCacheKey(


### PR DESCRIPTION
## Summary
- Caches fallback Slack user info for permanent users.info errors.
- Keeps transient Slack user lookup failures retryable.

Fixes a review gap identified during slack-message-timezones.md.