### PR TITLE
Log which signal triggered daemon shutdown

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -34,10 +34,10 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
   let shuttingDown = false;
   let exitCode = 0;
 
-  const shutdown = async () => {
+  const shutdown = async (signal?: NodeJS.Signals) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    log.info("Shutting down daemon...");
+    log.warn({ signal: signal ?? "unknown" }, "Daemon shutdown initiated");
 
     // Force exit if graceful shutdown takes too long.
     // Set this BEFORE awaiting heartbeat stop so it covers all
@@ -156,9 +156,9 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     process.exit(exitCode);
   };
 
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
-  process.on("SIGHUP", shutdown);
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    process.on(sig, () => shutdown(sig));
+  }
 
   process.on("unhandledRejection", (reason) => {
     log.error(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -34,10 +34,9 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
   let shuttingDown = false;
   let exitCode = 0;
 
-  const shutdown = async (signal?: NodeJS.Signals) => {
+  const shutdown = async (_signal?: NodeJS.Signals) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    log.warn({ signal: signal ?? "unknown" }, "Daemon shutdown initiated");
 
     // Force exit if graceful shutdown takes too long.
     // Set this BEFORE awaiting heartbeat stop so it covers all
@@ -156,9 +155,29 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     process.exit(exitCode);
   };
 
-  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
-    process.on(sig, () => shutdown(sig));
-  }
+  process.on("SIGTERM", () => {
+    log.warn(
+      { signal: "SIGTERM", pid: process.pid, uptime: process.uptime() },
+      "Received SIGTERM — process termination requested",
+    );
+    void shutdown("SIGTERM");
+  });
+
+  process.on("SIGINT", () => {
+    log.warn(
+      { signal: "SIGINT", pid: process.pid, uptime: process.uptime() },
+      "Received SIGINT — user interrupt",
+    );
+    void shutdown("SIGINT");
+  });
+
+  process.on("SIGHUP", () => {
+    log.warn(
+      { signal: "SIGHUP", pid: process.pid, uptime: process.uptime() },
+      "Received SIGHUP — terminal hangup",
+    );
+    void shutdown("SIGHUP");
+  });
 
   process.on("unhandledRejection", (reason) => {
     log.error(


### PR DESCRIPTION
## Summary
- Changes shutdown handler to accept and log the signal name (SIGTERM, SIGINT, SIGHUP) that initiated the shutdown
- Elevates from `log.info` to `log.warn` so it's visible in filtered log views

## Context
When debugging crashlooping pods in production, we can't tell whether the daemon was killed by a k8s liveness probe (SIGTERM), user interrupt (SIGINT), or terminal hangup (SIGHUP). This makes it hard to distinguish between intentional restarts and probe-triggered kills.

## Test plan
- [x] Lint + format pass
- [ ] CI type check + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)