### PR TITLE
fix(web): prevent auto-greet double-send with content-automation cohort

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -668,6 +668,7 @@ export function ChatPage() {
     const pending = pendingOnboardingInitialMessageRef.current;
     if (!pending || !assistantId || activeConversationKey !== pending.conversationKey) return;
     pendingOnboardingInitialMessageRef.current = null;
+    autoGreetRef.current = false;
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
 
@@ -675,7 +676,7 @@ export function ChatPage() {
   // content-automation initialMessage is queued (avoids double-send).
   useEffect(() => {
     if (!autoGreetPending || !activeConversationKey || !assistantId) return;
-    if (pendingOnboardingInitialMessageRef.current !== null) return;
+    if (!autoGreetRef.current) return;
     setAutoGreetPending(false);
     if (awaitingAutoGreetTimeoutRef.current) {
       clearTimeout(awaitingAutoGreetTimeoutRef.current);


### PR DESCRIPTION
## Summary
- Disarm autoGreetRef in the pendingOnboardingInitialMessageRef effect so it signals to the auto-greet effect not to fire
- Add autoGreetRef.current guard in the auto-greet effect as a synchronous mutex — prevents double-send when both effects run in the same React render cycle

Part of plan: fix-web-auto-greet.md (review fix)

LUM-1824