### PR TITLE
Revert Slack assistant thread placeholder filtering

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -12,7 +12,6 @@ mock.module("../config/loader.js", () => ({
     return {
       ...real,
       memory: { ...real.memory, v2: { ...real.memory.v2, enabled: false } },
-      slack: { ...real.slack, botUserId: "U_BOT" },
     };
   },
 }));
@@ -4183,7 +4182,6 @@ describe("assembleSlackChronologicalMessages", () => {
   // Anchor times mirror the renderer's HH:MM (UTC) output.
   // 14:25:00 UTC on 2023-11-14 = epoch second 1699971900.
   const TS_14_25 = "1699971900.000100"; // 14:25 UTC
-  const TS_14_26 = "1699971960.000200"; // 14:26 UTC
   const TS_14_28 = "1699972080.000300"; // 14:28 UTC
   const MS_14_25 = 1699971900_000;
   const MS_14_26 = 1699971960_000;
@@ -4373,56 +4371,6 @@ describe("assembleSlackChronologicalMessages", () => {
       ],
     );
   });
-
-  test("Slack context skips configured assistant new-thread placeholder rows", () => {
-    const placeholderMeta: SlackMessageMetadata = {
-      source: "slack",
-      channelId: DM_CHANNEL_ID,
-      channelTs: TS_14_25,
-      eventKind: "message",
-      displayName: "Ada",
-      actorExternalUserId: "U_BOT",
-    };
-    const otherBotMeta: SlackMessageMetadata = {
-      source: "slack",
-      channelId: DM_CHANNEL_ID,
-      channelTs: TS_14_26,
-      eventKind: "message",
-      displayName: "Build Bot",
-      actorExternalUserId: "B_OTHER",
-    };
-    const realBotMeta: SlackMessageMetadata = {
-      source: "slack",
-      channelId: DM_CHANNEL_ID,
-      channelTs: TS_14_28,
-      eventKind: "message",
-      actorExternalUserId: "B_ASSISTANT",
-    };
-    const rows: SlackTranscriptInputRow[] = [
-      row(
-        "user",
-        "New Assistant Thread",
-        MS_14_25,
-        metadataEnvelope(placeholderMeta),
-      ),
-      row(
-        "user",
-        "New Assistant Thread",
-        MS_14_26,
-        metadataEnvelope(otherBotMeta),
-      ),
-      row("user", "real bot context", MS_14_28, metadataEnvelope(realBotMeta)),
-    ];
-
-    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
-    expect(result).not.toBeNull();
-    const rendered = JSON.stringify(result);
-    expect(rendered).not.toContain("Ada");
-    expect(rendered.split("New Assistant Thread").length - 1).toBe(1);
-    expect(rendered).toContain("Build Bot");
-    expect(rendered).toContain("real bot context");
-  });
-
   test("legacy-DM fixture: pre-upgrade rows (no slackMeta) interleave with post-upgrade rows", () => {
     // Mix:
     //  - Two pre-upgrade rows (created before PR 16 wired slackMeta into

--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -40,20 +40,6 @@ mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async () => {},
 }));
 
-mock.module("../messaging/providers/slack/adapter.js", () => ({
-  withSlackBotToken: async (
-    _account: string | undefined,
-    fn: (token: string) => Promise<unknown>,
-  ) => fn("test-slack-token"),
-  resolveSlackBotUserId: async (
-    _account: string | undefined,
-    botId: string,
-  ) => {
-    if (botId === "B_ASSISTANT") return "U_BOT";
-    return null;
-  },
-}));
-
 import type { Message } from "../messaging/provider-types.js";
 
 // `backfillDm` is the only piece of the slack provider surface this test
@@ -73,11 +59,6 @@ mock.module("../messaging/providers/slack/backfill.js", () => ({
   backfillThread: () => backfillThreadMock(),
 }));
 
-import {
-  loadRawConfig,
-  saveRawConfig,
-  setNestedValue,
-} from "../config/loader.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -107,13 +88,6 @@ function resetState(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   db.run("DELETE FROM external_conversation_bindings");
-  setConfiguredSlackBotUserId("U_BOT");
-}
-
-function setConfiguredSlackBotUserId(botUserId: string): void {
-  const raw = loadRawConfig();
-  setNestedValue(raw, "slack.botUserId", botUserId);
-  saveRawConfig(raw);
 }
 
 function seedActiveMember(): void {
@@ -518,44 +492,6 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(botRow?.provenanceTrustClass).toBe("unknown");
     expect(botRow?.provenanceSourceChannel).toBe("slack");
     expect(botRow?.provenanceRequesterIdentifier).toBe("B_BOT");
-  });
-
-  test("skips Slack assistant new-thread placeholder during DM backfill", async () => {
-    backfillDmMock.mockImplementation(async () => [
-      makeBackfilledMessage({
-        id: "1700000000.000001",
-        text: "New Assistant Thread",
-        sender: { id: "B_ASSISTANT", name: "Ada" },
-        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
-      }),
-      makeBackfilledMessage({
-        id: "1700000000.000002",
-        text: "real bot context",
-        sender: { id: "B_ASSISTANT", name: "Ada" },
-        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
-      }),
-      makeBackfilledMessage({
-        id: "1700000000.000003",
-        text: "New Assistant Thread",
-        sender: { id: "B_OTHER", name: "Build Bot" },
-        metadata: { isBot: true, slackBotId: "B_OTHER" },
-      }),
-    ]);
-
-    await handleChannelInbound(
-      buildDmRequest("live new DM"),
-      noopProcessMessage,
-      TEST_BEARER_TOKEN,
-    );
-
-    const rows = readPersistedSlackRows();
-    expect(rows.map((row) => row.rawContent).sort()).toEqual([
-      "New Assistant Thread",
-      "real bot context",
-    ]);
-    expect(
-      rows.some((row) => row.slackMeta?.actorExternalUserId === "B_OTHER"),
-    ).toBe(true);
   });
 
   test("backfill skips channelTs values already stored", async () => {

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -1351,56 +1351,6 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.provenanceRequesterIdentifier).toBe("U_OTHER_BOT");
   });
 
-  test("skips Slack assistant new-thread placeholder during backfill", async () => {
-    const conv = createTestConversation();
-
-    backfillThreadMock.mockImplementation(async () => [
-      makeBackfillMessage({
-        id: "1234.0",
-        text: "New Assistant Thread",
-        threadId: undefined,
-        sender: { id: "B_ASSISTANT", name: "Ada" },
-        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
-      }),
-      makeBackfillMessage({
-        id: "1234.1",
-        text: "real bot context",
-        threadId: "1234.0",
-        sender: { id: "B_ASSISTANT", name: "Ada" },
-        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
-      }),
-      makeBackfillMessage({
-        id: "1234.2",
-        text: "New Assistant Thread",
-        threadId: undefined,
-        sender: { id: "B_OTHER", name: "Build Bot" },
-        metadata: { isBot: true, slackBotId: "B_OTHER" },
-      }),
-    ]);
-
-    const result = await triggerSlackThreadBackfillIfNeeded({
-      conversationId: conv.id,
-      channelId: SLACK_CHANNEL_ID,
-      threadTs: "1234.0",
-    });
-
-    expect(result.fetched).toBe(3);
-    expect(result.persisted).toBe(2);
-    const rows = readPersistedSlackRows(conv.id);
-    expect(rows.map((row) => row.rawContent).sort()).toEqual([
-      "New Assistant Thread",
-      "real bot context",
-    ]);
-    const assistantRow = rows.find(
-      (row) => row.rawContent === "real bot context",
-    );
-    expect(assistantRow?.role).toBe("assistant");
-    expect(assistantRow?.actorExternalUserId).toBe("B_ASSISTANT");
-    expect(rows.some((row) => row.actorExternalUserId === "B_OTHER")).toBe(
-      true,
-    );
-  });
-
   test("backfilled non-bot message with empty text is persisted unwrapped", async () => {
     const conv = createTestConversation();
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -9,7 +9,6 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
-import { getConfig } from "../config/loader.js";
 import { createContextSummaryMessage } from "../context/window-manager.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
 import {
@@ -50,7 +49,6 @@ import {
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
-import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { filterMessagesForUntrustedActor } from "./conversation-lifecycle.js";
@@ -1291,60 +1289,6 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
   };
 }
 
-const SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT = "New Assistant Thread";
-
-function isSlackAssistantThreadPlaceholder(
-  message: RenderableSlackMessage,
-  canonicalConfiguredBotUserId: string | null,
-): boolean {
-  if (!canonicalConfiguredBotUserId) return false;
-  const metadata = message.metadata;
-  if (!metadata || metadata.eventKind !== "message") return false;
-  const actorExternalUserId = metadata.actorExternalUserId?.trim();
-  if (!actorExternalUserId) return false;
-
-  const canonicalActor =
-    canonicalizeInboundIdentity("slack", actorExternalUserId) ??
-    actorExternalUserId;
-  const isThreadRoot =
-    metadata.threadTs === undefined || metadata.threadTs === metadata.channelTs;
-  const hasSlackFiles =
-    Array.isArray(metadata.slackFiles) && metadata.slackFiles.length > 0;
-
-  return (
-    message.role === "user" &&
-    canonicalActor === canonicalConfiguredBotUserId &&
-    isThreadRoot &&
-    !hasSlackFiles &&
-    message.content.replace(/\s+/g, " ").trim() ===
-      SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT
-  );
-}
-
-function getCanonicalConfiguredSlackBotUserId(): string | null {
-  const configuredBotUserId = getConfig().slack.botUserId.trim();
-  if (!configuredBotUserId) return null;
-  return (
-    canonicalizeInboundIdentity("slack", configuredBotUserId) ??
-    configuredBotUserId
-  );
-}
-
-function rowsToRenderableSlackMessages(
-  rows: SlackTranscriptInputRow[],
-): RenderableSlackMessage[] {
-  const canonicalConfiguredBotUserId = getCanonicalConfiguredSlackBotUserId();
-  return rows
-    .map(rowToRenderable)
-    .filter(
-      (message) =>
-        !isSlackAssistantThreadPlaceholder(
-          message,
-          canonicalConfiguredBotUserId,
-        ),
-    );
-}
-
 /**
  * Compatibility projection for callers that still need the legacy
  * `Message[] | null` shape. New runtime callers should use
@@ -1440,7 +1384,7 @@ function assembleSlackChronologicalContext(
   if (capabilities.channel !== "slack") {
     return null;
   }
-  const renderable = rowsToRenderableSlackMessages(rows);
+  const renderable = rows.map(rowToRenderable);
   const rendered = renderSlackTranscriptWithProvenance(renderable);
   const contextSummary = options.contextSummary?.trim();
   const renderedMessages = rendered.renderedMessages;
@@ -1683,7 +1627,7 @@ export function assembleSlackActiveThreadFocusBlock(
   // conversation and omits the field for DMs, so gate the focus block
   // on the positive `"channel"` match.
   if (capabilities.chatType !== "channel") return null;
-  const renderable = rowsToRenderableSlackMessages(rows);
+  const renderable = rows.map(rowToRenderable);
   const activeThreadTs = detectActiveThreadTs(renderable);
   if (!activeThreadTs) return null;
   return buildActiveThreadBlockFromRenderable(renderable, activeThreadTs);

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -398,8 +398,8 @@ function mapMessage(
   renderedText: string,
 ): Message {
   // Bot-authored when Slack sets `subtype: "bot_message"` or attributes the
-  // row to a `bot_id` with no user. Backfill callers use this flag for
-  // bot-specific filtering while preserving real bot rows as channel replay.
+  // row to a `bot_id` with no user. Backfill callers rely on this flag to
+  // avoid rehydrating assistant/bot replies as user turns.
   const isBot =
     msg.subtype === "bot_message" || (msg.bot_id != null && !msg.user);
   const slackFiles = mapSlackFiles(msg.files);

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1795,26 +1795,6 @@ function isBackfilledSlackGuardianMessage(
   return canonicalSender === canonicalGuardian;
 }
 
-const SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT = "New Assistant Thread";
-
-async function isSlackAssistantThreadPlaceholder(
-  message: ProviderMessage,
-  account: string | undefined,
-): Promise<boolean> {
-  if (message.metadata?.isBot !== true) return false;
-  const hasSlackFiles =
-    Array.isArray(message.metadata.slackFiles) &&
-    message.metadata.slackFiles.length > 0;
-  return (
-    message.text.replace(/\s+/g, " ").trim() ===
-      SLACK_ASSISTANT_THREAD_PLACEHOLDER_TEXT &&
-    (message.threadId === undefined || message.threadId === message.id) &&
-    message.hasAttachments !== true &&
-    !hasSlackFiles &&
-    (await isBackfilledSlackAssistantMessage(message, account))
-  );
-}
-
 async function isBackfilledSlackAssistantMessage(
   message: ProviderMessage,
   account: string | undefined,
@@ -1981,9 +1961,6 @@ async function runBackfillSlackDmIfCold(params: {
     const ordered = [...fetched].reverse();
     for (const message of ordered) {
       if (seen.has(message.id)) continue;
-      if (await isSlackAssistantThreadPlaceholder(message, params.account)) {
-        continue;
-      }
       try {
         await persistBackfilledSlackMessage({
           conversationId: params.conversationId,
@@ -2547,9 +2524,6 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     for (const message of fetched) {
       if (!message.id) continue;
       if (threadState.storedChannelTs.has(message.id)) continue;
-      if (await isSlackAssistantThreadPlaceholder(message, account)) {
-        continue;
-      }
       try {
         await persistBackfilledSlackMessage({
           conversationId,


### PR DESCRIPTION
## Summary

Manual revert of #31442 after GitHub could not auto-revert it. This restores Slack backfill and chronological context assembly to persist and render the assistant-created `New Assistant Thread` placeholder rows instead of filtering them out.

## Why

We saw a severe Slack context regression in newly-started Slack DM/thread conversations. The placeholder filtering PR changed persistence/context behavior around exactly that path, so this hotfix prioritizes restoring the previous known behavior over keeping the placeholder out of model context.

## Validation

- `cd assistant && bun test src/__tests__/thread-backfill.test.ts src/__tests__/dm-backfill.test.ts src/__tests__/conversation-runtime-assembly.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-push assistant typecheck and lint passed

## Review focus

This is intentionally a narrow revert of #31442. The follow-up should reland placeholder filtering only with an end-to-end Slack thread/DM context regression test.