### PR TITLE
fix(providers): skip oauth_subscription connections for non-Codex models in auto-resolution

### DIFF
--- a/assistant/src/providers/__tests__/connection-model-compat.test.ts
+++ b/assistant/src/providers/__tests__/connection-model-compat.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the Codex-subscription model-compatibility gate on auto-resolved
+ * provider connections.
+ *
+ * When a profile uses "Any active OpenAI connection" (no `provider_connection`
+ * pinned), the daemon auto-picks an active OpenAI connection. An
+ * `oauth_subscription` (ChatGPT Codex) connection hard-routes to the Codex
+ * endpoint, which rejects non-Codex models with HTTP 400. The gate skips such
+ * a connection during auto-resolution unless the model is Codex-compatible.
+ *
+ * Two layers are covered:
+ *   1. `isConnectionCompatibleWithModel` — the pure predicate.
+ *   2. `getConfiguredProvider` — the auto-resolution path that uses the
+ *      predicate as an additional `.find()` filter, plus the pinned-connection
+ *      path which bypasses the gate entirely.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { isConnectionCompatibleWithModel } from "../connection-model-compat.js";
+import type { Auth } from "../inference/auth.js";
+
+// ---------------------------------------------------------------------------
+// Pure predicate tests — no mocking required.
+// ---------------------------------------------------------------------------
+
+const apiKeyAuth: Auth = { type: "api_key", credential: "credential/x" };
+const platformAuth: Auth = { type: "platform" };
+const oauthAuth: Auth = {
+  type: "oauth_subscription",
+  credential: "credential/x",
+};
+
+describe("isConnectionCompatibleWithModel", () => {
+  test("api_key connection is compatible with any model", () => {
+    const conn = { auth: apiKeyAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5")).toBe(true);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.4")).toBe(true);
+  });
+
+  test("platform connection is compatible with any model", () => {
+    const conn = { auth: platformAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.4-nano")).toBe(true);
+  });
+
+  test("oauth_subscription connection is incompatible with a non-Codex model", () => {
+    const conn = { auth: oauthAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5")).toBe(false);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.5")).toBe(false);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.4-nano")).toBe(false);
+  });
+
+  test("oauth_subscription connection is compatible with a Codex model", () => {
+    const conn = { auth: oauthAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.4")).toBe(true);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.3-codex")).toBe(true);
+  });
+
+  test("undefined model applies no gating (compatible)", () => {
+    const conn = { auth: oauthAuth };
+    expect(isConnectionCompatibleWithModel(conn, undefined)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests through `getConfiguredProvider` — module mocks below must
+// be declared before the import-under-test.
+// ---------------------------------------------------------------------------
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: mockLlmConfig,
+    services: { inference: { mode: "your-own" } },
+  }),
+}));
+
+const mockDbSentinel = { __mock: "db" };
+mock.module("../../memory/db-connection.js", () => ({
+  getDb: () => mockDbSentinel,
+}));
+
+type Connection = {
+  name: string;
+  provider: string;
+  status: string;
+  auth: { type: string; credential?: string };
+};
+
+// Ordered list the mocked `listConnections` returns. `.find()` walks it in
+// order, so insertion order is meaningful for these tests.
+let fakeConnectionList: Connection[] = [];
+const fakeConnectionsByName = new Map<string, Connection>();
+
+mock.module("../inference/connections.js", () => ({
+  getConnection: (_db: unknown, name: string) =>
+    fakeConnectionsByName.get(name) ?? null,
+  listConnections: (_db: unknown, filter?: { provider?: string }) =>
+    filter?.provider
+      ? fakeConnectionList.filter((c) => c.provider === filter.provider)
+      : fakeConnectionList,
+}));
+
+// Records the connection name handed to the resolver so tests can assert
+// which connection auto-resolution selected.
+const resolveProviderCalls: Connection[] = [];
+
+mock.module("../registry.js", () => ({
+  getProvider: (name: string) => {
+    throw new Error(`legacy getProvider should not be called: ${name}`);
+  },
+  initializeProviders: async () => {},
+  listProviders: () => [{ name: "stub" }],
+  resolveProviderFromConnection: async (connection: Connection) => {
+    resolveProviderCalls.push(connection);
+    return { name: connection.provider, tag: connection.name };
+  },
+}));
+
+import { getConfiguredProvider } from "../provider-send-message.js";
+
+function registerConnections(connections: Connection[]): void {
+  fakeConnectionList = connections;
+  for (const c of connections) fakeConnectionsByName.set(c.name, c);
+}
+
+function reset(): void {
+  resolveProviderCalls.length = 0;
+  fakeConnectionList = [];
+  fakeConnectionsByName.clear();
+  mockLlmConfig = {};
+}
+
+const OPENAI_KEY: Connection = {
+  name: "openai-key",
+  provider: "openai",
+  status: "active",
+  auth: { type: "api_key", credential: "credential/openai" },
+};
+const OPENAI_CODEX: Connection = {
+  name: "openai-codex",
+  provider: "openai",
+  status: "active",
+  auth: {
+    type: "oauth_subscription",
+    credential: "credential/openai-codex/access_token",
+  },
+};
+
+describe("auto-resolution skips oauth_subscription connections for non-Codex models", () => {
+  beforeEach(reset);
+
+  test("non-Codex model picks the api_key connection over a (first-listed) oauth_subscription one", async () => {
+    // oauth_subscription listed FIRST — without the gate, insertion order
+    // would have selected it and misrouted gpt-5 to the Codex endpoint.
+    registerConnections([OPENAI_CODEX, OPENAI_KEY]);
+    setOpenAiProfile("gpt-5");
+
+    const result = await getConfiguredProvider("mainAgent", {
+      overrideProfile: "openai-any",
+    });
+
+    expect(result).not.toBeNull();
+    expect(resolveProviderCalls.length).toBe(1);
+    expect(resolveProviderCalls[0].name).toBe("openai-key");
+  });
+
+  test("Codex model can select the oauth_subscription connection", async () => {
+    registerConnections([OPENAI_CODEX, OPENAI_KEY]);
+    setOpenAiProfile("gpt-5.4");
+
+    const result = await getConfiguredProvider("mainAgent", {
+      overrideProfile: "openai-any",
+    });
+
+    expect(result).not.toBeNull();
+    expect(resolveProviderCalls.length).toBe(1);
+    expect(resolveProviderCalls[0].name).toBe("openai-codex");
+  });
+
+  test("non-Codex model with only an oauth_subscription connection resolves to null (no misroute)", async () => {
+    // Pure-predicate gate: the lone oauth_subscription connection is filtered
+    // out, so auto-resolution finds nothing and the call site falls back
+    // gracefully rather than dispatching gpt-5 to the Codex endpoint.
+    registerConnections([OPENAI_CODEX]);
+    setOpenAiProfile("gpt-5");
+
+    const result = await getConfiguredProvider("mainAgent", {
+      overrideProfile: "openai-any",
+    });
+
+    expect(result).toBeNull();
+    expect(resolveProviderCalls.length).toBe(0);
+  });
+
+  test("explicitly pinned oauth_subscription connection is used regardless of model", async () => {
+    registerConnections([OPENAI_CODEX, OPENAI_KEY]);
+    mockLlmConfig = {
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        "openai-pinned": {
+          provider: "openai",
+          model: "gpt-5",
+          provider_connection: "openai-codex",
+        },
+      },
+    };
+
+    const result = await getConfiguredProvider("mainAgent", {
+      overrideProfile: "openai-pinned",
+    });
+
+    // The pinned connection bypasses the auto-resolution gate entirely.
+    expect(result).not.toBeNull();
+    expect(resolveProviderCalls.length).toBe(1);
+    expect(resolveProviderCalls[0].name).toBe("openai-codex");
+  });
+});
+
+function setOpenAiProfile(model: string): void {
+  mockLlmConfig = {
+    default: { provider: "anthropic", model: "claude-opus-4-7" },
+    profiles: {
+      // "Any active OpenAI connection" — provider set, no provider_connection.
+      "openai-any": { provider: "openai", model },
+    },
+  };
+}

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -24,6 +24,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { getDb } from "../memory/db-connection.js";
+import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
 import {
   ConnectionResolutionError,
   tryResolveProviderForConnectionName,
@@ -73,10 +74,15 @@ export class CallSiteRoutingProvider implements Provider {
      * `expectedProvider` is the provider name the resolved profile
      * declared. The hook verifies the connection's provider matches
      * and throws on mismatch.
+     *
+     * `model` is the resolved call-site model, threaded through so the
+     * connection lookup can gate `oauth_subscription` (Codex) connections
+     * by model compatibility.
      */
     private readonly resolveByConnection: (
       connectionName: string,
       expectedProvider: string,
+      model: string | undefined,
     ) => Promise<Provider | null>,
   ) {
     this.tokenEstimationProvider = defaultProvider.tokenEstimationProvider;
@@ -155,7 +161,11 @@ export class CallSiteRoutingProvider implements Provider {
         const candidates = listConnections(getDb(), {
           provider: resolved.provider,
         });
-        const active = candidates.find((c) => c.status === "active");
+        const active = candidates.find(
+          (c) =>
+            c.status === "active" &&
+            isConnectionCompatibleWithModel(c, resolved.model),
+        );
         if (active) {
           connectionName = active.name;
         }
@@ -168,6 +178,7 @@ export class CallSiteRoutingProvider implements Provider {
       const connectionProvider = await this.resolveByConnection(
         connectionName,
         resolved.provider,
+        resolved.model,
       );
       if (connectionProvider) return connectionProvider;
       return this.defaultProvider;
@@ -200,11 +211,12 @@ export function wrapWithCallSiteRouting(
 ): Provider {
   return new CallSiteRoutingProvider(
     base,
-    (connectionName, expectedProvider) =>
+    (connectionName, expectedProvider, model) =>
       tryResolveProviderForConnectionName(
         connectionName,
         config,
         expectedProvider,
+        model,
       ),
   );
 }

--- a/assistant/src/providers/connection-model-compat.ts
+++ b/assistant/src/providers/connection-model-compat.ts
@@ -1,0 +1,38 @@
+/**
+ * Model-compatibility gate for auto-resolved provider connections.
+ *
+ * When a profile uses "Any active <provider> connection" (no
+ * `provider_connection` pinned), the daemon auto-picks an active connection
+ * for the provider. `oauth_subscription` connections (ChatGPT Codex) hard-
+ * route every request to the Codex endpoint, which rejects non-Codex models
+ * with HTTP 400. This helper lets the auto-resolution sites skip such a
+ * connection when the requested model is not Codex-compatible.
+ */
+
+import type { ProviderConnection } from "./inference/auth.js";
+import { isCodexSubscriptionModel } from "./openai/codex-models.js";
+
+/**
+ * Whether `connection` can serve a request for `model` during
+ * auto-resolution.
+ *
+ * `oauth_subscription` connections route through the ChatGPT Codex endpoint,
+ * so they are only compatible with Codex models. Every other auth type
+ * imposes no model restriction and is always compatible.
+ *
+ * `model` may be undefined when the call site has no resolved model; in that
+ * case no model gating is applied (returns true) so resolution behaviour is
+ * unchanged.
+ *
+ * This gate applies to auto-resolution only — an explicitly pinned
+ * `provider_connection` bypasses connection selection entirely and is used
+ * regardless of model.
+ */
+export function isConnectionCompatibleWithModel(
+  connection: Pick<ProviderConnection, "auth">,
+  model: string | undefined,
+): boolean {
+  if (connection.auth.type !== "oauth_subscription") return true;
+  if (!model) return true;
+  return isCodexSubscriptionModel(model);
+}

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -30,6 +30,7 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getDb } from "../memory/db-connection.js";
 import { getLogger } from "../util/logger.js";
+import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
 import { getConnection, listConnections } from "./inference/connections.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
@@ -79,11 +80,16 @@ export class ConnectionResolutionError extends Error {
  * `expectedProvider` is the provider name the resolving profile declared.
  * Pass `undefined` to skip the mismatch check (callers that don't yet
  * know the expected provider).
+ *
+ * `model` is the resolved call-site model. It gates the `provider_mismatch`
+ * auto-recovery below so a non-Codex model is never rerouted onto an
+ * `oauth_subscription` (ChatGPT Codex) connection.
  */
 export async function tryResolveProviderForConnectionName(
   connectionName: string,
   config: ProvidersConfig,
   expectedProvider?: string,
+  model?: string,
 ): Promise<Provider | null> {
   let connection;
   try {
@@ -113,7 +119,10 @@ export async function tryResolveProviderForConnectionName(
     try {
       const db = getDb();
       const candidates = listConnections(db, { provider: expectedProvider });
-      const active = candidates.find((c) => c.status === "active");
+      const active = candidates.find(
+        (c) =>
+          c.status === "active" && isConnectionCompatibleWithModel(c, model),
+      );
       if (active) {
         log.info(
           {
@@ -192,7 +201,11 @@ export async function resolveDefaultProvider(
         const candidates = listConnections(getDb(), {
           provider: resolved.provider,
         });
-        const active = candidates.find((c) => c.status === "active");
+        const active = candidates.find(
+          (c) =>
+            c.status === "active" &&
+            isConnectionCompatibleWithModel(c, resolved.model),
+        );
         if (active) {
           log.info(
             { provider: resolved.provider, resolvedConnection: active.name },
@@ -216,5 +229,6 @@ export async function resolveDefaultProvider(
     connectionName,
     config,
     resolved.provider,
+    resolved.model,
   );
 }

--- a/assistant/src/providers/openai/codex-models.ts
+++ b/assistant/src/providers/openai/codex-models.ts
@@ -1,0 +1,18 @@
+/**
+ * Model IDs accepted by the ChatGPT Codex subscription endpoint
+ * (`https://chatgpt.com/backend-api/codex`).
+ *
+ * `oauth_subscription` OpenAI connections hard-route every request to that
+ * endpoint, which rejects any model outside this set with HTTP 400. The set
+ * gates whether such a connection may serve a given model during auto-
+ * resolution of an "Any active OpenAI connection" profile.
+ */
+export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-5.4",
+  "gpt-5.3-codex",
+]);
+
+/** True when `model` is accepted by the Codex subscription endpoint. */
+export function isCodexSubscriptionModel(model: string): boolean {
+  return CODEX_SUBSCRIPTION_MODEL_IDS.has(model);
+}

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -9,6 +9,7 @@ import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getDb } from "../memory/db-connection.js";
 import { getLogger } from "../util/logger.js";
+import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
 import { tryResolveProviderForConnectionName } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import { initializeProviders, listProviders } from "./registry.js";
@@ -126,7 +127,11 @@ export async function resolveConfiguredProvider(
         const candidates = listConnections(getDb(), {
           provider: inferenceProvider,
         });
-        const active = candidates.find((c) => c.status === "active");
+        const active = candidates.find(
+          (c) =>
+            c.status === "active" &&
+            isConnectionCompatibleWithModel(c, resolved.model),
+        );
         if (active) {
           connectionName = active.name;
         }
@@ -147,6 +152,7 @@ export async function resolveConfiguredProvider(
     connectionName,
     config,
     inferenceProvider,
+    resolved.model,
   );
   if (!connectionProvider) {
     // Soft credential failure — the connection resolved to no usable


### PR DESCRIPTION
## Summary

When a profile uses "Any active OpenAI connection" (no `provider_connection` pinned), the daemon auto-picks an active connection for the provider at dispatch time. The selection (`candidates.find(c => c.status === "active")`) used **insertion order with zero model awareness**.

An `oauth_subscription` (ChatGPT Codex) connection hard-routes every request to `https://chatgpt.com/backend-api/codex` (`adapter-factory.ts` sets `codexSubscription = connection.auth.type === "oauth_subscription"`). That endpoint rejects non-Codex models with **HTTP 400**. So if a user had both an `api_key` and an `oauth_subscription` OpenAI connection and the subscription one was created first, every `gpt-5` / `gpt-5.5` / `gpt-5.4-nano` request was misrouted to the Codex endpoint and failed.

### Fix

- New `assistant/src/providers/openai/codex-models.ts` — `CODEX_SUBSCRIPTION_MODEL_IDS` (`gpt-5.4`, `gpt-5.3-codex`).
- New `assistant/src/providers/connection-model-compat.ts` — `isConnectionCompatibleWithModel(connection, model)`: returns `false` only when the connection is `oauth_subscription` and the model is not Codex-compatible; `true` for every other auth type.
- Added the helper as an **additional `.find()` predicate** at all four auto-resolution sites:
  - `provider-send-message.ts` (conversation-level dispatch)
  - `call-site-routing.ts` (per-call-site routing)
  - `connection-resolution.ts` — `resolveDefaultProvider` and the `provider_mismatch` recovery in `tryResolveProviderForConnectionName`
- The resolved call-site model is threaded into each site (and through `tryResolveProviderForConnectionName` / the `CallSiteRoutingProvider` hook).
- **Explicitly pinned `provider_connection`s are unaffected** — they bypass connection selection entirely and are used regardless of model.

### Behavior note

This is a pure-predicate filter with no fallback. If the *only* active OpenAI connection is an `oauth_subscription` one and the model is non-Codex, auto-resolution now yields no connection (the call site falls back to its null-handling) rather than misrouting the request to a 400.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun test src/providers/__tests__/connection-model-compat.test.ts` — 9 pass (predicate unit tests + `getConfiguredProvider` integration: non-Codex model picks the api_key connection over a first-listed oauth one; Codex model can pick the oauth connection; lone oauth connection + non-Codex model resolves to null; pinned connection used regardless of model)
- [x] `bun test src/providers/__tests__/dispatch-connection-routing.test.ts src/providers/__tests__/satellite-connection-routing.test.ts` — 11 pass (no regressions)

https://claude.ai/code/session_01Gn2jn55MmQuTgbUPdYM7v9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gn2jn55MmQuTgbUPdYM7v9)_