### PR TITLE
feat(web): add color-coded scope chips to feature flags table

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -1,7 +1,7 @@
 import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { Tag } from "@vellum/design-library/components/tag";
+import { Tag, type TagTone } from "@vellum/design-library/components/tag";
 import { Toggle } from "@vellum/design-library/components/toggle";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store.js";
@@ -9,8 +9,15 @@ import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feat
 import {
   ALL_FLAGS,
   ldKeyToStoreKey,
+  scopeIncludes,
   type FlagScope,
+  type SingleScope,
 } from "@/lib/feature-flags/feature-flag-catalog.js";
+
+const SCOPE_TONE: Record<SingleScope, TagTone> = {
+  client: "warning",
+  assistant: "positive",
+};
 
 interface FlagDisplayEntry {
   storeKey: string;
@@ -30,7 +37,8 @@ export function FeatureFlagsPanel() {
     const entries: FlagDisplayEntry[] = [];
     for (const flag of ALL_FLAGS) {
       const storeKey = ldKeyToStoreKey(flag.key);
-      const state = flag.scope === "client" ? clientState : assistantState;
+      const state =
+        flag.scope === "assistant" ? assistantState : clientState;
       const value = state[storeKey];
       if (typeof value !== "boolean") continue;
       entries.push({
@@ -57,7 +65,9 @@ export function FeatureFlagsPanel() {
         flag.label.toLowerCase().includes(query) ||
         flag.description.toLowerCase().includes(query) ||
         flag.storeKey.toLowerCase().includes(query) ||
-        flag.scope.toLowerCase().includes(query),
+        flag.scope.includes(query) ||
+        (flag.scope === "both" &&
+          ("client".includes(query) || "assistant".includes(query))),
     );
   }, [flags, searchText]);
 
@@ -100,14 +110,27 @@ interface FeatureFlagRowProps {
   flag: FlagDisplayEntry;
 }
 
+function ScopeChips({ scope }: { scope: FlagScope }) {
+  if (scope === "both") {
+    return (
+      <>
+        <Tag tone={SCOPE_TONE.client}>client</Tag>
+        <Tag tone={SCOPE_TONE.assistant}>assistant</Tag>
+      </>
+    );
+  }
+  return <Tag tone={SCOPE_TONE[scope]}>{scope}</Tag>;
+}
+
 function FeatureFlagRow({ flag }: FeatureFlagRowProps) {
   const clientSetFlag = useClientFeatureFlagStore.use.setFlag();
   const assistantSetFlag = useAssistantFeatureFlagStore.use.setFlag();
 
   const handleToggle = (next: boolean) => {
-    if (flag.scope === "client") {
+    if (scopeIncludes(flag.scope, "client")) {
       clientSetFlag(flag.storeKey, next);
-    } else {
+    }
+    if (scopeIncludes(flag.scope, "assistant")) {
       assistantSetFlag(flag.storeKey, next);
     }
   };
@@ -126,7 +149,7 @@ function FeatureFlagRow({ flag }: FeatureFlagRowProps) {
           <span className="text-body-medium-default text-[var(--content-default)]">
             {flag.label}
           </span>
-          <Tag tone="neutral">{flag.scope}</Tag>
+          <ScopeChips scope={flag.scope} />
         </div>
         <span className="block text-body-small-default text-[var(--content-tertiary)]">
           {flag.description}

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -37,9 +37,14 @@ export function FeatureFlagsPanel() {
     const entries: FlagDisplayEntry[] = [];
     for (const flag of ALL_FLAGS) {
       const storeKey = ldKeyToStoreKey(flag.key);
-      const state =
-        flag.scope === "assistant" ? assistantState : clientState;
-      const value = state[storeKey];
+      const clientVal = clientState[storeKey];
+      const assistantVal = assistantState[storeKey];
+      const value =
+        flag.scope === "both"
+          ? clientVal === true || assistantVal === true
+          : flag.scope === "assistant"
+            ? assistantVal
+            : clientVal;
       if (typeof value !== "boolean") continue;
       entries.push({
         storeKey,

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -1,6 +1,14 @@
 import registry from "./feature-flag-registry.json" with { type: "json" };
 
-export type FlagScope = "client" | "assistant";
+export type FlagScope = "client" | "assistant" | "both";
+export type SingleScope = Exclude<FlagScope, "both">;
+
+export function scopeIncludes(
+  scope: FlagScope,
+  target: SingleScope,
+): boolean {
+  return scope === target || scope === "both";
+}
 
 export interface FlagDefinition {
   id: string;
@@ -30,10 +38,10 @@ function kebabToStoreKey(kebabKey: string): string {
     .join("");
 }
 
-function buildScopeDefaults(scope: FlagScope): Record<string, boolean> {
+function buildScopeDefaults(scope: SingleScope): Record<string, boolean> {
   const defaults: Record<string, boolean> = {};
   for (const flag of flags) {
-    if (flag.scope === scope) {
+    if (scopeIncludes(flag.scope, scope)) {
       defaults[kebabToStoreKey(flag.key)] = flag.defaultEnabled;
     }
   }


### PR DESCRIPTION
## Summary
- Color-coded scope chips in the developer settings feature flags table: amber for "client", green for "assistant", and both chips shown together for flags scoped to "both"
- Added `"both"` as a new `FlagScope` value so flags can apply to both client and assistant stores
- Extracted `scopeIncludes` helper and `SingleScope` type to centralize scope-matching logic

## Original prompt
Add chips to the feature flag table in /assistant/settings/developer that visually distinguish whether each flag applies to client, assistant, or both. Use two separate chips (client + assistant) instead of a single "both" chip, with distinct colors for each scope.