### PR TITLE
Log why CES RPC session ended on shutdown

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -627,10 +627,13 @@ async function main(): Promise<void> {
     },
   });
 
-  await server.serve();
+  const endReason = await server.serve();
 
   rpcConnected = false;
-  log.info("RPC session ended. Shutting down...");
+  log.warn(
+    { reason: endReason, uptime: process.uptime(), pid: process.pid },
+    "RPC session ended — shutting down",
+  );
   controller.abort();
 }
 

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -94,6 +94,11 @@ export interface CesServerOptions {
   onApiKeyUpdate?: (assistantApiKey: string, assistantId?: string) => void;
 }
 
+export type ServeEndReason =
+  | "input_stream_ended"
+  | "signal_aborted"
+  | "signal_aborted_before_start";
+
 // ---------------------------------------------------------------------------
 // Server implementation
 // ---------------------------------------------------------------------------
@@ -134,17 +139,17 @@ export class CesRpcServer {
    * Start serving. Returns a promise that resolves when the input stream
    * ends or the abort signal fires.
    */
-  async serve(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+  async serve(): Promise<ServeEndReason> {
+    return new Promise<ServeEndReason>((resolve, reject) => {
       if (this.signal?.aborted) {
         this.close();
-        resolve();
+        resolve("signal_aborted_before_start");
         return;
       }
 
       const onAbort = () => {
         this.close();
-        resolve();
+        resolve("signal_aborted");
       };
 
       if (this.signal) {
@@ -162,7 +167,7 @@ export class CesRpcServer {
           this.signal.removeEventListener("abort", onAbort);
         }
         this.close();
-        resolve();
+        resolve("input_stream_ended");
       });
 
       this.input.on("error", (err) => {


### PR DESCRIPTION
## Summary
- `CesRpcServer.serve()` now returns a `ServeEndReason` discriminant instead of `void`
- The shutdown log in `managed-main.ts` includes the reason, uptime, and pid
- Elevated from `log.info` to `log.warn` for visibility

## Context
When debugging crashlooping pods, the CES log `"RPC session ended. Shutting down..."` gives no indication of *why* the session ended. The three cases have very different implications:
- `input_stream_ended` — the assistant process died (k8s killed it, OOM, crash)
- `signal_aborted` — CES itself was told to shut down
- `signal_aborted_before_start` — CES was aborted before it even started serving

## Test plan
- [x] No type errors in changed files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)