### PR TITLE
feat(macos): memory router playground tab in Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -16,6 +16,7 @@ enum SettingsTab: String {
     case debug = "Debug"
     case developer = "Developer"
     case compactionPlayground = "Compaction Playground"
+    case memoryRouterPlayground = "Memory Router Playground"
 
     var icon: VIcon {
         switch self {
@@ -33,6 +34,7 @@ enum SettingsTab: String {
         case .debug: return .bug
         case .developer: return .terminal
         case .compactionPlayground: return .flask
+        case .memoryRouterPlayground: return .flask
         }
     }
 
@@ -40,11 +42,15 @@ enum SettingsTab: String {
         soundsEnabled: Bool = true,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false,
+        includeMemoryRouterPlayground: Bool = false,
         bookmarksEnabled: Bool = false
     ) -> [SettingsTab] {
         var tabs: [SettingsTab] = []
         if includeCompactionPlayground {
             tabs.append(.compactionPlayground)
+        }
+        if includeMemoryRouterPlayground {
+            tabs.append(.memoryRouterPlayground)
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
@@ -113,6 +119,9 @@ struct SettingsPanel: View {
         let bookmarksEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.bookmarksFeatureFlagKey)
         _isBookmarksEnabled = State(initialValue: bookmarksEnabled)
 
+        let memoryRouterPlaygroundEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.memoryRouterPlaygroundFeatureFlagKey)
+        _isMemoryRouterPlaygroundEnabled = State(initialValue: memoryRouterPlaygroundEnabled)
+
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
         // those fire *after* the first render and are susceptible to timing
@@ -132,6 +141,7 @@ struct SettingsPanel: View {
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false,
+                includeMemoryRouterPlayground: false,
                 bookmarksEnabled: bookmarksEnabled
             )
             if developerEnabled { visibleTabs.append(.developer) }
@@ -166,6 +176,7 @@ struct SettingsPanel: View {
     @State private var hasLoadedFeatureFlags: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
+    @State private var isMemoryRouterPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isBookmarksEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
@@ -176,11 +187,15 @@ struct SettingsPanel: View {
     @State private var bootstrapGeneration: Int = 0
     private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
+    private static let memoryRouterPlaygroundFeatureFlagKey = "memory-router-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
     private static let bookmarksFeatureFlagKey = "bookmarks"
-    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.compactionPlayground]
+    private static let deferredDeepLinkTabs: Set<SettingsTab> = [
+        .compactionPlayground,
+        .memoryRouterPlayground,
+    ]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -400,6 +415,7 @@ struct SettingsPanel: View {
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible,
+            includeMemoryRouterPlayground: isMemoryRouterPlaygroundVisible,
             bookmarksEnabled: isBookmarksEnabled
         )
     }
@@ -414,6 +430,10 @@ struct SettingsPanel: View {
 
     private var isCompactionPlaygroundVisible: Bool {
         isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
+    }
+
+    private var isMemoryRouterPlaygroundVisible: Bool {
+        isDeveloperEnabled && isMemoryRouterPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
@@ -512,6 +532,12 @@ struct SettingsPanel: View {
             SettingsCompactionPlaygroundTab(
                 store: store,
                 conversationManager: conversationManager,
+                showToast: showToast,
+                onClose: onClose
+            )
+        case .memoryRouterPlayground:
+            SettingsMemoryRouterPlaygroundTab(
+                store: store,
                 showToast: showToast,
                 onClose: onClose
             )

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -1,0 +1,406 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Settings tab for the v4 memory router simulator. Lets a developer
+/// preview which concept pages the router would select for a given query
+/// under custom `tier1_size`, `tier2_size`, and `batch_size` overrides —
+/// without touching the live EMA event log or activation log.
+///
+/// Gated by:
+///   1. `settings-developer-nav` (developer-nav visibility)
+///   2. `memory-router-playground` (this tab)
+///   3. `DevModeManager.shared.isDevMode`
+@MainActor
+struct SettingsMemoryRouterPlaygroundTab: View {
+    let store: SettingsStore
+    let showToast: (String, ToastInfo.Style) -> Void
+    let onClose: () -> Void
+
+    private let client = MemoryRouterPlaygroundClient()
+
+    @State private var query: String = ""
+    @State private var tier1Raw: String = ""
+    @State private var tier2Raw: String = ""
+    @State private var batchRaw: String = ""
+    @State private var isRunning: Bool = false
+    @State private var validationError: String?
+    @State private var clientError: String?
+    @State private var lastResult: MemoryRouterSimulateResponse?
+    @State private var lastQuery: String = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                header
+                formCard
+                if let err = validationError ?? clientError {
+                    errorBanner(err)
+                }
+                if let result = lastResult {
+                    resultSection(result)
+                }
+            }
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Memory Router Playground")
+                .font(VFont.titleLarge)
+                .foregroundStyle(VColor.contentEmphasized)
+            Text(
+                "Dry-run the v4 router with custom tier/batch overrides. Read-only — no rows are written to memory_v2_injection_events or memory_v2_activation_logs, and no activation state is mutated. Leave an override blank to inherit the live config value; enter 'null' to explicitly disable a tier."
+            )
+            .font(VFont.bodyMediumLighter)
+            .foregroundStyle(VColor.contentSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Form
+
+    private var formCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Query")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                TextEditor(text: $query)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .scrollContentBackground(.hidden)
+                    .padding(VSpacing.sm)
+                    .frame(minHeight: 80)
+                    .background(VColor.surfaceBase)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                overrideField(label: "tier1_size", value: $tier1Raw)
+                overrideField(label: "tier2_size", value: $tier2Raw)
+                overrideField(label: "batch_size", value: $batchRaw)
+            }
+
+            HStack {
+                Spacer()
+                VButton(
+                    label: isRunning ? "Running…" : "Run simulation",
+                    style: .primary,
+                    isDisabled: !canRun
+                ) {
+                    runSimulation()
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func overrideField(label: String, value: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            TextField("inherit", text: value)
+                .textFieldStyle(.plain)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.surfaceBase)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Result Section
+
+    @ViewBuilder
+    private func resultSection(_ result: MemoryRouterSimulateResponse) -> some View {
+        summaryCard(result)
+        configCard(result)
+        if let reason = result.failureReason {
+            errorBanner("Router failure: \(reason)")
+        }
+        let groups = groupSlugsBySource(result)
+        if groups.isEmpty {
+            emptyResultCard
+        } else {
+            ForEach(groups, id: \.source) { group in
+                tierCard(group: group, scores: result.scores)
+            }
+        }
+    }
+
+    private func summaryCard(_ result: MemoryRouterSimulateResponse) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Summary")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            metaRow(label: "Query", value: lastQuery)
+            metaRow(
+                label: "Total candidate pages",
+                value: "\(result.totalCandidatePages)"
+            )
+            metaRow(
+                label: "Selected",
+                value: "\(result.selectedSlugs.count) / \(result.effectiveConfig.maxPageIds)"
+            )
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func configCard(_ result: MemoryRouterSimulateResponse) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Effective config")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            metaRow(
+                label: "tier1_size",
+                value: formatKnob(
+                    effective: result.effectiveConfig.tier1Size,
+                    override: result.overrides.tier1Size
+                )
+            )
+            metaRow(
+                label: "tier2_size",
+                value: formatKnob(
+                    effective: result.effectiveConfig.tier2Size,
+                    override: result.overrides.tier2Size
+                )
+            )
+            metaRow(
+                label: "batch_size",
+                value: formatKnob(
+                    effective: result.effectiveConfig.batchSize,
+                    override: result.overrides.batchSize
+                )
+            )
+            metaRow(
+                label: "max_page_ids",
+                value: "\(result.effectiveConfig.maxPageIds)"
+            )
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func tierCard(
+        group: SourceGroup,
+        scores: [String: Double]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack {
+                Text(formatSourceLabel(group.source))
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer()
+                Text("\(group.slugs.count) \(group.slugs.count == 1 ? "page" : "pages")")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(group.slugs, id: \.self) { slug in
+                    HStack {
+                        Text(slug)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .textSelection(.enabled)
+                        Spacer()
+                        if group.source == "tier2" {
+                            Text("EMA \(formatScore(scores[slug] ?? 0))")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private var emptyResultCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("No pages selected")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text(
+                "The router returned an empty selection. Try a more specific query, or relax the override values."
+            )
+            .font(VFont.bodyMediumLighter)
+            .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        Text(message)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.systemNegativeStrong)
+            .padding(VSpacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    // MARK: - Helpers
+
+    private var canRun: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunning
+    }
+
+    private func metaRow(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            Spacer()
+            Text(value)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func formatKnob(effective: Int?, override: MemoryRouterOverride) -> String {
+        let effStr: String
+        if let v = effective { effStr = "\(v)" } else { effStr = "null" }
+        switch override {
+        case .inherit: return effStr
+        case .value, .disable: return "\(effStr)  (override)"
+        }
+    }
+
+    private func formatScore(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private func runSimulation() {
+        validationError = nil
+        clientError = nil
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { return }
+
+        let tier1Override: MemoryRouterOverride
+        let tier2Override: MemoryRouterOverride
+        let batchOverride: MemoryRouterOverride
+        do {
+            tier1Override = try parseOverride(field: "tier1_size", raw: tier1Raw)
+            tier2Override = try parseOverride(field: "tier2_size", raw: tier2Raw)
+            batchOverride = try parseOverride(field: "batch_size", raw: batchRaw)
+        } catch {
+            validationError = error.localizedDescription
+            return
+        }
+
+        let input = MemoryRouterSimulateInput(
+            query: trimmedQuery,
+            tier1Size: tier1Override,
+            tier2Size: tier2Override,
+            batchSize: batchOverride
+        )
+
+        isRunning = true
+        lastQuery = trimmedQuery
+        Task {
+            defer { isRunning = false }
+            do {
+                let result = try await client.simulate(input: input)
+                lastResult = result
+                clientError = nil
+            } catch MemoryRouterPlaygroundError.memoryV2Disabled {
+                clientError = "Memory v2 is not enabled on this assistant — set memory.v2.enabled to true in workspace config."
+                lastResult = nil
+            } catch MemoryRouterPlaygroundError.notAvailable {
+                clientError = "Simulate route is not available — the daemon may need to be updated."
+                lastResult = nil
+            } catch let MemoryRouterPlaygroundError.http(statusCode, body) {
+                clientError = "HTTP \(statusCode): \(body.isEmpty ? "Failed to run simulation" : body)"
+                lastResult = nil
+            } catch {
+                clientError = error.localizedDescription
+                lastResult = nil
+            }
+        }
+    }
+
+    private func parseOverride(field: String, raw: String) throws -> MemoryRouterOverride {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return .inherit }
+        if trimmed.lowercased() == "null" { return .disable }
+        guard let parsed = Int(trimmed), parsed >= 1 else {
+            throw MemoryRouterPlaygroundInputError.invalidOverride(field: field, raw: trimmed)
+        }
+        return .value(parsed)
+    }
+
+    private struct SourceGroup {
+        let source: String
+        let slugs: [String]
+    }
+
+    private func groupSlugsBySource(
+        _ result: MemoryRouterSimulateResponse
+    ) -> [SourceGroup] {
+        var byKey: [String: [String]] = [:]
+        for slug in result.selectedSlugs {
+            guard let source = result.sourceBySlug[slug] else { continue }
+            byKey[source, default: []].append(slug)
+        }
+        return byKey.keys
+            .sorted(by: { sourceOrder($0) < sourceOrder($1) })
+            .map { SourceGroup(source: $0, slugs: byKey[$0] ?? []) }
+    }
+
+    private func sourceOrder(_ source: String) -> Int {
+        if source == "tier1" { return 0 }
+        if source == "tier2" { return 1 }
+        if source.hasPrefix("tier3:"),
+           let idx = Int(source.dropFirst("tier3:".count)) {
+            return 2 + idx
+        }
+        return Int.max
+    }
+
+    private func formatSourceLabel(_ source: String) -> String {
+        if source == "tier1" { return "tier 1" }
+        if source == "tier2" { return "tier 2" }
+        if source.hasPrefix("tier3:") {
+            return "tier 3 · b\(source.dropFirst("tier3:".count))"
+        }
+        return source
+    }
+}
+
+private enum MemoryRouterPlaygroundInputError: LocalizedError {
+    case invalidOverride(field: String, raw: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidOverride(let field, let raw):
+            return "\(field) must be a positive integer or 'null' (got \"\(raw)\")"
+        }
+    }
+}

--- a/clients/shared/Network/MemoryRouterPlaygroundClient.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundClient.swift
@@ -1,0 +1,110 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MemoryRouterPlaygroundClient")
+
+/// Errors surfaced by ``MemoryRouterPlaygroundClient``. Mirrors the
+/// classification scheme used by ``CompactionPlaygroundClient``: a 404 from
+/// the simulate endpoint typically means the daemon's `memory_v2.enabled`
+/// gate is off, while other non-2xx responses surface as generic HTTP errors.
+public enum MemoryRouterPlaygroundError: Error {
+    /// Memory v2 isn't enabled on this assistant. The daemon returns 409
+    /// `MEMORY_V2_DISABLED` from the simulate route's gate.
+    case memoryV2Disabled
+    /// The route isn't available at all (e.g. older daemon without the
+    /// simulate endpoint shipped). Includes the path for diagnostics.
+    case notAvailable
+    /// Catch-all for non-2xx responses with a body the caller can show.
+    case http(statusCode: Int, body: String)
+}
+
+/// Gateway-backed client for the daemon's `memory_v2_simulate_router` route.
+///
+/// Paths are gateway-relative — `GatewayHTTPClient` auto-prefixes the
+/// `assistants/{assistantId}/` segment and routes to `/v1/*` on the daemon.
+public struct MemoryRouterPlaygroundClient: Sendable {
+    public init() {}
+
+    public func simulate(
+        input: MemoryRouterSimulateInput
+    ) async throws -> MemoryRouterSimulateResponse {
+        let path = "memory/v2/simulate-router/"
+        let body = buildRequestBody(input: input)
+        let response = try await GatewayHTTPClient.post(
+            path: path,
+            json: body,
+            timeout: 120
+        )
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(
+            MemoryRouterSimulateResponse.self,
+            from: response.data
+        )
+    }
+
+    /// Construct the JSON dict the daemon expects. Built by hand because the
+    /// override fields have three states (inherit / value / explicit-null)
+    /// and a plain Codable `Encodable` would conflate "absent" with "null".
+    private func buildRequestBody(input: MemoryRouterSimulateInput) -> [String: Any] {
+        var body: [String: Any] = ["query": input.query]
+        var overrides: [String: Any] = [:]
+        addOverride(input.tier1Size, key: "tier1_size", into: &overrides)
+        addOverride(input.tier2Size, key: "tier2_size", into: &overrides)
+        addOverride(input.batchSize, key: "batch_size", into: &overrides)
+        if !overrides.isEmpty {
+            body["configOverrides"] = overrides
+        }
+        return body
+    }
+
+    private func addOverride(
+        _ override: MemoryRouterOverride,
+        key: String,
+        into dict: inout [String: Any]
+    ) {
+        switch override {
+        case .inherit:
+            return
+        case .value(let n):
+            dict[key] = n
+        case .disable:
+            dict[key] = NSNull()
+        }
+    }
+
+    private func throwIfUnsuccessful(
+        _ response: GatewayHTTPClient.Response,
+        path: String
+    ) throws {
+        guard !response.isSuccess else { return }
+
+        if response.statusCode == 409,
+           let code = parseErrorCode(from: response.data),
+           code == "MEMORY_V2_DISABLED" {
+            log.error("memory router simulate 409 (memory v2 disabled) for path \(path, privacy: .public)")
+            throw MemoryRouterPlaygroundError.memoryV2Disabled
+        }
+        if response.statusCode == 404 {
+            log.error("memory router simulate 404 (route unavailable) for path \(path, privacy: .public)")
+            throw MemoryRouterPlaygroundError.notAvailable
+        }
+        let bodyText = String(data: response.data, encoding: .utf8) ?? ""
+        log.error("memory router simulate HTTP \(response.statusCode, privacy: .public) for path \(path, privacy: .public): \(bodyText, privacy: .public)")
+        throw MemoryRouterPlaygroundError.http(
+            statusCode: response.statusCode,
+            body: bodyText
+        )
+    }
+
+    /// Best-effort parse of `{ "error": { "code": "<string>" } }` from the
+    /// response body. Returns `nil` on any structural mismatch so the caller
+    /// can fall back to status-code-only classification.
+    private func parseErrorCode(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let errorObj = json["error"] as? [String: Any],
+              let code = errorObj["code"] as? String else {
+            return nil
+        }
+        return code
+    }
+}

--- a/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+// MARK: - Memory Router Playground Wire Types
+//
+// Codable types mirroring the daemon's `memory_v2_simulate_router` HTTP
+// surface. Keys are lowerCamelCase to match the daemon JSON convention — do
+// not add a key-decoding strategy; the wire contract already matches Swift
+// property names.
+
+/// A single per-call override for a `memory.v2.router` knob. Distinct from
+/// a plain `Int?` so the caller can express the three states the playground
+/// supports: "inherit live" (nil), "use this integer", and "explicitly
+/// disable this tier" (`.disable`).
+public enum MemoryRouterOverride: Equatable, Sendable {
+    case inherit
+    case value(Int)
+    case disable
+}
+
+/// Parsed form input for the playground. Encoded into the wire JSON by
+/// ``MemoryRouterPlaygroundClient`` so the explicit-null branch is handled
+/// in one place instead of leaking through a custom Codable.
+public struct MemoryRouterSimulateInput: Equatable, Sendable {
+    public let query: String
+    public let tier1Size: MemoryRouterOverride
+    public let tier2Size: MemoryRouterOverride
+    public let batchSize: MemoryRouterOverride
+
+    public init(
+        query: String,
+        tier1Size: MemoryRouterOverride = .inherit,
+        tier2Size: MemoryRouterOverride = .inherit,
+        batchSize: MemoryRouterOverride = .inherit
+    ) {
+        self.query = query
+        self.tier1Size = tier1Size
+        self.tier2Size = tier2Size
+        self.batchSize = batchSize
+    }
+}
+
+/// The `memory.v2.router` config the simulator actually ran with (live ∪
+/// overrides). Mirrors the daemon's `effectiveConfig` object.
+public struct MemoryRouterEffectiveConfig: Codable, Sendable {
+    public let tier1Size: Int?
+    public let tier2Size: Int?
+    public let batchSize: Int?
+    public let maxPageIds: Int
+
+    public init(tier1Size: Int?, tier2Size: Int?, batchSize: Int?, maxPageIds: Int) {
+        self.tier1Size = tier1Size
+        self.tier2Size = tier2Size
+        self.batchSize = batchSize
+        self.maxPageIds = maxPageIds
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case tier1Size = "tier1_size"
+        case tier2Size = "tier2_size"
+        case batchSize = "batch_size"
+        case maxPageIds = "max_page_ids"
+    }
+}
+
+/// The overrides the simulator response echoes back. Each field's presence
+/// indicates whether the caller overrode that knob; `nil` means inherited.
+public struct MemoryRouterReportedOverrides: Sendable {
+    public let tier1Size: MemoryRouterOverride
+    public let tier2Size: MemoryRouterOverride
+    public let batchSize: MemoryRouterOverride
+
+    public init(
+        tier1Size: MemoryRouterOverride = .inherit,
+        tier2Size: MemoryRouterOverride = .inherit,
+        batchSize: MemoryRouterOverride = .inherit
+    ) {
+        self.tier1Size = tier1Size
+        self.tier2Size = tier2Size
+        self.batchSize = batchSize
+    }
+}
+
+extension MemoryRouterReportedOverrides: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case tier1Size = "tier1_size"
+        case tier2Size = "tier2_size"
+        case batchSize = "batch_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.tier1Size = try Self.decode(forKey: .tier1Size, in: container)
+        self.tier2Size = try Self.decode(forKey: .tier2Size, in: container)
+        self.batchSize = try Self.decode(forKey: .batchSize, in: container)
+    }
+
+    private static func decode(
+        forKey key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> MemoryRouterOverride {
+        if !container.contains(key) { return .inherit }
+        if try container.decodeNil(forKey: key) { return .disable }
+        return .value(try container.decode(Int.self, forKey: key))
+    }
+}
+
+/// Response from `POST /v1/assistants/{id}/memory/v2/simulate-router/`.
+public struct MemoryRouterSimulateResponse: Decodable, Sendable {
+    /// Slugs the router would select, in model-returned order.
+    public let selectedSlugs: [String]
+    /// Per-slug provenance: `"tier1"`, `"tier2"`, or `"tier3:<bucket>"`.
+    public let sourceBySlug: [String: String]
+    /// EMA scores for the selected slugs (0 when the slug has no events).
+    public let scores: [String: Double]
+    /// `nil` on success; one of the router failure reasons otherwise.
+    public let failureReason: String?
+    public let effectiveConfig: MemoryRouterEffectiveConfig
+    public let overrides: MemoryRouterReportedOverrides
+    /// Page index size the router was given (post-tier-carve, all batches).
+    public let totalCandidatePages: Int
+}


### PR DESCRIPTION
## Summary

- Native SwiftUI port of the web playground page added as a Settings tab.
- Same UX as the web version: query input, three override fields, grouped tier output with EMA scores for tier 2 picks.
- Gated by `settings-developer-nav` + `memory-router-playground` + `DevModeManager.isDevMode` (mirrors compaction-playground precedent).
- Wire types in `clients/shared/Network/`; the macOS-specific tab view in `clients/macos/.../Settings/`.

## Why

The CLI works and the web UI ships, but the macOS app is pure native SwiftUI — the web playground is unreachable there. Putting it in Settings → Memory Router Playground makes the dry-run loop one click from the chat window.

## Test plan

- [x] `swift build --target VellumAssistantShared` clean
- [x] `swift build --target VellumAssistantLib` clean
- [ ] Smoke after merge: enable both flags (`settings-developer-nav`, `memory-router-playground`) in `MacOSFeatureFlag.*` UserDefaults or via Settings → Developer → Feature Flags, ensure dev mode is on, open Settings → Memory Router Playground, run a sample query with overrides, confirm row counts for `memory_v2_injection_events` + `memory_v2_activation_logs` unchanged pre/post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)