### PR TITLE
fix(web): port missed sidebar + settings UI tweaks from platform

### DIFF
--- a/apps/web/src/components/collapsible-nav-section.tsx
+++ b/apps/web/src/components/collapsible-nav-section.tsx
@@ -86,7 +86,7 @@ function CollapsibleNavSectionSection({
       className={className}
       {...itemProps}
     >
-      <div data-slot="collapsible-nav-section-header" className="flex items-center">
+      <div data-slot="collapsible-nav-section-header" className="flex items-center justify-between">
         <Collapsible.Trigger
           className={cn(
             "group h-[28px] max-md:h-auto gap-[4px] max-md:gap-[8px]",

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -4,7 +4,6 @@ import {
   ChevronRight,
   House,
   Menu as MenuIcon,
-  MessageSquarePlus,
   PanelLeft,
   Search,
 } from "lucide-react";
@@ -17,7 +16,6 @@ export interface ChatLayoutHeaderProps {
   toggleSidebar: () => void;
   topBarCenter?: ReactNode;
   topBarRightSlot?: ReactNode;
-  onStartNewConversation?: () => void;
   canGoBack?: boolean;
   canGoForward?: boolean;
   onGoBack?: () => void;
@@ -35,7 +33,6 @@ export function ChatLayoutHeader({
   toggleSidebar,
   topBarCenter,
   topBarRightSlot,
-  onStartNewConversation,
   canGoBack,
   canGoForward,
   onGoBack,
@@ -142,14 +139,6 @@ export function ChatLayoutHeader({
             aria-label="Search (Ctrl+K)"
             title="Search (Ctrl+K)"
             onClick={onSearchClick}
-          />
-        ) : null}
-        {onStartNewConversation ? (
-          <Button
-            variant="ghost"
-            iconOnly={<MessageSquarePlus />}
-            aria-label="New conversation"
-            onClick={onStartNewConversation}
           />
         ) : null}
         {topBarRightSlot}

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -152,7 +152,7 @@ export function ChatLayout() {
   // create/rename/delete affordances are rendered here, not in ChatPage.
   // The hook is self-sufficient (cache invalidation handles rollback), so
   // it can live wherever the sidebar lives.
-  const { handleCreateGroup, handleRenameGroup, handleDeleteGroup } =
+  const { handleRenameGroup, handleDeleteGroup } =
     useConversationGroupActions({
       assistantId: lifecycle.assistantId,
       conversationGroups,
@@ -445,7 +445,6 @@ export function ChatLayout() {
         onOpenIntelligence={handleOpenIdentity}
         isLibraryActive={isLibraryActive}
         onOpenLibrary={handleOpenLibrary}
-        onCreateGroup={handleCreateGroup}
         onRenameGroup={handleRenameGroup}
         onDeleteGroup={handleDeleteGroup}
         footerBanner={footerBanner}
@@ -471,7 +470,6 @@ export function ChatLayout() {
       attentionKeys,
       handleSelectConversation,
       handleStartNewConversation,
-      handleCreateGroup,
       handleRenameGroup,
       handleDeleteGroup,
       isIdentityActive,

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -20,6 +20,7 @@ import { useHomeUnreadBadge } from "@/hooks/use-home-unread-badge.js";
 import type { AssistantContextValue } from "@/components/layout/assistant-context.js";
 
 import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import {
   useConversationGroupsQuery,
   useConversationListQuery,
@@ -248,6 +249,14 @@ export function ChatLayout() {
   const canGoBack = historyIndexRef.current > 0;
   const canGoForward = historyIndexRef.current < maxHistoryIndexRef.current;
 
+  const handleStartNewConversation = useCallback(() => {
+    haptic.light();
+    useViewerStore.getState().setMainView("chat");
+    const draftKey = createDraftConversationKey();
+    useConversationStore.getState().setActiveKey(draftKey);
+    void navigate(routes.conversation(draftKey));
+  }, [navigate]);
+
   const handleOpenHome = useCallback(() => {
     navigate(routes.home);
   }, [navigate]);
@@ -431,6 +440,7 @@ export function ChatLayout() {
         processingConversationKeys={processingKeys}
         attentionConversationKeys={attentionKeys}
         onSelectConversation={handleSelectConversation}
+        onStartNewConversation={handleStartNewConversation}
         isIntelligenceActive={isIdentityActive}
         onOpenIntelligence={handleOpenIdentity}
         isLibraryActive={isLibraryActive}
@@ -460,6 +470,7 @@ export function ChatLayout() {
       processingKeys,
       attentionKeys,
       handleSelectConversation,
+      handleStartNewConversation,
       handleCreateGroup,
       handleRenameGroup,
       handleDeleteGroup,

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -35,7 +35,6 @@ import { OfflineBanner } from "@/components/offline-banner.js";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu.js";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu.js";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
-import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import { ChatLayoutHeader } from "./chat-layout-header.js";
 
 /**
@@ -249,14 +248,6 @@ export function ChatLayout() {
   const canGoBack = historyIndexRef.current > 0;
   const canGoForward = historyIndexRef.current < maxHistoryIndexRef.current;
 
-  const handleStartNewConversation = useCallback(() => {
-    haptic.light();
-    useViewerStore.getState().setMainView("chat");
-    const draftKey = createDraftConversationKey();
-    useConversationStore.getState().setActiveKey(draftKey);
-    void navigate(routes.conversation(draftKey));
-  }, [navigate]);
-
   const handleOpenHome = useCallback(() => {
     navigate(routes.home);
   }, [navigate]);
@@ -440,7 +431,6 @@ export function ChatLayout() {
         processingConversationKeys={processingKeys}
         attentionConversationKeys={attentionKeys}
         onSelectConversation={handleSelectConversation}
-        onStartNewConversation={handleStartNewConversation}
         isIntelligenceActive={isIdentityActive}
         onOpenIntelligence={handleOpenIdentity}
         isLibraryActive={isLibraryActive}
@@ -470,7 +460,6 @@ export function ChatLayout() {
       processingKeys,
       attentionKeys,
       handleSelectConversation,
-      handleStartNewConversation,
       handleCreateGroup,
       handleRenameGroup,
       handleDeleteGroup,
@@ -491,7 +480,6 @@ export function ChatLayout() {
         toggleSidebar={toggleSidebar}
         topBarCenter={topBarCenter}
         topBarRightSlot={topBarRightSlot}
-        onStartNewConversation={handleStartNewConversation}
         canGoBack={canGoBack}
         canGoForward={canGoForward}
         onGoBack={handleGoBack}

--- a/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -85,7 +85,7 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     expect(html).not.toContain(">Slack<");
   });
 
-  test("renders Slack as a conditional peer section before Recents", () => {
+  test("renders Slack as a conditional peer section after Background", () => {
     const conversations = [
       makeConversation({ conversationKey: "regular", title: "Regular thread" }),
       makeConversation({
@@ -99,12 +99,16 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     const html = renderMenu({ conversations });
     expect(html).toContain(">Slack<");
 
+    const pinnedIndex = html.indexOf(">Pinned<");
+    const recentsIndex = html.indexOf(">Recents<");
+    const scheduledIndex = html.indexOf(">Scheduled<");
     const backgroundIndex = html.indexOf(">Background<");
     const slackIndex = html.indexOf(">Slack<");
-    const recentsIndex = html.indexOf(">Recents<");
-    expect(backgroundIndex).toBeGreaterThanOrEqual(0);
+    expect(pinnedIndex).toBeGreaterThanOrEqual(0);
+    expect(recentsIndex).toBeGreaterThan(pinnedIndex);
+    expect(scheduledIndex).toBeGreaterThan(recentsIndex);
+    expect(backgroundIndex).toBeGreaterThan(scheduledIndex);
     expect(slackIndex).toBeGreaterThan(backgroundIndex);
-    expect(recentsIndex).toBeGreaterThan(slackIndex);
   });
 
   test("renders a count badge only for non-empty category buckets", () => {

--- a/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -247,13 +247,3 @@ describe("AssistantSideMenu · overlay close affordance", () => {
   });
 });
 
-describe("AssistantSideMenu · compose button mobile close wiring", () => {
-  test("compose button onClick calls onClose alongside onStartNewConversation", () => {
-    const src = readFileSync(
-      new URL("./assistant-side-menu.tsx", import.meta.url).pathname,
-      "utf8",
-    );
-
-    expect(src).toContain("onStartNewConversation(); onClose?.();");
-  });
-});

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -2,13 +2,13 @@ import {
   Brain,
   Calendar,
   Clock,
-  FolderPlus,
   Globe,
   Hash,
   Layers,
   LayoutGrid,
   Pin,
   Search,
+  SquarePen,
   X,
 } from "lucide-react";
 import { useCallback, type ReactNode } from "react";
@@ -51,6 +51,7 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onOpenLibrary?: () => void;
   onOpenApp?: (appId: string) => void;
   activeAppId?: string;
+  onStartNewConversation?: () => void;
   footerBanner?: ReactNode;
   footerAction?: ReactNode;
   onClose?: () => void;
@@ -109,6 +110,7 @@ export function AssistantSideMenu({
   onOpenLibrary,
   onOpenApp,
   activeAppId,
+  onStartNewConversation,
   footerBanner,
   footerAction,
   onPinConversation,
@@ -263,13 +265,13 @@ export function AssistantSideMenu({
 
   // --- Header actions ---
 
-  const headerActions = sidebar.conversationGroupsEnabled ? (
+  const headerActions = onStartNewConversation ? (
     <Button
       variant="ghost"
       size="compact"
-      iconOnly={<FolderPlus />}
-      aria-label="Create group"
-      onClick={onCreateGroup}
+      iconOnly={<SquarePen />}
+      aria-label="New conversation"
+      onClick={() => { onStartNewConversation(); onClose?.(); }}
     />
   ) : null;
 

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -9,7 +9,6 @@ import {
   LayoutGrid,
   Pin,
   Search,
-  SquarePen,
   X,
 } from "lucide-react";
 import { useCallback, type ReactNode } from "react";
@@ -52,7 +51,6 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onOpenLibrary?: () => void;
   onOpenApp?: (appId: string) => void;
   activeAppId?: string;
-  onStartNewConversation?: () => void;
   footerBanner?: ReactNode;
   footerAction?: ReactNode;
   onClose?: () => void;
@@ -111,7 +109,6 @@ export function AssistantSideMenu({
   onOpenLibrary,
   onOpenApp,
   activeAppId,
-  onStartNewConversation,
   footerBanner,
   footerAction,
   onPinConversation,
@@ -266,26 +263,15 @@ export function AssistantSideMenu({
 
   // --- Header actions ---
 
-  const headerActions = (
-    <>
-      {sidebar.conversationGroupsEnabled ? (
-        <Button
-          variant="ghost"
-          size="compact"
-          iconOnly={<FolderPlus />}
-          aria-label="Create group"
-          onClick={onCreateGroup}
-        />
-      ) : null}
-      <Button
-        variant="ghost"
-        size="compact"
-        iconOnly={<SquarePen />}
-        aria-label="New conversation"
-        onClick={onStartNewConversation ? () => { onStartNewConversation(); onClose?.(); } : undefined}
-      />
-    </>
-  );
+  const headerActions = sidebar.conversationGroupsEnabled ? (
+    <Button
+      variant="ghost"
+      size="compact"
+      iconOnly={<FolderPlus />}
+      aria-label="Create group"
+      onClick={onCreateGroup}
+    />
+  ) : null;
 
   // --- Flat conversation list renderer ---
 
@@ -418,6 +404,15 @@ export function AssistantSideMenu({
               </CollapsibleNavSection.Section>
 
               <CollapsibleNavSection.Section
+                value="recents"
+                icon={Clock}
+                label="Recents"
+                trailing={countBadge(sidebar.recents.totalCount)}
+              >
+                {renderFlatList(sidebar.recents.items, sidebar.recents.showMore, sidebar.recents.onShowMore)}
+              </CollapsibleNavSection.Section>
+
+              <CollapsibleNavSection.Section
                 value="scheduled"
                 icon={Calendar}
                 label="Scheduled"
@@ -451,15 +446,6 @@ export function AssistantSideMenu({
                   {renderFlatList(sidebar.slack.items, sidebar.slack.showMore, sidebar.slack.onShowMore)}
                 </CollapsibleNavSection.Section>
               ) : null}
-
-              <CollapsibleNavSection.Section
-                value="recents"
-                icon={Clock}
-                label="Recents"
-                trailing={countBadge(sidebar.recents.totalCount)}
-              >
-                {renderFlatList(sidebar.recents.items, sidebar.recents.showMore, sidebar.recents.onShowMore)}
-              </CollapsibleNavSection.Section>
             </CollapsibleNavSection.Root>
 
             {sidebar.conversationGroupsEnabled && sidebar.customGroups.length > 0 ? (

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -62,7 +62,6 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onUnarchiveConversation?: (conversation: Conversation) => void;
   onMarkConversationUnread?: (conversation: Conversation) => void;
   onMarkConversationRead?: (conversation: Conversation) => void;
-  onCreateGroup?: () => void;
   onMoveToGroup?: (conversation: Conversation, groupId: string) => void;
   onRemoveFromGroup?: (conversation: Conversation) => void;
   onRenameGroup?: (groupId: string) => void;
@@ -120,7 +119,6 @@ export function AssistantSideMenu({
   onMarkConversationUnread,
   onMarkConversationRead,
   conversationGroups,
-  onCreateGroup,
   onMoveToGroup,
   onRemoveFromGroup,
   onRenameGroup,

--- a/apps/web/src/domains/settings/components/settings-shell.tsx
+++ b/apps/web/src/domains/settings/components/settings-shell.tsx
@@ -70,7 +70,7 @@ export function SettingsShell({
       className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 p-4 sm:p-6 md:gap-0"
       style={{
         paddingTop:
-          "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+          "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)",
       }}
     >
       {/* Mobile header */}

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -49,16 +49,12 @@ export function SettingsLayout() {
   );
 
   const pageTitle = useMemo(() => {
+    if (pathname === routes.settings.root) return "Settings";
     const match = SETTINGS_SIDEBAR.find(
       (item) =>
         pathname === item.href || pathname.startsWith(item.href + "/"),
     );
     if (match) return match.label;
-    // Index route (/assistant/settings) renders GeneralPage but doesn't
-    // match any sidebar href — use the first sidebar item's label.
-    if (pathname === routes.settings.root) {
-      return SETTINGS_SIDEBAR[0]?.label ?? "Settings";
-    }
     return "Settings";
   }, [pathname]);
 


### PR DESCRIPTION
## Summary
1-to-1 conversion catching UI tweaks missed during the platform → web migration.

- **Sidebar count badges** push to the right edge of each section row (`justify-between` on the collapsible nav header).
- **Conversations section order** is now Pinned → Recents → Scheduled → Background → Slack (Recents moved up under Pinned).
- **Settings root title** now reads "Settings" instead of "General" (the index route was falling through to the first sidebar item's label).
- **Settings top padding** restored — the `paddingTop` inline style was *replacing* the `p-4`/`sm:p-6` top padding with `0` in the browser; switched to an additive `calc(safe-area-inset + 1rem)`.
- **New-chat button removed** from both top corners (sidebar header `SquarePen`, chat top bar `MessageSquarePlus`). Underlying `startNewConversation` callback in `chat-page.tsx` is preserved for routes/keyboard entry points.

## Test plan
- [ ] Open the sidebar — confirm count badges (e.g. "Background 68", "Heartbeat 19") sit on the far right of their rows
- [ ] Confirm Conversations order: Pinned, Recents, Scheduled, Background, Slack
- [ ] Open Settings root — header should read "Settings", with top padding above the back button
- [ ] Click into Settings → General — header should read "General"
- [ ] Confirm no new-chat icon in the sidebar top-right (next to the folder+ icon) and none in the chat layout header top-right
- [ ] Start a new conversation via any other entry point (route navigation / keyboard) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)