### PR TITLE
fix(web): force-complete stale running tool calls on reconciliation

### DIFF
--- a/apps/web/src/domains/chat/hooks/stream-message-updaters.test.ts
+++ b/apps/web/src/domains/chat/hooks/stream-message-updaters.test.ts
@@ -7,6 +7,7 @@ import {
   applyToolProgress,
   applyToolResult,
   createStreamingBubble,
+  finalizeOnIdle,
   handleConversationError,
   stopStreaming,
   upsertToolCall,
@@ -370,5 +371,152 @@ describe("applyToolProgress", () => {
       timeoutSec: 30,
     });
     expect(result[0]!.toolCalls![0]!.progressElapsedSec).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finalizeOnIdle — multi-message coverage
+// ---------------------------------------------------------------------------
+
+describe("finalizeOnIdle", () => {
+  it("finalizes running tool calls across ALL streaming assistant messages", () => {
+    const msg1 = makeAssistantMsg({
+      stableId: "a1",
+      content: "",
+      toolCalls: [
+        { id: "tc-1", toolName: "web_search", input: {}, status: "running" },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-1" }],
+    });
+    const msg2 = makeAssistantMsg({
+      stableId: "a2",
+      content: "some text",
+      toolCalls: [
+        { id: "tc-2", toolName: "web_fetch", input: {}, status: "running" },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-2" }],
+    });
+    const result = finalizeOnIdle([userMsg, msg1, msg2]);
+
+    expect(result).toHaveLength(3);
+    expect(result[1]!.toolCalls![0]!.status).toBe("completed");
+    expect(result[1]!.toolCalls![0]!.completedAt).toBeDefined();
+    expect(result[2]!.toolCalls![0]!.status).toBe("completed");
+    expect(result[2]!.toolCalls![0]!.completedAt).toBeDefined();
+  });
+
+  it("returns prev unchanged when no streaming assistant messages exist", () => {
+    const prev = [userMsg];
+    const result = finalizeOnIdle(prev);
+    expect(result).toBe(prev);
+  });
+
+  it("returns prev unchanged when streaming messages have no running tool calls", () => {
+    const msg = makeAssistantMsg({
+      toolCalls: [
+        { id: "tc-1", toolName: "web_search", input: {}, status: "completed" },
+      ],
+    });
+    const prev = [msg];
+    const result = finalizeOnIdle(prev);
+    expect(result).toBe(prev);
+  });
+
+  it("does not modify non-streaming assistant messages", () => {
+    const finishedMsg = makeAssistantMsg({
+      stableId: "a-done",
+      isStreaming: false,
+      toolCalls: [
+        { id: "tc-old", toolName: "bash", input: {}, status: "running" },
+      ],
+    });
+    const streamingMsg = makeAssistantMsg({
+      stableId: "a-stream",
+      toolCalls: [
+        { id: "tc-new", toolName: "web_search", input: {}, status: "running" },
+      ],
+    });
+    const result = finalizeOnIdle([finishedMsg, streamingMsg]);
+
+    // The non-streaming message's tool call should remain "running"
+    expect(result[0]!.toolCalls![0]!.status).toBe("running");
+    // The streaming message's tool call should be finalized
+    expect(result[1]!.toolCalls![0]!.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyToolResult — cross-message matching
+// ---------------------------------------------------------------------------
+
+describe("applyToolResult — cross-message matching", () => {
+  it("finds the tool call on an earlier message when toolUseId is provided", () => {
+    // Simulate: tool_use_start on msg1, then a new bubble was created (msg2),
+    // then tool_result arrives with toolUseId pointing to msg1's tool call.
+    const msg1 = makeAssistantMsg({
+      stableId: "a1",
+      content: "",
+      toolCalls: [
+        { id: "tc-early", toolName: "web_search", input: {}, status: "running" },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-early" }],
+    });
+    const msg2 = makeAssistantMsg({
+      stableId: "a2",
+      content: "some later text",
+      toolCalls: [
+        { id: "tc-later", toolName: "bash", input: {}, status: "running" },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-later" }],
+    });
+    const result = applyToolResult([userMsg, msg1, msg2], {
+      toolUseId: "tc-early",
+      result: "search results",
+    });
+
+    // msg1's tool call should be completed
+    expect(result[1]!.toolCalls![0]!.status).toBe("completed");
+    expect(result[1]!.toolCalls![0]!.result).toBe("search results");
+    // msg2's tool call should remain running
+    expect(result[2]!.toolCalls![0]!.status).toBe("running");
+  });
+
+  it("falls back to last assistant message when toolUseId is not provided", () => {
+    const msg1 = makeAssistantMsg({
+      stableId: "a1",
+      content: "",
+      toolCalls: [
+        { id: "tc-1", toolName: "web_search", input: {}, status: "running" },
+      ],
+    });
+    const msg2 = makeAssistantMsg({
+      stableId: "a2",
+      content: "",
+      toolCalls: [
+        { id: "tc-2", toolName: "bash", input: {}, status: "running" },
+      ],
+    });
+    const result = applyToolResult([userMsg, msg1, msg2], {
+      result: "done",
+    });
+
+    // Without toolUseId, falls back to the last assistant message's last running tool call
+    expect(result[1]!.toolCalls![0]!.status).toBe("running");
+    expect(result[2]!.toolCalls![0]!.status).toBe("completed");
+  });
+
+  it("falls back to last running tool call when toolUseId does not match any message", () => {
+    const msg = makeAssistantMsg({
+      toolCalls: [
+        { id: "tc-1", toolName: "bash", input: {}, status: "running" },
+      ],
+    });
+    const result = applyToolResult([msg], {
+      toolUseId: "nonexistent-id",
+      result: "done",
+    });
+
+    // Should fall back and complete the last running tool call
+    expect(result[0]!.toolCalls![0]!.status).toBe("completed");
   });
 });

--- a/apps/web/src/domains/chat/hooks/stream-message-updaters.ts
+++ b/apps/web/src/domains/chat/hooks/stream-message-updaters.ts
@@ -102,15 +102,16 @@ export function appendTextDelta(
 // assistant_activity_state (idle)
 // ---------------------------------------------------------------------------
 
-/** Finalize running tool calls on the last streaming message (idle signal). */
+/** Finalize running tool calls on ALL streaming assistant messages (idle signal). */
 export function finalizeOnIdle(prev: DisplayMessage[]): DisplayMessage[] {
-  const last = prev[prev.length - 1];
-  if (!last || last.role !== "assistant" || !last.isStreaming) return prev;
-
-  const finalized = finalizeRunningToolCalls(last.toolCalls);
-  if (!finalized) return prev;
-
-  return [...prev.slice(0, -1), { ...last, toolCalls: finalized }];
+  let changed = false;
+  const updated = prev.map((m) => {
+    if (m.role !== "assistant" || !m.isStreaming) return m;
+    if (!m.toolCalls?.some((tc) => tc.status === "running")) return m;
+    changed = true;
+    return { ...m, toolCalls: finalizeRunningToolCalls(m.toolCalls)! };
+  });
+  return changed ? updated : prev;
 }
 
 // ---------------------------------------------------------------------------
@@ -469,26 +470,44 @@ export function applyToolResult(
     activityMetadata?: ToolActivityMetadata;
   },
 ): DisplayMessage[] {
-  const msgIdx = prev.findLastIndex(
-    (m) => m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0,
-  );
-  if (msgIdx === -1) return prev;
+  // When we have a toolUseId, search all assistant messages (in reverse) for
+  // the matching tool call — the tool call may live on an earlier message if
+  // a new bubble was created between tool_use_start and tool_result.
+  let msgIdx = -1;
+  let tcIdx = -1;
 
-  const msg = prev[msgIdx];
-  if (!msg?.toolCalls) return prev;
+  if (opts.toolUseId) {
+    for (let i = prev.length - 1; i >= 0; i--) {
+      const m = prev[i];
+      if (m?.role !== "assistant" || !m.toolCalls?.length) continue;
+      const j = m.toolCalls.findIndex((tc) => tc.id === opts.toolUseId);
+      if (j !== -1) {
+        msgIdx = i;
+        tcIdx = j;
+        break;
+      }
+    }
+  }
 
-  let tcIdx = opts.toolUseId
-    ? msg.toolCalls.findIndex((tc) => tc.id === opts.toolUseId)
-    : -1;
-  if (tcIdx === -1) {
+  // Fallback: no toolUseId or not found — use the last assistant message
+  // with any running tool call (legacy behavior).
+  if (msgIdx === -1) {
+    msgIdx = prev.findLastIndex(
+      (m) => m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0,
+    );
+    if (msgIdx === -1) return prev;
+    const msg = prev[msgIdx];
+    if (!msg?.toolCalls) return prev;
     tcIdx = msg.toolCalls.findLastIndex((tc) => tc.status === "running");
   }
+
   if (tcIdx === -1) return prev;
 
-  const existingTc = msg.toolCalls[tcIdx];
+  const msg = prev[msgIdx]!;
+  const existingTc = msg.toolCalls![tcIdx];
   if (!existingTc) return prev;
 
-  const updatedToolCalls = [...msg.toolCalls];
+  const updatedToolCalls = [...msg.toolCalls!];
   updatedToolCalls[tcIdx] = {
     ...existingTc,
     status: opts.isError ? "error" : "completed",

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -894,3 +894,118 @@ describe("startReconciliationLoop", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// reconcileActiveConversation — stale tool call cleanup
+// ---------------------------------------------------------------------------
+
+describe("reconcileActiveConversation — stale tool call cleanup", () => {
+  test("force-completes stale running tool calls when turn is idle", async () => {
+    messages = [
+      makeMessage({ id: "m1", role: "user", content: "Hello" }),
+      makeMessage({
+        id: "m2",
+        role: "assistant",
+        content: "",
+        isStreaming: true,
+        toolCalls: [
+          { id: "tc-1", toolName: "web_search", input: {}, status: "running" as const },
+        ],
+      }),
+    ];
+    mockFetchResult = [];
+    const idleTurnState: TurnState = {
+      phase: "idle",
+      pendingQueuedCount: 0,
+      activeToolCallCount: 0,
+      activeTurnId: null,
+      lastTerminalReason: null,
+      statusText: null,
+      liveWebActivity: {},
+    };
+    const { reconcileActiveConversation } = createHarness({
+      streamContext: { assistantId: "asst-1", conversationKey: "conv-1" },
+      activeConversationKey: "conv-1",
+      turnState: idleTurnState,
+    });
+    await reconcileActiveConversation();
+
+    // Both isStreaming and running tool calls should be cleared
+    expect(messages[1]!.isStreaming).toBe(false);
+    expect(messages[1]!.toolCalls![0]!.status).toBe("completed");
+    expect(messages[1]!.toolCalls![0]!.completedAt).toBeDefined();
+  });
+
+  test("force-completes stale tool calls even when isStreaming is already false", async () => {
+    messages = [
+      makeMessage({ id: "m1", role: "user", content: "Hello" }),
+      makeMessage({
+        id: "m2",
+        role: "assistant",
+        content: "partial",
+        isStreaming: false,
+        toolCalls: [
+          { id: "tc-1", toolName: "web_search", input: {}, status: "running" as const },
+          { id: "tc-2", toolName: "bash", input: {}, status: "completed" as const },
+        ],
+      }),
+    ];
+    mockFetchResult = [];
+    const idleTurnState: TurnState = {
+      phase: "idle",
+      pendingQueuedCount: 0,
+      activeToolCallCount: 0,
+      activeTurnId: null,
+      lastTerminalReason: null,
+      statusText: null,
+      liveWebActivity: {},
+    };
+    const { reconcileActiveConversation } = createHarness({
+      streamContext: { assistantId: "asst-1", conversationKey: "conv-1" },
+      activeConversationKey: "conv-1",
+      turnState: idleTurnState,
+    });
+    await reconcileActiveConversation();
+
+    // The running tool call should be force-completed
+    expect(messages[1]!.toolCalls![0]!.status).toBe("completed");
+    expect(messages[1]!.toolCalls![0]!.completedAt).toBeDefined();
+    // The already-completed tool call should be unchanged
+    expect(messages[1]!.toolCalls![1]!.status).toBe("completed");
+  });
+
+  test("does NOT force-complete tool calls when turn is still sending", async () => {
+    messages = [
+      makeMessage({ id: "m1", role: "user", content: "Hello" }),
+      makeMessage({
+        id: "m2",
+        role: "assistant",
+        content: "",
+        isStreaming: true,
+        toolCalls: [
+          { id: "tc-1", toolName: "web_search", input: {}, status: "running" as const },
+        ],
+      }),
+    ];
+    mockFetchResult = [];
+    const streamingTurnState: TurnState = {
+      phase: "streaming",
+      pendingQueuedCount: 0,
+      activeToolCallCount: 0,
+      activeTurnId: "turn-42",
+      lastTerminalReason: null,
+      statusText: null,
+      liveWebActivity: {},
+    };
+    const { reconcileActiveConversation } = createHarness({
+      streamContext: { assistantId: "asst-1", conversationKey: "conv-1" },
+      activeConversationKey: "conv-1",
+      turnState: streamingTurnState,
+    });
+    await reconcileActiveConversation();
+
+    // Tool call should remain running since the turn is still active
+    expect(messages[1]!.isStreaming).toBe(true);
+    expect(messages[1]!.toolCalls![0]!.status).toBe("running");
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -238,15 +238,40 @@ export function useMessageReconciliation({
         });
       }
 
-      // Clear stale isStreaming flags. After onPollReconciled the turn is
-      // idle. With Zustand, getState() reflects the update immediately.
+      // Clear stale isStreaming flags and force-complete stale running
+      // tool calls. After onPollReconciled the turn is idle. With Zustand,
+      // getState() reflects the update immediately.
       if (wasStuck || !isSending(useTurnStore.getState())) {
         setMessages((prev) => {
-          const hasStale = prev.some((m) => m.isStreaming);
-          if (!hasStale) return prev;
-          return prev.map((m) =>
-            m.isStreaming ? { ...m, isStreaming: false } : m,
+          const hasStaleStreaming = prev.some((m) => m.isStreaming);
+          const hasStaleToolCalls = prev.some((m) =>
+            m.toolCalls?.some((tc) => tc.status === "running"),
           );
+          if (!hasStaleStreaming && !hasStaleToolCalls) return prev;
+          return prev.map((m) => {
+            const needsClearStreaming = m.isStreaming;
+            const needsClearToolCalls = m.toolCalls?.some(
+              (tc) => tc.status === "running",
+            );
+            if (!needsClearStreaming && !needsClearToolCalls) return m;
+            return {
+              ...m,
+              ...(needsClearStreaming ? { isStreaming: false } : {}),
+              ...(needsClearToolCalls
+                ? {
+                    toolCalls: m.toolCalls!.map((tc) =>
+                      tc.status === "running"
+                        ? {
+                            ...tc,
+                            status: "completed" as const,
+                            completedAt: Date.now(),
+                          }
+                        : tc,
+                    ),
+                  }
+                : {}),
+            };
+          });
         });
       }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the `WebSearchProgressCard` gets stuck in a loading state (animated dots) after a turn has completed. The card derives its state from tool call statuses, and if any `web_search`/`web_fetch` tool call remains `status: "running"`, the card shows loading indefinitely.

Three gaps in the tool-call lifecycle allowed this:

- **`finalizeOnIdle`** only processed the last assistant message. If an earlier message had running tool calls (e.g., a new bubble was created mid-turn), they were never finalized. Now processes ALL streaming assistant messages.
- **`applyToolResult`** only searched the last assistant message for the matching tool call via `findLastIndex`. If a new bubble was created between `tool_use_start` and `tool_result`, the result was silently dropped. Now searches all assistant messages (in reverse) when `toolUseId` is provided, with fallback to legacy behavior.
- **Reconciliation cleanup** cleared `isStreaming` flags but did not force-complete stale "running" tool calls when the turn was detected as no longer sending. Now also transitions remaining running tool calls to "completed" with a timestamp.

## Test plan

- [x] Existing `stream-message-updaters.test.ts` tests pass (25 existing + 7 new)
- [x] Existing `use-message-reconciliation.test.tsx` tests pass (26 existing + 3 new)
- [x] `reconcile.test.ts` passes (68 tests)
- [x] `tool-call-handlers.test.ts` passes (7 tests)
- [x] `bunx tsc --noEmit` passes with no type errors
- [ ] Manual: trigger a web_search tool call, verify the progress card completes after the turn finishes
- [ ] Manual: verify no regression when tool calls complete normally via SSE events

🤖 Generated with [Claude Code](https://claude.com/claude-code)