### PR TITLE
[codex] Deliver Slack DM text before tool calls

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -577,6 +577,40 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls).toHaveLength(0);
   });
 
+  it("updates a live-delivered message when skipped text has attachments", async () => {
+    const seenTs: string[] = [];
+    const attachments: RuntimeAttachmentMetadata[] = [
+      {
+        id: "attachment-1",
+        filename: "report.txt",
+        mimeType: "text/plain",
+        sizeBytes: 12,
+        kind: "file",
+      },
+    ];
+
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-live",
+      textSegments: ["Already sent live."],
+      attachments,
+      startFromSegment: 1,
+      messageTs: "1700000000.000055",
+      onMessageTs: (ts) => seenTs.push(ts),
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload).toEqual({
+      chatId: "chat-live",
+      attachments,
+      assistantId: undefined,
+      ephemeral: undefined,
+      user: undefined,
+      messageTs: "1700000000.000055",
+    });
+    expect(seenTs).toEqual(["1700000000.000055"]);
+  });
+
   it("passes ephemeral and user through to each delivery call", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/slack",

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -16,6 +16,7 @@ const deliveryCalls: Array<{
   assistantId?: string;
   messageId?: string;
   startFromSegment?: number;
+  messageTs?: string;
 }> = [];
 const liveDeliveryCalls: Array<{
   callbackUrl: string;
@@ -35,16 +36,24 @@ mock.module("../runtime/channel-reply-delivery.js", () => ({
     externalChatId: string,
     callbackUrl: string,
     assistantId?: string,
-    options?: { messageId?: string; startFromSegment?: number },
+    options?: {
+      messageId?: string;
+      startFromSegment?: number;
+      messageTs?: string;
+    },
   ) => {
-    deliveryCalls.push({
+    const call: (typeof deliveryCalls)[number] = {
       conversationId,
       externalChatId,
       callbackUrl,
       assistantId,
       messageId: options?.messageId,
       startFromSegment: options?.startFromSegment,
-    });
+    };
+    if (options?.messageTs !== undefined) {
+      call.messageTs = options.messageTs;
+    }
+    deliveryCalls.push(call);
     return deliverReplyViaCallbackImpl(
       conversationId,
       externalChatId,
@@ -534,11 +543,20 @@ describe("channel-retry-sweep", () => {
     ).toEqual(["New live response."]);
     expect(rawPayload.slackDmLiveDeliveredTextResponseIndexes).toEqual([1, 2]);
     expect(rawPayload.replyMessageId).toBe("assistant-live-retry-final");
-    expect(deliveryCalls).toEqual([]);
+    expect(deliveryCalls).toEqual([
+      {
+        conversationId: inbound.conversationId,
+        externalChatId: "D-LIVE-RETRY",
+        callbackUrl: "https://example.test/deliver/slack",
+        assistantId: undefined,
+        messageId: "assistant-live-retry-final",
+        startFromSegment: 2,
+      },
+    ]);
     expect(row?.processingStatus).toBe("processed");
   });
 
-  test("Slack DM processing retries skip final delivery when the reply was posted live", async () => {
+  test("Slack DM processing retries resume final delivery after live text", async () => {
     const inbound = deliveryCrud.recordInbound(
       "slack",
       "D-LIVE-RETRY-SAME-REPLY",
@@ -567,6 +585,10 @@ describe("channel-retry-sweep", () => {
       })
       .where(eq(channelInboundEvents.id, inbound.eventId))
       .run();
+    deliverChannelReplyImpl = async () => ({
+      ok: true,
+      ts: "1700000000.000044",
+    });
 
     await sweepFailedEvents(async (conversationId, _content, _ids, options) => {
       options?.onEvent?.({
@@ -610,7 +632,17 @@ describe("channel-retry-sweep", () => {
     expect(
       liveDeliveryCalls.map((entry) => entry.payload.text).filter(Boolean),
     ).toEqual(["Live retry response."]);
-    expect(deliveryCalls).toEqual([]);
+    expect(deliveryCalls).toEqual([
+      {
+        conversationId: inbound.conversationId,
+        externalChatId: "D-LIVE-RETRY-SAME-REPLY",
+        callbackUrl: "https://example.test/deliver/slack",
+        assistantId: undefined,
+        messageId: "assistant-live-retry-same-reply",
+        startFromSegment: 1,
+        messageTs: "1700000000.000044",
+      },
+    ]);
     expect(rawPayload.slackDmLiveDeliveredTextResponseIndexes).toEqual([1]);
     expect(rawPayload.replyMessageId).toBe("assistant-live-retry-same-reply");
     expect(row?.processingStatus).toBe("processed");

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -17,9 +17,17 @@ const deliveryCalls: Array<{
   messageId?: string;
   startFromSegment?: number;
 }> = [];
+const liveDeliveryCalls: Array<{
+  callbackUrl: string;
+  payload: Record<string, unknown>;
+}> = [];
 let deliverReplyViaCallbackImpl: (
   ...args: unknown[]
 ) => Promise<void> = async () => {};
+let deliverChannelReplyImpl: (
+  callbackUrl: string,
+  payload: Record<string, unknown>,
+) => Promise<Record<string, unknown>> = async () => ({ ok: true });
 
 mock.module("../runtime/channel-reply-delivery.js", () => ({
   deliverReplyViaCallback: async (
@@ -66,6 +74,16 @@ mock.module("../runtime/channel-reply-delivery.js", () => ({
       }
     }
     return candidate;
+  },
+}));
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async (
+    callbackUrl: string,
+    payload: Record<string, unknown>,
+  ) => {
+    liveDeliveryCalls.push({ callbackUrl, payload });
+    return deliverChannelReplyImpl(callbackUrl, payload);
   },
 }));
 
@@ -158,7 +176,9 @@ describe("channel-retry-sweep", () => {
   beforeEach(() => {
     resetTables();
     deliveryCalls.length = 0;
+    liveDeliveryCalls.length = 0;
     deliverReplyViaCallbackImpl = async () => {};
+    deliverChannelReplyImpl = async () => ({ ok: true });
   });
 
   test("replays canonical payloads with trustClass correctly", async () => {
@@ -425,6 +445,176 @@ describe("channel-retry-sweep", () => {
     expect(
       row?.rawPayload ? JSON.parse(row.rawPayload).replyMessageId : undefined,
     ).toBe("assistant-delivery-fails");
+  });
+
+  test("Slack DM processing retries skip previously delivered live text responses", async () => {
+    const inbound = deliveryCrud.recordInbound(
+      "slack",
+      "D-LIVE-RETRY",
+      "slack-msg-live-retry",
+    );
+    deliveryCrud.storePayload(inbound.eventId, {
+      content: "retry me",
+      sourceChannel: "slack",
+      interface: "slack",
+      externalChatId: "D-LIVE-RETRY",
+      replyCallbackUrl: "https://example.test/deliver/slack",
+      sourceMetadata: { chatType: "im" },
+      trustCtx: {
+        trustClass: "unknown",
+        sourceChannel: "slack",
+        requesterChatId: "D-LIVE-RETRY",
+      },
+      slackDmLiveDeliveredTextResponseIndexes: [1],
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "failed",
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    await sweepFailedEvents(async (conversationId, _content, _ids, options) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Already delivered live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "one" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "New live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "two" },
+        conversationId,
+        toolUseId: "toolu_2",
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-live-retry-final",
+      });
+      db.insert(messages)
+        .values({
+          id: "user-live-retry",
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: "retry me" }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId: "user-live-retry" };
+    });
+
+    const row = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .get();
+    const rawPayload = row?.rawPayload
+      ? (JSON.parse(row.rawPayload) as Record<string, unknown>)
+      : {};
+
+    expect(
+      liveDeliveryCalls.map((entry) => entry.payload.text).filter(Boolean),
+    ).toEqual(["New live response."]);
+    expect(rawPayload.slackDmLiveDeliveredTextResponseIndexes).toEqual([1, 2]);
+    expect(rawPayload.replyMessageId).toBe("assistant-live-retry-final");
+    expect(deliveryCalls).toEqual([]);
+    expect(row?.processingStatus).toBe("processed");
+  });
+
+  test("Slack DM processing retries skip final delivery when the reply was posted live", async () => {
+    const inbound = deliveryCrud.recordInbound(
+      "slack",
+      "D-LIVE-RETRY-SAME-REPLY",
+      "slack-msg-live-retry-same-reply",
+    );
+    deliveryCrud.storePayload(inbound.eventId, {
+      content: "retry me",
+      sourceChannel: "slack",
+      interface: "slack",
+      externalChatId: "D-LIVE-RETRY-SAME-REPLY",
+      replyCallbackUrl: "https://example.test/deliver/slack",
+      sourceMetadata: { chatType: "im" },
+      trustCtx: {
+        trustClass: "unknown",
+        sourceChannel: "slack",
+        requesterChatId: "D-LIVE-RETRY-SAME-REPLY",
+      },
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "failed",
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    await sweepFailedEvents(async (conversationId, _content, _ids, options) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Live retry response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-live-retry-same-reply",
+      });
+      db.insert(messages)
+        .values({
+          id: "user-live-retry-same-reply",
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: "retry me" }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId: "user-live-retry-same-reply" };
+    });
+
+    const row = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .get();
+    const rawPayload = row?.rawPayload
+      ? (JSON.parse(row.rawPayload) as Record<string, unknown>)
+      : {};
+
+    expect(
+      liveDeliveryCalls.map((entry) => entry.payload.text).filter(Boolean),
+    ).toEqual(["Live retry response."]);
+    expect(deliveryCalls).toEqual([]);
+    expect(rawPayload.slackDmLiveDeliveredTextResponseIndexes).toEqual([1]);
+    expect(rawPayload.replyMessageId).toBe("assistant-live-retry-same-reply");
+    expect(row?.processingStatus).toBe("processed");
+    expect(row?.deliveryStatus).toBe("delivered");
   });
 
   test("delivery retry for processed events resumes delivery without processing", async () => {

--- a/assistant/src/memory/delivery-channels.ts
+++ b/assistant/src/memory/delivery-channels.ts
@@ -10,6 +10,36 @@ import { eq } from "drizzle-orm";
 import { getDb } from "./db-connection.js";
 import { channelInboundEvents } from "./schema.js";
 
+const SLACK_DM_LIVE_DELIVERED_TEXT_RESPONSE_INDEXES =
+  "slackDmLiveDeliveredTextResponseIndexes";
+
+function parseRawPayload(
+  rawPayload: string | null,
+): Record<string, unknown> | undefined {
+  if (!rawPayload) return undefined;
+  try {
+    const parsed = JSON.parse(rawPayload) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizePositiveIntegerIndexes(value: unknown): number[] {
+  if (!Array.isArray(value)) return [];
+  const indexes = value.filter(
+    (item): item is number => Number.isSafeInteger(item) && item > 0,
+  );
+  return [...new Set(indexes)].sort((a, b) => a - b);
+}
+
 // ── Pending verification reply helpers ───────────────────────────────
 //
 // When a guardian verification succeeds but the confirmation reply fails
@@ -98,6 +128,58 @@ export function updateDeliveredSegmentCount(
     .set({ deliveredSegmentCount: count, updatedAt: Date.now() })
     .where(eq(channelInboundEvents.id, eventId))
     .run();
+}
+
+export function getSlackDmLiveDeliveredTextResponseIndexes(
+  eventId: string,
+): number[] {
+  const db = getDb();
+  const row = db
+    .select({ rawPayload: channelInboundEvents.rawPayload })
+    .from(channelInboundEvents)
+    .where(eq(channelInboundEvents.id, eventId))
+    .get();
+  const payload = parseRawPayload(row?.rawPayload ?? null);
+  if (!payload) return [];
+  return normalizePositiveIntegerIndexes(
+    payload[SLACK_DM_LIVE_DELIVERED_TEXT_RESPONSE_INDEXES],
+  );
+}
+
+export function addSlackDmLiveDeliveredTextResponseIndex(
+  eventId: string,
+  responseIndex: number,
+): void {
+  if (!Number.isSafeInteger(responseIndex) || responseIndex <= 0) return;
+
+  const db = getDb();
+  db.transaction((tx) => {
+    const row = tx
+      .select({ rawPayload: channelInboundEvents.rawPayload })
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, eventId))
+      .get();
+    if (!row?.rawPayload) return;
+
+    const payload = parseRawPayload(row.rawPayload);
+    if (!payload) return;
+    const indexes = normalizePositiveIntegerIndexes(
+      payload[SLACK_DM_LIVE_DELIVERED_TEXT_RESPONSE_INDEXES],
+    );
+    if (!indexes.includes(responseIndex)) indexes.push(responseIndex);
+    indexes.sort((a, b) => a - b);
+
+    tx.update(channelInboundEvents)
+      .set({
+        rawPayload: JSON.stringify({
+          ...payload,
+          [SLACK_DM_LIVE_DELIVERED_TEXT_RESPONSE_INDEXES]: indexes,
+        }),
+        updatedAt: Date.now(),
+      })
+      .where(eq(channelInboundEvents.id, eventId))
+      .run();
+  });
 }
 
 // ── Deliver-once guard for terminal reply idempotency ────────────────

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -141,6 +141,29 @@ export async function deliverRenderedReplyViaCallback(
     return;
   }
 
+  if (startFromSegment >= deliverableSegments.length) {
+    if (replyAttachments) {
+      const result: ChannelDeliveryResult = await deliverChannelReply(
+        callbackUrl,
+        {
+          chatId,
+          attachments: replyAttachments,
+          assistantId,
+          ephemeral,
+          user,
+          messageTs,
+        },
+      );
+      const deliveredTs = result.ts ?? messageTs;
+      if (deliveredTs) {
+        onMessageTs?.(deliveredTs);
+      }
+    } else if (messageTs) {
+      onMessageTs?.(messageTs);
+    }
+    return;
+  }
+
   const isSlack = isSlackCallbackUrl(callbackUrl);
 
   // Only the first segment uses messageTs for in-place update;

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -11,7 +11,11 @@ import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../daemon/disk-pressure-policy.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
-import { updateDeliveredSegmentCount } from "../memory/delivery-channels.js";
+import {
+  addSlackDmLiveDeliveredTextResponseIndex,
+  getSlackDmLiveDeliveredTextResponseIndexes,
+  updateDeliveredSegmentCount,
+} from "../memory/delivery-channels.js";
 import {
   clearPayload,
   linkMessage,
@@ -33,6 +37,7 @@ import {
 } from "./channel-reply-delivery.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { MessageProcessor } from "./http-types.js";
+import { createSlackDmTextDeliveryController } from "./slack-dm-text-delivery.js";
 import { resolveRoutingStateFromRuntime } from "./trust-context-resolver.js";
 
 const log = getLogger("runtime-http");
@@ -258,6 +263,27 @@ export async function sweepFailedEvents(
       sourceMetadata.chatType.trim().length > 0
         ? sourceMetadata.chatType.trim()
         : undefined;
+    const replyCallbackUrl =
+      typeof payload.replyCallbackUrl === "string"
+        ? payload.replyCallbackUrl
+        : undefined;
+    const externalChatId =
+      typeof payload.externalChatId === "string"
+        ? payload.externalChatId
+        : undefined;
+    const slackDmTextDelivery = externalChatId
+      ? createSlackDmTextDeliveryController({
+          sourceChannel,
+          chatType: metadataChatType,
+          replyCallbackUrl,
+          chatId: externalChatId,
+          assistantId,
+          deliveredTextResponseIndexes:
+            getSlackDmLiveDeliveredTextResponseIndexes(event.id),
+          onTextResponseDelivered: (responseIndex) =>
+            addSlackDmLiveDeliveredTextResponseIndex(event.id, responseIndex),
+        })
+      : undefined;
     let replyMessageId: string | undefined;
     const observeAgentEvent = (msg: ServerMessage): void => {
       if (
@@ -267,6 +293,7 @@ export async function sweepFailedEvents(
       ) {
         replyMessageId = msg.messageId;
       }
+      slackDmTextDelivery?.observeEvent(msg);
     };
 
     let userMessageId: string | undefined;
@@ -304,39 +331,39 @@ export async function sweepFailedEvents(
       );
     } catch (err) {
       log.error({ err, eventId: event.id }, "Retry failed for channel event");
+      if (slackDmTextDelivery) {
+        await slackDmTextDelivery.waitForPendingDeliveries();
+      }
       recordProcessingFailure(event.id, err);
       continue;
     }
 
-    const replyCallbackUrl =
-      typeof payload.replyCallbackUrl === "string"
-        ? payload.replyCallbackUrl
-        : undefined;
     if (replyCallbackUrl) {
-      const externalChatId =
-        typeof payload.externalChatId === "string"
-          ? payload.externalChatId
-          : undefined;
       if (externalChatId) {
         try {
+          if (slackDmTextDelivery) {
+            await slackDmTextDelivery.waitForPendingDeliveries();
+          }
           // processMessage above generated a fresh assistant response, so any
-          // previously tracked segment progress belongs to the old response and
-          // must not carry over. Reset to 0 so we deliver all segments of the
-          // new response.
+          // previously tracked final-delivery progress belongs to the old
+          // response and must not carry over. Live Slack DM progress is tracked
+          // separately below so a fully live-delivered reply is not duplicated.
           updateDeliveredSegmentCount(event.id, 0);
-          await deliverReplyViaCallback(
-            event.conversationId,
-            externalChatId,
-            replyCallbackUrl,
-            assistantId,
-            {
-              messageId: replyMessageId,
-              sinceMessageId: userMessageId,
-              startFromSegment: 0,
-              onSegmentDelivered: (count) =>
-                updateDeliveredSegmentCount(event.id, count),
-            },
-          );
+          if (!slackDmTextDelivery?.wasMessageDeliveredLive(replyMessageId)) {
+            await deliverReplyViaCallback(
+              event.conversationId,
+              externalChatId,
+              replyCallbackUrl,
+              assistantId,
+              {
+                messageId: replyMessageId,
+                sinceMessageId: userMessageId,
+                startFromSegment: 0,
+                onSegmentDelivered: (count) =>
+                  updateDeliveredSegmentCount(event.id, count),
+              },
+            );
+          }
           markDeliveryDelivered(event.id);
         } catch (err) {
           log.error(

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -349,21 +349,25 @@ export async function sweepFailedEvents(
           // response and must not carry over. Live Slack DM progress is tracked
           // separately below so a fully live-delivered reply is not duplicated.
           updateDeliveredSegmentCount(event.id, 0);
-          if (!slackDmTextDelivery?.wasMessageDeliveredLive(replyMessageId)) {
-            await deliverReplyViaCallback(
-              event.conversationId,
-              externalChatId,
-              replyCallbackUrl,
-              assistantId,
-              {
-                messageId: replyMessageId,
-                sinceMessageId: userMessageId,
-                startFromSegment: 0,
-                onSegmentDelivered: (count) =>
-                  updateDeliveredSegmentCount(event.id, count),
-              },
-            );
-          }
+          const liveDeliveryResumeOptions =
+            slackDmTextDelivery?.getFinalDeliveryResumeOptions(replyMessageId);
+          await deliverReplyViaCallback(
+            event.conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            assistantId,
+            {
+              messageId: replyMessageId,
+              sinceMessageId: userMessageId,
+              startFromSegment:
+                liveDeliveryResumeOptions?.startFromSegment ?? 0,
+              ...(liveDeliveryResumeOptions?.messageTs
+                ? { messageTs: liveDeliveryResumeOptions.messageTs }
+                : {}),
+              onSegmentDelivered: (count) =>
+                updateDeliveredSegmentCount(event.id, count),
+            },
+          );
           markDeliveryDelivered(event.id);
         } catch (err) {
           log.error(

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -15,7 +15,11 @@ const storedReplyMessageIds: Array<{
   eventId: string;
   replyMessageId: string;
 }> = [];
-const replyDeliveryCalls: Array<{ messageId?: string }> = [];
+const replyDeliveryCalls: Array<{
+  messageId?: string;
+  startFromSegment?: number;
+  messageTs?: string;
+}> = [];
 let deliverChannelReplyImpl: (
   callbackUrl: string,
   payload: Record<string, unknown>,
@@ -83,8 +87,19 @@ mock.module("../../gateway-client.js", () => ({
 
 mock.module("../channel-delivery-routes.js", () => ({
   deliverReplyViaCallback: async (...args: unknown[]) => {
-    const options = args[4] as { messageId?: string } | undefined;
-    replyDeliveryCalls.push({ messageId: options?.messageId });
+    const options = args[4] as
+      | { messageId?: string; startFromSegment?: number; messageTs?: string }
+      | undefined;
+    const call: (typeof replyDeliveryCalls)[number] = {
+      messageId: options?.messageId,
+    };
+    if (options?.startFromSegment !== undefined) {
+      call.startFromSegment = options.startFromSegment;
+    }
+    if (options?.messageTs !== undefined) {
+      call.messageTs = options.messageTs;
+    }
+    replyDeliveryCalls.push(call);
     return deliverReplyViaCallbackImpl(...args);
   },
 }));
@@ -362,6 +377,11 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
         conversationId,
         toolUseId: "toolu_1",
       });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-pre-tool",
+      });
 
       await flush();
       expect(
@@ -425,6 +445,10 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
   test("does not redeliver a Slack DM assistant message already posted live", async () => {
     const conversationId = "conv-dm-live-only";
     const channelId = "D-LIVE-ONLY";
+    deliverChannelReplyImpl = async () => ({
+      ok: true,
+      ts: "1700000000.000033",
+    });
 
     const processMessage: MessageProcessor = async (
       _conversationId,
@@ -473,7 +497,13 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
         .map((entry) => entry.payload.text)
         .filter(Boolean),
     ).toEqual(["Live response before the tool."]);
-    expect(replyDeliveryCalls).toEqual([]);
+    expect(replyDeliveryCalls).toEqual([
+      {
+        messageId: "assistant-msg-live-only",
+        startFromSegment: 1,
+        messageTs: "1700000000.000033",
+      },
+    ]);
     expect(storedReplyMessageIds).toEqual([
       {
         eventId: "evt-live-only",

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -8,11 +8,18 @@ const markedProcessedEvents: string[] = [];
 const processingFailureEvents: string[] = [];
 const deliveredEvents: string[] = [];
 const deliveryFailureEvents: string[] = [];
+const deliveredSegmentCounts: Array<{ eventId: string; count: number }> = [];
+const liveDeliveredTextResponseIndexes = new Map<string, number[]>();
+const operationOrder: string[] = [];
 const storedReplyMessageIds: Array<{
   eventId: string;
   replyMessageId: string;
 }> = [];
 const replyDeliveryCalls: Array<{ messageId?: string }> = [];
+let deliverChannelReplyImpl: (
+  callbackUrl: string,
+  payload: Record<string, unknown>,
+) => Promise<Record<string, unknown>> = async () => ({ ok: true });
 let deliverReplyViaCallbackImpl: (
   ...args: unknown[]
 ) => Promise<void> = async () => {};
@@ -25,7 +32,20 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 mock.module("../../../memory/delivery-channels.js", () => ({
-  updateDeliveredSegmentCount: () => {},
+  addSlackDmLiveDeliveredTextResponseIndex: (
+    eventId: string,
+    responseIndex: number,
+  ) => {
+    operationOrder.push(`live:${responseIndex}`);
+    const indexes = liveDeliveredTextResponseIndexes.get(eventId) ?? [];
+    if (!indexes.includes(responseIndex)) indexes.push(responseIndex);
+    liveDeliveredTextResponseIndexes.set(eventId, indexes);
+  },
+  getSlackDmLiveDeliveredTextResponseIndexes: (eventId: string) =>
+    liveDeliveredTextResponseIndexes.get(eventId) ?? [],
+  updateDeliveredSegmentCount: (eventId: string, count: number) => {
+    deliveredSegmentCounts.push({ eventId, count });
+  },
 }));
 
 mock.module("../../../memory/delivery-crud.js", () => ({
@@ -46,6 +66,7 @@ mock.module("../../../memory/delivery-status.js", () => ({
     deliveryFailureEvents.push(eventId);
   },
   recordProcessingFailure: (eventId: string) => {
+    operationOrder.push("processing-failure");
     processingFailureEvents.push(eventId);
   },
 }));
@@ -56,7 +77,7 @@ mock.module("../../gateway-client.js", () => ({
     payload: Record<string, unknown>,
   ) => {
     deliveredChannelReplies.push({ callbackUrl, payload });
-    return { ok: true };
+    return deliverChannelReplyImpl(callbackUrl, payload);
   },
 }));
 
@@ -88,8 +109,12 @@ beforeEach(() => {
   processingFailureEvents.length = 0;
   deliveredEvents.length = 0;
   deliveryFailureEvents.length = 0;
+  deliveredSegmentCounts.length = 0;
+  liveDeliveredTextResponseIndexes.clear();
+  operationOrder.length = 0;
   storedReplyMessageIds.length = 0;
   replyDeliveryCalls.length = 0;
+  deliverChannelReplyImpl = async () => ({ ok: true });
   deliverReplyViaCallbackImpl = async () => {};
 });
 
@@ -303,10 +328,383 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 
     clearThreadTs(conversationId);
   });
+
+  test("delivers Slack DM assistant text before tools as it becomes ready", async () => {
+    const conversationId = "conv-dm-incremental-text";
+    const channelId = "D-INCREMENTAL";
+    deliverReplyViaCallbackImpl = async (...args: unknown[]) => {
+      const options = args[4] as
+        | { onSegmentDelivered?: (count: number) => void }
+        | undefined;
+      options?.onSegmentDelivered?.(1);
+    };
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<no_response/>\nFirst response before the tool.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "assistant_thinking_delta",
+        thinking: "private reasoning",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+
+      await flush();
+      expect(
+        deliveredChannelReplies
+          .map((entry) => entry.payload.text)
+          .filter(Boolean),
+      ).toEqual(["First response before the tool."]);
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Final response after the tool.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-final",
+      });
+      return { messageId: "user-msg-incremental" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-incremental-text",
+      content: "please look this up",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["First response before the tool."]);
+    expect(
+      deliveredChannelReplies.every((entry) => !entry.payload.thinking),
+    ).toBe(true);
+    expect(replyDeliveryCalls).toEqual([{ messageId: "assistant-msg-final" }]);
+    expect(deliveredSegmentCounts).toEqual([
+      { eventId: "evt-incremental-text", count: 1 },
+    ]);
+    expect(storedReplyMessageIds).toEqual([
+      {
+        eventId: "evt-incremental-text",
+        replyMessageId: "assistant-msg-final",
+      },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-incremental-text"]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("does not redeliver a Slack DM assistant message already posted live", async () => {
+    const conversationId = "conv-dm-live-only";
+    const channelId = "D-LIVE-ONLY";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Live response before the tool.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-live-only",
+      });
+      return { messageId: "user-msg-live-only" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-live-only",
+      content: "please look this up",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["Live response before the tool."]);
+    expect(replyDeliveryCalls).toEqual([]);
+    expect(storedReplyMessageIds).toEqual([
+      {
+        eventId: "evt-live-only",
+        replyMessageId: "assistant-msg-live-only",
+      },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-live-only"]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("keeps Slack channel replies on the existing final delivery path", async () => {
+    const conversationId = "conv-channel-final-delivery";
+    const channelId = "C-FINAL-DELIVERY";
+    const threadTs = "1700000000.000022";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Intermediate text.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Final text.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-channel-final",
+      });
+      return { messageId: "user-msg-channel" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-channel-final-delivery",
+      content: "channel request",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "channel",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual([]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: "assistant-msg-channel-final" },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-channel-final-delivery"]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("continues later Slack DM text sends after an intermediate delivery failure", async () => {
+    const conversationId = "conv-dm-live-failure-recovery";
+    const channelId = "D-LIVE-FAILURE-RECOVERY";
+    let liveAttempt = 0;
+    deliverChannelReplyImpl = async () => {
+      liveAttempt += 1;
+      if (liveAttempt === 1) throw new Error("temporary slack failure");
+      return { ok: true };
+    };
+    deliverReplyViaCallbackImpl = async (...args: unknown[]) => {
+      const options = args[4] as
+        | { onSegmentDelivered?: (count: number) => void }
+        | undefined;
+      options?.onSegmentDelivered?.(1);
+    };
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "First live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "one" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      await flush();
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Second live response.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "two" },
+        conversationId,
+        toolUseId: "toolu_2",
+      });
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-msg-live-failure-final",
+      });
+      return { messageId: "user-msg-live-failure" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-live-failure-recovery",
+      content: "please do two things",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["First live response.", "Second live response."]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: "assistant-msg-live-failure-final" },
+    ]);
+    expect(deliveryFailureEvents).toEqual([]);
+    expect(deliveredEvents).toEqual(["evt-live-failure-recovery"]);
+    expect(deliveredSegmentCounts).toEqual([
+      { eventId: "evt-live-failure-recovery", count: 1 },
+    ]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("persists Slack DM live text progress before processing failures", async () => {
+    const conversationId = "conv-dm-processing-failure-after-live";
+    const channelId = "D-PROCESSING-FAILURE-AFTER-LIVE";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "Live response before failure.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "example" },
+        conversationId,
+        toolUseId: "toolu_1",
+      });
+      throw new Error("processing failed after live text");
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-live-before-processing-failure",
+      content: "please do the thing",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(
+      deliveredChannelReplies
+        .map((entry) => entry.payload.text)
+        .filter(Boolean),
+    ).toEqual(["Live response before failure."]);
+    expect(
+      liveDeliveredTextResponseIndexes.get(
+        "evt-live-before-processing-failure",
+      ),
+    ).toEqual([1]);
+    expect(operationOrder).toEqual(["live:1", "processing-failure"]);
+    expect(processingFailureEvents).toEqual([
+      "evt-live-before-processing-failure",
+    ]);
+
+    clearThreadTs(conversationId);
+  });
 });
 
 describe("Slack thinking status timing", () => {
-  const slackStatusLabels = ["is on it", "is working hard", "is touching grass"];
+  const slackStatusLabels = [
+    "is on it",
+    "is working hard",
+    "is touching grass",
+  ];
 
   const trustCtx: TrustContext = {
     trustClass: "guardian",

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -11,7 +11,11 @@ import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
 import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context.js";
-import { updateDeliveredSegmentCount } from "../../../memory/delivery-channels.js";
+import {
+  addSlackDmLiveDeliveredTextResponseIndex,
+  getSlackDmLiveDeliveredTextResponseIndexes,
+  updateDeliveredSegmentCount,
+} from "../../../memory/delivery-channels.js";
 import {
   linkMessage,
   storeReplyMessageId,
@@ -44,6 +48,10 @@ import type {
   MessageProcessor,
   SlackInboundMessageMetadata,
 } from "../../http-types.js";
+import {
+  createSlackDmTextDeliveryController,
+  isSlackDeliveryCallbackUrl,
+} from "../../slack-dm-text-delivery.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
 import { deliverReplyViaCallback } from "../channel-delivery-routes.js";
 import { deliverGeneratedApprovalPrompt } from "../guardian-approval-prompt.js";
@@ -228,6 +236,17 @@ export function processChannelMessageInBackground(
             }
           : undefined;
       let replyMessageId: string | undefined;
+      const slackDmTextDelivery = createSlackDmTextDeliveryController({
+        sourceChannel,
+        chatType,
+        replyCallbackUrl,
+        chatId: externalChatId,
+        assistantId,
+        deliveredTextResponseIndexes:
+          getSlackDmLiveDeliveredTextResponseIndexes(eventId),
+        onTextResponseDelivered: (responseIndex) =>
+          addSlackDmLiveDeliveredTextResponseIndex(eventId, responseIndex),
+      });
       const observeAgentEvent = (msg: ServerMessage): void => {
         if (
           msg.type === "message_complete" &&
@@ -236,6 +255,7 @@ export function processChannelMessageInBackground(
         ) {
           replyMessageId = msg.messageId;
         }
+        slackDmTextDelivery?.observeEvent(msg);
         slackThinkingStatus?.observeEvent(msg);
       };
 
@@ -297,24 +317,33 @@ export function processChannelMessageInBackground(
           { err, conversationId },
           "Background channel message processing failed",
         );
+        if (slackDmTextDelivery) {
+          await slackDmTextDelivery.waitForPendingDeliveries();
+        }
         recordProcessingFailure(eventId, err);
         return;
       }
 
       if (replyCallbackUrl) {
         try {
-          await deliverReplyViaCallback(
-            conversationId,
-            externalChatId,
-            replyCallbackUrl,
-            assistantId,
-            {
-              messageId: replyMessageId,
-              sinceMessageId: userMessageId,
-              onSegmentDelivered: (count) =>
-                updateDeliveredSegmentCount(eventId, count),
-            },
-          );
+          if (slackDmTextDelivery) {
+            await slackDmTextDelivery.waitForPendingDeliveries();
+          }
+
+          if (!slackDmTextDelivery?.wasMessageDeliveredLive(replyMessageId)) {
+            await deliverReplyViaCallback(
+              conversationId,
+              externalChatId,
+              replyCallbackUrl,
+              assistantId,
+              {
+                messageId: replyMessageId,
+                sinceMessageId: userMessageId,
+                onSegmentDelivered: (count) =>
+                  updateDeliveredSegmentCount(eventId, count),
+              },
+            );
+          }
           markDeliveryDelivered(eventId);
         } catch (err) {
           log.error(
@@ -440,12 +469,9 @@ function shouldEmitSlackThinkingStatus(
   sourceChannel: ChannelId,
   replyCallbackUrl?: string,
 ): boolean {
-  if (sourceChannel !== "slack" || !replyCallbackUrl) return false;
-  try {
-    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/slack");
-  } catch {
-    return replyCallbackUrl.endsWith("/deliver/slack");
-  }
+  return (
+    sourceChannel === "slack" && isSlackDeliveryCallbackUrl(replyCallbackUrl)
+  );
 }
 
 export function shouldStartSlackThinkingStatusImmediately(params: {
@@ -627,7 +653,9 @@ function getTaskProgressLoadingMessage(
 
   const activeStep = progress.steps[activeStepIndex]!;
   return [
-    `In progress (${activeStepIndex + 1}/${progress.steps.length}): ${activeStep.label}`,
+    `In progress (${activeStepIndex + 1}/${progress.steps.length}): ${
+      activeStep.label
+    }`,
   ];
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -329,21 +329,22 @@ export function processChannelMessageInBackground(
           if (slackDmTextDelivery) {
             await slackDmTextDelivery.waitForPendingDeliveries();
           }
+          const liveDeliveryResumeOptions =
+            slackDmTextDelivery?.getFinalDeliveryResumeOptions(replyMessageId);
 
-          if (!slackDmTextDelivery?.wasMessageDeliveredLive(replyMessageId)) {
-            await deliverReplyViaCallback(
-              conversationId,
-              externalChatId,
-              replyCallbackUrl,
-              assistantId,
-              {
-                messageId: replyMessageId,
-                sinceMessageId: userMessageId,
-                onSegmentDelivered: (count) =>
-                  updateDeliveredSegmentCount(eventId, count),
-              },
-            );
-          }
+          await deliverReplyViaCallback(
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            assistantId,
+            {
+              messageId: replyMessageId,
+              sinceMessageId: userMessageId,
+              ...liveDeliveryResumeOptions,
+              onSegmentDelivered: (count) =>
+                updateDeliveredSegmentCount(eventId, count),
+            },
+          );
           markDeliveryDelivered(eventId);
         } catch (err) {
           log.error(

--- a/assistant/src/runtime/slack-dm-text-delivery.ts
+++ b/assistant/src/runtime/slack-dm-text-delivery.ts
@@ -31,7 +31,9 @@ export function shouldDeliverSlackDmTextResponses(params: {
 export type SlackDmTextDeliveryController = {
   observeEvent: (msg: ServerMessage) => void;
   waitForPendingDeliveries: () => Promise<void>;
-  wasMessageDeliveredLive: (messageId: string | undefined) => boolean;
+  getFinalDeliveryResumeOptions: (
+    messageId: string | undefined,
+  ) => { startFromSegment: number; messageTs?: string } | undefined;
 };
 
 export function createSlackDmTextDeliveryController(params: {
@@ -52,6 +54,7 @@ export function createSlackDmTextDeliveryController(params: {
     params.deliveredTextResponseIndexes ?? [],
   );
   const messageIdToResponseIndexes = new Map<string, number[]>();
+  const responseIndexToMessageTs = new Map<number, string>();
   const messagesWithUndeliveredText = new Set<string>();
   let textResponseIndex = 0;
   let pendingText = "";
@@ -87,8 +90,9 @@ export function createSlackDmTextDeliveryController(params: {
     deliveryChain = deliveryChain
       .catch(() => undefined)
       .then(async () => {
+        let result: Awaited<ReturnType<typeof deliverChannelReply>>;
         try {
-          await deliverChannelReply(replyCallbackUrl, {
+          result = await deliverChannelReply(replyCallbackUrl, {
             chatId: params.chatId,
             text: deliverableText,
             assistantId: params.assistantId,
@@ -102,6 +106,9 @@ export function createSlackDmTextDeliveryController(params: {
           return;
         }
 
+        if (result.ts) {
+          responseIndexToMessageTs.set(currentResponseIndex, result.ts);
+        }
         deliveredTextResponseIndexes.add(currentResponseIndex);
         try {
           params.onTextResponseDelivered?.(currentResponseIndex);
@@ -140,20 +147,28 @@ export function createSlackDmTextDeliveryController(params: {
       }
     },
     waitForPendingDeliveries: () => deliveryChain,
-    wasMessageDeliveredLive: (messageId) => {
-      if (
-        typeof messageId !== "string" ||
-        messagesWithUndeliveredText.has(messageId)
-      ) {
-        return false;
+    getFinalDeliveryResumeOptions: (messageId) => {
+      if (typeof messageId !== "string") {
+        return undefined;
       }
       const responseIndexes = messageIdToResponseIndexes.get(messageId) ?? [];
-      return (
-        responseIndexes.length > 0 &&
-        responseIndexes.every((responseIndex) =>
-          deliveredTextResponseIndexes.has(responseIndex),
-        )
-      );
+      let deliveredPrefixCount = 0;
+      for (const responseIndex of responseIndexes) {
+        if (!deliveredTextResponseIndexes.has(responseIndex)) break;
+        deliveredPrefixCount += 1;
+      }
+      if (deliveredPrefixCount === 0) return undefined;
+
+      const firstLiveResponseIndex = responseIndexes[0];
+      const messageTs =
+        !messagesWithUndeliveredText.has(messageId) &&
+        firstLiveResponseIndex !== undefined
+          ? responseIndexToMessageTs.get(firstLiveResponseIndex)
+          : undefined;
+      return {
+        startFromSegment: deliveredPrefixCount,
+        ...(messageTs ? { messageTs } : {}),
+      };
     },
   };
 }

--- a/assistant/src/runtime/slack-dm-text-delivery.ts
+++ b/assistant/src/runtime/slack-dm-text-delivery.ts
@@ -1,0 +1,159 @@
+import type { ChannelId } from "../channels/types.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getLogger } from "../util/logger.js";
+import { deliverChannelReply } from "./gateway-client.js";
+
+const log = getLogger("runtime-http");
+
+const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
+
+export function isSlackDeliveryCallbackUrl(replyCallbackUrl?: string): boolean {
+  if (!replyCallbackUrl) return false;
+  try {
+    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/slack");
+  } catch {
+    return replyCallbackUrl.endsWith("/deliver/slack");
+  }
+}
+
+export function shouldDeliverSlackDmTextResponses(params: {
+  sourceChannel: ChannelId;
+  chatType?: string;
+  replyCallbackUrl?: string;
+}): boolean {
+  return (
+    params.sourceChannel === "slack" &&
+    params.chatType === "im" &&
+    isSlackDeliveryCallbackUrl(params.replyCallbackUrl)
+  );
+}
+
+export type SlackDmTextDeliveryController = {
+  observeEvent: (msg: ServerMessage) => void;
+  waitForPendingDeliveries: () => Promise<void>;
+  wasMessageDeliveredLive: (messageId: string | undefined) => boolean;
+};
+
+export function createSlackDmTextDeliveryController(params: {
+  sourceChannel: ChannelId;
+  chatType?: string;
+  replyCallbackUrl?: string;
+  chatId: string;
+  assistantId?: string;
+  deliveredTextResponseIndexes?: readonly number[];
+  onTextResponseDelivered?: (responseIndex: number) => void;
+}): SlackDmTextDeliveryController | undefined {
+  const { replyCallbackUrl } = params;
+  if (!shouldDeliverSlackDmTextResponses(params) || !replyCallbackUrl) {
+    return undefined;
+  }
+
+  const deliveredTextResponseIndexes = new Set(
+    params.deliveredTextResponseIndexes ?? [],
+  );
+  const messageIdToResponseIndexes = new Map<string, number[]>();
+  const messagesWithUndeliveredText = new Set<string>();
+  let textResponseIndex = 0;
+  let pendingText = "";
+  let currentMessageResponseIndexes: number[] = [];
+  let deliveryChain = Promise.resolve();
+
+  const associateCurrentMessageResponses = (
+    messageId: string | undefined,
+  ): void => {
+    if (!messageId || currentMessageResponseIndexes.length === 0) return;
+    const responseIndexes = messageIdToResponseIndexes.get(messageId) ?? [];
+    for (const responseIndex of currentMessageResponseIndexes) {
+      if (!responseIndexes.includes(responseIndex)) {
+        responseIndexes.push(responseIndex);
+      }
+    }
+    messageIdToResponseIndexes.set(messageId, responseIndexes);
+    currentMessageResponseIndexes = [];
+  };
+
+  const flushPendingText = (): void => {
+    const text = pendingText;
+    pendingText = "";
+
+    const deliverableText = text.replace(NO_RESPONSE_INLINE_RE, "").trim();
+    if (deliverableText.length === 0) return;
+
+    textResponseIndex += 1;
+    const currentResponseIndex = textResponseIndex;
+    currentMessageResponseIndexes.push(currentResponseIndex);
+    if (deliveredTextResponseIndexes.has(currentResponseIndex)) return;
+
+    deliveryChain = deliveryChain
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: params.chatId,
+            text: deliverableText,
+            assistantId: params.assistantId,
+            useBlocks: true,
+          });
+        } catch (err) {
+          log.warn(
+            { err, chatId: params.chatId },
+            "Failed to deliver intermediate Slack DM assistant text",
+          );
+          return;
+        }
+
+        deliveredTextResponseIndexes.add(currentResponseIndex);
+        try {
+          params.onTextResponseDelivered?.(currentResponseIndex);
+        } catch (err) {
+          log.warn(
+            { err, chatId: params.chatId, responseIndex: currentResponseIndex },
+            "Failed to persist intermediate Slack DM assistant text progress",
+          );
+        }
+      });
+  };
+
+  return {
+    observeEvent(msg) {
+      if (msg.type === "assistant_text_delta") {
+        pendingText += msg.text;
+        return;
+      }
+
+      if (msg.type === "message_complete") {
+        if (typeof msg.messageId === "string") {
+          associateCurrentMessageResponses(msg.messageId);
+          if (
+            pendingText.replace(NO_RESPONSE_INLINE_RE, "").trim().length > 0
+          ) {
+            messagesWithUndeliveredText.add(msg.messageId);
+          }
+        }
+        pendingText = "";
+        currentMessageResponseIndexes = [];
+        return;
+      }
+
+      if (msg.type === "tool_use_start") {
+        flushPendingText();
+      }
+    },
+    waitForPendingDeliveries: () => deliveryChain,
+    wasMessageDeliveredLive: (messageId) => {
+      if (
+        typeof messageId !== "string" ||
+        messagesWithUndeliveredText.has(messageId)
+      ) {
+        return false;
+      }
+      const responseIndexes = messageIdToResponseIndexes.get(messageId) ?? [];
+      return (
+        responseIndexes.length > 0 &&
+        responseIndexes.every((responseIndex) =>
+          deliveredTextResponseIndexes.has(responseIndex),
+        )
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Deliver Slack DM assistant text live when a response segment is followed by a tool call, so the user sees the text before the assistant continues working.
- Persist live-delivered Slack DM response indexes on the inbound event so processing retries do not repost the same live text.
- Resume final callback delivery from the live-delivered segment and reuse the Slack message ts when available, preserving `slackMeta.channelTs` reconciliation and attachment delivery behavior.

## Root Cause

The shipped mainline path only delivered Slack DM replies at the final callback stage. If the assistant emitted text and then ended that model turn with a tool call, the UI transcript showed the text, but Slack did not receive it until the later final-delivery path. `origin/main` also lacked the live-delivery helper/signatures from the feature branch (`createSlackDmTextDeliveryController`, `slackDmLiveDeliveredTextResponseIndexes`, `getFinalDeliveryResumeOptions`).

## Validation

- `cd assistant && bun test src/__tests__/channel-reply-delivery.test.ts`
- `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts src/__tests__/channel-retry-sweep.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-push hook: assistant typecheck and ESLint on changed files passed

Note: running all three focused test files in a single Bun process hits an existing mock-isolation issue in `channel-reply-delivery.test.ts`; the affected suites pass when run in separate scoped commands.