### PR TITLE
test(assistant): add setConversationHistoryStrippedAt to crud mocks

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -129,6 +129,7 @@ mock.module("../security/secret-allowlist.js", () => ({
 mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
+  setConversationHistoryStrippedAt: () => {},
   deleteMessageById: () => {},
   provenanceFromTrustContext: () => ({
     source: "user",

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -179,6 +179,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
+  setConversationHistoryStrippedAt: () => {},
   getConversationOriginChannel: () => null,
   getConversationOriginInterface: () => null,
   provenanceFromTrustContext: () => ({}),


### PR DESCRIPTION
## Summary
- Add the missing `setConversationHistoryStrippedAt` stub to the `conversation-crud.js` mocks in `compaction-events.test.ts` and `conversation-provider-retry-repair.test.ts`.
- Without the stub, `applyCompactionResult` fell through to the real DB write and threw `SQLiteError: no such table: conversations`, breaking 6 tests in CI on main after the `historyStrippedAt` refactor (#31712).

## Original prompt
Fix the specific CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/26296970933/job/77412032736 — two test files (`compaction-events.test.ts` and `conversation-provider-retry-repair.test.ts`) regressed on main after the `historyStrippedAt` refactor because their `conversation-crud.js` mocks didn't include the new `setConversationHistoryStrippedAt` export.