### PR TITLE
fix(web): restore post-onboarding auto-greet message send

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -671,6 +671,20 @@ export function ChatPage() {
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
 
+  // Auto-send generic onboarding greet when the pending flag fires and no
+  // content-automation initialMessage is queued (avoids double-send).
+  useEffect(() => {
+    if (!_autoGreetPending || !activeConversationKey || !assistantId) return;
+    if (pendingOnboardingInitialMessageRef.current !== null) return;
+    setAutoGreetPending(false);
+    if (awaitingAutoGreetTimeoutRef.current) {
+      clearTimeout(awaitingAutoGreetTimeoutRef.current);
+      awaitingAutoGreetTimeoutRef.current = null;
+    }
+    autoGreetRef.current = false;
+    void sendMessage("Wake up, my friend!");
+  }, [_autoGreetPending, activeConversationKey, assistantId, sendMessage]);
+
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);
   useEffect(() => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -150,7 +150,7 @@ export function ChatPage() {
 
   const [restoredDraftConversationKey, setRestoredDraftConversationKey] = useState<string | null>(null);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const [autoGreetPending, setAutoGreetPending] = useState(false);
+  const [_autoGreetPending, setAutoGreetPending] = useState(false);
   const awaitingAutoGreetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
@@ -668,23 +668,8 @@ export function ChatPage() {
     const pending = pendingOnboardingInitialMessageRef.current;
     if (!pending || !assistantId || activeConversationKey !== pending.conversationKey) return;
     pendingOnboardingInitialMessageRef.current = null;
-    autoGreetRef.current = false;
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
-
-  // Auto-send generic onboarding greet when the pending flag fires and no
-  // content-automation initialMessage is queued (avoids double-send).
-  useEffect(() => {
-    if (!autoGreetPending || !activeConversationKey || !assistantId) return;
-    if (!autoGreetRef.current) return;
-    setAutoGreetPending(false);
-    if (awaitingAutoGreetTimeoutRef.current) {
-      clearTimeout(awaitingAutoGreetTimeoutRef.current);
-      awaitingAutoGreetTimeoutRef.current = null;
-    }
-    autoGreetRef.current = false;
-    void sendMessage("Wake up, my friend!");
-  }, [autoGreetPending, activeConversationKey, assistantId, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -668,6 +668,7 @@ export function ChatPage() {
     const pending = pendingOnboardingInitialMessageRef.current;
     if (!pending || !assistantId || activeConversationKey !== pending.conversationKey) return;
     pendingOnboardingInitialMessageRef.current = null;
+    autoGreetRef.current = false;
     void sendMessage(pending.content);
   }, [activeConversationKey, assistantId, sendMessage]);
 
@@ -675,7 +676,7 @@ export function ChatPage() {
   // content-automation initialMessage is queued (avoids double-send).
   useEffect(() => {
     if (!autoGreetPending || !activeConversationKey || !assistantId) return;
-    if (pendingOnboardingInitialMessageRef.current !== null) return;
+    if (!autoGreetRef.current) return;
     setAutoGreetPending(false);
     if (awaitingAutoGreetTimeoutRef.current) {
       clearTimeout(awaitingAutoGreetTimeoutRef.current);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -150,7 +150,7 @@ export function ChatPage() {
 
   const [restoredDraftConversationKey, setRestoredDraftConversationKey] = useState<string | null>(null);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const [_autoGreetPending, setAutoGreetPending] = useState(false);
+  const [autoGreetPending, setAutoGreetPending] = useState(false);
   const awaitingAutoGreetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
@@ -674,7 +674,7 @@ export function ChatPage() {
   // Auto-send generic onboarding greet when the pending flag fires and no
   // content-automation initialMessage is queued (avoids double-send).
   useEffect(() => {
-    if (!_autoGreetPending || !activeConversationKey || !assistantId) return;
+    if (!autoGreetPending || !activeConversationKey || !assistantId) return;
     if (pendingOnboardingInitialMessageRef.current !== null) return;
     setAutoGreetPending(false);
     if (awaitingAutoGreetTimeoutRef.current) {
@@ -683,7 +683,7 @@ export function ChatPage() {
     }
     autoGreetRef.current = false;
     void sendMessage("Wake up, my friend!");
-  }, [_autoGreetPending, activeConversationKey, assistantId, sendMessage]);
+  }, [autoGreetPending, activeConversationKey, assistantId, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -214,6 +214,7 @@ export function PreChatFlow() {
       tools: stripOtherPrefix([...selectedTools]),
       tasks: [...selectedTasks].sort(),
       tone: selectedGroupId ?? DEFAULT_GROUP_ID,
+      initialMessage: "Wake up, my friend!",
     };
     const trimmedUser = userName.trim();
     if (trimmedUser) context.userName = trimmedUser;


### PR DESCRIPTION
## Summary
Set `initialMessage: "Wake up, my friend!"` in `pre-chat-flow.tsx`'s `finish()` function so the existing `pendingOnboardingInitialMessageRef` → `sendMessage` plumbing handles the generic post-onboarding auto-greet. This was broken after migration — the platform hardcoded the send in `AssistantPageClient.tsx`, but the web app's `finish()` never set `initialMessage`, leaving the auto-greet dead.

## Approach
Uses Option A (reuse existing `initialMessage` plumbing) rather than Option B (new `useEffect` watching `_autoGreetPending`). This avoids adding complexity to `chat-page.tsx` and sidesteps a render-order race condition between the `pendingOnboardingInitialMessageRef` effect and a hypothetical `autoGreetPending` effect.

## Test plan
- [ ] Fresh onboarding flow (standard path) sends "Wake up, my friend!" after history loads
- [ ] Content-automation cohort still sends "I want to write articles that rank better for GEO." (not overwritten)
- [ ] Page refresh after greet does not re-trigger

Closes LUM-1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)