### PR TITLE
fix(daemon): remove server-side feature flag gate from steer endpoint (JARVIS-845)

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -20,7 +20,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   deepMergeOverwrite,
   fillContextDefaultsForMissingKeys,
@@ -925,10 +924,6 @@ function handleSteerToMessage({
   pathParams = {},
   body,
 }: RouteHandlerArgs) {
-  const config = getConfig();
-  if (!isAssistantFeatureFlagEnabled("queue-steering", config)) {
-    throw new BadRequestError("Queue steering is not enabled");
-  }
   const conversationId =
     queryParams.conversationId ??
     (body && typeof body === "object" && "conversationId" in body


### PR DESCRIPTION
## Summary

- Remove the redundant `isAssistantFeatureFlagEnabled("queue-steering")` check from the daemon's steer handler
- The steer button is already gated by the `queue-steering` feature flag in both the web app (`useAssistantFeatureFlagStore`) and macOS client (`AssistantFeatureFlagStore`), so the server-side check is redundant
- The server-side check blocks steering in local dev (gateway IPC unavailable → flag resolves to `defaultEnabled: false`) and on managed deployments where the LD flag sync chain may not propagate

## Test plan

- [ ] With `queue-steering` flag enabled in client: steer works
- [ ] With `queue-steering` flag disabled in client: steer button not shown (no way to reach the endpoint)
- [ ] Direct API call to steer endpoint without flag: returns 200 (acceptable — no UI path reaches it without the flag)

Part of JARVIS-845

🤖 Generated with [Claude Code](https://claude.com/claude-code)