### PR TITLE
fix(memory-v2): register simulate-router route policy and CLI test

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -2,9 +2,9 @@
  * Tests for the `assistant memory v2` CLI subgroup.
  *
  * Validates:
- *   - Subcommand registration (reembed, reembed-skills, activation, validate)
- *     under `memory v2`. The `memory` parent is created by the v2 registrar
- *     itself; v1 had its own subcommands but those were retired.
+ *   - Subcommand registration (reembed, reembed-skills, activation, validate,
+ *     ema, simulate) under `memory v2`. The `memory` parent is created by the
+ *     v2 registrar itself; v1 had its own subcommands but those were retired.
  *   - Each mutating subcommand maps to the right `memory_v2_backfill` op.
  *   - `validate` calls `memory_v2_validate` and pretty-prints the report.
  *   - `reembed-skills` calls `memory_v2_reembed_skills` synchronously.
@@ -146,6 +146,7 @@ describe("subcommand registration", () => {
       "ema",
       "reembed",
       "reembed-skills",
+      "simulate",
       "validate",
     ]);
   });
@@ -159,6 +160,7 @@ describe("subcommand registration", () => {
     expect(help).toContain("reembed-skills");
     expect(help).toContain("activation");
     expect(help).toContain("validate");
+    expect(help).toContain("simulate");
     // Removed subcommands must not surface in help.
     expect(help).not.toContain("migrate");
     expect(help).not.toContain("explain");

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -470,6 +470,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/concept-frequency:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/ema-scores:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v2/simulate-router:POST", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Add \`memory/v2/simulate-router:POST\` to \`route-policy.ts\` with \`settings.read\` scope (handler is read-only — dry-runs the router without writes).
- Add \`simulate\` to the expected subcommand list in \`memory-v2.test.ts\` (both the \`toEqual\` set and the \`--help\` assertion).

## Original prompt
Fix the specific CI issue in the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/26269927346/job/77321013101. The job had two failing tests downstream of the simulate-router work (#31643): \`guard-tests.test.ts\` failed because the new endpoint had no route policy entry, and \`memory-v2.test.ts\` failed because its expected subcommand list didn't include the new \`simulate\` CLI command.