### PR TITLE
fix(web): subagent path self-review remediation

### DIFF
--- a/apps/web/src/domains/avatar/subagent-avatar-chip.test.tsx
+++ b/apps/web/src/domains/avatar/subagent-avatar-chip.test.tsx
@@ -34,7 +34,19 @@ describe("SubagentAvatarChip", () => {
       <SubagentAvatarChip subagentId="alpha" className="ml-1" />,
     );
     expect(html).toContain('aria-label="Subagent alpha"');
-    expect(html).toContain('class="ml-1"');
+    // The wrapper composes `inline-flex` (so the avatar still flows inline)
+    // with any caller-supplied className.
+    expect(html).toContain("ml-1");
+    expect(html).toContain("inline-flex");
+  });
+
+  test("renders the wrapper as a div (not a span) — see HTML validity fix", () => {
+    // The wrapper used to be a `<span>`, but `AvatarRenderer` renders a
+    // `<div>` inside. `<div>` inside `<span>` is invalid HTML and browsers
+    // auto-close the span, dropping the className and aria-label. Use a
+    // `<div>` wrapper so the chrome stays valid.
+    const html = renderToStaticMarkup(<SubagentAvatarChip subagentId="alpha" />);
+    expect(html.startsWith("<div")).toBe(true);
   });
 
   test("defaults to 16px size when none provided", () => {

--- a/apps/web/src/domains/avatar/subagent-avatar-chip.tsx
+++ b/apps/web/src/domains/avatar/subagent-avatar-chip.tsx
@@ -28,8 +28,16 @@ export function SubagentAvatarChip({
 }: SubagentAvatarChipProps) {
   const traits = subagentTraits(subagentId);
 
+  // `AvatarRenderer` renders a `<div>` — wrapping it in a `<span>` produces
+  // invalid HTML (block element inside an inline element) which browsers
+  // may auto-correct by closing the span early, dropping our className and
+  // aria-label. Use an inline-flex `<div>` instead so the wrapper still
+  // composes inline visually but stays a valid block container.
   return (
-    <span aria-label={`Subagent ${subagentId}`} className={className}>
+    <div
+      aria-label={`Subagent ${subagentId}`}
+      className={`inline-flex ${className ?? ""}`.trim()}
+    >
       <AvatarRenderer
         components={BUNDLED_COMPONENTS}
         bodyShapeId={traits.bodyShape}
@@ -37,6 +45,6 @@ export function SubagentAvatarChip({
         colorId={traits.color}
         size={size}
       />
-    </span>
+    </div>
   );
 }

--- a/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -77,8 +77,39 @@ export function SubagentInlineProgressCard({
 
   const leadingIcon = <SubagentAvatarChip subagentId={subagentId} size={16} />;
 
+  // Action cluster slotted into the shell's `headerActionSlot`. The shell
+  // positions it just to the left of the step-count pill so we no longer
+  // need fragile per-consumer pixel offsets to align with the pill chrome.
+  const hasAction = Boolean(onSubagentClick || (onStopSubagent && isRunning));
+  const actionSlot = hasAction ? (
+    <>
+      {onStopSubagent && isRunning && (
+        <button
+          type="button"
+          aria-label="Stop subagent"
+          data-testid="subagent-inline-card-stop"
+          onClick={handleStop}
+          className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--system-negative-strong)]"
+        >
+          <Square className="h-3 w-3" fill="currentColor" />
+        </button>
+      )}
+      {onSubagentClick && (
+        <button
+          type="button"
+          aria-label="Open subagent timeline"
+          data-testid="subagent-inline-card-open"
+          onClick={handleOpen}
+          className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]"
+        >
+          <ExternalLink className="h-3 w-3" />
+        </button>
+      )}
+    </>
+  ) : undefined;
+
   return (
-    <div className="relative w-full" data-testid="subagent-inline-progress-card">
+    <div className="w-full" data-testid="subagent-inline-progress-card">
       <ToolProgressCardShell
         data-testid="subagent-inline-card-shell"
         statusIndicatorTestId="subagent-inline-card-status-indicator"
@@ -88,42 +119,12 @@ export function SubagentInlineProgressCard({
         currentStepInfo={data.currentStepInfo}
         stepCount={data.stepCount}
         disableExpand={data.steps.length === 0}
+        headerActionSlot={actionSlot}
       >
         <div className="flex w-full flex-col gap-3 px-3 pb-3">
           <PhaseGroupedStepList steps={data.steps} />
         </div>
       </ToolProgressCardShell>
-      {/* Right-rail action cluster — absolute-positioned over the shell's
-          header so the shell stays a pure presentational primitive. The
-          shell already exposes a "step count" pill on the right; the
-          actions render to the *left* of that pill via the absolute
-          overlay so they don't clip the existing layout. */}
-      {(onSubagentClick || (onStopSubagent && isRunning)) && (
-        <div className="pointer-events-none absolute right-[64px] top-[14px] flex items-center gap-1">
-          {onStopSubagent && isRunning && (
-            <button
-              type="button"
-              aria-label="Stop subagent"
-              data-testid="subagent-inline-card-stop"
-              onClick={handleStop}
-              className="pointer-events-auto flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--system-negative-strong)]"
-            >
-              <Square className="h-3 w-3" fill="currentColor" />
-            </button>
-          )}
-          {onSubagentClick && (
-            <button
-              type="button"
-              aria-label="Open subagent timeline"
-              data-testid="subagent-inline-card-open"
-              onClick={handleOpen}
-              className="pointer-events-auto flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </button>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/tool-call-chip/utils.ts
+++ b/apps/web/src/domains/chat/components/tool-call-chip/utils.ts
@@ -3,6 +3,8 @@
  * Ported from the macOS desktop app's ChatBubbleToolHelpers.swift.
  */
 
+import { truncate as truncateShared } from "@/domains/chat/utils/truncate.js";
+
 /** Extract just the filename from a file path string. */
 function extractFileName(path: string): string | null {
   if (!path) {
@@ -18,10 +20,7 @@ function extractFileName(path: string): string | null {
 
 /** Truncate a string to `max` characters, appending "..." if truncated. */
 function truncate(str: string, max: number): string {
-  if (str.length <= max) {
-    return str;
-  }
-  return str.slice(0, max - 3) + "...";
+  return truncateShared(str, max, "...");
 }
 
 /**
@@ -465,14 +464,20 @@ export function progressiveLabels(toolName: string): string[] {
 }
 
 /**
- * Title Case a snake_case tool name for use as a fallback display label.
- * Splits on underscores, capitalizes the first letter of each word, and joins
- * with spaces.
+ * Title Case a snake_case / kebab-case tool name for use as a fallback display
+ * label. Splits on `_` and `-` (one or more), filters out empty segments
+ * produced by repeated separators, capitalizes the first letter of each word
+ * and lowercases the remainder, then joins with spaces.
+ *
+ * Exported for reuse by the unified tool-progress card and the subagent
+ * inline card so a single helper produces the "Tool Name" mapping across
+ * the chat domain.
  */
-function titleCaseToolName(toolName: string): string {
+export function titleCaseToolName(toolName: string): string {
   return toolName
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .split(/[_-]+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
 }
 

--- a/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
@@ -195,6 +195,40 @@ describe("ToolProgressCardShell — disableExpand", () => {
   });
 });
 
+describe("ToolProgressCardShell — headerActionSlot", () => {
+  test("renders the headerActionSlot when provided", () => {
+    const { getByTestId } = renderShell({
+      headerActionSlot: (
+        <button data-testid="action-button" type="button">
+          stop
+        </button>
+      ),
+    });
+    expect(getByTestId("tool-progress-card-action-slot")).toBeTruthy();
+    expect(getByTestId("action-button")).toBeTruthy();
+  });
+
+  test("omits the action slot when headerActionSlot is undefined", () => {
+    const { queryByTestId } = renderShell();
+    expect(queryByTestId("tool-progress-card-action-slot")).toBeNull();
+  });
+
+  test("action-slot children are NOT nested inside the toggle button", () => {
+    // Regression guard for the nested-<button> HTML invalidity. The action
+    // slot must render as a sibling of the toggle Button, not a descendant.
+    const { getByTestId, getByRole } = renderShell({
+      headerActionSlot: (
+        <button data-testid="action-button" type="button">
+          stop
+        </button>
+      ),
+    });
+    const toggle = getByRole("button", { name: /expand steps/i });
+    const actionButton = getByTestId("action-button");
+    expect(toggle.contains(actionButton)).toBe(false);
+  });
+});
+
 describe("ToolProgressCardShell — props interface export", () => {
   test("ToolProgressCardState union enumerates the four supported states", () => {
     // Compile-time check: the union is `loading | complete | denied | error`.

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
+import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils.js";
+import { truncate } from "@/domains/chat/utils/truncate.js";
 
 /**
  * Canonical icon names used by the unified tool-call progress card.
@@ -40,12 +42,6 @@ export interface StepLabel {
 
 const INFO_MAX_LENGTH = 80;
 
-/** Truncate a string to `max` chars, appending an ellipsis when truncated. */
-function truncate(value: string, max: number): string {
-  if (value.length <= max) return value;
-  return value.slice(0, max - 1) + "…";
-}
-
 /** Read a string property from a tool input bag, returning `""` when absent. */
 function readString(
   input: Record<string, unknown>,
@@ -70,21 +66,6 @@ function basename(path: string): string {
 }
 
 /**
- * Title-case a snake_case / kebab-case tool name for the fallback label.
- * Kept local so this module has zero deps on the legacy `tool-call-chip` code,
- * which PRs 5+ will retire. Exported for reuse by adjacent consumers (e.g. the
- * subagent inline card) that need the same "Tool Name" → "Tool Name" mapping
- * but operate on a different tool-call shape than `ChatMessageToolCall`.
- */
-export function humanizeToolName(toolName: string): string {
-  return toolName
-    .split(/[_-]+/)
-    .filter((part) => part.length > 0)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join(" ");
-}
-
-/**
  * Parse an `mcp__<server>__<method>` tool name into its server/method parts.
  * MCP tool names follow the pattern produced by `toProviderSafeToolName` in
  * `assistant/src/tools/mcp/mcp-tool-factory.ts`. Returns `null` when the
@@ -104,16 +85,18 @@ function parseMcpToolName(
 }
 
 /**
- * Derive the (title, info, iconName) tuple for a non-web tool call.
- *
- * Branches mirror the tool names already understood by the legacy
- * `ToolCallChip` (`apps/web/src/domains/chat/components/tool-call-chip/`) plus
- * the additional Anthropic-native tool names (`str_replace_editor`,
- * `text_editor`, `computer`, MCP-prefixed tools, skills, subagent spawns) that
- * the unified card needs to label.
+ * Tool input bag understood by `deriveStepLabelFromName`. The full
+ * `ChatMessageToolCall` carries additional fields (status, completedAt,
+ * etc.) that this helper does not need — accepting just `(toolName, input)`
+ * lets non-`ChatMessageToolCall` callers (the subagent inline card, which
+ * operates on `SubagentTimelineEvent`) share the same labeling table.
  */
-export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
-  const { toolName, input } = toolCall;
+export function deriveStepLabelFromName(
+  toolName: string,
+  input?: unknown,
+): StepLabel {
+  const inputBag: Record<string, unknown> =
+    input && typeof input === "object" ? (input as Record<string, unknown>) : {};
   const name = toolName.toLowerCase();
 
   const mcp = parseMcpToolName(toolName);
@@ -128,7 +111,7 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
   switch (name) {
     case "bash":
     case "host_bash": {
-      const command = readString(input, "command", "cmd");
+      const command = readString(inputBag, "command", "cmd");
       const cleaned = command.replace(/\s+/g, " ").trim();
       return {
         title: "Working (bash)",
@@ -139,8 +122,10 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
 
     case "str_replace_editor":
     case "text_editor": {
-      const sub = readString(input, "command").toLowerCase();
-      const file = basename(readString(input, "path", "file_path", "filePath"));
+      const sub = readString(inputBag, "command").toLowerCase();
+      const file = basename(
+        readString(inputBag, "path", "file_path", "filePath"),
+      );
       if (sub === "view") {
         return { title: "Reading", info: file, iconName: "file" };
       }
@@ -150,7 +135,7 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
     }
 
     case "computer": {
-      const action = readString(input, "action");
+      const action = readString(inputBag, "action");
       return {
         title: "Using computer",
         info: action,
@@ -162,7 +147,7 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
     case "skill_execute":
     case "skill_invoke":
     case "skill_load": {
-      const skillName = readString(input, "skill", "name", "skillName");
+      const skillName = readString(inputBag, "skill", "name", "skillName");
       return {
         title: "Using a skill",
         info: skillName,
@@ -171,7 +156,7 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
     }
 
     case "subagent_spawn": {
-      const label = readString(input, "label", "objective", "task");
+      const label = readString(inputBag, "label", "objective", "task");
       return {
         title: "Spawning subagent",
         info: label,
@@ -181,9 +166,22 @@ export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
 
     default:
       return {
-        title: `Running ${humanizeToolName(toolName)}`,
+        title: toolName ? `Running ${titleCaseToolName(toolName)}` : "Running tool",
         info: "",
         iconName: "bolt",
       };
   }
+}
+
+/**
+ * Derive the (title, info, iconName) tuple for a non-web tool call.
+ *
+ * Branches mirror the tool names already understood by the legacy
+ * `ToolCallChip` (`apps/web/src/domains/chat/components/tool-call-chip/`) plus
+ * the additional Anthropic-native tool names (`str_replace_editor`,
+ * `text_editor`, `computer`, MCP-prefixed tools, skills, subagent spawns) that
+ * the unified card needs to label.
+ */
+export function deriveStepLabel(toolCall: ChatMessageToolCall): StepLabel {
+  return deriveStepLabelFromName(toolCall.toolName, toolCall.input);
 }

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -83,6 +83,16 @@ export interface ToolProgressCardShellProps {
    * consumers override to preserve existing integration-test hooks.
    */
   statusIndicatorTestId?: string;
+  /**
+   * Optional action cluster rendered inside the header flex row, immediately
+   * BEFORE the step-count pill. Used by inline-card variants (e.g. the
+   * subagent inline card) to slot stop / open buttons into the header
+   * without absolute-positioning over the shell's chrome. The slot is
+   * rendered outside the surrounding `<Button>` so its interactive children
+   * don't toggle the card's expand/collapse state — callers are responsible
+   * for `stopPropagation()` on their own click handlers when needed.
+   */
+  headerActionSlot?: ReactNode;
 }
 
 function StatusIndicator({
@@ -146,6 +156,7 @@ export function ToolProgressCardShell({
   children,
   "data-testid": dataTestId = "tool-progress-card-shell",
   statusIndicatorTestId = "tool-progress-card-status-indicator",
+  headerActionSlot,
 }: ToolProgressCardShellProps) {
   const [uncontrolledExpanded, setUncontrolledExpanded] =
     useState(defaultExpanded);
@@ -181,12 +192,15 @@ export function ToolProgressCardShell({
     //     the divider + body section flow flush below.
     <div
       data-testid={dataTestId}
-      className="flex w-full flex-col rounded-[var(--radius-lg)] border-b border-[var(--border-base)] bg-[var(--surface-overlay)]"
+      className="relative flex w-full flex-col rounded-[var(--radius-lg)] border-b border-[var(--border-base)] bg-[var(--surface-overlay)]"
     >
       {/* The entire row is the toggle — clicking the label cluster, dots,
           subtext, or pill expands / collapses. The step-count pill is a
           visual-only <span>; the surrounding Button already provides the
-          interactive semantics. */}
+          interactive semantics. The optional action slot is rendered as a
+          sibling AFTER the Button (not inside it — nested <button>s are
+          invalid HTML) and aligned into the header row via absolute
+          positioning so consumers don't have to compute pixel offsets. */}
       <Button
         variant="ghost"
         size="compact"
@@ -216,7 +230,10 @@ export function ToolProgressCardShell({
             bypassDwell={state !== "loading"}
           />
         </span>
-        <span className="flex shrink-0 items-center rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[6px] py-[4px]">
+        <span
+          data-testid="tool-progress-card-step-count-pill"
+          className="flex shrink-0 items-center rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[6px] py-[4px]"
+        >
           <Typography
             variant="body-small-default"
             className="text-[var(--content-emphasised)]"
@@ -225,6 +242,26 @@ export function ToolProgressCardShell({
           </Typography>
         </span>
       </Button>
+      {/* Action slot — absolute-positioned over the right end of the header
+          row, immediately to the left of the step-count pill. Living
+          outside the Button avoids the nested-<button> HTML issue and lets
+          consumers retain their own click handlers without the surrounding
+          expand toggle eating events. Consumers should still
+          stopPropagation() inside their handlers to keep the click from
+          bubbling to the toggle. The fixed `right-[64px]` offset centralises
+          the positioning logic that previously lived in callers as a
+          fragile per-consumer pixel offset; updating the step-count pill
+          chrome later only requires a single edit here. */}
+      {headerActionSlot ? (
+        <div
+          data-testid="tool-progress-card-action-slot"
+          className="pointer-events-none absolute right-[64px] top-[14px] flex items-center gap-1"
+        >
+          <div className="pointer-events-auto flex items-center gap-1">
+            {headerActionSlot}
+          </div>
+        </div>
+      ) : null}
 
       {/* Expanded body — divider + children. Animated height-collapse honors
           prefers-reduced-motion (snap when reduced via 0-duration transition). */}

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -141,10 +141,40 @@ describe("computeSubagentCardData — step mapping", () => {
     const step = data.steps[0]!;
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
-      expect(step.title).toBe("Using File Read");
+      // `file_read` isn't a known branch in `deriveStepLabelFromName`, so
+      // it falls through to the default "Running <Name>" path with the
+      // bolt icon.
+      expect(step.title).toBe("Running File Read");
       expect(step.info).toBe("src/foo.ts");
       expect(step.status).toBe("running");
       expect(step.toolCallId).toBe("tu-file-1");
+      expect(step.iconName).toBe("bolt");
+    }
+  });
+
+  test("tool_call for bash uses tool-specific title + icon (Fix 1)", () => {
+    // Regression guard: before Fix 1, every tool step in the subagent
+    // inline card rendered the bolt icon and a generic "Using <Tool>"
+    // title. After Fix 1, `mapToolEventToStep` routes through the shared
+    // `deriveStepLabelFromName` so bash → "Working (bash)" / code icon.
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "bash",
+            toolUseId: "tu-bash-1",
+            content: "ls -la",
+          }),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("tool");
+    if (step.kind === "tool") {
+      expect(step.title).toBe("Working (bash)");
+      expect(step.iconName).toBe("code");
+      expect(step.info).toBe("ls -la");
     }
   });
 
@@ -456,7 +486,7 @@ describe("computeSubagentCardData — step count", () => {
 // ---------------------------------------------------------------------------
 
 describe("mapToolEventToStep", () => {
-  test("derives a Using <Tool> title from snake_case names", () => {
+  test("derives a tool-specific title + icon for bash/host_bash (Fix 1)", () => {
     const step = mapToolEventToStep({
       id: "te-1",
       type: "tool_call",
@@ -465,20 +495,100 @@ describe("mapToolEventToStep", () => {
       toolUseId: "tu-1",
       timestamp: 0,
     });
-    expect(step.title).toBe("Using Host Bash");
+    // host_bash routes through `deriveStepLabelFromName`'s bash branch.
+    expect(step.title).toBe("Working (bash)");
+    expect(step.iconName).toBe("code");
     expect(step.info).toBe("summary");
     expect(step.status).toBe("running");
     expect(step.toolCallId).toBe("tu-1");
   });
 
-  test("falls back to a generic title when toolName is missing", () => {
+  test("unknown tools fall through to the Running <Name> default with the bolt icon", () => {
     const step = mapToolEventToStep({
       id: "te-2",
+      type: "tool_call",
+      content: "details",
+      toolName: "some_custom_tool",
+      toolUseId: "tu-custom",
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Running Some Custom Tool");
+    expect(step.iconName).toBe("bolt");
+    // The default branch produces an empty info; the timeline summary is
+    // surfaced as the info fallback so the pill still shows context.
+    expect(step.info).toBe("details");
+  });
+
+  test("falls back to a generic title when toolName is missing", () => {
+    const step = mapToolEventToStep({
+      id: "te-3",
       type: "tool_call",
       content: "",
       timestamp: 0,
     });
     expect(step.title).toBe("Running tool");
     expect(step.toolCallId).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// error event tool-step correlation (Fix 2)
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — error event toolUseId correlation", () => {
+  test("error with toolUseId closes only the matching parallel tool step", () => {
+    // Two bash calls in-flight (tu-A first, tu-B second). An error event
+    // for tu-A arrives while tu-B is still running. Only the tu-A step
+    // should flip to "error"; tu-B remains "running".
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-A",
+              content: "first",
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              content: "second",
+            },
+            1,
+          ),
+          makeEvent(
+            {
+              type: "error",
+              toolName: "bash",
+              toolUseId: "tu-A",
+              content: "boom",
+            },
+            2,
+          ),
+        ],
+      }),
+    );
+    // 2 tool steps + 1 tool_error step.
+    expect(data.steps).toHaveLength(3);
+    const first = data.steps[0]!;
+    const second = data.steps[1]!;
+    if (first.kind === "tool") {
+      expect(first.toolCallId).toBe("tu-A");
+      expect(first.status).toBe("error");
+    }
+    if (second.kind === "tool") {
+      expect(second.toolCallId).toBe("tu-B");
+      expect(second.status).toBe("running");
+    }
+    const err = data.steps[2]!;
+    expect(err.kind).toBe("tool_error");
+    if (err.kind === "tool_error") {
+      expect(err.message).toBe("boom");
+    }
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -37,7 +37,9 @@ import {
 } from "@/domains/subagents/subagent-store.js";
 import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
 import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell.js";
-import { humanizeToolName } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label.js";
+import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils.js";
+import { truncate } from "@/domains/chat/utils/truncate.js";
 import {
   formatMs,
   type ToolCallCardData,
@@ -59,35 +61,114 @@ const TEXT_PREVIEW_MAX = 160;
 /** Trim newlines + collapse whitespace, then clamp to TEXT_PREVIEW_MAX. */
 function trimTextPreview(input: string): string {
   const collapsed = input.replace(/\s+/g, " ").trim();
-  if (collapsed.length <= TEXT_PREVIEW_MAX) return collapsed;
-  // -1 to leave room for the ellipsis. Mirrors `derive-step-label.ts`.
-  return collapsed.slice(0, TEXT_PREVIEW_MAX - 1) + "…";
+  return truncate(collapsed, TEXT_PREVIEW_MAX);
+}
+
+/**
+ * Best-effort reconstruction of a tool input bag from a subagent timeline
+ * event. Subagent events carry only a `content` summary string (produced by
+ * `summarizeToolInput` in the store) — not the raw input object — so we
+ * stuff that summary back into the most likely input key for the tool. The
+ * resulting bag is good enough for `deriveStepLabelFromName` to recover
+ * tool-specific labels (bash command, file path, computer action, etc.)
+ * instead of falling back to the generic "Running <Name>" path.
+ *
+ * Tools not enumerated here fall through to `deriveStepLabelFromName`'s
+ * default branch, which still produces a sensible title + the `bolt` icon.
+ */
+function reconstructInputBag(
+  toolName: string,
+  content: string,
+): Record<string, unknown> {
+  const name = toolName.toLowerCase();
+  if (!content) return {};
+
+  switch (name) {
+    case "bash":
+    case "host_bash":
+      return { command: content };
+    case "str_replace_editor":
+    case "text_editor":
+      // We lack the editor sub-command in the timeline summary, so route
+      // through "Editing" by default — safer than mis-classifying writes
+      // as reads. Callers who need the precise variant can wire raw input
+      // through when the subagent store starts preserving it.
+      return { path: content };
+    case "computer":
+      return { action: content };
+    case "skill":
+    case "skill_execute":
+    case "skill_invoke":
+    case "skill_load":
+      return { skill: content };
+    case "subagent_spawn":
+      return { label: content };
+    default:
+      return {};
+  }
 }
 
 /**
  * Map a subagent `tool_call` timeline event into a fresh in-flight `tool`
- * step. Exposed for testability — kept separate from `deriveStepLabel`
- * because the subagent timeline event has a different shape (`toolName`
- * + `content` summary) than the assistant-side `ChatMessageToolCall`.
+ * step. Exposed for testability.
  *
- * `iconName` is hard-coded to `"bolt"` (the generic-tool icon) and
+ * Routes through the shared `deriveStepLabelFromName` helper so the inline
+ * card's step pills inherit tool-specific titles + icons (`code` for bash,
+ * `file` for str_replace_editor view, etc.) rather than always rendering
+ * `bolt` / generic "Using <Tool>" labels. The subagent timeline carries
+ * only a `content` summary string (no raw input object), so we
+ * best-effort-reconstruct an input bag via `reconstructInputBag` before
+ * dispatching.
+ *
  * `toolCallId` mirrors `toolUseId` so the renderer key + result matcher
- * have a stable identifier. The inline card renderer doesn't consume
- * `iconName` today, so the value is effectively a placeholder.
+ * have a stable identifier.
  */
 export function mapToolEventToStep(
   event: SubagentTimelineEvent,
 ): Extract<ToolCallCardStep, { kind: "tool" }> {
   const toolName = event.toolName ?? "";
+  const content = event.content ?? "";
+  const input = reconstructInputBag(toolName, content);
+  const label = deriveStepLabelFromName(toolName, input);
   return {
     kind: "tool",
     durationLabel: "",
     toolCallId: event.toolUseId ?? "",
-    iconName: "bolt",
-    title: toolName ? `Using ${humanizeToolName(toolName)}` : "Running tool",
-    info: event.content ?? "",
+    iconName: label.iconName,
+    title: label.title,
+    info: label.info || content,
     status: "running",
   };
+}
+
+/**
+ * Find the index of the most recent in-flight tool step that matches a
+ * follow-up event (`tool_result` or `error`). Match precedence:
+ *   1. Exact `toolUseId` match — required when the event carries one (so
+ *      parallel calls to the same tool don't bleed into each other).
+ *   2. `toolName` match against the originating `tool_call`'s name.
+ *   3. "Latest in-flight" — when neither identifier is present.
+ *
+ * Returns -1 when no in-flight step matches.
+ */
+function findMatchingInFlightToolIndex(
+  steps: ToolCallCardStep[],
+  toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
+  event: { toolUseId?: string; toolName?: string },
+): number {
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const step = steps[i]!;
+    if (step.kind !== "tool" || step.status !== "running") continue;
+    if (event.toolUseId) {
+      if (step.toolCallId === event.toolUseId) return i;
+      // Exact-match-only when the event carries a toolUseId — do NOT fall
+      // through to toolName matching for a different ID.
+      continue;
+    }
+    const stepToolName = toolMeta[i]?.toolName ?? "";
+    if (!event.toolName || stepToolName === event.toolName) return i;
+  }
+  return -1;
 }
 
 /**
@@ -153,31 +234,7 @@ export function computeSubagentCardData(
     }
 
     if (event.type === "tool_result") {
-      // Close the most recent matching in-flight tool step. Match by
-      // `toolUseId` when both sides carry one — subagent streams can
-      // contain parallel calls to the same tool (e.g. two `bash`) which
-      // `toolName` alone cannot disambiguate. Fall back to `toolName`
-      // when the result lacks a `toolUseId`, and to "latest in-flight"
-      // when neither identifier is present.
-      let matchIndex = -1;
-      for (let i = steps.length - 1; i >= 0; i--) {
-        const step = steps[i]!;
-        if (step.kind !== "tool" || step.status !== "running") continue;
-        if (event.toolUseId) {
-          if (step.toolCallId === event.toolUseId) {
-            matchIndex = i;
-            break;
-          }
-          // When the result has a toolUseId, require an exact match —
-          // do NOT fall through to toolName matching for a different ID.
-          continue;
-        }
-        const stepToolName = toolMeta[i]?.toolName ?? "";
-        if (!event.toolName || stepToolName === event.toolName) {
-          matchIndex = i;
-          break;
-        }
-      }
+      const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
       if (matchIndex === -1) continue;
       const target = steps[matchIndex] as Extract<
         ToolCallCardStep,
@@ -197,13 +254,17 @@ export function computeSubagentCardData(
     }
 
     if (event.type === "error") {
-      // If there's an in-flight tool, close it as error.
-      for (let i = steps.length - 1; i >= 0; i--) {
-        const step = steps[i]!;
-        if (step.kind === "tool" && step.status === "running") {
-          steps[i] = { ...step, status: "error" };
-          break;
-        }
+      // Close the matching in-flight tool step (if any) as `error` before
+      // appending the `tool_error` row. Same matching precedence as
+      // `tool_result` — see `findMatchingInFlightToolIndex` — so parallel
+      // calls to the same tool close the correct step.
+      const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
+      if (matchIndex !== -1) {
+        const target = steps[matchIndex] as Extract<
+          ToolCallCardStep,
+          { kind: "tool" }
+        >;
+        steps[matchIndex] = { ...target, status: "error" };
       }
       const message = trimTextPreview(event.content) || "Subagent error";
       steps.push({ kind: "tool_error", message });
@@ -310,7 +371,7 @@ function deriveCurrentStep(
     const toolName = toolMeta[steps.length - 1]?.toolName ?? "";
     return {
       currentStepTitle: toolName
-        ? `Used ${humanizeToolName(toolName)}`
+        ? `Used ${titleCaseToolName(toolName)}`
         : "Done",
       currentStepInfo: latest.info,
     };

--- a/apps/web/src/domains/chat/utils/truncate.ts
+++ b/apps/web/src/domains/chat/utils/truncate.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared `truncate` helper for chat-domain text previews.
+ *
+ * Consolidates three formerly-local copies that lived in
+ * `tool-call-chip/utils.ts`, `tool-progress-card/derive-step-label.ts`, and
+ * `use-subagent-card-data.ts` (as `trimTextPreview`). Behaviour matches the
+ * common case: when `text` exceeds `maxLength`, slice to make room for the
+ * ellipsis and append it.
+ *
+ * The default ellipsis is the single-character `…` (preferred for tight
+ * pill / chip chrome). Pass `"..."` (three dots) to mimic the legacy
+ * `tool-call-chip` formatting where a 3-char trailing ellipsis was used.
+ */
+export function truncate(
+  text: string,
+  maxLength: number,
+  ellipsis: string = "…",
+): string {
+  if (text.length <= maxLength) return text;
+  // Reserve room for the ellipsis so the final string is exactly `maxLength`.
+  return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+}


### PR DESCRIPTION
## Summary
Remediation from self-review of unify-tool-progress-cards plan.

### Bugs fixed
- Subagent inline card step pills now use tool-specific icons and titles (was hardcoded `bolt` / generic `Using X`).
- Subagent error events match by `toolUseId` for parallel-tool-call correctness.
- Avatar chip wrapper switched from invalid `<span><div></div></span>` HTML to `<div>`.

### Architecture
- Added `headerActionSlot` to `ToolProgressCardShell` so inline cards stop fragile absolute-positioning their action buttons.

### Cleanup
- Deduped `humanizeToolName` against existing `titleCaseToolName` (now exported).
- Consolidated three `truncate` helpers into one shared util.

Part of plan: unify-tool-progress-cards.md (self-review remediation B)