### PR TITLE
feat(macos): add ChatGPT subscription OAuth UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -584,6 +584,7 @@ struct SettingsPanel: View {
             // ANTHROPIC / INFERENCE
             InferenceServiceCard(
                 store: store,
+                assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: showToast
             )
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -11,6 +11,7 @@ import VellumAssistantShared
 @MainActor
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
     var showToast: (String, ToastInfo.Style) -> Void
 
     /// Whether the read-only per-call-site overrides sheet is presented.
@@ -38,7 +39,7 @@ struct InferenceServiceCard: View {
             InferenceProfilesSheet(store: store, isPresented: $showProfilesSheet)
         }
         .sheet(isPresented: $showProvidersSheet) {
-            ProvidersSheet(store: store, isPresented: $showProvidersSheet)
+            ProvidersSheet(store: store, isPresented: $showProvidersSheet, assistantFeatureFlagStore: assistantFeatureFlagStore)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -1304,7 +1304,7 @@ struct ProvidersSheet: View {
 
         let auth = ProviderConnectionAuth(
             type: draft.authType,
-            credential: draft.authType == "api_key" ? credentialRef : nil
+            credential: (draft.authType == "api_key" || draft.authType == "oauth_subscription") ? credentialRef : nil
         )
         let label: String? = draft.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft.label.trimmingCharacters(in: .whitespacesAndNewlines)
         let status = draft.status

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -14,6 +14,7 @@ struct ProvidersSheet: View {
     @ObservedObject var store: SettingsStore
     @Binding var isPresented: Bool
     var client: ProviderConnectionClientProtocol
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore?
 
     @State private var connections: [ProviderConnection] = []
     @State private var editorState: EditorState?
@@ -47,6 +48,29 @@ struct ProvidersSheet: View {
     /// sequence can't produce out-of-order responses that clobber the user's
     /// final intent.
     @State private var inFlightStatusToggles: Set<String> = []
+
+    // -- ChatGPT Subscription OAuth state -----------------------------------
+
+    enum ChatgptOAuthState {
+        case idle, starting, pasteUrl, exchanging, completed, failed
+    }
+
+    @State private var chatgptOAuthState: ChatgptOAuthState = .idle
+    @State private var chatgptPastedUrl = ""
+    @State private var chatgptOAuthError: String?
+    @State private var chatgptOAuthStoredState = ""
+
+    /// True when the ChatGPT subscription OAuth section should be visible:
+    /// feature flag enabled, provider is "openai", and we're in create mode.
+    private var isChatgptSubscriptionVisible: Bool {
+        guard let flagStore = assistantFeatureFlagStore,
+              flagStore.isEnabled("chatgpt-subscription-auth"),
+              editorDraft.provider == "openai",
+              case .create = editorState else {
+            return false
+        }
+        return true
+    }
 
     // MARK: - Nested Types
 
@@ -99,11 +123,13 @@ struct ProvidersSheet: View {
     init(
         store: SettingsStore,
         isPresented: Binding<Bool>,
-        client: ProviderConnectionClientProtocol = ProviderConnectionClient()
+        client: ProviderConnectionClientProtocol = ProviderConnectionClient(),
+        assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil
     ) {
         self.store = store
         self._isPresented = isPresented
         self.client = client
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
     }
 
     // MARK: - Body
@@ -138,6 +164,11 @@ struct ProvidersSheet: View {
                 newCredentialName = ""
                 loadMaskedTask?.cancel()
                 loadMaskedTask = nil
+                // Reset ChatGPT OAuth state
+                chatgptOAuthState = .idle
+                chatgptPastedUrl = ""
+                chatgptOAuthError = nil
+                chatgptOAuthStoredState = ""
             }
         }
         .animation(VAnimation.fast, value: editorState != nil)
@@ -370,6 +401,9 @@ struct ProvidersSheet: View {
                     }
                     .disabled(isAuthLocked)
                     editorStatusToggle
+                    if isChatgptSubscriptionVisible {
+                        chatgptSubscriptionSection
+                    }
                     if let actionError {
                         Text(actionError)
                             .font(VFont.bodySmallDefault)
@@ -794,6 +828,172 @@ struct ProvidersSheet: View {
         case .create: return "Create"
         case .edit, .managedEdit, .none: return "Save"
         }
+    }
+
+    // MARK: - ChatGPT Subscription OAuth
+
+    /// Bordered section for the ChatGPT subscription copy-paste PKCE flow.
+    /// Visible when `isChatgptSubscriptionVisible` is true (feature flag +
+    /// provider=openai + create mode). Mirrors the web UI's bordered section
+    /// in `provider-editor-modal.tsx`.
+    @ViewBuilder
+    private var chatgptSubscriptionSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("ChatGPT Subscription")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Connect your ChatGPT subscription to use OpenAI models without an API key.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentTertiary)
+
+            switch chatgptOAuthState {
+            case .idle:
+                VButton(label: "Sign in with ChatGPT", style: .outlined, size: .compact) {
+                    Task { await handleChatgptSignIn() }
+                }
+
+            case .starting:
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Starting sign-in...")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                .frame(height: 32)
+
+            case .pasteUrl:
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("1. Sign in with ChatGPT in the browser")
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Text("2. After sign-in, you'll see an error page")
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Text("3. Copy the URL from the address bar and paste it below")
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                    }
+                    VTextField(
+                        placeholder: "Paste callback URL here...",
+                        text: Binding(
+                            get: { chatgptPastedUrl },
+                            set: { newValue in
+                                chatgptPastedUrl = newValue
+                                chatgptOAuthError = nil
+                            }
+                        )
+                    )
+                    HStack {
+                        Spacer()
+                        VButton(
+                            label: "Complete Sign In",
+                            style: .primary,
+                            size: .compact,
+                            isDisabled: chatgptPastedUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ) {
+                            Task { await handleChatgptUrlSubmit() }
+                        }
+                    }
+                }
+
+            case .exchanging:
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Completing sign-in...")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                .frame(height: 32)
+
+            case .completed:
+                Text("ChatGPT subscription connected successfully.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.systemPositiveStrong)
+
+            case .failed:
+                VButton(label: "Try Again", style: .outlined, size: .compact) {
+                    chatgptOAuthState = .idle
+                    chatgptPastedUrl = ""
+                    chatgptOAuthError = nil
+                }
+            }
+
+            if let chatgptOAuthError {
+                Text(chatgptOAuthError)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+        .padding(VSpacing.md)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+    }
+
+    /// Start the ChatGPT subscription OAuth flow: call the daemon, open the
+    /// authorize URL in the default browser, and transition to the paste-URL
+    /// state.
+    private func handleChatgptSignIn() async {
+        chatgptOAuthState = .starting
+        chatgptOAuthError = nil
+        guard let result = await client.startChatgptSubscriptionAuth() else {
+            chatgptOAuthState = .failed
+            chatgptOAuthError = "Failed to start ChatGPT sign-in. Please try again."
+            return
+        }
+        chatgptOAuthStoredState = result.state
+        if let url = URL(string: result.authorizeUrl) {
+            NSWorkspace.shared.open(url)
+        }
+        chatgptOAuthState = .pasteUrl
+    }
+
+    /// Extract `code` and `state` from the pasted callback URL and exchange
+    /// them for tokens via the daemon. On success, find the newly-created
+    /// connection and dismiss the editor.
+    private func handleChatgptUrlSubmit() async {
+        chatgptOAuthError = nil
+        let trimmed = chatgptPastedUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            chatgptOAuthError = "Please paste the URL from the error page."
+            return
+        }
+        guard let components = URLComponents(string: trimmed) else {
+            chatgptOAuthError = "Invalid URL. Please paste the full URL from the address bar."
+            return
+        }
+        guard let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
+            chatgptOAuthError = "The URL is missing the authorization code. Make sure you copied the full URL."
+            return
+        }
+        guard let state = components.queryItems?.first(where: { $0.name == "state" })?.value else {
+            chatgptOAuthError = "The URL is missing the state parameter. Make sure you copied the full URL."
+            return
+        }
+
+        chatgptOAuthState = .exchanging
+        let success = await client.exchangeChatgptAuthCode(code: code, state: state)
+        guard success else {
+            chatgptOAuthState = .failed
+            chatgptOAuthError = "Failed to complete sign-in. Please try again."
+            return
+        }
+
+        chatgptOAuthState = .completed
+
+        // Fetch the newly-created connection and dismiss the editor.
+        if let conns = await client.listProviderConnections(provider: "openai") {
+            let chatgptConn = conns.first { $0.name == "chatgpt-subscription" || $0.name == "openai-chatgpt" }
+            if let conn = chatgptConn {
+                connections.append(conn)
+            }
+        }
+        await refresh()
+        editorState = nil
     }
 
     // MARK: - Editor Validation

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -60,6 +60,7 @@ final class InferenceServiceCardTests: XCTestCase {
     private func makeCard() -> InferenceServiceCard {
         InferenceServiceCard(
             store: store,
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             showToast: { _, _ in }
         )
     }

--- a/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
@@ -85,6 +85,27 @@ final class MockProviderConnectionClient: ProviderConnectionClientProtocol {
         deleteNameArg = name
         return deleteResponse
     }
+
+    // MARK: Spy: ChatGPT subscription auth
+    var startChatgptAuthCallCount = 0
+    var startChatgptAuthResponse: ChatgptAuthStartResult? = nil
+
+    func startChatgptSubscriptionAuth() async -> ChatgptAuthStartResult? {
+        startChatgptAuthCallCount += 1
+        return startChatgptAuthResponse
+    }
+
+    var exchangeChatgptCallCount = 0
+    var exchangeChatgptCodeArg: String?
+    var exchangeChatgptStateArg: String?
+    var exchangeChatgptResponse: Bool = false
+
+    func exchangeChatgptAuthCode(code: String, state: String) async -> Bool {
+        exchangeChatgptCallCount += 1
+        exchangeChatgptCodeArg = code
+        exchangeChatgptStateArg = state
+        return exchangeChatgptResponse
+    }
 }
 
 // MARK: - Fixtures

--- a/clients/shared/Network/ProviderConnectionClient.swift
+++ b/clients/shared/Network/ProviderConnectionClient.swift
@@ -30,6 +30,12 @@ public enum ProviderConnectionCreateResult: Sendable {
     case error
 }
 
+/// Result of starting a ChatGPT subscription OAuth flow.
+public struct ChatgptAuthStartResult: Sendable {
+    public let authorizeUrl: String
+    public let state: String
+}
+
 public protocol ProviderConnectionClientProtocol {
     func listProviderConnections(provider: String?) async -> [ProviderConnection]?
     func getProviderConnection(name: String) async -> ProviderConnection?
@@ -38,6 +44,10 @@ public protocol ProviderConnectionClientProtocol {
     /// `status`: nil = omit from body (no change). `label`: nil outer = omit; `.some(nil)` = send null (clear); `.some("v")` = set.
     func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection?
     func deleteProviderConnection(name: String) async -> ProviderConnectionDeleteResult
+    /// Start a ChatGPT subscription OAuth flow. Returns the authorize URL and state token.
+    func startChatgptSubscriptionAuth() async -> ChatgptAuthStartResult?
+    /// Exchange an OAuth authorization code for tokens, completing the ChatGPT subscription sign-in.
+    func exchangeChatgptAuthCode(code: String, state: String) async -> Bool
 }
 
 public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
@@ -236,6 +246,46 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         if tail.hasSuffix(".") { tail = String(tail.dropLast()) }
         let names = tail.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
         return names.isEmpty ? [] : names
+    }
+
+    public func startChatgptSubscriptionAuth() async -> ChatgptAuthStartResult? {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "inference/chatgpt-subscription/auth",
+                json: [:]
+            )
+            guard response.isSuccess else {
+                log.warning("POST /inference/chatgpt-subscription/auth failed: \(response.statusCode)")
+                return nil
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                  let authorizeUrl = json["authorize_url"] as? String,
+                  let state = json["state"] as? String else {
+                log.error("startChatgptSubscriptionAuth: unexpected response shape")
+                return nil
+            }
+            return ChatgptAuthStartResult(authorizeUrl: authorizeUrl, state: state)
+        } catch {
+            log.error("startChatgptSubscriptionAuth: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    public func exchangeChatgptAuthCode(code: String, state: String) async -> Bool {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "inference/chatgpt-subscription/auth/exchange",
+                json: ["code": code, "state": state]
+            )
+            guard response.isSuccess else {
+                log.warning("POST /inference/chatgpt-subscription/auth/exchange failed: \(response.statusCode)")
+                return false
+            }
+            return true
+        } catch {
+            log.error("exchangeChatgptAuthCode: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Ports the ChatGPT subscription copy-paste PKCE OAuth flow from the web UI (`apps/web/src/domains/settings/ai/provider-editor-modal.tsx`) to the macOS native Swift app
- Adds `startChatgptSubscriptionAuth()` and `exchangeChatgptAuthCode()` API methods to `ProviderConnectionClientProtocol` and the concrete `ProviderConnectionClient`
- Adds a bordered ChatGPT subscription section to `ProvidersSheet` with a full state machine: idle, starting, pasteUrl, exchanging, completed, failed
- Gates the UI behind the `chatgpt-subscription-auth` feature flag, visible only when provider is "openai" and mode is "create"
- Threads `AssistantFeatureFlagStore` through `SettingsPanel` -> `InferenceServiceCard` -> `ProvidersSheet`
- Updates `MockProviderConnectionClient` with spy methods for the new endpoints

## Test plan
- [ ] Enable `chatgpt-subscription-auth` feature flag
- [ ] Open Settings -> Language Model -> Providers -> + New Connection
- [ ] Select "OpenAI" as provider
- [ ] Verify the "ChatGPT Subscription" bordered section appears below the Status toggle
- [ ] Click "Sign in with ChatGPT" and verify the browser opens to the authorize URL
- [ ] After OAuth redirect, copy the error page URL and paste into the text field
- [ ] Click "Complete Sign In" and verify the connection is created
- [ ] Verify the section does not appear for non-OpenAI providers
- [ ] Verify the section does not appear in edit mode
- [ ] Verify the section does not appear when the feature flag is disabled
- [ ] Run `swift test --filter ProviderConnectionClientTests` (15 tests pass)
- [ ] Run `swift build` (compiles cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)