### PR TITLE
feat(web): memory router playground UI behind dev flag

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -1,0 +1,552 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import { Card } from "@vellum/design-library";
+
+import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
+import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
+import { useSimulateMemoryRouter } from "@/domains/chat/inspector/memory-router-simulator-api.js";
+import type {
+  MemoryRouterSimulateRequest,
+  MemoryRouterSimulateResponse,
+  RouterSource,
+} from "@/domains/chat/inspector/memory-router-simulator-api.js";
+import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store.js";
+import { useAuthStore } from "@/stores/auth-store.js";
+
+/**
+ * Developer-only page for dry-running the v4 memory router with custom
+ * config overrides. Hits the daemon's read-only `simulate_memory_router`
+ * route — no writes to the EMA event log or activation logs.
+ *
+ * Gated by:
+ *   1. The `memoryRouterPlayground` client feature flag (default off).
+ *   2. The same staff gate that protects /assistant/inspect.
+ */
+export function MemoryRouterPlaygroundPage(): ReactNode {
+  const user = useAuthStore.use.user();
+  const authLoading = useAuthStore.use.isLoading();
+  const flagEnabled = useClientFeatureFlagStore.use.memoryRouterPlayground();
+
+  if (authLoading) {
+    return <CenteredMessage>Loading…</CenteredMessage>;
+  }
+  if (!canUseLlmInspector(user) || !flagEnabled) {
+    return (
+      <CenteredMessage>
+        Memory router playground is not available.
+      </CenteredMessage>
+    );
+  }
+
+  return <PlaygroundView />;
+}
+
+function PlaygroundView(): ReactNode {
+  const { assistantId } = useActiveAssistantContext();
+  const mutation = useSimulateMemoryRouter(assistantId);
+
+  const [query, setQuery] = useState("");
+  const [tier1Raw, setTier1Raw] = useState("");
+  const [tier2Raw, setTier2Raw] = useState("");
+  const [batchRaw, setBatchRaw] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const runSimulation = () => {
+    setValidationError(null);
+    let configOverrides: MemoryRouterSimulateRequest["configOverrides"];
+    try {
+      configOverrides = {
+        ...maybeOverride("tier1_size", tier1Raw),
+        ...maybeOverride("tier2_size", tier2Raw),
+        ...maybeOverride("batch_size", batchRaw),
+      };
+      if (Object.keys(configOverrides).length === 0) {
+        configOverrides = undefined;
+      }
+    } catch (err) {
+      setValidationError(
+        err instanceof Error ? err.message : "Invalid override input"
+      );
+      return;
+    }
+    mutation.mutate({
+      query: query.trim(),
+      ...(configOverrides ? { configOverrides } : {}),
+    });
+  };
+
+  const canRun = query.trim().length > 0 && !mutation.isPending;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-[940px] flex-col gap-6 p-6">
+        <PageHeader />
+        <InputForm
+          query={query}
+          onQueryChange={setQuery}
+          tier1={tier1Raw}
+          onTier1Change={setTier1Raw}
+          tier2={tier2Raw}
+          onTier2Change={setTier2Raw}
+          batch={batchRaw}
+          onBatchChange={setBatchRaw}
+          onRun={runSimulation}
+          canRun={canRun}
+          isRunning={mutation.isPending}
+        />
+        {validationError !== null && <ErrorBanner message={validationError} />}
+        {mutation.isError && (
+          <ErrorBanner
+            message={
+              mutation.error instanceof Error
+                ? mutation.error.message
+                : "Failed to run simulation"
+            }
+          />
+        )}
+        {mutation.data !== undefined && (
+          <ResultPanel result={mutation.data} query={query} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function maybeOverride(
+  fieldName: string,
+  raw: string
+): Record<string, number | null> {
+  const trimmed = raw.trim();
+  if (trimmed === "") return {};
+  if (trimmed === "null") return { [fieldName]: null };
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `${fieldName} must be a positive integer or 'null' (got "${trimmed}")`
+    );
+  }
+  return { [fieldName]: parsed };
+}
+
+function PageHeader(): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <h1
+        className="text-body-large-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        Memory Router Playground
+      </h1>
+      <p
+        className="text-body-medium-lighter"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Dry-run the v4 router with custom tier/batch overrides. Read-only — no
+        rows are written to <code>memory_v2_injection_events</code> or{" "}
+        <code>memory_v2_activation_logs</code>, and no activation state is
+        mutated. Leave an override blank to inherit the live config value; enter{" "}
+        <code>null</code> to explicitly disable a tier.
+      </p>
+    </div>
+  );
+}
+
+function InputForm({
+  query,
+  onQueryChange,
+  tier1,
+  onTier1Change,
+  tier2,
+  onTier2Change,
+  batch,
+  onBatchChange,
+  onRun,
+  canRun,
+  isRunning,
+}: {
+  query: string;
+  onQueryChange: (value: string) => void;
+  tier1: string;
+  onTier1Change: (value: string) => void;
+  tier2: string;
+  onTier2Change: (value: string) => void;
+  batch: string;
+  onBatchChange: (value: string) => void;
+  onRun: () => void;
+  canRun: boolean;
+  isRunning: boolean;
+}): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="memory-router-playground-query"
+            className="text-label-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            Query
+          </label>
+          <textarea
+            id="memory-router-playground-query"
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            rows={3}
+            placeholder="e.g. what should we ship next"
+            className="rounded-md border px-3 py-2 text-body-medium-default"
+            style={{
+              borderColor: "var(--border-base)",
+              background: "var(--surface-base)",
+              color: "var(--content-default)",
+              resize: "vertical",
+            }}
+          />
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <OverrideInput
+            label="tier1_size"
+            value={tier1}
+            onChange={onTier1Change}
+          />
+          <OverrideInput
+            label="tier2_size"
+            value={tier2}
+            onChange={onTier2Change}
+          />
+          <OverrideInput
+            label="batch_size"
+            value={batch}
+            onChange={onBatchChange}
+          />
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={!canRun}
+            className="rounded-md px-4 py-2 text-body-medium-default transition-colors"
+            style={{
+              background: canRun
+                ? "var(--system-positive-strong)"
+                : "var(--surface-overlay)",
+              color: canRun
+                ? "var(--content-on-positive)"
+                : "var(--content-disabled)",
+              border: "none",
+              cursor: canRun ? "pointer" : "not-allowed",
+            }}
+          >
+            {isRunning ? "Running…" : "Run simulation"}
+          </button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function OverrideInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor={`memory-router-playground-${label}`}
+        className="text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {label}
+      </label>
+      <input
+        id={`memory-router-playground-${label}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="inherit"
+        className="rounded-md border px-3 py-2 text-body-medium-default"
+        style={{
+          borderColor: "var(--border-base)",
+          background: "var(--surface-base)",
+          color: "var(--content-default)",
+        }}
+      />
+    </div>
+  );
+}
+
+function ResultPanel({
+  result,
+  query,
+}: {
+  result: MemoryRouterSimulateResponse;
+  query: string;
+}): ReactNode {
+  const groups = groupSlugsBySource(result);
+  return (
+    <div className="flex flex-col gap-4">
+      <SummaryCard result={result} query={query} />
+      <ConfigCard result={result} />
+      {result.failureReason !== null && (
+        <ErrorBanner message={`Router failure: ${result.failureReason}`} />
+      )}
+      {groups.length === 0 ? (
+        <EmptyResultCard />
+      ) : (
+        groups.map((group) => (
+          <TierSectionCard
+            key={group.source}
+            source={group.source}
+            slugs={group.slugs}
+            scores={result.scores}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  result,
+  query,
+}: {
+  result: MemoryRouterSimulateResponse;
+  query: string;
+}): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          Summary
+        </span>
+        <MetaGrid
+          rows={[
+            { label: "Query", value: query },
+            {
+              label: "Total candidate pages",
+              value: result.totalCandidatePages.toLocaleString(),
+            },
+            {
+              label: "Selected",
+              value: `${result.selectedSlugs.length} / ${result.effectiveConfig.max_page_ids}`,
+            },
+          ]}
+        />
+      </div>
+    </Card>
+  );
+}
+
+function ConfigCard({
+  result,
+}: {
+  result: MemoryRouterSimulateResponse;
+}): ReactNode {
+  const knobs: Array<keyof MemoryRouterSimulateResponse["effectiveConfig"]> = [
+    "tier1_size",
+    "tier2_size",
+    "batch_size",
+    "max_page_ids",
+  ];
+  const rows = knobs.map((key) => {
+    const eff = result.effectiveConfig[key];
+    const overrideValue = (result.overrides as Record<
+      string,
+      number | null | undefined
+    >)[key];
+    const effStr = eff === null ? "null" : String(eff);
+    const suffix = overrideValue !== undefined ? "  (override)" : "";
+    return { label: key, value: `${effStr}${suffix}` };
+  });
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          Effective config
+        </span>
+        <MetaGrid rows={rows} />
+      </div>
+    </Card>
+  );
+}
+
+interface SourceGroup {
+  source: RouterSource;
+  slugs: string[];
+}
+
+function groupSlugsBySource(
+  result: MemoryRouterSimulateResponse
+): SourceGroup[] {
+  const byKey = new Map<RouterSource, string[]>();
+  for (const slug of result.selectedSlugs) {
+    const source = result.sourceBySlug[slug];
+    if (source === undefined) continue;
+    const bucket = byKey.get(source) ?? [];
+    bucket.push(slug);
+    byKey.set(source, bucket);
+  }
+  const sorted = [...byKey.keys()].sort(
+    (a, b) => sourceOrder(a) - sourceOrder(b)
+  );
+  return sorted.map((source) => ({
+    source,
+    slugs: byKey.get(source)!,
+  }));
+}
+
+function sourceOrder(source: RouterSource): number {
+  if (source === "tier1") return 0;
+  if (source === "tier2") return 1;
+  if (source.startsWith("tier3:")) {
+    return 2 + Number(source.slice("tier3:".length));
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function formatSourceLabel(source: RouterSource): string {
+  if (source === "tier1") return "tier 1";
+  if (source === "tier2") return "tier 2";
+  if (source.startsWith("tier3:")) {
+    return `tier 3 · b${source.slice("tier3:".length)}`;
+  }
+  return source;
+}
+
+function TierSectionCard({
+  source,
+  slugs,
+  scores,
+}: {
+  source: RouterSource;
+  slugs: string[];
+  scores: Record<string, number>;
+}): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-baseline justify-between">
+          <span
+            className="text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {formatSourceLabel(source)}
+          </span>
+          <span
+            className="text-label-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {slugs.length} {slugs.length === 1 ? "page" : "pages"}
+          </span>
+        </div>
+        <ul className="flex flex-col gap-1">
+          {slugs.map((slug) => (
+            <li
+              key={slug}
+              className="flex items-baseline justify-between gap-3"
+            >
+              <code
+                className="text-body-medium-default"
+                style={{ color: "var(--content-default)" }}
+              >
+                {slug}
+              </code>
+              {source === "tier2" && (
+                <span
+                  className="tabular-nums text-label-default"
+                  style={{ color: "var(--content-secondary)" }}
+                >
+                  EMA {(scores[slug] ?? 0).toFixed(3)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Card>
+  );
+}
+
+function EmptyResultCard(): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-2 p-4">
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          No pages selected
+        </span>
+        <span
+          className="text-label-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          The router returned an empty selection. Try a more specific query, or
+          relax the override values.
+        </span>
+      </div>
+    </Card>
+  );
+}
+
+function MetaGrid({
+  rows,
+}: {
+  rows: { label: string; value: string }[];
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map(({ label, value }) => (
+        <div key={label} className="flex items-baseline justify-between gap-3">
+          <span
+            className="shrink-0 text-label-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {label}
+          </span>
+          <span
+            className="text-right text-body-medium-lighter"
+            style={{ color: "var(--content-default)" }}
+          >
+            {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }): ReactNode {
+  return (
+    <div
+      className="rounded-md px-4 py-3 text-body-medium-default"
+      style={{
+        background: "var(--surface-overlay)",
+        color: "var(--system-negative-strong)",
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+function CenteredMessage({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center p-8 text-label-default"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -1,0 +1,99 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { client } from "@/generated/api/client.gen.js";
+
+/**
+ * Client for the daemon's read-only memory-router simulator endpoint.
+ *
+ * Mirrors the daemon route at `POST /v1/memory/v2/simulate-router`
+ * (operationId `memory_v2_simulate_router`), reached through the platform's
+ * runtime proxy at `/v1/assistants/{assistantId}/memory/v2/simulate-router/`.
+ * Not in the generated OpenAPI client (the wildcard proxy isn't typed), so
+ * we call `client.post` directly and carry the response shape locally.
+ */
+
+export type RouterSource = "tier1" | "tier2" | `tier3:${number}`;
+
+export interface MemoryRouterSimulateRequest {
+  query: string;
+  configOverrides?: {
+    tier1_size?: number | null;
+    tier2_size?: number | null;
+    batch_size?: number | null;
+  };
+}
+
+export interface MemoryRouterSimulateEffectiveConfig {
+  tier1_size: number | null;
+  tier2_size: number | null;
+  batch_size: number | null;
+  max_page_ids: number;
+}
+
+export interface MemoryRouterSimulateResponse {
+  selectedSlugs: string[];
+  sourceBySlug: Record<string, RouterSource>;
+  scores: Record<string, number>;
+  failureReason: string | null;
+  effectiveConfig: MemoryRouterSimulateEffectiveConfig;
+  overrides: {
+    tier1_size?: number | null;
+    tier2_size?: number | null;
+    batch_size?: number | null;
+  };
+  totalCandidatePages: number;
+}
+
+export class SimulateMemoryRouterError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "SimulateMemoryRouterError";
+    this.status = status;
+  }
+}
+
+export async function simulateMemoryRouter(
+  assistantId: string,
+  request: MemoryRouterSimulateRequest,
+  signal?: AbortSignal
+): Promise<MemoryRouterSimulateResponse> {
+  const { data, response } = await client.post<MemoryRouterSimulateResponse>({
+    url: "/v1/assistants/{assistant_id}/memory/v2/simulate-router/",
+    path: { assistant_id: assistantId },
+    body: request,
+    signal,
+    throwOnError: false,
+  });
+  if (!response || !response.ok) {
+    const text = await response
+      ?.clone()
+      .text()
+      .catch(() => "");
+    throw new SimulateMemoryRouterError(
+      response?.status ?? 0,
+      text || response?.statusText || "Failed to simulate memory router"
+    );
+  }
+  if (!data) {
+    throw new SimulateMemoryRouterError(
+      response.status,
+      "Empty response from memory router simulator endpoint"
+    );
+  }
+  return data;
+}
+
+export function useSimulateMemoryRouter(assistantId: string | undefined) {
+  return useMutation({
+    mutationFn: async (
+      request: MemoryRouterSimulateRequest
+    ): Promise<MemoryRouterSimulateResponse> => {
+      if (!assistantId) {
+        throw new SimulateMemoryRouterError(0, "Missing assistantId");
+      }
+      return simulateMemoryRouter(assistantId, request);
+    },
+  });
+}

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -424,6 +424,14 @@
       "label": "Velvet",
       "description": "Enable the Velvet design theme.",
       "defaultEnabled": false
+    },
+    {
+      "id": "memory-router-playground",
+      "scope": "client",
+      "key": "memory-router-playground",
+      "label": "Memory Router Playground",
+      "description": "Expose the developer-only Memory Router Playground page at /assistant/memory-router-playground for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,4 +1,9 @@
-import { createBrowserRouter, Navigate, useNavigate, useSearchParams } from "react-router";
+import {
+  createBrowserRouter,
+  Navigate,
+  useNavigate,
+  useSearchParams,
+} from "react-router";
 
 import { authMiddleware } from "@/lib/auth/auth-middleware.js";
 import { RootLayout } from "@/root-layout.js";
@@ -15,6 +20,7 @@ import { ConnectPage } from "@/domains/contacts/connect-page.js";
 import { ContactsPage } from "@/domains/contacts/contacts-page.js";
 import { WorkspacePage } from "@/domains/workspace/workspace-page.js";
 import { InspectPage } from "@/domains/chat/inspector/inspect-page.js";
+import { MemoryRouterPlaygroundPage } from "@/domains/chat/inspector/memory-router-playground-page.js";
 import { NotFound } from "@/components/not-found.js";
 import { SettingsLayout } from "@/domains/settings/settings-layout.js";
 import { GeneralPage } from "@/domains/settings/pages/general-page.js";
@@ -70,7 +76,12 @@ function ConversationKeyRedirect() {
     const remaining = new URLSearchParams(searchParams);
     remaining.delete("conversationKey");
     const qs = remaining.toString();
-    return <Navigate to={`${routes.conversation(conversationKey)}${qs ? `?${qs}` : ""}`} replace />;
+    return (
+      <Navigate
+        to={`${routes.conversation(conversationKey)}${qs ? `?${qs}` : ""}`}
+        replace
+      />
+    );
   }
   return <ChatPage />;
 }
@@ -99,125 +110,138 @@ function HomePageRoute() {
 // References:
 // - React Router data mode routing: https://reactrouter.com/start/data/routing
 // - React Router middleware: https://reactrouter.com/how-to/middleware
-export const router = createBrowserRouter([
-  // Account routes — standalone auth pages, no app chrome
+export const router = createBrowserRouter(
+  [
+    // Account routes — standalone auth pages, no app chrome
+    {
+      path: "/account",
+      children: [
+        { index: true, element: <AccountPage /> },
+        { path: "login", element: <LoginPage /> },
+        { path: "signup", element: <SignupPage /> },
+        { path: "provider/callback", element: <ProviderCallbackPage /> },
+        { path: "provider/signup", element: <ProviderSignupPage /> },
+        { path: "oauth/popup-complete", element: <OAuthPopupCompletePage /> },
+        {
+          path: "oauth/desktop-complete",
+          element: <DesktopOAuthCompletePage />,
+        },
+        { path: "password/reset", element: <PasswordResetPage /> },
+        { path: "password/reset/key/:key", element: <PasswordResetPage /> },
+      ],
+    },
+
+    // Logout — standalone page, no app chrome
+    { path: "/logout", element: <LogoutPage /> },
+
+    // Assistant routes — auth-protected app with layout
+    {
+      path: "/assistant",
+      middleware: [authMiddleware],
+      element: <RootLayout />,
+      children: [
+        // Onboarding routes — full-screen (no ChatLayout sidebar)
+        { path: "onboarding/privacy", element: <PrivacyScreen /> },
+        { path: "onboarding/prechat", element: <PreChatFlow /> },
+        { path: "onboarding/hatching", element: <HatchingScreen /> },
+
+        // Settings routes — full-screen overlay panel (no ChatLayout sidebar).
+        // SettingsShell provides its own layout with back-arrow, sidebar nav,
+        // and content area — the main app sidebar is intentionally hidden.
+        {
+          path: "settings",
+          element: <SettingsLayout />,
+          children: [
+            { index: true, element: <GeneralPage /> },
+            { path: "general", element: <GeneralPage /> },
+            { path: "ai", element: <AiPage /> },
+            { path: "integrations", element: <IntegrationsPage /> },
+            { path: "schedules", element: <SchedulesPage /> },
+            { path: "notifications", element: <NotificationsPage /> },
+            { path: "sounds", element: <SoundsPage /> },
+            { path: "voice", element: <VoicePage /> },
+            { path: "devices", element: <DevicesPage /> },
+            { path: "privacy", element: <PrivacyPage /> },
+            { path: "archive", element: <ArchivePage /> },
+            { path: "billing", element: <BillingPage /> },
+            { path: "billing/onboarding", element: <BillingOnboardingPage /> },
+            { path: "billing/upgrade/cancel", element: <UpgradeCancelPage /> },
+            {
+              path: "billing/upgrade/success",
+              element: <UpgradeSuccessPage />,
+            },
+            { path: "community", element: <CommunityPage /> },
+            { path: "debug", element: <DebugPage /> },
+            { path: "developer", element: <DeveloperPage /> },
+            { path: "advanced", element: <AdvancedPage /> },
+            { path: "danger-zone", element: <DangerZoneRedirectPage /> },
+            { path: "system-events", element: <SystemEventsRedirectPage /> },
+          ],
+        },
+
+        // Logs routes — full-screen overlay panel (like SettingsLayout).
+        // LogsLayout reuses SettingsShell for visual consistency.
+        {
+          path: "logs",
+          element: <LogsLayout />,
+          children: [
+            { index: true, element: <UsagePage /> },
+            { path: "trace", element: <TracePage /> },
+            { path: "usage", element: <UsagePage /> },
+            { path: "system-events", element: <SystemEventsPage /> },
+            { path: "emails", element: <EmailsPage /> },
+          ],
+        },
+
+        {
+          element: <ChatLayout />,
+          children: [
+            // ChatPage / DocumentViewerPage own their own lifecycle UI
+            // (loading screens, hatching, version-selection, errors) and
+            // must render in every assistant state — they are NOT placed
+            // under <ActiveAssistantGate>.
+            { index: true, element: <ConversationKeyRedirect /> },
+            { path: "conversations/:conversationKey", element: <ChatPage /> },
+            { path: "documents/:surfaceId", element: <DocumentViewerPage /> },
+            // Everything below requires a resolved assistantId AND an
+            // active daemon. The gate defers child rendering until the
+            // lifecycle resolves so route components can rely on a
+            // non-null assistantId via useActiveAssistantContext().
+            {
+              element: <ActiveAssistantGate />,
+              children: [
+                { path: "home", element: <HomePageRoute /> },
+                {
+                  element: <IntelligenceLayout />,
+                  children: [
+                    { path: "identity", element: <IdentityPage /> },
+                    { path: "skills", element: <SkillsPage /> },
+                    { path: "library", element: <LibraryPage /> },
+                    { path: "workspace", element: <WorkspacePage /> },
+                    { path: "contacts", element: <ContactsPage /> },
+                  ],
+                },
+                { path: "library/:appId", element: <LibraryDetailPage /> },
+                { path: "connect", element: <ConnectPage /> },
+                { path: "inspect", element: <InspectPage /> },
+                {
+                  path: "memory-router-playground",
+                  element: <MemoryRouterPlaygroundPage />,
+                },
+              ],
+            },
+          ],
+        },
+
+        // Catch-all within /assistant/*
+        { path: "*", element: <NotFound /> },
+      ],
+    },
+
+    // Top-level catch-all
+    { path: "*", element: <NotFound /> },
+  ],
   {
-    path: "/account",
-    children: [
-      { index: true, element: <AccountPage /> },
-      { path: "login", element: <LoginPage /> },
-      { path: "signup", element: <SignupPage /> },
-      { path: "provider/callback", element: <ProviderCallbackPage /> },
-      { path: "provider/signup", element: <ProviderSignupPage /> },
-      { path: "oauth/popup-complete", element: <OAuthPopupCompletePage /> },
-      { path: "oauth/desktop-complete", element: <DesktopOAuthCompletePage /> },
-      { path: "password/reset", element: <PasswordResetPage /> },
-      { path: "password/reset/key/:key", element: <PasswordResetPage /> },
-    ],
-  },
-
-  // Logout — standalone page, no app chrome
-  { path: "/logout", element: <LogoutPage /> },
-
-  // Assistant routes — auth-protected app with layout
-  {
-    path: "/assistant",
-    middleware: [authMiddleware],
-    element: <RootLayout />,
-    children: [
-      // Onboarding routes — full-screen (no ChatLayout sidebar)
-      { path: "onboarding/privacy", element: <PrivacyScreen /> },
-      { path: "onboarding/prechat", element: <PreChatFlow /> },
-      { path: "onboarding/hatching", element: <HatchingScreen /> },
-
-      // Settings routes — full-screen overlay panel (no ChatLayout sidebar).
-      // SettingsShell provides its own layout with back-arrow, sidebar nav,
-      // and content area — the main app sidebar is intentionally hidden.
-      {
-        path: "settings",
-        element: <SettingsLayout />,
-        children: [
-          { index: true, element: <GeneralPage /> },
-          { path: "general", element: <GeneralPage /> },
-          { path: "ai", element: <AiPage /> },
-          { path: "integrations", element: <IntegrationsPage /> },
-          { path: "schedules", element: <SchedulesPage /> },
-          { path: "notifications", element: <NotificationsPage /> },
-          { path: "sounds", element: <SoundsPage /> },
-          { path: "voice", element: <VoicePage /> },
-          { path: "devices", element: <DevicesPage /> },
-          { path: "privacy", element: <PrivacyPage /> },
-          { path: "archive", element: <ArchivePage /> },
-          { path: "billing", element: <BillingPage /> },
-          { path: "billing/onboarding", element: <BillingOnboardingPage /> },
-          { path: "billing/upgrade/cancel", element: <UpgradeCancelPage /> },
-          { path: "billing/upgrade/success", element: <UpgradeSuccessPage /> },
-          { path: "community", element: <CommunityPage /> },
-          { path: "debug", element: <DebugPage /> },
-          { path: "developer", element: <DeveloperPage /> },
-          { path: "advanced", element: <AdvancedPage /> },
-          { path: "danger-zone", element: <DangerZoneRedirectPage /> },
-          { path: "system-events", element: <SystemEventsRedirectPage /> },
-        ],
-      },
-
-      // Logs routes — full-screen overlay panel (like SettingsLayout).
-      // LogsLayout reuses SettingsShell for visual consistency.
-      {
-        path: "logs",
-        element: <LogsLayout />,
-        children: [
-          { index: true, element: <UsagePage /> },
-          { path: "trace", element: <TracePage /> },
-          { path: "usage", element: <UsagePage /> },
-          { path: "system-events", element: <SystemEventsPage /> },
-          { path: "emails", element: <EmailsPage /> },
-        ],
-      },
-
-      {
-        element: <ChatLayout />,
-        children: [
-          // ChatPage / DocumentViewerPage own their own lifecycle UI
-          // (loading screens, hatching, version-selection, errors) and
-          // must render in every assistant state — they are NOT placed
-          // under <ActiveAssistantGate>.
-          { index: true, element: <ConversationKeyRedirect /> },
-          { path: "conversations/:conversationKey", element: <ChatPage /> },
-          { path: "documents/:surfaceId", element: <DocumentViewerPage /> },
-          // Everything below requires a resolved assistantId AND an
-          // active daemon. The gate defers child rendering until the
-          // lifecycle resolves so route components can rely on a
-          // non-null assistantId via useActiveAssistantContext().
-          {
-            element: <ActiveAssistantGate />,
-            children: [
-              { path: "home", element: <HomePageRoute /> },
-              {
-                element: <IntelligenceLayout />,
-                children: [
-                  { path: "identity", element: <IdentityPage /> },
-                  { path: "skills", element: <SkillsPage /> },
-                  { path: "library", element: <LibraryPage /> },
-                  { path: "workspace", element: <WorkspacePage /> },
-                  { path: "contacts", element: <ContactsPage /> },
-                ],
-              },
-              { path: "library/:appId", element: <LibraryDetailPage /> },
-              { path: "connect", element: <ConnectPage /> },
-              { path: "inspect", element: <InspectPage /> },
-            ],
-          },
-        ],
-      },
-
-      // Catch-all within /assistant/*
-      { path: "*", element: <NotFound /> },
-    ],
-  },
-
-  // Top-level catch-all
-  { path: "*", element: <NotFound /> },
-], {
-  future: { v8_middleware: true },
-});
+    future: { v8_middleware: true },
+  }
+);


### PR DESCRIPTION
## Summary

- New page at `/assistant/memory-router-playground` for dry-running the v4 router with custom `tier1_size` / `tier2_size` / `batch_size` overrides.
- Visual style mirrors the existing inspector memory tab — query input, three override fields, grouped tier output with EMA scores for tier 2 picks.
- Gated by the same staff check as `/inspect` plus a new `memory-router-playground` client feature flag (default off).
- Calls the daemon's read-only `memory_v2_simulate_router` route via the platform proxy. No nav link — direct URL only.

## Why

The CLI command works but a UI lets us iterate faster on config knob changes — paste a query, tweak overrides, see the grouped result, repeat. Same playground-first principle: never tune the live router by feel.

## Test plan

- [x] `bunx tsc --noEmit` clean for the new files (apps/web has pre-existing design-library errors unrelated to this PR)
- [x] `bunx eslint --fix` clean
- [x] `bunx prettier --check` clean
- [ ] Smoke after merge: enable the `memoryRouterPlayground` localStorage flag, navigate to `/assistant/memory-router-playground`, run a sample query with overrides, confirm row counts for `memory_v2_injection_events` + `memory_v2_activation_logs` unchanged pre/post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)