### PR TITLE
fix(web): auto-send first message for content-automation cohort onboarding

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -271,7 +271,7 @@ export function ChatPage() {
   const initialPageOldestTsRef = useRef<number | null>(null);
   const conversationListInvalidatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
-  const pendingOnboardingInitialMessageRef = useRef<string | null>(null);
+  const pendingOnboardingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
   const expandedToolCallIdsRef = useRef<Set<string>>(new Set());
   const contextWindowUsageByConversationRef = useRef<Map<string, ContextWindowUsage>>(new Map());
   const syncRouterRef = useRef<WebSyncRouter | null>(null);
@@ -493,7 +493,10 @@ export function ChatPage() {
         pendingOnboardingContextRef.current.tasks.length === 0,
       );
       if (pendingOnboardingContextRef.current.initialMessage) {
-        pendingOnboardingInitialMessageRef.current = pendingOnboardingContextRef.current.initialMessage;
+        pendingOnboardingInitialMessageRef.current = {
+          conversationKey: onboardingDraftKey,
+          content: pendingOnboardingContextRef.current.initialMessage,
+        };
       }
     }
     void navigate(routes.conversation(onboardingDraftKey), { replace: true });
@@ -666,10 +669,10 @@ export function ChatPage() {
 
   // Auto-send onboarding initial message once the draft conversation is ready
   useEffect(() => {
-    const msg = pendingOnboardingInitialMessageRef.current;
-    if (!msg || !activeConversationKey) return;
+    const pending = pendingOnboardingInitialMessageRef.current;
+    if (!pending || activeConversationKey !== pending.conversationKey) return;
     pendingOnboardingInitialMessageRef.current = null;
-    void sendMessage(msg);
+    void sendMessage(pending.content);
   }, [activeConversationKey, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -271,6 +271,7 @@ export function ChatPage() {
   const initialPageOldestTsRef = useRef<number | null>(null);
   const conversationListInvalidatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
+  const pendingOnboardingInitialMessageRef = useRef<string | null>(null);
   const expandedToolCallIdsRef = useRef<Set<string>>(new Set());
   const contextWindowUsageByConversationRef = useRef<Map<string, ContextWindowUsage>>(new Map());
   const syncRouterRef = useRef<WebSyncRouter | null>(null);
@@ -491,6 +492,9 @@ export function ChatPage() {
       setOnboardingTasksEmpty(
         pendingOnboardingContextRef.current.tasks.length === 0,
       );
+      if (pendingOnboardingContextRef.current.initialMessage) {
+        pendingOnboardingInitialMessageRef.current = pendingOnboardingContextRef.current.initialMessage;
+      }
     }
     void navigate(routes.conversation(onboardingDraftKey), { replace: true });
     return () => {
@@ -659,6 +663,14 @@ export function ChatPage() {
     promptConsumedRef.current = prompt;
     void sendMessage(prompt);
   }, [searchParams, activeConversationKey, sendMessage]);
+
+  // Auto-send onboarding initial message once the draft conversation is ready
+  useEffect(() => {
+    const msg = pendingOnboardingInitialMessageRef.current;
+    if (!msg || !activeConversationKey) return;
+    pendingOnboardingInitialMessageRef.current = null;
+    void sendMessage(msg);
+  }, [activeConversationKey, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -195,6 +195,7 @@ export function PreChatFlow() {
       tone: DEFAULT_GROUP_ID,
       googleConnected: false,
       cohort: "content-automation",
+      initialMessage: "I want to write articles that rank better for GEO.",
     };
     setPendingPreChatContext(context);
     try {

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -48,6 +48,8 @@ export interface PreChatOnboardingContext {
   googleScopes?: string[];
   /** GTM cohort identifier, e.g. "content-automation". */
   cohort?: string;
+  /** Auto-send this message on first load instead of waiting for user input. */
+  initialMessage?: string;
 }
 
 /**
@@ -220,6 +222,9 @@ function isPreChatOnboardingContext(
     if (!candidate.priorAssistants.every((s) => typeof s === "string")) return false;
   }
   if (candidate.cohort !== undefined && typeof candidate.cohort !== "string") {
+    return false;
+  }
+  if (candidate.initialMessage !== undefined && typeof candidate.initialMessage !== "string") {
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- Add `initialMessage` optional field to `PreChatOnboardingContext` interface and validator
- Set initial message to GEO prompt in content-automation cohort auto-skip path
- Wire auto-send via ref + effect in chat-page.tsx so the message fires once the draft conversation is established

Part of plan: ca-cohort-auto-msg.md (PR 1 of 1)