### PR TITLE
[codex] Fix Slack placeholder history visibility

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -183,6 +183,7 @@ function readPersistedSlackRows(): Array<{
   provenanceSourceChannel: string | undefined;
   provenanceGuardianExternalUserId: string | undefined;
   provenanceRequesterIdentifier: string | undefined;
+  slackAssistantThreadPlaceholder: boolean | undefined;
 }> {
   const db = getDb();
   return db
@@ -233,6 +234,10 @@ function readPersistedSlackRows(): Array<{
         provenanceRequesterIdentifier:
           typeof envelope.provenanceRequesterIdentifier === "string"
             ? envelope.provenanceRequesterIdentifier
+            : undefined,
+        slackAssistantThreadPlaceholder:
+          typeof envelope.slackAssistantThreadPlaceholder === "boolean"
+            ? envelope.slackAssistantThreadPlaceholder
             : undefined,
       };
     });
@@ -520,7 +525,7 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(botRow?.provenanceRequesterIdentifier).toBe("B_BOT");
   });
 
-  test("skips Slack assistant new-thread placeholder during DM backfill", async () => {
+  test("persists Slack assistant new-thread placeholder during DM backfill and marks it out of model context", async () => {
     backfillDmMock.mockImplementation(async () => [
       makeBackfilledMessage({
         id: "1700000000.000001",
@@ -551,8 +556,22 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     const rows = readPersistedSlackRows();
     expect(rows.map((row) => row.rawContent).sort()).toEqual([
       "New Assistant Thread",
+      "New Assistant Thread",
       "real bot context",
     ]);
+    const assistantPlaceholder = rows.find(
+      (row) =>
+        row.rawContent === "New Assistant Thread" &&
+        row.slackMeta?.actorExternalUserId === "B_ASSISTANT",
+    );
+    expect(assistantPlaceholder?.role).toBe("assistant");
+    expect(assistantPlaceholder?.slackAssistantThreadPlaceholder).toBe(true);
+    const otherPlaceholder = rows.find(
+      (row) =>
+        row.rawContent === "New Assistant Thread" &&
+        row.slackMeta?.actorExternalUserId === "B_OTHER",
+    );
+    expect(otherPlaceholder?.slackAssistantThreadPlaceholder).toBeUndefined();
     expect(
       rows.some((row) => row.slackMeta?.actorExternalUserId === "B_OTHER"),
     ).toBe(true);

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -115,6 +115,7 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import type { Message } from "../providers/types.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 import {
   _backfillTriggerCache,
   triggerSlackThreadBackfillIfNeeded,
@@ -1351,7 +1352,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.provenanceRequesterIdentifier).toBe("U_OTHER_BOT");
   });
 
-  test("skips Slack assistant new-thread placeholder during backfill", async () => {
+  test("persists Slack assistant new-thread placeholder during backfill while excluding it from model context", async () => {
     const conv = createTestConversation();
 
     backfillThreadMock.mockImplementation(async () => [
@@ -1385,12 +1386,19 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     });
 
     expect(result.fetched).toBe(3);
-    expect(result.persisted).toBe(2);
+    expect(result.persisted).toBe(3);
     const rows = readPersistedSlackRows(conv.id);
     expect(rows.map((row) => row.rawContent).sort()).toEqual([
       "New Assistant Thread",
+      "New Assistant Thread",
       "real bot context",
     ]);
+    const assistantPlaceholder = rows.find(
+      (row) =>
+        row.rawContent === "New Assistant Thread" &&
+        row.actorExternalUserId === "B_ASSISTANT",
+    );
+    expect(assistantPlaceholder?.role).toBe("assistant");
     const assistantRow = rows.find(
       (row) => row.rawContent === "real bot context",
     );
@@ -1399,6 +1407,16 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(rows.some((row) => row.actorExternalUserId === "B_OTHER")).toBe(
       true,
     );
+
+    const context = loadSlackChronologicalContext(conv.id, SLACK_CHANNEL_CAPS, {
+      loader: readMessageRowsByConversation,
+      trustClass: "guardian",
+    });
+    expect(context).not.toBeNull();
+    const rendered = JSON.stringify(context!.messages);
+    expect(rendered.split("New Assistant Thread").length - 1).toBe(1);
+    expect(rendered).toContain("Build Bot");
+    expect(rendered).toContain("real bot context");
   });
 
   test("backfilled non-bot message with empty text is persisted unwrapped", async () => {
@@ -2582,6 +2600,72 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
     expect(calledChannel).toBe(dmChannelId);
     expect(calledThread).toBe(threadTs);
+  });
+
+  test("placeholder-only Slack assistant thread backfill still leaves visible history while live turn is pending", async () => {
+    const dmChannelId = "D0HTTPAPPPLACEHOLDER";
+    const threadTs = "1700000000.000100";
+    const inboundTs = "1700000000.000300";
+    setConfiguredSlackBotUserId("U_BOT");
+    seedHttpActiveMember(dmChannelId);
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: threadTs,
+        conversationId: dmChannelId,
+        text: "New Assistant Thread",
+        sender: { id: "B_ASSISTANT", name: "Ada" },
+        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
+      }),
+    ]);
+
+    let capturedConversationId: string | undefined;
+    let resolveProcessed: (() => void) | undefined;
+    const processed = new Promise<void>((resolve) => {
+      resolveProcessed = resolve;
+    });
+    const processMessage = async (
+      conversationId: string,
+    ): Promise<{ messageId: string }> => {
+      capturedConversationId = conversationId;
+      resolveProcessed?.();
+      throw new Error("Conversation is already processing a message");
+    };
+    setAdapterProcessMessage(processMessage);
+
+    const resp = await handleChannelInbound(
+      buildSlackDmRequest(dmChannelId, inboundTs, {
+        sourceMetadata: {
+          messageId: inboundTs,
+          threadId: threadTs,
+          chatType: "im",
+        },
+      }),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    expect(resp.status).toBe(200);
+    await Promise.race([
+      processed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("processMessage not called")), 250),
+      ),
+    ]);
+    expect(capturedConversationId).toBeDefined();
+
+    const history = handleListMessages({
+      queryParams: {
+        conversationKey: capturedConversationId!,
+        page: "latest",
+        limit: "50",
+      },
+    }) as { messages: Array<{ role: string; content: string }> };
+
+    expect(history.messages).toEqual([
+      expect.objectContaining({
+        content: "New Assistant Thread",
+      }),
+    ]);
   });
 
   test("second thread reply within the TTL window can fetch a newer bounded gap", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1206,15 +1206,19 @@ function placeholderForBlockType(type: ContentBlock["type"]): string | null {
 function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
   let slackMeta: ReturnType<typeof readSlackMetadata> = null;
   let provenanceTrustClass: TrustClass | undefined;
+  let slackAssistantThreadPlaceholder = false;
   if (row.metadata) {
     try {
       const outer = JSON.parse(row.metadata) as {
         slackMeta?: unknown;
         provenanceTrustClass?: unknown;
+        slackAssistantThreadPlaceholder?: unknown;
       };
       if (typeof outer.slackMeta === "string") {
         slackMeta = readSlackMetadata(outer.slackMeta);
       }
+      slackAssistantThreadPlaceholder =
+        outer.slackAssistantThreadPlaceholder === true;
       if (
         outer.provenanceTrustClass === "guardian" ||
         outer.provenanceTrustClass === "trusted_contact" ||
@@ -1283,6 +1287,9 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
     role: row.role,
     content: plainText,
     metadata: slackMeta,
+    ...(slackAssistantThreadPlaceholder
+      ? { slackAssistantThreadPlaceholder: true }
+      : {}),
     senderLabel,
     createdAt: row.createdAt,
     contentBlocks,
@@ -1297,6 +1304,7 @@ function isSlackAssistantThreadPlaceholder(
   message: RenderableSlackMessage,
   canonicalConfiguredBotUserId: string | null,
 ): boolean {
+  if (message.slackAssistantThreadPlaceholder === true) return true;
   if (!canonicalConfiguredBotUserId) return false;
   const metadata = message.metadata;
   if (!metadata || metadata.eventKind !== "message") return false;
@@ -1312,7 +1320,7 @@ function isSlackAssistantThreadPlaceholder(
     Array.isArray(metadata.slackFiles) && metadata.slackFiles.length > 0;
 
   return (
-    message.role === "user" &&
+    (message.role === "user" || message.role === "assistant") &&
     canonicalActor === canonicalConfiguredBotUserId &&
     isThreadRoot &&
     !hasSlackFiles &&

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -119,6 +119,7 @@ export const messageMetadataSchema = z
     provenanceSourceChannel: channelIdSchema.optional(),
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
+    slackAssistantThreadPlaceholder: z.boolean().optional(),
     automated: z.boolean().optional(),
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -31,6 +31,8 @@ export interface RenderableSlackMessage {
   content: string;
   /** `null` indicates a legacy pre-upgrade row stored without Slack metadata. */
   metadata: SlackMessageMetadata | null;
+  /** True for Slack's synthetic assistant-thread starter row. */
+  slackAssistantThreadPlaceholder?: boolean;
   /**
    * Sender display name to prepend to the tag line (e.g. `"@alice"`), or
    * `null` to omit the label entirely. Callers should pass `null` when the

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -86,6 +86,7 @@ import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { deliverChannelReply } from "../gateway-client.js";
+import { publishConversationMessagesChanged } from "../sync/resource-sync-events.js";
 import { resolveTrustContext } from "../trust-context-resolver.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
@@ -1632,6 +1633,12 @@ async function persistBackfilledSlackMessage(params: {
     message.metadata,
     "actorTimezoneLabel",
   );
+  const assistantAuthored = await isBackfilledSlackAssistantMessage(
+    message,
+    params.account,
+  );
+  const assistantThreadPlaceholder =
+    assistantAuthored && isSlackAssistantThreadPlaceholderShape(message);
   const isGuardian = isBackfilledSlackGuardianMessage(
     message,
     params.guardianExternalUserId,
@@ -1658,17 +1665,15 @@ async function persistBackfilledSlackMessage(params: {
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
 
-  const role = (await isBackfilledSlackAssistantMessage(
-    message,
-    params.account,
-  ))
-    ? "assistant"
-    : "user";
+  const role = assistantAuthored ? "assistant" : "user";
 
   const rawText = message.text ?? "";
 
   const persisted = await addMessage(params.conversationId, role, rawText, {
     slackMeta: writeSlackMetadata(slackMeta),
+    ...(assistantThreadPlaceholder
+      ? { slackAssistantThreadPlaceholder: true }
+      : {}),
     provenanceTrustClass: isGuardian ? "guardian" : "unknown",
     provenanceSourceChannel: "slack",
     ...(params.guardianExternalUserId
@@ -1797,10 +1802,9 @@ function isBackfilledSlackGuardianMessage(
 
 const SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT = "New Assistant Thread";
 
-async function isSlackAssistantThreadPlaceholder(
+function isSlackAssistantThreadPlaceholderShape(
   message: ProviderMessage,
-  account: string | undefined,
-): Promise<boolean> {
+): boolean {
   if (message.metadata?.isBot !== true) return false;
   const hasSlackFiles =
     Array.isArray(message.metadata.slackFiles) &&
@@ -1810,8 +1814,7 @@ async function isSlackAssistantThreadPlaceholder(
       SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT &&
     (message.threadId === undefined || message.threadId === message.id) &&
     message.hasAttachments !== true &&
-    !hasSlackFiles &&
-    (await isBackfilledSlackAssistantMessage(message, account))
+    !hasSlackFiles
   );
 }
 
@@ -1981,9 +1984,6 @@ async function runBackfillSlackDmIfCold(params: {
     const ordered = [...fetched].reverse();
     for (const message of ordered) {
       if (seen.has(message.id)) continue;
-      if (await isSlackAssistantThreadPlaceholder(message, params.account)) {
-        continue;
-      }
       try {
         await persistBackfilledSlackMessage({
           conversationId: params.conversationId,
@@ -2018,6 +2018,9 @@ async function runBackfillSlackDmIfCold(params: {
       },
       "DM cold-start backfill complete",
     );
+    if (written > 0) {
+      publishConversationMessagesChanged(params.conversationId);
+    }
   } catch (err) {
     // `channel_not_found` almost always means the resolved connection is
     // pointing at the wrong Slack workspace (a real config bug), so log it
@@ -2547,9 +2550,6 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     for (const message of fetched) {
       if (!message.id) continue;
       if (threadState.storedChannelTs.has(message.id)) continue;
-      if (await isSlackAssistantThreadPlaceholder(message, account)) {
-        continue;
-      }
       try {
         await persistBackfilledSlackMessage({
           conversationId,
@@ -2579,6 +2579,9 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
       },
       "Slack thread backfill persisted thread messages",
     );
+    if (persisted > 0) {
+      publishConversationMessagesChanged(conversationId);
+    }
     return {
       fetched: fetched.length,
       persisted,


### PR DESCRIPTION
## Summary

- Persist Slack's synthetic `New Assistant Thread` starter row during DM and thread backfill so new Slack conversations have visible web history even while the live turn is still pending.
- Mark assistant-owned starter rows with `slackAssistantThreadPlaceholder` and filter that marker from Slack model-context assembly, preserving the intent of the earlier placeholder-filtering PR.
- Publish conversation message invalidations after Slack backfill writes so active web views refresh when history is created.

## Root Cause

The earlier placeholder filtering change skipped Slack's synthetic assistant-thread starter row during backfill. That kept the row out of model context, but it also allowed a newly created Slack DM/thread conversation to have zero visible persisted messages if the live inbound turn was delayed or failed before writing its user row. The web app then rendered the blank assistant start state for a real Slack conversation.

## Validation

- `cd assistant && bun test src/__tests__/thread-backfill.test.ts src/__tests__/dm-backfill.test.ts src/__tests__/conversation-runtime-assembly.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `git diff --check`
- Pre-commit: secret scan, generic examples, Prettier, eslint
- Pre-push: assistant typecheck and eslint