### PR TITLE
fix(feature-flags): add memory-router-playground to canonical meta registry

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -424,6 +424,14 @@
       "label": "Velvet",
       "description": "Enable the Velvet design theme.",
       "defaultEnabled": false
+    },
+    {
+      "id": "memory-router-playground",
+      "scope": "client",
+      "key": "memory-router-playground",
+      "label": "Memory Router Playground",
+      "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -424,6 +424,14 @@
       "label": "Velvet",
       "description": "Enable the Velvet design theme.",
       "defaultEnabled": false
+    },
+    {
+      "id": "memory-router-playground",
+      "scope": "client",
+      "key": "memory-router-playground",
+      "label": "Memory Router Playground",
+      "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The \`memory-router-playground\` flag was added to \`apps/web/src/lib/feature-flags/feature-flag-registry.json\` in #31647 — a bundled copy, not the canonical source.
- A later sync run overwrote the bundled copy with canonical (which didn't have the entry), silently removing the flag from main.
- This PR adds it to \`meta/feature-flags/feature-flag-registry.json\` (canonical) and re-runs sync so all bundled copies match.
- The macOS app's \`build.sh\` copies the canonical file into the app bundle at build time, so a rebuild surfaces the flag in Settings → Developer → Feature Flags.

## Why

User reported the flag was missing from the macOS Feature Flags panel. Root cause was a process mistake — bundled copies are sync targets, not canonical sources, per \`meta/feature-flags/AGENTS.md\`.

## Test plan

- [x] \`bun run meta/feature-flags/sync-bundled-copies.ts\` clean
- [x] Verify all four registries contain the entry (\`grep -c memory-router-playground\`)
- [ ] After merge: \`./clients/macos/build.sh run\`, confirm flag appears in Settings → Developer → Feature Flags, toggle it on, confirm Memory Router Playground tab appears in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)