### PR TITLE
fix: scope gateway Slack user cache

### DIFF
--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -44,6 +44,7 @@ const {
   normalizeSlackAppMention,
   resolveSlackChannel,
   resolveSlackUser,
+  resolveSlackUserSync,
   clearChannelInfoCache,
   clearInFlightFetches,
   clearUserInfoCache,
@@ -188,6 +189,100 @@ describe("resolveSlackUser", () => {
 
     expect(callCount).toBe(1);
     expect(getUserInfoCacheSize()).toBe(1);
+  });
+
+  test("scopes cached user info by bot token", async () => {
+    let callCount = 0;
+    fetchMock = mock(async (_input, init) => {
+      callCount++;
+      const auth = new Headers(init?.headers).get("authorization");
+      const user =
+        auth === "Bearer xoxb-team-a"
+          ? {
+              name: "alice",
+              tz: "America/New_York",
+              tz_label: "Eastern Daylight Time",
+              tz_offset: -14400,
+              profile: { display_name: "Alice" },
+            }
+          : {
+              name: "bob",
+              tz: "America/Los_Angeles",
+              tz_label: "Pacific Daylight Time",
+              tz_offset: -25200,
+              profile: { display_name: "Bob" },
+            };
+      return new Response(JSON.stringify({ ok: true, user }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const [teamAInfo, teamBInfo] = await Promise.all([
+      resolveSlackUser("U_SHARED", "xoxb-team-a"),
+      resolveSlackUser("U_SHARED", "xoxb-team-b"),
+    ]);
+
+    expect(teamAInfo!.displayName).toBe("Alice");
+    expect(teamAInfo!.timezone).toBe("America/New_York");
+    expect(teamBInfo!.displayName).toBe("Bob");
+    expect(teamBInfo!.timezone).toBe("America/Los_Angeles");
+    expect(callCount).toBe(2);
+    expect(getUserInfoCacheSize()).toBe(2);
+
+    await resolveSlackUser("U_SHARED", "xoxb-team-a");
+    await resolveSlackUser("U_SHARED", "xoxb-team-b");
+    expect(callCount).toBe(2);
+  });
+
+  test("sync cache lookup uses the bot token scope", async () => {
+    let callCount = 0;
+    fetchMock = mock(async (_input, init) => {
+      callCount++;
+      const auth = new Headers(init?.headers).get("authorization");
+      const user =
+        auth === "Bearer xoxb-team-a"
+          ? {
+              name: "alice",
+              tz: "America/Denver",
+              tz_label: "Mountain Daylight Time",
+              tz_offset: -21600,
+              profile: { display_name: "Alice" },
+            }
+          : {
+              name: "bob",
+              tz: "Europe/London",
+              tz_label: "British Summer Time",
+              tz_offset: 3600,
+              profile: { display_name: "Bob" },
+            };
+      return new Response(JSON.stringify({ ok: true, user }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    await resolveSlackUser("U_SHARED_SYNC", "xoxb-team-a");
+
+    const teamACached = resolveSlackUserSync("U_SHARED_SYNC", "xoxb-team-a");
+    expect(teamACached!.displayName).toBe("Alice");
+    expect(teamACached!.timezone).toBe("America/Denver");
+
+    const teamBMiss = resolveSlackUserSync("U_SHARED_SYNC", "xoxb-team-b");
+    expect(teamBMiss).toBeUndefined();
+
+    const teamBResolved = await resolveSlackUser(
+      "U_SHARED_SYNC",
+      "xoxb-team-b",
+    );
+    expect(teamBResolved!.displayName).toBe("Bob");
+    expect(teamBResolved!.timezone).toBe("Europe/London");
+
+    const teamBCached = resolveSlackUserSync("U_SHARED_SYNC", "xoxb-team-b");
+    expect(teamBCached!.displayName).toBe("Bob");
+    expect(teamBCached!.timezone).toBe("Europe/London");
+    expect(callCount).toBe(2);
+    expect(getUserInfoCacheSize()).toBe(2);
   });
 });
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,4 +1,5 @@
 import { renderSlackTextForModel } from "@vellumai/slack-text";
+import { createHash } from "node:crypto";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
@@ -16,7 +17,7 @@ interface SlackUserInfo {
   timezoneOffsetSeconds?: number;
 }
 
-type SlackUserActorFields = Pick<
+export type SlackUserActorFields = Pick<
   SlackUserInfo,
   | "displayName"
   | "username"
@@ -59,6 +60,11 @@ const inFlightChannelFetches = new Map<
   string,
   Promise<SlackChannelInfo | undefined>
 >();
+
+function slackUserCacheKey(userId: string, botToken: string): string {
+  const authScope = createHash("sha256").update(botToken).digest("hex");
+  return `${authScope}:${userId}`;
+}
 
 function evictExpired<T>(cache: Map<string, CacheEntry<T>>): void {
   const now = Date.now();
@@ -118,11 +124,12 @@ export async function resolveSlackUser(
   userId: string,
   botToken: string,
 ): Promise<SlackUserInfo | undefined> {
-  const cached = cacheGet(userInfoCache, userId);
+  const cacheKey = slackUserCacheKey(userId, botToken);
+  const cached = cacheGet(userInfoCache, cacheKey);
   if (cached) return cached;
 
   // If another caller is already fetching this user, reuse that promise
-  const existing = inFlightUserFetches.get(userId);
+  const existing = inFlightUserFetches.get(cacheKey);
   if (existing) return existing;
 
   const fetchPromise = (async (): Promise<SlackUserInfo | undefined> => {
@@ -176,7 +183,7 @@ export async function resolveSlackUser(
       };
       cacheSet(
         userInfoCache,
-        userId,
+        cacheKey,
         info,
         USER_CACHE_TTL_MS,
         USER_CACHE_MAX_SIZE,
@@ -187,11 +194,11 @@ export async function resolveSlackUser(
     }
   })();
 
-  inFlightUserFetches.set(userId, fetchPromise);
+  inFlightUserFetches.set(cacheKey, fetchPromise);
   try {
     return await fetchPromise;
   } finally {
-    inFlightUserFetches.delete(userId);
+    inFlightUserFetches.delete(cacheKey);
   }
 }
 
@@ -266,8 +273,9 @@ export function resolveSlackUserSync(
   userId: string,
   botToken: string,
 ): SlackUserInfo | undefined {
-  const cached = cacheGet(userInfoCache, userId);
-  if (!cached && !inFlightUserFetches.has(userId)) {
+  const cacheKey = slackUserCacheKey(userId, botToken);
+  const cached = cacheGet(userInfoCache, cacheKey);
+  if (!cached && !inFlightUserFetches.has(cacheKey)) {
     // Fire-and-forget: warm the cache for next time
     resolveSlackUser(userId, botToken).catch(() => {});
   }
@@ -426,7 +434,9 @@ function renderSlackInboundText(
   });
 }
 
-function slackUserActorFields(userInfo: SlackUserInfo): SlackUserActorFields {
+export function slackUserActorFields(
+  userInfo: SlackUserInfo,
+): SlackUserActorFields {
   return {
     displayName: userInfo.displayName,
     username: userInfo.username,

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -25,6 +25,7 @@ import {
   normalizeSlackReactionRemoved,
   resolveSlackChannel,
   resolveSlackUser,
+  slackUserActorFields,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
@@ -1018,17 +1019,7 @@ export class SlackSocketModeClient {
         ),
       ]);
       if (userInfo) {
-        actor.displayName = userInfo.displayName;
-        actor.username = userInfo.username;
-        if (userInfo.timezone !== undefined) {
-          actor.timezone = userInfo.timezone;
-        }
-        if (userInfo.timezoneLabel !== undefined) {
-          actor.timezoneLabel = userInfo.timezoneLabel;
-        }
-        if (userInfo.timezoneOffsetSeconds !== undefined) {
-          actor.timezoneOffsetSeconds = userInfo.timezoneOffsetSeconds;
-        }
+        Object.assign(actor, slackUserActorFields(userInfo));
       }
     }
 


### PR DESCRIPTION
## Summary
- Scopes cached gateway Slack user info by bot token/account context.
- Reuses shared Slack actor field plumbing in Socket Mode.

Fixes review gaps identified during slack-message-timezones.md.