### PR TITLE
fix(macos): populate requestIdToMessageId from POST response for queue steering

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -867,15 +867,15 @@ final class ChatActionHandler {
     }
 
     /// Handles the synthetic queuedMessageAcked event from the POST /v1/messages
-    /// response. Pops the oldest pending message ID and maps it to the requestId
-    /// so steerQueuedMessage can find the requestId before the SSE message_queued
-    /// event arrives.
+    /// response. Maps the requestId to the oldest pending message ID so
+    /// steerQueuedMessage can find the requestId before the SSE message_queued
+    /// event arrives. Does NOT pop from pendingMessageIds — that is deferred to
+    /// handleMessageQueued so the FIFO stays intact for deletion reconciliation.
     private func handleQueuedMessageAcked(conversationId: String, requestId: String, vm: ChatViewModel) {
         guard belongsToConversation(conversationId) else { return }
         // Skip if the SSE message_queued event already populated this mapping
         guard vm.requestIdToMessageId[requestId] == nil else { return }
         guard let messageId = vm.pendingMessageIds.first else { return }
-        vm.pendingMessageIds.removeFirst()
         vm.requestIdToMessageId[requestId] = messageId
     }
 
@@ -884,9 +884,13 @@ final class ChatActionHandler {
         vm.pendingQueuedCount += 1
 
         // If the POST response already populated the mapping for this requestId
-        // (via queuedMessageAcked), skip the FIFO pop and just update the
-        // queue position and handle pending deletions.
+        // (via queuedMessageAcked), consume the FIFO entry and handle pending
+        // deletions / position updates.
         if let existingMessageId = vm.requestIdToMessageId[queued.requestId] {
+            // Pop the FIFO entry that queuedMessageAcked peeked but left in place
+            if vm.pendingMessageIds.first == existingMessageId {
+                vm.pendingMessageIds.removeFirst()
+            }
             if vm.pendingLocalDeletions.remove(existingMessageId) != nil {
                 Task {
                     let success = await vm.conversationQueueClient.deleteQueuedMessage(

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -211,6 +211,9 @@ final class ChatActionHandler {
         case .messageQueued(let queued):
             handleMessageQueued(queued, vm: vm)
 
+        case .queuedMessageAcked(let conversationId, let requestId):
+            handleQueuedMessageAcked(conversationId: conversationId, requestId: requestId, vm: vm)
+
         case .messageQueuedDeleted(let msg):
             guard belongsToConversation(msg.conversationId) else { return }
             vm.applyQueuedMessageDeletion(requestId: msg.requestId)
@@ -863,9 +866,45 @@ final class ChatActionHandler {
         vm.dispatchPendingSendDirect()
     }
 
+    /// Handles the synthetic queuedMessageAcked event from the POST /v1/messages
+    /// response. Pops the oldest pending message ID and maps it to the requestId
+    /// so steerQueuedMessage can find the requestId before the SSE message_queued
+    /// event arrives.
+    private func handleQueuedMessageAcked(conversationId: String, requestId: String, vm: ChatViewModel) {
+        guard belongsToConversation(conversationId) else { return }
+        // Skip if the SSE message_queued event already populated this mapping
+        guard vm.requestIdToMessageId[requestId] == nil else { return }
+        guard let messageId = vm.pendingMessageIds.first else { return }
+        vm.pendingMessageIds.removeFirst()
+        vm.requestIdToMessageId[requestId] = messageId
+    }
+
     private func handleMessageQueued(_ queued: MessageQueuedMessage, vm: ChatViewModel) {
         guard belongsToConversation(queued.conversationId) else { return }
         vm.pendingQueuedCount += 1
+
+        // If the POST response already populated the mapping for this requestId
+        // (via queuedMessageAcked), skip the FIFO pop and just update the
+        // queue position and handle pending deletions.
+        if let existingMessageId = vm.requestIdToMessageId[queued.requestId] {
+            if vm.pendingLocalDeletions.remove(existingMessageId) != nil {
+                Task {
+                    let success = await vm.conversationQueueClient.deleteQueuedMessage(
+                        conversationId: queued.conversationId,
+                        requestId: queued.requestId
+                    )
+                    if success {
+                        vm.applyQueuedMessageDeletion(requestId: queued.requestId)
+                    } else {
+                        log.error("Failed to send deferred delete_queued_message")
+                    }
+                }
+            } else if let index = vm.messages.firstIndex(where: { $0.id == existingMessageId }) {
+                vm.messages[index].status = .queued(position: queued.position)
+            }
+            return
+        }
+
         // Associate this requestId with the oldest pending user message
         if let messageId = vm.pendingMessageIds.first {
             vm.pendingMessageIds.removeFirst()

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -317,12 +317,18 @@ public final class EventStreamClient {
             )
 
             switch sendResult {
-            case .success(let serverConvId, let messageId):
+            case .success(let serverConvId, let messageId, let requestId):
                 if let messageId {
                     self.broadcastMessage(.userMessagePersisted(
                         conversationId: conversationId,
                         content: content ?? "",
                         messageId: messageId
+                    ))
+                }
+                if let requestId {
+                    self.broadcastMessage(.queuedMessageAcked(
+                        conversationId: conversationId,
+                        requestId: requestId
                     ))
                 }
                 if let serverConvId, serverConvId != conversationId {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -16,7 +16,8 @@ public enum AttachmentUploadResult: Sendable {
 /// Result of sending a message.
 public enum MessageSendResult: Sendable {
     /// Message accepted by the server.
-    case success(serverConversationId: String?, messageId: String?)
+    /// `requestId` is populated when the message was queued (daemon busy).
+    case success(serverConversationId: String?, messageId: String?, requestId: String?)
     /// Authentication failed terminally (already emitted upstream).
     case authRequired
     /// Message blocked by secret-ingress check.
@@ -266,7 +267,8 @@ public struct MessageClient: MessageClientProtocol {
                 let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
                 let serverConvId = json?["conversationId"] as? String
                 let messageId = json?["messageId"] as? String
-                return .success(serverConversationId: serverConvId, messageId: messageId)
+                let requestId = json?["requestId"] as? String
+                return .success(serverConversationId: serverConvId, messageId: messageId, requestId: requestId)
             } else if response.statusCode == 401 {
                 return .authRequired
             } else if response.statusCode == 422 {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -3091,6 +3091,10 @@ public enum ServerMessage: Decodable, Sendable {
     /// (HTTP 202 with messageId). Broadcast so the per-conversation ChatActionHandler
     /// can tag the optimistic row with the daemon-assigned ID.
     case userMessagePersisted(conversationId: String, content: String, messageId: String)
+    /// Synthetic client-side event: POST /v1/messages returned a requestId for a
+    /// queued message. Populates requestIdToMessageId from the HTTP response so
+    /// the steer button works even before the SSE message_queued event arrives.
+    case queuedMessageAcked(conversationId: String, requestId: String)
     case relationshipStateUpdated(updatedAt: String)
     case homeFeedUpdated(updatedAt: String, newItemCount: Int)
     case pong


### PR DESCRIPTION
## Summary
- Parse `requestId` from the POST `/v1/messages` response when the daemon queues a message (`queued: true`)
- Broadcast a synthetic `queuedMessageAcked` event so `ChatActionHandler` populates `requestIdToMessageId` immediately from the HTTP response
- Update `handleMessageQueued` to skip the FIFO pop when the mapping already exists for that `requestId`, preventing double-counting when both the POST response and SSE event arrive

This fixes the "Push to agent" (steer) button being non-functional on queued messages. The button calls `steerQueuedMessage(messageId:)` which reverse-looks up the `requestId` from `requestIdToMessageId` — but that dictionary was only populated from the SSE `message_queued` event, not from the POST response. The web app already handles this correctly.

Closes JARVIS-940

## Test plan
- [ ] Send a message while the assistant is busy (message gets queued)
- [ ] Click the steer/"Push to agent" button on the queued message
- [ ] Verify the steer succeeds (assistant aborts current generation and processes the steered message)
- [ ] Verify that sending multiple queued messages and steering different ones works correctly
- [ ] Verify that deleting a queued message before the SSE event arrives still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)