### PR TITLE
[codex] Show saved connection key state

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -26,6 +26,7 @@ import {
   updateConnection,
   writeSecret,
 } from "@/domains/settings/ai/provider-connections-client.js";
+import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder.js";
 import { toKebabCase } from "@/domains/settings/ai/slugify.js";
 import { providerSupportsPlatformAuth } from "@/assistant/llm-model-catalog.js";
 
@@ -152,9 +153,7 @@ export function ProviderEditorContent({
   // New state for inline API key editing
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
-  const [maskedCredentialValue, setMaskedCredentialValue] = useState<
-    string | null
-  >(null);
+  const [hasStoredCredential, setHasStoredCredential] = useState(false);
   const [isLoadingCredential, setIsLoadingCredential] = useState(false);
   const [availableCredentials, setAvailableCredentials] = useState<
     CredentialEntry[]
@@ -258,23 +257,28 @@ export function ProviderEditorContent({
     }
   }
 
-  const loadMaskedValue = useCallback(
+  const loadCredentialPresence = useCallback(
     async (credRef: string) => {
       const parts = credRef.split("/");
       if (parts.length < 3 || parts[0] !== "credential") {
-        setMaskedCredentialValue(null);
+        setHasStoredCredential(false);
         return;
       }
       const service = parts[1];
       const field = parts.slice(2).join("/");
       setIsLoadingCredential(true);
-      const result = await readSecret(
-        assistantId,
-        "credential",
-        `${service}:${field}`,
-      );
-      setMaskedCredentialValue(result.masked);
-      setIsLoadingCredential(false);
+      try {
+        const result = await readSecret(
+          assistantId,
+          "credential",
+          `${service}:${field}`,
+        );
+        setHasStoredCredential(result.found);
+      } catch {
+        setHasStoredCredential(false);
+      } finally {
+        setIsLoadingCredential(false);
+      }
     },
     [assistantId],
   );
@@ -318,7 +322,7 @@ export function ProviderEditorContent({
 
     // Reset credential UI state
     setApiKeyValue("");
-    setMaskedCredentialValue(null);
+    setHasStoredCredential(false);
     setIsLoadingCredential(false);
     setAvailableCredentials([]);
     setIsCreatingNewCredential(false);
@@ -334,13 +338,13 @@ export function ProviderEditorContent({
 
     // Load credential data for edit mode with api_key auth
     if (connection?.auth.type === "api_key") {
-      void loadMaskedValue(connection.auth.credential);
+      void loadCredentialPresence(connection.auth.credential);
       void loadAvailableCredentials();
     } else if (!connection) {
       // Create mode: pre-load available credentials for the Advanced section
       void loadAvailableCredentials();
     }
-  }, [connection, loadMaskedValue, loadAvailableCredentials]);
+  }, [connection, loadCredentialPresence, loadAvailableCredentials]);
 
   // Auto-derive key from label when not dirty and in create mode
   function handleLabelChange(newLabel: string) {
@@ -380,7 +384,7 @@ export function ProviderEditorContent({
       setCredential(`credential/${provider}/api_key`);
     }
     setApiKeyValue("");
-    setMaskedCredentialValue(null);
+    setHasStoredCredential(false);
     setBaseUrl("");
     setConnectionModels("");
     // New connection starts active by convention; user can toggle off
@@ -430,6 +434,7 @@ export function ProviderEditorContent({
             } else {
               await writeSecret(assistantId, "api_key", provider, trimmedKey);
             }
+            setHasStoredCredential(true);
           } catch {
             setError("Failed to save API key. Please try again.");
             return;
@@ -437,7 +442,7 @@ export function ProviderEditorContent({
             setIsSavingKey(false);
           }
         } else if (
-          maskedCredentialValue === null &&
+          !hasStoredCredential &&
           effectiveMode === "create"
         ) {
           setError("Enter an API key or select an existing credential.");
@@ -532,6 +537,10 @@ export function ProviderEditorContent({
     providerCredentials.length > 0 ||
     isCreatingNewCredential ||
     isEditingApiKeyConnection;
+  const apiKeyPlaceholder = secretPlaceholder(
+    "Enter your API key",
+    hasStoredCredential,
+  );
 
   return (
     <Modal.Content size="md">
@@ -621,7 +630,7 @@ export function ProviderEditorContent({
                   });
                   setCredential(`credential/${newProvider}/api_key`);
                 }
-                setMaskedCredentialValue(null);
+                setHasStoredCredential(false);
               }
             }}
             disabled={effectiveMode !== "create"}
@@ -708,7 +717,7 @@ export function ProviderEditorContent({
         {/* API Key + Advanced disclosure — only shown for api_key auth */}
         {authType === "api_key" && (
           <>
-            {/* Primary: masked API Key field */}
+            {/* Primary: saved-state API Key field */}
             <div className="space-y-1">
               <label className="block text-body-small-default text-[var(--content-tertiary)]">
                 API Key
@@ -731,19 +740,10 @@ export function ProviderEditorContent({
                     setApiKeyValue(e.target.value);
                     setError(null);
                   }}
-                  placeholder={maskedCredentialValue ?? "Enter your API key"}
+                  placeholder={apiKeyPlaceholder}
                   disabled={isAuthLocked}
                   fullWidth
                 />
-              )}
-              {maskedCredentialValue !== null && apiKeyValue === "" && (
-                <Typography
-                  variant="body-small-default"
-                  as="p"
-                  className="text-[var(--content-tertiary)]"
-                >
-                  A key is configured. Enter a new value to replace it.
-                </Typography>
               )}
             </div>
 
@@ -804,7 +804,7 @@ export function ProviderEditorContent({
                           value={credential}
                           onChange={(v) => {
                             setCredential(v);
-                            void loadMaskedValue(v);
+                            void loadCredentialPresence(v);
                           }}
                           disabled={isAuthLocked}
                           options={dropdownOptions}
@@ -837,7 +837,7 @@ export function ProviderEditorContent({
                             setCredential(ref);
                             setIsCreatingNewCredential(false);
                             setNewCredentialName("");
-                            void loadMaskedValue(ref);
+                            void loadCredentialPresence(ref);
                           }}
                         >
                           Use


### PR DESCRIPTION
## Summary

- Reuse the shared AI settings saved-secret placeholder for provider connection API-key fields.
- Update provider connection API-key editing to track `readSecret().found` instead of relying on the masked preview value.
- Show the same `••••••••` saved-key placeholder used by Web Search and keep existing selected credentials valid when no replacement key is entered.

## Why

Provider connections could look like they had no saved key because the password field depended on the masked secret preview. This matches the web-search API-key input behavior from #31610 by using the same saved-secret placeholder helper and an explicit saved-secret state.

## Validation

- `bun test src/domains/settings/ai/ai-page.test.ts`
- `bun run lint src/domains/settings/ai/provider-editor-modal.tsx`
- `git diff --check origin/main`
- pre-push hook on the latest force-push completed successfully

Attempted `bunx tsc --noEmit` before rebasing, but the web workspace was blocked by unrelated existing issues: duplicate React types under `@vellum/design-library/node_modules` and generated billing/resize API type mismatches.