### PR TITLE
fix(assistant): make /clean durable on reload and fork-aware

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -297,6 +297,114 @@ describe("forkConversation", () => {
     ]);
   });
 
+  test("inherits cleanedAt when forking past the clean event", async () => {
+    const source = createConversation("Clean thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const preClean = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const cleanedAt = preClean.createdAt + 1;
+    getDb()
+      .update(conversations)
+      .set({ cleanedAt })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const postClean = await addMessage(
+      source.id,
+      "user",
+      "Message 3",
+      undefined,
+      { skipIndexing: true },
+    );
+    expect(postClean.createdAt).toBeGreaterThanOrEqual(cleanedAt);
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: postClean.id,
+    });
+
+    expect(fork.cleanedAt).toBe(cleanedAt);
+  });
+
+  test("does not inherit cleanedAt when forking before the clean event", async () => {
+    const source = createConversation("Clean thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const preClean = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const cleanedAt = preClean.createdAt + 1;
+    getDb()
+      .update(conversations)
+      .set({ cleanedAt })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    await addMessage(source.id, "user", "Message 3", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: preClean.id,
+    });
+
+    expect(fork.cleanedAt).toBeNull();
+  });
+
+  test("inherits cleanedAt on a full-history fork", async () => {
+    const source = createConversation("Clean thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const last = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const cleanedAt = last.createdAt - 1;
+    getDb()
+      .update(conversations)
+      .set({ cleanedAt })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(fork.cleanedAt).toBe(cleanedAt);
+  });
+
+  test("leaves cleanedAt null when the source has no clean event", async () => {
+    const source = createConversation("Unclean thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "Message 2", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(fork.cleanedAt).toBeNull();
+  });
+
   test("rejects forks when the source conversation has no persisted messages", () => {
     const source = createConversation("Empty thread");
 

--- a/assistant/src/__tests__/conversation-load-cleaned-at.test.ts
+++ b/assistant/src/__tests__/conversation-load-cleaned-at.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    llm: {
+      default: {
+        provider: "mock-provider",
+        model: "mock-model",
+        maxTokens: 4096,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: false, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 100000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+let mockDbMessages: Array<{
+  id: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata?: string | null;
+}> = [];
+let mockConversation: Record<string, unknown> | null = null;
+
+mock.module("../memory/conversation-crud.js", () => ({
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  updateConversationTitle: () => {},
+  updateConversationUsage: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => mockDbMessages,
+  getConversation: () => mockConversation,
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: async () => ({ id: "persisted" }),
+  setConversationCleanedAt: () => {},
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+}));
+
+mock.module("../memory/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+import { Conversation } from "../daemon/conversation.js";
+
+function makeConversation(): Conversation {
+  const provider = {
+    name: "mock",
+    sendMessage: async () => ({
+      content: [],
+      model: "mock",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      stopReason: "end_turn",
+    }),
+  };
+  const conv = new Conversation(
+    "conv-1",
+    provider,
+    "system prompt",
+    4096,
+    () => {},
+    "/tmp",
+  );
+  conv.setTrustContext({ trustClass: "guardian", sourceChannel: "vellum" });
+  return conv;
+}
+
+function textBlocks(content: ReadonlyArray<{ type: string; text?: string }>) {
+  return content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text);
+}
+
+describe("loadFromDb with cleanedAt", () => {
+  beforeEach(() => {
+    mockDbMessages = [];
+    mockConversation = null;
+  });
+
+  test("strips injection prefixes from pre-clean user content", async () => {
+    const cleanedAt = 1000;
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      cleanedAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "<channel_capabilities>old</channel_capabilities>",
+          },
+          { type: "text", text: "Hello" },
+        ]),
+        createdAt: 500,
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Hi back" }]),
+        createdAt: 600,
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "<channel_capabilities>fresh</channel_capabilities>",
+          },
+          { type: "text", text: "Second turn" },
+        ]),
+        createdAt: 1500,
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(textBlocks(messages[0].content)).toEqual(["Hello"]);
+    expect(textBlocks(messages[1].content)).toEqual(["Hi back"]);
+    expect(textBlocks(messages[2].content)).toEqual([
+      "<channel_capabilities>fresh</channel_capabilities>",
+      "Second turn",
+    ]);
+  });
+
+  test("skips metadata rehydration for pre-clean messages", async () => {
+    const cleanedAt = 1000;
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      cleanedAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Pre-clean turn" }]),
+        createdAt: 500,
+        metadata: JSON.stringify({
+          pkbContextBlock: "<knowledge_base>stale</knowledge_base>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        createdAt: 600,
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Mid post-clean turn" },
+        ]),
+        createdAt: 1500,
+        metadata: JSON.stringify({
+          pkbContextBlock: "<knowledge_base>kept</knowledge_base>",
+        }),
+      },
+      {
+        id: "m4",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Tail reply" }]),
+        createdAt: 1600,
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(textBlocks(messages[0].content)).toEqual(["Pre-clean turn"]);
+    expect(textBlocks(messages[2].content).join("\n")).toContain(
+      "<knowledge_base>kept</knowledge_base>",
+    );
+  });
+
+  test("leaves messages untouched when cleanedAt is null", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      cleanedAt: null,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "<channel_capabilities>kept</channel_capabilities>",
+          },
+          { type: "text", text: "Hi" },
+        ]),
+        createdAt: 500,
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(textBlocks(messages[0].content)).toEqual([
+      "<channel_capabilities>kept</channel_capabilities>",
+      "Hi",
+    ]);
+  });
+});

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -31,6 +31,7 @@ import { type AbortReason, createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { unregisterCallNotifiers } from "./conversation-notifiers.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
+import { stripInjectionsForCompaction } from "./conversation-runtime-assembly.js";
 import { resetSkillToolProjection } from "./conversation-skill-tools.js";
 import { resolveTrustClass } from "./conversation-tool-setup.js";
 import { repairHistory } from "./history-repair.js";
@@ -188,6 +189,19 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
     ctx.contextCompactedAt = conv?.contextCompactedAt ?? null;
   }
 
+  // `/clean` persists a timestamp; messages older than this should skip
+  // metadata rehydration and have any injection prefixes still embedded in
+  // their content stripped, so the cleaned state survives reload and forks.
+  const cleanedAt = conv?.cleanedAt ?? null;
+  const slicedDbMessages = dbMessages.slice(ctx.contextCompactedMessageCount);
+  let preCleanCount = 0;
+  if (cleanedAt != null) {
+    const boundary = slicedDbMessages.findIndex(
+      (m) => m.createdAt >= cleanedAt,
+    );
+    preCleanCount = boundary === -1 ? slicedDbMessages.length : boundary;
+  }
+
   // Mirror the injection-time gate (`shouldExposePersonalMemory` in
   // `conversation-agent-loop.ts`) so background/local conversations
   // (sourceChannel `undefined` or `"vellum"`) can rehydrate the persisted
@@ -198,129 +212,141 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
     sourceChannel: ctx.trustContext?.sourceChannel,
     isTrustedActor: resolveTrustClass(ctx.trustContext) === "guardian",
   });
-  const parsedMessages: Message[] = dbMessages
-    .slice(ctx.contextCompactedMessageCount)
-    .map((m, index, arr) => {
-      const role = m.role as "user" | "assistant";
-      let content: ContentBlock[];
+  const parsedMessages: Message[] = slicedDbMessages.map((m, index, arr) => {
+    const isPreClean = index < preCleanCount;
+    const role = m.role as "user" | "assistant";
+    let content: ContentBlock[];
+    try {
+      const parsed = JSON.parse(m.content);
+      content = Array.isArray(parsed)
+        ? parsed
+        : [{ type: "text", text: m.content }];
+    } catch {
+      log.warn(
+        { conversationId: ctx.conversationId, messageId: m.id },
+        "Invalid JSON in persisted message content, replacing with safe text block",
+      );
+      content = [{ type: "text", text: m.content }];
+    }
+
+    content = reinjectImageSourcePaths(content, role, m.metadata);
+
+    // Re-inject persisted injection blocks from metadata so it survives
+    // conversation reloads (eviction, restart, fork).
+    if (role === "user" && m.metadata && !isPreClean) {
       try {
-        const parsed = JSON.parse(m.content);
-        content = Array.isArray(parsed)
-          ? parsed
-          : [{ type: "text", text: m.content }];
-      } catch {
-        log.warn(
-          { conversationId: ctx.conversationId, messageId: m.id },
-          "Invalid JSON in persisted message content, replacing with safe text block",
-        );
-        content = [{ type: "text", text: m.content }];
-      }
+        const meta = JSON.parse(m.metadata);
+        const isTail = index === arr.length - 1;
 
-      content = reinjectImageSourcePaths(content, role, m.metadata);
-
-      // Re-inject persisted injection blocks from metadata so it survives
-      // conversation reloads (eviction, restart, fork).
-      if (role === "user" && m.metadata) {
-        try {
-          const meta = JSON.parse(m.metadata);
-          const isTail = index === arr.length - 1;
-
-          // Rehydrate in reverse injection order (innermost block first)
-          // so the resulting layout matches `applyRuntimeInjections`'s
-          // after-memory-prefix splices in ascending injector order
-          // (pkb-context 30, pkb-reminder 35, memory-v2-static 38,
-          // now-md 40 — the v2 static block lands inside the memory
-          // prefix, so now-md splices *after* it):
-          //   [<workspace>, <turn_context>, <memory __injected>,
-          //    <memory>\n…</memory>, <NOW.md>, <system_reminder>,
-          //    <knowledge_base>, ...original]
-          // Required so Anthropic's prefix cache keeps matching msg[0]
-          // across daemon restart and conversation eviction. The tail
-          // row only rehydrates `memoryInjectedBlock` — the next turn
-          // re-injects the rest fresh.
-          if (!isTail && typeof meta.pkbContextBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.pkbContextBlock },
-              ...content,
-            ];
-          }
-
-          if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.pkbSystemReminderBlock },
-              ...content,
-            ];
-          }
-
-          if (!isTail && typeof meta.nowScratchpadBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.nowScratchpadBlock },
-              ...content,
-            ];
-          }
-
-          // The v2 static memory block (essentials/threads/recent/buffer
-          // wrapped in `<memory>…</memory>`) carries personal user memory.
-          // Trust-gated to mirror `shouldExposePersonalMemory` at injection
-          // time — untrusted-actor views must not read persisted personal
-          // memory back through metadata. Skipped on the tail row because
-          // the next turn re-injects fresh content on full-mode turns.
-          if (
-            !isTail &&
-            personalMemoryAllowed &&
-            typeof meta.memoryV2StaticBlock === "string"
-          ) {
-            content = [
-              { type: "text" as const, text: meta.memoryV2StaticBlock },
-              ...content,
-            ];
-          }
-
-          // Memory remains rehydrated on all rows (existing behavior).
-          // Strip any pre-existing wrapper before re-wrapping so historical
-          // rows persisted with the wrapper (v2 path before the
-          // injectedBlockText contract was unified with v1's unwrapped form)
-          // don't render double-wrapped after rehydrate. Only unwrap when
-          // the full <memory>...</memory> pair is present so we don't mutate
-          // legitimate unwrapped payloads that happen to start with
-          // "<memory>\n" or end with "\n</memory>".
-          if (typeof meta.memoryInjectedBlock === "string") {
-            const block = meta.memoryInjectedBlock;
-            const inner =
-              block.startsWith("<memory>\n") && block.endsWith("\n</memory>")
-                ? block.slice("<memory>\n".length, -"\n</memory>".length)
-                : block;
-            content = [
-              {
-                type: "text" as const,
-                text: `<memory>\n${inner}\n</memory>`,
-              },
-              ...content,
-            ];
-          }
-
-          if (!isTail && typeof meta.turnContextBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.turnContextBlock },
-              ...content,
-            ];
-          }
-
-          if (!isTail && typeof meta.workspaceBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.workspaceBlock },
-              ...content,
-            ];
-          }
-        } catch {
-          /* ignore parse errors — metadata may be malformed */
+        // Rehydrate in reverse injection order (innermost block first)
+        // so the resulting layout matches `applyRuntimeInjections`'s
+        // after-memory-prefix splices in ascending injector order
+        // (pkb-context 30, pkb-reminder 35, memory-v2-static 38,
+        // now-md 40 — the v2 static block lands inside the memory
+        // prefix, so now-md splices *after* it):
+        //   [<workspace>, <turn_context>, <memory __injected>,
+        //    <memory>\n…</memory>, <NOW.md>, <system_reminder>,
+        //    <knowledge_base>, ...original]
+        // Required so Anthropic's prefix cache keeps matching msg[0]
+        // across daemon restart and conversation eviction. The tail
+        // row only rehydrates `memoryInjectedBlock` — the next turn
+        // re-injects the rest fresh.
+        if (!isTail && typeof meta.pkbContextBlock === "string") {
+          content = [
+            { type: "text" as const, text: meta.pkbContextBlock },
+            ...content,
+          ];
         }
+
+        if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
+          content = [
+            { type: "text" as const, text: meta.pkbSystemReminderBlock },
+            ...content,
+          ];
+        }
+
+        if (!isTail && typeof meta.nowScratchpadBlock === "string") {
+          content = [
+            { type: "text" as const, text: meta.nowScratchpadBlock },
+            ...content,
+          ];
+        }
+
+        // The v2 static memory block (essentials/threads/recent/buffer
+        // wrapped in `<memory>…</memory>`) carries personal user memory.
+        // Trust-gated to mirror `shouldExposePersonalMemory` at injection
+        // time — untrusted-actor views must not read persisted personal
+        // memory back through metadata. Skipped on the tail row because
+        // the next turn re-injects fresh content on full-mode turns.
+        if (
+          !isTail &&
+          personalMemoryAllowed &&
+          typeof meta.memoryV2StaticBlock === "string"
+        ) {
+          content = [
+            { type: "text" as const, text: meta.memoryV2StaticBlock },
+            ...content,
+          ];
+        }
+
+        // Memory remains rehydrated on all rows (existing behavior).
+        // Strip any pre-existing wrapper before re-wrapping so historical
+        // rows persisted with the wrapper (v2 path before the
+        // injectedBlockText contract was unified with v1's unwrapped form)
+        // don't render double-wrapped after rehydrate. Only unwrap when
+        // the full <memory>...</memory> pair is present so we don't mutate
+        // legitimate unwrapped payloads that happen to start with
+        // "<memory>\n" or end with "\n</memory>".
+        if (typeof meta.memoryInjectedBlock === "string") {
+          const block = meta.memoryInjectedBlock;
+          const inner =
+            block.startsWith("<memory>\n") && block.endsWith("\n</memory>")
+              ? block.slice("<memory>\n".length, -"\n</memory>".length)
+              : block;
+          content = [
+            {
+              type: "text" as const,
+              text: `<memory>\n${inner}\n</memory>`,
+            },
+            ...content,
+          ];
+        }
+
+        if (!isTail && typeof meta.turnContextBlock === "string") {
+          content = [
+            { type: "text" as const, text: meta.turnContextBlock },
+            ...content,
+          ];
+        }
+
+        if (!isTail && typeof meta.workspaceBlock === "string") {
+          content = [
+            { type: "text" as const, text: meta.workspaceBlock },
+            ...content,
+          ];
+        }
+      } catch {
+        /* ignore parse errors — metadata may be malformed */
       }
+    }
 
-      return { role, content };
-    });
+    return { role, content };
+  });
 
-  const { messages: repairedMessages, stats } = repairHistory(parsedMessages);
+  // Strip pre-clean messages only; post-clean messages keep the fresh
+  // injections they were generated with.
+  const messagesBeforeRepair =
+    preCleanCount === 0
+      ? parsedMessages
+      : [
+          ...stripInjectionsForCompaction(
+            parsedMessages.slice(0, preCleanCount),
+          ),
+          ...parsedMessages.slice(preCleanCount),
+        ];
+
+  const { messages: repairedMessages, stats } =
+    repairHistory(messagesBeforeRepair);
   if (
     stats.assistantToolResultsMigrated > 0 ||
     stats.missingToolResultsInserted > 0 ||

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -53,6 +53,7 @@ import {
   getConversation,
   getConversationOriginChannel,
   getConversationOverrideProfileFromRow,
+  setConversationCleanedAt,
 } from "../memory/conversation-crud.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { shouldExposePersonalMemory } from "../memory/v2/static-context.js";
@@ -1154,6 +1155,7 @@ export class Conversation {
     this.messages = stripped;
     await this.graphMemory.onCompacted(0);
     this.pendingPostCompactReinject = true;
+    setConversationCleanedAt(this.conversationId, Date.now());
     const estimatedInputTokens = this.contextWindowManager.estimateInputTokens(
       this.messages,
     );

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -190,6 +190,7 @@ export interface ConversationRow {
   contextSummary: string | null;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
+  cleanedAt: number | null;
   slackContextCompactionWatermarkTs: string | null;
   slackContextCompactionWatermarkAt: number | null;
   conversationType: string;
@@ -223,6 +224,7 @@ export const parseConversation = createRowMapper<
   contextSummary: "contextSummary",
   contextCompactedMessageCount: "contextCompactedMessageCount",
   contextCompactedAt: "contextCompactedAt",
+  cleanedAt: "cleanedAt",
   slackContextCompactionWatermarkTs: "slackContextCompactionWatermarkTs",
   slackContextCompactionWatermarkAt: "slackContextCompactionWatermarkAt",
   conversationType: "conversationType",
@@ -604,6 +606,16 @@ export function forkConversation(params: {
     copyBoundaryIndex >= 0
       ? sourceMessages.slice(0, copyBoundaryIndex + 1)
       : ([] as MessageRow[]);
+
+  // Inherit /clean state only when the fork boundary is at-or-after the
+  // clean event. Pre-clean forks branch from history that pre-dates the
+  // clean, so the marker would be a no-op and is misleading to copy.
+  const sourceCleanedAt = sourceConversation.cleanedAt ?? null;
+  const boundaryMessageCreatedAt = messagesToCopy.at(-1)?.createdAt ?? null;
+  const inheritsCleanedAt =
+    sourceCleanedAt != null &&
+    boundaryMessageCreatedAt != null &&
+    boundaryMessageCreatedAt >= sourceCleanedAt;
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -650,6 +662,7 @@ export function forkConversation(params: {
         slackContextCompactionWatermarkAt: preserveSourceCompactionState
           ? sourceConversation.slackContextCompactionWatermarkAt
           : null,
+        cleanedAt: inheritsCleanedAt ? sourceCleanedAt : null,
         inferenceProfile: sourceConversation.inferenceProfile,
       })
       .where(eq(conversations.id, fc.id))
@@ -1432,6 +1445,20 @@ export function updateConversationContextWindow(
       contextSummary,
       contextCompactedMessageCount,
       contextCompactedAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    .where(eq(conversations.id, id))
+    .run();
+}
+
+export function setConversationCleanedAt(
+  id: string,
+  cleanedAt: number | null,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      cleanedAt,
       updatedAt: Date.now(),
     })
     .where(eq(conversations.id, id))

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -66,6 +66,7 @@ import {
   migrateContactsNotesColumn,
   migrateContactsRolePrincipal,
   migrateContactsUserFileColumn,
+  migrateConversationCleanedAt,
   migrateConversationForkLineage,
   migrateConversationHostAccess,
   migrateConversationInferenceProfileSession,
@@ -450,6 +451,7 @@ export function initializeDb(): void {
     migrateConversationLastNotifiedProfile,
     migrateStripBaseUrlNonOpenaiCompatible,
     migrateOnboardingEventsPriorAssistants,
+    migrateConversationCleanedAt,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/259-conversation-cleaned-at.ts
+++ b/assistant/src/memory/migrations/259-conversation-cleaned-at.ts
@@ -1,0 +1,33 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_conversation_cleaned_at_v1";
+
+const COLUMN_NAME = "cleaned_at";
+const COLUMN_DEFINITION = "cleaned_at INTEGER";
+
+/**
+ * Add a `cleaned_at` timestamp to conversations.
+ *
+ * Records the moment `/clean` ran. The load path uses it to skip metadata
+ * reinjection (and strip injection prefixes from message content) for
+ * messages whose `created_at < cleaned_at`, so the clean survives daemon
+ * restart and conversation eviction. `forkConversation` copies the marker
+ * to the child only when the fork point is at-or-after the clean.
+ */
+export function migrateConversationCleanedAt(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    if (tableHasColumn(database, "conversations", COLUMN_NAME)) {
+      return;
+    }
+    database.run(`ALTER TABLE conversations ADD COLUMN ${COLUMN_DEFINITION}`);
+  });
+}
+
+export function downConversationCleanedAt(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "conversations", COLUMN_NAME)) {
+    return;
+  }
+  database.run(`ALTER TABLE conversations DROP COLUMN ${COLUMN_NAME}`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -231,6 +231,10 @@ export {
 export { migrateStripBaseUrlNonOpenaiCompatible } from "./257-strip-base-url-non-openai-compatible.js";
 export { migrateOnboardingEventsPriorAssistants } from "./258-onboarding-events-prior-assistants.js";
 export {
+  downConversationCleanedAt,
+  migrateConversationCleanedAt,
+} from "./259-conversation-cleaned-at.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -52,6 +52,7 @@ import { downNormalizeSlackExternalContent } from "./249-normalize-slack-externa
 import { downA2ATasks } from "./251-a2a-tasks.js";
 import { downExternalConversationBindingChatName } from "./254-external-conversation-binding-chat-name.js";
 import { downMemoryV2InjectionEvents } from "./256-memory-v2-injection-events.js";
+import { downConversationCleanedAt } from "./259-conversation-cleaned-at.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -444,6 +445,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create memory_v2_injection_events table and backfill from activation logs for EMA-based tier 2 routing",
     down: downMemoryV2InjectionEvents,
+  },
+  {
+    key: "migration_conversation_cleaned_at_v1",
+    version: 52,
+    description:
+      "Add cleaned_at timestamp to conversations so /clean survives reload and forks inherit conditionally on fork point",
+    down: downConversationCleanedAt,
   },
 ];
 

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -21,6 +21,7 @@ export const conversations = sqliteTable(
       .notNull()
       .default(0),
     contextCompactedAt: integer("context_compacted_at"),
+    cleanedAt: integer("cleaned_at"),
     slackContextCompactionWatermarkTs: text(
       "slack_context_compaction_watermark_ts",
     ),


### PR DESCRIPTION
## Summary
- Persist a `cleaned_at` timestamp on `conversations` when `/clean` runs so the strip survives daemon restart and conversation eviction.
- `loadFromDb` now skips metadata rehydration and applies `stripInjectionsForCompaction` to messages older than `cleaned_at`, matching the in-memory post-`/clean` view.
- `forkConversation` inherits `cleaned_at` to the child only when the fork point is at-or-after the clean event; pre-clean forks see the original (un-cleaned) history.

## Original prompt
Asked: "what happens when I run /clean on a conversation, continue, then fork from a post-clean message — does the cleaning persist?" Answer was no, because `/clean` only mutated in-memory state and `forkConversation` reads straight from SQLite. Follow-up: make post-clean forks behave as if `/clean` ran and pre-clean forks behave as if it hadn't, and also fix the parallel bug where the original loses the clean on daemon restart.

## Test plan
- [x] \`bunx tsc --noEmit\`
- [x] \`bun test src/__tests__/conversation-fork-crud.test.ts src/__tests__/conversation-load-cleaned-at.test.ts src/__tests__/conversation-load-history-repair.test.ts\`
- [ ] Manual: run \`/clean\`, restart daemon (\`vellum sleep && vellum wake\`), confirm pre-clean messages stay clean.
- [ ] Manual: fork from a post-clean message and confirm pre-clean prefix is stripped in the fork; fork from a pre-clean message and confirm injections remain.