### PR TITLE
Deliver Slack DM assistant text before tool calls

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -8,6 +8,7 @@ const markedProcessedEvents: string[] = [];
 const processingFailureEvents: string[] = [];
 const deliveredEvents: string[] = [];
 const deliveryFailureEvents: string[] = [];
+const deliveredSegmentCounts: Array<{ eventId: string; count: number }> = [];
 const storedReplyMessageIds: Array<{
   eventId: string;
   replyMessageId: string;
@@ -25,7 +26,9 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 mock.module("../../../memory/delivery-channels.js", () => ({
-  updateDeliveredSegmentCount: () => {},
+  updateDeliveredSegmentCount: (eventId: string, count: number) => {
+    deliveredSegmentCounts.push({ eventId, count });
+  },
 }));
 
 mock.module("../../../memory/delivery-crud.js", () => ({
@@ -88,6 +91,7 @@ beforeEach(() => {
   processingFailureEvents.length = 0;
   deliveredEvents.length = 0;
   deliveryFailureEvents.length = 0;
+  deliveredSegmentCounts.length = 0;
   storedReplyMessageIds.length = 0;
   replyDeliveryCalls.length = 0;
   deliverReplyViaCallbackImpl = async () => {};
@@ -303,10 +307,173 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 
     clearThreadTs(conversationId);
   });
+
+  test("delivers Slack DM assistant text before tools as it becomes ready", async () => {
+    const conversationId = "conv-dm-incremental-text";
+    const channelId = "D-INCREMENTAL";
+    deliverReplyViaCallbackImpl = async (...args: unknown[]) => {
+      const options = args[4] as
+        | { onSegmentDelivered?: (count: number) => void }
+        | undefined;
+      options?.onSegmentDelivered?.(1);
+    };
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<no_response/>\nFirst response before the tool.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "assistant_thinking_delta",
+        thinking: "private reasoning",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+
+      await flush();
+      expect(
+        deliveredChannelReplies
+          .map((entry) => entry.payload.text)
+          .filter(Boolean),
+      ).toEqual(["First response before the tool."]);
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Final response after the tool.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-final",
+      });
+      return { messageId: "user-msg-incremental" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-incremental-text",
+      content: "please look this up",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["First response before the tool."]);
+    expect(
+      deliveredChannelReplies.every((entry) => !entry.payload.thinking),
+    ).toBe(true);
+    expect(replyDeliveryCalls).toEqual([{ messageId: "assistant-msg-final" }]);
+    expect(deliveredSegmentCounts).toEqual([
+      { eventId: "evt-incremental-text", count: 1 },
+      { eventId: "evt-incremental-text", count: 2 },
+    ]);
+    expect(storedReplyMessageIds).toEqual([
+      {
+        eventId: "evt-incremental-text",
+        replyMessageId: "assistant-msg-final",
+      },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-incremental-text"]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("keeps Slack channel replies on the existing final delivery path", async () => {
+    const conversationId = "conv-channel-final-delivery";
+    const channelId = "C-FINAL-DELIVERY";
+    const threadTs = "1700000000.000022";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Intermediate text.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Final text.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-channel-final",
+      });
+      return { messageId: "user-msg-channel" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-channel-final-delivery",
+      content: "channel request",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "channel",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual([]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: "assistant-msg-channel-final" },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-channel-final-delivery"]);
+
+    clearThreadTs(conversationId);
+  });
 });
 
 describe("Slack thinking status timing", () => {
-  const slackStatusLabels = ["is on it", "is working hard", "is touching grass"];
+  const slackStatusLabels = [
+    "is on it",
+    "is working hard",
+    "is touching grass",
+  ];
 
   const trustCtx: TrustContext = {
     trustClass: "guardian",

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -14,6 +14,10 @@ const storedReplyMessageIds: Array<{
   replyMessageId: string;
 }> = [];
 const replyDeliveryCalls: Array<{ messageId?: string }> = [];
+let deliverChannelReplyImpl: (
+  callbackUrl: string,
+  payload: Record<string, unknown>,
+) => Promise<Record<string, unknown>> = async () => ({ ok: true });
 let deliverReplyViaCallbackImpl: (
   ...args: unknown[]
 ) => Promise<void> = async () => {};
@@ -59,7 +63,7 @@ mock.module("../../gateway-client.js", () => ({
     payload: Record<string, unknown>,
   ) => {
     deliveredChannelReplies.push({ callbackUrl, payload });
-    return { ok: true };
+    return deliverChannelReplyImpl(callbackUrl, payload);
   },
 }));
 
@@ -94,6 +98,7 @@ beforeEach(() => {
   deliveredSegmentCounts.length = 0;
   storedReplyMessageIds.length = 0;
   replyDeliveryCalls.length = 0;
+  deliverChannelReplyImpl = async () => ({ ok: true });
   deliverReplyViaCallbackImpl = async () => {};
 });
 
@@ -389,7 +394,6 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     expect(replyDeliveryCalls).toEqual([{ messageId: "assistant-msg-final" }]);
     expect(deliveredSegmentCounts).toEqual([
       { eventId: "evt-incremental-text", count: 1 },
-      { eventId: "evt-incremental-text", count: 2 },
     ]);
     expect(storedReplyMessageIds).toEqual([
       {
@@ -463,6 +467,95 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
       { messageId: "assistant-msg-channel-final" },
     ]);
     expect(deliveredEvents).toEqual(["evt-channel-final-delivery"]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("continues later Slack DM text sends after an intermediate delivery failure", async () => {
+    const conversationId = "conv-dm-live-failure-recovery";
+    const channelId = "D-LIVE-FAILURE-RECOVERY";
+    let liveAttempt = 0;
+    deliverChannelReplyImpl = async () => {
+      liveAttempt += 1;
+      if (liveAttempt === 1) throw new Error("temporary slack failure");
+      return { ok: true };
+    };
+    deliverReplyViaCallbackImpl = async (...args: unknown[]) => {
+      const options = args[4] as
+        | { onSegmentDelivered?: (count: number) => void }
+        | undefined;
+      options?.onSegmentDelivered?.(1);
+    };
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "First live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "one" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      await flush();
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Second live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "two" },
+        conversationId,
+        toolUseId: "toolu_2",
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-live-failure-final",
+      });
+      return { messageId: "user-msg-live-failure" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-live-failure-recovery",
+      content: "please do two things",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["First live response.", "Second live response."]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: "assistant-msg-live-failure-final" },
+    ]);
+    expect(deliveryFailureEvents).toEqual([]);
+    expect(deliveredEvents).toEqual(["evt-live-failure-recovery"]);
+    expect(deliveredSegmentCounts).toEqual([
+      { eventId: "evt-live-failure-recovery", count: 1 },
+    ]);
 
     clearThreadTs(conversationId);
   });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -231,8 +231,6 @@ export function processChannelMessageInBackground(
         replyCallbackUrl,
         chatId: externalChatId,
         assistantId,
-        onSegmentDelivered: (count) =>
-          updateDeliveredSegmentCount(eventId, count),
       });
       const observeAgentEvent = (msg: ServerMessage): void => {
         if (
@@ -309,11 +307,8 @@ export function processChannelMessageInBackground(
 
       if (replyCallbackUrl) {
         try {
-          let liveSlackDmSegmentCount = 0;
           if (slackDmTextDelivery) {
             await slackDmTextDelivery.waitForPendingDeliveries();
-            liveSlackDmSegmentCount =
-              slackDmTextDelivery.getDeliveredSegmentCount();
           }
 
           await deliverReplyViaCallback(
@@ -325,10 +320,7 @@ export function processChannelMessageInBackground(
               messageId: replyMessageId,
               sinceMessageId: userMessageId,
               onSegmentDelivered: (count) =>
-                updateDeliveredSegmentCount(
-                  eventId,
-                  liveSlackDmSegmentCount + count,
-                ),
+                updateDeliveredSegmentCount(eventId, count),
             },
           );
           markDeliveryDelivered(eventId);
@@ -460,7 +452,6 @@ export function shouldDeliverSlackDmTextResponses(params: {
 type SlackDmTextDeliveryController = {
   observeEvent: (msg: ServerMessage) => void;
   waitForPendingDeliveries: () => Promise<void>;
-  getDeliveredSegmentCount: () => number;
 };
 
 function createSlackDmTextDeliveryController(params: {
@@ -469,7 +460,6 @@ function createSlackDmTextDeliveryController(params: {
   replyCallbackUrl?: string;
   chatId: string;
   assistantId?: string;
-  onSegmentDelivered?: (deliveredCount: number) => void;
 }): SlackDmTextDeliveryController | undefined {
   const { replyCallbackUrl } = params;
   if (!shouldDeliverSlackDmTextResponses(params) || !replyCallbackUrl) {
@@ -477,7 +467,6 @@ function createSlackDmTextDeliveryController(params: {
   }
 
   let pendingText = "";
-  let deliveredCount = 0;
   let deliveryChain = Promise.resolve();
 
   const flushPendingText = (): void => {
@@ -487,16 +476,23 @@ function createSlackDmTextDeliveryController(params: {
     const deliverableText = text.replace(NO_RESPONSE_INLINE_RE, "").trim();
     if (deliverableText.length === 0) return;
 
-    deliveryChain = deliveryChain.then(async () => {
-      await deliverChannelReply(replyCallbackUrl, {
-        chatId: params.chatId,
-        text: deliverableText,
-        assistantId: params.assistantId,
-        useBlocks: true,
+    deliveryChain = deliveryChain
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: params.chatId,
+            text: deliverableText,
+            assistantId: params.assistantId,
+            useBlocks: true,
+          });
+        } catch (err) {
+          log.warn(
+            { err, chatId: params.chatId },
+            "Failed to deliver intermediate Slack DM assistant text",
+          );
+        }
       });
-      deliveredCount += 1;
-      params.onSegmentDelivered?.(deliveredCount);
-    });
   };
 
   return {
@@ -511,7 +507,6 @@ function createSlackDmTextDeliveryController(params: {
       }
     },
     waitForPendingDeliveries: () => deliveryChain,
-    getDeliveredSegmentCount: () => deliveredCount,
   };
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -225,6 +225,15 @@ export function processChannelMessageInBackground(
             }
           : undefined;
       let replyMessageId: string | undefined;
+      const slackDmTextDelivery = createSlackDmTextDeliveryController({
+        sourceChannel,
+        chatType,
+        replyCallbackUrl,
+        chatId: externalChatId,
+        assistantId,
+        onSegmentDelivered: (count) =>
+          updateDeliveredSegmentCount(eventId, count),
+      });
       const observeAgentEvent = (msg: ServerMessage): void => {
         if (
           msg.type === "message_complete" &&
@@ -233,6 +242,7 @@ export function processChannelMessageInBackground(
         ) {
           replyMessageId = msg.messageId;
         }
+        slackDmTextDelivery?.observeEvent(msg);
         slackThinkingStatus?.observeEvent(msg);
       };
 
@@ -299,6 +309,13 @@ export function processChannelMessageInBackground(
 
       if (replyCallbackUrl) {
         try {
+          let liveSlackDmSegmentCount = 0;
+          if (slackDmTextDelivery) {
+            await slackDmTextDelivery.waitForPendingDeliveries();
+            liveSlackDmSegmentCount =
+              slackDmTextDelivery.getDeliveredSegmentCount();
+          }
+
           await deliverReplyViaCallback(
             conversationId,
             externalChatId,
@@ -308,7 +325,10 @@ export function processChannelMessageInBackground(
               messageId: replyMessageId,
               sinceMessageId: userMessageId,
               onSegmentDelivered: (count) =>
-                updateDeliveredSegmentCount(eventId, count),
+                updateDeliveredSegmentCount(
+                  eventId,
+                  liveSlackDmSegmentCount + count,
+                ),
             },
           );
           markDeliveryDelivered(eventId);
@@ -416,6 +436,85 @@ const NO_RESPONSE_SENTINEL_FORMS = [
   "<no_response>",
 ] as const;
 
+function isSlackDeliveryCallbackUrl(replyCallbackUrl?: string): boolean {
+  if (!replyCallbackUrl) return false;
+  try {
+    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/slack");
+  } catch {
+    return replyCallbackUrl.endsWith("/deliver/slack");
+  }
+}
+
+export function shouldDeliverSlackDmTextResponses(params: {
+  sourceChannel: ChannelId;
+  chatType?: string;
+  replyCallbackUrl?: string;
+}): boolean {
+  return (
+    params.sourceChannel === "slack" &&
+    params.chatType === "im" &&
+    isSlackDeliveryCallbackUrl(params.replyCallbackUrl)
+  );
+}
+
+type SlackDmTextDeliveryController = {
+  observeEvent: (msg: ServerMessage) => void;
+  waitForPendingDeliveries: () => Promise<void>;
+  getDeliveredSegmentCount: () => number;
+};
+
+function createSlackDmTextDeliveryController(params: {
+  sourceChannel: ChannelId;
+  chatType?: string;
+  replyCallbackUrl?: string;
+  chatId: string;
+  assistantId?: string;
+  onSegmentDelivered?: (deliveredCount: number) => void;
+}): SlackDmTextDeliveryController | undefined {
+  const { replyCallbackUrl } = params;
+  if (!shouldDeliverSlackDmTextResponses(params) || !replyCallbackUrl) {
+    return undefined;
+  }
+
+  let pendingText = "";
+  let deliveredCount = 0;
+  let deliveryChain = Promise.resolve();
+
+  const flushPendingText = (): void => {
+    const text = pendingText;
+    pendingText = "";
+
+    const deliverableText = text.replace(NO_RESPONSE_INLINE_RE, "").trim();
+    if (deliverableText.length === 0) return;
+
+    deliveryChain = deliveryChain.then(async () => {
+      await deliverChannelReply(replyCallbackUrl, {
+        chatId: params.chatId,
+        text: deliverableText,
+        assistantId: params.assistantId,
+        useBlocks: true,
+      });
+      deliveredCount += 1;
+      params.onSegmentDelivered?.(deliveredCount);
+    });
+  };
+
+  return {
+    observeEvent(msg) {
+      if (msg.type === "assistant_text_delta") {
+        pendingText += msg.text;
+        return;
+      }
+
+      if (msg.type === "tool_use_start") {
+        flushPendingText();
+      }
+    },
+    waitForPendingDeliveries: () => deliveryChain,
+    getDeliveredSegmentCount: () => deliveredCount,
+  };
+}
+
 function isPotentialNoResponsePrefix(text: string): boolean {
   const lower = text.toLowerCase();
   return NO_RESPONSE_SENTINEL_FORMS.some((sentinel) =>
@@ -436,12 +535,9 @@ function shouldEmitSlackThinkingStatus(
   sourceChannel: ChannelId,
   replyCallbackUrl?: string,
 ): boolean {
-  if (sourceChannel !== "slack" || !replyCallbackUrl) return false;
-  try {
-    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/slack");
-  } catch {
-    return replyCallbackUrl.endsWith("/deliver/slack");
-  }
+  return (
+    sourceChannel === "slack" && isSlackDeliveryCallbackUrl(replyCallbackUrl)
+  );
 }
 
 export function shouldStartSlackThinkingStatusImmediately(params: {


### PR DESCRIPTION
## Summary
Adds Slack-DM-only live delivery for completed assistant text before tool calls, so intermediate text responses are posted to the DM as soon as they are ready instead of being lost behind the final persisted reply.

The final assistant response still uses the existing persisted-row delivery path, preserving attachment handling, Slack timestamp reconciliation, and retry bookkeeping.

## Changes
- Adds a Slack DM text delivery controller in background dispatch.
- Buffers `assistant_text_delta` and flushes deliverable text at `tool_use_start` boundaries.
- Leaves Slack channels and other channel delivery on the existing final callback path.
- Tracks live-delivered segments so final persisted delivery reports cumulative segment counts.

## Issues
Part of #31648
Implements #31649

## Test plan
- `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts`
- `cd assistant && bunx tsc --noEmit`