### PR TITLE
fix: hash Slack token cache keys

### DIFF
--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -5,6 +5,8 @@
  * implements the MessagingProvider interface.
  */
 
+import { createHash } from "node:crypto";
+
 import {
   buildSlackUserLabelMap,
   renderSlackTextForModel,
@@ -280,7 +282,7 @@ function slackUserInfoCacheKey(
 ): string {
   const authScope =
     typeof auth === "string"
-      ? `token:${auth}`
+      ? `token:${createHash("sha256").update(auth).digest("hex")}`
       : `connection:${auth.id}:${auth.accountInfo ?? ""}`;
   return `${authScope}:user:${userId}`;
 }


### PR DESCRIPTION
## Summary
- Hashes raw Slack token scopes before using them in assistant user-info cache keys.

Fixes final cleanup feedback for slack-message-timezones.md.