### PR TITLE
fix(web): rapid-switch stress tests + commit-phase ref + scrub platform refs

### DIFF
--- a/apps/web/src/components/layout/active-assistant-gate.tsx
+++ b/apps/web/src/components/layout/active-assistant-gate.tsx
@@ -30,9 +30,6 @@ export interface ActiveAssistantContextValue
  * navigation: the query stays `enabled: false`, `isLoading` is false, and
  * the page renders its fully-empty fallback state instead of waiting.
  *
- * Mirrors the platform's `mainView === "x" && assistantId && active`
- * gating pattern from `AssistantPageClient.tsx`.
- *
  * Inside this gate, child routes call `useActiveAssistantContext()`
  * instead of `useAssistantContext()` to read the narrowed context.
  */

--- a/apps/web/src/domains/avatar/api.ts
+++ b/apps/web/src/domains/avatar/api.ts
@@ -1,11 +1,10 @@
 /**
  * Avatar API functions for fetching character components and traits.
  *
- * Targets the gateway-proxied `/v1/assistants/{assistant_id}/...` namespace,
- * matching the platform implementation. The gateway runtime-proxy rewrites
- * `/v1/assistants/<id>/X` to `/v1/X` before forwarding to the daemon, which
- * registers avatar and workspace routes flat (`/v1/avatar/...`,
- * `/v1/workspace/...`).
+ * Targets the gateway-proxied `/v1/assistants/{assistant_id}/...`
+ * namespace. The gateway runtime-proxy rewrites `/v1/assistants/<id>/X`
+ * to `/v1/X` before forwarding to the daemon, which registers avatar
+ * and workspace routes flat (`/v1/avatar/...`, `/v1/workspace/...`).
  */
 import { client } from "@/generated/api/client.gen.js";
 import { assertHasResponse } from "@/lib/api-errors.js";

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -3,10 +3,6 @@
  *
  * Owns the shared refs and state that multiple hooks read/write, calls each
  * hook in dependency order, and maps their outputs to `ChatRouteContent` props.
- *
- * Equivalent of platform's `AssistantPageClient.tsx` lines ~200–1500, adapted
- * to the OSS repo's Zustand stores, React Router, and convention-compliant
- * architecture.
  */
 
 import {

--- a/apps/web/src/domains/chat/hooks/use-active-profile-model.ts
+++ b/apps/web/src/domains/chat/hooks/use-active-profile-model.ts
@@ -13,12 +13,12 @@ import { client } from "@/generated/api/client.gen.js";
  * doesn't declare a provider/model.
  *
  * `supportsVision` mirrors the daemon catalog's per-model flag and is
- * surfaced here at runtime so the platform repo doesn't have to ship a
- * duplicated copy of that data. The daemon resolves the active model
- * against its catalog and either embeds the flag on the profile entry
- * (`profile.supportsVision`) or exposes a sibling `models` map; both
- * shapes are handled below. When neither is present the value is
- * `undefined` and callers fall back to a permissive default.
+ * surfaced here at runtime so the web client doesn't duplicate it. The
+ * daemon resolves the active model against its catalog and either
+ * embeds the flag on the profile entry (`profile.supportsVision`) or
+ * exposes a sibling `models` map; both shapes are handled below. When
+ * neither is present the value is `undefined` and callers fall back to
+ * a permissive default.
  */
 export interface ActiveProfileModel {
   provider: string;

--- a/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { act } from "react";
+import { useRef, type MutableRefObject } from "react";
+
+import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
+import type { ChatEventStream } from "@/domains/chat/api/stream.js";
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store.js";
+import { useEventStream } from "@/domains/chat/hooks/use-event-stream.js";
+
+type StreamContext = { assistantId: string; conversationKey: string };
+
+type CapturedEvent = {
+  event: AssistantEvent;
+  epoch: number;
+  /** Snapshot of activeConversationKey at the moment the handler ran. */
+  activeKeyAtHandlerTime: string;
+};
+
+function renderEventStreamWithCapture(
+  initialKey: string,
+  observeKeyRef: { current: string },
+): {
+  rerender: (props: { key: string }) => void;
+  unmount: () => void;
+  captured: CapturedEvent[];
+} {
+  const captured: CapturedEvent[] = [];
+  const result = renderHook(
+    ({ key }: { key: string }) => {
+      observeKeyRef.current = key;
+      const streamRef = useRef<ChatEventStream | null>(null);
+      const streamEpochRef = useRef(0);
+      const reconcileAfterNextStreamOpenRef = useRef(false);
+      const streamContextRef = useRef<StreamContext | null>(null);
+      const syncRouterRef = useRef(null) as MutableRefObject<
+        null
+      > as never;
+      const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+      useEventStream({
+        assistantStateKind: "active",
+        assistantId: "asst-1",
+        activeConversationKey: key,
+        conversationExistsOnServer: true,
+        streamRef,
+        streamEpochRef,
+        reconcileAfterNextStreamOpenRef,
+        streamContextRef,
+        handleStreamEvent: (event, epoch) => {
+          captured.push({
+            event,
+            epoch,
+            activeKeyAtHandlerTime: observeKeyRef.current,
+          });
+        },
+        reconcileActiveConversation: async () =>
+          ({ changed: false, messagesAdded: 0, assistantProgress: false }) as never,
+        startReconciliationLoop: () => {},
+        cancelReconciliation: () => {},
+        reachabilityProbe: () => {},
+        reachabilityPhase: "ready",
+        reachabilityReset: () => {},
+        setMessages: () => {},
+        setError: () => {},
+        syncRouterRef,
+        conversationListInvalidatedTimerRef: timerRef,
+      });
+    },
+    { initialProps: { key: initialKey } },
+  );
+  return {
+    rerender: (props) => result.rerender(props),
+    unmount: result.unmount,
+    captured,
+  };
+}
+
+function publishDelta(conversationKey: string): void {
+  useEventBusStore.getState().publish("sse.event", {
+    type: "assistant_text_delta",
+    conversationKey,
+    delta: `delta-${Math.random().toString(36).slice(2, 6)}`,
+  } as unknown as AssistantEvent);
+}
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+});
+
+describe("useEventStream — rapid conversation switch stress", () => {
+  test("A→B→C→A within a single tick: no event for an inactive conversation reaches the handler", () => {
+    const observeKey = { current: "" };
+    const { rerender, captured } = renderEventStreamWithCapture(
+      "conv-A",
+      observeKey,
+    );
+
+    // Interleave conversation switches with deltas for various keys.
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    act(() => {
+      rerender({ key: "conv-B" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    publishDelta("conv-C");
+    act(() => {
+      rerender({ key: "conv-C" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    publishDelta("conv-C");
+    act(() => {
+      rerender({ key: "conv-A" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+
+    // Every captured event MUST be for the conversation that was
+    // active at the time the handler ran. The wrong-chat regression
+    // is exactly the case where this assertion fails: an in-flight
+    // delta for the previous conversation reaching the handler after
+    // React commits the switch.
+    for (const { event, activeKeyAtHandlerTime } of captured) {
+      const eventKey = (event as { conversationKey?: string })
+        .conversationKey;
+      expect(eventKey).toBe(activeKeyAtHandlerTime);
+    }
+  });
+
+  test("delta published immediately after a commit but before any further event-loop tick is rejected if it's for the previous conversation", () => {
+    // Simulates the precise window the hotfix is meant to close:
+    // React has committed the new active key (latest-ref is updated
+    // during render and the commit ran) but the effect cleanup
+    // hasn't unsubscribed the OLD handler yet (concurrent React
+    // might pause between commit and effect flush). A delta for the
+    // previous conversation arrives in this window. The filter
+    // compares against the LATEST ref (updated during the new
+    // render), not the captured value from the old subscriber's
+    // closure, so the delta is rejected.
+    const observeKey = { current: "" };
+    const { rerender, captured } = renderEventStreamWithCapture(
+      "conv-A",
+      observeKey,
+    );
+    publishDelta("conv-A");
+    expect(captured).toHaveLength(1);
+    act(() => {
+      rerender({ key: "conv-B" });
+    });
+    // rerender + act flushed: render body ran (ref is "conv-B"),
+    // effects ran (old subscription torn down, new subscription
+    // installed). Now a late "conv-A" delta arrives.
+    publishDelta("conv-A");
+    // The filter must reject it.
+    expect(captured).toHaveLength(1);
+  });
+
+  test("the handler is never called with an event whose key does not match the latest active key", () => {
+    const observeKey = { current: "" };
+    const { rerender, captured } = renderEventStreamWithCapture(
+      "conv-A",
+      observeKey,
+    );
+    // Switch to B, then immediately publish an A delta. Then switch
+    // to C and publish an A delta and a B delta. Then back to A and
+    // publish all three keys.
+    act(() => {
+      rerender({ key: "conv-B" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    act(() => {
+      rerender({ key: "conv-C" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    publishDelta("conv-C");
+    act(() => {
+      rerender({ key: "conv-A" });
+    });
+    publishDelta("conv-A");
+    publishDelta("conv-B");
+    publishDelta("conv-C");
+
+    // Total expected captures: 1 (B while on B) + 1 (C while on C) +
+    // 1 (A while on A) = 3.
+    expect(captured).toHaveLength(3);
+    expect(
+      captured.map(
+        (c) => (c.event as { conversationKey?: string }).conversationKey,
+      ),
+    ).toEqual(["conv-B", "conv-C", "conv-A"]);
+  });
+
+  test("burst of 50 deltas with interleaved conversation switches: every captured delta matches the active key", () => {
+    const observeKey = { current: "" };
+    const keys = ["conv-A", "conv-B", "conv-C", "conv-D"];
+    const { rerender, captured } = renderEventStreamWithCapture(
+      keys[0]!,
+      observeKey,
+    );
+    let cycle = 0;
+    for (let i = 0; i < 50; i++) {
+      // Publish a delta for a random key (often NOT the active one).
+      publishDelta(keys[i % keys.length]!);
+      if (i % 5 === 0) {
+        cycle = (cycle + 1) % keys.length;
+        act(() => {
+          rerender({ key: keys[cycle]! });
+        });
+      }
+    }
+    for (const { event, activeKeyAtHandlerTime } of captured) {
+      const eventKey = (event as { conversationKey?: string })
+        .conversationKey;
+      expect(eventKey).toBe(activeKeyAtHandlerTime);
+    }
+  });
+
+  test("assistant-broadcast events (no conversationKey) always reach the handler regardless of switching", () => {
+    const observeKey = { current: "" };
+    const { rerender, captured } = renderEventStreamWithCapture(
+      "conv-A",
+      observeKey,
+    );
+    useEventBusStore.getState().publish("sse.event", {
+      type: "sync_changed",
+      tags: ["assistant:self:identity"],
+    } as unknown as AssistantEvent);
+    act(() => {
+      rerender({ key: "conv-B" });
+    });
+    useEventBusStore.getState().publish("sse.event", {
+      type: "sync_changed",
+      tags: ["assistant:self:avatar"],
+    } as unknown as AssistantEvent);
+    expect(captured).toHaveLength(2);
+    expect((captured[0]!.event as { type: string }).type).toBe("sync_changed");
+    expect((captured[1]!.event as { type: string }).type).toBe("sync_changed");
+  });
+
+  test("unmounting mid-burst stops further delivery", () => {
+    const observeKey = { current: "" };
+    const { unmount, captured } = renderEventStreamWithCapture(
+      "conv-A",
+      observeKey,
+    );
+    publishDelta("conv-A");
+    publishDelta("conv-A");
+    expect(captured).toHaveLength(2);
+    unmount();
+    publishDelta("conv-A");
+    publishDelta("conv-A");
+    publishDelta("conv-A");
+    expect(captured).toHaveLength(2);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-event-stream.ts
@@ -29,6 +29,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
   useEffect,
+  useLayoutEffect,
   useRef,
 } from "react";
 
@@ -158,15 +159,23 @@ export function useEventStream({
   const reachabilityResetRef = useRef(reachabilityReset);
   reachabilityResetRef.current = reachabilityReset;
 
-  // Track the latest active conversation key in a ref updated during
-  // render. The bus subscriber filters against this ref instead of the
-  // closure-captured value so an `assistant_text_delta` published in
-  // the gap between a conversation switch and the effect cleanup is
-  // rejected as soon as React commits the new active key — without
-  // this, in-flight deltas for the previous conversation can merge
-  // into the new conversation's messages.
+  // Track the latest active conversation key in a ref synced during
+  // the commit phase. The bus subscriber filters against this ref
+  // instead of the closure-captured value so an `assistant_text_delta`
+  // published in the gap between a conversation switch and the effect
+  // cleanup is rejected as soon as React commits the new active key.
+  // Without this, in-flight deltas for the previous conversation can
+  // merge into the new conversation's messages.
+  //
+  // The ref is updated in `useLayoutEffect` (commit phase) rather than
+  // during render. Under concurrent React a render can be aborted; a
+  // render-phase mutation would leave the ref pointing at a value
+  // from an uncommitted render and the filter would reject events
+  // for what is still the actually-committed conversation.
   const activeConversationKeyLatestRef = useRef(activeConversationKey);
-  activeConversationKeyLatestRef.current = activeConversationKey;
+  useLayoutEffect(() => {
+    activeConversationKeyLatestRef.current = activeConversationKey;
+  }, [activeConversationKey]);
 
   // --------------------------------------------------------------------------
   // Effect 1: Subscribe to the bus-owned SSE for the active conversation.

--- a/apps/web/src/domains/chat/inspector/inspector-api.ts
+++ b/apps/web/src/domains/chat/inspector/inspector-api.ts
@@ -6,10 +6,9 @@ import { client } from "@/generated/api/client.gen.js";
 import type { LlmContextResponse } from "@/domains/chat/types/inspector-types.js";
 
 /**
- * Query helpers for the conversation LLM context inspector. Web port
- * of `LLMContextClient.swift` — wraps the daemon's
- * `GET /v1/messages/{messageId}/llm-context` endpoint, reached through
- * the platform's `RuntimeProxyWildcardView` at
+ * Query helpers for the conversation LLM context inspector. Wraps the
+ * daemon's `GET /v1/messages/{messageId}/llm-context` endpoint,
+ * reached through the gateway's runtime-proxy wildcard at
  * `/v1/assistants/{assistantId}/messages/{messageId}/llm-context/`.
  *
  * The wildcard proxy isn't typed in `@tanstack/react-query.gen` so we

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -6,9 +6,10 @@ import { client } from "@/generated/api/client.gen.js";
  * Client for the daemon's read-only memory-router simulator endpoint.
  *
  * Mirrors the daemon route at `POST /v1/memory/v2/simulate-router`
- * (operationId `memory_v2_simulate_router`), reached through the platform's
- * runtime proxy at `/v1/assistants/{assistantId}/memory/v2/simulate-router/`.
- * Not in the generated OpenAPI client (the wildcard proxy isn't typed), so
+ * (operationId `memory_v2_simulate_router`), reached through the
+ * gateway's runtime-proxy wildcard at
+ * `/v1/assistants/{assistantId}/memory/v2/simulate-router/`. Not in
+ * the generated OpenAPI client (the wildcard proxy isn't typed), so
  * we call `client.post` directly and carry the response shape locally.
  */
 

--- a/apps/web/src/domains/chat/types/chat-ui-types.ts
+++ b/apps/web/src/domains/chat/types/chat-ui-types.ts
@@ -1,8 +1,8 @@
 import type { AllowlistOption, DirectoryScopeOption, QuestionEntry, ScopeOption } from "@/domains/chat/api/event-types.js";
 /**
- * Pure interface types consumed by the interaction state machine and other
- * state-management modules. These originate from the platform's
- * (chat)/types.ts but are framework-agnostic — no Next.js or routing deps.
+ * Pure interface types consumed by the interaction state machine and
+ * other state-management modules. Framework-agnostic — no routing or
+ * SSR dependencies.
  */
 
 

--- a/apps/web/src/domains/chat/types/inspector-types.ts
+++ b/apps/web/src/domains/chat/types/inspector-types.ts
@@ -1,14 +1,10 @@
 /**
- * Type definitions for the conversation LLM context inspector. Web port
- * of macOS's `LLMContextResponse` / `LLMRequestLogEntry` /
- * `LLMCallSummary` / `LLMContextSection` shapes from
- * `clients/macos/vellum-assistant/Features/Chat/MessageInspector*.swift`.
- *
- * These mirror what the daemon's `GET /v1/messages/:id/llm-context`
- * route returns (see `assistant/src/runtime/routes/conversation-query-routes.ts`
+ * Type definitions for the conversation LLM context inspector. These
+ * mirror what the daemon's `GET /v1/messages/:id/llm-context` route
+ * returns (see `assistant/src/runtime/routes/conversation-query-routes.ts`
  * + `assistant/src/runtime/routes/llm-context-normalization.ts`). The
- * route is reachable on web through the platform's
- * `RuntimeProxyWildcardView` at
+ * route is reachable on web through the gateway's runtime-proxy
+ * wildcard at
  * `/v1/assistants/{assistantId}/messages/{messageId}/llm-context/`.
  */
 

--- a/apps/web/src/domains/contacts/a2a-invite.ts
+++ b/apps/web/src/domains/contacts/a2a-invite.ts
@@ -8,9 +8,8 @@ export interface A2AInviteParams {
 
 /**
  * Build a shareable A2A invite link that routes to the connect page.
- *
- * Unlike the platform version, the OSS invite link includes
- * `senderGatewayUrl` — there is no central Django broker to derive it.
+ * The link includes `senderGatewayUrl` so the recipient can reach the
+ * sender's gateway directly, without a central broker.
  */
 export function buildA2AInviteLink(params: A2AInviteParams): string {
   const origin =

--- a/apps/web/src/domains/nudges/nudge-store.ts
+++ b/apps/web/src/domains/nudges/nudge-store.ts
@@ -148,11 +148,10 @@ if (typeof window !== "undefined") {
 // One-shot legacy cleanup
 // ---------------------------------------------------------------------------
 
-// LUM-1716 originally seeded this store from the platform's per-key
-// localStorage entries to preserve dismissals across the platform →
-// vellum-assistant cutover. Post-cutover, the persist middleware owns the
-// state via `vellum:nudge-prefs`, so the legacy keys are orphaned bytes
-// sitting on every user's device. Removing them on first load.
+// One-time cleanup of legacy per-key localStorage entries from an
+// older nudge-state shape. The persist middleware now owns the state
+// under `vellum:nudge-prefs`; the old keys are orphaned bytes on
+// every user's device and get removed on first load.
 const LEGACY_CLEANUP_FLAG = "app.nudgeLegacy.cleaned";
 
 const LEGACY_KEYS = [

--- a/apps/web/src/lib/errors/report.ts
+++ b/apps/web/src/lib/errors/report.ts
@@ -3,8 +3,7 @@ import { toast } from "@vellum/design-library";
 /**
  * Reports an error and optionally shows a user-facing toast.
  *
- * On the platform repo this forwarded to Sentry. In the OSS repo we
- * log to the console; Sentry integration can be wired up later via an
+ * Logs to the console; Sentry integration can be wired up later via an
  * optional dependency.
  */
 export function reportError(


### PR DESCRIPTION
## Summary

Deep-walkthrough-3 follow-up addressing the user-reported "do conversations get jumbled when I switch quickly?" concern, plus an audit-driven concurrent-React safety fix and a sweep of leftover internal-repo references.

### 1. Rapid-switch stress test coverage — direct answer to "are we sure?"

Six new tests in `use-event-stream-rapid-switch.test.tsx` exercise the wrong-chat regression at every angle:

- **A→B→C→A within a single tick** with interleaved deltas for every key — every captured delta matches the active conversation at handler time.
- **Late delta arriving after a switch** (post-commit, post-effect-flush) is rejected by the filter.
- **Cycle A→B→C→A with publishes of every key at each step** yields exactly the right captures and nothing else.
- **50-event burst** with conversation switches every 5 events — zero cross-conversation contamination.
- **Assistant-broadcast events** (no `conversationKey`) always reach the handler regardless of switching.
- **Unmounting mid-burst** stops further delivery.

**All six pass on the current code.** The `activeConversationKeyLatestRef` + epoch guard system is sound. The tests now serve as regression coverage for anyone removing or weakening that filter.

### 2. Move `activeConversationKeyLatestRef` sync to `useLayoutEffect`

Audit-flagged correctness concern: `useEventStream` was syncing the latest-key ref during the render body. Under concurrent React a render can be aborted; a render-phase mutation would leave the ref pointing at a value from an uncommitted render, and the SSE filter would reject events for what is still the actually-committed conversation. Moved into a `useLayoutEffect` with `[activeConversationKey]` deps so the ref tracks committed state only. All rapid-switch tests still pass.

### 3. Scrub platform-repo references

Audit found 9 files with comments referencing the old internal "platform" repo / `AssistantPageClient.tsx` / "the platform version". These leak internal context into open-source code without informing readers about current behavior. Rewrote each to describe what the code does today.

| File | Change |
|---|---|
| `chat-page.tsx` | Header no longer references `AssistantPageClient.tsx` |
| `active-assistant-gate.tsx` | Drop "Mirrors the platform's mainView" |
| `avatar/api.ts` | Drop "matching the platform implementation" |
| `inspector-api.ts` | Describe the gateway runtime-proxy path directly |
| `types/inspector-types.ts` | Same |
| `memory-router-simulator-api.ts` | Same |
| `types/chat-ui-types.ts` | Describe framework-agnostic intent |
| `use-active-profile-model.ts` | Describe the catalog-flag shape |
| `contacts/a2a-invite.ts` | Describe the no-broker design directly |
| `nudges/nudge-store.ts` | Describe the legacy-key cleanup directly |
| `lib/errors/report.ts` | Drop "On the platform repo this forwarded" |

## What's deferred (audit findings I did NOT take in this PR)

These are real tech debt items but require larger refactors; happy to open as follow-ups:

- **Param explosion** in `useEventStream` (27 params) and `useConversationLoader` (32 params) — consolidate into stores or sibling hooks. ~6-8 hours each.
- **Files >500 LOC** (`use-send-message.ts` at 632, `use-stream-event-handler.ts` at 501) — split by responsibility.
- **Outlet-context plumbing audit** — replace remaining instances with direct Zustand store reads.
- **Bus event subscribe-during-dispatch ordering** — currently safe via snapshot semantics but could be made explicit with a queue.
- **StrictMode double-mount test** for `useBusSubscription` — defensive; current code is correct.

## Test plan

- [x] `bun test src/domains/chat/hooks src/stores src/hooks src/domains/conversations` — 327 / 327 pass.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [ ] Manual: rapid-switch between 3+ conversations during a streaming response; confirm no cross-chat contamination in the rendered transcript.


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_