### PR TITLE
fix(web): pro onboarding modal sizing and lint

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -89,7 +89,7 @@ export function BillingOnboardingModal({
 
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
-      <Modal.Content size="md" hideCloseButton className="min-h-[400px] overflow-hidden">
+      <Modal.Content size="md" hideCloseButton className="overflow-hidden">
         {renderStep()}
       </Modal.Content>
     </Modal.Root>

--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -63,7 +63,7 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
   return (
     <>
       <Modal.Body
-        className="space-y-5 pt-10 pb-4"
+        className="min-h-[320px] space-y-5 pt-10 pb-4"
         style={{ animation: "onboarding-step-in 350ms ease-out" }}
       >
         <div className="flex flex-col items-center gap-3 pb-2 text-center">

--- a/apps/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
@@ -1,7 +1,6 @@
 import { AlertCircle } from "lucide-react";
 
 import { Button } from "@vellum/design-library/components/button";
-import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
 
 import { IconBadge } from "./primitives.js";

--- a/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -82,7 +82,7 @@ export function SetupStep({
   return (
     <>
       <Modal.Body
-        className="space-y-5 pt-10 pb-4"
+        className="min-h-[320px] space-y-5 pt-10 pb-4"
         style={{ animation: "onboarding-step-in 350ms ease-out" }}
       >
         <div className="flex flex-col items-center gap-3 pb-2 text-center">


### PR DESCRIPTION
## Summary
- Move `min-h-[400px]` from the modal container to wizard step bodies (`min-h-[320px]`) so loading, error, welcome, and complete states size to their content instead of being stretched
- Remove unused `Notice` import in `error-states.tsx` that caused CI lint failure

## Original prompt
The loading/error states were inheriting the wizard's min-height, making the modal too tall for those compact states. Also fixing the lint error from the previous PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)