### PR TITLE
fix(web): restore post-onboarding auto-greet message send

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -671,6 +671,20 @@ export function ChatPage() {
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
 
+  // Auto-send generic onboarding greet when the pending flag fires and no
+  // content-automation initialMessage is queued (avoids double-send).
+  useEffect(() => {
+    if (!_autoGreetPending || !activeConversationKey || !assistantId) return;
+    if (pendingOnboardingInitialMessageRef.current !== null) return;
+    setAutoGreetPending(false);
+    if (awaitingAutoGreetTimeoutRef.current) {
+      clearTimeout(awaitingAutoGreetTimeoutRef.current);
+      awaitingAutoGreetTimeoutRef.current = null;
+    }
+    autoGreetRef.current = false;
+    void sendMessage("Wake up, my friend!");
+  }, [_autoGreetPending, activeConversationKey, assistantId, sendMessage]);
+
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add missing useEffect that observes _autoGreetPending and calls sendMessage('Wake up, my friend!') after history loads empty on a fresh onboarding
- Guards against double-send when content-automation cohort already sets initialMessage via pendingOnboardingInitialMessageRef

Part of plan: fix-web-auto-greet.md (PR 1 of 2)

Closes LUM-1824