### PR TITLE
feat: add suffix slot to Dropdown, show Current chip on machine size

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -7,6 +7,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Dropdown, type DropdownOption } from "@vellum/design-library/components/dropdown";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Notice } from "@vellum/design-library/components/notice";
+import { Tag } from "@vellum/design-library/components/tag";
 import { Typography } from "@vellum/design-library/components/typography";
 import type { MachineSizeEnum, MachineTierEnum } from "@/generated/api/types.gen.js";
 import {
@@ -33,13 +34,17 @@ export function SetupStep({
   onAdvance: () => void;
 }) {
   const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
+  const currentSize = activeAssistant?.machine_size as MachineSizeEnum | null | undefined;
   const machineSizeOptions = useMemo<DropdownOption<MachineSizeEnum>[]>(
     () =>
       allowedMachineSizesForTier(maxTier).map((size) => ({
         value: size,
         label: `${SIZE_LABEL[size]} — ${SIZE_DESCRIPTION[size]}`,
+        suffix: size === currentSize
+          ? <Tag tone="positive">Current</Tag>
+          : undefined,
       })),
-    [maxTier],
+    [maxTier, currentSize],
   );
   const [selectedSize, setSelectedSize] = useState<MachineSizeEnum>(
     machineSizeOptions[0]?.value ?? "small",

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -3,6 +3,7 @@ import { Globe, Lock, Users } from "lucide-react";
 import { useState } from "react";
 
 import { Dropdown, type DropdownOption, type DropdownProps } from "./dropdown.js";
+import { Tag } from "./tag.js";
 
 const fruits: DropdownOption<string>[] = [
   { value: "apple", label: "Apple" },
@@ -164,6 +165,35 @@ export const EndAligned: Story = {
             onChange={setValue}
           />
         </div>
+      </div>
+    );
+  },
+};
+
+const machineSizes: DropdownOption<"small" | "medium" | "large">[] = [
+  {
+    value: "small",
+    label: "Small — 2 vCPU, 3 GiB",
+    suffix: <Tag tone="positive">Current</Tag>,
+  },
+  { value: "medium", label: "Medium — 2.5 vCPU, 5 GiB" },
+  { value: "large", label: "Large — 4 vCPU, 8 GiB" },
+];
+
+export const WithSuffix: Story = {
+  args: {
+    "aria-label": "Machine size",
+  },
+  render: function SuffixDropdown(args) {
+    const [value, setValue] = useState<"small" | "medium" | "large">("small");
+    return (
+      <div className="w-80">
+        <Dropdown
+          {...(args as DropdownProps<"small" | "medium" | "large">)}
+          options={machineSizes}
+          value={value}
+          onChange={setValue}
+        />
       </div>
     );
   },

--- a/packages/design-library/src/components/dropdown.test.tsx
+++ b/packages/design-library/src/components/dropdown.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Dropdown, type DropdownOption } from "./dropdown.js";
+
+const options: DropdownOption<"a" | "b">[] = [
+  { value: "a", label: "Option A" },
+  { value: "b", label: "Option B" },
+];
+
+describe("Dropdown", () => {
+  test("renders the selected option label in the trigger", () => {
+    const html = renderToStaticMarkup(
+      <Dropdown options={options} value="a" onChange={() => {}} aria-label="Test" />,
+    );
+    expect(html).toContain("Option A");
+  });
+
+  test("renders placeholder when no value matches", () => {
+    const html = renderToStaticMarkup(
+      <Dropdown
+        options={options}
+        value={"" as "a"}
+        onChange={() => {}}
+        placeholder="Pick one…"
+        aria-label="Test"
+      />,
+    );
+    expect(html).toContain("Pick one…");
+  });
+
+  test("renders suffix in the trigger when the selected option has one", () => {
+    const withSuffix: DropdownOption<"a" | "b">[] = [
+      { value: "a", label: "Option A", suffix: <span data-testid="suffix">Current</span> },
+      { value: "b", label: "Option B" },
+    ];
+    const html = renderToStaticMarkup(
+      <Dropdown options={withSuffix} value="a" onChange={() => {}} aria-label="Test" />,
+    );
+    expect(html).toContain('data-testid="suffix"');
+    expect(html).toContain("Current");
+  });
+
+  test("does not render suffix in the trigger when the selected option has none", () => {
+    const withSuffix: DropdownOption<"a" | "b">[] = [
+      { value: "a", label: "Option A", suffix: <span data-testid="suffix">Current</span> },
+      { value: "b", label: "Option B" },
+    ];
+    const html = renderToStaticMarkup(
+      <Dropdown options={withSuffix} value="b" onChange={() => {}} aria-label="Test" />,
+    );
+    expect(html).not.toContain('data-testid="suffix"');
+    expect(html).not.toContain("Current");
+  });
+
+  test("renders disabled trigger with aria attributes", () => {
+    const html = renderToStaticMarkup(
+      <Dropdown options={options} value="a" onChange={() => {}} disabled aria-label="Test" />,
+    );
+    expect(html).toContain("disabled");
+  });
+});

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -30,6 +30,7 @@ export interface DropdownOption<T extends string> {
   readonly value: T;
   readonly label: string;
   readonly icon?: ReactNode;
+  readonly suffix?: ReactNode;
   /**
    * When true, the option renders dimmed and cannot be selected (by click,
    * keyboard, or hover-highlight). The option still occupies a row so the
@@ -347,8 +348,11 @@ export function Dropdown<T extends string>({
                 {option.icon}
               </span>
             )}
-            <span className="min-w-0 flex-1 truncate">
-              {option.label}
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="truncate">{option.label}</span>
+              {option.suffix && (
+                <span className="shrink-0">{option.suffix}</span>
+              )}
             </span>
             {isSelected && (
               <Check
@@ -406,8 +410,13 @@ export function Dropdown<T extends string>({
             {selectedOption.icon}
           </span>
         )}
-        <span className="flex-1 truncate">
-          {selectedOption?.label ?? placeholder ?? ""}
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="truncate">
+            {selectedOption?.label ?? placeholder ?? ""}
+          </span>
+          {selectedOption?.suffix && (
+            <span className="shrink-0">{selectedOption.suffix}</span>
+          )}
         </span>
         <ChevronDown
           className="h-3.5 w-3.5 shrink-0"

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -349,7 +349,7 @@ export function Dropdown<T extends string>({
               </span>
             )}
             <span className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="truncate">{option.label}</span>
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
               {option.suffix && (
                 <span className="shrink-0">{option.suffix}</span>
               )}
@@ -411,7 +411,7 @@ export function Dropdown<T extends string>({
           </span>
         )}
         <span className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="truncate">
+          <span className="min-w-0 flex-1 truncate">
             {selectedOption?.label ?? placeholder ?? ""}
           </span>
           {selectedOption?.suffix && (


### PR DESCRIPTION
## Summary
- Add optional `suffix?: ReactNode` field to `DropdownOption` in the design library, rendered inline after the label (grouped with `gap-2` so it sits right next to the text)
- Use it in the Pro onboarding setup step to show a green "Current" `Tag` chip on the assistant's active machine size
- Add `WithSuffix` storybook story and dropdown unit tests

## Original prompt
User wanted a "Current" chip/tag in the machine size dropdown to indicate the assistant's active size. Required extending the Dropdown component to support a trailing suffix ReactNode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)