### PR TITLE
feat(web): generalize useWebSearchCardData into useToolCallCardData

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -98,11 +98,11 @@
     "conversations",
     "messaging"
   ],
+  "src/domains/chat/hooks/use-tool-call-card-data.ts": [
+    "messaging"
+  ],
   "src/domains/chat/hooks/use-voice-input.ts": [
     "voice"
-  ],
-  "src/domains/chat/hooks/use-web-search-card-data.ts": [
-    "messaging"
   ],
   "src/domains/chat/transcript/latest-turn-row.tsx": [
     "subagents"

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for `computeToolCallCardData` — the pure projection that
+ * `useToolCallCardData` wraps.
+ *
+ * Covered behaviours:
+ *   - One case per `ToolCallCardStep` kind (`thinking` /
+ *     `web_search` / `web_search_error` / `tool`).
+ *   - Leading-thinking text prepending.
+ *   - Card-level `state` transitions (loading → complete, mixed
+ *     running+completed, denied present, error present).
+ *   - Header `currentStepTitle` / `currentStepInfo` for non-web tools.
+ *   - Backward-compatibility: feeding the existing web-search fixtures
+ *     through the unified path yields the same step + state outputs as the
+ *     legacy hook (regression-checked against the matching cases in
+ *     `use-web-search-card-data.test.ts`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeToolCallCardData,
+  hasWebTool,
+} from "@/domains/chat/hooks/use-tool-call-card-data.js";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+import type {
+  ToolActivityMetadata,
+  WebSearchResultItem,
+} from "@/assistant/web-activity-types.js";
+
+function makeResult(
+  i: number,
+  overrides: Partial<WebSearchResultItem> = {},
+): WebSearchResultItem {
+  return {
+    rank: i,
+    title: `Result ${i}`,
+    url: `https://example-${i}.test/article`,
+    domain: `example-${i}.test`,
+    faviconUrl: `https://example-${i}.test/favicon.ico`,
+    ...overrides,
+  };
+}
+
+function makeToolCall(
+  overrides: Partial<ChatMessageToolCall> & {
+    id: string;
+    toolName: string;
+  },
+): ChatMessageToolCall {
+  return {
+    input: {},
+    status: "completed",
+    ...overrides,
+  };
+}
+
+describe("computeToolCallCardData — step kinds", () => {
+  test("emits a `tool` step for a non-web tool via deriveStepLabel", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 2500,
+        input: { command: "echo hello" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0]).toEqual({
+      kind: "tool",
+      durationLabel: "2s",
+      title: "Working (bash)",
+      info: "echo hello",
+      iconName: "code",
+      toolCallId: "tc-1",
+      status: "completed",
+    });
+    expect(data.state).toBe("complete");
+    // `currentStepTitle` / `currentStepInfo` mirror the tool step.
+    expect(data.currentStepTitle).toBe("Working (bash)");
+    expect(data.currentStepInfo).toBe("echo hello");
+  });
+
+  test("emits a `web_search` step with the legacy descriptor shape", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 2,
+          durationMs: 1500,
+          results: [makeResult(1), makeResult(2)],
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0]).toMatchObject({
+      kind: "web_search",
+      title: "Searched the web",
+      durationLabel: "2s",
+      linkCount: 2,
+    });
+  });
+
+  test("emits a `web_search_error` step when metadata has errorMessage and empty results", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "q",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          errorMessage: "max_uses_exceeded",
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      errorMessage: "max_uses_exceeded",
+    });
+  });
+
+  test("emits a `thinking` step for web_fetch metadata", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_fetch", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webFetch: {
+          url: "https://nytimes.com/article",
+          finalUrl: "https://nytimes.com/article",
+          status: 200,
+          byteCount: 1,
+          charCount: 1,
+          truncated: false,
+          title: "Breaking news",
+          domain: "nytimes.com",
+          redirectCount: 0,
+          durationMs: 500,
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "thinking",
+      durationLabel: "<1s",
+      text: "Reading Breaking news",
+    });
+  });
+});
+
+describe("computeToolCallCardData — leadingThinkingText", () => {
+  test("prepends a `thinking` step when leadingThinkingText is non-null", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const data = computeToolCallCardData(
+      toolCalls,
+      {},
+      "I'll look at the bash output first.",
+    );
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0]).toEqual({
+      kind: "thinking",
+      durationLabel: "",
+      text: "I'll look at the bash output first.",
+    });
+    expect(data.steps[1]!.kind).toBe("tool");
+    expect(data.stepCount).toBe("2 steps");
+  });
+
+  test("does not prepend when leadingThinkingText is null", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0]!.kind).toBe("tool");
+  });
+
+  test("does not prepend when leadingThinkingText is empty", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, "");
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0]!.kind).toBe("tool");
+  });
+});
+
+describe("computeToolCallCardData — state transitions", () => {
+  test("state is `loading` while any tool call is still running", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "running" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("loading");
+  });
+
+  test("state is `loading` for a mix of running + completed tools", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+      makeToolCall({ id: "tc-2", toolName: "edit_file", status: "running" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("loading");
+  });
+
+  test("state is `complete` once every tool reaches a terminal status", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "str_replace_editor",
+        status: "completed",
+        input: { command: "view", path: "/tmp/x.txt" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("complete");
+    expect(data.stepCount).toBe("2 steps");
+  });
+
+  test("state is `denied` when any tool has confirmationDecision === 'denied'", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        confirmationDecision: "denied",
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("denied");
+    expect((data.steps[0] as { status: string }).status).toBe("denied");
+  });
+
+  test("state is `denied` even when another tool is still running (precedence)", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        confirmationDecision: "denied",
+      }),
+      makeToolCall({ id: "tc-2", toolName: "edit_file", status: "running" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("denied");
+  });
+
+  test("state is `error` when a tool ended in error and no tools are still running", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "error" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("error");
+    expect((data.steps[0] as { status: string }).status).toBe("error");
+  });
+
+  test("state is `loading` (not `error`) when an error tool sits alongside a still-running tool", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "error" }),
+      makeToolCall({ id: "tc-2", toolName: "edit_file", status: "running" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.state).toBe("loading");
+  });
+});
+
+describe("computeToolCallCardData — leadingIcon", () => {
+  test("leadingIcon is null for non-subagent groups (PR 7 will populate)", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.leadingIcon).toBeNull();
+  });
+});
+
+describe("computeToolCallCardData — regression vs. legacy web-search hook", () => {
+  // Same fixture as the legacy hook's "emits two web_search step descriptors
+  // in toolCall order" case — checking that the unified path produces the
+  // same step set + state for purely-web inputs.
+  test("matches the legacy hook's output for the 'two completed web_search' fixture", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search" }),
+      makeToolCall({ id: "tc-2", toolName: "web_search" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "first",
+          provider: "anthropic-native",
+          resultCount: 2,
+          durationMs: 1234,
+          results: [makeResult(1), makeResult(2)],
+        },
+      },
+      "tc-2": {
+        webSearch: {
+          query: "second",
+          provider: "anthropic-native",
+          resultCount: 3,
+          durationMs: 2500,
+          results: [makeResult(3), makeResult(4), makeResult(5)],
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0]).toMatchObject({
+      kind: "web_search",
+      title: "Searched the web",
+      durationLabel: "1s",
+      linkCount: 2,
+    });
+    expect(data.steps[1]).toMatchObject({
+      kind: "web_search",
+      title: "Searched the web",
+      durationLabel: "3s",
+      linkCount: 3,
+    });
+    expect(data.currentStepTitle).toBe("Searched the web");
+    expect(data.state).toBe("complete");
+    expect(data.stepCount).toBe("2 steps");
+    expect(data.carouselItems).toHaveLength(3);
+  });
+
+  test("emits the same `Searching...` placeholder for an in-flight web tool with no metadata", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "running",
+        input: { query: "tigers" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps[0]).toEqual({
+      kind: "thinking",
+      durationLabel: "",
+      text: "Searching...",
+    });
+    expect(data.state).toBe("loading");
+    expect(data.currentStepTitle).toBe("Searching the web");
+    expect(data.currentStepInfo).toBe("Searching tigers");
+  });
+});
+
+describe("computeToolCallCardData — mixed web + non-web groups", () => {
+  test("emits a `tool` step alongside a `web_search` step in declared order", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "completed",
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "bash",
+        status: "completed",
+        startedAt: 0,
+        completedAt: 500,
+        input: { command: "ls" },
+      }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "x",
+          provider: "anthropic-native",
+          resultCount: 1,
+          durationMs: 500,
+          results: [makeResult(1)],
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0]!.kind).toBe("web_search");
+    expect(data.steps[1]!.kind).toBe("tool");
+    // currentStepTitle reflects the latest call (the bash tool).
+    expect(data.currentStepTitle).toBe("Working (bash)");
+    expect(data.currentStepInfo).toBe("ls");
+  });
+});
+
+describe("hasWebTool", () => {
+  test("returns true when any tool call is a web tool", () => {
+    expect(
+      hasWebTool([
+        makeToolCall({ id: "tc-1", toolName: "bash" }),
+        makeToolCall({ id: "tc-2", toolName: "web_search" }),
+      ]),
+    ).toBe(true);
+  });
+
+  test("returns false when no tool calls are web tools", () => {
+    expect(
+      hasWebTool([makeToolCall({ id: "tc-1", toolName: "bash" })]),
+    ).toBe(false);
+  });
+
+  test("returns false on an empty list", () => {
+    expect(hasWebTool([])).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -1,0 +1,528 @@
+/**
+ * Unified data hook that powers the upcoming tool-call progress card
+ * (PR 6 wires it up). Generalises the legacy `useWebSearchCardData` so the
+ * same card chrome can drive both web tools (`web_search` / `web_fetch`) and
+ * non-web tools (`bash`, `str_replace_editor`, MCP, skills, subagent spawns,
+ * etc.) from one path.
+ *
+ * The hook is intentionally pure relative to its inputs — the React surface
+ * (`useToolCallCardData`) only adds a Zustand subscription to the active
+ * turn's `liveWebActivity` map; the actual `(toolCalls, liveWebActivity,
+ * leadingThinkingText) → ToolCallCardData` projection is exposed as
+ * `computeToolCallCardData` so callers/tests can drive it without React
+ * context plumbing.
+ *
+ * Web-tool steps reuse the existing builders moved over from
+ * `use-web-search-card-data.ts` verbatim, so the regression behaviour is
+ * exercised end-to-end by the legacy hook's wrapper (which re-exports this
+ * module's output narrowed back to `WebSearchCardData`).
+ */
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+import type {
+  ToolActivityMetadata,
+  WebSearchResultItem,
+} from "@/assistant/web-activity-types.js";
+import {
+  deriveStepLabel,
+  type IconName,
+} from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+import {
+  extractDomain,
+  parseWebSearchResultText,
+} from "@/domains/chat/utils/web-search-result-text.js";
+import { useTurnStore } from "@/domains/messaging/turn-store.js";
+
+/** Max favicon chips to render inside a single `web_search` step row. */
+const MAX_VISIBLE_RESULTS = 5;
+
+/** Tool names whose presence triggers the web-search step path. */
+export const WEB_TOOL_NAMES = new Set(["web_search", "web_fetch"]);
+
+/**
+ * Discriminated step descriptor for the unified tool-call progress card.
+ *
+ * The first three variants (`thinking`, `web_search`, `web_search_error`)
+ * preserve the existing `StepDescriptor` shape from
+ * `WebSearchProgressCard`, so the legacy renderer keeps working unchanged.
+ * The new `tool` variant carries the title/info/icon tuple produced by
+ * `deriveStepLabel` plus the per-call duration + status fields the unified
+ * card needs to drive its row chrome.
+ */
+export type ToolCallCardStep =
+  | { kind: "thinking"; durationLabel: string; text: string }
+  | {
+      kind: "web_search";
+      title: string;
+      durationLabel: string;
+      linkCount: number;
+      results: WebSearchResultItem[];
+      overflow?: number;
+    }
+  | {
+      kind: "web_search_error";
+      title: string;
+      durationLabel: string;
+      errorMessage: string;
+    }
+  | {
+      kind: "tool";
+      durationLabel: string;
+      title: string;
+      info: string;
+      iconName: IconName;
+      toolCallId: string;
+      status: "running" | "completed" | "error" | "denied";
+    };
+
+/**
+ * Card-level data for the unified tool-call progress card.
+ *
+ * Mirrors the legacy `WebSearchCardData` field-for-field plus:
+ *   - `steps` widens to `ToolCallCardStep[]` so non-web tools can ride along.
+ *   - `state` adds `"error"` / `"denied"` variants so cards that mix
+ *     successful and failed tool calls can render a distinct chrome state.
+ *   - `leadingIcon` is reserved for PR 7's subagent-group rendering (always
+ *     `null` for non-subagent groups today).
+ */
+export interface ToolCallCardData {
+  /**
+   * Title text rendered in the collapsed header. Reflects the most recent
+   * step's title (e.g. "Searching the web" → "Searched the web") so the
+   * header carousels through each step's tense as the turn progresses.
+   */
+  currentStepTitle: string;
+  /**
+   * Per-step gray subtext rendered after the title. Animates alongside
+   * `currentStepTitle` via the card's throttled carousel. See the
+   * per-kind table in `deriveCurrentStepInfo`.
+   */
+  currentStepInfo: string;
+  /** Pre-formatted step count, e.g. `"2 steps"`. */
+  stepCount: string;
+  /** Ordered sub-steps to render when expanded. */
+  steps: ToolCallCardStep[];
+  /**
+   * Card-wide visual state:
+   * - `"loading"` while any tool call is still running.
+   * - `"denied"` when any tool call was denied via `confirmationDecision`.
+   * - `"error"` when at least one tool ended in `status === "error"` and no
+   *   tool is still running.
+   * - `"complete"` once every tool call has reached a terminal status.
+   */
+  state: "loading" | "complete" | "error" | "denied";
+  /** Results to feed the collapsed-header rotating carousel (web-search only). */
+  carouselItems: WebSearchResultItem[];
+  /**
+   * Optional leading icon for subagent-rooted tool groups. PR 7 populates
+   * this; for now every non-subagent group leaves it as `null`.
+   */
+  leadingIcon: { kind: "subagent"; subagentId: string } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Small pure helpers — moved verbatim from `use-web-search-card-data.ts` so
+// the legacy hook can re-export them for its tests/consumers.
+// ---------------------------------------------------------------------------
+
+/** Format a duration in ms for the row-meta cluster (e.g. `<1s`, `2s`). */
+export function formatMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 1000) return "<1s";
+  return `${Math.round(ms / 1000)}s`;
+}
+
+/** True when `tc.toolName` is a web tool (`web_search` / `web_fetch`). */
+function isWebTool(tc: ChatMessageToolCall): boolean {
+  return WEB_TOOL_NAMES.has(tc.toolName);
+}
+
+/** True when at least one tool call in `toolCalls` is a web tool. */
+export function hasWebTool(toolCalls: ChatMessageToolCall[]): boolean {
+  return toolCalls.some(isWebTool);
+}
+
+/**
+ * Decide the StepRow label for a `web_search` row. Past-tense once the
+ * underlying tool call is terminal so a completed turn doesn't read as if
+ * the search is still in flight.
+ */
+function webSearchStepTitle(terminal: boolean): string {
+  return terminal ? "Searched the web" : "Searching the web";
+}
+
+function clampResults(results: WebSearchResultItem[]): {
+  visible: WebSearchResultItem[];
+  overflow: number;
+} {
+  return {
+    visible: results.slice(0, MAX_VISIBLE_RESULTS),
+    overflow: Math.max(0, results.length - MAX_VISIBLE_RESULTS),
+  };
+}
+
+function buildWebSearchStep(
+  metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
+  terminal: boolean,
+): ToolCallCardStep {
+  const { visible, overflow } = clampResults(metadata.results);
+  return {
+    kind: "web_search",
+    title: webSearchStepTitle(terminal),
+    durationLabel: formatMs(metadata.durationMs),
+    linkCount: metadata.resultCount,
+    results: visible,
+    overflow,
+  };
+}
+
+function buildWebFetchStep(
+  metadata: NonNullable<ToolActivityMetadata["webFetch"]>,
+): ToolCallCardStep {
+  const label = metadata.title ?? metadata.domain;
+  return {
+    kind: "thinking",
+    durationLabel: formatMs(metadata.durationMs),
+    text: `Reading ${label}`,
+  };
+}
+
+function buildPlaceholderStep(): ToolCallCardStep {
+  return { kind: "thinking", durationLabel: "", text: "Searching..." };
+}
+
+function buildWebSearchStepFromResultText(
+  text: string,
+): (ToolCallCardStep & { kind: "web_search" }) | null {
+  const parsed = parseWebSearchResultText(text);
+  if (parsed.length === 0) return null;
+  const { visible, overflow } = clampResults(parsed);
+  return {
+    kind: "web_search",
+    title: webSearchStepTitle(true),
+    durationLabel: "",
+    linkCount: parsed.length,
+    results: visible,
+    overflow,
+  };
+}
+
+function buildWebSearchErrorStep(
+  metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
+): ToolCallCardStep {
+  return {
+    kind: "web_search_error",
+    title: "Web search failed",
+    durationLabel: formatMs(metadata.durationMs),
+    errorMessage: metadata.errorMessage ?? "Search failed.",
+  };
+}
+
+function buildEmptyWebSearchStep(): ToolCallCardStep {
+  return {
+    kind: "web_search",
+    title: webSearchStepTitle(true),
+    durationLabel: "",
+    linkCount: 0,
+    results: [],
+  };
+}
+
+function resolveMetadata(
+  tc: ChatMessageToolCall,
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+): ToolActivityMetadata | undefined {
+  return liveWebActivity[tc.id] ?? tc.activityMetadata;
+}
+
+function isTerminalStatus(tc: ChatMessageToolCall): boolean {
+  return tc.status === "completed" || tc.status === "error";
+}
+
+/**
+ * Map a tool call's `confirmationDecision` + `status` to the unified card's
+ * narrowed step-status enum. `"denied"` precedence beats both `"error"` and
+ * `"completed"` so the denied chrome stays visible after the daemon
+ * eventually stamps an error tool_result for the same call.
+ */
+function deriveToolStepStatus(
+  tc: ChatMessageToolCall,
+): "running" | "completed" | "error" | "denied" {
+  if (
+    tc.confirmationDecision === "denied" ||
+    tc.confirmationDecision === "timed_out"
+  ) {
+    return "denied";
+  }
+  if (tc.status === "error") return "error";
+  if (tc.status === "completed") return "completed";
+  return "running";
+}
+
+/**
+ * Per-tool duration, mirroring the legacy generic card: start time
+ * (`startedAt`) → completion time (`completedAt`) → `formatMs`. Returns an
+ * empty string when timings are missing so the row chrome can hide the
+ * meta cluster rather than render a misleading `<1s`.
+ */
+function computeToolDurationLabel(tc: ChatMessageToolCall): string {
+  if (tc.startedAt == null) return "";
+  if (tc.completedAt == null) {
+    // Still running — no duration to display yet. The legacy generic card
+    // ticks an elapsed counter via `useElapsedTime`, but the unified card
+    // hides duration mid-flight to avoid jitter.
+    return "";
+  }
+  return formatMs(Math.max(0, tc.completedAt - tc.startedAt));
+}
+
+function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
+  const { title, info, iconName } = deriveStepLabel(tc);
+  return {
+    kind: "tool",
+    durationLabel: computeToolDurationLabel(tc),
+    title,
+    info,
+    iconName,
+    toolCallId: tc.id,
+    status: deriveToolStepStatus(tc),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Header carousel — currentStepTitle / currentStepInfo
+// ---------------------------------------------------------------------------
+
+/**
+ * Title shown in the collapsed header for the most recent tool call. Walks
+ * the calls in reverse so the latest one wins, mirroring the legacy
+ * web-search hook's selector logic for the web-tool branch and adding a
+ * non-web `deriveStepLabel().title` branch alongside it.
+ */
+function deriveCurrentStepTitle(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+): string {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const tc = toolCalls[i]!;
+    if (isWebTool(tc)) {
+      const metadata = resolveMetadata(tc, liveWebActivity);
+      const terminal = isTerminalStatus(tc);
+      if (
+        metadata?.webSearch &&
+        metadata.webSearch.errorMessage &&
+        metadata.webSearch.results.length === 0
+      ) {
+        return "Web search failed";
+      }
+      if (tc.toolName === "web_search") {
+        return webSearchStepTitle(terminal);
+      }
+      if (tc.toolName === "web_fetch") {
+        return "Thinking";
+      }
+    } else {
+      return deriveStepLabel(tc).title;
+    }
+  }
+  return "";
+}
+
+/**
+ * Per-step subtext for the carousel header. Web branch mirrors the legacy
+ * web-search hook's fallback ladder; non-web branch uses
+ * `deriveStepLabel().info`.
+ */
+function deriveCurrentStepInfo(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+): string {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const tc = toolCalls[i]!;
+    if (!isWebTool(tc)) {
+      return deriveStepLabel(tc).info;
+    }
+    const metadata = resolveMetadata(tc, liveWebActivity);
+    const terminal = isTerminalStatus(tc);
+
+    if (metadata?.webSearch) {
+      const ws = metadata.webSearch;
+      if (ws.errorMessage && ws.results.length === 0) {
+        return ws.errorMessage;
+      }
+      if (ws.results.length > 0) {
+        return ws.results[ws.results.length - 1]!.title;
+      }
+      if (!terminal && ws.query) {
+        return `Searching ${ws.query}`;
+      }
+    }
+
+    if (metadata?.webFetch) {
+      const wf = metadata.webFetch;
+      if (terminal) {
+        return wf.title ?? wf.domain;
+      }
+      return `Reading ${wf.domain}`;
+    }
+
+    if (tc.toolName === "web_search") {
+      if (!terminal) {
+        const query =
+          typeof tc.input?.query === "string" ? tc.input.query.trim() : "";
+        return query ? `Searching ${query}` : "";
+      }
+      if (typeof tc.result === "string") {
+        const parsed = parseWebSearchResultText(tc.result);
+        if (parsed.length > 0) {
+          const title = parsed[parsed.length - 1]!.title;
+          if (title) return title;
+        }
+      }
+    }
+
+    if (tc.toolName === "web_fetch") {
+      const url = typeof tc.input?.url === "string" ? tc.input.url : "";
+      const host = url ? extractDomain(url) : "";
+      if (host) return terminal ? host : `Reading ${host}`;
+    }
+  }
+  return "";
+}
+
+/**
+ * Results to feed the collapsed-header rotating carousel. Returns the
+ * results from the *most recently completed* `web_search` tool call, or
+ * an empty array when none has landed yet (or no web_search ran at all).
+ */
+function deriveCarouselItems(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+): WebSearchResultItem[] {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const tc = toolCalls[i]!;
+    if (tc.toolName !== "web_search") continue;
+    const metadata = resolveMetadata(tc, liveWebActivity);
+    const results = metadata?.webSearch?.results;
+    if (results && results.length > 0) return results;
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Card-level state
+// ---------------------------------------------------------------------------
+
+/**
+ * Card-level state derivation. Precedence (highest first):
+ *   1. `denied` — any tool call whose confirmation was denied or timed-out.
+ *   2. `loading` — any tool call still running.
+ *   3. `error` — any tool ended in `status === "error"` (no still-running).
+ *   4. `complete` — every tool call reached a terminal status without error.
+ */
+function deriveCardState(
+  toolCalls: ChatMessageToolCall[],
+): "loading" | "complete" | "error" | "denied" {
+  let anyRunning = false;
+  let anyError = false;
+  let anyDenied = false;
+  for (const tc of toolCalls) {
+    if (
+      tc.confirmationDecision === "denied" ||
+      tc.confirmationDecision === "timed_out"
+    ) {
+      anyDenied = true;
+    }
+    if (tc.status === "running") anyRunning = true;
+    if (tc.status === "error") anyError = true;
+  }
+  if (anyDenied) return "denied";
+  if (anyRunning) return "loading";
+  if (anyError) return "error";
+  return "complete";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure projection of (toolCalls, liveWebActivity, leadingThinkingText) →
+ * card data. Split out from the hook so tests can drive it without React
+ * context plumbing.
+ *
+ * Always returns a `ToolCallCardData` (never null) so non-web groups still
+ * render the unified card. Callers that need legacy "no web tools → bail
+ * to legacy card" behaviour (the PR-6 cutover keeps the legacy card alive
+ * for mixed/pending-confirmation groups) should layer that decision on top.
+ */
+export function computeToolCallCardData(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+  leadingThinkingText: string | null,
+): ToolCallCardData {
+  const steps: ToolCallCardStep[] = [];
+
+  if (leadingThinkingText) {
+    steps.push({
+      kind: "thinking",
+      durationLabel: "",
+      text: leadingThinkingText,
+    });
+  }
+
+  for (const tc of toolCalls) {
+    if (!isWebTool(tc)) {
+      steps.push(buildToolStep(tc));
+      continue;
+    }
+    const metadata = resolveMetadata(tc, liveWebActivity);
+    const terminal = isTerminalStatus(tc);
+    if (metadata?.webSearch) {
+      const ws = metadata.webSearch;
+      if (ws.errorMessage && ws.results.length === 0) {
+        steps.push(buildWebSearchErrorStep(ws));
+      } else {
+        steps.push(buildWebSearchStep(ws, terminal));
+      }
+    } else if (metadata?.webFetch) {
+      steps.push(buildWebFetchStep(metadata.webFetch));
+    } else if (!terminal) {
+      steps.push(buildPlaceholderStep());
+    } else if (tc.toolName === "web_search" && typeof tc.result === "string") {
+      const parsed = buildWebSearchStepFromResultText(tc.result);
+      steps.push(parsed ?? buildEmptyWebSearchStep());
+    } else {
+      steps.push(buildEmptyWebSearchStep());
+    }
+  }
+
+  const state = deriveCardState(toolCalls);
+  const currentStepTitle = deriveCurrentStepTitle(toolCalls, liveWebActivity);
+  const currentStepInfo = deriveCurrentStepInfo(toolCalls, liveWebActivity);
+  const carouselItems = deriveCarouselItems(toolCalls, liveWebActivity);
+  const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
+
+  return {
+    currentStepTitle,
+    currentStepInfo,
+    stepCount,
+    steps,
+    state,
+    carouselItems,
+    leadingIcon: null,
+  };
+}
+
+/**
+ * React hook flavour of {@link computeToolCallCardData}. Subscribes to the
+ * turn store's `liveWebActivity` map so the card data updates in lockstep
+ * with daemon-emitted metadata, then delegates to the pure projection.
+ */
+export function useToolCallCardData(
+  toolCalls: ChatMessageToolCall[],
+  leadingThinkingText: string | null,
+): ToolCallCardData {
+  const liveWebActivity = useTurnStore.use.liveWebActivity();
+  return computeToolCallCardData(toolCalls, liveWebActivity, leadingThinkingText);
+}
+

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.test.ts
@@ -856,6 +856,28 @@ describe("computeWebSearchCardData — state", () => {
     expect(data!.currentStepTitle).toBe("Searching the web");
   });
 
+  test("state is `loading` for a denied web tool whose status is still `running`", () => {
+    // After the user clicks deny, `pendingConfirmation` is cleared
+    // immediately but the tool call can remain `status: "running"` until
+    // the error `tool_result` arrives. The unified pipeline promotes the
+    // card to `"denied"` as soon as `confirmationDecision === "denied"`,
+    // but the wrapper must keep the legacy state at `"loading"` because
+    // the legacy card has no denied chrome and we don't want to render a
+    // completed checkmark while the call is still in flight.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "running",
+        input: { query: "tigers" },
+        confirmationDecision: "denied",
+      }),
+    ];
+    const data = computeWebSearchCardData(toolCalls, {});
+    expect(data).not.toBeNull();
+    expect(data!.state).toBe("loading");
+  });
+
   test("state is `loading` for a mix of in-flight and completed web tools", () => {
     const toolCalls = [
       makeToolCall({ id: "tc-1", toolName: "web_search" }),

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
@@ -12,9 +12,12 @@
  *   - Bails to `null` whenever any tool call is awaiting confirmation —
  *     strict-mode permission prompts surface approve/deny UI in the legacy
  *     card and the web-search card path doesn't thread that plumbing.
- *   - Narrows the unified card's wider `state` enum back to
- *     `"loading" | "complete"` since the legacy card doesn't render
- *     `"error"` / `"denied"` chrome.
+ *   - Recomputes the legacy `"loading" | "complete"` state from the raw
+ *     tool-call statuses rather than narrowing the unified `state`. The
+ *     unified state promotes `"denied"` the instant a confirmation is
+ *     rejected, but the underlying tool call can remain `status: "running"`
+ *     until the error `tool_result` arrives, so the legacy card has to stay
+ *     in `"loading"` during that window.
  *
  * The narrow set of historical behaviours above is locked in by
  * `use-web-search-card-data.test.ts`, which now exercises this wrapper as
@@ -35,6 +38,16 @@ import {
   useToolCallCardData,
   type ToolCallCardData,
 } from "@/domains/chat/hooks/use-tool-call-card-data.js";
+
+function deriveLegacyState(
+  toolCalls: ChatMessageToolCall[],
+): "loading" | "complete" {
+  // See the file-level doc — must consult raw `status`, not `unified.state`,
+  // because a denied confirmation can race ahead of the error `tool_result`.
+  return toolCalls.some((tc) => tc.status === "running")
+    ? "loading"
+    : "complete";
+}
 
 // Re-exports preserved for any straggler imports of the old module name.
 export { formatMs, WEB_TOOL_NAMES };
@@ -78,19 +91,20 @@ function shouldUseLegacyWebSearchCard(
  * `StepDescriptor[]` — every step emitted for purely-web groups is already
  * one of the three legacy descriptor kinds by construction (the `tool`
  * variant only appears for non-web tools, filtered out by the guards).
+ *
+ * `state` is recomputed from the raw tool-call statuses rather than derived
+ * from `unified.state` — see {@link deriveLegacyState} for why.
  */
 function narrowToWebSearchCardData(
   unified: ToolCallCardData,
+  toolCalls: ChatMessageToolCall[],
 ): WebSearchCardData {
   return {
     currentStepTitle: unified.currentStepTitle,
     currentStepInfo: unified.currentStepInfo,
     stepCount: unified.stepCount,
     steps: unified.steps as StepDescriptor[],
-    // For purely-web groups, the wider state collapses to the legacy
-    // two-value enum (no denied confirmations, errors collapse to complete
-    // per the legacy contract).
-    state: unified.state === "loading" ? "loading" : "complete",
+    state: deriveLegacyState(toolCalls),
     carouselItems: unified.carouselItems,
   };
 }
@@ -107,6 +121,7 @@ export function computeWebSearchCardData(
   if (!shouldUseLegacyWebSearchCard(toolCalls)) return null;
   return narrowToWebSearchCardData(
     computeToolCallCardData(toolCalls, liveWebActivity, null),
+    toolCalls,
   );
 }
 
@@ -118,5 +133,5 @@ export function useWebSearchCardData(
   // that path renders the legacy card anyway and re-walks the same data.
   const unified = useToolCallCardData(toolCalls, null);
   if (!shouldUseLegacyWebSearchCard(toolCalls)) return null;
-  return narrowToWebSearchCardData(unified);
+  return narrowToWebSearchCardData(unified, toolCalls);
 }

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
@@ -1,26 +1,24 @@
 /**
- * Builds the props for `WebSearchProgressCard` from the active turn's
- * tool calls + `liveWebActivity` metadata.
+ * Thin wrapper around {@link useToolCallCardData} / {@link computeToolCallCardData}
+ * that preserves the legacy `WebSearchCardData` shape consumed by
+ * `ToolCallProgressCard` (PR 6 retires this consumer).
  *
- * Returns `null` when no tool call in the supplied list is a web tool
- * (`web_search` / `web_fetch`) — callers should fall back to the legacy
- * `ToolCallProgressCard` rendering. When at least one web tool is present,
- * the hook walks the tool calls in order and emits a `StepDescriptor` for
- * each. Metadata is sourced from either the live turn state
- * (`liveWebActivity[tc.id]`) or, once that is cleared on idle transitions,
- * from the tool call's persisted `activityMetadata` field (stamped by
- * `applyToolResult`). In-flight calls with no metadata yet get a
- * `"Searching..."` placeholder so the card renders immediately on
- * `tool_use_start` rather than waiting for `tool_result`.
+ * Behaviour relative to the unified hook:
+ *   - Returns `null` when no tool call is a web tool (`web_search` /
+ *     `web_fetch`) so the legacy card path can still render non-web groups.
+ *   - Bails to `null` for mixed groups (any non-web tool present) so the
+ *     legacy card renders every call rather than silently dropping the
+ *     non-web entries.
+ *   - Bails to `null` whenever any tool call is awaiting confirmation —
+ *     strict-mode permission prompts surface approve/deny UI in the legacy
+ *     card and the web-search card path doesn't thread that plumbing.
+ *   - Narrows the unified card's wider `state` enum back to
+ *     `"loading" | "complete"` since the legacy card doesn't render
+ *     `"error"` / `"denied"` chrome.
  *
- * Returns a `state: "loading" | "complete"` flag derived from the tool-call
- * statuses so the card chrome (indicator icon, header label, carousel) can
- * swap between the live and completed presentations.
- *
- * Historical reopens — a server-hydrated message whose tool calls have no
- * persisted metadata — still emit a minimal `web_search` step so the new
- * card chrome stays consistent. The legacy card path is reserved for
- * non-web tools and mixed/confirmation groups.
+ * The narrow set of historical behaviours above is locked in by
+ * `use-web-search-card-data.test.ts`, which now exercises this wrapper as
+ * a regression suite against the unified pipeline.
  */
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
@@ -28,466 +26,97 @@ import type {
   ToolActivityMetadata,
   WebSearchResultItem,
 } from "@/assistant/web-activity-types.js";
-import {
-  extractDomain,
-  parseWebSearchResultText,
-} from "@/domains/chat/utils/web-search-result-text.js";
 import type { StepDescriptor } from "@/domains/chat/components/web-search/web-search-progress-card.js";
-import { useTurnStore } from "@/domains/messaging/turn-store.js";
+import {
+  computeToolCallCardData,
+  hasWebTool,
+  WEB_TOOL_NAMES,
+  formatMs,
+  useToolCallCardData,
+  type ToolCallCardData,
+} from "@/domains/chat/hooks/use-tool-call-card-data.js";
 
-/** Max favicon chips to render inside a single `web_search` step row. */
-const MAX_VISIBLE_RESULTS = 5;
+// Re-exports preserved for any straggler imports of the old module name.
+export { formatMs, WEB_TOOL_NAMES };
 
-/** Tool names whose presence triggers the web-search card path. */
-const WEB_TOOL_NAMES = new Set(["web_search", "web_fetch"]);
-
+/**
+ * Legacy card-data shape consumed by `WebSearchProgressCard`. Mirrors
+ * `ToolCallCardData` field-for-field but:
+ *   - `steps` is the narrower `StepDescriptor[]` (no `tool` variant).
+ *   - `state` is narrower (`"loading" | "complete"` only).
+ *   - `leadingIcon` is omitted (web-only path never sets it).
+ */
 export interface WebSearchCardData {
-  /**
-   * Title text rendered in the collapsed header. Reflects the most recent
-   * step's per-row title (e.g. "Searching the web" → "Searched the web") so
-   * the header carousels through each step's tense as the turn progresses.
-   * Falls back to the overall card-level label when no steps have rendered.
-   */
   currentStepTitle: string;
-  /**
-   * Per-step gray subtext rendered after the title. Animates alongside
-   * `currentStepTitle` via the card's throttled carousel.
-   *
-   * Semantics per step kind (see `deriveCurrentStepInfo` for the full table):
-   *   - thinking (in-flight, real reasoning) → the model's reasoning text
-   *   - web_fetch (in-flight) → "Reading <domain>"
-   *   - web_fetch (completed) → page title or fallback domain
-   *   - web_search (in-flight, no results yet) → "Searching <query>"
-   *   - web_search (results present) → the last result's title
-   *   - web_search_error → the provider's error message
-   *   - historical reopen with no data → empty string
-   */
   currentStepInfo: string;
   stepCount: string;
   steps: StepDescriptor[];
-  /**
-   * Visual state of the card:
-   * - `"loading"` while any web tool call is still running (or pending
-   *   confirmation rejected upstream)
-   * - `"complete"` once every web tool call has reached a terminal status
-   *   (`completed` / `error`)
-   * Drives the header indicator (animated dots vs. static check) and the
-   * per-step row tense in the expanded body.
-   */
   state: "loading" | "complete";
-  /**
-   * Results from the most recently completed `web_search` in the turn,
-   * suitable for feeding the collapsed-header `WebsiteCarousel`.
-   *
-   * The daemon emits `web_search` results atomically on `tool_result` — there
-   * is no mid-stream progress event. So this stays empty until at least one
-   * search returns, and re-feeds each time a subsequent search completes
-   * (the carousel always reflects the most recent search batch).
-   *
-   * Sourced from `liveWebActivity[tc.id]` first, falling back to the
-   * persisted `tc.activityMetadata` for historical reopens. Skips
-   * error-state results (an `errorMessage` with empty `results` would yield
-   * nothing to show anyway).
-   */
   carouselItems: WebSearchResultItem[];
 }
 
 /**
- * Format a duration in ms for the row-meta cluster (e.g. `<1s`, `2s`).
- *
- * Exported for direct testing — the rest of this module's behaviour is
- * exercised end-to-end via the React hook.
+ * Guards that decide whether the legacy card path applies. Mirrors the
+ * historical bail-outs from the pre-unification implementation.
  */
-export function formatMs(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 1000) return "<1s";
-  return `${Math.round(ms / 1000)}s`;
-}
-
-/**
- * True when `tc.toolName` is a web tool (`web_search` / `web_fetch`).
- *
- * Anthropic-native `web_search` is the only path that currently emits
- * `activityMetadata`; OpenAI's `web_search_call` does not (it has a
- * different tool name and no metadata) so this gate also correctly skips
- * it, falling back to the legacy card.
- */
-function isWebTool(tc: ChatMessageToolCall): boolean {
-  return WEB_TOOL_NAMES.has(tc.toolName);
-}
-
-/**
- * Decide the StepRow label for a `web_search` row. Past-tense once the
- * underlying tool call is terminal so a completed turn doesn't read as if
- * the search is still in flight ("Searching the web · 0 links" was the
- * pre-fix complaint).
- */
-function webSearchStepTitle(terminal: boolean): string {
-  return terminal ? "Searched the web" : "Searching the web";
-}
-
-/**
- * Clamp a result list to the visible cap and report the overflow count for
- * the trailing "+N more" pill. Shared between the structured-metadata path
- * and the result-text fallback so both rows follow the same truncation rule.
- */
-function clampResults(results: WebSearchResultItem[]): {
-  visible: WebSearchResultItem[];
-  overflow: number;
-} {
-  return {
-    visible: results.slice(0, MAX_VISIBLE_RESULTS),
-    overflow: Math.max(0, results.length - MAX_VISIBLE_RESULTS),
-  };
-}
-
-function buildWebSearchStep(
-  metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
-  terminal: boolean,
-): StepDescriptor {
-  const { visible, overflow } = clampResults(metadata.results);
-  return {
-    kind: "web_search",
-    title: webSearchStepTitle(terminal),
-    durationLabel: formatMs(metadata.durationMs),
-    linkCount: metadata.resultCount,
-    results: visible,
-    overflow,
-  };
-}
-
-function buildWebFetchStep(
-  metadata: NonNullable<ToolActivityMetadata["webFetch"]>,
-): StepDescriptor {
-  const label = metadata.title ?? metadata.domain;
-  return {
-    kind: "thinking",
-    durationLabel: formatMs(metadata.durationMs),
-    text: `Reading ${label}`,
-  };
-}
-
-function buildPlaceholderStep(): StepDescriptor {
-  return { kind: "thinking", durationLabel: "", text: "Searching..." };
-}
-
-/**
- * Reconstruct a `web_search` step from the daemon's `result: string` text
- * dump. The Anthropic-native daemon path doesn't persist `activityMetadata`
- * across reloads (v1 scope) but it does persist `tc.result` — the same
- * text the model sees. Parsing that recovers titles + URLs so the step
- * row can render real chips instead of "0 links". We don't recover
- * snippet, duration, provider, or favicon — those stay omitted and the
- * card degrades gracefully (FaviconChip falls back to a domain monogram).
- *
- * Returns `null` when parsing yields no URLs — caller falls through to the
- * empty fallback.
- */
-function buildWebSearchStepFromResultText(
-  text: string,
-): (StepDescriptor & { kind: "web_search" }) | null {
-  const parsed = parseWebSearchResultText(text);
-  if (parsed.length === 0) return null;
-  const { visible, overflow } = clampResults(parsed);
-  return {
-    kind: "web_search",
-    // Always past-tense — this fallback only runs when the call is terminal.
-    title: webSearchStepTitle(true),
-    durationLabel: "",
-    linkCount: parsed.length,
-    results: visible,
-    overflow,
-  };
-}
-
-function buildWebSearchErrorStep(
-  metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
-): StepDescriptor {
-  return {
-    kind: "web_search_error",
-    title: "Web search failed",
-    durationLabel: formatMs(metadata.durationMs),
-    errorMessage: metadata.errorMessage ?? "Search failed.",
-  };
-}
-
-/**
- * Historical-reopen fallback row. Used when the tool call is terminal but
- * neither `liveWebActivity` nor the persisted `tc.activityMetadata` carry
- * the structured payload AND the result text didn't parse into anything
- * useful (no URLs). Renders the new card chrome with an empty results row
- * rather than falling back to the legacy card so the visual language stays
- * consistent.
- */
-function buildEmptyWebSearchStep(): StepDescriptor {
-  return {
-    kind: "web_search",
-    title: webSearchStepTitle(true),
-    durationLabel: "",
-    linkCount: 0,
-    results: [],
-  };
-}
-
-/** Resolve the structured metadata for a tool call from either source. */
-function resolveMetadata(
-  tc: ChatMessageToolCall,
-  liveWebActivity: Record<string, ToolActivityMetadata>,
-): ToolActivityMetadata | undefined {
-  return liveWebActivity[tc.id] ?? tc.activityMetadata;
-}
-
-/** Tool-call statuses that count as terminal (no further work expected). */
-function isTerminalStatus(tc: ChatMessageToolCall): boolean {
-  return tc.status === "completed" || tc.status === "error";
-}
-
-/**
- * Per-step title for the carousel header. Reflects the *most recent* web
- * tool call's own row title so the header reads in-context as the turn
- * progresses (e.g. "Searching the web" → "Searched the web" → "Searched
- * the web" again on a follow-up query). Falls back to the empty string if
- * no web tool call is present (caller hides the row).
- */
-function deriveCurrentStepTitle(
+function shouldUseLegacyWebSearchCard(
   toolCalls: ChatMessageToolCall[],
-  liveWebActivity: Record<string, ToolActivityMetadata>,
-): string {
-  for (let i = toolCalls.length - 1; i >= 0; i--) {
-    const tc = toolCalls[i]!;
-    if (!isWebTool(tc)) continue;
-    const metadata = resolveMetadata(tc, liveWebActivity);
-    const terminal = isTerminalStatus(tc);
-    // web_search_error precedence mirrors the step builder: error row when
-    // the search itself failed and there are no results to surface.
-    if (
-      metadata?.webSearch &&
-      metadata.webSearch.errorMessage &&
-      metadata.webSearch.results.length === 0
-    ) {
-      return "Web search failed";
-    }
-    if (tc.toolName === "web_search") {
-      return webSearchStepTitle(terminal);
-    }
-    if (tc.toolName === "web_fetch") {
-      // web_fetch steps render under a generic "Thinking" row in the
-      // expanded body (the selector currently maps fetches to a `thinking`
-      // descriptor). Mirror that label in the header so the carousel
-      // transition stays semantically aligned with what the user sees on
-      // expand.
-      return "Thinking";
-    }
-  }
-  return "";
+): boolean {
+  if (!hasWebTool(toolCalls)) return false;
+  // Mixed-group guard — `TranscriptMessageBody` groups consecutive tool
+  // calls into a single card; a mix of web + non-web must defer to the
+  // legacy card so every call still renders.
+  if (!toolCalls.every((tc) => WEB_TOOL_NAMES.has(tc.toolName))) return false;
+  // Pending-confirmation guard — the legacy card threads approve/deny UI
+  // that the web-search card doesn't render.
+  if (toolCalls.some((tc) => tc.pendingConfirmation != null)) return false;
+  return true;
 }
 
 /**
- * Results to feed the collapsed-header `WebsiteCarousel` (favicon + title
- * chips rotating). Returns the result list from the most recently completed
- * `web_search` tool call, or an empty array when nothing has landed yet.
- *
- * Why the *latest* search only (not a flatMap across all searches):
- * - Keeps the carousel "current" — what the model just looked at rotates,
- *   re-feeding as each subsequent search completes.
- * - Bounds the rotation cycle to a single search's `resultCount` (~5 items
- *   @2.5s = ~12.5s full loop), so the carousel doesn't drag through a
- *   20-item backlog by the end of a long turn.
- *
- * Skips searches with no results — both empty-results-with-error rows and
- * pristine in-flight calls — so the carousel only ever feeds on real data.
+ * Narrow the unified card output to the legacy shape. Steps are cast to
+ * `StepDescriptor[]` — every step emitted for purely-web groups is already
+ * one of the three legacy descriptor kinds by construction (the `tool`
+ * variant only appears for non-web tools, filtered out by the guards).
  */
-function deriveCarouselItems(
-  toolCalls: ChatMessageToolCall[],
-  liveWebActivity: Record<string, ToolActivityMetadata>,
-): WebSearchResultItem[] {
-  for (let i = toolCalls.length - 1; i >= 0; i--) {
-    const tc = toolCalls[i]!;
-    if (tc.toolName !== "web_search") continue;
-    const metadata = resolveMetadata(tc, liveWebActivity);
-    const results = metadata?.webSearch?.results;
-    if (results && results.length > 0) return results;
-  }
-  return [];
+function narrowToWebSearchCardData(
+  unified: ToolCallCardData,
+): WebSearchCardData {
+  return {
+    currentStepTitle: unified.currentStepTitle,
+    currentStepInfo: unified.currentStepInfo,
+    stepCount: unified.stepCount,
+    steps: unified.steps as StepDescriptor[],
+    // For purely-web groups, the wider state collapses to the legacy
+    // two-value enum (no denied confirmations, errors collapse to complete
+    // per the legacy contract).
+    state: unified.state === "loading" ? "loading" : "complete",
+    carouselItems: unified.carouselItems,
+  };
 }
 
 /**
- * Per-step gray subtext shown in the collapsed header. The card carousels
- * through this value alongside `currentStepTitle` so each transition reads
- * as a discrete step. Driven by the *most recent* web tool call.
- *
- * Strategy (walks tool calls in reverse so the latest wins):
- *   1. web_search with `errorMessage` and empty results → the error message.
- *   2. web_search with any results (in-flight or terminal) → the *last*
- *      result's `title`. The trailing result is the most recently surfaced
- *      to the user, so it reads as "what we just looked at".
- *   3. web_search in-flight with no results yet → `Searching <query>` from
- *      the tool-call input, falling back to empty when no query is present.
- *   4. web_fetch in-flight → `Reading <domain>` derived from the metadata
- *      (or, when metadata is absent, the tool-call input URL's host).
- *   5. web_fetch terminal → `metadata.title ?? metadata.domain`.
- *   6. Reload fallback: a terminal web_search with no metadata but a
- *      parseable `tc.result` string dump → the last recovered title.
- *   7. Otherwise (historical reopen with nothing to recover) → empty
- *      string.
- */
-function deriveCurrentStepInfo(
-  toolCalls: ChatMessageToolCall[],
-  liveWebActivity: Record<string, ToolActivityMetadata>,
-): string {
-  for (let i = toolCalls.length - 1; i >= 0; i--) {
-    const tc = toolCalls[i]!;
-    if (!isWebTool(tc)) continue;
-    const metadata = resolveMetadata(tc, liveWebActivity);
-    const terminal = isTerminalStatus(tc);
-
-    if (metadata?.webSearch) {
-      const ws = metadata.webSearch;
-      if (ws.errorMessage && ws.results.length === 0) {
-        return ws.errorMessage;
-      }
-      if (ws.results.length > 0) {
-        return ws.results[ws.results.length - 1]!.title;
-      }
-      // Live metadata exists but no results yet (mid-stream). Prefer the
-      // query from metadata over the input field — it's the canonical
-      // copy the provider acted on.
-      if (!terminal && ws.query) {
-        return `Searching ${ws.query}`;
-      }
-    }
-
-    if (metadata?.webFetch) {
-      const wf = metadata.webFetch;
-      if (terminal) {
-        return wf.title ?? wf.domain;
-      }
-      return `Reading ${wf.domain}`;
-    }
-
-    // No metadata path
-    if (tc.toolName === "web_search") {
-      if (!terminal) {
-        const query =
-          typeof tc.input?.query === "string" ? tc.input.query.trim() : "";
-        return query ? `Searching ${query}` : "";
-      }
-      // Reload fallback — parse the daemon's result-string dump and use
-      // the last recovered title so the header still reads as a page
-      // title rather than empty.
-      if (typeof tc.result === "string") {
-        const parsed = parseWebSearchResultText(tc.result);
-        if (parsed.length > 0) {
-          const title = parsed[parsed.length - 1]!.title;
-          // Some providers (Perplexity citations) have URL-only entries —
-          // skip those rather than fall back to an empty string.
-          if (title) return title;
-        }
-      }
-    }
-
-    if (tc.toolName === "web_fetch") {
-      // No metadata — best-effort `Reading <host>` from `tc.input.url` so
-      // the header is useful while the fetch is in flight.
-      const url = typeof tc.input?.url === "string" ? tc.input.url : "";
-      const host = url ? extractDomain(url) : "";
-      if (host) return terminal ? host : `Reading ${host}`;
-    }
-  }
-  return "";
-}
-
-export function useWebSearchCardData(
-  toolCalls: ChatMessageToolCall[],
-): WebSearchCardData | null {
-  // Subscribe directly to the turn store — no React context required.
-  // The store returns the canonical empty-object reference between
-  // terminal transitions so identity stays stable when nothing is live.
-  const liveWebActivity = useTurnStore.use.liveWebActivity();
-  return computeWebSearchCardData(toolCalls, liveWebActivity);
-}
-
-/**
- * Pure projection of (toolCalls, liveWebActivity) → card props. Split out
- * from the hook so tests can drive it without React context plumbing.
+ * Pure projection compatible with the historical signature. Returns
+ * `null` for the same set of cases the original implementation did so the
+ * upstream call site keeps falling back to the legacy card unchanged.
  */
 export function computeWebSearchCardData(
   toolCalls: ChatMessageToolCall[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
 ): WebSearchCardData | null {
-  const hasAnyWebTool = toolCalls.some(isWebTool);
-  if (!hasAnyWebTool) return null;
+  if (!shouldUseLegacyWebSearchCard(toolCalls)) return null;
+  return narrowToWebSearchCardData(
+    computeToolCallCardData(toolCalls, liveWebActivity, null),
+  );
+}
 
-  // Mixed-group guard: `TranscriptMessageBody` groups consecutive tool calls
-  // into a single `ToolCallProgressCard`. When such a group mixes web and
-  // non-web tool calls (e.g. `web_search` + `bash`), short-circuiting to the
-  // web-search card silently drops the non-web entries because the iteration
-  // below skips them. Defer to the legacy card whenever the group isn't
-  // purely web tools so every call still renders.
-  if (!toolCalls.every(isWebTool)) return null;
-
-  // Pending-confirmation guard: when strict-mode permission prompts a web
-  // tool, the legacy `ToolCallProgressCard` surfaces approve/deny buttons via
-  // `pendingConfirmationToolCallId` + `onConfirmationSubmit`. The new card
-  // path doesn't thread that UI, so bail to the legacy card whenever any tool
-  // call is awaiting confirmation — otherwise the user is stuck on
-  // "Searching..." indefinitely.
-  if (toolCalls.some((tc) => tc.pendingConfirmation != null)) return null;
-
-  const steps: StepDescriptor[] = [];
-  let anyInFlight = false;
-
-  for (const tc of toolCalls) {
-    if (!isWebTool(tc)) continue;
-    const metadata = resolveMetadata(tc, liveWebActivity);
-    const terminal = isTerminalStatus(tc);
-    if (!terminal) anyInFlight = true;
-    if (metadata?.webSearch) {
-      const ws = metadata.webSearch;
-      // Error-state precedence: when the search itself failed the provider
-      // emits `errorMessage` and `results` is empty — surface a distinct
-      // error row instead of an empty results row that reads as success.
-      if (ws.errorMessage && ws.results.length === 0) {
-        steps.push(buildWebSearchErrorStep(ws));
-      } else {
-        steps.push(buildWebSearchStep(ws, terminal));
-      }
-    } else if (metadata?.webFetch) {
-      steps.push(buildWebFetchStep(metadata.webFetch));
-    } else if (!terminal) {
-      steps.push(buildPlaceholderStep());
-    } else if (tc.toolName === "web_search" && typeof tc.result === "string") {
-      // Terminal `web_search` with no structured metadata anywhere — most
-      // likely a page reload (the daemon doesn't persist `activityMetadata`
-      // per v1 scope, only `result: string` survives in the snapshot).
-      // Best-effort parse the text dump so the row still shows favicon
-      // chips rather than "0 links". webFetch's `result` is the raw page
-      // body — not worth parsing — so we let it fall through to the empty
-      // fallback below.
-      const parsed = buildWebSearchStepFromResultText(tc.result);
-      if (parsed) {
-        steps.push(parsed);
-      } else {
-        steps.push(buildEmptyWebSearchStep());
-      }
-    } else {
-      // Terminal status, no metadata, no parseable result text — emit an
-      // empty `web_search` row so the new card chrome still renders.
-      steps.push(buildEmptyWebSearchStep());
-    }
-  }
-
-  const state: "loading" | "complete" = anyInFlight ? "loading" : "complete";
-  const currentStepTitle = deriveCurrentStepTitle(toolCalls, liveWebActivity);
-  const currentStepInfo = deriveCurrentStepInfo(toolCalls, liveWebActivity);
-  const carouselItems = deriveCarouselItems(toolCalls, liveWebActivity);
-  const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
-
-  return {
-    currentStepTitle,
-    currentStepInfo,
-    stepCount,
-    steps,
-    state,
-    carouselItems,
-  };
+export function useWebSearchCardData(
+  toolCalls: ChatMessageToolCall[],
+): WebSearchCardData | null {
+  // Hook is unconditionally called to keep React's rules-of-hooks happy;
+  // the cheap subscription is wasted in the no-web-tool fall-through but
+  // that path renders the legacy card anyway and re-walks the same data.
+  const unified = useToolCallCardData(toolCalls, null);
+  if (!shouldUseLegacyWebSearchCard(toolCalls)) return null;
+  return narrowToWebSearchCardData(unified);
 }


### PR DESCRIPTION
## Summary
- New useToolCallCardData / computeToolCallCardData that handle web and non-web tool groups uniformly.
- Adds the 'tool' step variant alongside the existing thinking/web_search/web_search_error kinds.
- Threads leadingThinkingText through so any group can surface a preceding assistant text delta.
- Re-exports useWebSearchCardData as a thin wrapper so PR 6 can switch consumers cleanly.

Part of plan: unify-tool-progress-cards.md (PR 5 of 9)