### PR TITLE
feat(web): add SubagentAvatarChip for inline subagent rendering

### DIFF
--- a/apps/web/src/domains/avatar/subagent-avatar-chip.test.tsx
+++ b/apps/web/src/domains/avatar/subagent-avatar-chip.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SubagentAvatarChip } from "@/domains/avatar/subagent-avatar-chip.js";
+import { subagentTraits } from "@/domains/avatar/subagent-avatar.js";
+
+describe("SubagentAvatarChip", () => {
+  test("is deterministic: same subagentId renders identical DOM", () => {
+    const a = renderToStaticMarkup(<SubagentAvatarChip subagentId="alpha" />);
+    const b = renderToStaticMarkup(<SubagentAvatarChip subagentId="alpha" />);
+    expect(a).toBe(b);
+  });
+
+  test("different subagentIds produce different traits", () => {
+    const t1 = subagentTraits("alpha");
+    const t2 = subagentTraits("beta-quite-different");
+    expect(
+      t1.bodyShape !== t2.bodyShape ||
+        t1.eyeStyle !== t2.eyeStyle ||
+        t1.color !== t2.color,
+    ).toBe(true);
+  });
+
+  test("different subagentIds produce different DOM", () => {
+    const a = renderToStaticMarkup(<SubagentAvatarChip subagentId="alpha" />);
+    const b = renderToStaticMarkup(
+      <SubagentAvatarChip subagentId="beta-quite-different" />,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  test("sets aria-label and applies className passthrough", () => {
+    const html = renderToStaticMarkup(
+      <SubagentAvatarChip subagentId="alpha" className="ml-1" />,
+    );
+    expect(html).toContain('aria-label="Subagent alpha"');
+    expect(html).toContain('class="ml-1"');
+  });
+
+  test("defaults to 16px size when none provided", () => {
+    const html = renderToStaticMarkup(<SubagentAvatarChip subagentId="alpha" />);
+    expect(html).toContain("width:16px");
+    expect(html).toContain("height:16px");
+  });
+
+  test("honors a custom size", () => {
+    const html = renderToStaticMarkup(
+      <SubagentAvatarChip subagentId="alpha" size={24} />,
+    );
+    expect(html).toContain("width:24px");
+    expect(html).toContain("height:24px");
+  });
+});

--- a/apps/web/src/domains/avatar/subagent-avatar-chip.tsx
+++ b/apps/web/src/domains/avatar/subagent-avatar-chip.tsx
@@ -1,0 +1,42 @@
+/**
+ * Inline-sized subagent avatar.
+ *
+ * Wraps the shared `AvatarRenderer` with the deterministic
+ * `subagentTraits(subagentId)` mapping so callers can drop a small
+ * (16px default) avatar inline — e.g. as the leading icon slot of a
+ * subagent tool-call card, per Figma node `4922-103839`.
+ *
+ * Does not introduce a new bundle; reuses `BUNDLED_COMPONENTS` already
+ * consumed by `SubagentProgressCard`.
+ */
+
+import { AvatarRenderer } from "@/components/avatar-renderer.js";
+import { BUNDLED_COMPONENTS } from "@/domains/avatar/bundled-components.js";
+import { subagentTraits } from "@/domains/avatar/subagent-avatar.js";
+
+export interface SubagentAvatarChipProps {
+  subagentId: string;
+  /** Pixel size for the rendered avatar. Defaults to 16 (inline size). */
+  size?: number;
+  className?: string;
+}
+
+export function SubagentAvatarChip({
+  subagentId,
+  size = 16,
+  className,
+}: SubagentAvatarChipProps) {
+  const traits = subagentTraits(subagentId);
+
+  return (
+    <span aria-label={`Subagent ${subagentId}`} className={className}>
+      <AvatarRenderer
+        components={BUNDLED_COMPONENTS}
+        bodyShapeId={traits.bodyShape}
+        eyeStyleId={traits.eyeStyle}
+        colorId={traits.color}
+        size={size}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Inline-sized (16px default) wrapper around the existing AvatarRenderer, driven by deterministic subagentTraits(subagentId).
- Designed to slot into the unified tool-call progress card as the leading icon for subagent cards per Figma 4922-103839.
- Standalone — no integration yet (later PRs in this plan wire it in).

Part of plan: unify-tool-progress-cards.md (PR 4 of 9)