### PR TITLE
feat(web): add getLeadingThinkingText util for tool-card carousels

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/get-leading-thinking-text.test.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/get-leading-thinking-text.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+
+import { getLeadingThinkingText } from "@/domains/chat/components/tool-progress-card/get-leading-thinking-text.js";
+import type { DisplayMessage } from "@/domains/chat/types/types.js";
+
+function makeMessage(
+  contentOrder: Array<{ type: string; id: string }>,
+  textSegments: Array<{ type: string; content: string }> = [],
+): DisplayMessage {
+  return {
+    stableId: "stable-1",
+    role: "assistant",
+    content: "",
+    contentOrder,
+    textSegments,
+  };
+}
+
+describe("getLeadingThinkingText", () => {
+  test("returns the trimmed text when a text group sits directly before the tool group", () => {
+    /**
+     * Mirrors the common streaming case: the assistant emits a short
+     * text delta announcing its intent ("Let me check the docs…") and
+     * then opens a tool call. The unified progress card should surface
+     * that preamble as the "thinking" step.
+     */
+    // GIVEN a message whose contentOrder is [text, toolCall]
+    const message = makeMessage(
+      [
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "tc-1" },
+      ],
+      [{ type: "text", content: "  Looking up the docs.  " }],
+    );
+
+    // WHEN we ask for the thinking text preceding the tool group at index 1
+    const result = getLeadingThinkingText(message, 1);
+
+    // THEN we get the trimmed text back
+    expect(result).toBe("Looking up the docs.");
+  });
+
+  test("returns null when another tool group precedes the tool group", () => {
+    /**
+     * Two consecutive tool-call groups (separated by something that
+     * is itself not assistant text, e.g. an inline surface) must not
+     * borrow text from earlier in the message — we only look one
+     * step back.
+     */
+    // GIVEN [text, toolCall, surface, toolCall] — the second tool
+    // group is preceded by a surface group, not by text
+    const message = makeMessage(
+      [
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "tc-1" },
+        { type: "surface", id: "s-1" },
+        { type: "toolCall", id: "tc-2" },
+      ],
+      [{ type: "text", content: "Earlier preamble." }],
+    );
+
+    // WHEN we ask for the thinking text preceding the second tool group (index 3)
+    const result = getLeadingThinkingText(message, 3);
+
+    // THEN we get null — the preceding group is a surface, not text
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the tool group is the first group", () => {
+    /**
+     * If the assistant opens with a tool call before emitting any
+     * text, there is nothing to surface as "thinking".
+     */
+    // GIVEN a message that opens with a tool call
+    const message = makeMessage([{ type: "toolCall", id: "tc-1" }]);
+
+    // WHEN we ask for the thinking text at index 0
+    const result = getLeadingThinkingText(message, 0);
+
+    // THEN we get null
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the preceding text segment is empty after trimming", () => {
+    /**
+     * Streaming sometimes flushes an empty text segment right before
+     * a tool call (e.g. whitespace-only deltas). We treat those as
+     * "no preamble" so the carousel doesn't render a blank step.
+     */
+    // GIVEN a text segment containing only whitespace
+    const message = makeMessage(
+      [
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "tc-1" },
+      ],
+      [{ type: "text", content: "   \n  " }],
+    );
+
+    // WHEN we ask for the thinking text preceding the tool group
+    const result = getLeadingThinkingText(message, 1);
+
+    // THEN we get null — the trimmed text is empty
+    expect(result).toBeNull();
+  });
+
+  test("truncates text longer than 160 characters", () => {
+    /**
+     * The thinking step is a single-line preview, so very long
+     * preambles must be clipped to keep the card compact.
+     */
+    // GIVEN a long assistant preamble
+    const longText = "a".repeat(200);
+    const message = makeMessage(
+      [
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "tc-1" },
+      ],
+      [{ type: "text", content: longText }],
+    );
+
+    // WHEN we ask for the thinking text
+    const result = getLeadingThinkingText(message, 1);
+
+    // THEN it is truncated to 160 characters
+    expect(result).toBe("a".repeat(160));
+  });
+
+  test("merges consecutive tool entries into one group when computing the index", () => {
+    /**
+     * The renderer collapses adjacent toolCall/tool entries into one
+     * group. The util mirrors that so callers can pass the same
+     * `toolGroupIndex` the renderer computes — here the second tool
+     * group is at index 1, not 2.
+     */
+    // GIVEN [text, toolCall, toolCall] which collapses to [text, toolCalls]
+    const message = makeMessage(
+      [
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "tc-1" },
+        { type: "toolCall", id: "tc-2" },
+      ],
+      [{ type: "text", content: "Thinking step." }],
+    );
+
+    // WHEN we ask for the thinking text preceding the merged tool group at index 1
+    const result = getLeadingThinkingText(message, 1);
+
+    // THEN we get the preceding text back
+    expect(result).toBe("Thinking step.");
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-progress-card/get-leading-thinking-text.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/get-leading-thinking-text.ts
@@ -1,0 +1,83 @@
+import type { DisplayMessage } from "@/domains/chat/types/types.js";
+
+/**
+ * Maximum number of characters from the preceding assistant text delta to
+ * display as the "thinking" step in the unified tool-progress card.
+ */
+const MAX_THINKING_TEXT_LENGTH = 160;
+
+/**
+ * Returns the assistant text delta that immediately precedes the tool-call
+ * group at `toolGroupIndex` within `message`, trimmed and truncated to
+ * {@link MAX_THINKING_TEXT_LENGTH} characters.
+ *
+ * Returns `null` when:
+ * - `toolGroupIndex` is `0` (no preceding group), or
+ * - the preceding `contentOrder` group is anything other than a text
+ *   segment (e.g. another tool-call group, an inline surface), or
+ * - the preceding text segment is missing or empty after trimming.
+ *
+ * The "groups" referenced here are the consecutive-toolCall-merged groups
+ * built in `transcript-message-body.tsx` from `message.contentOrder`; this
+ * util mirrors that grouping so callers can pass the same `toolGroupIndex`
+ * they use when rendering tool-call cards.
+ *
+ * Pure function — no store access, no React. Only looks one step back; does
+ * not chain across multiple non-tool groups.
+ */
+export function getLeadingThinkingText(
+  message: DisplayMessage,
+  toolGroupIndex: number,
+): string | null {
+  if (toolGroupIndex <= 0) {
+    return null;
+  }
+
+  const contentOrder = message.contentOrder;
+  if (!contentOrder || contentOrder.length === 0) {
+    return null;
+  }
+
+  // Rebuild the same merged-group structure as transcript-message-body.tsx
+  // so toolGroupIndex lines up with what the renderer sees.
+  type ContentGroup =
+    | { type: "text"; id: string }
+    | { type: "toolCalls"; ids: string[] }
+    | { type: "surface"; id: string };
+
+  const groups: ContentGroup[] = [];
+  for (const entry of contentOrder) {
+    if (entry.type === "toolCall" || entry.type === "tool") {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "toolCalls") {
+        lastGroup.ids.push(entry.id);
+      } else {
+        groups.push({ type: "toolCalls", ids: [entry.id] });
+      }
+    } else if (entry.type === "text") {
+      groups.push({ type: "text", id: entry.id });
+    } else if (entry.type === "surface") {
+      groups.push({ type: "surface", id: entry.id });
+    }
+  }
+
+  const previous = groups[toolGroupIndex - 1];
+  if (!previous || previous.type !== "text") {
+    return null;
+  }
+
+  const textSegments = message.textSegments ?? [];
+  const numericIdx = parseInt(previous.id, 10);
+  const segment = !isNaN(numericIdx)
+    ? textSegments[numericIdx]
+    : textSegments.find(
+        (s) => (s as Record<string, unknown>).id === previous.id,
+      );
+
+  const rawText = segment?.content?.trim();
+  if (!rawText) {
+    return null;
+  }
+
+  return rawText.slice(0, MAX_THINKING_TEXT_LENGTH);
+}


### PR DESCRIPTION
## Summary
- Pure util returning the assistant text delta immediately preceding a tool-call group within a message.
- Used by the unified tool-call progress card to prepend a 'thinking' step matching today's web-search behavior.
- Tests cover the positive case, missing preceding group, non-text preceding group, and empty text.

Part of plan: unify-tool-progress-cards.md (PR 3 of 9)