### PR TITLE
Persist web theme selection across reloads

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,29 @@
   <link rel="icon" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>
+  <script>
+    (function() {
+      try {
+        var theme = window.localStorage.getItem("vellum_theme") || "system";
+        var prefersDark =
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var shouldBeDark =
+          theme === "velvet" ||
+          theme === "dark" ||
+          (theme === "system" && prefersDark);
+        var root = document.documentElement;
+        root.setAttribute(
+          "data-theme",
+          shouldBeDark ? "dark" : "light"
+        );
+        root.classList.toggle("dark", shouldBeDark);
+        root.classList.remove("velvet");
+      } catch {
+        // Theme startup is best-effort. React will apply the default later.
+      }
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -39,6 +39,10 @@ export function ThemeToggle({ className }: { className?: string } = {}) {
   );
 
   useEffect(() => {
+    setTheme(readStoredThemePreference({ velvetEnabled: velvet }));
+  }, [velvet]);
+
+  useEffect(() => {
     const handleExternalThemeChange = (event: CustomEvent<string>) => {
       setTheme(
         normalizeThemePreference(event.detail, { velvetEnabled: velvet }),

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -43,6 +43,10 @@ function ThemeCard() {
   );
 
   useEffect(() => {
+    setTheme(readStoredThemePreference({ velvetEnabled: velvet }));
+  }, [velvet]);
+
+  useEffect(() => {
     const handleExternalThemeChange = (event: CustomEvent<string>) => {
       setTheme(
         normalizeThemePreference(event.detail, { velvetEnabled: velvet }),

--- a/apps/web/src/domains/settings/utils/theme-preferences.ts
+++ b/apps/web/src/domains/settings/utils/theme-preferences.ts
@@ -62,6 +62,8 @@ export function applyThemePreference(theme: ThemePreference): void {
     "data-theme",
     isVelvet ? "velvet" : shouldBeDark ? "dark" : "light",
   );
+  root.classList.toggle("dark", shouldBeDark);
+  root.classList.toggle("velvet", isVelvet);
 }
 
 export function getEffectiveThemePreference(

--- a/apps/web/src/hooks/use-app-theme.ts
+++ b/apps/web/src/hooks/use-app-theme.ts
@@ -13,7 +13,6 @@ import {
   applyThemePreference,
   normalizeThemePreference,
   THEME_STORAGE_KEY,
-  writeStoredThemePreference,
 } from "@/domains/settings/utils/theme-preferences.js";
 
 function readRawStoredTheme(): string | null {
@@ -33,9 +32,6 @@ export function useAppTheme() {
       velvetEnabled: velvet,
     });
 
-    if (stored !== null && stored !== theme) {
-      writeStoredThemePreference(theme);
-    }
     applyThemePreference(theme);
 
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");


### PR DESCRIPTION
## Summary
- Add a pre-React theme bootstrap in the Vite HTML shell so the persisted `vellum_theme` value is applied before the app renders.
- Keep `data-theme` and the legacy `dark`/`velvet` classes in sync when applying theme preferences.
- Preserve stored Velvet selections while client feature flags finish syncing, then resync the settings/menu controls once the flag value is known.

## Original prompt
The web app theme selector appeared not to persist after reloads or restarts. The old frontend in `vellum-assistant-platform` needed to be checked to see whether theme was browser-local or server-backed; it used localStorage under `vellum_theme`, so this ports the missing frontend persistence behavior into the migrated Vite app.