### PR TITLE
feat(memory-v2): dry-run router simulator with config overrides

### DIFF
--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -24,6 +24,7 @@ import type {
   MemoryV2BackfillResult,
   MemoryV2EmaScoresResult,
   MemoryV2ReembedSkillsResult,
+  MemoryV2SimulateRouterResult,
   MemoryV2ValidateResult,
 } from "../../runtime/routes/memory-v2-routes.js";
 import { registerCommand } from "../lib/register-command.js";
@@ -366,6 +367,197 @@ Examples:
             log.info(
               `\n${rows.length} of ${visible.length} shown (${totalScored} total with score > 0, ${allEntries.length} pages indexed).`,
             );
+          },
+        );
+
+      // ── simulate ──────────────────────────────────────────────────────────
+
+      v2.command("simulate")
+        .description(
+          "Dry-run the v4 router against a synthetic query (read-only)",
+        )
+        .requiredOption(
+          "-q, --query <text>",
+          "User query to route the simulated turn against",
+        )
+        .option(
+          "--tier1-size <n>",
+          "Override memory.v2.router.tier1_size for this run (number or 'null')",
+        )
+        .option(
+          "--tier2-size <n>",
+          "Override memory.v2.router.tier2_size for this run (number or 'null')",
+        )
+        .option(
+          "--batch-size <n>",
+          "Override memory.v2.router.batch_size for this run (number or 'null')",
+        )
+        .option("--json", "Emit raw JSON instead of a grouped report")
+        .addHelpText(
+          "after",
+          `
+Runs the v4 router read-only against the live page index + EMA scores, with
+optional tier/batch overrides applied on top of the live config. NO writes:
+no row is appended to memory_v2_injection_events or memory_v2_activation_logs,
+and no activation state is mutated. Use this to preview the effect of a
+config knob change before flipping it in workspace config.json.
+
+Limitations:
+  - priorEverInjected is empty (single-turn simulation; live router dedups
+    against pages already in context).
+  - NOW.md is read at simulate-time, not historical-turn time.
+  - assistantMessage is empty.
+
+Pass 'null' to an override flag to explicitly disable that tier for this run
+(e.g. --tier2-size null reverts to tier1 → tier3). Omitting an override
+inherits the live config value.
+
+Examples:
+  $ assistant memory v2 simulate -q "what should we ship next"
+  $ assistant memory v2 simulate -q "..." --tier1-size 100 --tier2-size 200 --batch-size 50
+  $ assistant memory v2 simulate -q "..." --json | jq '.selectedSlugs'`,
+        )
+        .action(
+          async (opts: {
+            query: string;
+            tier1Size?: string;
+            tier2Size?: string;
+            batchSize?: string;
+            json?: boolean;
+          }) => {
+            const parseOverride = (
+              flag: string,
+              raw: string | undefined,
+            ): number | null | undefined => {
+              if (raw === undefined) return undefined;
+              if (raw === "null") return null;
+              const parsed = Number(raw);
+              if (!Number.isInteger(parsed) || parsed < 1) {
+                log.error(
+                  `${flag} must be a positive integer or 'null' (got "${raw}")`,
+                );
+                process.exitCode = 1;
+                throw new Error("invalid-override");
+              }
+              return parsed;
+            };
+
+            let configOverrides:
+              | {
+                  tier1_size?: number | null;
+                  tier2_size?: number | null;
+                  batch_size?: number | null;
+                }
+              | undefined;
+            try {
+              const t1 = parseOverride("--tier1-size", opts.tier1Size);
+              const t2 = parseOverride("--tier2-size", opts.tier2Size);
+              const bs = parseOverride("--batch-size", opts.batchSize);
+              configOverrides = {
+                ...(t1 !== undefined ? { tier1_size: t1 } : {}),
+                ...(t2 !== undefined ? { tier2_size: t2 } : {}),
+                ...(bs !== undefined ? { batch_size: bs } : {}),
+              };
+              if (Object.keys(configOverrides).length === 0) {
+                configOverrides = undefined;
+              }
+            } catch {
+              return;
+            }
+
+            const result = await cliIpcCall<MemoryV2SimulateRouterResult>(
+              "memory_v2_simulate_router",
+              {
+                body: {
+                  query: opts.query,
+                  ...(configOverrides ? { configOverrides } : {}),
+                },
+              },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to simulate router");
+              process.exitCode = 1;
+              return;
+            }
+
+            const payload = result.result!;
+
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+
+            log.info("Memory Router Simulation");
+            log.info("========================");
+            log.info(`Query: ${JSON.stringify(opts.query)}`);
+            log.info("");
+            log.info("Config (effective):");
+            const formatKnob = (
+              key: keyof MemoryV2SimulateRouterResult["effectiveConfig"],
+            ): string => {
+              const eff = payload.effectiveConfig[key];
+              const override = (
+                payload.overrides as Record<string, number | null | undefined>
+              )[key];
+              const effStr = eff === null ? "null" : String(eff);
+              if (override === undefined) {
+                return `  ${key}: ${effStr}`;
+              }
+              return `  ${key}: ${effStr}  (override)`;
+            };
+            log.info(formatKnob("tier1_size"));
+            log.info(formatKnob("tier2_size"));
+            log.info(formatKnob("batch_size"));
+            log.info(`  max_page_ids: ${payload.effectiveConfig.max_page_ids}`);
+            log.info("");
+            log.info(`Total candidate pages: ${payload.totalCandidatePages}`);
+            log.info(
+              `Selected: ${payload.selectedSlugs.length} / ${payload.effectiveConfig.max_page_ids} pages`,
+            );
+            if (payload.failureReason) {
+              log.info(`Failure: ${payload.failureReason}`);
+            }
+            log.info("");
+
+            const grouped = new Map<string, string[]>();
+            for (const slug of payload.selectedSlugs) {
+              const source = payload.sourceBySlug[slug] ?? "unknown";
+              const bucket = grouped.get(source) ?? [];
+              bucket.push(slug);
+              grouped.set(source, bucket);
+            }
+            const sortedKeys = [...grouped.keys()].sort((a, b) => {
+              const order = (s: string) => {
+                if (s === "tier1") return 0;
+                if (s === "tier2") return 1;
+                if (s.startsWith("tier3:")) {
+                  return 2 + Number(s.slice("tier3:".length));
+                }
+                return Number.MAX_SAFE_INTEGER;
+              };
+              return order(a) - order(b);
+            });
+
+            for (const key of sortedKeys) {
+              const label = key.startsWith("tier3:")
+                ? `tier 3 · b${key.slice("tier3:".length)}`
+                : key === "tier1"
+                  ? "tier 1"
+                  : key === "tier2"
+                    ? "tier 2"
+                    : key;
+              log.info(label);
+              for (const slug of grouped.get(key)!) {
+                if (key === "tier2") {
+                  const score = payload.scores[slug] ?? 0;
+                  log.info(`  - ${slug}  (EMA ${score.toFixed(3)})`);
+                } else {
+                  log.info(`  - ${slug}`);
+                }
+              }
+              log.info("");
+            }
           },
         );
     },

--- a/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the `memory_v2_simulate_router` route handler.
+ *
+ * The route is a read-only playground for previewing router config knob
+ * changes (`tier1_size`, `tier2_size`, `batch_size`) against the live page
+ * index. Tests assert:
+ *   1. The handler returns selected slugs with `sourceBySlug` populated.
+ *   2. Overrides are reflected in the response's `effectiveConfig`.
+ *   3. The handler never calls `recordInjectionEvents` — the simulate path
+ *      must not touch the EMA event log.
+ *
+ * Workspace lives in a `mkdtemp` directory per test; `~/.vellum/` is never
+ * touched. The provider and DB are stubbed so no network or SQLite I/O
+ * fires.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+  ToolUseContent,
+} from "../../../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks (installed before the route module is imported)
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Skill store: empty by default so the page index only contains test pages.
+mock.module("../../../memory/v2/skill-store.js", () => ({
+  SKILL_SLUG_PREFIX: "skills/",
+  listSkillEntries: () => [],
+  seedV2SkillEntries: async () => undefined,
+}));
+
+// NOW.md loader: return a fixed string. The route reads NOW from the
+// workspace at call time; stubbing keeps the test independent of disk state.
+mock.module("../../../memory/v2/now-text.js", () => ({
+  loadNowText: async () => "2026-05-22 14:00 PT",
+}));
+
+// Injection-events module. `recordInjectionEvents` must never be called by
+// the simulate path — record any call so the assertion catches a regression.
+// `computeInjectionScores` is called twice per simulate (once inside runRouter
+// for tier 2, once in the handler for the response payload); always returns
+// zero scores since the test workspace has no event history.
+const recordCalls: Array<{ slugs: readonly string[]; at: number }> = [];
+mock.module("../../../memory/v2/injection-events.js", () => ({
+  recordInjectionEvents: (
+    _db: unknown,
+    slugs: readonly string[],
+    at: number,
+  ) => {
+    recordCalls.push({ slugs, at });
+  },
+  computeInjectionScores: (
+    _db: unknown,
+    slugs: readonly string[],
+    _now: number,
+  ): Map<string, number> => new Map(slugs.map((s) => [s, 0])),
+}));
+
+// Database handle: the simulate route only passes this through to
+// `runRouter` and `computeInjectionScores`. Both are stubbed above, so a
+// sentinel object is sufficient.
+mock.module("../../../memory/db-connection.js", () => ({
+  getDb: () => ({ __stub: true }),
+}));
+
+// Config loader. The simulate route reads `memory.v2.enabled` (must be
+// true) and the full `memory.v2.router` block (overrides merged on top).
+const liveRouterConfig = {
+  enabled: true,
+  max_page_ids: 25,
+  router_prompt_path: null,
+  batch_size: null,
+  tier1_size: null,
+  tier2_size: null,
+};
+const mockConfigValue = {
+  memory: {
+    v2: {
+      enabled: true,
+      router: liveRouterConfig,
+    },
+  },
+};
+mock.module("../../../config/loader.js", () => ({
+  loadConfig: () => mockConfigValue,
+  getConfig: () => mockConfigValue,
+  getConfigReadOnly: () => mockConfigValue,
+  invalidateConfigCache: () => {},
+  API_KEY_PROVIDERS: [],
+}));
+
+// Provider stub. Default returns [1, 2] (selects first two pages).
+let providerStub: Provider | null = null;
+interface ProviderCall {
+  messages: Message[];
+  tools: ToolDefinition[] | undefined;
+  systemPrompt: string | undefined;
+  options: SendMessageOptions | undefined;
+}
+const providerCalls: ProviderCall[] = [];
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+// Platform helpers. `getWorkspaceDir` must return the per-test tmp dir so
+// the route's page index points at the test workspace.
+let workspaceDir = "";
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => workspaceDir,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks above)
+// ---------------------------------------------------------------------------
+
+const { handleSimulateRouter } = await import("../memory-v2-routes.js");
+const { writePage } = await import("../../../memory/v2/page-store.js");
+const { invalidatePageIndex } =
+  await import("../../../memory/v2/page-index.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProvider(pageIds: number[]): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (messages, tools, systemPrompt, options) => {
+      providerCalls.push({ messages, tools, systemPrompt, options });
+      return {
+        model: "stub-model",
+        stopReason: "tool_use",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "select_pages_to_inject",
+            input: { page_ids: pageIds },
+          },
+        ],
+      };
+    },
+  };
+}
+
+function makePage(slug: string, summary: string) {
+  return {
+    slug,
+    frontmatter: {
+      edges: [],
+      ref_files: [],
+      ref_urls: [],
+      summary,
+    },
+    body: "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-test setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "memory-v2-simulate-test-"));
+  recordCalls.length = 0;
+  providerCalls.length = 0;
+  providerStub = null;
+  // Reset live router config to defaults between tests.
+  liveRouterConfig.batch_size = null;
+  liveRouterConfig.tier1_size = null;
+  liveRouterConfig.tier2_size = null;
+  liveRouterConfig.max_page_ids = 25;
+  invalidatePageIndex();
+});
+
+afterEach(() => {
+  invalidatePageIndex();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleSimulateRouter", () => {
+  test("returns selectedSlugs + sourceBySlug populated for each pick", async () => {
+    await writePage(workspaceDir, makePage("alice", "A"));
+    await writePage(workspaceDir, makePage("bob", "B"));
+    await writePage(workspaceDir, makePage("carol", "C"));
+    providerStub = makeProvider([3, 1]);
+
+    const result = await handleSimulateRouter({
+      body: { query: "what's relevant?" },
+    });
+
+    expect(result.failureReason).toBeNull();
+    expect(result.selectedSlugs).toEqual(["carol", "alice"]);
+    expect(result.sourceBySlug["carol"]).toBe("tier3:0");
+    expect(result.sourceBySlug["alice"]).toBe("tier3:0");
+    expect(result.scores["carol"]).toBe(0);
+    expect(result.scores["alice"]).toBe(0);
+    expect(result.totalCandidatePages).toBe(3);
+  });
+
+  test("propagates overrides into effectiveConfig and reports them in overrides", async () => {
+    await writePage(workspaceDir, makePage("alice", "A"));
+    providerStub = makeProvider([1]);
+
+    const result = await handleSimulateRouter({
+      body: {
+        query: "test",
+        configOverrides: {
+          tier1_size: 50,
+          batch_size: 25,
+        },
+      },
+    });
+
+    expect(result.effectiveConfig.tier1_size).toBe(50);
+    expect(result.effectiveConfig.tier2_size).toBeNull(); // not overridden, inherits live
+    expect(result.effectiveConfig.batch_size).toBe(25);
+    expect(result.effectiveConfig.max_page_ids).toBe(25);
+    expect(result.overrides).toEqual({ tier1_size: 50, batch_size: 25 });
+  });
+
+  test("never writes to the EMA event log (recordInjectionEvents not called)", async () => {
+    await writePage(workspaceDir, makePage("alice", "A"));
+    await writePage(workspaceDir, makePage("bob", "B"));
+    providerStub = makeProvider([1, 2]);
+
+    await handleSimulateRouter({
+      body: { query: "should not record" },
+    });
+
+    expect(recordCalls).toEqual([]);
+  });
+
+  test("rejects an empty query at the schema layer", async () => {
+    await expect(
+      handleSimulateRouter({ body: { query: "" } }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects negative tier size at the schema layer", async () => {
+    await expect(
+      handleSimulateRouter({
+        body: { query: "test", configOverrides: { tier1_size: -5 } },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { z } from "zod";
 
 import { loadConfig } from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
   enqueueMemoryJob,
@@ -23,6 +24,7 @@ import {
   validateEdgeTargets,
 } from "../../memory/v2/edge-index.js";
 import { computeInjectionScores } from "../../memory/v2/injection-events.js";
+import { loadNowText } from "../../memory/v2/now-text.js";
 import { getPageIndex } from "../../memory/v2/page-index.js";
 import {
   getConceptsDir,
@@ -30,6 +32,7 @@ import {
   readPage,
   renderPageContent,
 } from "../../memory/v2/page-store.js";
+import { type RouterSource, runRouter } from "../../memory/v2/router.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -334,6 +337,154 @@ async function handleEmaScores({
   return { entries };
 }
 
+// ── Simulate router (dry-run playground) ────────────────────────────────
+
+const SimulateRouterOverridesSchema = z
+  .object({
+    tier1_size: z.number().int().min(1).nullable().optional(),
+    tier2_size: z.number().int().min(1).nullable().optional(),
+    batch_size: z.number().int().min(1).nullable().optional(),
+  })
+  .strict();
+
+const MemoryV2SimulateRouterParams = z
+  .object({
+    query: z.string().min(1, "query must be non-empty"),
+    configOverrides: SimulateRouterOverridesSchema.optional(),
+  })
+  .strict();
+
+export interface MemoryV2SimulateRouterEffectiveConfig {
+  tier1_size: number | null;
+  tier2_size: number | null;
+  batch_size: number | null;
+  max_page_ids: number;
+}
+
+export interface MemoryV2SimulateRouterResult {
+  /** Slugs the router would select, in model-returned order. */
+  selectedSlugs: string[];
+  /** Per-slug provenance: `"tier1"`, `"tier2"`, or `"tier3:<bucket>"`. */
+  sourceBySlug: Record<string, RouterSource>;
+  /** EMA scores for the selected slugs (0 when the slug has no events). */
+  scores: Record<string, number>;
+  /** `null` on success; otherwise one of the router failure reasons. */
+  failureReason: string | null;
+  /** The router config that actually ran (live merged with overrides). */
+  effectiveConfig: MemoryV2SimulateRouterEffectiveConfig;
+  /** The overrides the caller submitted, for display. */
+  overrides: {
+    tier1_size?: number | null;
+    tier2_size?: number | null;
+    batch_size?: number | null;
+  };
+  /** Page index size the router was given (post-tier-carve, all batches). */
+  totalCandidatePages: number;
+}
+
+/**
+ * Build the config the router will see by overlaying override values on top
+ * of the live workspace config. Only the three new tier knobs are exposed —
+ * everything else (provider, prompts, weights) stays exactly as it would on
+ * a real turn. `undefined` means "inherit live"; `null` is a valid override
+ * value (meaning "disable this tier").
+ */
+function applySimulateOverrides(
+  live: AssistantConfig,
+  overrides: z.infer<typeof SimulateRouterOverridesSchema> | undefined,
+): AssistantConfig {
+  if (!overrides) return live;
+  const liveRouter = live.memory.v2.router;
+  const mergedRouter = {
+    ...liveRouter,
+    ...("tier1_size" in overrides && overrides.tier1_size !== undefined
+      ? { tier1_size: overrides.tier1_size }
+      : {}),
+    ...("tier2_size" in overrides && overrides.tier2_size !== undefined
+      ? { tier2_size: overrides.tier2_size }
+      : {}),
+    ...("batch_size" in overrides && overrides.batch_size !== undefined
+      ? { batch_size: overrides.batch_size }
+      : {}),
+  };
+  return {
+    ...live,
+    memory: {
+      ...live.memory,
+      v2: {
+        ...live.memory.v2,
+        router: mergedRouter,
+      },
+    },
+  };
+}
+
+export async function handleSimulateRouter({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2SimulateRouterResult> {
+  requireMemoryV2Enabled();
+  const { query, configOverrides } = MemoryV2SimulateRouterParams.parse(body);
+
+  const liveConfig = loadConfig();
+  const mergedConfig = applySimulateOverrides(liveConfig, configOverrides);
+  const effectiveRouter = mergedConfig.memory.v2.router;
+
+  const workspaceDir = getWorkspaceDir();
+  const nowText = await loadNowText(workspaceDir);
+
+  const routerResult = await runRouter({
+    workspaceDir,
+    userMessage: query,
+    assistantMessage: "",
+    nowText,
+    priorEverInjected: [],
+    config: mergedConfig,
+    database: getDb(),
+  });
+
+  const pageIndex = await getPageIndex(workspaceDir);
+  const scores = computeInjectionScores(
+    getDb(),
+    routerResult.selectedSlugs,
+    Date.now(),
+  );
+
+  const sourceBySlug: Record<string, RouterSource> = {};
+  for (const [slug, source] of routerResult.sourceBySlug.entries()) {
+    sourceBySlug[slug] = source;
+  }
+
+  const scoresOut: Record<string, number> = {};
+  for (const slug of routerResult.selectedSlugs) {
+    scoresOut[slug] = scores.get(slug) ?? 0;
+  }
+
+  return {
+    selectedSlugs: routerResult.selectedSlugs,
+    sourceBySlug,
+    scores: scoresOut,
+    failureReason: routerResult.failureReason,
+    effectiveConfig: {
+      tier1_size: effectiveRouter.tier1_size,
+      tier2_size: effectiveRouter.tier2_size,
+      batch_size: effectiveRouter.batch_size,
+      max_page_ids: effectiveRouter.max_page_ids,
+    },
+    overrides: {
+      ...(configOverrides?.tier1_size !== undefined
+        ? { tier1_size: configOverrides.tier1_size }
+        : {}),
+      ...(configOverrides?.tier2_size !== undefined
+        ? { tier2_size: configOverrides.tier2_size }
+        : {}),
+      ...(configOverrides?.batch_size !== undefined
+        ? { batch_size: configOverrides.batch_size }
+        : {}),
+    },
+    totalCandidatePages: pageIndex.entries.length,
+  };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -413,5 +564,16 @@ export const ROUTES: RouteDefinition[] = [
       "Computes the time-decayed injection frequency (3-day half-life) for every entry in the current page index by reading memory_v2_injection_events. Returns entries sorted by score descending then slug ASCII, including zero-score pages so callers can decide whether to filter. Read-only; tier 2 of the v4 router uses the same computation to pick its top-M.",
     tags: ["memory"],
     requestBody: MemoryV2EmaScoresParams,
+  },
+  {
+    operationId: "memory_v2_simulate_router",
+    method: "POST",
+    endpoint: "memory/v2/simulate-router",
+    handler: handleSimulateRouter,
+    summary: "Dry-run the v4 router with config overrides (read-only)",
+    description:
+      "Runs the memory router against the live page index + EMA scores with optional tier_size / batch_size overrides, without recording an injection event or writing an activation log. Returns the slugs that would have been selected, per-slug tier provenance, EMA scores, and the effective router config so operators can validate knob changes before flipping them in workspace config.",
+    tags: ["memory"],
+    requestBody: MemoryV2SimulateRouterParams,
   },
 ];


### PR DESCRIPTION
## Summary

- Add `assistant memory v2 simulate` — a read-only playground for previewing v4 router behavior with custom `tier1_size` / `tier2_size` / `batch_size` overrides without touching the EMA event log or activation logs.
- New IPC route `memory_v2_simulate_router` calls `runRouter` directly. All writes live in `injectViaRouter` (which the simulator never enters), so no `dryRun` flag threads through router internals.
- Output is grouped by tier provenance (tier 1 / tier 2 / tier 3 · bN) with EMA scores shown for tier 2 picks. JSON mode via `--json`.

## Why

Before flipping the live tier knobs on real workspaces, operators need to see what the router would pick under a candidate config. Tuning by feel against the live router risks lossy drift between intent and observed behavior.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts` — 5 pass: shape, override propagation, zero EMA-log writes, schema rejects on empty query + negative tier size
- [x] `bun test src/memory/v2/__tests__/router.test.ts` — 35 pass (no regression)
- [ ] Smoke after merge: `assistant memory v2 simulate -q "what should we ship next" --tier1-size 100 --batch-size 50` against a live workspace; row counts for `memory_v2_injection_events` and `memory_v2_activation_logs` unchanged pre/post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)