### PR TITLE
fix(web): stop Sentry release injection from re-hashing every built asset

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -122,6 +122,11 @@ jobs:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Pin both to the commit SHA so the plugin-created release (source-map
+          # upload) and the client-tagged release match. See vite.config.ts for
+          # why injection is disabled in favor of VITE_SENTRY_RELEASE.
+          SENTRY_RELEASE: ${{ github.sha }}
+          VITE_SENTRY_RELEASE: ${{ github.sha }}
         run: bun run build
 
   checks:
@@ -206,6 +211,11 @@ jobs:
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_APP_VERSION: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Pin both to the commit SHA so the plugin-created release (source-map
+          # upload) and the client-tagged release match. See vite.config.ts for
+          # why injection is disabled in favor of VITE_SENTRY_RELEASE.
+          SENTRY_RELEASE: ${{ github.sha }}
+          VITE_SENTRY_RELEASE: ${{ github.sha }}
         run: bun run build
 
       - name: Authenticate to GCP

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -14,6 +14,8 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   /** Sentry environment tag (e.g. "production", "staging"). */
   readonly VITE_SENTRY_ENVIRONMENT?: string;
+  /** Release identifier used to tag Sentry events. Injected by CI/CD pipeline. */
+  readonly VITE_SENTRY_RELEASE?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */

--- a/apps/web/src/lib/sentry/sentry-init.ts
+++ b/apps/web/src/lib/sentry/sentry-init.ts
@@ -28,6 +28,12 @@ import { sanitizeUrl } from "@/lib/sentry/url-sanitize.js";
 const options: BrowserOptions = {
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local",
+  // Tag events with the release explicitly. The Sentry Vite plugin's
+  // automatic release injection is disabled (see vite.config.ts) because it
+  // re-hashed every asset on each release; setting it here bakes the release
+  // into this single init chunk instead. Undefined in builds without the var,
+  // which Sentry treats as "no release" — same as the local/dev default.
+  release: import.meta.env.VITE_SENTRY_RELEASE,
   tracesSampleRate: 0,
   // Attach a synthetic JS stack to `Sentry.captureMessage` calls so events
   // emitted without a thrown exception still resolve to a source location

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,6 +30,16 @@ export default defineConfig(({ mode }) => {
         authToken: env.SENTRY_AUTH_TOKEN,
         release: {
           name: env.SENTRY_RELEASE,
+          // Disable release injection. The injected snippet lives in a shared
+          // `_sentry-release-injection-file-[hash].js` that *every* chunk
+          // imports; because it embeds the release string, a new release
+          // re-hashes that file and cascades a fresh content hash onto every
+          // asset — so each deploy re-uploads the entire bundle under new
+          // names and our additive GCS rsync never reclaims the old copies.
+          // Release tagging is set explicitly on the client via
+          // `VITE_SENTRY_RELEASE` (see src/lib/sentry/sentry-init.ts), and
+          // source-map symbolication still works via content-derived debug IDs.
+          inject: false,
         },
         sourcemaps: {
           filesToDeleteAfterUpload: ["./dist/**/*.map"],


### PR DESCRIPTION
## Summary
- Set `release.inject: false` in the Sentry Vite plugin. Its injected snippet lived in a shared `_sentry-release-injection-file-[hash].js` that *every* chunk imports; embedding the release string there made a new release re-hash that file and cascade a fresh content hash onto all ~320 assets. With the additive GCS rsync, each deploy re-uploaded the whole bundle under new names — the cause of the SPA bucket filling up.
- Tag Sentry events explicitly via `release: import.meta.env.VITE_SENTRY_RELEASE` in `sentry-init.ts` (declared in `env.d.ts`), so the release lands in a single init chunk instead of cascading. Source-map symbolication still works via content-derived debug IDs.
- Pin `SENTRY_RELEASE` + `VITE_SENTRY_RELEASE` to `github.sha` in both web build jobs so the plugin-created release and the client-tagged release match (same value the plugin previously auto-detected from git).
- Verified locally: across two builds with different release SHAs, asset filenames are now stable (2 of 321 change vs all 320 before), the release string is still baked into the client bundle, and the cascade file is gone.

## Original prompt
While publishing Vite-built assets to a GCS bucket, the bucket was filling up fast because asset filenames changed on every build even with no source changes. Investigation traced the churn to the Sentry plugin's release injection cascading a new content hash onto every chunk each release. The ask was to ship the fix: disable release injection, preserve Sentry release tagging via an explicit client env var, and wire that var through CI.