### PR TITLE
fix(web): use existing initialMessage plumbing for auto-greet

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -150,7 +150,7 @@ export function ChatPage() {
 
   const [restoredDraftConversationKey, setRestoredDraftConversationKey] = useState<string | null>(null);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const [autoGreetPending, setAutoGreetPending] = useState(false);
+  const [_autoGreetPending, setAutoGreetPending] = useState(false);
   const awaitingAutoGreetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
@@ -668,23 +668,8 @@ export function ChatPage() {
     const pending = pendingOnboardingInitialMessageRef.current;
     if (!pending || !assistantId || activeConversationKey !== pending.conversationKey) return;
     pendingOnboardingInitialMessageRef.current = null;
-    autoGreetRef.current = false;
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
-
-  // Auto-send generic onboarding greet when the pending flag fires and no
-  // content-automation initialMessage is queued (avoids double-send).
-  useEffect(() => {
-    if (!autoGreetPending || !activeConversationKey || !assistantId) return;
-    if (!autoGreetRef.current) return;
-    setAutoGreetPending(false);
-    if (awaitingAutoGreetTimeoutRef.current) {
-      clearTimeout(awaitingAutoGreetTimeoutRef.current);
-      awaitingAutoGreetTimeoutRef.current = null;
-    }
-    autoGreetRef.current = false;
-    void sendMessage("Wake up, my friend!");
-  }, [autoGreetPending, activeConversationKey, assistantId, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -214,6 +214,7 @@ export function PreChatFlow() {
       tools: stripOtherPrefix([...selectedTools]),
       tasks: [...selectedTasks].sort(),
       tone: selectedGroupId ?? DEFAULT_GROUP_ID,
+      initialMessage: "Wake up, my friend!",
     };
     const trimmedUser = userName.trim();
     if (trimmedUser) context.userName = trimmedUser;


### PR DESCRIPTION
## Summary
- Switch to Option A: set initialMessage in pre-chat-flow.tsx finish() instead of adding a new effect
- Reuses existing pendingOnboardingInitialMessageRef → sendMessage plumbing that already works for content-automation cohort
- Removes the auto-greet useEffect and related changes (net diff vs main: +1 line in pre-chat-flow.tsx)

Part of plan: fix-web-auto-greet.md (rework to Option A)

LUM-1824