### PR TITLE
fix(web): seed onboarding assistant name and auto-send first greeting

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -475,6 +475,7 @@ export function ChatPage() {
       onboardingDraftConversationKeyRef.current ?? createDraftConversationKey();
     onboardingDraftConversationKeyRef.current = onboardingDraftKey;
     setOnboardingConversationKey(onboardingDraftKey);
+    useConversationStore.getState().setActiveKey(onboardingDraftKey);
     // Drain pending PreChat context from sessionStorage at the same moment
     // the auto-greet is armed so the payload rides along the single greet
     // send and doesn't leak onto a later message.

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -43,7 +43,7 @@ import type { TranscriptHandle } from "@/domains/chat/transcript/transcript.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import { getThinkingStatusText, shouldShowThinkingIndicator, type UIContext } from "@/domains/messaging/turn-selectors.js";
-import { consumePendingInitialMessage, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
+import { clearPendingInitialMessage, peekPendingInitialMessage, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
 import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
@@ -649,17 +649,20 @@ export function ChatPage() {
   }, [searchParams, activeConversationKey, sendMessage]);
 
   // Auto-send onboarding initial message once the conversation is ready.
-  // Read from sessionStorage (not a ref) because ChatPage remounts during
-  // the onboarding redirect. No reachability gate — matches the ?prompt=
-  // pattern above; sendMessage handles unreachable state internally.
+  // Peek at sessionStorage without consuming — only clear after the send
+  // succeeds so a failed attempt (daemon not ready) can retry on the next
+  // effect cycle. Gates on assistantId + reachability so the send doesn't
+  // fire before the daemon can accept it.
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
-    if (initialMessageConsumedRef.current || !activeConversationKey) return;
-    const message = consumePendingInitialMessage();
+    if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
+    if (reachability.state.phase !== "ready") return;
+    const message = peekPendingInitialMessage();
     if (!message) return;
     initialMessageConsumedRef.current = true;
+    clearPendingInitialMessage();
     void sendMessage(message);
-  }, [activeConversationKey, sendMessage]);
+  }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -43,7 +43,7 @@ import type { TranscriptHandle } from "@/domains/chat/transcript/transcript.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import { getThinkingStatusText, shouldShowThinkingIndicator, type UIContext } from "@/domains/messaging/turn-selectors.js";
-import { consumePendingPreChatContext, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
+import { consumePendingInitialMessage, consumePendingPreChatContext, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
 import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
@@ -663,12 +663,17 @@ export function ChatPage() {
     void sendMessage(prompt);
   }, [searchParams, activeConversationKey, sendMessage]);
 
-  // Auto-send onboarding initial message once the draft conversation is ready
+  // Auto-send onboarding initial message once the conversation is ready.
+  // The message is read from sessionStorage (not a ref) because ChatPage
+  // unmounts and remounts during the onboarding redirect (index route →
+  // /conversations/:key), which resets all refs.
+  const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
-    const pending = pendingOnboardingInitialMessageRef.current;
-    if (!pending || !assistantId || activeConversationKey !== pending.conversationKey) return;
-    pendingOnboardingInitialMessageRef.current = null;
-    void sendMessage(pending.content);
+    if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
+    const message = consumePendingInitialMessage();
+    if (!message) return;
+    initialMessageConsumedRef.current = true;
+    void sendMessage(message);
   }, [activeConversationKey, assistantId, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -667,15 +667,18 @@ export function ChatPage() {
   // Auto-send onboarding initial message once the conversation is ready.
   // The message is read from sessionStorage (not a ref) because ChatPage
   // unmounts and remounts during the onboarding redirect (index route →
-  // /conversations/:key), which resets all refs.
+  // /conversations/:key), which resets all refs. Gate on reachability so
+  // we don't consume the message before the daemon can accept it — the
+  // POST would fail and the message would be lost.
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
+    if (reachability.state.phase !== "ready") return;
     const message = consumePendingInitialMessage();
     if (!message) return;
     initialMessageConsumedRef.current = true;
     void sendMessage(message);
-  }, [activeConversationKey, assistantId, sendMessage]);
+  }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -269,7 +269,6 @@ export function ChatPage() {
   const initialPageOldestTsRef = useRef<number | null>(null);
   const conversationListInvalidatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
-  const pendingOnboardingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
   const expandedToolCallIdsRef = useRef<Set<string>>(new Set());
   const contextWindowUsageByConversationRef = useRef<Map<string, ContextWindowUsage>>(new Map());
   const syncRouterRef = useRef<WebSyncRouter | null>(null);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -648,20 +648,29 @@ export function ChatPage() {
     void sendMessage(prompt);
   }, [searchParams, activeConversationKey, sendMessage]);
 
-  // Auto-send onboarding initial message once the conversation is ready.
-  // Peek at sessionStorage without consuming — only clear after the send
-  // Auto-send onboarding initial message — matches the ?prompt= pattern
-  // above (no reachability gate). sendMessage and the streaming layer
-  // handle unreachable state internally.
+  // Kick off a background reachability probe immediately when a pending
+  // onboarding message exists, instead of waiting for a 502 from
+  // getChatContext to trigger the unreachable-bus.
+  useEffect(() => {
+    if (!assistantId) return;
+    const message = peekPendingInitialMessage();
+    if (!message) return;
+    if (reachability.state.phase === "idle") {
+      reachability.probe({ mode: "background" });
+    }
+  }, [assistantId, reachability]);
+
+  // Auto-send onboarding initial message once the daemon is reachable.
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
+    if (reachability.state.phase !== "ready") return;
     const message = peekPendingInitialMessage();
     if (!message) return;
     initialMessageConsumedRef.current = true;
     clearPendingInitialMessage();
     void sendMessage(message);
-  }, [activeConversationKey, assistantId, sendMessage]);
+  }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -43,7 +43,7 @@ import type { TranscriptHandle } from "@/domains/chat/transcript/transcript.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import { getThinkingStatusText, shouldShowThinkingIndicator, type UIContext } from "@/domains/messaging/turn-selectors.js";
-import { consumePendingInitialMessage, consumePendingPreChatContext, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
+import { consumePendingInitialMessage, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
 import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
@@ -476,26 +476,10 @@ export function ChatPage() {
     onboardingDraftConversationKeyRef.current = onboardingDraftKey;
     setOnboardingConversationKey(onboardingDraftKey);
     useConversationStore.getState().setActiveKey(onboardingDraftKey);
-    // Drain pending PreChat context from sessionStorage at the same moment
-    // the auto-greet is armed so the payload rides along the single greet
-    // send and doesn't leak onto a later message.
-    //
-    // React strict-mode double-fires effects in dev; guard so the second
-    // invocation is a no-op (sessionStorage was already drained).
-    if (pendingOnboardingContextRef.current === null) {
-      pendingOnboardingContextRef.current = consumePendingPreChatContext();
-    }
-    if (pendingOnboardingContextRef.current) {
-      setOnboardingTasksEmpty(
-        pendingOnboardingContextRef.current.tasks.length === 0,
-      );
-      if (pendingOnboardingContextRef.current.initialMessage) {
-        pendingOnboardingInitialMessageRef.current = {
-          conversationKey: onboardingDraftKey,
-          content: pendingOnboardingContextRef.current.initialMessage,
-        };
-      }
-    }
+    // Do NOT drain sessionStorage here — this ChatPage instance unmounts
+    // when we navigate to /conversations/:key (different route entry),
+    // losing all refs. Leave the context in sessionStorage so the new
+    // mount's sendMessage hook and auto-send effect can consume it.
     void navigate(routes.conversation(onboardingDraftKey), { replace: true });
     return () => {
       if (awaitingAutoGreetTimeoutRef.current) {
@@ -665,20 +649,33 @@ export function ChatPage() {
   }, [searchParams, activeConversationKey, sendMessage]);
 
   // Auto-send onboarding initial message once the conversation is ready.
-  // The message is read from sessionStorage (not a ref) because ChatPage
-  // unmounts and remounts during the onboarding redirect (index route →
-  // /conversations/:key), which resets all refs. Gate on reachability so
-  // we don't consume the message before the daemon can accept it — the
-  // POST would fail and the message would be lost.
+  // Read from sessionStorage (not a ref) because ChatPage remounts during
+  // the onboarding redirect. No reachability gate — matches the ?prompt=
+  // pattern above; sendMessage handles unreachable state internally.
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
-    if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
-    if (reachability.state.phase !== "ready") return;
+    if (initialMessageConsumedRef.current || !activeConversationKey) return;
     const message = consumePendingInitialMessage();
     if (!message) return;
     initialMessageConsumedRef.current = true;
     void sendMessage(message);
-  }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
+  }, [activeConversationKey, sendMessage]);
+
+  // Derive onboardingTasksEmpty from the pending context in sessionStorage.
+  // Runs once on mount — if initial message key is present, this is an
+  // onboarding mount, so peek at the context for the tasks-empty flag.
+  useEffect(() => {
+    try {
+      const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
+      if (!raw) return;
+      const ctx = JSON.parse(raw) as { tasks?: string[] };
+      if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
+        setOnboardingTasksEmpty(true);
+      }
+    } catch {
+      // Storage or parse failure — ignore.
+    }
+  }, []);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   const deepLinkAppConsumed = useRef(false);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -650,19 +650,18 @@ export function ChatPage() {
 
   // Auto-send onboarding initial message once the conversation is ready.
   // Peek at sessionStorage without consuming — only clear after the send
-  // succeeds so a failed attempt (daemon not ready) can retry on the next
-  // effect cycle. Gates on assistantId + reachability so the send doesn't
-  // fire before the daemon can accept it.
+  // Auto-send onboarding initial message — matches the ?prompt= pattern
+  // above (no reachability gate). sendMessage and the streaming layer
+  // handle unreachable state internally.
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
-    if (reachability.state.phase !== "ready") return;
     const message = peekPendingInitialMessage();
     if (!message) return;
     initialMessageConsumedRef.current = true;
     clearPendingInitialMessage();
     void sendMessage(message);
-  }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
+  }, [activeConversationKey, assistantId, sendMessage]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -150,7 +150,9 @@ export function ChatPage() {
 
   const [restoredDraftConversationKey, setRestoredDraftConversationKey] = useState<string | null>(null);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const [_autoGreetPending, setAutoGreetPending] = useState(false);
+  const [autoGreetPending, setAutoGreetPending] = useState(
+    () => peekPendingInitialMessage() !== null,
+  );
   const awaitingAutoGreetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
@@ -671,6 +673,16 @@ export function ChatPage() {
     clearPendingInitialMessage();
     void sendMessage(message);
   }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
+
+  // Clear the auto-greet loading gate once messages arrive (the assistant
+  // responded) or the 10-second safety timeout expires. Matches platform's
+  // awaitingAutoGreet pattern.
+  useEffect(() => {
+    if (!autoGreetPending) return;
+    if (messages.length > 0) {
+      setAutoGreetPending(false);
+    }
+  }, [autoGreetPending, messages.length]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an
@@ -1229,7 +1241,7 @@ export function ChatPage() {
   // -------------------------------------------------------------------------
   // Loading / error guards
   // -------------------------------------------------------------------------
-  if (authLoading || assistantState.kind === "loading") {
+  if (authLoading || assistantState.kind === "loading" || autoGreetPending) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-[var(--text-secondary)]">Connecting…</p>

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -231,6 +231,7 @@ export function PreChatFlow() {
     if (selectedPriorAssistants.size > 0) {
       context.priorAssistants = stripOtherPrefix([...selectedPriorAssistants]);
     }
+    context.initialMessage = "Wake up, my friend!";
 
     setPendingPreChatContext(context);
     if (trimmedAssistant) setPendingAssistantName(trimmedAssistant);
@@ -304,6 +305,7 @@ export function PreChatFlow() {
         context.assistantName = trimmedAssistant;
       }
       context.googleConnected = false;
+      context.initialMessage = "Wake up, my friend!";
       setPendingPreChatContext(context);
       if (trimmedAssistant) {
         setPendingAssistantName(trimmedAssistant);

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -20,6 +20,7 @@ import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react
 import { usePrefilledInput } from "@/hooks/use-prefilled-input.js";
 import {
   setPendingAssistantName,
+  setPendingInitialMessage,
   setPendingPreChatContext,
   type PreChatOnboardingContext,
 } from "@/domains/onboarding/prechat.js";
@@ -235,6 +236,7 @@ export function PreChatFlow() {
 
     setPendingPreChatContext(context);
     if (trimmedAssistant) setPendingAssistantName(trimmedAssistant);
+    setPendingInitialMessage(context.initialMessage!);
     try {
       setOnboardingCompleted(true);
     } catch (err) {
@@ -310,6 +312,7 @@ export function PreChatFlow() {
       if (trimmedAssistant) {
         setPendingAssistantName(trimmedAssistant);
       }
+      setPendingInitialMessage(context.initialMessage);
       if (screenStorageKey) {
         try {
           sessionStorage.removeItem(screenStorageKey);

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -402,3 +402,24 @@ export function consumePendingInitialMessage(): string | null {
     return null;
   }
 }
+
+export function peekPendingInitialMessage(): string | null {
+  const storage = getSessionStorage();
+  if (storage === null) return null;
+  try {
+    const value = storage.getItem(INITIAL_MESSAGE_KEY);
+    return typeof value === "string" && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInitialMessage(): void {
+  const storage = getSessionStorage();
+  if (storage === null) return;
+  try {
+    storage.removeItem(INITIAL_MESSAGE_KEY);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+}

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -366,3 +366,39 @@ export function consumePendingAssistantName(): string | null {
     return null;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Initial-message handoff
+//
+// The initial message (e.g. "Wake up, my friend!") is stored in the full
+// PreChatOnboardingContext, but `ChatPage` unmounts and remounts during
+// the onboarding redirect (index route → /conversations/:key), losing
+// the ref that held the message. A separate sessionStorage key lets the
+// new mount pick it up.
+// ---------------------------------------------------------------------------
+
+export const INITIAL_MESSAGE_KEY = "onboarding.prechat.initialMessage";
+
+export function setPendingInitialMessage(message: string): void {
+  const trimmed = message.trim();
+  if (!trimmed) return;
+  const storage = getSessionStorage();
+  if (storage === null) return;
+  try {
+    storage.setItem(INITIAL_MESSAGE_KEY, trimmed);
+  } catch {
+    // Storage unavailable — degrade silently.
+  }
+}
+
+export function consumePendingInitialMessage(): string | null {
+  const storage = getSessionStorage();
+  if (storage === null) return null;
+  try {
+    const value = storage.getItem(INITIAL_MESSAGE_KEY);
+    storage.removeItem(INITIAL_MESSAGE_KEY);
+    return typeof value === "string" && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/hooks/use-assistant-identity-init.ts
+++ b/apps/web/src/hooks/use-assistant-identity-init.ts
@@ -50,23 +50,6 @@ export function useAssistantIdentityInit({
 }: UseAssistantIdentityInitParams) {
   const isActive = assistantStateKind === "active" && Boolean(assistantId);
 
-  // Seed the store with the user-chosen name from onboarding before the
-  // async identity fetch resolves. This is the apps/web equivalent of
-  // platform web's `consumePendingAssistantName()` in AssistantPageClient —
-  // ensures the sidebar shows the chosen name immediately on first render
-  // rather than falling back to "Your Assistant".
-  const seededRef = useRef(false);
-  useEffect(() => {
-    if (seededRef.current || !isActive) return;
-    seededRef.current = true;
-    const optimisticName = consumePendingAssistantName();
-    if (!optimisticName) return;
-    const { name: current } = useAssistantIdentityStore.getState();
-    if (!current) {
-      useAssistantIdentityStore.getState().setIdentity(optimisticName, null);
-    }
-  }, [isActive]);
-
   const identityQuery = useQuery({
     queryKey: assistantIdentityQueryKey(assistantId),
     queryFn: () => fetchAssistantIdentity(assistantId as string),
@@ -90,6 +73,23 @@ export function useAssistantIdentityInit({
     if (lastWrittenForRef.current !== assistantId) {
       useAssistantIdentityStore.getState().clearIdentity();
       lastWrittenForRef.current = null;
+    }
+  }, [isActive, assistantId]);
+
+  // Seed the store with the user-chosen name from onboarding before the
+  // async identity fetch resolves. Declared after the clear effect so
+  // React's effect execution order (declaration order) guarantees the
+  // clear runs first and this seed survives.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !isActive) return;
+    seededRef.current = true;
+    const optimisticName = consumePendingAssistantName();
+    if (!optimisticName) return;
+    const { name: current } = useAssistantIdentityStore.getState();
+    if (!current) {
+      useAssistantIdentityStore.getState().setIdentity(optimisticName, null);
+      lastWrittenForRef.current = assistantId;
     }
   }, [isActive, assistantId]);
 

--- a/apps/web/src/hooks/use-assistant-identity-init.ts
+++ b/apps/web/src/hooks/use-assistant-identity-init.ts
@@ -29,6 +29,7 @@ import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchAssistantIdentity } from "@/assistant/identity.js";
+import { consumePendingAssistantName } from "@/domains/onboarding/prechat.js";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
 import type { AssistantState } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
 
@@ -48,6 +49,23 @@ export function useAssistantIdentityInit({
   assistantStateKind,
 }: UseAssistantIdentityInitParams) {
   const isActive = assistantStateKind === "active" && Boolean(assistantId);
+
+  // Seed the store with the user-chosen name from onboarding before the
+  // async identity fetch resolves. This is the apps/web equivalent of
+  // platform web's `consumePendingAssistantName()` in AssistantPageClient —
+  // ensures the sidebar shows the chosen name immediately on first render
+  // rather than falling back to "Your Assistant".
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !isActive) return;
+    seededRef.current = true;
+    const optimisticName = consumePendingAssistantName();
+    if (!optimisticName) return;
+    const { name: current } = useAssistantIdentityStore.getState();
+    if (!current) {
+      useAssistantIdentityStore.getState().setIdentity(optimisticName, null);
+    }
+  }, [isActive]);
 
   const identityQuery = useQuery({
     queryKey: assistantIdentityQueryKey(assistantId),


### PR DESCRIPTION
## Summary
- `consumePendingAssistantName()` was defined but never called in apps/web after the refactor from platform web's monolithic `AssistantPageClient` to the Zustand store + `useAssistantIdentityInit` hook
- The optimistic name written by `PreChatFlow.finish()` sat unconsumed in sessionStorage, so the sidebar always showed "Your Assistant" until the async identity fetch resolved
- Seeds the Zustand identity store with the pending name on first mount, before the TanStack Query fetch resolves
- **Auto-sends "Wake up, my friend!"** after onboarding completes (matching platform behavior) so the onboarding payload — including `assistantName` — reaches the daemon before it bootstraps its own LLM-generated name

## Test plan
- [ ] Complete onboarding flow, choose a custom assistant name (e.g., "Alfred")
- [ ] Verify the sidebar immediately shows the chosen name (not "Your Assistant") after navigating to the chat page
- [ ] Verify "Wake up, my friend!" is auto-sent as the first message
- [ ] Verify the assistant responds using the chosen name (not an LLM-generated one)
- [ ] Refresh the page — verify the name persists via the real identity fetch
- [ ] Verify normal (non-onboarding) page loads still work — no regression on sidebar name display
- [ ] Verify iOS native onboarding flow also auto-sends the greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)