### PR TITLE
fix(macos): expose /clean in slash command picker

### DIFF
--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -108,6 +108,15 @@ public enum ChatSlashCommandCatalog {
             sendPathPlatforms: allPlatforms
         ),
         ChatSlashCommandDescriptor(
+            name: "clean",
+            description: "Strip injected runtime context and reset memory injection state",
+            icon: "eraser",
+            selectionBehavior: .autoSend,
+            pickerPlatforms: allPlatforms,
+            helpBubblePlatforms: allPlatforms,
+            sendPathPlatforms: allPlatforms
+        ),
+        ChatSlashCommandDescriptor(
             name: "model",
             description: "List or switch inference profile",
             icon: "cpu",

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -8,7 +8,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .picker
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/clean", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testMacOSHelpOrderMatchesExpectedDesktopCommands() {
@@ -16,7 +16,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/clean", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testIOSHelpShowsForkAlongsideCommonCommands() {
@@ -24,7 +24,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .ios,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/clean", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testIOSPickerOmitsForkCommand() {
@@ -32,7 +32,19 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .ios,
             surface: .picker
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/clean", "/model", "/models", "/status", "/btw"])
+    }
+
+    func testCleanCommandIsDiscoverableInPickerAcrossPlatforms() {
+        for platform in [ChatSlashCommandPlatform.macos, .ios] {
+            let descriptor = ChatSlashCommandCatalog.descriptor(
+                forRawInput: "/clean",
+                platform: platform,
+                surface: .picker
+            )
+            XCTAssertEqual(descriptor?.name, "clean")
+            XCTAssertEqual(descriptor?.selectionBehavior, .autoSend)
+        }
     }
 
     func testStatusDescriptionMatchesConversationCopy() {
@@ -100,6 +112,11 @@ final class SlashCommandCatalogTests: XCTestCase {
             surface: .sendPath
         ))
         XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/clean",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/fork",
             platform: .macos,
             surface: .sendPath
@@ -122,6 +139,11 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/status foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/clean foo",
             platform: .macos,
             surface: .sendPath
         ))


### PR DESCRIPTION
## Summary
- Add a `/clean` `ChatSlashCommandDescriptor` to `ChatSlashCommandCatalog.allCommands` so macOS and iOS pickers/help bubbles surface it and the send path bypasses workspace refinement.
- Description and `autoSend` behavior mirror the web catalog entry; daemon parsing already rejects arguments (`sendPathMatchRule: .exact`).
- Update the four enumeration tests to include `/clean` in the expected order, extend the existing sendPath kitchen-sink test with `/clean` and `/clean foo` cases, and add a small picker-discoverability test that asserts `autoSend` across both platforms.

## Original prompt
The `/clean` slash command was implemented in the daemon (`assistant/src/daemon/conversation-slash.ts`) and listed in the web catalog (`apps/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts`) but was missing from the shared Swift catalog that macOS and iOS read. As a result, typing `/cle…` in the macOS composer produced no autocomplete entry, and sending `/clean` skipped the picker's workspace-refinement bypass. The fix is the catalog parity entry plus matching test updates — no daemon or web changes needed.