### PR TITLE
feat(web): prefill subdomain with assistant handle in onboarding

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Modal } from "@vellum/design-library/components/modal";
 import type { MachineTierEnum } from "@/generated/api/types.gen.js";
 import {
+  assistantsActiveRetrieveOptions,
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
@@ -76,6 +77,11 @@ export function BillingOnboardingModal({
   const onboardingQuery = useQuery({
     ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
     enabled: open && step !== "confirm-pro",
+  });
+
+  useQuery({
+    ...assistantsActiveRetrieveOptions(),
+    enabled: open,
   });
 
   const domainSetupAvailable = onboardingQuery.data?.domain_setup_available;

--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -1,14 +1,17 @@
 import { ArrowLeft, Globe } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@vellum/design-library/components/button";
 import { Input } from "@vellum/design-library/components/input";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
-import { organizationsBillingSubscriptionOnboardingDomainCreateMutation } from "@/generated/api/@tanstack/react-query.gen.js";
+import {
+  assistantsActiveRetrieveOptions,
+  organizationsBillingSubscriptionOnboardingDomainCreateMutation,
+} from "@/generated/api/@tanstack/react-query.gen.js";
 import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 
 import { IconBadge, StepDots } from "./primitives.js";
@@ -16,7 +19,15 @@ import { DOMAIN_EXIT_DELAY_MS, extractOnboardingErrorMessage } from "./utils.js"
 
 export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () => void }) {
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
+  const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
   const [subdomain, setSubdomain] = useState("");
+  const [prefilled, setPrefilled] = useState(false);
+
+  useEffect(() => {
+    if (prefilled || !activeAssistant?.handle) return;
+    setSubdomain(activeAssistant.handle);
+    setPrefilled(true);
+  }, [activeAssistant?.handle, prefilled]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
   const domainMutation = useMutation(

--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -24,10 +24,10 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
   const [prefilled, setPrefilled] = useState(false);
 
   useEffect(() => {
-    if (prefilled || !activeAssistant?.handle) return;
+    if (prefilled || !activeAssistant?.handle || subdomain) return;
     setSubdomain(activeAssistant.handle);
     setPrefilled(true);
-  }, [activeAssistant?.handle, prefilled]);
+  }, [activeAssistant?.handle, prefilled, subdomain]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
   const domainMutation = useMutation(


### PR DESCRIPTION
## Summary
- Prefill the domain step subdomain input with the active assistant's `handle`
- Prefetch `assistantsActiveRetrieveOptions` when the modal opens so data is cached before the user reaches setup/domain steps

## Original prompt
User wanted the subdomain input pre-populated with the assistant's handle so users don't have to type it from scratch. Also wanted the query prefetched early so there's no loading delay when arriving at the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)