### PR TITLE
[codex] Deliver prior channel text for empty final turns

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -392,6 +392,71 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload.text).toBe("Current answer.");
   });
 
+  it("falls back to current-turn assistant text when an explicit final assistant row is empty", async () => {
+    conversationMessages.push(
+      { id: "msg-old-user", role: "user", content: "old prompt" },
+      {
+        id: "msg-old-assistant",
+        role: "assistant",
+        content: '[{"type":"text","text":"old answer"}]',
+      },
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer before tool"}]',
+      },
+      {
+        id: "msg-current-tool-result",
+        role: "user",
+        content: '[{"type":"tool_result","tool_use_id":"tu-1","content":"ok"}]',
+      },
+      {
+        id: "msg-current-empty-final",
+        role: "assistant",
+        content: "[]",
+      },
+    );
+    const emptyRendered = {
+      text: "",
+      textSegments: [],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: [],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    const textRendered = {
+      text: "Current answer before tool.",
+      textSegments: ["Current answer before tool."],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    renderedHistoryContentQueue.push(
+      emptyRendered,
+      emptyRendered,
+      textRendered,
+      textRendered,
+    );
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      {
+        messageId: "msg-current-empty-final",
+        sinceMessageId: "msg-current-user",
+      },
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Current answer before tool.");
+  });
+
   it("does not cross the current user boundary when no current-turn assistant text exists", async () => {
     conversationMessages.push(
       { id: "msg-old-user", role: "user", content: "old prompt" },

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -15,6 +15,7 @@ const deliveryCalls: Array<{
   callbackUrl: string;
   assistantId?: string;
   messageId?: string;
+  sinceMessageId?: string;
   startFromSegment?: number;
   messageTs?: string;
 }> = [];
@@ -38,6 +39,7 @@ mock.module("../runtime/channel-reply-delivery.js", () => ({
     assistantId?: string,
     options?: {
       messageId?: string;
+      sinceMessageId?: string;
       startFromSegment?: number;
       messageTs?: string;
     },
@@ -50,6 +52,9 @@ mock.module("../runtime/channel-reply-delivery.js", () => ({
       messageId: options?.messageId,
       startFromSegment: options?.startFromSegment,
     };
+    if (options?.sinceMessageId !== undefined) {
+      call.sinceMessageId = options.sinceMessageId;
+    }
     if (options?.messageTs !== undefined) {
       call.messageTs = options.messageTs;
     }
@@ -550,6 +555,7 @@ describe("channel-retry-sweep", () => {
         callbackUrl: "https://example.test/deliver/slack",
         assistantId: undefined,
         messageId: "assistant-live-retry-final",
+        sinceMessageId: "user-live-retry",
         startFromSegment: 2,
       },
     ]);
@@ -639,6 +645,7 @@ describe("channel-retry-sweep", () => {
         callbackUrl: "https://example.test/deliver/slack",
         assistantId: undefined,
         messageId: "assistant-live-retry-same-reply",
+        sinceMessageId: "user-live-retry-same-reply",
         startFromSegment: 1,
         messageTs: "1700000000.000044",
       },
@@ -735,6 +742,7 @@ describe("channel-retry-sweep", () => {
         callbackUrl: "https://example.test/deliver/slack",
         assistantId: undefined,
         messageId: "assistant-live-retry-final-fails",
+        sinceMessageId: "user-live-retry-final-fails",
         startFromSegment: 1,
         messageTs: "1700000000.000055",
       },
@@ -878,6 +886,7 @@ describe("channel-retry-sweep", () => {
         callbackUrl: "https://example.test/deliver/telegram",
         assistantId: "assistant-1",
         messageId: "assistant-delivery-fallback",
+        sinceMessageId: "user-delivery-fallback",
         startFromSegment: 0,
       },
     ]);
@@ -885,5 +894,76 @@ describe("channel-retry-sweep", () => {
       row?.rawPayload ? JSON.parse(row.rawPayload).replyMessageId : undefined,
     ).toBe("assistant-delivery-fallback");
     expect(row?.deliveryStatus).toBe("delivered");
+  });
+
+  test("delivery retry passes linked user id when stored reply id is a final empty assistant row", async () => {
+    const inbound = deliveryCrud.recordInbound(
+      "telegram",
+      "chat-delivery-empty-final",
+      "msg-delivery-empty-final",
+    );
+    deliveryCrud.storePayload(inbound.eventId, {
+      content: "already processed",
+      sourceChannel: "telegram",
+      interface: "telegram",
+      externalChatId: "chat-delivery-empty-final",
+      replyCallbackUrl: "https://example.test/deliver/telegram",
+      assistantId: "assistant-1",
+      replyMessageId: "assistant-empty-final",
+    });
+
+    const db = getDb();
+    db.insert(messages)
+      .values([
+        {
+          id: "user-delivery-empty-final",
+          conversationId: inbound.conversationId,
+          role: "user",
+          content: JSON.stringify([
+            { type: "text", text: "already processed" },
+          ]),
+          createdAt: 1_000,
+        },
+        {
+          id: "assistant-visible-before-tool",
+          conversationId: inbound.conversationId,
+          role: "assistant",
+          content: JSON.stringify([{ type: "text", text: "visible reply" }]),
+          createdAt: 1_001,
+        },
+        {
+          id: "assistant-empty-final",
+          conversationId: inbound.conversationId,
+          role: "assistant",
+          content: JSON.stringify([]),
+          createdAt: 1_002,
+        },
+      ])
+      .run();
+    deliveryCrud.linkMessage(inbound.eventId, "user-delivery-empty-final");
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "processed",
+        deliveryStatus: "failed",
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    await sweepFailedEvents(async () => {
+      throw new Error("processMessage should not be called");
+    });
+
+    expect(deliveryCalls).toEqual([
+      {
+        conversationId: inbound.conversationId,
+        externalChatId: "chat-delivery-empty-final",
+        callbackUrl: "https://example.test/deliver/telegram",
+        assistantId: "assistant-1",
+        messageId: "assistant-empty-final",
+        sinceMessageId: "user-delivery-empty-final",
+        startFromSegment: 0,
+      },
+    ]);
   });
 });

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -357,13 +357,31 @@ export async function deliverReplyViaCallback(
         `Target assistant reply message not found: ${options.messageId}`,
       );
     }
-    await deliverPersistedAssistantMessageViaCallback(
+    const delivered = await deliverPersistedAssistantMessageViaCallback(
       msg,
       externalChatId,
       callbackUrl,
       assistantId,
       options,
     );
+    if (!delivered && options.sinceMessageId) {
+      const replyMessageId = findAssistantReplyMessageIdForTurn(
+        conversationId,
+        options.sinceMessageId,
+      );
+      if (replyMessageId && replyMessageId !== options.messageId) {
+        const fallbackMsg = getMessageById(replyMessageId, conversationId);
+        if (fallbackMsg && fallbackMsg.role === "assistant") {
+          await deliverPersistedAssistantMessageViaCallback(
+            fallbackMsg,
+            externalChatId,
+            callbackUrl,
+            assistantId,
+            options,
+          );
+        }
+      }
+    }
     return;
   }
 

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -448,6 +448,7 @@ export async function sweepFailedEvents(
         assistantId,
         {
           messageId: replyMessageId,
+          sinceMessageId: event.messageId ?? undefined,
           startFromSegment: event.deliveredSegmentCount,
           onSegmentDelivered: (count) =>
             updateDeliveredSegmentCount(event.id, count),


### PR DESCRIPTION
## Summary

- Fix the shared callback delivery path so an explicit final assistant `messageId` that has no deliverable content can fall back to earlier deliverable assistant text from the same user turn.
- Pass the linked user message id into processed-event delivery retries, so the same fallback works after transient channel delivery failures.
- Add regression coverage for both immediate callback delivery and delivery retry.

## Root Cause

This is the broader channel/DM issue, not the Slack-DM-specific live-delivery feature branch. When the assistant streams visible text, then calls a tool, and finally ends with an empty assistant row, the runtime can pass that final empty assistant row as the explicit `messageId` to `deliverReplyViaCallback`. The helper already knew how to search the current turn for prior visible assistant text via `sinceMessageId`, but the explicit `messageId` branch returned immediately after seeing the empty row. That bypassed the existing fallback, so callback-based channels could deliver nothing even though the transcript showed text.

## Validation

- `cd assistant && bun test src/__tests__/channel-reply-delivery.test.ts`
- `cd assistant && bun test src/__tests__/channel-retry-sweep.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-push hook: assistant typecheck and ESLint on changed files passed

Note: I closed the earlier draft PR #31658 because it pulled in DM-specific work from `feature/slack-dm-assistant-responses`, which is intended to merge separately.