### PR TITLE
refactor(web): unify all tool-call progress cards on ToolProgressCardShell

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -284,17 +284,17 @@ describe("ToolCallProgressCard — unknown-command nudge", () => {
         input: { command: "frobnicate" },
       }),
     ];
-    let dismissed: string | null = null;
+    const dismissed: { value: string | null } = { value: null };
     const { getByLabelText } = renderCard(toolCalls, {
       unknownNudgeToolCallIds: new Set(["tc-1"]),
       onOpenRuleEditor: () => {},
       onDismissUnknownNudge: (id) => {
-        dismissed = id;
+        dismissed.value = id;
       },
       expandedCardIds: new Map([["tc-1", true]]),
     });
     fireEvent.click(getByLabelText("Dismiss"));
-    expect(dismissed).toBe("tc-1");
+    expect(dismissed.value).toBe("tc-1");
   });
 
   test("does not render the nudge for tool calls not in the set", () => {

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Tests for the unified `ToolCallProgressCard` dispatcher.
+ *
+ * Covers the post-unification rendering contract:
+ *  - Non-web tool groups (bash, read, MCP, etc.) render via the shared
+ *    `ToolProgressCardShell` with `useToolCallCardData`-derived header text
+ *    and step pill.
+ *  - Web-only groups continue to render through `WebSearchProgressCard` for
+ *    regression parity.
+ *  - Mixed groups (web + non-web) render through the unified shell with one
+ *    step per tool call in the expanded body.
+ *  - A pending confirmation in the group short-circuits to the inline
+ *    approve/deny UI rather than the progress-card chrome.
+ *  - A `subagent_spawn`-only group renders `null` (PR 8 wires the inline
+ *    subagent card; until then the legacy bottom card handles spawned
+ *    subagents).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeToolCall(
+  overrides: Partial<ChatMessageToolCall> & {
+    id: string;
+    toolName: string;
+  },
+): ChatMessageToolCall {
+  return {
+    input: {},
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function renderCard(
+  toolCalls: ChatMessageToolCall[],
+  overrides: Partial<
+    React.ComponentProps<typeof ToolCallProgressCard>
+  > = {},
+) {
+  return render(
+    <ToolCallProgressCard
+      toolCalls={toolCalls}
+      expandedToolCallIds={new Set()}
+      onExpandChange={() => {}}
+      expandedCardIds={new Map()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("ToolCallProgressCard — non-web tool group", () => {
+  test("renders the unified shell with the bash carousel header + step pill", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }),
+    ];
+    const { getAllByText, getByTestId } = renderCard(toolCalls);
+    // The unified card mounts the shared shell wrapper.
+    expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+    // Title comes from `deriveStepLabel("bash")`, info from the `command`
+    // input, and the step pill counts the single tool call. Title appears
+    // twice — once in the carousel header, once in the auto-expanded
+    // `ToolStepRow` body.
+    expect(getAllByText("Working (bash)").length).toBe(2);
+    expect(getAllByText("git status").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("1 step").length).toBe(1);
+  });
+
+  test("auto-expands while loading so step rows are visible without a click", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }),
+    ];
+    const { getAllByText } = renderCard(toolCalls);
+    // Title appears once in the header and once in the expanded body row.
+    expect(getAllByText("Working (bash)").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("uses the loading indicator while any tool is running", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "running" }),
+    ];
+    const { getByTestId } = renderCard(toolCalls);
+    const indicator = getByTestId("tool-progress-card-status-indicator");
+    expect(indicator.tagName).toBe("SPAN");
+  });
+
+  test("uses the complete indicator once every tool call is terminal", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+    ];
+    const { getByTestId } = renderCard(toolCalls);
+    const indicator = getByTestId("tool-progress-card-status-indicator");
+    expect(indicator.tagName.toLowerCase()).toBe("svg");
+    expect(indicator.getAttribute("data-state")).toBe("complete");
+  });
+});
+
+describe("ToolCallProgressCard — web tool group regression", () => {
+  test("web_search-only groups still render through WebSearchProgressCard", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "running",
+        input: { query: "tigers" },
+      }),
+    ];
+    const { getByTestId, queryByTestId } = renderCard(toolCalls);
+    expect(getByTestId("web-search-progress-card")).toBeTruthy();
+    // Unified shell is NOT used for purely-web groups — they continue to
+    // flow through the dedicated web-search card.
+    expect(queryByTestId("tool-progress-card-shell")).toBeNull();
+  });
+});
+
+describe("ToolCallProgressCard — mixed group", () => {
+  test("web_search + bash falls through to the unified shell with one step per call", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "running",
+        input: { query: "tigers" },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByText, getByTestId } = renderCard(toolCalls);
+    // Unified shell — the legacy web-search card bails on mixed groups.
+    expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+    expect(getByText("2 steps")).toBeTruthy();
+  });
+});
+
+describe("ToolCallProgressCard — confirmation short-circuit", () => {
+  test("pendingConfirmationToolCallId renders the inline approve/deny UI, not the progress card", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "rm -rf /" },
+        pendingConfirmation: {
+          requestId: "req-1",
+          title: "Allow bash command?",
+        },
+      }),
+    ];
+    const { getByText, queryByTestId } = renderCard(toolCalls, {
+      pendingConfirmationToolCallId: "tc-1",
+      isSubmittingConfirmation: false,
+      onConfirmationSubmit: () => {},
+    });
+    // The inline confirmation card is mounted via ToolCallChip — its title
+    // and Allow/Deny buttons should appear.
+    expect(getByText("Allow bash command?")).toBeTruthy();
+    expect(getByText("Allow")).toBeTruthy();
+    expect(getByText("Deny")).toBeTruthy();
+    // The unified shell is NOT mounted — confirmation has its own chrome.
+    expect(queryByTestId("tool-progress-card-shell")).toBeNull();
+  });
+});
+
+describe("ToolCallProgressCard — subagent_spawn-only group", () => {
+  test("renders null pending the inline subagent card in PR 8", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Investigate logs" },
+      }),
+    ];
+    const { container, queryByTestId } = renderCard(toolCalls);
+    expect(queryByTestId("tool-progress-card-shell")).toBeNull();
+    expect(queryByTestId("web-search-progress-card")).toBeNull();
+    // No DOM produced at all.
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("subagent_spawn alongside another tool DOES render the unified shell", () => {
+    // Regression guard — the null short-circuit is intentionally tight
+    // (length === 1 && first is subagent_spawn). Any other shape, including
+    // multiple subagent_spawn calls, must render the unified shell so the
+    // user still sees activity.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Investigate logs" },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByTestId } = renderCard(toolCalls);
+    expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+  });
+});
+
+describe("ToolCallProgressCard — leadingThinkingText", () => {
+  test("prepends a thinking step to the expanded body when supplied", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByText, getByText: getByText2 } = renderCard(toolCalls, {
+      leadingThinkingText: "Let me check the directory first.",
+    });
+    // The thinking text appears as a separate step row in the expanded body.
+    expect(getByText("Let me check the directory first.")).toBeTruthy();
+    // The step count reflects the prepended thinking step.
+    expect(getByText2("2 steps")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -18,7 +18,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
@@ -221,6 +221,264 @@ describe("ToolCallProgressCard — subagent_spawn-only group", () => {
     ];
     const { getByTestId } = renderCard(toolCalls);
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+  });
+});
+
+describe("ToolCallProgressCard — unknown-command nudge", () => {
+  test("renders the 'Create a rule' nudge for tool calls flagged as unknown", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "frobnicate" },
+      }),
+    ];
+    const { getByText } = renderCard(toolCalls, {
+      unknownNudgeToolCallIds: new Set(["tc-1"]),
+      onOpenRuleEditor: () => {},
+      onDismissUnknownNudge: () => {},
+      // Force the body open so the nudge inside the expanded region is in
+      // the DOM regardless of the auto-collapse-on-completion behavior.
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    expect(getByText("This command wasn't recognized.")).toBeTruthy();
+    expect(getByText("Create a rule")).toBeTruthy();
+    expect(getByText("to classify it for next time.")).toBeTruthy();
+  });
+
+  test("'Create a rule' click invokes onOpenRuleEditor with the tool call's context", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "frobnicate" },
+        riskLevel: "high",
+        riskReason: "unrecognized command",
+        allowlistOptions: [],
+        scopeOptions: [],
+        directoryScopeOptions: [],
+      }),
+    ];
+    let captured: { toolName?: string; riskLevel?: string } = {};
+    const { getByText } = renderCard(toolCalls, {
+      unknownNudgeToolCallIds: new Set(["tc-1"]),
+      onOpenRuleEditor: (ctx) => {
+        captured = { toolName: ctx.toolName, riskLevel: ctx.riskLevel };
+      },
+      onDismissUnknownNudge: () => {},
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    fireEvent.click(getByText("Create a rule"));
+    expect(captured.toolName).toBe("bash");
+    expect(captured.riskLevel).toBe("high");
+  });
+
+  test("dismiss-X button invokes onDismissUnknownNudge with the tool call id", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "frobnicate" },
+      }),
+    ];
+    let dismissed: string | null = null;
+    const { getByLabelText } = renderCard(toolCalls, {
+      unknownNudgeToolCallIds: new Set(["tc-1"]),
+      onOpenRuleEditor: () => {},
+      onDismissUnknownNudge: (id) => {
+        dismissed = id;
+      },
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    fireEvent.click(getByLabelText("Dismiss"));
+    expect(dismissed).toBe("tc-1");
+  });
+
+  test("does not render the nudge for tool calls not in the set", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+      }),
+    ];
+    const { queryByText } = renderCard(toolCalls, {
+      unknownNudgeToolCallIds: new Set([]),
+      onOpenRuleEditor: () => {},
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    expect(queryByText("This command wasn't recognized.")).toBeNull();
+  });
+});
+
+describe("ToolCallProgressCard — expansion derived from state", () => {
+  test("mounts expanded while loading", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls);
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+  });
+
+  test("collapses automatically once the card reaches a terminal state", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls);
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
+
+  test("auto-collapses on the loading → complete transition without a user toggle", () => {
+    const expandedCardIds = new Map<string, boolean>();
+    const running = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole, rerender } = render(
+      <ToolCallProgressCard
+        toolCalls={running}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+
+    const completed = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    rerender(
+      <ToolCallProgressCard
+        toolCalls={completed}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
+
+  test("user toggle wins after a state transition (manual expand survives → complete)", () => {
+    const expandedCardIds = new Map<string, boolean>();
+    const running = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole, rerender } = render(
+      <ToolCallProgressCard
+        toolCalls={running}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    // Card mounts expanded; user collapses it manually.
+    fireEvent.click(getByRole("button", { name: /collapse steps/i }));
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+    // User expands it back.
+    fireEvent.click(getByRole("button", { name: /expand steps/i }));
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+
+    // Card transitions to complete — user's explicit "expanded" must win.
+    const completed = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    rerender(
+      <ToolCallProgressCard
+        toolCalls={completed}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+  });
+
+  test("persisted expanded=false survives remount of a completed card", () => {
+    // Simulates a user who collapsed a running card; after the turn finishes
+    // the card remounts in `complete` (e.g. latest-turn → history transition)
+    // and must respect the persisted collapse decision.
+    const expandedCardIds = new Map<string, boolean>([["tc-1", false]]);
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const { getByRole } = render(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
+
+  test("persisted expanded=true overrides the auto-collapse on completion", () => {
+    const expandedCardIds = new Map<string, boolean>([["tc-1", true]]);
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const { getByRole } = render(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+      />,
+    );
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
   });
 });
 

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -1,224 +1,33 @@
 
-import {
-  AlertCircle,
-  AlertTriangle,
-  CheckCircle2,
-  ChevronDown,
-  ChevronUp,
-  Clock,
-  X,
-} from "lucide-react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { AlertCircle, X } from "lucide-react";
+import { Fragment } from "react";
 
-import { BusyIndicator } from "@/domains/chat/components/busy-indicator.js";
 import { ToolCallChip } from "@/domains/chat/components/tool-call-chip/tool-call-chip.js";
-import {
-  extractInputSummary,
-  friendlyRunningLabel,
-  progressiveLabels,
-} from "@/domains/chat/components/tool-call-chip/utils.js";
+import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.js";
+import { StepRow } from "@/domains/chat/components/web-search/step-row.js";
+import { ThinkingChip } from "@/domains/chat/components/web-search/thinking-chip.js";
 import { WebSearchProgressCard } from "@/domains/chat/components/web-search/web-search-progress-card.js";
-import { useElapsedTime } from "@/domains/chat/hooks/use-elapsed-time.js";
-import { useWebSearchCardData } from "@/domains/chat/hooks/use-web-search-card-data.js";
-import type { AllowlistOption, ChatMessageToolCall, ConfirmationDecision, DirectoryScopeOption, ScopeOption } from "@/domains/chat/api/event-types.js";
+import type { StepDescriptor } from "@/domains/chat/components/web-search/web-search-progress-card.js";
+import { Typography } from "@vellum/design-library";
 
-// ---------------------------------------------------------------------------
-// Phase system — mirrors macOS ProgressCardPhase
-// ---------------------------------------------------------------------------
-
-/**
- * Resolved display phase for the progress card header.
- *
- * - `thinking`   — all tools complete, assistant is streaming its response
- *                  (post-tool thinking gap). Mirrors macOS `.toolsCompleteThinking`.
- * - `toolRunning` — at least one tool call is in flight.
- * - `complete`   — all tools done, turn finished, no denials.
- * - `denied`     — one or more tool calls were blocked/denied.
- */
-type Phase = "thinking" | "toolRunning" | "complete" | "denied";
-
-function computePhase({
-  hasRunning,
-  allCompleted,
-  hasDenied,
-  isStreaming,
-}: {
-  hasRunning: boolean;
-  allCompleted: boolean;
-  hasDenied: boolean;
-  isStreaming: boolean;
-}): Phase {
-  // Mirrors macOS resolvePhase priority order exactly:
-  // 1. Denied takes precedence over toolRunning — if any tool was blocked and tools are
-  //    still incomplete, show denied even if another tool is still actively running.
-  //    (macOS line 288: `if hasDeniedToolCalls && hasIncompleteTools { return .denied }`)
-  if (hasDenied && !allCompleted) return "denied";
-  if (hasRunning) return "toolRunning";
-  if (allCompleted && isStreaming && !hasDenied) return "thinking";
-  return "complete";
-}
-
-// ---------------------------------------------------------------------------
-// Progressive label hook — cycles through descriptive labels for app tools
-// ---------------------------------------------------------------------------
-
-/** Interval in ms between label advances — matches macOS ~8s timing. */
-const PROGRESSIVE_LABEL_INTERVAL_MS = 8_000;
-
-/**
- * Returns the current progressive label for a running app tool, or null for
- * tools that don't have progressive labels. Advances through the label array
- * on a timer and resets when the tool call changes.
- *
- * The index is stored in state and advanced by the interval callback. When
- * `startedAt` changes (new tool invocation), the effect tears down and
- * re-runs, resetting the index to 0 via the initializer.
- */
-function useProgressiveLabel(
-  toolName: string | undefined,
-  startedAt: number | undefined,
-): string | null {
-  const labels = useMemo(
-    () => (toolName ? progressiveLabels(toolName) : []),
-    [toolName],
-  );
-
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (labels.length === 0) return;
-
-    // Reset to 0 whenever this effect re-runs (tool or startedAt changed).
-    setIndex(0);
-
-    const id = setInterval(() => {
-      setIndex((prev) => Math.min(prev + 1, labels.length - 1));
-    }, PROGRESSIVE_LABEL_INTERVAL_MS);
-
-    return () => clearInterval(id);
-  }, [labels, startedAt]);
-
-  if (labels.length === 0) return null;
-  return labels[index] ?? null;
-}
-
-// ---------------------------------------------------------------------------
-// Stall watchdog
-// ---------------------------------------------------------------------------
-
-/** Threshold (ms) after which the client considers events stalled. */
-const CLIENT_STALL_THRESHOLD_MS = 45_000;
-
-/**
- * When tool_progress events report a long-running tool, return a user-friendly
- * "still working" message. Also acts as a client-side stall watchdog: if a
- * tool has been running >45s with no progress event at all, or the last
- * progress event is >45s stale, show a stall indicator.
- */
-function stallSuffix(
-  tc: ChatMessageToolCall | undefined,
-  now: number,
-): string | null {
-  if (!tc || tc.status !== "running") return null;
-
-  // Server-driven progress: the daemon sends tool_progress every ~10s
-  if (tc.progressElapsedSec != null && tc.progressElapsedSec >= 30) {
-    if (tc.progressElapsedSec >= 60) return "This is taking longer than expected...";
-    return "Still working...";
-  }
-
-  // Client-side stall watchdog: no tool_progress events received but
-  // the tool has been running longer than the stall threshold.
-  if (tc.startedAt != null) {
-    const runningMs = now - tc.startedAt;
-    if (runningMs >= CLIENT_STALL_THRESHOLD_MS) {
-      // If we had progress events but they stopped arriving, that's a stall
-      if (tc.lastProgressAt != null) {
-        const sinceLast = now - tc.lastProgressAt;
-        if (sinceLast >= CLIENT_STALL_THRESHOLD_MS) {
-          return "Connection may be interrupted...";
-        }
-      } else {
-        // No progress events ever received — server may not support them,
-        // but tool has been running a long time
-        if (runningMs >= 60_000) return "This is taking longer than expected...";
-        return "Still working...";
-      }
-    }
-  }
-
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Headline
-// ---------------------------------------------------------------------------
-
-function computeHeadline(
-  phase: Phase,
-  totalSteps: number,
-  deniedCount: number,
-  currentRunningCall: ChatMessageToolCall | undefined,
-  firstDeniedCall: ChatMessageToolCall | undefined,
-  skillExecuteLabel: string,
-): string {
-  switch (phase) {
-    case "thinking":
-      return "Thinking...";
-
-    case "toolRunning": {
-      if (currentRunningCall) {
-        const reason = currentRunningCall.input?.reason;
-        if (typeof reason === "string" && reason.trim()) {
-          return reason.trim();
-        }
-        if (currentRunningCall.toolName === "skill_execute") {
-          return skillExecuteLabel;
-        }
-        const inputSummary = extractInputSummary(
-          currentRunningCall.toolName,
-          currentRunningCall.input,
-        );
-        const buildingStatus =
-          typeof currentRunningCall.input.building_status === "string"
-            ? currentRunningCall.input.building_status
-            : undefined;
-        return friendlyRunningLabel(currentRunningCall.toolName, inputSummary, buildingStatus);
-      }
-      const suffix = totalSteps !== 1 ? "s" : "";
-      return `Running ${totalSteps} step${suffix}`;
-    }
-
-    case "denied": {
-      // Mirrors macOS headlineText for .denied:
-      // `ChatBubble.friendlyRunningLabel(primary) + " denied"`
-      // where primary = uniqueToolNamesSorted.first. Shows e.g. "Fetching a webpage denied"
-      // rather than "Completed with N blocked permissions" — that string belongs at .complete.
-      if (firstDeniedCall) {
-        const inputSummary = extractInputSummary(firstDeniedCall.toolName, firstDeniedCall.input);
-        return `${friendlyRunningLabel(firstDeniedCall.toolName, inputSummary)} denied`;
-      }
-      const permSuffix = deniedCount !== 1 ? "s" : "";
-      return `Completed with ${deniedCount} blocked permission${permSuffix}`;
-    }
-
-    case "complete":
-    default: {
-      // Mirrors macOS headlineText for .complete with hasDeniedToolCalls:
-      // `"Completed with \(model.deniedCount) blocked permission\(s)"`
-      if (deniedCount > 0) {
-        const permSuffix = deniedCount !== 1 ? "s" : "";
-        return `Completed with ${deniedCount} blocked permission${permSuffix}`;
-      }
-      const suffix = totalSteps !== 1 ? "s" : "";
-      return `Completed ${totalSteps} step${suffix}`;
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
+import {
+  ToolProgressCardShell,
+  type ToolProgressCardState,
+} from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell.js";
+import { ToolStepRow } from "@/domains/chat/components/tool-call-progress-card/tool-step-row.js";
+import {
+  useToolCallCardData,
+  WEB_TOOL_NAMES,
+  type ToolCallCardData,
+  type ToolCallCardStep,
+} from "@/domains/chat/hooks/use-tool-call-card-data.js";
+import type {
+  AllowlistOption,
+  ChatMessageToolCall,
+  ConfirmationDecision,
+  DirectoryScopeOption,
+  ScopeOption,
+} from "@/domains/chat/api/event-types.js";
 
 export interface ToolCallProgressCardProps {
   toolCalls: ChatMessageToolCall[];
@@ -250,108 +59,252 @@ export interface ToolCallProgressCardProps {
   onDismissUnknownNudge?: (toolCallId: string) => void;
   /**
    * Whether the parent assistant message is currently streaming a response.
-   * Used to detect the post-tool thinking phase so we can show "Thinking..."
-   * instead of "Completed N steps" while the turn is still active.
+   * Retained for API compatibility with the legacy dispatcher; the unified
+   * card derives its visual state from `useToolCallCardData` instead.
    */
   isStreaming?: boolean;
+  /**
+   * Optional leading "thinking" text segment that immediately preceded this
+   * tool-call group in the message's `contentOrder`. When supplied the
+   * unified card prepends a `thinking` step to the expanded body so the
+   * carousel shows the model's reasoning before the first tool fires.
+   */
+  leadingThinkingText?: string | null;
 }
 
-function CardStatusIcon({
-  phase,
-  hasDenied,
-  isTimeout,
-}: {
-  phase: Phase;
-  hasDenied: boolean;
-  isTimeout: boolean;
-}) {
-  switch (phase) {
-    case "thinking":
-    case "toolRunning":
-      return <BusyIndicator size={8} />;
-    case "denied":
-      // Timed-out denials: clock icon in muted tertiary. Active denials: circleAlert in red.
-      // Mirrors macOS statusIcon() which checks decidedConfirmations for .timedOut.
-      return isTimeout
-        ? <Clock className="h-4 w-4 text-[var(--content-tertiary)] shrink-0" />
-        : <AlertCircle className="h-4 w-4 text-[var(--system-negative-strong)] shrink-0" />;
-    case "complete":
-    default:
-      // When some tools were blocked but the overall turn completed, show a warning
-      // triangle (systemNegativeHover) instead of a success check. Mirrors macOS
-      // statusIcon() which uses .triangleAlert when model.hasDeniedToolCalls.
-      return hasDenied
-        ? <AlertTriangle className="h-4 w-4 text-[var(--system-negative-hover)] shrink-0" />
-        : <CheckCircle2 className="h-4 w-4 text-[var(--system-positive-strong)] shrink-0" />;
+/**
+ * Unified tool-call progress card. All tool groups — web search, bash, file
+ * ops, MCP, computer use, skills — render through the shared
+ * {@link ToolProgressCardShell} driven by {@link useToolCallCardData}.
+ *
+ * Special cases short-circuit before the shell:
+ *
+ * - `pendingConfirmationToolCallId` matches a tool call in this group →
+ *   render the inline confirmation UI via {@link ToolCallChip} so the
+ *   approve/deny path is preserved bit-for-bit from the legacy card.
+ * - `subagent_spawn`-only group → return `null` until PR 8 wires the inline
+ *   subagent card; the legacy bottom-of-message `SubagentProgressCard`
+ *   continues to render the spawned subagent's progress.
+ */
+export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
+  const {
+    toolCalls,
+    pendingConfirmationToolCallId,
+    leadingThinkingText,
+  } = props;
+
+  const hasActiveConfirmation =
+    pendingConfirmationToolCallId != null &&
+    toolCalls.some((tc) => tc.id === pendingConfirmationToolCallId);
+
+  // Single subscription to the unified hook so the dispatcher and every
+  // downstream branch share the same projection. `leadingThinkingText`
+  // prepends a `thinking` step ahead of the first tool call when supplied;
+  // purely-web groups (which historically didn't have a leading-thinking
+  // slot) typically pass `null` so the prepend is a no-op.
+  const cardData = useToolCallCardData(
+    toolCalls,
+    leadingThinkingText ?? null,
+  );
+
+  // Confirmation short-circuit — render the inline approve/deny UI via the
+  // existing chip-based rendering. Bypasses the progress-card chrome
+  // entirely so the confirmation card sits flush in the transcript and the
+  // user can act on it without first expanding a collapsed card.
+  if (hasActiveConfirmation) {
+    return <ConfirmationView {...props} />;
   }
+
+  // Subagent-only group — PR 7 introduces an inline subagent card; until
+  // then the spawned subagent continues to render via the legacy bottom-of-
+  // message `SubagentProgressCard`, so this card returns nothing.
+  if (
+    toolCalls.length === 1 &&
+    toolCalls[0]?.toolName === "subagent_spawn"
+  ) {
+    return null;
+  }
+
+  // Purely-web groups continue to flow through `WebSearchProgressCard` for
+  // its mature rendering (carousel header, error chips). Mixed / non-web
+  // groups fall through to the unified shell below.
+  if (isPurelyWebGroup(toolCalls)) {
+    return <WebSearchView toolCalls={toolCalls} cardData={cardData} />;
+  }
+
+  return <UnifiedToolCallProgressCard {...props} cardData={cardData} />;
+}
+
+/**
+ * True when every tool call in the group is a web tool (`web_search` /
+ * `web_fetch`). Matches the legacy `useWebSearchCardData` predicate.
+ */
+function isPurelyWebGroup(toolCalls: ChatMessageToolCall[]): boolean {
+  if (toolCalls.length === 0) return false;
+  return toolCalls.every((tc) => WEB_TOOL_NAMES.has(tc.toolName));
+}
+
+/**
+ * Renders the web-search variant by narrowing the unified card data to the
+ * legacy `WebSearchProgressCard` props. State is recomputed from the raw
+ * tool-call statuses rather than the unified `state` because a denied
+ * confirmation can race ahead of the error `tool_result` and the legacy
+ * card has to stay in `"loading"` until the tool actually exits.
+ */
+function WebSearchView({
+  toolCalls,
+  cardData,
+}: {
+  toolCalls: ChatMessageToolCall[];
+  cardData: ToolCallCardData;
+}) {
+  const state: "loading" | "complete" = toolCalls.some(
+    (tc) => tc.status === "running",
+  )
+    ? "loading"
+    : "complete";
+  return (
+    <WebSearchProgressCard
+      currentStepTitle={cardData.currentStepTitle}
+      currentStepInfo={cardData.currentStepInfo}
+      stepCount={cardData.stepCount}
+      // Every step in a purely-web group is one of the legacy three kinds
+      // by construction — the `tool` variant only appears for non-web
+      // tools, which this branch filters out.
+      steps={cardData.steps as StepDescriptor[]}
+      state={state}
+      carouselItems={cardData.carouselItems}
+    />
+  );
+}
+
+/**
+ * Render the unified shell for a non-web tool-call group. Wraps
+ * `ToolProgressCardShell` with the step-row body that mixes
+ * `web_search` / `web_search_error` / `thinking` (from web tools or the
+ * `leadingThinkingText` slot) with the new `tool` variant emitted by
+ * `useToolCallCardData` for non-web tools.
+ */
+function UnifiedToolCallProgressCard({
+  toolCalls,
+  expandedCardIds,
+  cardData,
+}: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
+  const cardId = toolCalls[0]?.id ?? null;
+  const persistedExpanded =
+    cardId != null ? expandedCardIds.get(cardId) : undefined;
+  // Auto-expand while loading so the user can watch progress; collapse once
+  // the card reaches a terminal state. The persistent map captures the user's
+  // explicit toggle so the preference survives latest-turn → history transitions.
+  const defaultExpanded =
+    persistedExpanded ?? cardData.state === "loading";
+
+  const handleExpandChange = (next: boolean) => {
+    if (cardId != null) expandedCardIds.set(cardId, next);
+  };
+
+  const shellState: ToolProgressCardState = cardData.state;
+
+  return (
+    <ToolProgressCardShell
+      state={shellState}
+      currentStepTitle={cardData.currentStepTitle}
+      currentStepInfo={cardData.currentStepInfo}
+      stepCount={cardData.stepCount}
+      defaultExpanded={defaultExpanded}
+      onExpandChange={handleExpandChange}
+    >
+      <div className="flex w-full flex-col gap-3 px-3 pb-3">
+        {cardData.steps.map((step, idx) => (
+          <ExpandedStep key={stepKey(step, idx)} step={step} />
+        ))}
+      </div>
+    </ToolProgressCardShell>
+  );
+}
+
+/**
+ * Stable key for a step descriptor. The `tool` variant ties back to a
+ * specific tool call id; the rest of the variants are positional.
+ */
+function stepKey(step: ToolCallCardStep, idx: number): string {
+  if (step.kind === "tool") return step.toolCallId;
+  return `${step.kind}-${idx}`;
+}
+
+/**
+ * Render a single step inside the expanded body. The `web_search` /
+ * `web_search_error` / `thinking` variants reuse the chips from
+ * `WebSearchProgressCard` so the visual language stays consistent between
+ * web and mixed groups; the `tool` variant uses the new `ToolStepRow`.
+ */
+function ExpandedStep({ step }: { step: ToolCallCardStep }) {
+  if (step.kind === "thinking") {
+    return (
+      <StepRow title="Thinking" durationLabel={step.durationLabel}>
+        <ThinkingChip>{step.text}</ThinkingChip>
+      </StepRow>
+    );
+  }
+  if (step.kind === "web_search_error") {
+    return (
+      <StepRow
+        title={step.title}
+        durationLabel={step.durationLabel}
+        tone="error"
+      >
+        <ErrorChip message={step.errorMessage} />
+      </StepRow>
+    );
+  }
+  if (step.kind === "web_search") {
+    return (
+      <StepRow
+        title={step.title}
+        durationLabel={step.durationLabel}
+        linkCount={step.linkCount}
+      >
+        {step.results.map((r) => (
+          <FaviconChip
+            key={r.rank}
+            faviconUrl={r.faviconUrl}
+            title={r.title}
+            domain={r.domain}
+          />
+        ))}
+        {step.overflow && step.overflow > 0 ? (
+          <OverflowChip count={step.overflow} />
+        ) : null}
+      </StepRow>
+    );
+  }
+  return (
+    <ToolStepRow
+      title={step.title}
+      info={step.info}
+      iconName={step.iconName}
+      status={step.status}
+      durationLabel={step.durationLabel}
+    />
+  );
 }
 
 // ---------------------------------------------------------------------------
-// ThinkingRow — post-tool synthetic thinking phase row
+// Confirmation view — preserved bit-for-bit from the legacy card
 // ---------------------------------------------------------------------------
 
 /**
- * Shown at the bottom of the expanded chip list when all tools are done but
- * the assistant is still composing its reply. Ticks every second to give a
- * sense of live activity. Mirrors macOS ThinkingStepRow.
+ * Inline approve/deny UI for a group that contains an active permission
+ * prompt. Renders each tool call as an embedded `ToolCallChip` (the chip
+ * itself owns the `InlineConfirmationCard` mounting for the matching call).
+ *
+ * Kept structurally identical to the legacy card's confirmation branch so
+ * existing tests, screenshots, and keyboard flows stay unchanged.
  */
-function ThinkingRow({ sinceMs }: { sinceMs: number | undefined }) {
-  const [elapsed, setElapsed] = useState(() =>
-    sinceMs !== undefined ? Math.floor((Date.now() - sinceMs) / 1000) : 0,
-  );
-
-  useEffect(() => {
-    if (sinceMs === undefined) return;
-    const id = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - sinceMs) / 1000));
-    }, 1000);
-    return () => clearInterval(id);
-  }, [sinceMs]);
-
-  if (sinceMs === undefined) return null;
-
-  return (
-    <div className="flex items-center gap-2 pl-6 pr-3 py-2 text-body-small-default">
-      <BusyIndicator size={6} />
-      <span className="text-[var(--content-secondary)]">Thinking</span>
-      <span className="ml-auto text-[var(--content-tertiary)]">{elapsed}s</span>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
-
-export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
-  // Short-circuit to the new web-search progress card whenever the active
-  // turn has any `web_search` / `web_fetch` tool calls. The selector hook
-  // returns `null` for non-web tool calls and historical (reopened) turns —
-  // those continue through the legacy generic card rendering below.
-  //
-  // The legacy renderer is its own component so the conditional return
-  // doesn't sit in front of the legacy path's hook calls (rules-of-hooks).
-  const webSearchData = useWebSearchCardData(props.toolCalls);
-  if (webSearchData) {
-    return (
-      <WebSearchProgressCard
-        currentStepTitle={webSearchData.currentStepTitle}
-        currentStepInfo={webSearchData.currentStepInfo}
-        stepCount={webSearchData.stepCount}
-        steps={webSearchData.steps}
-        state={webSearchData.state}
-        carouselItems={webSearchData.carouselItems}
-      />
-    );
-  }
-  return <LegacyToolCallProgressCard {...props} />;
-}
-
-function LegacyToolCallProgressCard({
+function ConfirmationView({
   toolCalls,
   expandedToolCallIds,
   onExpandChange,
-  expandedCardIds,
   onOpenRuleEditor,
   isSubmittingConfirmation,
   onConfirmationSubmit,
@@ -359,244 +312,108 @@ function LegacyToolCallProgressCard({
   pendingConfirmationToolCallId,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
-  isStreaming = false,
 }: ToolCallProgressCardProps) {
-  const cardId = toolCalls[0]?.id;
-  const hasActiveConfirmation = pendingConfirmationToolCallId
-    ? toolCalls.some((tc) => tc.id === pendingConfirmationToolCallId)
-    : false;
-
-  const {
-    hasRunning,
-    hasDenied,
-    hasTimeout,
-    deniedCount,
-    earliestStart,
-    latestCompleted,
-    allCompleted,
-    currentRunningCall,
-    firstDeniedCall,
-    skillExecuteLabel,
-  } = useMemo(() => {
-    let running = false;
-    let denied = 0;
-    let timeout = false;
-    let minStart: number | undefined;
-    let maxComplete: number | undefined;
-    // Status-first: a non-running tool is done regardless of completedAt.
-    // completedAt is only used for displayed duration, not completion gating.
-    let allDone = toolCalls.length > 0;
-    let firstRunning: ChatMessageToolCall | undefined;
-    let firstDenied: ChatMessageToolCall | undefined;
-    let lastSkillLoad: ChatMessageToolCall | undefined;
-
-    for (const tc of toolCalls) {
-      if (tc.status === "running") {
-        // Decouple "actively running" from "incomplete". Only denied/timed-out tools
-        // are excluded from hasRunning — they're waiting for the daemon to send back
-        // the error tool_result, not doing active work. Approved tools (confirmationDecision
-        // === "approved") are stamped immediately on user click but are still executing,
-        // so they must stay in the running pool. Undecided tools (null) are also running.
-        // This mirrors macOS ToolCallData.isComplete (false until tool_result) vs isRunning.
-        const isDeniedDecision =
-          tc.confirmationDecision === "denied" || tc.confirmationDecision === "timed_out";
-        if (!isDeniedDecision) {
-          running = true;
-          if (!firstRunning) firstRunning = tc;
-        }
-        // allCompleted still tracks any status="running" tool, decided or not,
-        // so the "denied" branch (hasDenied && !allCompleted) fires correctly.
-        allDone = false;
-      }
-      if (tc.confirmationDecision === "denied" || tc.confirmationDecision === "timed_out") {
-        denied++;
-        if (!firstDenied) firstDenied = tc;
-      }
-      if (tc.confirmationDecision === "timed_out") {
-        timeout = true;
-      }
-      if (tc.toolName === "skill_load" && tc.status !== "running") {
-        lastSkillLoad = tc;
-      }
-      if (tc.startedAt != null && (minStart === undefined || tc.startedAt < minStart)) minStart = tc.startedAt;
-      if (tc.completedAt != null && (maxComplete === undefined || tc.completedAt > maxComplete)) maxComplete = tc.completedAt;
-    }
-
-    // Derive contextual label for skill_execute from the last completed skill_load's input.
-    // Mirrors macOS ProgressCardPresentationModel.swift lines 200-208.
-    let skillExecuteLabel = "Using a skill";
-    if (lastSkillLoad) {
-      const skillId = lastSkillLoad.input?.skill;
-      if (typeof skillId === "string" && skillId) {
-        const display = skillId.replace(/[-_]/g, " ");
-        skillExecuteLabel = `Using my ${display} skill`;
-      }
-    }
-
-    return {
-      hasRunning: running,
-      hasDenied: denied > 0,
-      hasTimeout: timeout,
-      deniedCount: denied,
-      earliestStart: minStart,
-      latestCompleted: maxComplete,
-      allCompleted: allDone,
-      currentRunningCall: firstRunning,
-      firstDeniedCall: firstDenied,
-      skillExecuteLabel,
-    };
-  }, [toolCalls]);
-
-  const phase = computePhase({ hasRunning, allCompleted, hasDenied, isStreaming });
-
-  // Tick every 5s while tools are running so stallSuffix can detect
-  // client-side stalls even when no SSE events are flowing. Stops ticking
-  // once all tools complete.
-  const [stallNow, setStallNow] = useState(Date.now);
-  useEffect(() => {
-    if (!hasRunning) return;
-    const id = setInterval(() => setStallNow(Date.now()), 5_000);
-    return () => clearInterval(id);
-  }, [hasRunning]);
-
-  // Phase-based default: auto-expand while tools are running, thinking, or
-  // denied. Collapse only once the card reaches "complete". The persistent
-  // expandedCardIds set stores the user's explicit toggle so the preference
-  // survives component remounts (e.g. latest-turn → history transition).
-  const defaultExpanded = phase !== "complete";
-  const persistedState = cardId != null ? expandedCardIds.get(cardId) : undefined;
-  const [localExpanded, setLocalExpanded] = useState<boolean | null>(null);
-  const expanded = hasActiveConfirmation || (localExpanded ?? (persistedState ?? defaultExpanded));
-
-  // Progressive label for app_create / app_refresh / app_update tools.
-  // Only used as a fallback when no server-driven status is available.
-  const progressiveLabel = useProgressiveLabel(
-    phase === "toolRunning" ? currentRunningCall?.toolName : undefined,
-    phase === "toolRunning" ? currentRunningCall?.startedAt : undefined,
-  );
-
-  const baseHeadline = computeHeadline(phase, toolCalls.length, deniedCount, currentRunningCall, firstDeniedCall, skillExecuteLabel);
-  // Server-driven content (input.reason, input.building_status) takes priority
-  // over generic progressive labels. Only fall back to progressive labels when
-  // no server-driven headline is available.
-  const hasServerDrivenHeadline = phase === "toolRunning" && currentRunningCall && (
-    (typeof currentRunningCall.input?.reason === "string" && currentRunningCall.input.reason.trim()) ||
-    (typeof currentRunningCall.input?.building_status === "string" && currentRunningCall.input.building_status)
-  );
-  // When a tool_progress event reports a stall (>=30s), override the headline
-  // with a user-friendly "still working" message. This takes highest priority
-  // so the user always sees feedback during long-running tool executions.
-  const stall = phase === "toolRunning" ? stallSuffix(currentRunningCall, stallNow) : null;
-  const headline = stall
-    ? stall
-    : (phase === "toolRunning" && progressiveLabel && !hasServerDrivenHeadline)
-      ? progressiveLabel
-      : baseHeadline;
-  const elapsed = useElapsedTime(earliestStart, allCompleted && !isStreaming, latestCompleted, "header");
-
   return (
     <div className="my-1 w-full">
-      {/* Header row */}
-      <button
-        type="button"
-        onClick={() => {
-          if (!hasActiveConfirmation && cardId != null) {
-            const next = !expanded;
-            setLocalExpanded(next);
-            expandedCardIds.set(cardId, next);
-          }
-        }}
-        className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-body-medium-default bg-[var(--surface-overlay)] cursor-default ${
-          expanded ? "rounded-b-none" : ""
-        }`}
-      >
-        <CardStatusIcon phase={phase} hasDenied={hasDenied} isTimeout={hasTimeout} />
-        <span className="shrink-0 text-[var(--content-default)]">
-          {headline}
-        </span>
-        <span className="ml-auto flex items-center gap-1.5 shrink-0">
-          {elapsed && (
-            <span className="text-label-small-default text-[var(--content-tertiary)]">
-              {elapsed}
-            </span>
-          )}
-          {expanded ? (
-            <ChevronUp className="h-4 w-4 text-[var(--content-tertiary)]" />
-          ) : (
-            <ChevronDown className="h-4 w-4 text-[var(--content-tertiary)]" />
-          )}
-        </span>
-      </button>
+      <div className="space-y-0 rounded-lg bg-[var(--surface-overlay)]">
+        {toolCalls.map((tc) => {
+          const isConfirmationTarget =
+            tc.id === pendingConfirmationToolCallId;
+          return (
+            <Fragment key={tc.id}>
+              <ToolCallChip
+                toolCall={tc}
+                defaultExpanded={expandedToolCallIds.has(tc.id)}
+                onExpandChange={(isExpanded) =>
+                  onExpandChange(tc.id, isExpanded)
+                }
+                onOpenRuleEditor={onOpenRuleEditor}
+                embedded
+                {...(isConfirmationTarget
+                  ? {
+                      isSubmittingConfirmation,
+                      isActiveConfirmation: true,
+                      onConfirmationSubmit,
+                      onAllowAndCreateRule,
+                    }
+                  : {})}
+              />
+              {unknownNudgeToolCallIds?.has(tc.id) && onOpenRuleEditor && (
+                <div className="flex items-center gap-1 pl-6 text-body-small-default text-[var(--content-tertiary)]">
+                  <span>This command wasn&apos;t recognized.</span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onOpenRuleEditor({
+                        toolName: tc.toolName,
+                        riskLevel: tc.riskLevel,
+                        riskReason: tc.riskReason,
+                        input: tc.input ?? {},
+                        allowlistOptions: tc.allowlistOptions ?? [],
+                        scopeOptions: tc.scopeOptions ?? [],
+                        directoryScopeOptions:
+                          tc.directoryScopeOptions ?? [],
+                      })
+                    }
+                    // typography: off-scale — inline link within body-small nudge
 
-      {/* Expanded content: individual tool call chips */}
-      {expanded && (
-        <div className="space-y-0 rounded-b-lg bg-[var(--surface-overlay)]">
-          {toolCalls.map((tc) => {
-            const isConfirmationTarget =
-              tc.id === pendingConfirmationToolCallId;
-            return (
-              <Fragment key={tc.id}>
-                <ToolCallChip
-                  toolCall={tc}
-                  defaultExpanded={expandedToolCallIds.has(tc.id)}
-                  onExpandChange={(isExpanded) =>
-                    onExpandChange(tc.id, isExpanded)
-                  }
-                  onOpenRuleEditor={onOpenRuleEditor}
-                  embedded
-                  {...(isConfirmationTarget
-                    ? {
-                        isSubmittingConfirmation,
-                        isActiveConfirmation: true,
-                        onConfirmationSubmit,
-                        onAllowAndCreateRule,
-                      }
-                    : {})}
-                />
-                {unknownNudgeToolCallIds?.has(tc.id) && onOpenRuleEditor && (
-                  <div className="flex items-center gap-1 pl-6 text-body-small-default text-[var(--content-tertiary)]">
-                    <span>This command wasn&apos;t recognized.</span>
+                    className="font-medium text-[var(--content-default)] underline underline-offset-2 hover:text-[var(--content-secondary)]"
+                  >
+                    Create a rule
+                  </button>
+                  <span>to classify it for next time.</span>
+                  {onDismissUnknownNudge && (
                     <button
                       type="button"
-                      onClick={() =>
-                        onOpenRuleEditor({
-                          toolName: tc.toolName,
-                          riskLevel: tc.riskLevel,
-                          riskReason: tc.riskReason,
-                          input: tc.input ?? {},
-                          allowlistOptions: tc.allowlistOptions ?? [],
-                          scopeOptions: tc.scopeOptions ?? [],
-                          directoryScopeOptions:
-                            tc.directoryScopeOptions ?? [],
-                        })
-                      }
-                      // typography: off-scale — inline link within body-small nudge
-                       
-                      className="font-medium text-[var(--content-default)] underline underline-offset-2 hover:text-[var(--content-secondary)]"
+                      aria-label="Dismiss"
+                      onClick={() => onDismissUnknownNudge(tc.id)}
+                      className="ml-1 text-[var(--content-disabled)] hover:text-[var(--content-tertiary)]"
                     >
-                      Create a rule
+                      <X className="h-3.5 w-3.5" />
                     </button>
-                    <span>to classify it for next time.</span>
-                    {onDismissUnknownNudge && (
-                      <button
-                        type="button"
-                        aria-label="Dismiss"
-                        onClick={() => onDismissUnknownNudge(tc.id)}
-                        className="ml-1 text-[var(--content-disabled)] hover:text-[var(--content-tertiary)]"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    )}
-                  </div>
-                )}
-              </Fragment>
-            );
-          })}
-          {phase === "thinking" && (
-            <ThinkingRow sinceMs={latestCompleted} />
-          )}
-        </div>
-      )}
+                  )}
+                </div>
+              )}
+            </Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small shared chips — kept local so the file is self-contained
+// ---------------------------------------------------------------------------
+
+function OverflowChip({ count }: { count: number }) {
+  return (
+    <div className="rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
+      <Typography
+        variant="body-small-emphasised"
+        className="text-[var(--content-default)]"
+      >
+        +{count} more
+      </Typography>
+    </div>
+  );
+}
+
+function ErrorChip({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="tool-progress-error-chip"
+      className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[10px] py-[6px]"
+    >
+      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+        <AlertCircle className="h-[14px] w-[14px] text-[var(--system-negative-strong)]" />
+      </span>
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--system-negative-strong)]"
+      >
+        {message}
+      </Typography>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -1,6 +1,6 @@
 
 import { AlertCircle, X } from "lucide-react";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 
 import { ToolCallChip } from "@/domains/chat/components/tool-call-chip/tool-call-chip.js";
 import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.js";
@@ -189,21 +189,18 @@ function UnifiedToolCallProgressCard({
   toolCalls,
   expandedCardIds,
   cardData,
+  onOpenRuleEditor,
+  unknownNudgeToolCallIds,
+  onDismissUnknownNudge,
 }: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
   const cardId = toolCalls[0]?.id ?? null;
-  const persistedExpanded =
-    cardId != null ? expandedCardIds.get(cardId) : undefined;
-  // Auto-expand while loading so the user can watch progress; collapse once
-  // the card reaches a terminal state. The persistent map captures the user's
-  // explicit toggle so the preference survives latest-turn → history transitions.
-  const defaultExpanded =
-    persistedExpanded ?? cardData.state === "loading";
-
-  const handleExpandChange = (next: boolean) => {
-    if (cardId != null) expandedCardIds.set(cardId, next);
-  };
+  const expanded = useCardExpanded(cardId, cardData.state, expandedCardIds);
 
   const shellState: ToolProgressCardState = cardData.state;
+
+  // Nudge rows need the raw call (riskLevel, allowlistOptions, …) which
+  // isn't carried on the step descriptor.
+  const toolCallById = new Map(toolCalls.map((tc) => [tc.id, tc]));
 
   return (
     <ToolProgressCardShell
@@ -211,15 +208,112 @@ function UnifiedToolCallProgressCard({
       currentStepTitle={cardData.currentStepTitle}
       currentStepInfo={cardData.currentStepInfo}
       stepCount={cardData.stepCount}
-      defaultExpanded={defaultExpanded}
-      onExpandChange={handleExpandChange}
+      expanded={expanded.value}
+      onExpandChange={expanded.onChange}
     >
       <div className="flex w-full flex-col gap-3 px-3 pb-3">
-        {cardData.steps.map((step, idx) => (
-          <ExpandedStep key={stepKey(step, idx)} step={step} />
-        ))}
+        {cardData.steps.map((step, idx) => {
+          const nudgeTarget =
+            step.kind === "tool" &&
+            unknownNudgeToolCallIds?.has(step.toolCallId)
+              ? toolCallById.get(step.toolCallId)
+              : undefined;
+          return (
+            <Fragment key={stepKey(step, idx)}>
+              <ExpandedStep step={step} />
+              {nudgeTarget && onOpenRuleEditor && (
+                <UnknownCommandNudge
+                  toolCall={nudgeTarget}
+                  onOpenRuleEditor={onOpenRuleEditor}
+                  onDismiss={onDismissUnknownNudge}
+                />
+              )}
+            </Fragment>
+          );
+        })}
       </div>
     </ToolProgressCardShell>
+  );
+}
+
+/**
+ * Drives the unified card's expand/collapse state. Mirrors legacy behavior:
+ * auto-expand while loading, auto-collapse on terminal state, but a user
+ * toggle (now or in a previous mount, recorded in `expandedCardIds`) wins
+ * across state transitions and remounts.
+ *
+ * `localToggle` mirrors the map mutation so React re-renders on click —
+ * mutating the map alone wouldn't trigger one.
+ */
+function useCardExpanded(
+  cardId: string | null,
+  state: ToolCallCardData["state"],
+  expandedCardIds: Map<string, boolean>,
+): { value: boolean; onChange: (next: boolean) => void } {
+  const [localToggle, setLocalToggle] = useState<boolean | undefined>(
+    undefined,
+  );
+  const persisted =
+    cardId != null ? expandedCardIds.get(cardId) : undefined;
+  const userChoice = localToggle ?? persisted;
+  const value = userChoice ?? state === "loading";
+
+  const onChange = (next: boolean) => {
+    setLocalToggle(next);
+    if (cardId != null) expandedCardIds.set(cardId, next);
+  };
+
+  return { value, onChange };
+}
+
+/**
+ * Inline "This command wasn't recognized." nudge rendered beneath a tool
+ * step whose call is flagged in `unknownNudgeToolCallIds`. Restores the
+ * legacy affordance one-for-one — same copy, same "Create a rule" link, same
+ * dismiss-X button.
+ */
+function UnknownCommandNudge({
+  toolCall,
+  onOpenRuleEditor,
+  onDismiss,
+}: {
+  toolCall: ChatMessageToolCall;
+  onOpenRuleEditor: NonNullable<ToolCallProgressCardProps["onOpenRuleEditor"]>;
+  onDismiss?: ToolCallProgressCardProps["onDismissUnknownNudge"];
+}) {
+  return (
+    <div className="flex items-center gap-1 pl-6 text-body-small-default text-[var(--content-tertiary)]">
+      <span>This command wasn&apos;t recognized.</span>
+      <button
+        type="button"
+        onClick={() =>
+          onOpenRuleEditor({
+            toolName: toolCall.toolName,
+            riskLevel: toolCall.riskLevel,
+            riskReason: toolCall.riskReason,
+            input: toolCall.input ?? {},
+            allowlistOptions: toolCall.allowlistOptions ?? [],
+            scopeOptions: toolCall.scopeOptions ?? [],
+            directoryScopeOptions: toolCall.directoryScopeOptions ?? [],
+          })
+        }
+        // typography: off-scale — inline link within body-small nudge
+        className="font-medium text-[var(--content-default)] underline underline-offset-2 hover:text-[var(--content-secondary)]"
+      >
+        Create a rule
+      </button>
+      <span>to classify it for next time.</span>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => onDismiss(toolCall.id)}
+          className="ml-1 text-[var(--content-disabled)] hover:text-[var(--content-tertiary)]"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -339,40 +433,11 @@ function ConfirmationView({
                   : {})}
               />
               {unknownNudgeToolCallIds?.has(tc.id) && onOpenRuleEditor && (
-                <div className="flex items-center gap-1 pl-6 text-body-small-default text-[var(--content-tertiary)]">
-                  <span>This command wasn&apos;t recognized.</span>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      onOpenRuleEditor({
-                        toolName: tc.toolName,
-                        riskLevel: tc.riskLevel,
-                        riskReason: tc.riskReason,
-                        input: tc.input ?? {},
-                        allowlistOptions: tc.allowlistOptions ?? [],
-                        scopeOptions: tc.scopeOptions ?? [],
-                        directoryScopeOptions:
-                          tc.directoryScopeOptions ?? [],
-                      })
-                    }
-                    // typography: off-scale — inline link within body-small nudge
-
-                    className="font-medium text-[var(--content-default)] underline underline-offset-2 hover:text-[var(--content-secondary)]"
-                  >
-                    Create a rule
-                  </button>
-                  <span>to classify it for next time.</span>
-                  {onDismissUnknownNudge && (
-                    <button
-                      type="button"
-                      aria-label="Dismiss"
-                      onClick={() => onDismissUnknownNudge(tc.id)}
-                      className="ml-1 text-[var(--content-disabled)] hover:text-[var(--content-tertiary)]"
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
-                  )}
-                </div>
+                <UnknownCommandNudge
+                  toolCall={tc}
+                  onOpenRuleEditor={onOpenRuleEditor}
+                  onDismiss={onDismissUnknownNudge}
+                />
               )}
             </Fragment>
           );

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -372,6 +372,16 @@ function ExpandedStep({ step }: { step: ToolCallCardStep }) {
       </StepRow>
     );
   }
+  if (step.kind === "tool_error") {
+    // Subagent-side error step — surfaces in mixed groups when a subagent
+    // bubbles a tool failure into the parent transcript. Mirror the
+    // web_search_error layout for visual consistency.
+    return (
+      <StepRow title="Error" tone="error">
+        <ErrorChip message={step.message} />
+      </StepRow>
+    );
+  }
   return (
     <ToolStepRow
       title={step.title}

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-step-row.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-step-row.tsx
@@ -1,0 +1,125 @@
+
+import {
+  AlertCircle,
+  Bolt,
+  CheckCircle2,
+  Code,
+  FileText,
+  Monitor,
+  Pen,
+  Plug,
+  Sparkles,
+  UserPlus,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Typography } from "@vellum/design-library";
+
+import { BusyIndicator } from "@/domains/chat/components/busy-indicator.js";
+import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+
+/**
+ * Map each `IconName` from `deriveStepLabel` to its concrete lucide icon.
+ *
+ * Centralised here so the dispatcher row doesn't have to branch on icon
+ * identifiers — `deriveStepLabel` chooses the name, this map renders it.
+ */
+const ICON_MAP: Record<IconName, LucideIcon> = {
+  code: Code,
+  file: FileText,
+  pen: Pen,
+  monitor: Monitor,
+  plug: Plug,
+  sparkle: Sparkles,
+  "user-plus": UserPlus,
+  bolt: Bolt,
+};
+
+/**
+ * A single non-web tool-call step row inside the expanded
+ * `ToolCallProgressCard`. Renders a leading status icon (busy dot while
+ * running, check / alert when terminal), a tool-specific glyph chosen via
+ * `iconName`, the step's title, an optional info subtext, and an optional
+ * duration label on the right.
+ *
+ * The row geometry mirrors the embedded `ToolCallChip` layout the unified
+ * card replaced: 24-pixel left indent under the carousel header, gap-2
+ * between status icon / glyph / label, and a right-aligned duration cluster.
+ */
+export function ToolStepRow({
+  title,
+  info,
+  iconName,
+  status,
+  durationLabel,
+}: {
+  title: string;
+  info: string;
+  iconName: IconName;
+  status: "running" | "completed" | "error" | "denied";
+  /** Pre-formatted duration label (e.g. "2s"). Empty / omitted hides the cluster. */
+  durationLabel?: string;
+}) {
+  const Glyph = ICON_MAP[iconName] ?? Bolt;
+  return (
+    <div className="flex min-w-0 items-center gap-2 pl-6 pr-3 py-2 text-body-small-default">
+      <StatusIcon status={status} />
+      <Glyph
+        aria-hidden="true"
+        className="h-3.5 w-3.5 shrink-0 text-[var(--content-secondary)]"
+      />
+      <Typography
+        variant="body-small-default"
+        className="min-w-0 truncate text-[var(--content-default)]"
+      >
+        {title}
+      </Typography>
+      {info ? (
+        <Typography
+          variant="body-small-default"
+          className="min-w-0 truncate text-[var(--content-secondary)]"
+        >
+          {info}
+        </Typography>
+      ) : null}
+      {durationLabel ? (
+        <Typography
+          variant="label-small-default"
+          className="ml-auto shrink-0 text-[var(--content-tertiary)]"
+        >
+          {durationLabel}
+        </Typography>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusIcon({
+  status,
+}: {
+  status: "running" | "completed" | "error" | "denied";
+}) {
+  if (status === "running") {
+    return (
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+        <BusyIndicator size={6} />
+      </span>
+    );
+  }
+  if (status === "error" || status === "denied") {
+    return (
+      <AlertCircle
+        aria-hidden="true"
+        data-status={status}
+        className="h-4 w-4 shrink-0 text-[var(--system-negative-strong)]"
+      />
+    );
+  }
+  return (
+    <CheckCircle2
+      aria-hidden="true"
+      data-status="completed"
+      className="h-4 w-4 shrink-0 text-[var(--system-positive-strong)]"
+    />
+  );
+}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -14,6 +14,7 @@ import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-mes
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions.js";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router.js";
 import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js";
+import { getLeadingThinkingText } from "@/domains/chat/components/tool-progress-card/get-leading-thinking-text.js";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { getSlackLinkUrl, type Surface } from "@/domains/chat/types/types.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
@@ -369,6 +370,7 @@ export function TranscriptMessageBody({
                   unknownNudgeToolCallIds={unknownNudgeToolCallIds}
                   onDismissUnknownNudge={onDismissUnknownNudge}
                   isStreaming={message.isStreaming ?? false}
+                  leadingThinkingText={getLeadingThinkingText(message, gi)}
                 />
               );
             }


### PR DESCRIPTION
## Summary
- All tool-call groups (web search, bash, file ops, MCP, computer, skills) now render via ToolProgressCardShell driven by useToolCallCardData.
- LegacyToolCallProgressCard is removed.
- Confirmation/denial paths preserved unchanged; subagent_spawn-only groups return null pending PR 8 inline-card wiring.
- transcript-message-body now threads getLeadingThinkingText into the card.

Part of plan: unify-tool-progress-cards.md (PR 6 of 9)