### PR TITLE
Keep Slack-visible context for trusted contacts

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3041,10 +3041,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   });
 
   // ── trust-filter regression for loadSlackChronologicalMessages ───────
-  // For untrusted actors, guardian-scoped rows must be excluded
-  // from the chronological transcript the same way `loadFromDb` filters
-  // them out of the default history.
-  test("loadSlackChronologicalMessages filters guardian-scoped rows for untrusted actors", () => {
+  // For untrusted actors, Slack-sourced rows are still shared channel/thread
+  // context, while non-Slack guardian-scoped rows remain private.
+  test("loadSlackChronologicalMessages keeps Slack-visible guardian rows for untrusted actors", () => {
     const caps: ChannelCapabilities = {
       channel: "slack",
       dashboardCapable: false,
@@ -3052,14 +3051,15 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       supportsVoiceInput: false,
       chatType: "channel",
     };
-    // Row 1 has no provenance → guardian-scoped (filtered out).
-    // Row 2 has provenance.trustClass === "trusted_contact" (kept).
     const rows: MessageRow[] = [
       userRow({
         id: "m1",
         createdAt: 1700000000_000,
-        text: "guardian-only context",
+        text: "public guardian instruction",
         slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+        extraOuterMetadata: {
+          provenanceTrustClass: "guardian",
+        },
       }),
       userRow({
         id: "m2",
@@ -3068,6 +3068,14 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         slackMeta: buildSlackMeta({ channelTs: T1, displayName: "bob" }),
         extraOuterMetadata: {
           provenanceTrustClass: "trusted_contact",
+        },
+      }),
+      userRow({
+        id: "m3",
+        createdAt: 1700000020_000,
+        text: "private guardian-only context",
+        extraOuterMetadata: {
+          provenanceTrustClass: "guardian",
         },
       }),
     ];
@@ -3081,8 +3089,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
       .map((b) => b.text)
       .join("\n");
-    expect(allText).not.toContain("guardian-only context");
+    expect(allText).toContain("public guardian instruction");
     expect(allText).toContain("from untrusted actor");
+    expect(allText).not.toContain("private guardian-only context");
   });
 
   test("loadSlackChronologicalContext preserves summary and filters by Slack watermark", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -20,7 +20,10 @@ import {
   extractMemoryPrefixBlocks,
 } from "../memory/graph/conversation-graph-memory.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
-import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import {
+  readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
 import {
   compareSlackTs,
   extractTagLineTexts,
@@ -1110,6 +1113,27 @@ function messageRowsToSlackTranscriptRows(
   }));
 }
 
+function hasSlackMetadata(row: MessageRow): boolean {
+  return (
+    readSlackMetadataFromMessageMetadata(row.metadata, {
+      allowFlatLegacy: true,
+    }) !== null
+  );
+}
+
+function filterSlackConversationRowsForActor(
+  rows: MessageRow[],
+  trustClass: TrustClass | undefined,
+): MessageRow[] {
+  if (!isUntrustedTrustClass(trustClass)) return rows;
+  const nonSlackVisibleRows = filterMessagesForUntrustedActor(rows);
+  const nonSlackVisibleIds = new Set(nonSlackVisibleRows.map((row) => row.id));
+  return rows.filter((row) => {
+    if (hasSlackMetadata(row)) return true;
+    return nonSlackVisibleIds.has(row.id);
+  });
+}
+
 /**
  * Extract the user-facing plain text from an already-parsed `ContentBlock[]`.
  * Only `text` blocks contribute to the rendered transcript line. Tool-use /
@@ -1391,11 +1415,10 @@ function assembleSlackChronologicalContext(
  * Compatibility wrapper over `loadSlackChronologicalContext` for callers that
  * still need only the legacy `Message[] | null` projection.
  *
- * When `trustClass` identifies an untrusted actor (guardian-scoped rows
- * must not leak into the model context), rows are passed through
- * `filterMessagesForUntrustedActor` before assembly — mirroring the
- * filtering applied in `loadFromDb` so the chronological transcript
- * respects the same per-actor scoping as the default history path.
+ * When `trustClass` identifies an untrusted actor, non-Slack/private rows
+ * are passed through the default trust filter. Slack-tagged rows stay visible
+ * because the transcript is scoped to the external Slack chat/thread, which
+ * the inbound actor can already read in Slack.
  *
  * Returns `null` when the channel is not Slack — callers should fall
  * through to the default in-memory message history.
@@ -1444,9 +1467,10 @@ export function loadSlackChronologicalContext(
   }
   const loader = options.loader ?? defaultGetMessages;
   const allRows = loader(conversationId);
-  const scopedRows = isUntrustedTrustClass(options.trustClass)
-    ? filterMessagesForUntrustedActor(allRows)
-    : allRows;
+  const scopedRows = filterSlackConversationRowsForActor(
+    allRows,
+    options.trustClass,
+  );
   const rows = filterRowsAfterSlackCompactionBoundary(
     messageRowsToSlackTranscriptRows(scopedRows),
     options,
@@ -1630,9 +1654,10 @@ export function loadSlackActiveThreadFocusBlock(
   if (capabilities.chatType !== "channel") return null;
   const loader = options.loader ?? defaultGetMessages;
   const allRows = loader(conversationId);
-  const scopedRows = isUntrustedTrustClass(options.trustClass)
-    ? filterMessagesForUntrustedActor(allRows)
-    : allRows;
+  const scopedRows = filterSlackConversationRowsForActor(
+    allRows,
+    options.trustClass,
+  );
   const rows = filterRowsAfterSlackCompactionBoundary(
     messageRowsToSlackTranscriptRows(scopedRows),
     options,


### PR DESCRIPTION
## Summary
- Keep Slack-tagged conversation rows visible when assembling Slack chronological and active-thread context for trusted-contact/unknown actors.
- Continue applying the untrusted-actor filter to non-Slack/private rows so guardian-only context does not leak.
- Update the Slack chronological regression test to cover public Slack guardian rows plus private non-Slack guardian rows.

## Tests
- `cd assistant && bun test src/__tests__/conversation-runtime-assembly.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-push hook: assistant typecheck and lint passed
