### PR TITLE
[codex] Use assistant name for Slack attribution fallback

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -377,7 +377,7 @@ export interface ChatRouteContentProps {
 export function ChatRouteContent({
   assistantId,
   assistantState,
-  assistantIdentity: _assistantIdentity,
+  assistantIdentity,
   chatPullToRefreshEnabled,
   deployToVercel,
   doctor: doctorEnabled,
@@ -1051,6 +1051,7 @@ export function ChatRouteContent({
 
   const chatTranscriptProps: TranscriptProps = {
     items: transcriptItems,
+    assistantDisplayName: assistantIdentity?.name?.trim() || undefined,
     expandedToolCallIds: expandedToolCallIdsRef.current,
     onOpenRuleEditor: handleOpenRuleEditorForToolCall,
     onOpenApp: handleOpenApp,

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -24,6 +24,7 @@ import type { ConfirmationDecision } from "@/domains/chat/api/event-types.js";
 export interface LatestTurnRowProps {
   anchorMessage: MessageItem;
   responseItems: TranscriptItem[];
+  assistantDisplayName?: string | null;
   /** Current scroll container height — drives `minHeight`. Provided by the
    *  parent `Transcript` via `useViewportMinHeight`. */
   viewportMinHeight: number;
@@ -82,6 +83,7 @@ export interface LatestTurnRowProps {
 export const LatestTurnRow = memo(function LatestTurnRow({
   anchorMessage,
   responseItems,
+  assistantDisplayName,
   viewportMinHeight,
   expandedToolCallIds,
   expandedCardIds,
@@ -118,6 +120,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
     >
       <TranscriptRow
         item={anchorMessage}
+        assistantDisplayName={assistantDisplayName}
         expandedToolCallIds={expandedToolCallIds}
         expandedCardIds={expandedCardIds}
         onSurfaceAction={onSurfaceAction}
@@ -145,6 +148,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         <Fragment key={response.key}>
           <TranscriptRow
             item={response}
+            assistantDisplayName={assistantDisplayName}
             expandedToolCallIds={expandedToolCallIds}
             expandedCardIds={expandedCardIds}
             onSurfaceAction={onSurfaceAction}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -40,11 +40,15 @@ afterEach(() => {
 
 function renderMessage(
   message: DisplayMessage,
-  props: { onInspectMessage?: (messageId: string) => void } = {},
+  props: {
+    assistantDisplayName?: string | null;
+    onInspectMessage?: (messageId: string) => void;
+  } = {},
 ): string {
   return renderToStaticMarkup(
     <TranscriptMessageBody
       message={message}
+      assistantDisplayName={props.assistantDisplayName}
       expandedToolCallIds={new Set()}
       expandedCardIds={new Map()}
       onSurfaceAction={noop}
@@ -97,6 +101,28 @@ describe("TranscriptMessageBody", () => {
 
     expect(html).toContain("title=");
     expect(html).toContain(":01");
+  });
+
+  test("uses the assistant identity name for Slack assistant attribution fallback", () => {
+    const html = renderMessage(
+      {
+        stableId: "m1",
+        id: "m1",
+        role: "assistant",
+        content: "hello from Slack",
+        slackMessage: {
+          channelId: "C123",
+          channelTs: "1710000000.000300",
+          messageLink: {
+            webUrl: "https://example.slack.com/archives/C123/p1710000000000300",
+          },
+        },
+      },
+      { assistantDisplayName: "Ada" },
+    );
+
+    expect(html).toContain(">Ada<");
+    expect(html).not.toContain(">Assistant<");
   });
 
   test("passes daemon message id to inspect handler", () => {

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -40,6 +40,7 @@ export interface OpenRuleEditorContext {
  */
 export interface TranscriptMessageBodyProps {
   message: DisplayMessage;
+  assistantDisplayName?: string | null;
   /**
    * Persistent set of expanded tool-call ids. Passed straight through to
    * `ToolCallChip` so expansion state survives virtualization unmounts.
@@ -108,8 +109,14 @@ function latestMessageActivityTimestamp(
   return Math.max(message.timestamp, latestToolTimestamp);
 }
 
-function fallbackRoleLabel(role: DisplayMessage["role"]): string {
-  return role === "assistant" ? "Assistant" : "User";
+function fallbackRoleLabel(
+  role: DisplayMessage["role"],
+  assistantDisplayName?: string | null,
+): string {
+  if (role === "assistant") {
+    return firstPresentLabel(assistantDisplayName) ?? "Assistant";
+  }
+  return "User";
 }
 
 function firstPresentLabel(
@@ -122,7 +129,10 @@ function firstPresentLabel(
   return undefined;
 }
 
-function getSlackSenderLabel(message: DisplayMessage): string | null {
+function getSlackSenderLabel(
+  message: DisplayMessage,
+  assistantDisplayName?: string | null,
+): string | null {
   if (!message.slackMessage) return null;
   const sender = message.slackMessage.sender;
   return firstPresentLabel(
@@ -130,7 +140,7 @@ function getSlackSenderLabel(message: DisplayMessage): string | null {
     sender?.name,
     sender?.username,
     sender?.externalUserId,
-  ) ?? fallbackRoleLabel(message.role);
+  ) ?? fallbackRoleLabel(message.role, assistantDisplayName);
 }
 
 function isInteractiveClickTarget(target: Element | null): boolean {
@@ -139,8 +149,14 @@ function isInteractiveClickTarget(target: Element | null): boolean {
   );
 }
 
-function SlackMessageAttribution({ message }: { message: DisplayMessage }) {
-  const label = getSlackSenderLabel(message);
+function SlackMessageAttribution({
+  message,
+  assistantDisplayName,
+}: {
+  message: DisplayMessage;
+  assistantDisplayName?: string | null;
+}) {
+  const label = getSlackSenderLabel(message, assistantDisplayName);
   if (!label) return null;
 
   const url = getSlackLinkUrl(message.slackMessage?.messageLink);
@@ -177,6 +193,7 @@ function SlackMessageAttribution({ message }: { message: DisplayMessage }) {
 
 export function TranscriptMessageBody({
   message,
+  assistantDisplayName,
   expandedToolCallIds,
   expandedCardIds,
   onSurfaceAction,
@@ -412,7 +429,10 @@ export function TranscriptMessageBody({
               assistantId={assistantId}
             />
           )}
-          <SlackMessageAttribution message={message} />
+          <SlackMessageAttribution
+            message={message}
+            assistantDisplayName={assistantDisplayName}
+          />
           <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
             <MessageHoverActions
               content={message.content}
@@ -544,7 +564,10 @@ export function TranscriptMessageBody({
             </div>
           ));
         })()}
-        <SlackMessageAttribution message={message} />
+        <SlackMessageAttribution
+          message={message}
+          assistantDisplayName={assistantDisplayName}
+        />
         <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
           <MessageHoverActions
             content={message.content}

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -23,6 +23,7 @@ import type { ConfirmationDecision } from "@/domains/chat/api/event-types.js";
  */
 export interface TranscriptRowProps {
   item: TranscriptItem;
+  assistantDisplayName?: string | null;
   expandedToolCallIds: Set<string>;
   expandedCardIds: Map<string, boolean>;
   onSurfaceAction: (
@@ -70,6 +71,7 @@ export interface TranscriptRowProps {
 
 export const TranscriptRow = memo(function TranscriptRow({
   item,
+  assistantDisplayName,
   expandedToolCallIds,
   expandedCardIds,
   onSurfaceAction,
@@ -98,6 +100,7 @@ export const TranscriptRow = memo(function TranscriptRow({
       return (
         <TranscriptMessageBody
           message={item.message}
+          assistantDisplayName={assistantDisplayName}
           expandedToolCallIds={expandedToolCallIds}
           expandedCardIds={expandedCardIds}
           onSurfaceAction={onSurfaceAction}

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -35,6 +35,7 @@ export type RefreshOutcome =
 
 export interface TranscriptProps {
   items: TranscriptItem[];
+  assistantDisplayName?: string | null;
   onSecretSubmit: (requestId: string, value: string) => void;
   onConfirmationDecision: (requestId: string, decision: string) => void;
   onSurfaceAction: (
@@ -221,6 +222,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       renderPendingConfirmation: rest.renderPendingConfirmation,
       renderPendingContactRequest: rest.renderPendingContactRequest,
       renderOnboardingChoice: rest.renderOnboardingChoice,
+      assistantDisplayName: rest.assistantDisplayName,
       onOpenRuleEditor: rest.onOpenRuleEditor,
       unknownNudgeToolCallIds: rest.unknownNudgeToolCallIds,
       onDismissUnknownNudge: rest.onDismissUnknownNudge,


### PR DESCRIPTION
## Summary

Fixes Slack read-only transcript attribution so assistant-authored Slack messages fall back to the assistant's configured display name when the Slack sender metadata is missing.

The earlier backend fix fills `slackMessage.sender.displayName` when history serialization can resolve it, but the web transcript still had a hardcoded role fallback of `Assistant`. This change threads the already-loaded assistant identity name through the transcript renderer and uses it for assistant-role Slack fallback labels.

## Root Cause

`TranscriptMessageBody` rendered Slack attribution from `message.slackMessage.sender` and then fell back to the generic role label. Any cached, older, or otherwise incomplete Slack payload with a message link but no sender metadata still displayed `Assistant`.

## Validation

- `cd apps/web && bun test src/domains/chat/transcript/transcript-message-body.test.tsx`
- `cd apps/web && bunx tsc --noEmit`
- `cd apps/web && bun run lint -- src/domains/chat/components/chat-route-content.tsx src/domains/chat/transcript/latest-turn-row.tsx src/domains/chat/transcript/transcript-message-body.test.tsx src/domains/chat/transcript/transcript-message-body.tsx src/domains/chat/transcript/transcript-row.tsx src/domains/chat/transcript/transcript.tsx`
