### PR TITLE
[DO NOT MERGE] Make /assistant/ Vite base path actually work end-to-end

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -227,24 +227,37 @@ jobs:
             exit 1
           fi
 
+          # Mirror dist/ into the bucket under the `/assistant/` prefix so the
+          # object key matches the URL the browser asks for. The Vite build sets
+          # `base: "/assistant/"`, so index.html references its assets as
+          # `/assistant/assets/<hash>.js`. With the dist tree at the bucket root
+          # those requests resolved only because the load balancer was stripping
+          # the `/assistant/` prefix before proxying — fine for `/assistant/*`
+          # routes, broken for any catch-all path (`/account/login`, `/logout`)
+          # that also has to serve the SPA shell. Pushing the tree under
+          # `assistant/` makes object key = URL path, so no LB prefix-stripping
+          # is needed and any path that catches to index.html boots cleanly.
+
           # 1. Upload everything EXCEPT index.html with a long immutable cache,
-          #    additive (no deletion) so clients that loaded the previous shell can
-          #    still fetch their lazy-loaded hashed chunks during the rollout.
-          #    index.html is excluded here so that a run cancelled before step 2
-          #    (e.g. superseded by concurrency.cancel-in-progress) can never leave
-          #    the entrypoint pinned with a year-long immutable cache.
+          #    additive (no deletion) so clients that loaded the previous shell
+          #    can still fetch their lazy-loaded hashed chunks during the
+          #    rollout. index.html is excluded here so that a run cancelled
+          #    before step 2 (e.g. superseded by concurrency.cancel-in-progress)
+          #    can never leave the entrypoint pinned with a year-long immutable
+          #    cache.
           gcloud storage rsync -r \
             --exclude="^index\.html$" \
             --cache-control="public, max-age=31536000, immutable" \
-            dist "gs://${BUCKET}"
+            dist "gs://${BUCKET}/assistant"
 
-          # 2. Upload the HTML entrypoint last, with no-cache, so the new release
-          #    only goes live once its assets exist and is always revalidated.
+          # 2. Upload the HTML entrypoint last, with no-cache, so the new
+          #    release only goes live once its assets exist and is always
+          #    revalidated.
           gcloud storage cp \
             --cache-control="no-cache, max-age=0, must-revalidate" \
-            dist/index.html "gs://${BUCKET}/index.html"
+            dist/index.html "gs://${BUCKET}/assistant/index.html"
 
-          echo "Published SPA to gs://${BUCKET}/ (environment=${TARGET_ENV})"
+          echo "Published SPA to gs://${BUCKET}/assistant/ (environment=${TARGET_ENV})"
 
   notify-web:
     name: Slack Notification (Web)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -35,6 +35,33 @@ export default defineConfig(({ mode }) => {
           filesToDeleteAfterUpload: ["./dist/**/*.map"],
         },
       }),
+      // Dev-server SPA fallback for routes that live outside Vite's `base`.
+      // With `base: "/assistant/"`, Vite's built-in fallback only serves
+      // index.html under `/assistant/*`. React Router intentionally claims
+      // `/account/*` and `/logout` at the root (see routes.tsx), so a
+      // hard-reload on those URLs would otherwise 404 in dev. Rewriting
+      // the request to `/assistant/` makes Vite serve index.html; the
+      // browser URL is unchanged, so React Router still matches the
+      // original path. Production relies on the deployed server's
+      // catch-all fallback (LB → SPA bucket).
+      {
+        name: "spa-fallback-outside-base",
+        configureServer(server) {
+          server.middlewares.use((req, _res, next) => {
+            const url = req.url ?? "";
+            const pathname = url.split("?")[0];
+            if (
+              pathname === "/account" ||
+              pathname.startsWith("/account/") ||
+              pathname === "/logout" ||
+              pathname.startsWith("/logout/")
+            ) {
+              req.url = "/assistant/";
+            }
+            next();
+          });
+        },
+      },
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
**🚫 DO NOT MERGE — explainer + proposed fix for review.**

Opening this draft so we have one place to discuss the dev iOS sign-in breakage, lay out what actually went wrong, and propose the shape of the real fix. Some of this needs infra confirmation before it can land safely (see "Open question" below).

---

## Symptom

Sign-in on the dev iOS TestFlight build does not work. The Capacitor shell loads `https://dev-assistant.vellum.ai/assistant` in a WKWebView, the cold-boot redirect chain lands the user on `/account/login`, and the page does not function correctly. The "what specifically breaks" varies depending on which path actually serves the shell.

## What changed yesterday (May 21)

| Time (UTC-4) | PR / commit | What it did | Lands on main? |
|---|---|---|---|
| 14:51 | #31525 (`0ecc4e6f0f`) | Vite `base: "/"` → `"/assistant/"` | ✅ |
| 14:57 | #31516 (`aed9433ba2`) | New CI/CD workflow publishes `dist/` to `gs://${PROJECT_ID}-assistant-spa/` | ✅ |
| 17:46 | `codex/vite-dev-base-root` (`2ea2b73620`) | `base` = `/` in dev, `/assistant/` only on build | ❌ branch only |
| 19:35 | #31538 (`4702c0d37f`) | Prefix runtime ``&lt;img src="/foo.svg"&gt;`` strings with `import.meta.env.BASE_URL` | ✅ |
| 20:57 | `claude/quirky-ride-89dXx` (`1cae44161e`) | Vite dev-server middleware rewrites `/account/*` and `/logout` to `/assistant/` so the SPA fallback fires | ❌ branch only |

So #31525 moved the assets under `/assistant/` in the URL space, #31516 wired up CD without changing the bucket layout, and the two follow-up fixes for the obvious dev-server gap never landed. PR #31538 patched the leaked `/foo.svg` strings in runtime JS but didn't touch the deploy or routing.

## The actual mismatch

Vite builds with `base: "/assistant/"` ([apps/web/vite.config.ts:22](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/vite.config.ts#L22)), so:

- `dist/index.html` references `/assistant/assets/index-<hash>.js`
- `dist/assets/index-<hash>.js` is where the file actually sits on disk

The CD step in [`ci-main-web.yaml`](https://github.com/vellum-ai/vellum-assistant/blob/main/.github/workflows/ci-main-web.yaml#L236-L245) does:

```yaml
gcloud storage rsync -r --exclude="^index\.html$" dist "gs://${BUCKET}"
gcloud storage cp dist/index.html "gs://${BUCKET}/index.html"
```

That puts the bundle at `gs://${BUCKET}/assets/index-<hash>.js`. For the URL `/assistant/assets/index-<hash>.js` to resolve, the LB/CDN in front of that bucket has to **strip `/assistant/`** before requesting the object. (PR #31538's manual verification — `/assistant/foo.svg` returns the asset — is consistent with that.)

That works for hits routed under `/assistant/*`. It does **not** work for the cold-boot path on iOS, which is:

1. WKWebView loads `https://dev-assistant.vellum.ai/assistant` → LB → bucket → `index.html` → assets fetched via `/assistant/assets/*` → LB strips → bucket serves → SPA boots ✅
2. `authMiddleware` ([`apps/web/src/lib/auth/auth-middleware.ts:32`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/src/lib/auth/auth-middleware.ts#L32)) sees no session, in-app redirects to `/account/login` (no full reload) → still working
3. User taps "Sign in" → `startNativeLogin()` → `ASWebAuthenticationSession` opens `/accounts/native/start` → Django → WorkOS → callback → exchange → `installSessionCookies()` ([`apps/web/src/runtime/native-auth.ts:109`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/src/runtime/native-auth.ts#L109))
4. **`window.location.href = "/assistant"`** ([`native-auth.ts:126`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/src/runtime/native-auth.ts#L126)) — hard nav, full page reload
5. Whichever path hits a routing rule that *isn't* prefix-stripping `/assistant/` will white-screen because the HTML resolves `/assistant/assets/<hash>.js` against a bucket object that doesn't exist at that key

The full enumeration of paths the SPA shell has to be served from is also visible in [`routes.tsx`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/src/routes.tsx) — `/account/*` and `/logout` are deliberately at the root, not under `/assistant`:

```ts
// Account routes — standalone auth pages, no app chrome
{ path: "/account", children: [{ path: "login", element: <LoginPage /> }, ...] },
// Logout — standalone page, no app chrome
{ path: "/logout", element: <LogoutPage /> },
// Assistant routes — auth-protected app with layout
{ path: "/assistant", middleware: [authMiddleware], ... },
```

## What this PR proposes

### 1. `ci(web): publish SPA under /assistant/ bucket prefix to match Vite base`

Push `dist/` into `gs://${BUCKET}/assistant/` instead of the bucket root. After this, object key = URL path with no LB rewrite required:

- URL `/assistant/index.html` → bucket `assistant/index.html` ✅
- URL `/assistant/assets/<hash>.js` → bucket `assistant/assets/<hash>.js` ✅
- URL `/account/login` (catch-all to SPA) → bucket serves `assistant/index.html` via the `NotFoundPage` rule → HTML's `/assistant/assets/*` URLs resolve normally ✅

This also makes the deploy portable to a plain CloudFront / Caddy / Nginx setup since there's no path-rewrite magic in the LB.

### 2. `fix(web): SPA fallback in dev for /account/* and /logout`

Cherry of `claude/quirky-ride-89dXx`. Adds a `configureServer` middleware that rewrites `/account/*` and `/logout` to `/assistant/` for Vite's dev server only. The browser URL is unchanged so React Router still matches the original path on hydration. Production relies on the deployed server's catch-all fallback; this just brings dev in line so local testing of the login flow works without a 404.

## Open question — before merging

This whole plan rests on **the LB no longer stripping the `/assistant/` prefix** when proxying to the SPA bucket. If Carson configured a `pathPrefix=/assistant` (or equivalent rewrite rule) on the backend bucket, then moving the object keys under `assistant/` in this PR will result in the LB asking the bucket for `assistant/assistant/assets/...` and break everything that currently works.

@carson (or whoever owns the assistant-spa LB / backend bucket): **does the LB strip the `/assistant/` prefix on its way to the bucket today?**

- **If yes:** that prefix-strip needs to be removed at the same time this PR merges. Otherwise stage them: drop the strip first, then merge this.
- **If no:** the only thing keeping `/assistant/*` working today is something I'm missing, and we should figure that out before this lands. (Curious how `/assistant/foo.svg` was resolving against `gs://${BUCKET}/foo.svg` without it.)

## What this PR does **not** include (intentionally)

- The "use root base in dev" alternative from `codex/vite-dev-base-root` — that's a different (simpler) approach to the same dev-server gap, but it sacrifices dev/prod parity. The middleware approach keeps `base: "/assistant/"` in both.
- Any change to the Capacitor `server.url` — it already points at `https://dev-assistant.vellum.ai/assistant`, which is correct.
- Any change to the native auth Swift plugin. The Explore agent that triaged this for me flagged a `VellumAssociatedDomain` plist-substitution theory, but that defends ATL-425 and would have to manifest in prod too — not just dev. Not the bug we're looking at.

## Pure-revert alternative

If the LB question can't be answered fast, the one-line escape hatch is to revert PR #31525 (`base: "/assistant/"` → `base: "/"`). Sign-in goes green in 15 minutes, deploy stays exactly as it is, and the consolidation plan from #31525 picks back up once the LB story is settled.

---

_Generated by [Claude Code](https://claude.ai/code/session_01CBubop6ettWD5Mr3yDai7X)_