### PR TITLE
Allow assistants to detach from Slack threads

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5058,6 +5058,57 @@ paths:
                 includeArchived:
                   type: boolean
               additionalProperties: false
+  /v1/conversations/cli/slack/detach:
+    post:
+      operationId: conversations_cli_slack_detach_post
+      summary: Detach the assistant from a Slack thread (CLI)
+      description: Stops Slack active-thread listening for a Slack thread. The CLI resolves current conversation defaults.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detached:
+                    type: boolean
+                  channelId:
+                    type: string
+                  threadTs:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - explicit
+                      - conversation_binding
+                  conversationId:
+                    type: string
+                required:
+                  - detached
+                  - channelId
+                  - threadTs
+                  - source
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  minLength: 1
+                channelId:
+                  type: string
+                  minLength: 1
+                threadTs:
+                  type: string
+                  minLength: 1
+              additionalProperties: false
   /v1/conversations/fork:
     post:
       operationId: conversations_fork_post

--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -30,6 +30,7 @@ let cliIpcResponse: {
   ok: boolean;
   result?: unknown;
   error?: string;
+  statusCode?: number;
 } = { ok: true, result: {} };
 let gatewayResponse: unknown = {
   detached: true,
@@ -45,12 +46,19 @@ mock.module("../../../ipc/cli-client.js", () => ({
   },
   cliIpcCallBinary: async () => cliIpcResponse,
   cliIpcCallStream: async () => cliIpcResponse,
-  exitFromIpcResult: (result: { error?: string }) => {
+  exitFromIpcResult: (result: { error?: string; statusCode?: number }) => {
     process.stderr.write((result.error ?? "Unknown error") + "\n");
-    process.exitCode = 1;
+    process.exitCode = exitCodeFromIpcResult(result);
   },
-  exitCodeFromIpcResult: () => 1,
+  exitCodeFromIpcResult,
 }));
+
+function exitCodeFromIpcResult(result: { statusCode?: number }): number {
+  if (result.statusCode === undefined) return 10;
+  if (result.statusCode >= 500) return 3;
+  if (result.statusCode >= 400) return 2;
+  return 1;
+}
 
 mock.module("../../../ipc/gateway-client.js", () => ({
   ipcCall: async (
@@ -419,5 +427,53 @@ describe("assistant conversations slack detach", () => {
     expect(parsed.error).toContain("--channel");
     expect(parsed.error).toContain("--thread");
     expect(cliIpcCalls).toHaveLength(0);
+  });
+
+  test("maps JSON IPC transport errors to the shared exit code", async () => {
+    cliIpcResponse = {
+      ok: false,
+      error: "Could not connect to assistant",
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--channel",
+      "C123",
+      "--thread",
+      "1700000000.000100",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(10);
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      error: "Could not connect to assistant",
+    });
+    expect(cliIpcCalls).toHaveLength(1);
+  });
+
+  test("maps JSON IPC 4xx errors to the shared exit code", async () => {
+    cliIpcResponse = {
+      ok: false,
+      error: "Conversation is not bound to a Slack thread",
+      statusCode: 400,
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "conv-1",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      error: "Conversation is not bound to a Slack thread",
+    });
+    expect(cliIpcCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type GatewayCall = {
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+type MockBinding = {
+  conversationId: string;
+  sourceChannel: string;
+  externalChatId: string;
+  externalThreadId?: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+const cliIpcCalls: IpcCall[] = [];
+const gatewayCalls: GatewayCall[] = [];
+const bindingCalls: string[] = [];
+
+let cliIpcResponse: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: {} };
+let gatewayResponse: unknown = {
+  detached: true,
+  channelId: "C123",
+  threadTs: "1700000000.000100",
+};
+let mockBinding: MockBinding | null = null;
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    cliIpcCalls.push({ method, params });
+    return cliIpcResponse;
+  },
+  cliIpcCallBinary: async () => cliIpcResponse,
+  cliIpcCallStream: async () => cliIpcResponse,
+  exitFromIpcResult: (result: { error?: string }) => {
+    process.stderr.write((result.error ?? "Unknown error") + "\n");
+    process.exitCode = 1;
+  },
+  exitCodeFromIpcResult: () => 1,
+}));
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    gatewayCalls.push({ method, params, timeoutMs });
+    return gatewayResponse;
+  },
+}));
+
+mock.module("../../../memory/external-conversation-store.js", () => ({
+  upsertBinding: () => {},
+  upsertOutboundBinding: () => {},
+  updateExternalChatName: () => {},
+  getBindingByConversation: (conversationId: string) => {
+    bindingCalls.push(conversationId);
+    return mockBinding;
+  },
+  getBindingByChannelChat: () => null,
+  getBindingByChannelChatThread: () => null,
+  deleteBindingByChannelChat: () => {},
+  deleteBindingByChannelChatThread: () => {},
+  getBindingsForConversations: () => new Map(),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { registerConversationsCommand } = await import("../conversations.js");
+const { ROUTES: CONVERSATION_CLI_ROUTES } =
+  await import("../../../runtime/routes/conversation-cli-routes.js");
+
+const slackDetachRouteCandidate = CONVERSATION_CLI_ROUTES.find(
+  (route) => route.operationId === "conversation_slack_detach_cli",
+);
+
+if (!slackDetachRouteCandidate) {
+  throw new Error("conversation_slack_detach_cli route not registered");
+}
+const slackDetachRoute = slackDetachRouteCandidate;
+
+let savedConvId: string | undefined;
+let savedSkillContext: string | undefined;
+
+beforeEach(() => {
+  cliIpcCalls.length = 0;
+  gatewayCalls.length = 0;
+  bindingCalls.length = 0;
+  cliIpcResponse = { ok: true, result: {} };
+  gatewayResponse = {
+    detached: true,
+    channelId: "C123",
+    threadTs: "1700000000.000100",
+  };
+  mockBinding = null;
+  process.exitCode = 0;
+
+  savedConvId = process.env.__CONVERSATION_ID;
+  savedSkillContext = process.env.__SKILL_CONTEXT_JSON;
+  delete process.env.__CONVERSATION_ID;
+  delete process.env.__SKILL_CONTEXT_JSON;
+});
+
+afterEach(() => {
+  if (savedConvId !== undefined) {
+    process.env.__CONVERSATION_ID = savedConvId;
+  } else {
+    delete process.env.__CONVERSATION_ID;
+  }
+
+  if (savedSkillContext !== undefined) {
+    process.env.__SKILL_CONTEXT_JSON = savedSkillContext;
+  } else {
+    delete process.env.__SKILL_CONTEXT_JSON;
+  }
+
+  process.exitCode = 0;
+});
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+    registerConversationsCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = Number(process.exitCode ?? 0);
+  process.exitCode = 0;
+  return {
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+    exitCode,
+  };
+}
+
+async function callSlackDetachRoute(body: Record<string, unknown>) {
+  return slackDetachRoute.handler({ body });
+}
+
+function makeBinding(overrides: Partial<MockBinding> = {}): MockBinding {
+  return {
+    conversationId: "conv-1",
+    sourceChannel: "slack",
+    externalChatId: "C123",
+    externalThreadId: "1700000000.000100",
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+async function expectRouteError(
+  body: Record<string, unknown>,
+  code: string,
+): Promise<void> {
+  try {
+    await callSlackDetachRoute(body);
+  } catch (err) {
+    expect((err as { code?: string }).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected route error ${code}`);
+}
+
+describe("conversation_slack_detach_cli route", () => {
+  test("detaches by explicit Slack identifiers without loading a binding", async () => {
+    const result = await callSlackDetachRoute({
+      channelId: "C123",
+      threadTs: "1700000000.000100",
+    });
+
+    expect(result).toEqual({
+      detached: true,
+      channelId: "C123",
+      threadTs: "1700000000.000100",
+      source: "explicit",
+    });
+    expect(bindingCalls).toHaveLength(0);
+    expect(gatewayCalls).toEqual([
+      {
+        method: "detach_slack_active_thread",
+        params: {
+          channelId: "C123",
+          threadTs: "1700000000.000100",
+        },
+        timeoutMs: 5000,
+      },
+    ]);
+  });
+
+  test("resolves Slack identifiers from a conversation binding", async () => {
+    mockBinding = makeBinding();
+
+    const result = await callSlackDetachRoute({ conversationId: "conv-1" });
+
+    expect(result).toEqual({
+      detached: true,
+      channelId: "C123",
+      threadTs: "1700000000.000100",
+      source: "conversation_binding",
+      conversationId: "conv-1",
+    });
+    expect(bindingCalls).toEqual(["conv-1"]);
+    expect(gatewayCalls[0]).toMatchObject({
+      method: "detach_slack_active_thread",
+      params: {
+        channelId: "C123",
+        threadTs: "1700000000.000100",
+      },
+    });
+  });
+
+  test("returns NOT_FOUND when no conversation binding exists", async () => {
+    await expectRouteError({ conversationId: "conv-missing" }, "NOT_FOUND");
+    expect(gatewayCalls).toHaveLength(0);
+  });
+
+  test("rejects non-Slack conversation bindings", async () => {
+    mockBinding = makeBinding({ sourceChannel: "telegram" });
+
+    await expectRouteError({ conversationId: "conv-1" }, "BAD_REQUEST");
+    expect(gatewayCalls).toHaveLength(0);
+  });
+
+  test("rejects Slack bindings that are not thread-bound", async () => {
+    mockBinding = makeBinding({ externalThreadId: null });
+
+    await expectRouteError({ conversationId: "conv-1" }, "BAD_REQUEST");
+    expect(gatewayCalls).toHaveLength(0);
+  });
+
+  test("rejects malformed gateway responses", async () => {
+    gatewayResponse = { detached: true };
+
+    await expectRouteError(
+      { channelId: "C123", threadTs: "1700000000.000100" },
+      "BAD_GATEWAY",
+    );
+  });
+});
+
+describe("assistant conversations slack detach", () => {
+  test("detaches with explicit Slack identifiers", async () => {
+    cliIpcResponse = {
+      ok: true,
+      result: {
+        detached: true,
+        channelId: "C123",
+        threadTs: "1700000000.000100",
+        source: "explicit",
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--channel",
+      "C123",
+      "--thread",
+      "1700000000.000100",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      ok: true,
+      result: {
+        detached: true,
+        channelId: "C123",
+        threadTs: "1700000000.000100",
+        source: "explicit",
+      },
+    });
+    expect(cliIpcCalls).toEqual([
+      {
+        method: "conversation_slack_detach_cli",
+        params: {
+          body: {
+            channelId: "C123",
+            threadTs: "1700000000.000100",
+          },
+        },
+      },
+    ]);
+  });
+
+  test("defaults to the current conversation when no Slack identifiers are provided", async () => {
+    process.env.__CONVERSATION_ID = "conv-env";
+    cliIpcResponse = {
+      ok: true,
+      result: {
+        detached: true,
+        channelId: "C123",
+        threadTs: "1700000000.000100",
+        source: "conversation_binding",
+        conversationId: "conv-env",
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).result.conversationId).toBe("conv-env");
+    expect(cliIpcCalls[0]).toEqual({
+      method: "conversation_slack_detach_cli",
+      params: { body: { conversationId: "conv-env" } },
+    });
+  });
+
+  test("supports mute as an alias for detach", async () => {
+    cliIpcResponse = {
+      ok: true,
+      result: {
+        detached: false,
+        channelId: "C123",
+        threadTs: "1700000000.000100",
+        source: "explicit",
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "mute",
+      "--channel",
+      "C123",
+      "--thread",
+      "1700000000.000100",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).result.detached).toBe(false);
+    expect(cliIpcCalls[0].method).toBe("conversation_slack_detach_cli");
+  });
+
+  test("fails locally when no target can be resolved", async () => {
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stdout).ok).toBe(false);
+    expect(cliIpcCalls).toHaveLength(0);
+  });
+
+  test("fails locally when only one explicit Slack identifier is provided", async () => {
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--channel",
+      "C123",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--channel");
+    expect(parsed.error).toContain("--thread");
+    expect(cliIpcCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -429,6 +429,28 @@ describe("assistant conversations slack detach", () => {
     expect(cliIpcCalls).toHaveLength(0);
   });
 
+  test("fails locally when explicit Slack identifiers are empty", async () => {
+    process.env.__CONVERSATION_ID = "conv-env";
+
+    const { stdout, exitCode } = await runCommand([
+      "conversations",
+      "slack",
+      "detach",
+      "--channel",
+      "",
+      "--thread",
+      "   ",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--channel");
+    expect(parsed.error).toContain("--thread");
+    expect(cliIpcCalls).toHaveLength(0);
+  });
+
   test("maps JSON IPC transport errors to the shared exit code", async () => {
     cliIpcResponse = {
       ok: false,

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -378,9 +378,11 @@ Examples:
           ) => {
             const channelId = opts.channel?.trim();
             const threadTs = opts.thread?.trim();
+            const hasExplicitSlackTarget =
+              opts.channel !== undefined || opts.thread !== undefined;
             const body: Record<string, string> = {};
 
-            if (channelId || threadTs) {
+            if (hasExplicitSlackTarget) {
               if (!channelId || !threadTs) {
                 outputSlackDetachError(
                   "Both --channel and --thread are required when using explicit Slack identifiers.",

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -6,6 +6,7 @@ import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import { registerCommand } from "../lib/register-command.js";
 import { timeAgo } from "../lib/time-ago.js";
 import { log } from "../logger.js";
+import { tryResolveConversationId } from "../utils/conversation-id.js";
 import { registerConversationsDeferCommand } from "./conversations-defer.js";
 import { registerConversationsImportCommand } from "./conversations-import.js";
 
@@ -13,6 +14,23 @@ type ConversationSeedMessage = {
   role: "user" | "assistant";
   content: string;
 };
+
+type SlackDetachCliResult = {
+  detached: boolean;
+  channelId: string;
+  threadTs: string;
+  source: "explicit" | "conversation_binding";
+  conversationId?: string;
+};
+
+function outputSlackDetachError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(`Error: ${message}`);
+  }
+  process.exitCode = 1;
+}
 
 function readSeedMessages(
   contentFile?: string,
@@ -314,6 +332,103 @@ Examples:
               log.info(`Exported to ${opts.output}`);
             } else {
               process.stdout.write(exported.output);
+            }
+          },
+        );
+
+      // -------------------------------------------------------------------
+      // slack
+      // -------------------------------------------------------------------
+
+      const slack = conversations
+        .command("slack")
+        .description("Manage Slack conversation bindings");
+
+      slack
+        .command("detach [conversationId]")
+        .alias("mute")
+        .description("Detach the assistant from a Slack thread")
+        .option("--channel <id>", "Slack channel ID")
+        .option("--thread <ts>", "Slack thread timestamp")
+        .option("--json", "Output result as JSON")
+        .addHelpText(
+          "after",
+          `
+Arguments:
+  conversationId   Optional conversation ID. Defaults to the current skill or
+                   tool conversation when available.
+
+Detaches the assistant from Socket Mode listening for the Slack thread bound
+to a conversation, or for explicit --channel and --thread identifiers.
+
+Examples:
+  $ assistant conversations slack detach
+  $ assistant conversations slack detach conv-123
+  $ assistant conversations slack mute --channel C123 --thread 1700000000.000100
+  $ assistant conversations slack detach --json`,
+        )
+        .action(
+          async (
+            conversationIdArg: string | undefined,
+            opts: { channel?: string; thread?: string; json?: boolean },
+          ) => {
+            const channelId = opts.channel?.trim();
+            const threadTs = opts.thread?.trim();
+            const body: Record<string, string> = {};
+
+            if (channelId || threadTs) {
+              if (!channelId || !threadTs) {
+                outputSlackDetachError(
+                  "Both --channel and --thread are required when using explicit Slack identifiers.",
+                  opts.json,
+                );
+                return;
+              }
+              body.channelId = channelId;
+              body.threadTs = threadTs;
+            } else {
+              const conversationId = tryResolveConversationId({
+                explicit: conversationIdArg,
+              });
+              if (!conversationId) {
+                outputSlackDetachError(
+                  "No conversation ID available. Pass a conversation ID, provide --channel and --thread, or run this command from a skill or bash tool context.",
+                  opts.json,
+                );
+                return;
+              }
+              body.conversationId = conversationId;
+            }
+
+            const result = await cliIpcCall<SlackDetachCliResult>(
+              "conversation_slack_detach_cli",
+              { body },
+            );
+
+            if (!result.ok) {
+              outputSlackDetachError(
+                result.error ?? "Failed to detach Slack thread",
+                opts.json,
+              );
+              return;
+            }
+
+            const detach = result.result!;
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: true, result: detach }) + "\n",
+              );
+              return;
+            }
+
+            if (detach.detached) {
+              log.info(
+                `Detached Slack thread ${detach.threadTs} in channel ${detach.channelId} from assistant listening.`,
+              );
+            } else {
+              log.info(
+                `Slack thread ${detach.threadTs} in channel ${detach.channelId} was already detached from assistant listening.`,
+              );
             }
           },
         );

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -2,7 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
-import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import {
+  cliIpcCall,
+  exitCodeFromIpcResult,
+  exitFromIpcResult,
+} from "../../ipc/cli-client.js";
 import { registerCommand } from "../lib/register-command.js";
 import { timeAgo } from "../lib/time-ago.js";
 import { log } from "../logger.js";
@@ -406,11 +410,17 @@ Examples:
             );
 
             if (!result.ok) {
-              outputSlackDetachError(
-                result.error ?? "Failed to detach Slack thread",
-                opts.json,
-              );
-              return;
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({
+                    ok: false,
+                    error: result.error ?? "Failed to detach Slack thread",
+                  }) + "\n",
+                );
+                process.exitCode = exitCodeFromIpcResult(result);
+                return;
+              }
+              return exitFromIpcResult(result);
             }
 
             const detach = result.result!;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -992,6 +992,10 @@ registerPolicy("conversations/cli/export", {
   requiredScopes: ["settings.read"],
   allowedPrincipalTypes: ["local"],
 });
+registerPolicy("conversations/cli/slack/detach", {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ["local"],
+});
 // `conversations/cli/clear` wipes every conversation + message + vector
 // collection. Elevated to settings.write and locked to local callers,
 // mirroring the `conversations/clear-all` and `conversations/wipe` gates.

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { clearAllConversations as clearAllActive } from "../../daemon/handlers/conversations.js";
 import { formatJson, formatMarkdown } from "../../export/formatter.js";
+import { ipcCall as ipcCallGateway } from "../../ipc/gateway-client.js";
 import {
   addMessage,
   createConversation,
@@ -19,8 +20,9 @@ import {
 } from "../../memory/conversation-crud.js";
 import { setConversationKey } from "../../memory/conversation-key-store.js";
 import { listConversations } from "../../memory/conversation-queries.js";
+import { getBindingByConversation } from "../../memory/external-conversation-store.js";
 import { getLogger } from "../../util/logger.js";
-import { BadRequestError, NotFoundError } from "./errors.js";
+import { BadGatewayError, BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("conversation-cli-routes");
@@ -151,6 +153,111 @@ async function handleClearCli(_args: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// slack detach (CLI)
+// ---------------------------------------------------------------------------
+
+const slackDetachRequestSchema = z.object({
+  conversationId: z.string().trim().min(1).optional(),
+  channelId: z.string().trim().min(1).optional(),
+  threadTs: z.string().trim().min(1).optional(),
+});
+
+const slackDetachResponseSchema = z.object({
+  detached: z.boolean(),
+  channelId: z.string(),
+  threadTs: z.string(),
+  source: z.enum(["explicit", "conversation_binding"]),
+  conversationId: z.string().optional(),
+});
+
+type SlackDetachGatewayResponse = {
+  detached: boolean;
+  channelId: string;
+  threadTs: string;
+};
+
+function isSlackDetachGatewayResponse(
+  value: unknown,
+): value is SlackDetachGatewayResponse {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof (value as SlackDetachGatewayResponse).detached === "boolean" &&
+    typeof (value as SlackDetachGatewayResponse).channelId === "string" &&
+    typeof (value as SlackDetachGatewayResponse).threadTs === "string"
+  );
+}
+
+async function handleSlackDetachCli({ body = {} }: RouteHandlerArgs) {
+  const parsed = slackDetachRequestSchema.parse(body);
+  const explicitChannelId = parsed.channelId;
+  const explicitThreadTs = parsed.threadTs;
+
+  let channelId: string;
+  let threadTs: string;
+  let source: "explicit" | "conversation_binding";
+  let conversationId: string | undefined;
+
+  if (explicitChannelId || explicitThreadTs) {
+    if (!explicitChannelId || !explicitThreadTs) {
+      throw new BadRequestError(
+        "Both channelId and threadTs are required when detaching by explicit Slack identifiers",
+      );
+    }
+    channelId = explicitChannelId;
+    threadTs = explicitThreadTs;
+    source = "explicit";
+  } else {
+    if (!parsed.conversationId) {
+      throw new BadRequestError(
+        "conversationId is required unless channelId and threadTs are provided",
+      );
+    }
+
+    const binding = getBindingByConversation(parsed.conversationId);
+    if (!binding) {
+      throw new NotFoundError(
+        `No channel binding found for conversation ${parsed.conversationId}`,
+      );
+    }
+    if (binding.sourceChannel !== "slack") {
+      throw new BadRequestError(
+        `Conversation ${parsed.conversationId} is bound to ${binding.sourceChannel}, not Slack`,
+      );
+    }
+    if (!binding.externalThreadId) {
+      throw new BadRequestError(
+        `Conversation ${parsed.conversationId} is not bound to a Slack thread`,
+      );
+    }
+
+    channelId = binding.externalChatId;
+    threadTs = binding.externalThreadId;
+    source = "conversation_binding";
+    conversationId = parsed.conversationId;
+  }
+
+  const gatewayResult = await ipcCallGateway(
+    "detach_slack_active_thread",
+    { channelId, threadTs },
+    5_000,
+  );
+  if (!isSlackDetachGatewayResponse(gatewayResult)) {
+    throw new BadGatewayError(
+      "Could not detach Slack thread from assistant listening",
+    );
+  }
+
+  return {
+    detached: gatewayResult.detached,
+    channelId: gatewayResult.channelId,
+    threadTs: gatewayResult.threadTs,
+    source,
+    ...(conversationId ? { conversationId } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -229,5 +336,17 @@ export const ROUTES: RouteDefinition[] = [
       cleared: z.number().int(),
     }),
     handler: handleClearCli,
+  },
+  {
+    operationId: "conversation_slack_detach_cli",
+    endpoint: "conversations/cli/slack/detach",
+    method: "POST",
+    summary: "Detach the assistant from a Slack thread (CLI)",
+    description:
+      "Stops Slack active-thread listening for a Slack thread. The CLI resolves current conversation defaults.",
+    tags: ["conversations"],
+    requestBody: slackDetachRequestSchema,
+    responseBody: slackDetachResponseSchema,
+    handler: handleSlackDetachCli,
   },
 ];

--- a/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
+++ b/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
@@ -1,0 +1,157 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { randomBytes } from "node:crypto";
+import { createConnection, type Socket } from "node:net";
+
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { SlackStore } from "../db/slack-store.js";
+import { slackActiveThreads } from "../db/schema.js";
+import { GatewayIpcServer } from "../ipc/server.js";
+import { slackThreadRoutes } from "../ipc/slack-thread-handlers.js";
+
+const CHANNEL_ID = "CFAKE00001";
+const OTHER_CHANNEL_ID = "COTHER0001";
+const THREAD_TS = "1700000000.000000";
+const OTHER_THREAD_TS = "1700000001.000000";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(slackActiveThreads).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function connectClient(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(path, () => resolve(client));
+    client.on("error", reject);
+  });
+}
+
+function sendRequest(
+  client: Socket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ id: string; result?: unknown; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const id = randomBytes(4).toString("hex");
+    let buffer = "";
+
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        client.off("data", onData);
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+
+    client.on("data", onData);
+    client.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+}
+
+function activeThreadRows(): Array<{ threadTs: string; channelId: string }> {
+  return new SlackStore(getGatewayDb()).listActiveThreadsWithChannel();
+}
+
+function trackThread(): void {
+  new SlackStore(getGatewayDb()).trackThread(THREAD_TS, CHANNEL_ID, 60_000);
+}
+
+describe("IPC Slack thread routes", () => {
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let client: Socket;
+
+  afterEach(() => {
+    client?.destroy();
+    server?.stop();
+  });
+
+  async function startServerAndConnect(): Promise<void> {
+    server = new GatewayIpcServer([...slackThreadRoutes]);
+    server.start();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client = await connectClient(server.getSocketPath());
+  }
+
+  test("detach_slack_active_thread removes a matching active thread", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: true,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([]);
+  });
+
+  test("detach_slack_active_thread is idempotent for an unknown thread", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: CHANNEL_ID,
+      threadTs: OTHER_THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: false,
+      channelId: CHANNEL_ID,
+      threadTs: OTHER_THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([
+      { threadTs: THREAD_TS, channelId: CHANNEL_ID },
+    ]);
+  });
+
+  test("detach_slack_active_thread does not remove channel mismatches", async () => {
+    trackThread();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: OTHER_CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: false,
+      channelId: OTHER_CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(activeThreadRows()).toEqual([
+      { threadTs: THREAD_TS, channelId: CHANNEL_ID },
+    ]);
+  });
+});

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -67,6 +67,16 @@ export class SlackStore {
     return row !== undefined;
   }
 
+  detachThread(threadTs: string, channelId: string): boolean {
+    const raw = (this.db as unknown as { $client: Database }).$client;
+    const changes = raw
+      .prepare(
+        "DELETE FROM slack_active_threads WHERE thread_ts = ? AND channel_id = ?",
+      )
+      .run(threadTs, channelId).changes;
+    return changes > 0;
+  }
+
   /**
    * Returns all unexpired active threads with a known channel for reconnect
    * catch-up. Rows with a NULL `channel_id` (legacy rows from before the

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -176,6 +176,7 @@ import {
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
+import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
 
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
@@ -2205,6 +2206,7 @@ async function main() {
   const ipcServer = new GatewayIpcServer([
     ...featureFlagRoutes,
     ...contactRoutes,
+    ...slackThreadRoutes,
     ...thresholdRoutes,
     ...riskClassificationRoutes,
     ...createVelayRoutes(velayTunnelClient),

--- a/gateway/src/ipc/slack-thread-handlers.ts
+++ b/gateway/src/ipc/slack-thread-handlers.ts
@@ -1,0 +1,39 @@
+/**
+ * IPC route definitions for Slack active-thread listener control.
+ *
+ * The gateway owns Slack Socket Mode listener state, so assistant-side
+ * controls call here instead of writing gateway storage directly.
+ */
+
+import { z } from "zod";
+
+import { SlackStore } from "../db/slack-store.js";
+import type { IpcRoute } from "./server.js";
+
+let store: SlackStore | null = null;
+
+function getStore(): SlackStore {
+  if (!store) {
+    store = new SlackStore();
+  }
+  return store;
+}
+
+const DetachSlackActiveThreadParamsSchema = z.object({
+  channelId: z.string().trim().min(1),
+  threadTs: z.string().trim().min(1),
+});
+
+export const slackThreadRoutes: IpcRoute[] = [
+  {
+    method: "detach_slack_active_thread",
+    schema: DetachSlackActiveThreadParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channelId, threadTs } = DetachSlackActiveThreadParamsSchema.parse(
+        params ?? {},
+      );
+      const detached = getStore().detachThread(threadTs, channelId);
+      return { detached, channelId, threadTs };
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add gateway IPC support to detach a Slack Socket Mode active-thread listener by channel/thread.
- Add assistant CLI support via `assistant conversations slack detach` with a `mute` alias, current-conversation fallback, explicit Slack ID targeting, and JSON output.
- Register the assistant route policy and regenerate the OpenAPI spec.

Closes #31626

## Milestones
- #31630 Add Slack thread detach IPC
- #31632 Add Slack thread detach CLI

## Review notes
- Milestone PR review waits timed out without bot feedback; this final PR is ready for holistic review.
- The feature branch was rebased onto current `main` before opening this PR.

## Test plan
- cd assistant && bun run generate:openapi -- --check
- cd assistant && bun test src/cli/commands/__tests__/conversations-slack.test.ts src/runtime/auth/__tests__/guard-tests.test.ts
- cd gateway && bun test src/__tests__/ipc-slack-thread-routes.test.ts
- pre-push: assistant typecheck and changed-file lint