### PR TITLE
fix(web): card/shell self-review remediation

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -184,8 +184,8 @@ describe("ToolCallProgressCard — confirmation short-circuit", () => {
   });
 });
 
-describe("ToolCallProgressCard — subagent_spawn-only group", () => {
-  test("renders null pending the inline subagent card in PR 8", () => {
+describe("ToolCallProgressCard — subagent_spawn filtering", () => {
+  test("renders null for a single subagent_spawn group (inline card handles it)", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -201,11 +201,36 @@ describe("ToolCallProgressCard — subagent_spawn-only group", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  test("subagent_spawn alongside another tool DOES render the unified shell", () => {
-    // Regression guard — the null short-circuit is intentionally tight
-    // (length === 1 && first is subagent_spawn). Any other shape, including
-    // multiple subagent_spawn calls, must render the unified shell so the
-    // user still sees activity.
+  test("renders null for a multi subagent_spawn group (no double render)", () => {
+    // The previous dispatcher only suppressed `length === 1` spawn-only
+    // groups, which meant 2+ spawn calls rendered "Spawning subagent" rows
+    // in the unified card on top of the transcript-level inline cards —
+    // showing each subagent twice. The data layer now filters
+    // `subagent_spawn` out, so this multi-spawn group reduces to zero steps
+    // and renders nothing.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "First" },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Second" },
+      }),
+    ];
+    const { container, queryByTestId } = renderCard(toolCalls);
+    expect(queryByTestId("tool-progress-card-shell")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("subagent_spawn alongside another tool renders only the non-spawn step", () => {
+    // Mixed groups still produce a unified card so users see the non-spawn
+    // tools. The spawn itself is suppressed (rendered inline elsewhere) so
+    // the shell only shows one step, not two.
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -220,8 +245,11 @@ describe("ToolCallProgressCard — subagent_spawn-only group", () => {
         input: { command: "ls" },
       }),
     ];
-    const { getByTestId } = renderCard(toolCalls);
+    const { getByTestId, getByText, queryByText } = renderCard(toolCalls);
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+    expect(getByText("1 step")).toBeTruthy();
+    // No "Spawning subagent" row in the body.
+    expect(queryByText(/Spawning subagent/i)).toBeNull();
   });
 });
 
@@ -480,6 +508,103 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
       />,
     );
     expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+  });
+
+  test("isStreaming=true keeps the card expanded after tools complete", () => {
+    // Tools finish before the assistant's final response — the card should
+    // stay expanded while `isStreaming` is true so the user sees the steps
+    // beside the streaming reply, not a prematurely-collapsed card.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls, { isStreaming: true });
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+  });
+
+  test("isStreaming=false collapses the completed card (regression vs the previous case)", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 1000,
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls, { isStreaming: false });
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
+});
+
+describe("ToolCallProgressCard — web group error chrome", () => {
+  test("a purely-web group with an errored tool call renders the shell's error icon", () => {
+    // Previously the `WebSearchView` recomputed state from raw status only,
+    // so an errored web_search rendered the green check (loading → complete)
+    // while non-web groups got the red AlertCircle. Now the unified state
+    // bubbles up so the icon matches.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "error",
+        input: { query: "tigers" },
+      }),
+    ];
+    const { getByTestId } = renderCard(toolCalls);
+    const indicator = getByTestId("web-search-status-indicator");
+    // lucide `AlertCircle` renders as an <svg>.
+    expect(indicator.tagName.toLowerCase()).toBe("svg");
+    expect(indicator.getAttribute("data-state")).toBe("error");
+  });
+});
+
+describe("ToolCallProgressCard — mixed group web_search_error rendering", () => {
+  test("renders an ErrorChip (not the default pill) for a web_search_error step in a mixed group", () => {
+    // The unified card's `ExpandedStep` previously fell through to
+    // `DefaultStepPill` for `web_search_error`, dropping the dedicated
+    // error chip the web-search card shows. A mixed group exercises that
+    // path since purely-web groups go through `WebSearchProgressCard`.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "error",
+        input: { query: "tigers" },
+        activityMetadata: {
+          webSearch: {
+            query: "tigers",
+            provider: "anthropic-native",
+            resultCount: 0,
+            durationMs: 200,
+            results: [],
+            errorMessage: "Provider returned max_uses_exceeded.",
+          },
+        },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "ls" },
+        startedAt: 0,
+        completedAt: 100,
+      }),
+    ];
+    const { getByTestId, getByText } = renderCard(toolCalls, {
+      // Force expand so the step body is in the DOM regardless of state.
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+    expect(getByTestId("web-search-error-chip")).toBeTruthy();
+    expect(getByText("Provider returned max_uses_exceeded.")).toBeTruthy();
   });
 });
 

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -1,13 +1,15 @@
-
 import { X } from "lucide-react";
 import { Fragment, useState } from "react";
 
 import { ToolCallChip } from "@/domains/chat/components/tool-call-chip/tool-call-chip.js";
-import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.js";
-import { WebSearchProgressCard } from "@/domains/chat/components/web-search/web-search-progress-card.js";
-import type { StepDescriptor } from "@/domains/chat/components/web-search/web-search-progress-card.js";
-import { Typography } from "@vellum/design-library";
-
+import {
+  WebSearchProgressCard,
+  type StepDescriptor,
+} from "@/domains/chat/components/web-search/web-search-progress-card.js";
+import {
+  WebSearchErrorRow,
+  WebSearchStepRow,
+} from "@/domains/chat/components/web-search/web-search-step-row.js";
 import {
   DefaultStepPill,
   PhaseGroupedStepList,
@@ -60,8 +62,10 @@ export interface ToolCallProgressCardProps {
   onDismissUnknownNudge?: (toolCallId: string) => void;
   /**
    * Whether the parent assistant message is currently streaming a response.
-   * Retained for API compatibility with the legacy dispatcher; the unified
-   * card derives its visual state from `useToolCallCardData` instead.
+   * Tools can finish before the assistant's final reply is complete; the
+   * card keeps itself expanded while either `isStreaming` is true or the
+   * tool group is still loading, so the user keeps seeing the steps next to
+   * the streaming reply instead of a prematurely-collapsed card.
    */
   isStreaming?: boolean;
   /**
@@ -83,9 +87,10 @@ export interface ToolCallProgressCardProps {
  * - `pendingConfirmationToolCallId` matches a tool call in this group →
  *   render the inline confirmation UI via {@link ToolCallChip} so the
  *   approve/deny path is preserved bit-for-bit from the legacy card.
- * - `subagent_spawn`-only group → return `null` until PR 8 wires the inline
- *   subagent card; the legacy bottom-of-message `SubagentProgressCard`
- *   continues to render the spawned subagent's progress.
+ * - Zero renderable steps (today: a group made up entirely of
+ *   `subagent_spawn` calls, which `useToolCallCardData` filters out) → render
+ *   `null`; the spawned subagents render as inline
+ *   `SubagentInlineProgressCard`s elsewhere in the transcript.
  */
 export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
   const {
@@ -103,6 +108,11 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
   // prepends a `thinking` step ahead of the first tool call when supplied;
   // purely-web groups (which historically didn't have a leading-thinking
   // slot) typically pass `null` so the prepend is a no-op.
+  //
+  // `subagent_spawn` calls are filtered out inside `computeToolCallCardData`
+  // — they're rendered inline by `SubagentInlineProgressCard` at the
+  // transcript level. If a group reduces to zero renderable steps the
+  // dispatcher falls through to a no-op below.
   const cardData = useToolCallCardData(
     toolCalls,
     leadingThinkingText ?? null,
@@ -116,13 +126,10 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
     return <ConfirmationView {...props} />;
   }
 
-  // Subagent-only group — PR 7 introduces an inline subagent card; until
-  // then the spawned subagent continues to render via the legacy bottom-of-
-  // message `SubagentProgressCard`, so this card returns nothing.
-  if (
-    toolCalls.length === 1 &&
-    toolCalls[0]?.toolName === "subagent_spawn"
-  ) {
+  // No renderable steps — every tool call in the group was filtered out
+  // (today that means a `subagent_spawn`-only group). Inline subagent cards
+  // handle the rendering elsewhere, so we return nothing here.
+  if (cardData.steps.length === 0) {
     return null;
   }
 
@@ -147,10 +154,18 @@ function isPurelyWebGroup(toolCalls: ChatMessageToolCall[]): boolean {
 
 /**
  * Renders the web-search variant by narrowing the unified card data to the
- * legacy `WebSearchProgressCard` props. State is recomputed from the raw
- * tool-call statuses rather than the unified `state` because a denied
- * confirmation can race ahead of the error `tool_result` and the legacy
- * card has to stay in `"loading"` until the tool actually exits.
+ * legacy `WebSearchProgressCard` props.
+ *
+ * State precedence (highest first):
+ *   1. `"loading"` — any tool call still has `status === "running"`. A denied
+ *      confirmation can race ahead of the error `tool_result`, so the legacy
+ *      card has to stay in `"loading"` until the tool actually exits.
+ *   2. unified `state === "error"` or `"denied"` — bubble the failed chrome
+ *      up so a purely-web group that ends with a tool error reads as failed
+ *      (consistent with mixed / non-web groups that already render through
+ *      the unified shell's error icon).
+ *   3. `"complete"` — every tool call reached a terminal status without
+ *      failure.
  */
 function WebSearchView({
   toolCalls,
@@ -159,11 +174,6 @@ function WebSearchView({
   toolCalls: ChatMessageToolCall[];
   cardData: ToolCallCardData;
 }) {
-  const state: "loading" | "complete" = toolCalls.some(
-    (tc) => tc.status === "running",
-  )
-    ? "loading"
-    : "complete";
   return (
     <WebSearchProgressCard
       currentStepTitle={cardData.currentStepTitle}
@@ -173,10 +183,19 @@ function WebSearchView({
       // by construction — the `tool` variant only appears for non-web
       // tools, which this branch filters out.
       steps={cardData.steps as StepDescriptor[]}
-      state={state}
+      state={deriveWebShellState(toolCalls, cardData.state)}
       carouselItems={cardData.carouselItems}
     />
   );
+}
+
+function deriveWebShellState(
+  toolCalls: ChatMessageToolCall[],
+  unifiedState: ToolCallCardData["state"],
+): ToolProgressCardState {
+  if (toolCalls.some((tc) => tc.status === "running")) return "loading";
+  if (unifiedState === "error" || unifiedState === "denied") return unifiedState;
+  return "complete";
 }
 
 /**
@@ -195,9 +214,15 @@ function UnifiedToolCallProgressCard({
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
+  isStreaming,
 }: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
   const cardId = toolCalls[0]?.id ?? null;
-  const expanded = useCardExpanded(cardId, cardData.state, expandedCardIds);
+  const expanded = useCardExpanded(
+    cardId,
+    cardData.state,
+    expandedCardIds,
+    isStreaming ?? false,
+  );
 
   const shellState: ToolProgressCardState = cardData.state;
 
@@ -244,9 +269,11 @@ function UnifiedToolCallProgressCard({
 
 /**
  * Drives the unified card's expand/collapse state. Mirrors legacy behavior:
- * auto-expand while loading, auto-collapse on terminal state, but a user
- * toggle (now or in a previous mount, recorded in `expandedCardIds`) wins
- * across state transitions and remounts.
+ * auto-expand while loading or while the parent message is still streaming
+ * (tools can finish before the assistant's final response is complete),
+ * auto-collapse on terminal state, but a user toggle (now or in a previous
+ * mount, recorded in `expandedCardIds`) wins across state transitions and
+ * remounts.
  *
  * `localToggle` mirrors the map mutation so React re-renders on click —
  * mutating the map alone wouldn't trigger one.
@@ -255,6 +282,7 @@ function useCardExpanded(
   cardId: string | null,
   state: ToolCallCardData["state"],
   expandedCardIds: Map<string, boolean>,
+  isStreaming: boolean,
 ): { value: boolean; onChange: (next: boolean) => void } {
   const [localToggle, setLocalToggle] = useState<boolean | undefined>(
     undefined,
@@ -262,7 +290,7 @@ function useCardExpanded(
   const persisted =
     cardId != null ? expandedCardIds.get(cardId) : undefined;
   const userChoice = localToggle ?? persisted;
-  const value = userChoice ?? state === "loading";
+  const value = userChoice ?? (state === "loading" || isStreaming);
 
   const onChange = (next: boolean) => {
     setLocalToggle(next);
@@ -325,28 +353,17 @@ function UnknownCommandNudge({
 
 /**
  * Render a single step inside the expanded body of a phase section. The
- * `web_search` variant keeps its favicon chip cluster + overflow pill so
- * the visual language matches the dedicated `WebSearchProgressCard`; all
- * other variants fall through to {@link DefaultStepPill} which matches
- * Figma `5010-103135`.
+ * `web_search` and `web_search_error` variants delegate to the shared
+ * `WebSearchStepRow` / `WebSearchErrorRow` primitives so the visual language
+ * matches the dedicated `WebSearchProgressCard`; all other variants fall
+ * through to {@link DefaultStepPill} which matches Figma `5010-103135`.
  */
 function ExpandedStep({ step }: { step: ToolCallCardStep }) {
   if (step.kind === "web_search") {
-    return (
-      <div className="flex flex-wrap items-center gap-1">
-        {step.results.map((r) => (
-          <FaviconChip
-            key={r.rank}
-            faviconUrl={r.faviconUrl}
-            title={r.title}
-            domain={r.domain}
-          />
-        ))}
-        {step.overflow && step.overflow > 0 ? (
-          <OverflowChip count={step.overflow} />
-        ) : null}
-      </div>
-    );
+    return <WebSearchStepRow step={step} />;
+  }
+  if (step.kind === "web_search_error") {
+    return <WebSearchErrorRow step={step} />;
   }
   return <DefaultStepPill step={step} />;
 }
@@ -415,19 +432,3 @@ function ConfirmationView({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Small shared chips — kept local so the file is self-contained
-// ---------------------------------------------------------------------------
-
-function OverflowChip({ count }: { count: number }) {
-  return (
-    <div className="rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
-      <Typography
-        variant="body-small-emphasised"
-        className="text-[var(--content-default)]"
-      >
-        +{count} more
-      </Typography>
-    </div>
-  );
-}

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -153,6 +153,42 @@ describe("PhaseGroupedStepList — phase header status icon", () => {
     expect(icons[0]!.getAttribute("data-status")).toBeNull();
     expect(icons[0]!.children.length).toBe(3);
   });
+
+  test("phase with an in-flight web_search step renders three-dot (not the green check)", () => {
+    // `web_search` carries no explicit status field — its present-tense
+    // title is the canonical in-flight signal. Without this branch the
+    // header reads as completed while the search is still running.
+    const steps: ToolCallCardStep[] = [
+      {
+        kind: "web_search",
+        title: "Searching the web",
+        durationLabel: "",
+        linkCount: 0,
+        results: [],
+      },
+    ];
+    const { getAllByTestId } = render(<PhaseGroupedStepList steps={steps} />);
+    const icons = getAllByTestId("phase-header-status-icon");
+    expect(icons.length).toBe(1);
+    expect(icons[0]!.getAttribute("data-status")).toBeNull();
+    expect(icons[0]!.children.length).toBe(3);
+  });
+
+  test("phase with only terminal web_search steps renders the green check", () => {
+    const steps: ToolCallCardStep[] = [
+      {
+        kind: "web_search",
+        title: "Searched the web",
+        durationLabel: "1s",
+        linkCount: 1,
+        results: [],
+      },
+    ];
+    const { getAllByTestId } = render(<PhaseGroupedStepList steps={steps} />);
+    const icons = getAllByTestId("phase-header-status-icon");
+    expect(icons.length).toBe(1);
+    expect(icons[0]!.getAttribute("data-status")).toBe("completed");
+  });
 });
 
 describe("PhaseGroupedStepList — renderStep override", () => {

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -121,8 +121,12 @@ type PhaseHeaderStatus = "completed" | "failed" | "running";
  *
  * Precedence: any running step → "running"; otherwise any failure
  * (`tool_error` / `web_search_error` / `tool` status `error`|`denied`) →
- * "failed"; otherwise → "completed". `thinking` / `web_search` have no
- * per-step status — they're neutral and don't influence the bucket.
+ * "failed"; otherwise → "completed".
+ *
+ * `web_search` steps carry no explicit status field — `useToolCallCardData`
+ * encodes "in-flight" via the present-tense title ("Searching the web" vs
+ * "Searched the web"), so we treat any `web_search` step with that title
+ * as in-flight. `thinking` is always neutral (no in-flight signal carried).
  */
 function phaseHeaderStatus(steps: ToolCallCardStep[]): PhaseHeaderStatus {
   if (steps.length === 0) return "running";
@@ -133,10 +137,16 @@ function phaseHeaderStatus(steps: ToolCallCardStep[]): PhaseHeaderStatus {
       if (step.status === "error" || step.status === "denied") failed = true;
       continue;
     }
+    if (step.kind === "web_search") {
+      // Title is the canonical in-flight signal — see `webSearchStepTitle`
+      // in `use-tool-call-card-data.ts`.
+      if (step.title === "Searching the web") return "running";
+      continue;
+    }
     if (step.kind === "tool_error" || step.kind === "web_search_error") {
       failed = true;
     }
-    // `thinking` / `web_search` are neutral — see docstring.
+    // `thinking` is neutral — see docstring.
   }
   return failed ? "failed" : "completed";
 }

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
@@ -1,12 +1,12 @@
 
-import { AlertCircle } from "lucide-react";
 import { useMemo } from "react";
 
-import { Typography } from "@vellum/design-library";
-
 import type { WebSearchResultItem } from "@/assistant/web-activity-types.js";
-import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.js";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel.js";
+import {
+  WebSearchErrorRow,
+  WebSearchStepRow,
+} from "@/domains/chat/components/web-search/web-search-step-row.js";
 import {
   DefaultStepPill,
   PhaseGroupedStepList,
@@ -26,7 +26,9 @@ import type { ToolCallCardStep } from "@/domains/chat/hooks/use-tool-call-card-d
  *   - `PhaseGroupedStepList` (expanded: phase-section headers + indented
  *     per-step content; the web card passes a `renderStep` override so
  *     `web_search` steps keep their favicon-chip cluster)
- *   - `FaviconChip` (expanded: a web_search step's result chips)
+ *   - `WebSearchStepRow` / `WebSearchErrorRow` (shared with the unified
+ *     `ToolCallProgressCard`'s `ExpandedStep` — single source of truth for
+ *     the favicon chip cluster, overflow pill, and error chip)
  *   - `WebsiteCarousel` (collapsed-header info slot during an active search
  *     with at least one completed `web_search` to feed the rotation)
  *
@@ -97,8 +99,12 @@ export interface WebSearchProgressCardProps {
    *   `WebsiteCarousel` in the collapsed header.
    * - `"complete"` → static green `CheckCircle2` icon + no carousel; the
    *   card is rendering a finished search result set.
+   * - `"error"` / `"denied"` → red `AlertCircle` icon + no carousel. Used
+   *   by the unified dispatcher when a purely-web group ends with a tool
+   *   error or a denied confirmation so the icon matches the chrome
+   *   shown for non-web groups.
    */
-  state?: "loading" | "complete";
+  state?: ToolProgressCardState;
   /**
    * Optional websites to feed the collapsed-header rotating carousel.
    * When non-empty AND `state === "loading"`, the info slot in the header
@@ -110,50 +116,6 @@ export interface WebSearchProgressCardProps {
    * derivation contract.
    */
   carouselItems?: WebSearchResultItem[];
-}
-
-/**
- * Small "+N more" pill used at the tail of a `web_search` row's result list.
- * Mirrors Figma node 4922:104082 — filled `--surface-base` pill with the
- * `body-small-emphasised` (Semi Bold 12) typography variant.
- */
-function OverflowChip({ count }: { count: number }) {
-  return (
-    <div className="rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
-      <Typography
-        variant="body-small-emphasised"
-        className="text-[var(--content-default)]"
-      >
-        +{count} more
-      </Typography>
-    </div>
-  );
-}
-
-/**
- * Negatively-toned chip used inside a `web_search_error` step row to
- * surface the provider's `errorMessage`. Mirrors the default pill's
- * outlined geometry but swaps the border + foreground tokens for the
- * `--system-negative-*` family so the failure reads as distinct from a
- * normal reasoning step.
- */
-function ErrorChip({ message }: { message: string }) {
-  return (
-    <div
-      data-testid="web-search-error-chip"
-      className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[10px] py-[6px]"
-    >
-      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-        <AlertCircle className="h-[14px] w-[14px] text-[var(--system-negative-strong)]" />
-      </span>
-      <Typography
-        variant="body-small-default"
-        className="text-[var(--system-negative-strong)]"
-      >
-        {message}
-      </Typography>
-    </div>
-  );
 }
 
 /**
@@ -188,14 +150,14 @@ export function WebSearchProgressCard({
 
   const headerInfo = useCarousel ? carouselNode : currentStepInfo;
 
-  const shellState: ToolProgressCardState =
-    state === "complete" ? "complete" : "loading";
-
   return (
     <ToolProgressCardShell
       data-testid="web-search-progress-card"
       statusIndicatorTestId="web-search-status-indicator"
-      state={shellState}
+      // `error` / `denied` propagate to the shell's red `AlertCircle` chrome
+      // when the unified dispatcher supplies them. The legacy two-value
+      // contract (`loading` / `complete`) is still valid by construction.
+      state={state}
       currentStepTitle={currentStepTitle}
       currentStepInfo={headerInfo}
       stepCount={stepCount}
@@ -206,29 +168,10 @@ export function WebSearchProgressCard({
           steps={steps as ToolCallCardStep[]}
           renderStep={(step) => {
             if (step.kind === "web_search") {
-              return (
-                <div className="flex flex-wrap items-center gap-1">
-                  {step.results.map((r) => (
-                    // Key by `rank` (the documented uniqueness invariant
-                    // on `WebSearchResultItem`) rather than `url` —
-                    // providers occasionally return duplicate URLs, which
-                    // would collide as React keys and cause stale/missing
-                    // chips during live updates.
-                    <FaviconChip
-                      key={r.rank}
-                      faviconUrl={r.faviconUrl}
-                      title={r.title}
-                      domain={r.domain}
-                    />
-                  ))}
-                  {step.overflow && step.overflow > 0 ? (
-                    <OverflowChip count={step.overflow} />
-                  ) : null}
-                </div>
-              );
+              return <WebSearchStepRow step={step} />;
             }
             if (step.kind === "web_search_error") {
-              return <ErrorChip message={step.errorMessage} />;
+              return <WebSearchErrorRow step={step} />;
             }
             return <DefaultStepPill step={step} />;
           }}

--- a/apps/web/src/domains/chat/components/web-search/web-search-step-row.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-step-row.tsx
@@ -1,0 +1,106 @@
+/**
+ * Shared web-search step-row primitives consumed by both
+ * `WebSearchProgressCard` (the dedicated purely-web card) and
+ * `ToolCallProgressCard` (the unified card that handles mixed groups).
+ *
+ * Lifted here to dedupe the previously copy/pasted `OverflowChip` definitions
+ * and the `web_search` / `web_search_error` step renderers across the two
+ * callsites. Keeping a single source of truth ensures that ExpandedStep in
+ * the unified card and renderStep in the dedicated web-search card present
+ * identical visuals for the same step descriptors.
+ */
+
+import { AlertCircle } from "lucide-react";
+
+import { Typography } from "@vellum/design-library";
+
+import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.js";
+import type { ToolCallCardStep } from "@/domains/chat/hooks/use-tool-call-card-data.js";
+
+/**
+ * Small "+N more" pill used at the tail of a `web_search` row's result list.
+ * Mirrors Figma node 4922:104082 — filled `--surface-base` pill with the
+ * `body-small-emphasised` (Semi Bold 12) typography variant.
+ */
+export function OverflowChip({ count }: { count: number }) {
+  return (
+    <div className="rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
+      <Typography
+        variant="body-small-emphasised"
+        className="text-[var(--content-default)]"
+      >
+        +{count} more
+      </Typography>
+    </div>
+  );
+}
+
+/**
+ * Negatively-toned chip used inside a `web_search_error` step row to
+ * surface the provider's `errorMessage`. Mirrors the default pill's
+ * outlined geometry but swaps the border + foreground tokens for the
+ * `--system-negative-*` family so the failure reads as distinct from a
+ * normal reasoning step.
+ */
+function ErrorChip({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="web-search-error-chip"
+      className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[10px] py-[6px]"
+    >
+      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+        <AlertCircle className="h-[14px] w-[14px] text-[var(--system-negative-strong)]" />
+      </span>
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--system-negative-strong)]"
+      >
+        {message}
+      </Typography>
+    </div>
+  );
+}
+
+/**
+ * Render a single `web_search` step as a wrapping cluster of favicon chips,
+ * optionally followed by a `+N more` overflow pill when the unified hook
+ * clamped the visible result count.
+ *
+ * Keyed by `rank` (the documented uniqueness invariant on
+ * `WebSearchResultItem`) rather than `url` — providers occasionally return
+ * duplicate URLs, which would collide as React keys and cause stale/missing
+ * chips during live updates.
+ */
+export function WebSearchStepRow({
+  step,
+}: {
+  step: Extract<ToolCallCardStep, { kind: "web_search" }>;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {step.results.map((r) => (
+        <FaviconChip
+          key={r.rank}
+          faviconUrl={r.faviconUrl}
+          title={r.title}
+          domain={r.domain}
+        />
+      ))}
+      {step.overflow && step.overflow > 0 ? (
+        <OverflowChip count={step.overflow} />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Render a single `web_search_error` step as an `ErrorChip` containing the
+ * provider-supplied error message.
+ */
+export function WebSearchErrorRow({
+  step,
+}: {
+  step: Extract<ToolCallCardStep, { kind: "web_search_error" }>;
+}) {
+  return <ErrorChip message={step.errorMessage} />;
+}

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -227,11 +227,10 @@ export function computeSubagentCardData(
     currentStepInfo,
     stepCount,
     steps,
-    // Subagent cards don't use the web-search carousel or the
-    // leading-icon slot exposed by `ToolCallCardData`. The inline
-    // renderer slots its own `SubagentAvatarChip` into the shell.
+    // Subagent cards don't use the web-search carousel — the inline
+    // renderer slots its own `SubagentAvatarChip` into the shell via
+    // `ToolProgressCardShell.leadingIcon` directly.
     carouselItems: [],
-    leadingIcon: null,
   };
 }
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -287,13 +287,67 @@ describe("computeToolCallCardData — state transitions", () => {
   });
 });
 
-describe("computeToolCallCardData — leadingIcon", () => {
-  test("leadingIcon is null for non-subagent groups (PR 7 will populate)", () => {
+describe("computeToolCallCardData — subagent_spawn filtering", () => {
+  test("a subagent_spawn-only group produces zero steps", () => {
+    // Inline `SubagentInlineProgressCard` renders the spawned subagent
+    // at the transcript level — surfacing a step inside the unified card
+    // would render the spawn twice.
     const toolCalls = [
-      makeToolCall({ id: "tc-1", toolName: "bash", status: "completed" }),
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Investigate logs" },
+      }),
     ];
     const data = computeToolCallCardData(toolCalls, {}, null);
-    expect(data.leadingIcon).toBeNull();
+    expect(data.steps).toHaveLength(0);
+    expect(data.stepCount).toBe("0 steps");
+  });
+
+  test("multiple subagent_spawn calls in one group still produce zero steps", () => {
+    // Multi-spawn used to slip past the dispatcher's `length === 1` guard
+    // and render "Spawning subagent" rows inside the unified card alongside
+    // the inline cards — a double render.
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "First" },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Second" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps).toHaveLength(0);
+  });
+
+  test("mixed group keeps non-subagent_spawn steps and drops the spawn", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "subagent_spawn",
+        status: "running",
+        input: { label: "Investigate" },
+      }),
+      makeToolCall({
+        id: "tc-2",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0]!.kind).toBe("tool");
+    // Header derivation also ignores the filtered spawn so the carousel
+    // reflects only the bash call.
+    expect(data.currentStepTitle).toBe("Working (bash)");
   });
 });
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -86,8 +86,10 @@ export type ToolCallCardStep =
  *   - `steps` widens to `ToolCallCardStep[]` so non-web tools can ride along.
  *   - `state` adds `"error"` / `"denied"` variants so cards that mix
  *     successful and failed tool calls can render a distinct chrome state.
- *   - `leadingIcon` is reserved for PR 7's subagent-group rendering (always
- *     `null` for non-subagent groups today).
+ *
+ * The subagent leading-icon slot (`<SubagentAvatarChip>`) is plumbed directly
+ * through the shell's `leadingIcon` ReactNode prop by
+ * `SubagentInlineProgressCard`, so this data shape doesn't need to carry it.
  */
 export interface ToolCallCardData {
   /**
@@ -117,11 +119,6 @@ export interface ToolCallCardData {
   state: "loading" | "complete" | "error" | "denied";
   /** Results to feed the collapsed-header rotating carousel (web-search only). */
   carouselItems: WebSearchResultItem[];
-  /**
-   * Optional leading icon for subagent-rooted tool groups. PR 7 populates
-   * this; for now every non-subagent group leaves it as `null`.
-   */
-  leadingIcon: { kind: "subagent"; subagentId: string } | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -464,6 +461,15 @@ export function computeToolCallCardData(
   liveWebActivity: Record<string, ToolActivityMetadata>,
   leadingThinkingText: string | null,
 ): ToolCallCardData {
+  // `subagent_spawn` calls are rendered inline by `SubagentInlineProgressCard`
+  // at the transcript level — surfacing them as steps inside the unified card
+  // would render the spawn twice. Filter them out here so the data layer
+  // alone handles suppression, and downstream consumers (header derivation,
+  // step list, state) all stay in lockstep.
+  const renderableToolCalls = toolCalls.filter(
+    (tc) => tc.toolName !== "subagent_spawn",
+  );
+
   const steps: ToolCallCardStep[] = [];
 
   if (leadingThinkingText) {
@@ -474,7 +480,7 @@ export function computeToolCallCardData(
     });
   }
 
-  for (const tc of toolCalls) {
+  for (const tc of renderableToolCalls) {
     if (!isWebTool(tc)) {
       steps.push(buildToolStep(tc));
       continue;
@@ -500,10 +506,19 @@ export function computeToolCallCardData(
     }
   }
 
-  const state = deriveCardState(toolCalls);
-  const currentStepTitle = deriveCurrentStepTitle(toolCalls, liveWebActivity);
-  const currentStepInfo = deriveCurrentStepInfo(toolCalls, liveWebActivity);
-  const carouselItems = deriveCarouselItems(toolCalls, liveWebActivity);
+  const state = deriveCardState(renderableToolCalls);
+  const currentStepTitle = deriveCurrentStepTitle(
+    renderableToolCalls,
+    liveWebActivity,
+  );
+  const currentStepInfo = deriveCurrentStepInfo(
+    renderableToolCalls,
+    liveWebActivity,
+  );
+  const carouselItems = deriveCarouselItems(
+    renderableToolCalls,
+    liveWebActivity,
+  );
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
 
   return {
@@ -513,7 +528,6 @@ export function computeToolCallCardData(
     steps,
     state,
     carouselItems,
-    leadingIcon: null,
   };
 }
 

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
@@ -57,7 +57,6 @@ export { formatMs, WEB_TOOL_NAMES };
  * `ToolCallCardData` field-for-field but:
  *   - `steps` is the narrower `StepDescriptor[]` (no `tool` variant).
  *   - `state` is narrower (`"loading" | "complete"` only).
- *   - `leadingIcon` is omitted (web-only path never sets it).
  */
 export interface WebSearchCardData {
   currentStepTitle: string;


### PR DESCRIPTION
## Summary
Remediation from self-review of unify-tool-progress-cards plan.

### Bugs fixed
- ExpandedStep now handles `web_search_error` (was silently falling through to DefaultStepPill).
- Multi-spawn groups no longer double-render — `subagent_spawn` steps filtered out of unified card; inline cards remain.
- Card stays expanded while parent message is still streaming, even after tools complete.
- Phase header classifies in-flight `web_search` steps as running (was showing green check too early).
- `WebSearchView` propagates error/denied state to the shell for consistent error chrome.

### Cleanup
- Removed unused `leadingIcon` field from `ToolCallCardData`.
- Lifted `OverflowChip` + web_search step renderers into shared web-search-step-row module.

Part of plan: unify-tool-progress-cards.md (self-review remediation A)