### PR TITLE
feat(web): add deriveStepLabel for non-web tool calls

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveStepLabel } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+
+/**
+ * Builds a minimal `ChatMessageToolCall` fixture for testing `deriveStepLabel`.
+ * Only the fields the function actually reads (`toolName`, `input`) need
+ * meaningful values; the rest are filled with safe defaults so the inline
+ * fixtures stay readable.
+ */
+function buildToolCall(
+  overrides: Partial<ChatMessageToolCall> & Pick<ChatMessageToolCall, "toolName">,
+): ChatMessageToolCall {
+  return {
+    id: "tc-test",
+    input: {},
+    status: "running",
+    ...overrides,
+  };
+}
+
+describe("deriveStepLabel", () => {
+  test("bash → Working (bash) with truncated command and code icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "bash",
+        input: { command: "echo hello world" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Working (bash)",
+      info: "echo hello world",
+      iconName: "code",
+    });
+  });
+
+  test("bash truncates commands longer than 80 chars with an ellipsis", () => {
+    const longCommand = "x".repeat(120);
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "bash",
+        input: { command: longCommand },
+      }),
+    );
+    expect(result.iconName).toBe("code");
+    expect(result.title).toBe("Working (bash)");
+    expect(result.info.length).toBe(80);
+    expect(result.info.endsWith("…")).toBe(true);
+  });
+
+  test("str_replace_editor view → Reading with basename and file icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "str_replace_editor",
+        input: { command: "view", path: "/repo/apps/web/src/index.ts" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Reading",
+      info: "index.ts",
+      iconName: "file",
+    });
+  });
+
+  test("text_editor view → Reading branch matches str_replace_editor", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "text_editor",
+        input: { command: "view", path: "/tmp/foo/bar.md" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Reading",
+      info: "bar.md",
+      iconName: "file",
+    });
+  });
+
+  test("str_replace_editor create → Editing with pen icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "str_replace_editor",
+        input: { command: "create", path: "/repo/new-file.tsx" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Editing",
+      info: "new-file.tsx",
+      iconName: "pen",
+    });
+  });
+
+  test("str_replace_editor str_replace → Editing with pen icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "str_replace_editor",
+        input: { command: "str_replace", path: "/repo/src/foo/bar.ts" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Editing",
+      info: "bar.ts",
+      iconName: "pen",
+    });
+  });
+
+  test("computer → Using computer with action name and monitor icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "computer",
+        input: { action: "screenshot" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Using computer",
+      info: "screenshot",
+      iconName: "monitor",
+    });
+  });
+
+  test("mcp__<server>__<method> → Using <server> with method as info", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "mcp__stripe__create_payment_link",
+        input: {},
+      }),
+    );
+    expect(result).toEqual({
+      title: "Using stripe",
+      info: "create_payment_link",
+      iconName: "plug",
+    });
+  });
+
+  test("skill → Using a skill with skill name and sparkle icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill",
+        input: { skill: "code-review" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Using a skill",
+      info: "code-review",
+      iconName: "sparkle",
+    });
+  });
+
+  test("skill_execute → Using a skill branch", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill_execute",
+        input: { name: "deep-research" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Using a skill",
+      info: "deep-research",
+      iconName: "sparkle",
+    });
+  });
+
+  test("subagent_spawn → Spawning subagent with label and user-plus icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "subagent_spawn",
+        input: { label: "Investigate flaky test" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Spawning subagent",
+      info: "Investigate flaky test",
+      iconName: "user-plus",
+    });
+  });
+
+  test("subagent_spawn falls back to objective when label is missing", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "subagent_spawn",
+        input: { objective: "Audit auth flow" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Spawning subagent",
+      info: "Audit auth flow",
+      iconName: "user-plus",
+    });
+  });
+
+  test("unknown tool name → Running <humanized> fallback with bolt icon", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "some_unknown_tool",
+        input: { whatever: "ignored" },
+      }),
+    );
+    expect(result).toEqual({
+      title: "Running Some Unknown Tool",
+      info: "",
+      iconName: "bolt",
+    });
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -1,0 +1,187 @@
+/**
+ * Pure utility that maps a non-web tool call to a `(title, info, iconName)`
+ * tuple used to populate the unified tool-call progress card's carousel
+ * header.
+ *
+ * Web tool calls (`web_search`, `web_fetch`) are handled separately by the
+ * existing web-search card data pipeline — they don't flow through this
+ * function. See `apps/web/src/domains/chat/hooks/use-web-search-card-data.ts`.
+ *
+ * This module is intentionally pure: no React, no Zustand, no I/O. Inputs are
+ * the tool call payload; outputs are deterministic strings + icon name.
+ */
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+
+/**
+ * Canonical icon names used by the unified tool-call progress card.
+ *
+ * Each value corresponds to a lucide-react icon the renderer maps to in the
+ * carousel header. Defined here so this module stays the single source of
+ * truth for icon identifiers; downstream PRs (card shell, hook) reuse this
+ * union.
+ */
+export type IconName =
+  | "code"
+  | "file"
+  | "pen"
+  | "monitor"
+  | "plug"
+  | "sparkle"
+  | "user-plus"
+  | "bolt";
+
+/** Result of mapping a tool call to its carousel-header label. */
+export interface StepLabel {
+  title: string;
+  info: string;
+  iconName: IconName;
+}
+
+const INFO_MAX_LENGTH = 80;
+
+/** Truncate a string to `max` chars, appending an ellipsis when truncated. */
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max - 1) + "…";
+}
+
+/** Read a string property from a tool input bag, returning `""` when absent. */
+function readString(
+  input: Record<string, unknown>,
+  ...keys: string[]
+): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return "";
+}
+
+/** Extract the trailing path segment from a file path. Returns `""` if empty. */
+function basename(path: string): string {
+  if (!path) return "";
+  const trimmed = path.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  if (idx === -1) return trimmed;
+  return trimmed.slice(idx + 1);
+}
+
+/**
+ * Title-case a snake_case / kebab-case tool name for the fallback label.
+ * Kept local so this module has zero deps on the legacy `tool-call-chip` code,
+ * which PRs 5+ will retire.
+ */
+function humanizeToolName(toolName: string): string {
+  return toolName
+    .split(/[_-]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/**
+ * Parse an `mcp__<server>__<method>` tool name into its server/method parts.
+ * MCP tool names follow the pattern produced by `toProviderSafeToolName` in
+ * `assistant/src/tools/mcp/mcp-tool-factory.ts`. Returns `null` when the
+ * pattern doesn't match.
+ */
+function parseMcpToolName(
+  toolName: string,
+): { serverName: string; toolMethod: string } | null {
+  if (!toolName.startsWith("mcp__")) return null;
+  const rest = toolName.slice("mcp__".length);
+  const sep = rest.indexOf("__");
+  if (sep === -1) return null;
+  const serverName = rest.slice(0, sep);
+  const toolMethod = rest.slice(sep + 2);
+  if (!serverName || !toolMethod) return null;
+  return { serverName, toolMethod };
+}
+
+/**
+ * Derive the (title, info, iconName) tuple for a non-web tool call.
+ *
+ * Branches mirror the tool names already understood by the legacy
+ * `ToolCallChip` (`apps/web/src/domains/chat/components/tool-call-chip/`) plus
+ * the additional Anthropic-native tool names (`str_replace_editor`,
+ * `text_editor`, `computer`, MCP-prefixed tools, skills, subagent spawns) that
+ * the unified card needs to label.
+ */
+export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
+  const { toolName, input } = toolCall;
+  const name = toolName.toLowerCase();
+
+  const mcp = parseMcpToolName(toolName);
+  if (mcp) {
+    return {
+      title: `Using ${mcp.serverName}`,
+      info: mcp.toolMethod,
+      iconName: "plug",
+    };
+  }
+
+  switch (name) {
+    case "bash":
+    case "host_bash": {
+      const command = readString(input, "command", "cmd");
+      const cleaned = command.replace(/\s+/g, " ").trim();
+      return {
+        title: "Working (bash)",
+        info: truncate(cleaned, INFO_MAX_LENGTH),
+        iconName: "code",
+      };
+    }
+
+    case "str_replace_editor":
+    case "text_editor": {
+      const sub = readString(input, "command").toLowerCase();
+      const file = basename(readString(input, "path", "file_path", "filePath"));
+      if (sub === "view") {
+        return { title: "Reading", info: file, iconName: "file" };
+      }
+      // create / insert / str_replace (and any other write sub-command) all
+      // map to "Editing" so any mutation surfaces as an edit.
+      return { title: "Editing", info: file, iconName: "pen" };
+    }
+
+    case "computer": {
+      const action = readString(input, "action");
+      return {
+        title: "Using computer",
+        info: action,
+        iconName: "monitor",
+      };
+    }
+
+    case "skill":
+    case "skill_execute":
+    case "skill_invoke":
+    case "skill_load": {
+      const skillName = readString(input, "skill", "name", "skillName");
+      return {
+        title: "Using a skill",
+        info: skillName,
+        iconName: "sparkle",
+      };
+    }
+
+    case "subagent_spawn": {
+      const label = readString(input, "label", "objective", "task");
+      return {
+        title: "Spawning subagent",
+        info: label,
+        iconName: "user-plus",
+      };
+    }
+
+    default:
+      return {
+        title: `Running ${humanizeToolName(toolName)}`,
+        info: "",
+        iconName: "bolt",
+      };
+  }
+}


### PR DESCRIPTION
## Summary
- Pure util mapping a non-web tool call to a (title, info, icon) tuple for the unified carousel header.
- Covers bash, str_replace_editor, computer, MCP servers, skills, subagent_spawn, and a fallback.
- Tests cover every branch including the fallback.

Part of plan: unify-tool-progress-cards.md (PR 2 of 9)