### PR TITLE
feat(web): add SubagentInlineProgressCard using the shared shell

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -39,6 +39,12 @@
     "avatar",
     "subagents"
   ],
+  "src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx": [
+    "subagents"
+  ],
+  "src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx": [
+    "avatar"
+  ],
   "src/domains/chat/components/subagent-progress-card.tsx": [
     "avatar",
     "subagents"
@@ -97,6 +103,12 @@
   "src/domains/chat/hooks/use-stream-event-handler.ts": [
     "conversations",
     "messaging"
+  ],
+  "src/domains/chat/hooks/use-subagent-card-data.test.ts": [
+    "subagents"
+  ],
+  "src/domains/chat/hooks/use-subagent-card-data.ts": [
+    "subagents"
   ],
   "src/domains/chat/hooks/use-tool-call-card-data.ts": [
     "messaging"

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -499,6 +499,14 @@ export interface SubagentInnerEvent {
   input?: Record<string, unknown>;
   toolName?: string;
   isError?: boolean;
+  /**
+   * Tool-use block ID for client-side correlation. Present on
+   * `tool_use_start` and `tool_result` envelopes; used to pair a result
+   * with its originating call when a subagent emits parallel calls to
+   * the same tool (e.g. two `bash` calls) which `toolName` alone cannot
+   * disambiguate.
+   */
+  toolUseId?: string;
 }
 
 export interface SubagentEventWrapperEvent {

--- a/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests for `SubagentInlineProgressCard`.
+ *
+ * Drives the Zustand subagent store with fixture timelines and asserts
+ * the rendered shell's title/info/pill transitions, the spawn-race
+ * `null` fallback, and the deterministic avatar trait variation across
+ * subagent IDs.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.js";
+import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function spawn(id: string, label = "Research Agent") {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label,
+    objective: "Find the answer",
+    timestamp: NOW,
+  });
+  useSubagentStore.getState().changeStatus({
+    subagentId: id,
+    status: "running",
+  });
+}
+
+describe("SubagentInlineProgressCard — spawn race", () => {
+  test("renders null when no entry exists in the store yet", () => {
+    const { container } = render(
+      <SubagentInlineProgressCard subagentId="missing" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("SubagentInlineProgressCard — fixture timeline", () => {
+  test("shows Thinking title with text preview while a text event is the latest", () => {
+    spawn("sa-1");
+    useSubagentStore.getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "assistant_text_delta", text: "Checking the docs" },
+      timestamp: NOW + 100,
+    });
+
+    const { getByText, getByTestId } = render(
+      <SubagentInlineProgressCard subagentId="sa-1" />,
+    );
+
+    expect(getByText("Thinking")).toBeTruthy();
+    expect(getByText("Checking the docs")).toBeTruthy();
+    expect(getByText("1 step")).toBeTruthy();
+    expect(getByTestId("subagent-inline-card-shell")).toBeTruthy();
+  });
+
+  test("transitions to Working when a tool_call lands after text", () => {
+    spawn("sa-2");
+    const store = useSubagentStore.getState();
+    store.receiveEvent({
+      subagentId: "sa-2",
+      event: { type: "assistant_text_delta", text: "Searching" },
+      timestamp: NOW + 100,
+    });
+    store.receiveEvent({
+      subagentId: "sa-2",
+      event: {
+        type: "tool_use_start",
+        toolName: "bash",
+        input: { command: "ls -la" },
+      },
+      timestamp: NOW + 200,
+    });
+
+    const { getByText } = render(
+      <SubagentInlineProgressCard subagentId="sa-2" />,
+    );
+    expect(getByText("Working")).toBeTruthy();
+    expect(getByText("ls -la")).toBeTruthy();
+    expect(getByText("2 steps")).toBeTruthy();
+  });
+
+  test("renders Used <Tool> when subagent reaches completed after a tool_result", () => {
+    spawn("sa-3");
+    const store = useSubagentStore.getState();
+    store.receiveEvent({
+      subagentId: "sa-3",
+      event: {
+        type: "tool_use_start",
+        toolName: "file_read",
+        input: { file_path: "/etc/hosts" },
+      },
+      timestamp: NOW + 100,
+    });
+    store.receiveEvent({
+      subagentId: "sa-3",
+      event: {
+        type: "tool_result",
+        toolName: "file_read",
+        result: "127.0.0.1 localhost",
+      },
+      timestamp: NOW + 2200,
+    });
+    store.changeStatus({ subagentId: "sa-3", status: "completed" });
+
+    const { getByText } = render(
+      <SubagentInlineProgressCard subagentId="sa-3" />,
+    );
+    expect(getByText("Used File Read")).toBeTruthy();
+    expect(getByText("1 step")).toBeTruthy();
+  });
+
+  test("renders the deterministic avatar in the leading slot", () => {
+    spawn("sa-avatar");
+    const { container } = render(
+      <SubagentInlineProgressCard subagentId="sa-avatar" />,
+    );
+    expect(
+      container.querySelector('[aria-label="Subagent sa-avatar"]'),
+    ).not.toBeNull();
+  });
+});
+
+describe("SubagentInlineProgressCard — action rail", () => {
+  test("clicking the open button invokes onSubagentClick", () => {
+    spawn("sa-open");
+    const seen: string[] = [];
+    const { getByTestId } = render(
+      <SubagentInlineProgressCard
+        subagentId="sa-open"
+        onSubagentClick={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByTestId("subagent-inline-card-open"));
+    expect(seen).toEqual(["sa-open"]);
+  });
+
+  test("clicking the open button does NOT toggle the shell's expanded state", () => {
+    spawn("sa-open-isolation");
+    // Give the shell at least one step so disableExpand is false and the
+    // body would be reachable on toggle.
+    act(() => {
+      useSubagentStore.getState().receiveEvent({
+        subagentId: "sa-open-isolation",
+        event: { type: "assistant_text_delta", text: "reasoning" },
+        timestamp: NOW + 100,
+      });
+    });
+    const { getByTestId, queryByRole } = render(
+      <SubagentInlineProgressCard
+        subagentId="sa-open-isolation"
+        onSubagentClick={() => {}}
+      />,
+    );
+
+    const expandButton = queryByRole("button", { name: /expand steps/i });
+    expect(expandButton?.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(getByTestId("subagent-inline-card-open"));
+
+    const stillCollapsed = queryByRole("button", {
+      name: /expand steps/i,
+    });
+    expect(stillCollapsed?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  test("stop button only renders while the subagent is in-flight", () => {
+    spawn("sa-stop");
+    const seen: string[] = [];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentInlineProgressCard
+        subagentId="sa-stop"
+        onStopSubagent={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByTestId("subagent-inline-card-stop"));
+    expect(seen).toEqual(["sa-stop"]);
+
+    act(() => {
+      useSubagentStore.getState().changeStatus({
+        subagentId: "sa-stop",
+        status: "completed",
+      });
+    });
+    expect(queryByTestId("subagent-inline-card-stop")).toBeNull();
+  });
+});
+
+describe("SubagentInlineProgressCard — deterministic avatar traits", () => {
+  test("different subagent IDs render different avatar DOM", () => {
+    spawn("sa-trait-a");
+    spawn("sa-trait-b-something-different");
+
+    const a = render(<SubagentInlineProgressCard subagentId="sa-trait-a" />);
+    const b = render(
+      <SubagentInlineProgressCard subagentId="sa-trait-b-something-different" />,
+    );
+    // The two avatar SVG markup should differ (deterministic-per-id traits).
+    const aAvatar = a.container.querySelector(
+      '[aria-label="Subagent sa-trait-a"]',
+    );
+    const bAvatar = b.container.querySelector(
+      '[aria-label="Subagent sa-trait-b-something-different"]',
+    );
+    expect(aAvatar).not.toBeNull();
+    expect(bAvatar).not.toBeNull();
+    expect(aAvatar?.innerHTML).not.toBe(bAvatar?.innerHTML);
+  });
+});

--- a/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -1,0 +1,169 @@
+/**
+ * Inline subagent progress card rendered per-subagent in the assistant
+ * transcript. Built on `ToolProgressCardShell` with the
+ * `SubagentAvatarChip` slotted into the leading-icon slot per
+ * Figma node `4922-103839`.
+ *
+ * Subscribes to the subagent store via `useSubagentCardData(subagentId)`.
+ * Returns `null` when the entry isn't in the store yet — handles the
+ * spawn race where the assistant message containing the inline card
+ * mounts a hair before the `subagent_spawned` SSE event lands. PR 8
+ * wires this into the transcript; this PR ships the component standalone.
+ *
+ * Interaction model:
+ *   - Clicking the card header expands/collapses the body inline (the
+ *     shell's default behaviour).
+ *   - The "open" affordance in the right rail opens the subagent's full
+ *     timeline panel via `onSubagentClick` — matches the existing
+ *     `SubagentProgressCard` interaction so users with deep timelines
+ *     keep the side-panel route. We keep both behaviours per the PR
+ *     plan so users don't lose the panel during the inline-card rollout.
+ *   - Stop is exposed via `onStopSubagent`; the shell renders a small
+ *     stop chip in the right rail next to the open button while the
+ *     subagent is in-flight.
+ */
+
+import { ExternalLink, Square } from "lucide-react";
+import { useCallback, type MouseEvent } from "react";
+
+import { Typography } from "@vellum/design-library";
+
+import { SubagentAvatarChip } from "@/domains/avatar/subagent-avatar-chip.js";
+import { ThinkingChip } from "@/domains/chat/components/web-search/thinking-chip.js";
+import { StepRow } from "@/domains/chat/components/web-search/step-row.js";
+import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell.js";
+import { useSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data.js";
+
+export interface SubagentInlineProgressCardProps {
+  subagentId: string;
+  /**
+   * Invoked when the user activates the "open full timeline" button in
+   * the right rail. Routes to the subagent detail panel — same contract
+   * as `SubagentProgressCard.onSubagentClick`.
+   */
+  onSubagentClick?: (subagentId: string) => void;
+  /**
+   * Invoked when the user activates the stop button while the subagent
+   * is in-flight. Omitted callers hide the button entirely.
+   */
+  onStopSubagent?: (subagentId: string) => void;
+}
+
+export function SubagentInlineProgressCard({
+  subagentId,
+  onSubagentClick,
+  onStopSubagent,
+}: SubagentInlineProgressCardProps) {
+  const data = useSubagentCardData(subagentId);
+  // The shell's `loading` state subsumes running / pending / awaiting_input
+  // (see `deriveCardState` in use-subagent-card-data) — exactly the window
+  // where stopping the subagent is a meaningful action.
+  const isRunning = data?.state === "loading";
+
+  const handleOpen = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onSubagentClick?.(subagentId);
+    },
+    [onSubagentClick, subagentId],
+  );
+
+  const handleStop = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onStopSubagent?.(subagentId);
+    },
+    [onStopSubagent, subagentId],
+  );
+
+  // Spawn-race: assistant message references a subagent before the
+  // `subagent_spawned` event lands. Render `null` rather than a blank
+  // shell so the transcript doesn't flicker an empty card.
+  if (!data) return null;
+
+  const leadingIcon = <SubagentAvatarChip subagentId={subagentId} size={16} />;
+
+  return (
+    <div className="relative w-full" data-testid="subagent-inline-progress-card">
+      <ToolProgressCardShell
+        data-testid="subagent-inline-card-shell"
+        statusIndicatorTestId="subagent-inline-card-status-indicator"
+        state={data.state}
+        leadingIcon={leadingIcon}
+        currentStepTitle={data.currentStepTitle}
+        currentStepInfo={data.currentStepInfo}
+        stepCount={data.stepCount}
+        disableExpand={data.steps.length === 0}
+      >
+        <div className="flex w-full flex-col gap-3 px-3 pb-3">
+          {data.steps.map((step, idx) => {
+            if (step.kind === "thinking") {
+              return (
+                <StepRow key={idx} title="Thinking">
+                  <ThinkingChip>{step.text}</ThinkingChip>
+                </StepRow>
+              );
+            }
+            if (step.kind === "tool_error") {
+              return (
+                <StepRow key={idx} title="Error" tone="error">
+                  <ThinkingChip>{step.message}</ThinkingChip>
+                </StepRow>
+              );
+            }
+            return (
+              <StepRow
+                key={idx}
+                title={step.title}
+                durationLabel={step.durationLabel}
+                tone={step.status === "error" ? "error" : "default"}
+              >
+                {step.info ? (
+                  <ThinkingChip>{step.info}</ThinkingChip>
+                ) : (
+                  <Typography
+                    variant="label-small-default"
+                    className="text-[var(--content-tertiary)]"
+                  >
+                    {step.status === "running" ? "Working…" : "Done"}
+                  </Typography>
+                )}
+              </StepRow>
+            );
+          })}
+        </div>
+      </ToolProgressCardShell>
+      {/* Right-rail action cluster — absolute-positioned over the shell's
+          header so the shell stays a pure presentational primitive. The
+          shell already exposes a "step count" pill on the right; the
+          actions render to the *left* of that pill via the absolute
+          overlay so they don't clip the existing layout. */}
+      {(onSubagentClick || (onStopSubagent && isRunning)) && (
+        <div className="pointer-events-none absolute right-[64px] top-[14px] flex items-center gap-1">
+          {onStopSubagent && isRunning && (
+            <button
+              type="button"
+              aria-label="Stop subagent"
+              data-testid="subagent-inline-card-stop"
+              onClick={handleStop}
+              className="pointer-events-auto flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--system-negative-strong)]"
+            >
+              <Square className="h-3 w-3" fill="currentColor" />
+            </button>
+          )}
+          {onSubagentClick && (
+            <button
+              type="button"
+              aria-label="Open subagent timeline"
+              data-testid="subagent-inline-card-open"
+              onClick={handleOpen}
+              className="pointer-events-auto flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -111,25 +111,31 @@ export function SubagentInlineProgressCard({
                 </StepRow>
               );
             }
-            return (
-              <StepRow
-                key={idx}
-                title={step.title}
-                durationLabel={step.durationLabel}
-                tone={step.status === "error" ? "error" : "default"}
-              >
-                {step.info ? (
-                  <ThinkingChip>{step.info}</ThinkingChip>
-                ) : (
-                  <Typography
-                    variant="label-small-default"
-                    className="text-[var(--content-tertiary)]"
-                  >
-                    {step.status === "running" ? "Working…" : "Done"}
-                  </Typography>
-                )}
-              </StepRow>
-            );
+            if (step.kind === "tool") {
+              return (
+                <StepRow
+                  key={idx}
+                  title={step.title}
+                  durationLabel={step.durationLabel}
+                  tone={step.status === "error" ? "error" : "default"}
+                >
+                  {step.info ? (
+                    <ThinkingChip>{step.info}</ThinkingChip>
+                  ) : (
+                    <Typography
+                      variant="label-small-default"
+                      className="text-[var(--content-tertiary)]"
+                    >
+                      {step.status === "running" ? "Working…" : "Done"}
+                    </Typography>
+                  )}
+                </StepRow>
+              );
+            }
+            // `web_search` / `web_search_error` aren't produced by
+            // `useSubagentCardData` today, but the unified step union
+            // includes them — render nothing rather than crash.
+            return null;
           })}
         </div>
       </ToolProgressCardShell>

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -72,9 +72,11 @@ function basename(path: string): string {
 /**
  * Title-case a snake_case / kebab-case tool name for the fallback label.
  * Kept local so this module has zero deps on the legacy `tool-call-chip` code,
- * which PRs 5+ will retire.
+ * which PRs 5+ will retire. Exported for reuse by adjacent consumers (e.g. the
+ * subagent inline card) that need the same "Tool Name" → "Tool Name" mapping
+ * but operate on a different tool-call shape than `ChatMessageToolCall`.
  */
-function humanizeToolName(toolName: string): string {
+export function humanizeToolName(toolName: string): string {
   return toolName
     .split(/[_-]+/)
     .filter((part) => part.length > 0)

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -131,6 +131,7 @@ describe("computeSubagentCardData — step mapping", () => {
           makeEvent({
             type: "tool_call",
             toolName: "file_read",
+            toolUseId: "tu-file-1",
             content: "src/foo.ts",
           }),
         ],
@@ -140,14 +141,14 @@ describe("computeSubagentCardData — step mapping", () => {
     const step = data.steps[0]!;
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
-      expect(step.toolName).toBe("file_read");
       expect(step.title).toBe("Using File Read");
       expect(step.info).toBe("src/foo.ts");
       expect(step.status).toBe("running");
+      expect(step.toolCallId).toBe("tu-file-1");
     }
   });
 
-  test("tool_call → tool_result transitions the step to complete with a duration", () => {
+  test("tool_call → tool_result transitions the step to completed with a duration", () => {
     const data = computeSubagentCardData(
       makeEntry({
         events: [
@@ -176,7 +177,7 @@ describe("computeSubagentCardData — step mapping", () => {
     const step = data.steps[0]!;
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
-      expect(step.status).toBe("complete");
+      expect(step.status).toBe("completed");
       expect(step.durationLabel).toBe("3s");
     }
   });
@@ -243,8 +244,55 @@ describe("computeSubagentCardData — step mapping", () => {
     expect(data.steps).toHaveLength(2);
     const bash = data.steps[0]!;
     const fileRead = data.steps[1]!;
-    if (bash.kind === "tool") expect(bash.status).toBe("complete");
-    if (fileRead.kind === "tool") expect(fileRead.status).toBe("complete");
+    if (bash.kind === "tool") expect(bash.status).toBe("completed");
+    if (fileRead.kind === "tool") expect(fileRead.status).toBe("completed");
+  });
+
+  test("parallel calls to the same tool are disambiguated by toolUseId", () => {
+    // Two bash calls in flight; the SECOND one's result lands first.
+    // Matching by `toolName` alone would close the first step (wrong);
+    // matching by `toolUseId` must close the second.
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-A",
+              content: "first",
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              content: "second",
+            },
+            1,
+          ),
+          makeEvent(
+            { type: "tool_result", toolName: "bash", toolUseId: "tu-B" },
+            2,
+          ),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(2);
+    const first = data.steps[0]!;
+    const second = data.steps[1]!;
+    // First bash call must still be running — its tu-A id wasn't closed.
+    if (first.kind === "tool") {
+      expect(first.status).toBe("running");
+      expect(first.toolCallId).toBe("tu-A");
+    }
+    // Second call must be completed — its tu-B id matched the result.
+    if (second.kind === "tool") {
+      expect(second.status).toBe("completed");
+      expect(second.toolCallId).toBe("tu-B");
+    }
   });
 });
 
@@ -266,6 +314,30 @@ describe("computeSubagentCardData — current step title/info", () => {
       makeEntry({ status: "completed", label: "Find tigers" }),
     );
     expect(data.currentStepTitle).toBe("Finished");
+    expect(data.currentStepInfo).toBe("Find tigers");
+  });
+
+  test("no steps + failed → Failed + error message", () => {
+    // Early-failure path: the subagent failed before emitting any
+    // timeline events (e.g. spawn error or rate limit on first call).
+    // The header must not read "Finished".
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "failed",
+        label: "Research crash",
+        error: "Rate limited",
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Failed");
+    expect(data.currentStepInfo).toBe("Rate limited");
+  });
+
+  test("no steps + aborted → Aborted + label fallback", () => {
+    const data = computeSubagentCardData(
+      makeEntry({ status: "aborted", label: "Find tigers" }),
+    );
+    expect(data.currentStepTitle).toBe("Aborted");
+    // No error string → falls back to the label.
     expect(data.currentStepInfo).toBe("Find tigers");
   });
 
@@ -390,11 +462,13 @@ describe("mapToolEventToStep", () => {
       type: "tool_call",
       content: "summary",
       toolName: "host_bash",
+      toolUseId: "tu-1",
       timestamp: 0,
     });
     expect(step.title).toBe("Using Host Bash");
     expect(step.info).toBe("summary");
     expect(step.status).toBe("running");
+    expect(step.toolCallId).toBe("tu-1");
   });
 
   test("falls back to a generic title when toolName is missing", () => {
@@ -405,6 +479,6 @@ describe("mapToolEventToStep", () => {
       timestamp: 0,
     });
     expect(step.title).toBe("Running tool");
-    expect(step.toolName).toBe("");
+    expect(step.toolCallId).toBe("");
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Tests for `computeSubagentCardData` — the pure projection that
+ * `useSubagentCardData` wraps. Driving the pure function avoids the
+ * React + Zustand context plumbing and keeps coverage focused on the
+ * `SubagentEntry → ToolCallCardData` mapping.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeSubagentCardData,
+  mapToolEventToStep,
+} from "@/domains/chat/hooks/use-subagent-card-data.js";
+import type {
+  SubagentEntry,
+  SubagentTimelineEvent,
+} from "@/domains/subagents/subagent-store.js";
+
+const NOW = 1700000000000;
+
+function makeEntry(
+  overrides: Partial<SubagentEntry> & {
+    events?: SubagentTimelineEvent[];
+  } = {},
+): SubagentEntry {
+  return {
+    subagentId: "sa-1",
+    label: "Research Agent",
+    objective: "Find the root cause",
+    status: "running",
+    isFork: false,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCost: 0,
+    spawnedAt: NOW,
+    events: [],
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  i: number = 0,
+): SubagentTimelineEvent {
+  return {
+    id: `te-${i}`,
+    content: "",
+    timestamp: NOW + i * 100,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State derivation
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — state derivation", () => {
+  test("running entry → loading state", () => {
+    const data = computeSubagentCardData(makeEntry({ status: "running" }));
+    expect(data.state).toBe("loading");
+  });
+
+  test("pending entry → loading state", () => {
+    const data = computeSubagentCardData(makeEntry({ status: "pending" }));
+    expect(data.state).toBe("loading");
+  });
+
+  test("awaiting_input entry → loading state", () => {
+    const data = computeSubagentCardData(
+      makeEntry({ status: "awaiting_input" }),
+    );
+    expect(data.state).toBe("loading");
+  });
+
+  test("completed entry → complete state", () => {
+    const data = computeSubagentCardData(makeEntry({ status: "completed" }));
+    expect(data.state).toBe("complete");
+  });
+
+  test("failed entry → error state", () => {
+    const data = computeSubagentCardData(makeEntry({ status: "failed" }));
+    expect(data.state).toBe("error");
+  });
+
+  test("aborted entry → error state", () => {
+    const data = computeSubagentCardData(makeEntry({ status: "aborted" }));
+    expect(data.state).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step mapping
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — step mapping", () => {
+  test("text event becomes a thinking step trimmed to 160 chars", () => {
+    const longText = "x".repeat(300);
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [makeEvent({ type: "text", content: longText })],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("thinking");
+    if (step.kind === "thinking") {
+      // 159 chars + ellipsis = 160.
+      expect(step.text.length).toBe(160);
+      expect(step.text.endsWith("…")).toBe(true);
+    }
+  });
+
+  test("empty text events are skipped", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({ type: "text", content: "   " }),
+          makeEvent({ type: "text", content: "" }),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(0);
+  });
+
+  test("tool_call event becomes a running tool step", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "file_read",
+            content: "src/foo.ts",
+          }),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("tool");
+    if (step.kind === "tool") {
+      expect(step.toolName).toBe("file_read");
+      expect(step.title).toBe("Using File Read");
+      expect(step.info).toBe("src/foo.ts");
+      expect(step.status).toBe("running");
+    }
+  });
+
+  test("tool_call → tool_result transitions the step to complete with a duration", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              content: "ls",
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              content: "ok",
+              timestamp: NOW + 2500,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("tool");
+    if (step.kind === "tool") {
+      expect(step.status).toBe("complete");
+      expect(step.durationLabel).toBe("3s");
+    }
+  });
+
+  test("tool_result with isError flips the tool step to error", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({ type: "tool_call", toolName: "bash" }, 0),
+          makeEvent(
+            { type: "tool_result", toolName: "bash", isError: true },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    if (step.kind === "tool") {
+      expect(step.status).toBe("error");
+    }
+  });
+
+  test("error event appends a tool_error step and closes any in-flight tool", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({ type: "tool_call", toolName: "bash" }, 0),
+          makeEvent({ type: "error", content: "Out of context window" }, 1),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(2);
+    const tool = data.steps[0]!;
+    const err = data.steps[1]!;
+    if (tool.kind === "tool") expect(tool.status).toBe("error");
+    expect(err.kind).toBe("tool_error");
+    if (err.kind === "tool_error") {
+      expect(err.message).toBe("Out of context window");
+    }
+  });
+
+  test("tool_result without a matching in-flight tool is ignored", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [makeEvent({ type: "tool_result", toolName: "bash" })],
+      }),
+    );
+    expect(data.steps).toHaveLength(0);
+  });
+
+  test("out-of-order tool_call/tool_result with toolName matches the right step", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({ type: "tool_call", toolName: "bash" }, 0),
+          makeEvent({ type: "tool_call", toolName: "file_read" }, 1),
+          // file_read finishes first.
+          makeEvent({ type: "tool_result", toolName: "file_read" }, 2),
+          makeEvent({ type: "tool_result", toolName: "bash" }, 3),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(2);
+    const bash = data.steps[0]!;
+    const fileRead = data.steps[1]!;
+    if (bash.kind === "tool") expect(bash.status).toBe("complete");
+    if (fileRead.kind === "tool") expect(fileRead.status).toBe("complete");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Header carousel content
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — current step title/info", () => {
+  test("no steps + running → Working + label", () => {
+    const data = computeSubagentCardData(
+      makeEntry({ status: "running", label: "Find tigers" }),
+    );
+    expect(data.currentStepTitle).toBe("Working");
+    expect(data.currentStepInfo).toBe("Find tigers");
+  });
+
+  test("no steps + completed → Finished + label", () => {
+    const data = computeSubagentCardData(
+      makeEntry({ status: "completed", label: "Find tigers" }),
+    );
+    expect(data.currentStepTitle).toBe("Finished");
+    expect(data.currentStepInfo).toBe("Find tigers");
+  });
+
+  test("latest step is text + running → Thinking + preview", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [makeEvent({ type: "text", content: "Hmm, let me check." })],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Thinking");
+    expect(data.currentStepInfo).toBe("Hmm, let me check.");
+  });
+
+  test("latest step is text + completed → Thought + preview", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [makeEvent({ type: "text", content: "Done." })],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Thought");
+    expect(data.currentStepInfo).toBe("Done.");
+  });
+
+  test("latest step is a running tool → Working + info", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "bash",
+            content: "ls -la",
+          }),
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Working");
+    expect(data.currentStepInfo).toBe("ls -la");
+  });
+
+  test("latest step is a closed tool + still running → Finalizing", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({ type: "tool_call", toolName: "bash" }, 0),
+          makeEvent({ type: "tool_result", toolName: "bash" }, 1),
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Finalizing");
+  });
+
+  test("latest step is a closed tool + terminal → Used <Tool>", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent({ type: "tool_call", toolName: "file_read" }, 0),
+          makeEvent({ type: "tool_result", toolName: "file_read" }, 1),
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Used File Read");
+  });
+
+  test("latest step is an error → Errored + message", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "failed",
+        events: [makeEvent({ type: "error", content: "rate-limited" })],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Errored");
+    expect(data.currentStepInfo).toBe("rate-limited");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step count
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — step count", () => {
+  test("0 steps renders pluralised pill", () => {
+    const data = computeSubagentCardData(makeEntry());
+    expect(data.stepCount).toBe("0 steps");
+  });
+
+  test("1 step renders singular pill", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [makeEvent({ type: "text", content: "alone" })],
+      }),
+    );
+    expect(data.stepCount).toBe("1 step");
+  });
+
+  test("multiple steps render pluralised pill with count", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({ type: "text", content: "a" }, 0),
+          makeEvent({ type: "text", content: "b" }, 1),
+          makeEvent({ type: "text", content: "c" }, 2),
+        ],
+      }),
+    );
+    expect(data.stepCount).toBe("3 steps");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapToolEventToStep helper (exposed for the inline adapter contract)
+// ---------------------------------------------------------------------------
+
+describe("mapToolEventToStep", () => {
+  test("derives a Using <Tool> title from snake_case names", () => {
+    const step = mapToolEventToStep({
+      id: "te-1",
+      type: "tool_call",
+      content: "summary",
+      toolName: "host_bash",
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Using Host Bash");
+    expect(step.info).toBe("summary");
+    expect(step.status).toBe("running");
+  });
+
+  test("falls back to a generic title when toolName is missing", () => {
+    const step = mapToolEventToStep({
+      id: "te-2",
+      type: "tool_call",
+      content: "",
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Running tool");
+    expect(step.toolName).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -10,18 +10,19 @@
  * card renders `null` in that window so the transcript layout doesn't
  * jiggle.
  *
- * This module is intentionally self-contained: it owns the
- * `ToolCallCardData` / `ToolCallCardStep` types it emits. The pure
- * projection `computeSubagentCardData(entry)` is exported alongside the
- * hook so tests can drive it without React or the Zustand context.
+ * Types (`ToolCallCardData`, `ToolCallCardStep`) are imported from
+ * `use-tool-call-card-data.ts` so the subagent and tool-call cards share
+ * one renderer-contract source of truth. The subagent-only `tool_error`
+ * variant lives in that same union — see the file header there for the
+ * full per-kind table.
  *
  * Step-kind mapping:
  * - `text` timeline event → `kind: "thinking"` with the content trimmed
  *   to a single line of ≤160 chars.
  * - `tool_call` timeline event → `kind: "tool"` with a humanised title
  *   derived from `toolName`. A subsequent `tool_result` event for the
- *   same tool flips the step's `status` to `"complete"` (or `"error"`
- *   when `isError` is set) and stamps a duration label.
+ *   same `toolUseId` flips the step's `status` to `"completed"` (or
+ *   `"error"` when `isError` is set) and stamps a duration label.
  * - `error` timeline event → `kind: "tool_error"` with the event content
  *   as the surfaced error message. Closes any preceding in-flight tool
  *   step so the body doesn't show a stale loader.
@@ -37,41 +38,13 @@ import {
 import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
 import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell.js";
 import { humanizeToolName } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
-import { formatMs } from "@/domains/chat/hooks/use-web-search-card-data.js";
+import {
+  formatMs,
+  type ToolCallCardData,
+  type ToolCallCardStep,
+} from "@/domains/chat/hooks/use-tool-call-card-data.js";
 
-// ---------------------------------------------------------------------------
-// Public types — mirrors the shape PR 5 (useToolCallCardData) will land.
-// ---------------------------------------------------------------------------
-
-/**
- * A single sub-step inside the expanded card. Discriminated by `kind`:
- *  - `"thinking"`   → text reasoning step (no tool involved).
- *  - `"tool"`       → tool invocation step. `status` flips from
- *                     `"running"` → `"complete"` / `"error"` once the
- *                     matching `tool_result` arrives.
- *  - `"tool_error"` → a tool-error timeline event with no preceding
- *                     in-flight `tool_call` (e.g. a synthesised abort).
- */
-export type ToolCallCardStep =
-  | { kind: "thinking"; text: string }
-  | {
-      kind: "tool";
-      toolName: string;
-      title: string;
-      info: string;
-      status: "running" | "complete" | "error";
-      durationLabel?: string;
-    }
-  | { kind: "tool_error"; message: string };
-
-/** Props the unified tool-progress card consumes. */
-export interface ToolCallCardData {
-  state: ToolProgressCardState;
-  currentStepTitle: string;
-  currentStepInfo: string;
-  stepCount: string;
-  steps: ToolCallCardStep[];
-}
+export type { ToolCallCardData, ToolCallCardStep };
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -96,6 +69,11 @@ function trimTextPreview(input: string): string {
  * step. Exposed for testability — kept separate from `deriveStepLabel`
  * because the subagent timeline event has a different shape (`toolName`
  * + `content` summary) than the assistant-side `ChatMessageToolCall`.
+ *
+ * `iconName` is hard-coded to `"bolt"` (the generic-tool icon) and
+ * `toolCallId` mirrors `toolUseId` so the renderer key + result matcher
+ * have a stable identifier. The inline card renderer doesn't consume
+ * `iconName` today, so the value is effectively a placeholder.
  */
 export function mapToolEventToStep(
   event: SubagentTimelineEvent,
@@ -103,7 +81,9 @@ export function mapToolEventToStep(
   const toolName = event.toolName ?? "";
   return {
     kind: "tool",
-    toolName,
+    durationLabel: "",
+    toolCallId: event.toolUseId ?? "",
+    iconName: "bolt",
     title: toolName ? `Using ${humanizeToolName(toolName)}` : "Running tool",
     info: event.content ?? "",
     status: "running",
@@ -144,36 +124,56 @@ export function computeSubagentCardData(
   entry: SubagentEntry,
 ): ToolCallCardData {
   const steps: ToolCallCardStep[] = [];
-  // Parallel array tracking the `tool_call` timestamp for each `tool`
-  // step so the matching `tool_result` can compute a duration. Indexed
+  // Parallel array tracking per-tool metadata not carried on the shared
+  // `tool` step shape: the start timestamp (for duration calc) and the
+  // originating `toolName` (so the resting "Used <Tool>" header can
+  // re-humanise the name without re-parsing the title string). Indexed
   // by `steps` position; `undefined` for non-tool entries.
-  const toolStartTs: Array<number | undefined> = [];
+  const toolMeta: Array<
+    { startTs: number; toolName: string } | undefined
+  > = [];
 
   for (const event of entry.events) {
     if (event.type === "text") {
       const text = trimTextPreview(event.content);
       // Skip empty text events — they'd render as a blank thinking step.
       if (text.length === 0) continue;
-      steps.push({ kind: "thinking", text });
-      toolStartTs.push(undefined);
+      steps.push({ kind: "thinking", durationLabel: "", text });
+      toolMeta.push(undefined);
       continue;
     }
 
     if (event.type === "tool_call") {
       steps.push(mapToolEventToStep(event));
-      toolStartTs.push(event.timestamp);
+      toolMeta.push({
+        startTs: event.timestamp,
+        toolName: event.toolName ?? "",
+      });
       continue;
     }
 
     if (event.type === "tool_result") {
       // Close the most recent matching in-flight tool step. Match by
-      // `toolName` when available so an out-of-order pair doesn't close
-      // the wrong step; fall back to "latest in-flight tool" otherwise.
+      // `toolUseId` when both sides carry one — subagent streams can
+      // contain parallel calls to the same tool (e.g. two `bash`) which
+      // `toolName` alone cannot disambiguate. Fall back to `toolName`
+      // when the result lacks a `toolUseId`, and to "latest in-flight"
+      // when neither identifier is present.
       let matchIndex = -1;
       for (let i = steps.length - 1; i >= 0; i--) {
         const step = steps[i]!;
         if (step.kind !== "tool" || step.status !== "running") continue;
-        if (!event.toolName || step.toolName === event.toolName) {
+        if (event.toolUseId) {
+          if (step.toolCallId === event.toolUseId) {
+            matchIndex = i;
+            break;
+          }
+          // When the result has a toolUseId, require an exact match —
+          // do NOT fall through to toolName matching for a different ID.
+          continue;
+        }
+        const stepToolName = toolMeta[i]?.toolName ?? "";
+        if (!event.toolName || stepToolName === event.toolName) {
           matchIndex = i;
           break;
         }
@@ -183,14 +183,14 @@ export function computeSubagentCardData(
         ToolCallCardStep,
         { kind: "tool" }
       >;
-      const start = toolStartTs[matchIndex];
+      const start = toolMeta[matchIndex]?.startTs;
       const durationLabel =
         typeof start === "number" && Number.isFinite(start)
           ? formatMs(event.timestamp - start)
-          : undefined;
+          : "";
       steps[matchIndex] = {
         ...target,
-        status: event.isError ? "error" : "complete",
+        status: event.isError ? "error" : "completed",
         durationLabel,
       };
       continue;
@@ -207,7 +207,7 @@ export function computeSubagentCardData(
       }
       const message = trimTextPreview(event.content) || "Subagent error";
       steps.push({ kind: "tool_error", message });
-      toolStartTs.push(undefined);
+      toolMeta.push(undefined);
       continue;
     }
   }
@@ -216,6 +216,7 @@ export function computeSubagentCardData(
   const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
     entry,
     steps,
+    toolMeta,
   );
 
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
@@ -226,6 +227,11 @@ export function computeSubagentCardData(
     currentStepInfo,
     stepCount,
     steps,
+    // Subagent cards don't use the web-search carousel or the
+    // leading-icon slot exposed by `ToolCallCardData`. The inline
+    // renderer slots its own `SubagentAvatarChip` into the shell.
+    carouselItems: [],
+    leadingIcon: null,
   };
 }
 
@@ -237,7 +243,8 @@ export function computeSubagentCardData(
  *   - latest step is a completed tool → "Used <Tool>"
  *   - latest step is an error → "Errored"
  *   - no steps yet but status is running → "Working"
- *   - no steps and status terminal → "Finished"
+ *   - no steps and status `completed` → "Finished"
+ *   - no steps and status `failed` / `aborted` → "Failed" / "Aborted"
  *
  * "Finalizing" — status is `running` but there are steps and no tool
  * currently in flight — reads as "the subagent has work in progress but
@@ -247,6 +254,7 @@ export function computeSubagentCardData(
 function deriveCurrentStep(
   entry: SubagentEntry,
   steps: ToolCallCardStep[],
+  toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
 ): { currentStepTitle: string; currentStepInfo: string } {
   const isTerminal =
     entry.status === "completed" ||
@@ -254,9 +262,19 @@ function deriveCurrentStep(
     entry.status === "aborted";
 
   if (steps.length === 0) {
+    // Branch on the actual terminal status so a subagent that failed or
+    // aborted before emitting any events doesn't read as "Finished".
+    let title: string;
+    if (entry.status === "failed") title = "Failed";
+    else if (entry.status === "aborted") title = "Aborted";
+    else if (entry.status === "completed") title = "Finished";
+    else title = "Working";
     return {
-      currentStepTitle: isTerminal ? "Finished" : "Working",
-      currentStepInfo: entry.label,
+      currentStepTitle: title,
+      // Falls back to the label when `error` is missing OR an empty
+      // string — daemon errors are sometimes set to "" before a real
+      // message lands, and an empty subtitle would read as a layout bug.
+      currentStepInfo: entry.error || entry.label,
     };
   }
 
@@ -289,19 +307,25 @@ function deriveCurrentStep(
         currentStepInfo: latest.info,
       };
     }
+    const toolName = toolMeta[steps.length - 1]?.toolName ?? "";
     return {
-      currentStepTitle: latest.toolName
-        ? `Used ${humanizeToolName(latest.toolName)}`
+      currentStepTitle: toolName
+        ? `Used ${humanizeToolName(toolName)}`
         : "Done",
       currentStepInfo: latest.info,
     };
   }
 
-  // tool_error
-  return {
-    currentStepTitle: "Errored",
-    currentStepInfo: latest.message,
-  };
+  if (latest.kind === "tool_error") {
+    return {
+      currentStepTitle: "Errored",
+      currentStepInfo: latest.message,
+    };
+  }
+
+  // `web_search` / `web_search_error` aren't produced by this hook today,
+  // but the union includes them — fall through to a neutral header.
+  return { currentStepTitle: "", currentStepInfo: "" };
 }
 
 /**

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -1,0 +1,320 @@
+/**
+ * Builds the props for `SubagentInlineProgressCard` from a single
+ * subagent's store entry. Translates the subagent's timeline events
+ * (`SubagentTimelineEvent[]`) into the unified `ToolCallCardStep[]`
+ * shape consumed by the shared tool-progress card chrome.
+ *
+ * The hook returns `null` when no entry exists for the given subagent ID
+ * yet — that's the spawn-race case where the assistant message containing
+ * the inline card mounts before the `subagent_spawned` event lands. The
+ * card renders `null` in that window so the transcript layout doesn't
+ * jiggle.
+ *
+ * This module is intentionally self-contained: it owns the
+ * `ToolCallCardData` / `ToolCallCardStep` types it emits. The pure
+ * projection `computeSubagentCardData(entry)` is exported alongside the
+ * hook so tests can drive it without React or the Zustand context.
+ *
+ * Step-kind mapping:
+ * - `text` timeline event → `kind: "thinking"` with the content trimmed
+ *   to a single line of ≤160 chars.
+ * - `tool_call` timeline event → `kind: "tool"` with a humanised title
+ *   derived from `toolName`. A subsequent `tool_result` event for the
+ *   same tool flips the step's `status` to `"complete"` (or `"error"`
+ *   when `isError` is set) and stamps a duration label.
+ * - `error` timeline event → `kind: "tool_error"` with the event content
+ *   as the surfaced error message. Closes any preceding in-flight tool
+ *   step so the body doesn't show a stale loader.
+ */
+
+import { useMemo } from "react";
+
+import {
+  useSubagentStore,
+  type SubagentEntry,
+  type SubagentTimelineEvent,
+} from "@/domains/subagents/subagent-store.js";
+import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
+import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell.js";
+import { humanizeToolName } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+import { formatMs } from "@/domains/chat/hooks/use-web-search-card-data.js";
+
+// ---------------------------------------------------------------------------
+// Public types — mirrors the shape PR 5 (useToolCallCardData) will land.
+// ---------------------------------------------------------------------------
+
+/**
+ * A single sub-step inside the expanded card. Discriminated by `kind`:
+ *  - `"thinking"`   → text reasoning step (no tool involved).
+ *  - `"tool"`       → tool invocation step. `status` flips from
+ *                     `"running"` → `"complete"` / `"error"` once the
+ *                     matching `tool_result` arrives.
+ *  - `"tool_error"` → a tool-error timeline event with no preceding
+ *                     in-flight `tool_call` (e.g. a synthesised abort).
+ */
+export type ToolCallCardStep =
+  | { kind: "thinking"; text: string }
+  | {
+      kind: "tool";
+      toolName: string;
+      title: string;
+      info: string;
+      status: "running" | "complete" | "error";
+      durationLabel?: string;
+    }
+  | { kind: "tool_error"; message: string };
+
+/** Props the unified tool-progress card consumes. */
+export interface ToolCallCardData {
+  state: ToolProgressCardState;
+  currentStepTitle: string;
+  currentStepInfo: string;
+  stepCount: string;
+  steps: ToolCallCardStep[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEXT_PREVIEW_MAX = 160;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Trim newlines + collapse whitespace, then clamp to TEXT_PREVIEW_MAX. */
+function trimTextPreview(input: string): string {
+  const collapsed = input.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= TEXT_PREVIEW_MAX) return collapsed;
+  // -1 to leave room for the ellipsis. Mirrors `derive-step-label.ts`.
+  return collapsed.slice(0, TEXT_PREVIEW_MAX - 1) + "…";
+}
+
+/**
+ * Map a subagent `tool_call` timeline event into a fresh in-flight `tool`
+ * step. Exposed for testability — kept separate from `deriveStepLabel`
+ * because the subagent timeline event has a different shape (`toolName`
+ * + `content` summary) than the assistant-side `ChatMessageToolCall`.
+ */
+export function mapToolEventToStep(
+  event: SubagentTimelineEvent,
+): Extract<ToolCallCardStep, { kind: "tool" }> {
+  const toolName = event.toolName ?? "";
+  return {
+    kind: "tool",
+    toolName,
+    title: toolName ? `Using ${humanizeToolName(toolName)}` : "Running tool",
+    info: event.content ?? "",
+    status: "running",
+  };
+}
+
+/**
+ * Translate the subagent's status to a shell-compatible visual state.
+ * `awaiting_input` is treated as `"loading"` (the subagent is waiting on
+ * a human reply but the card chrome still reads as in-flight). `aborted`
+ * surfaces as `"error"` so the card doesn't read as a clean completion.
+ */
+function deriveCardState(status: SubagentStatus): ToolProgressCardState {
+  switch (status) {
+    case "running":
+    case "pending":
+    case "awaiting_input":
+      return "loading";
+    case "completed":
+      return "complete";
+    case "failed":
+    case "aborted":
+      return "error";
+    default:
+      return "loading";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure projection of (entry) → card props. Split from the hook so tests
+ * can drive it without instantiating the Zustand store.
+ */
+export function computeSubagentCardData(
+  entry: SubagentEntry,
+): ToolCallCardData {
+  const steps: ToolCallCardStep[] = [];
+  // Parallel array tracking the `tool_call` timestamp for each `tool`
+  // step so the matching `tool_result` can compute a duration. Indexed
+  // by `steps` position; `undefined` for non-tool entries.
+  const toolStartTs: Array<number | undefined> = [];
+
+  for (const event of entry.events) {
+    if (event.type === "text") {
+      const text = trimTextPreview(event.content);
+      // Skip empty text events — they'd render as a blank thinking step.
+      if (text.length === 0) continue;
+      steps.push({ kind: "thinking", text });
+      toolStartTs.push(undefined);
+      continue;
+    }
+
+    if (event.type === "tool_call") {
+      steps.push(mapToolEventToStep(event));
+      toolStartTs.push(event.timestamp);
+      continue;
+    }
+
+    if (event.type === "tool_result") {
+      // Close the most recent matching in-flight tool step. Match by
+      // `toolName` when available so an out-of-order pair doesn't close
+      // the wrong step; fall back to "latest in-flight tool" otherwise.
+      let matchIndex = -1;
+      for (let i = steps.length - 1; i >= 0; i--) {
+        const step = steps[i]!;
+        if (step.kind !== "tool" || step.status !== "running") continue;
+        if (!event.toolName || step.toolName === event.toolName) {
+          matchIndex = i;
+          break;
+        }
+      }
+      if (matchIndex === -1) continue;
+      const target = steps[matchIndex] as Extract<
+        ToolCallCardStep,
+        { kind: "tool" }
+      >;
+      const start = toolStartTs[matchIndex];
+      const durationLabel =
+        typeof start === "number" && Number.isFinite(start)
+          ? formatMs(event.timestamp - start)
+          : undefined;
+      steps[matchIndex] = {
+        ...target,
+        status: event.isError ? "error" : "complete",
+        durationLabel,
+      };
+      continue;
+    }
+
+    if (event.type === "error") {
+      // If there's an in-flight tool, close it as error.
+      for (let i = steps.length - 1; i >= 0; i--) {
+        const step = steps[i]!;
+        if (step.kind === "tool" && step.status === "running") {
+          steps[i] = { ...step, status: "error" };
+          break;
+        }
+      }
+      const message = trimTextPreview(event.content) || "Subagent error";
+      steps.push({ kind: "tool_error", message });
+      toolStartTs.push(undefined);
+      continue;
+    }
+  }
+
+  const state = deriveCardState(entry.status);
+  const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
+    entry,
+    steps,
+  );
+
+  const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
+
+  return {
+    state,
+    currentStepTitle,
+    currentStepInfo,
+    stepCount,
+    steps,
+  };
+}
+
+/**
+ * Derive the carousel `(title, info)` tuple from the entry status + step
+ * stream. The title reflects what the subagent is doing *right now*:
+ *   - latest step is `thinking` → "Thinking" (or "Thought" terminal)
+ *   - latest step is a running tool → "Working"
+ *   - latest step is a completed tool → "Used <Tool>"
+ *   - latest step is an error → "Errored"
+ *   - no steps yet but status is running → "Working"
+ *   - no steps and status terminal → "Finished"
+ *
+ * "Finalizing" — status is `running` but there are steps and no tool
+ * currently in flight — reads as "the subagent has work in progress but
+ * isn't actively waiting on a tool result". This matches the macOS
+ * subagent header semantics so cross-platform copy stays aligned.
+ */
+function deriveCurrentStep(
+  entry: SubagentEntry,
+  steps: ToolCallCardStep[],
+): { currentStepTitle: string; currentStepInfo: string } {
+  const isTerminal =
+    entry.status === "completed" ||
+    entry.status === "failed" ||
+    entry.status === "aborted";
+
+  if (steps.length === 0) {
+    return {
+      currentStepTitle: isTerminal ? "Finished" : "Working",
+      currentStepInfo: entry.label,
+    };
+  }
+
+  const latest = steps[steps.length - 1]!;
+
+  if (latest.kind === "thinking") {
+    // Subagent has emitted text most recently. If it's still running
+    // we're "Thinking"; if it's terminal we surface the past tense so
+    // the resting card doesn't read as live.
+    return {
+      currentStepTitle: isTerminal ? "Thought" : "Thinking",
+      currentStepInfo: latest.text,
+    };
+  }
+
+  if (latest.kind === "tool") {
+    const inFlight = latest.status === "running";
+    if (inFlight) {
+      return {
+        currentStepTitle: "Working",
+        currentStepInfo: latest.info,
+      };
+    }
+    // Tool just closed — title swaps to "Used <Tool>". When the
+    // subagent reports `running` after a tool closed (no new tool in
+    // flight, no text yet) we read as "Finalizing".
+    if (!isTerminal) {
+      return {
+        currentStepTitle: "Finalizing",
+        currentStepInfo: latest.info,
+      };
+    }
+    return {
+      currentStepTitle: latest.toolName
+        ? `Used ${humanizeToolName(latest.toolName)}`
+        : "Done",
+      currentStepInfo: latest.info,
+    };
+  }
+
+  // tool_error
+  return {
+    currentStepTitle: "Errored",
+    currentStepInfo: latest.message,
+  };
+}
+
+/**
+ * React hook: subscribe to the subagent store entry for `subagentId`
+ * and project it into `ToolCallCardData`. Returns `null` when no entry
+ * exists yet (spawn race) so callers can short-circuit rendering.
+ */
+export function useSubagentCardData(
+  subagentId: string,
+): ToolCallCardData | null {
+  const entry = useSubagentStore((state) => state.byId[subagentId]);
+  return useMemo(() => {
+    if (!entry) return null;
+    return computeSubagentCardData(entry);
+  }, [entry]);
+}

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -45,9 +45,12 @@ export const WEB_TOOL_NAMES = new Set(["web_search", "web_fetch"]);
  * The first three variants (`thinking`, `web_search`, `web_search_error`)
  * preserve the existing `StepDescriptor` shape from
  * `WebSearchProgressCard`, so the legacy renderer keeps working unchanged.
- * The new `tool` variant carries the title/info/icon tuple produced by
+ * The `tool` variant carries the title/info/icon tuple produced by
  * `deriveStepLabel` plus the per-call duration + status fields the unified
- * card needs to drive its row chrome.
+ * card needs to drive its row chrome. The `tool_error` variant is used by
+ * `useSubagentCardData` for synthesised terminal-error events that have
+ * no preceding `tool_call` (e.g. context-window blowouts surfaced via
+ * the subagent timeline's `error` event type).
  */
 export type ToolCallCardStep =
   | { kind: "thinking"; durationLabel: string; text: string }
@@ -73,7 +76,8 @@ export type ToolCallCardStep =
       iconName: IconName;
       toolCallId: string;
       status: "running" | "completed" | "error" | "denied";
-    };
+    }
+  | { kind: "tool_error"; message: string };
 
 /**
  * Card-level data for the unified tool-call progress card.

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -26,6 +26,13 @@ export interface SubagentTimelineEvent {
   toolName?: string;
   isError?: boolean;
   timestamp: number;
+  /**
+   * Tool-use block ID copied from the daemon's `tool_use_start` /
+   * `tool_result` envelopes. Lets the UI pair a result with its
+   * originating call when a subagent makes parallel calls to the same
+   * tool (which `toolName` alone cannot disambiguate).
+   */
+  toolUseId?: string;
 }
 
 export interface SubagentEntry {
@@ -259,6 +266,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       toolName: params.event.toolName,
       isError: params.event.isError,
       timestamp: params.timestamp,
+      toolUseId: params.event.toolUseId,
     };
 
     set({


### PR DESCRIPTION
## Summary
- Standalone inline card per subagent built on ToolProgressCardShell, using SubagentAvatarChip in the leading-icon slot per Figma 4922-103839.
- New useSubagentCardData hook reads the subagent store and maps timeline events to ToolCallCardSteps.
- Not yet rendered in the transcript — PR 8 wires the inline cards in and removes the bottom-of-message SubagentProgressCard.

Part of plan: unify-tool-progress-cards.md (PR 7 of 9)