### PR TITLE
fix: scope gateway Slack channel cache

### DIFF
--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -350,6 +350,36 @@ describe("resolveSlackChannel", () => {
     expect(callCount).toBe(1);
     expect(getChannelInfoCacheSize()).toBe(1);
   });
+
+  test("scopes cached channel names by bot token", async () => {
+    let callCount = 0;
+    fetchMock = mock(async (_input, init) => {
+      callCount++;
+      const auth = new Headers(init?.headers).get("authorization");
+      const channel =
+        auth === "Bearer xoxb-team-a"
+          ? { id: "C_SHARED", name: "team-a-channel" }
+          : { id: "C_SHARED", name: "team-b-channel" };
+      return new Response(JSON.stringify({ ok: true, channel }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const [teamAInfo, teamBInfo] = await Promise.all([
+      resolveSlackChannel("C_SHARED", "xoxb-team-a"),
+      resolveSlackChannel("C_SHARED", "xoxb-team-b"),
+    ]);
+
+    expect(teamAInfo!.name).toBe("team-a-channel");
+    expect(teamBInfo!.name).toBe("team-b-channel");
+    expect(callCount).toBe(2);
+    expect(getChannelInfoCacheSize()).toBe(2);
+
+    await resolveSlackChannel("C_SHARED", "xoxb-team-a");
+    await resolveSlackChannel("C_SHARED", "xoxb-team-b");
+    expect(callCount).toBe(2);
+  });
 });
 
 describe("normalizeSlackAppMention with display name", () => {

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -66,6 +66,11 @@ function slackUserCacheKey(userId: string, botToken: string): string {
   return `${authScope}:${userId}`;
 }
 
+function slackChannelCacheKey(channelId: string, botToken: string): string {
+  const authScope = createHash("sha256").update(botToken).digest("hex");
+  return `${authScope}:${channelId}`;
+}
+
 function evictExpired<T>(cache: Map<string, CacheEntry<T>>): void {
   const now = Date.now();
   for (const [key, entry] of cache) {
@@ -213,10 +218,11 @@ export async function resolveSlackChannel(
   channelId: string,
   botToken: string,
 ): Promise<SlackChannelInfo | undefined> {
-  const cached = cacheGet(channelInfoCache, channelId);
+  const cacheKey = slackChannelCacheKey(channelId, botToken);
+  const cached = cacheGet(channelInfoCache, cacheKey);
   if (cached) return cached;
 
-  const existing = inFlightChannelFetches.get(channelId);
+  const existing = inFlightChannelFetches.get(cacheKey);
   if (existing) return existing;
 
   const fetchPromise = (async (): Promise<SlackChannelInfo | undefined> => {
@@ -245,7 +251,7 @@ export async function resolveSlackChannel(
       const info: SlackChannelInfo = { name };
       cacheSet(
         channelInfoCache,
-        channelId,
+        cacheKey,
         info,
         CHANNEL_CACHE_TTL_MS,
         CHANNEL_CACHE_MAX_SIZE,
@@ -256,11 +262,11 @@ export async function resolveSlackChannel(
     }
   })();
 
-  inFlightChannelFetches.set(channelId, fetchPromise);
+  inFlightChannelFetches.set(cacheKey, fetchPromise);
   try {
     return await fetchPromise;
   } finally {
-    inFlightChannelFetches.delete(channelId);
+    inFlightChannelFetches.delete(cacheKey);
   }
 }
 


### PR DESCRIPTION
## Summary
- Scopes gateway Slack channel-name cache and in-flight de-dupe by bot token.
- Adds regression coverage for same channel IDs under different Slack tokens.

Fixes final integration feedback for slack-message-timezones.md.