### PR TITLE
feat(macos): filter model dropdown for ChatGPT subscription connections

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -49,6 +49,12 @@ struct InferenceProfileEditor: View {
     var onSaveAs: (() -> Void)?
     let onCancel: () -> Void
 
+    /// Model IDs supported by ChatGPT subscription (Codex) connections.
+    /// When the effective connection uses `oauth_subscription` auth, the
+    /// model dropdown is filtered to this set. Mirrors the web app's
+    /// `CODEX_SUBSCRIPTION_MODEL_IDS` in `profile-editor-modal.tsx`.
+    static let codexSubscriptionModelIds: Set<String> = ["gpt-5.4", "gpt-5.3-codex"]
+
     /// Effort ladder mirrors the daemon's `EffortLevel` schema. Includes
     /// `none` so users can disable effort entirely; `xhigh`/`max` mirror
     /// the OpenAI provider's higher-effort models.
@@ -173,13 +179,20 @@ struct InferenceProfileEditor: View {
     }
 
     /// True when the user has picked a provider/model combo where the
-    /// model is not present in the provider's catalog. Treated the same
-    /// as the missing case for Save purposes — the daemon would route to
-    /// a model the provider doesn't know about.
+    /// model is not present in the provider's catalog — or when the
+    /// effective connection is `oauth_subscription` and the model is not
+    /// in the Codex-supported set. Treated the same as the missing case
+    /// for Save purposes — the daemon would route to a model the
+    /// provider doesn't know about.
     var isModelInvalid: Bool {
         guard let provider = profile.provider, !provider.isEmpty,
               let model = profile.model, !model.isEmpty else {
             return false
+        }
+        // ChatGPT subscription connections restrict available models to
+        // the Codex-supported subset regardless of catalog presence.
+        if effectiveConnection?.auth.type == "oauth_subscription" {
+            return !Self.codexSubscriptionModelIds.contains(model)
         }
         let catalogIds = store.dynamicProviderModels(provider).map(\.id)
         let connectionIds = effectiveConnection?.models?.map(\.id) ?? []
@@ -621,7 +634,14 @@ struct InferenceProfileEditor: View {
         let connectionModels: [CatalogModel] = effectiveConnection?.models?.map {
             CatalogModel(id: $0.id, displayName: $0.displayName ?? $0.id)
         } ?? []
-        let models = connectionModels.isEmpty ? catalogModels : connectionModels
+        let baseModels = connectionModels.isEmpty ? catalogModels : connectionModels
+        // ChatGPT subscription (Codex) connections only support a subset
+        // of OpenAI models. Filter the dropdown so users can't select an
+        // unsupported model. Mirrors the web app's filter in
+        // `profile-editor-modal.tsx`.
+        let models: [CatalogModel] = effectiveConnection?.auth.type == "oauth_subscription"
+            ? baseModels.filter { Self.codexSubscriptionModelIds.contains($0.id) }
+            : baseModels
         return labeled(
             "Model",
             accessory: {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -80,7 +80,31 @@ final class InferenceProfileEditorTests: XCTestCase {
     }
 
     private static func editorProviderCatalog() -> [ProviderCatalogEntry] {
-        SettingsTestFixture.anthropicAndOpenAICatalog() + [
+        // Override the OpenAI catalog to include Codex-supported models
+        // (`gpt-5.4`, `gpt-5.3-codex`) alongside the standard `gpt-5`, so
+        // the `oauth_subscription` model-filter tests can verify the dropdown
+        // narrows to the Codex subset.
+        [
+            ProviderCatalogEntry(
+                id: "anthropic",
+                displayName: "Anthropic",
+                models: [
+                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
+                ],
+                defaultModel: "claude-sonnet-4-6"
+            ),
+            ProviderCatalogEntry(
+                id: "openai",
+                displayName: "OpenAI",
+                models: [
+                    CatalogModel(id: "gpt-5", displayName: "GPT-5"),
+                    CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
+                    CatalogModel(id: "gpt-5.3-codex", displayName: "GPT-5.3 Codex"),
+                ],
+                defaultModel: "gpt-5"
+            ),
+        ] + [
             ProviderCatalogEntry(
                 id: "gemini",
                 displayName: "Google Gemini",
@@ -1256,6 +1280,92 @@ final class InferenceProfileEditorTests: XCTestCase {
             onCancel: {}
         )
         XCTAssertTrue(editor.availableProviderIds.isEmpty)
+    }
+
+    // MARK: - ChatGPT subscription (Codex) model filter
+
+    /// When the effective connection uses `oauth_subscription` auth, the
+    /// model dropdown must narrow to the Codex-supported subset. A
+    /// non-Codex model like `gpt-5` must not appear.
+    func testIsModelInvalidTrueForNonCodexModelOnOAuthSubscription() {
+        let connections = [
+            Self.makeConnection(
+                name: "chatgpt-sub",
+                provider: "openai",
+                authType: "oauth_subscription",
+                status: .active
+            ),
+        ]
+        let editor = InferenceProfileEditor(
+            store: store,
+            profile: .constant(InferenceProfile(
+                name: "draft",
+                provider: "openai",
+                model: "gpt-5"
+            )),
+            connections: connections,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertTrue(editor.isModelInvalid, "gpt-5 is not Codex-supported; should be invalid for oauth_subscription")
+    }
+
+    /// A Codex-supported model (`gpt-5.4`) must be valid on an
+    /// `oauth_subscription` connection.
+    func testIsModelInvalidFalseForCodexModelOnOAuthSubscription() {
+        let connections = [
+            Self.makeConnection(
+                name: "chatgpt-sub",
+                provider: "openai",
+                authType: "oauth_subscription",
+                status: .active
+            ),
+        ]
+        let editor = InferenceProfileEditor(
+            store: store,
+            profile: .constant(InferenceProfile(
+                name: "draft",
+                provider: "openai",
+                model: "gpt-5.4"
+            )),
+            connections: connections,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertFalse(editor.isModelInvalid, "gpt-5.4 is Codex-supported; should be valid for oauth_subscription")
+    }
+
+    /// Standard `api_key` connections must NOT apply the Codex filter —
+    /// all catalog models remain valid.
+    func testIsModelInvalidFalseForNonCodexModelOnApiKey() {
+        let connections = [
+            Self.makeConnection(
+                name: "openai-key",
+                provider: "openai",
+                authType: "api_key",
+                status: .active
+            ),
+        ]
+        let editor = InferenceProfileEditor(
+            store: store,
+            profile: .constant(InferenceProfile(
+                name: "draft",
+                provider: "openai",
+                model: "gpt-5"
+            )),
+            connections: connections,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertFalse(editor.isModelInvalid, "gpt-5 is in the catalog; should be valid for api_key connection")
+    }
+
+    /// The static constant must stay in sync with the web app's
+    /// `CODEX_SUBSCRIPTION_MODEL_IDS`.
+    func testCodexSubscriptionModelIdsContainsExpectedEntries() {
+        XCTAssertTrue(InferenceProfileEditor.codexSubscriptionModelIds.contains("gpt-5.4"))
+        XCTAssertTrue(InferenceProfileEditor.codexSubscriptionModelIds.contains("gpt-5.3-codex"))
+        XCTAssertEqual(InferenceProfileEditor.codexSubscriptionModelIds.count, 2)
     }
 
     /// Test helper mirroring `ProvidersSheetTests.makeConnection` so the


### PR DESCRIPTION
## Summary
- When the effective connection uses `oauth_subscription` auth (ChatGPT subscription / Codex), restricts the model dropdown in the macOS profile editor to only Codex-supported models (`gpt-5.4`, `gpt-5.3-codex`)
- Updates `isModelInvalid` validation to reject non-Codex models on `oauth_subscription` connections, preventing save of unsupported models
- Mirrors the web app's `CODEX_SUBSCRIPTION_MODEL_IDS` filter in `profile-editor-modal.tsx`

Follow-up to #31671.

## Test plan
- [ ] Open profile editor, select an OpenAI connection with `oauth_subscription` auth type
- [ ] Verify model dropdown shows only `gpt-5.4` and `gpt-5.3-codex`
- [ ] Switch to a standard `api_key` connection and verify all catalog models appear
- [ ] Verify Save is disabled when a non-Codex model is selected with an `oauth_subscription` connection
- [ ] Unit tests: `testIsModelInvalidTrueForNonCodexModelOnOAuthSubscription`, `testIsModelInvalidFalseForCodexModelOnOAuthSubscription`, `testIsModelInvalidFalseForNonCodexModelOnApiKey`, `testCodexSubscriptionModelIdsContainsExpectedEntries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)