### PR TITLE
fix(web): add min-height to welcome and complete onboarding states

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -14,7 +14,7 @@ export function CompleteState({ onBack }: { onBack: () => void }) {
   const assistantName = activeAssistant?.name || "your assistant";
 
   return (
-    <div className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-8 text-center">
+    <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 text-center">
       <div
         className="pointer-events-none absolute inset-0"
         style={{

--- a/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
@@ -4,7 +4,7 @@ import { Button } from "@vellum/design-library/components/button";
 
 export function WelcomeState({ onContinue }: { onContinue: () => void }) {
   return (
-    <div className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-8 text-center">
+    <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 text-center">
       <div
         className="pointer-events-none absolute inset-0"
         style={{


### PR DESCRIPTION
## Summary
- Add `min-h-[320px]` to welcome and complete state containers — they used `flex-1` which collapsed after `min-h` was removed from Modal.Content in #31688

🤖 Generated with [Claude Code](https://claude.com/claude-code)