### PR TITLE
fix(memory): suppress wake surface card on legacy retrospective wakes

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -315,6 +315,13 @@ describe("memoryRetrospectiveJob", () => {
     expect(bootstrapCalls[0]!.forkParentConversationId).toBe("src-conv-1");
   });
 
+  test("legacy path: wake opts include suppressWakeSurface so the full retrospective prompt isn't rendered as a 'Conversation Woke' card body to clients", async () => {
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.suppressWakeSurface).toBe(true);
+  });
+
   test("no-new-messages early return: neither field changes, no wake, no bootstrap", async () => {
     newMessages = [];
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -208,6 +208,11 @@ async function runLegacyRetrospective(
       source: MEMORY_RETROSPECTIVE_SOURCE,
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
+      // The background conversation's title already reads "Memory
+      // Retrospective", and `hint` is the full retrospective prompt — surfacing
+      // it verbatim as a "Conversation Woke" card body is noisy internal
+      // scaffolding for the user. Suppress it, matching the fork-based path.
+      suppressWakeSurface: true,
     });
     wakeSucceeded = result.invoked;
     failureReason = result.reason;


### PR DESCRIPTION
## Summary

- Pass `suppressWakeSurface: true` from the legacy `runLegacyRetrospective` wake call (`assistant/src/memory/memory-retrospective-job.ts:205-215`). This stops `agent-wake.ts:738-770` from both injecting the giant "Conversation Woke" inline card into the wake's first assistant message AND broadcasting `ui_surface_show` over SSE — same treatment the fork path got in #31372.
- The fork path is `defaultEnabled: false` in `meta/feature-flags/feature-flag-registry.json:18`, so the legacy path is the default for everyone — meaning the leak hit every user on default settings, not a per-user quirk.
- Add a regression test (`memory-retrospective-job.test.ts`) parallel to the existing fork-path coverage asserting the wake opts include `suppressWakeSurface: true`.

## Original prompt

Users reported a "Conversation Woke" card showing up mid-conversation in the web client (but not macOS) with a 3-4 KB body containing the full retrospective prompt: `<transcript>`, `<already_remembered>`, dedup rules. Investigation showed the legacy memory-retrospective path injects the prompt as a `ui_surface` card body via `agent-wake.ts:740-757`, then broadcasts `ui_surface_show` for it; the web app subscribes to SSE globally (per-assistant, not per-conversation) and the wake's `ui_surface_show` frame carries `conversationId` but no `conversationKey`, so the client-side per-conversation filter at `use-event-stream.ts:218-228` passes it through to the active conversation. The fork retrospective path already suppresses this via #31372; this PR mirrors that fix on the legacy default path.