### PR TITLE
fix(providers): strip reasoning and text params for Codex subscription endpoint

### DIFF
--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -1657,4 +1657,104 @@ describe("OpenAIResponsesProvider — Native Web Search", () => {
       text: "No search needed.",
     });
   });
+
+  // -----------------------------------------------------------------------
+  // codexSubscription — parameter stripping
+  // -----------------------------------------------------------------------
+  test("codexSubscription: strips max_output_tokens from params", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { max_tokens: 64000 } },
+    );
+
+    expect(lastStreamParams!.max_output_tokens).toBeUndefined();
+  });
+
+  test("codexSubscription: strips reasoning param even when effort is set", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { effort: "high" } },
+    );
+
+    expect(lastStreamParams!.reasoning).toBeUndefined();
+  });
+
+  test("codexSubscription: strips text.verbosity param", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "low" } },
+    );
+
+    expect(lastStreamParams!.text).toBeUndefined();
+  });
+
+  test("codexSubscription: uses Codex baseURL", async () => {
+    new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+
+    expect(lastConstructorOptions!.baseURL).toBe(
+      "https://chatgpt.com/backend-api/codex",
+    );
+  });
+
+  test("codexSubscription: strips tools param", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    const sampleTool: ToolDefinition = {
+      name: "test_tool",
+      description: "A test tool",
+      input_schema: { type: "object", properties: {} },
+    };
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      [sampleTool],
+    );
+
+    expect(lastStreamParams!.tools).toBeUndefined();
+  });
+
+  test("codexSubscription: still sends model, input, and instructions", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      "You are helpful.",
+      { config: { effort: "max", verbosity: "high", max_tokens: 64000 } },
+    );
+
+    expect(lastStreamParams!.model).toBe("gpt-5.4");
+    expect(lastStreamParams!.instructions).toBe("You are helpful.");
+    expect(lastStreamParams!.max_output_tokens).toBeUndefined();
+    expect(lastStreamParams!.reasoning).toBeUndefined();
+    expect(lastStreamParams!.text).toBeUndefined();
+  });
 });

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -24,7 +24,7 @@ export interface OpenAIResponsesProviderOptions {
   streamTimeoutMs?: number;
   useNativeWebSearch?: boolean;
   /** When true, target the Codex subscription endpoint and strip fields it
-   *  rejects (`max_output_tokens`, `metadata`). */
+   *  rejects (`max_output_tokens`, `reasoning`, `text`, `tools`). */
   codexSubscription?: boolean;
 }
 
@@ -162,22 +162,24 @@ export class OpenAIResponsesProvider implements Provider {
         params.max_output_tokens = maxTokens;
       }
 
-      const reasoningEffort = effort
-        ? EFFORT_TO_REASONING_EFFORT[effort]
-        : undefined;
-      if (reasoningEffort) {
-        params.reasoning = { effort: reasoningEffort };
+      if (!this.codexSubscription) {
+        const reasoningEffort = effort
+          ? EFFORT_TO_REASONING_EFFORT[effort]
+          : undefined;
+        if (reasoningEffort) {
+          params.reasoning = { effort: reasoningEffort };
+        }
+
+        if (
+          verbosity &&
+          VALID_VERBOSITIES.has(verbosity) &&
+          modelSupportsVerbosity(modelOverride ?? this.model)
+        ) {
+          params.text = { verbosity };
+        }
       }
 
-      if (
-        verbosity &&
-        VALID_VERBOSITIES.has(verbosity) &&
-        modelSupportsVerbosity(modelOverride ?? this.model)
-      ) {
-        params.text = { verbosity };
-      }
-
-      if (tools && tools.length > 0) {
+      if (tools && tools.length > 0 && !this.codexSubscription) {
         if (
           this.useNativeWebSearch &&
           tools.some((t) => t.name === "web_search")


### PR DESCRIPTION
## Summary
- The ChatGPT Codex endpoint (`chatgpt.com/backend-api/codex`) rejects `reasoning`, `text.verbosity`, and `tools` parameters that the standard OpenAI Responses API accepts, returning a 400 with no body
- Gate these fields behind `!codexSubscription` alongside the existing `max_output_tokens` stripping
- Add 6 targeted tests verifying all param stripping, Codex baseURL, and that model/input/instructions are still sent

## Test plan
- [x] All 69 tests in `openai-responses-provider.test.ts` pass (63 existing + 6 new)
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify on dev after deploy: send a message on a ChatGPT subscription connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)