### PR TITLE
Restore admin link in web preferences menu

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -5,6 +5,7 @@ import {
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
+  Shield,
   SlidersHorizontal,
 } from "lucide-react";
 import { useState } from "react";
@@ -109,6 +110,7 @@ function PreferencesMenuContent({
 }: PreferencesMenuContentProps) {
   const navigate = useNavigate();
   const logout = useAuthStore.use.logout();
+  const user = useAuthStore.use.user();
 
   return (
     <>
@@ -142,6 +144,18 @@ function PreferencesMenuContent({
           onShareFeedback();
         }}
       />
+
+      {user?.isStaff ? (
+        <PanelItem
+          icon={Shield}
+          label="Admin"
+          onSelect={() => {
+            onClose();
+            // /admin is still served by the platform app, outside this Vite router.
+            window.location.href = routes.admin.root;
+          }}
+        />
+      ) : null}
 
       <PanelItem
         icon={LogOut}

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -20,7 +20,7 @@ import {
 
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
-import { routes } from "@/utils/routes.js";
+import { adminUrl, routes } from "@/utils/routes.js";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal.js";
 import { ThemeToggle } from "@/components/theme-toggle.js";
 
@@ -151,8 +151,7 @@ function PreferencesMenuContent({
           label="Admin"
           onSelect={() => {
             onClose();
-            // /admin is still served by the platform app, outside this Vite router.
-            window.location.href = routes.admin.root;
+            window.location.href = adminUrl();
           }}
         />
       ) : null}

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -83,6 +83,10 @@ export const routes = {
     upgradeSuccess: r("/assistant/settings/billing/upgrade/success"),
   },
 
+  admin: {
+    root: r("/admin"),
+  },
+
   docs: {
     legal: {
       privacyPolicy: r("/docs/privacy-policy"),

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -13,6 +13,7 @@
 const r = <const T extends string>(path: T): T => path;
 
 const dyn = (parent: string, id: string): string => `${parent}/${id}`;
+const LOCAL_ADMIN_ORIGIN = "http://localhost:3000";
 
 export const routes = {
   assistant: r("/assistant"),
@@ -105,4 +106,11 @@ export function legalUrl(
   path: (typeof routes.docs.legal)[keyof typeof routes.docs.legal],
 ): string {
   return `https://${WWW_DOMAIN}${path}`;
+}
+
+/** URL for the platform-hosted admin UI. */
+export function adminUrl(): string {
+  return import.meta.env.DEV
+    ? `${LOCAL_ADMIN_ORIGIN}${routes.admin.root}`
+    : routes.admin.root;
 }


### PR DESCRIPTION
## Summary
- Restored the staff-only Admin row in the web preferences menu, matching the platform implementation.
- Added the /admin route constant and use full-page navigation so the link reaches the platform admin page outside the Vite router.

## Original prompt
The user asked to restore the missing admin page link in the web app preferences menu for staff users. They asked that the original implementation in vellum-assistant-platform be used as the reference for how the link should appear and where it should navigate.