### PR TITLE
fix(web): give Library its own page shell instead of nesting under About Assistant

### DIFF
--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@vellum/design-library";
+
+/**
+ * Shared rounded-overlay container for the assistant's main content pages
+ * (Intelligence "About Assistant" tabs, Library). Keeps the surface,
+ * border, padding, and min-h-0 flex behavior consistent across pages so
+ * children only own their per-page header/body layout.
+ */
+export function PageShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-6 py-5",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/domains/intelligence/components/apps/library-view.tsx
+++ b/apps/web/src/domains/intelligence/components/apps/library-view.tsx
@@ -207,6 +207,12 @@ function LibraryDocumentCard({ document, onOpen }: LibraryDocumentCardProps) {
 export interface LibraryViewProps {
   assistantId: string;
   assistantName?: string;
+  /**
+   * Optional page title rendered to the left of the Import action.
+   * Used when LibraryView is the page's primary content (e.g. the
+   * standalone /library route) so the title shares a row with Import.
+   */
+  title?: string;
   onNewConversation?: (initialMessage?: string) => void;
   onOpenDocument?: (documentSurfaceId: string) => void;
   onEditApp?: (app: { appId: string; dirName?: string; name: string; html: string }) => void;
@@ -222,6 +228,7 @@ export interface LibraryViewProps {
 export function LibraryView({
   assistantId,
   assistantName,
+  title,
   onNewConversation,
   onOpenDocument,
   onEditApp,
@@ -644,7 +651,14 @@ export function LibraryView({
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="mb-4 flex shrink-0 items-center justify-end">
+      <div className="mb-4 flex shrink-0 items-center justify-between gap-4">
+        {title ? (
+          <h1 className="text-title-large text-[var(--content-default)]">
+            {title}
+          </h1>
+        ) : (
+          <span />
+        )}
         <div className="flex items-center gap-2">
           <input
             ref={fileInputRef}

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -2,6 +2,7 @@ import { NavLink, Outlet, useLocation, useOutletContext } from "react-router";
 
 import { cn } from "@vellum/design-library";
 
+import { PageShell } from "@/components/page-shell.js";
 import { routes } from "@/utils/routes.js";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
 
@@ -31,7 +32,7 @@ export function IntelligenceLayout() {
   const outletContext = useOutletContext();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-6 py-5">
+    <PageShell>
       <h1 className="mb-4 shrink-0 text-title-large text-[var(--content-default)]">
         About {assistantName || "Assistant"}
       </h1>
@@ -68,6 +69,6 @@ export function IntelligenceLayout() {
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <Outlet context={outletContext} />
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/src/domains/library/library-page.tsx
+++ b/apps/web/src/domains/library/library-page.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
+import { PageShell } from "@/components/page-shell.js";
 import { LibraryView } from "@/domains/intelligence/components/apps/library-view.js";
 import { routes } from "@/utils/routes.js";
 
@@ -39,11 +40,14 @@ export function LibraryPage() {
   );
 
   return (
-    <LibraryView
-      assistantId={assistantId}
-      onNewConversation={handleNewConversation}
-      onOpenDocument={handleOpenDocument}
-      onOpenApp={handleOpenApp}
-    />
+    <PageShell>
+      <LibraryView
+        assistantId={assistantId}
+        title="Library"
+        onNewConversation={handleNewConversation}
+        onOpenDocument={handleOpenDocument}
+        onOpenApp={handleOpenApp}
+      />
+    </PageShell>
   );
 }

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -214,11 +214,11 @@ export const router = createBrowserRouter(
                   children: [
                     { path: "identity", element: <IdentityPage /> },
                     { path: "skills", element: <SkillsPage /> },
-                    { path: "library", element: <LibraryPage /> },
                     { path: "workspace", element: <WorkspacePage /> },
                     { path: "contacts", element: <ContactsPage /> },
                   ],
                 },
+                { path: "library", element: <LibraryPage /> },
                 { path: "library/:appId", element: <LibraryDetailPage /> },
                 { path: "connect", element: <ConnectPage /> },
                 { path: "inspect", element: <InspectPage /> },


### PR DESCRIPTION
## Summary
The `/library` route was a child of `IntelligenceLayout`, so it inherited the "About <Assistant>" title + Identity/Skills/Workspace/Contacts tabs above the library content. Lift it out so Library renders standalone with its own "Library" title.

- Extract a small `PageShell` component (rounded overlay container) so `IntelligenceLayout` and the Library page share the same outer chrome
- Re-parent the `/library` route in `routes.tsx` to be a peer of the `IntelligenceLayout` group instead of a child
- Wrap `LibraryPage` in `PageShell` and pass a `title` prop to `LibraryView` so the title sits to the left of the existing Import button row

## Test plan
- [ ] Click **Library** in the sidebar — header reads "Library" with Import on the right (no Identity/Skills/Workspace/Contacts tabs above)
- [ ] Click **Tirman** (Intelligence) in the sidebar — "About Tirman" header + tab bar still renders correctly in the same bordered container
- [ ] Identity, Skills, Workspace, Contacts tabs all still load under the About-Assistant chrome
- [ ] Navigating to `/library/:appId` (clicking a library app) still works — uses `LibraryDetailPage` and is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)