### PR TITLE
feat: live feature flag sync from gateway to daemon

### DIFF
--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Isolated temp directory for the IPC socket
+// ---------------------------------------------------------------------------
+const testRoot = mkdtempSync(join(tmpdir(), "flag-listener-test-"));
+const socketPath = join(testRoot, "gateway.sock");
+
+// ---------------------------------------------------------------------------
+// Mock socket-path resolution to use our test socket
+// ---------------------------------------------------------------------------
+mock.module("../ipc/socket-path.js", () => ({
+  resolveIpcSocketPath: (_name: string) => ({
+    path: socketPath,
+    source: "workspace" as const,
+  }),
+  getAssistantSocketPath: () => join(testRoot, "assistant.sock"),
+}));
+
+// ---------------------------------------------------------------------------
+// Track calls to refreshOverridesFromGateway
+// ---------------------------------------------------------------------------
+let refreshCallCount = 0;
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  refreshOverridesFromGateway: async () => {
+    refreshCallCount++;
+  },
+  initFeatureFlagOverrides: async () => {},
+  clearFeatureFlagOverridesCache: () => {},
+  isAssistantFeatureFlagEnabled: () => true,
+  _setOverridesForTesting: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports (after mock.module)
+// ---------------------------------------------------------------------------
+const { startGatewayFlagListener, stopGatewayFlagListener } = await import(
+  "../ipc/gateway-flag-listener.js"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestServer(): {
+  server: Server;
+  clients: Set<Socket>;
+  emit: (event: string, data?: unknown) => void;
+  waitForClient: () => Promise<Socket>;
+} {
+  const clients = new Set<Socket>();
+  const clientWaiters: Array<(socket: Socket) => void> = [];
+
+  const server = createServer((socket) => {
+    clients.add(socket);
+    socket.on("close", () => clients.delete(socket));
+    const waiter = clientWaiters.shift();
+    if (waiter) waiter(socket);
+  });
+
+  return {
+    server,
+    clients,
+    emit: (event: string, data?: unknown) => {
+      const payload = JSON.stringify({ event, data }) + "\n";
+      for (const client of clients) {
+        if (!client.destroyed) client.write(payload);
+      }
+    },
+    waitForClient: () =>
+      new Promise((resolve) => {
+        if (clients.size > 0) {
+          resolve(clients.values().next().value!);
+          return;
+        }
+        clientWaiters.push(resolve);
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("gateway-flag-listener", () => {
+  let testServer: ReturnType<typeof createTestServer>;
+
+  beforeEach(() => {
+    mkdirSync(testRoot, { recursive: true });
+    refreshCallCount = 0;
+    testServer = createTestServer();
+  });
+
+  afterEach(async () => {
+    stopGatewayFlagListener();
+    await new Promise<void>((resolve) => {
+      for (const client of testServer.clients) {
+        if (!client.destroyed) client.destroy();
+      }
+      testServer.server.close(() => resolve());
+    });
+    try {
+      rmSync(socketPath, { force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  test("refreshes flag cache on feature_flags_changed event", async () => {
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(refreshCallCount).toBe(1);
+  });
+
+  test("ignores non-flag events", async () => {
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+
+    testServer.emit("some_other_event");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(refreshCallCount).toBe(0);
+  });
+
+  test("reconnects on disconnect and handles events on new connection", async () => {
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    const firstClient = await testServer.waitForClient();
+
+    // Wait for the close event to propagate back to the server before
+    // setting up the next waitForClient — otherwise waitForClient might
+    // resolve with the old (now-destroyed) socket that is still in the set.
+    await new Promise<void>((resolve) => {
+      firstClient.on("close", resolve);
+      firstClient.destroy();
+    });
+
+    // Wait for reconnect (initial backoff is 1s)
+    const secondClient = await Promise.race([
+      testServer.waitForClient(),
+      new Promise<null>((r) => setTimeout(() => r(null), 3000)),
+    ]);
+
+    expect(secondClient).not.toBeNull();
+
+    refreshCallCount = 0;
+    const payload =
+      JSON.stringify({ event: "feature_flags_changed" }) + "\n";
+    secondClient!.write(payload);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(refreshCallCount).toBe(1);
+  });
+
+  test("stopGatewayFlagListener cleans up and does not reconnect", async () => {
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+
+    stopGatewayFlagListener();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const initialClientCount = testServer.clients.size;
+
+    // Wait past reconnect backoff — should not reconnect
+    await new Promise((r) => setTimeout(r, 1500));
+
+    expect(testServer.clients.size).toBeLessThanOrEqual(initialClientCount);
+  });
+});

--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import { createServer, type Server, type Socket } from "node:net";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach,beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Isolated temp directory for the IPC socket
@@ -110,18 +110,21 @@ describe("gateway-flag-listener", () => {
     }
   });
 
-  test("refreshes flag cache on feature_flags_changed event", async () => {
+  test("refreshes flag cache on connect and on feature_flags_changed event", async () => {
     await new Promise<void>((resolve) => {
       testServer.server.listen(socketPath, resolve);
     });
 
     startGatewayFlagListener();
     await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(refreshCallCount).toBe(1);
 
     testServer.emit("feature_flags_changed");
     await new Promise((r) => setTimeout(r, 100));
 
-    expect(refreshCallCount).toBe(1);
+    expect(refreshCallCount).toBe(2);
   });
 
   test("ignores non-flag events", async () => {
@@ -131,11 +134,14 @@ describe("gateway-flag-listener", () => {
 
     startGatewayFlagListener();
     await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const countAfterConnect = refreshCallCount;
 
     testServer.emit("some_other_event");
     await new Promise((r) => setTimeout(r, 100));
 
-    expect(refreshCallCount).toBe(0);
+    expect(refreshCallCount).toBe(countAfterConnect);
   });
 
   test("reconnects on disconnect and handles events on new connection", async () => {
@@ -162,13 +168,16 @@ describe("gateway-flag-listener", () => {
 
     expect(secondClient).not.toBeNull();
 
-    refreshCallCount = 0;
+    await new Promise((r) => setTimeout(r, 100));
+    const countAfterReconnect = refreshCallCount;
+    expect(countAfterReconnect).toBeGreaterThan(0);
+
     const payload =
       JSON.stringify({ event: "feature_flags_changed" }) + "\n";
     secondClient!.write(payload);
     await new Promise((r) => setTimeout(r, 200));
 
-    expect(refreshCallCount).toBe(1);
+    expect(refreshCallCount).toBe(countAfterReconnect + 1);
   });
 
   test("stopGatewayFlagListener cleans up and does not reconnect", async () => {

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -261,6 +261,19 @@ export function clearFeatureFlagOverridesCache(): void {
 }
 
 /**
+ * Re-fetch feature flag overrides from the gateway.
+ *
+ * Clears the cached overrides and re-runs the gateway IPC fetch without
+ * retries (the gateway is known to be up because it just pushed an event).
+ * Called by the gateway flag listener when a `feature_flags_changed` event
+ * arrives.
+ */
+export async function refreshOverridesFromGateway(): Promise<void> {
+  clearFeatureFlagOverridesCache();
+  await initFeatureFlagOverrides({ retryBackoffsMs: [] });
+}
+
+/**
  * Directly inject override values into the module-level cache.
  *
  * **Test-only** — bypasses the gateway IPC fetch so unit tests can control

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -9,10 +9,6 @@ import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import {
-  startGatewayFlagListener,
-  stopGatewayFlagListener,
-} from "../ipc/gateway-flag-listener.js";
-import {
   getPlatformAssistantId,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
@@ -39,6 +35,10 @@ import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { startHomeContentRefresh } from "../home/home-content-refresh.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
+import {
+  startGatewayFlagListener,
+  stopGatewayFlagListener,
+} from "../ipc/gateway-flag-listener.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import {
   getAttachmentsByIds,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -9,6 +9,10 @@ import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import {
+  startGatewayFlagListener,
+  stopGatewayFlagListener,
+} from "../ipc/gateway-flag-listener.js";
+import {
   getPlatformAssistantId,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
@@ -357,6 +361,8 @@ export async function runDaemon(): Promise<void> {
     void initFeatureFlagOverrides().catch((err) =>
       log.warn({ err }, "Background feature flag init failed"),
     );
+
+    startGatewayFlagListener();
 
     log.info("Daemon startup: initializing DB");
     ensurePromptFiles();
@@ -1347,6 +1353,7 @@ export async function runDaemon(): Promise<void> {
       mcpManager,
       telemetryReporter,
       cleanupPidFile: () => {
+        stopGatewayFlagListener();
         stopDiskPressureGuardForLifecycle();
         cleanupPidFile();
       },

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -1,0 +1,104 @@
+import { connect, type Socket } from "node:net";
+
+import { refreshOverridesFromGateway } from "../config/assistant-feature-flags.js";
+import { getLogger } from "../util/logger.js";
+import { resolveIpcSocketPath } from "./socket-path.js";
+
+const log = getLogger("gateway-flag-listener");
+
+const MAX_BACKOFF_MS = 30_000;
+const INITIAL_BACKOFF_MS = 1_000;
+
+let socket: Socket | null = null;
+let stopped = false;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let currentBackoffMs = INITIAL_BACKOFF_MS;
+
+function getSocketPath(): string {
+  return resolveIpcSocketPath("gateway").path;
+}
+
+function handleData(chunk: Buffer): void {
+  const lines = chunk.toString().split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const msg = JSON.parse(trimmed) as { event?: string };
+      if (msg.event === "feature_flags_changed") {
+        log.info("Received feature_flags_changed event — refreshing overrides");
+        refreshOverridesFromGateway().catch((err) => {
+          log.warn({ err }, "Failed to refresh feature flag overrides");
+        });
+      }
+    } catch {
+      // Ignore non-JSON lines (e.g. IPC responses on a shared socket)
+    }
+  }
+}
+
+function scheduleReconnect(): void {
+  if (stopped) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectToGateway();
+  }, currentBackoffMs);
+  currentBackoffMs = Math.min(currentBackoffMs * 2, MAX_BACKOFF_MS);
+}
+
+function connectToGateway(): void {
+  if (stopped) return;
+
+  const socketPath = getSocketPath();
+  const conn = connect(socketPath);
+
+  conn.on("connect", () => {
+    log.info("Connected to gateway IPC for flag events");
+    currentBackoffMs = INITIAL_BACKOFF_MS;
+    socket = conn;
+  });
+
+  let buffer = "";
+  conn.on("data", (chunk) => {
+    buffer += chunk.toString();
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, newlineIdx);
+      buffer = buffer.slice(newlineIdx + 1);
+      if (line.trim()) {
+        handleData(Buffer.from(line));
+      }
+    }
+  });
+
+  conn.on("close", () => {
+    socket = null;
+    if (!stopped) {
+      log.debug("Gateway IPC connection closed — reconnecting");
+      scheduleReconnect();
+    }
+  });
+
+  conn.on("error", (err) => {
+    log.debug({ err }, "Gateway IPC connection error");
+    conn.destroy();
+  });
+}
+
+export function startGatewayFlagListener(): void {
+  stopped = false;
+  currentBackoffMs = INITIAL_BACKOFF_MS;
+  connectToGateway();
+}
+
+export function stopGatewayFlagListener(): void {
+  stopped = true;
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  if (socket) {
+    socket.destroy();
+    socket = null;
+  }
+}

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -53,9 +53,16 @@ function connectToGateway(): void {
   const conn = connect(socketPath);
 
   conn.on("connect", () => {
+    if (stopped) {
+      conn.destroy();
+      return;
+    }
     log.info("Connected to gateway IPC for flag events");
     currentBackoffMs = INITIAL_BACKOFF_MS;
     socket = conn;
+    refreshOverridesFromGateway().catch((err) => {
+      log.warn({ err }, "Failed to refresh feature flag overrides on reconnect");
+    });
   });
 
   let buffer = "";

--- a/gateway/src/__tests__/feature-flag-watcher-callback.test.ts
+++ b/gateway/src/__tests__/feature-flag-watcher-callback.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { testWorkspaceDir } from "./test-preload.js";
+
+const flagDir = join(testWorkspaceDir, "flags");
+
+mock.module("../feature-flag-store.js", () => ({
+  clearFeatureFlagStoreCache: mock(() => {}),
+  getFeatureFlagStorePath: () => join(flagDir, "feature-flags.json"),
+}));
+
+mock.module("../feature-flag-remote-store.js", () => ({
+  refreshRemoteFeatureFlagStoreCache: mock(() => {}),
+  getRemoteFeatureFlagStorePath: () =>
+    join(flagDir, "remote-feature-flags.json"),
+}));
+
+const { FeatureFlagWatcher } = await import("../feature-flag-watcher.js");
+
+describe("FeatureFlagWatcher onChanged callback", () => {
+  beforeEach(() => {
+    mkdirSync(flagDir, { recursive: true });
+    writeFileSync(join(flagDir, "feature-flags.json"), "{}");
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(flagDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  test("calls onChanged after debounce fires on local flag file change", async () => {
+    const onChanged = mock(() => {});
+    const watcher = new FeatureFlagWatcher({ onChanged });
+    watcher.start();
+
+    writeFileSync(
+      join(flagDir, "feature-flags.json"),
+      JSON.stringify({ test: true }),
+    );
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    watcher.stop();
+  });
+
+  test("calls onChanged after debounce fires on remote flag file change", async () => {
+    const onChanged = mock(() => {});
+    const watcher = new FeatureFlagWatcher({ onChanged });
+    watcher.start();
+
+    writeFileSync(
+      join(flagDir, "remote-feature-flags.json"),
+      JSON.stringify({ remote: true }),
+    );
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    watcher.stop();
+  });
+
+  test("does not call onChanged when no callback is provided", async () => {
+    const watcher = new FeatureFlagWatcher();
+    watcher.start();
+
+    writeFileSync(
+      join(flagDir, "feature-flags.json"),
+      JSON.stringify({ test: true }),
+    );
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    // No assertion needed — just verify no error is thrown
+    watcher.stop();
+  });
+});

--- a/gateway/src/__tests__/feature-flag-watcher-callback.test.ts
+++ b/gateway/src/__tests__/feature-flag-watcher-callback.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { testWorkspaceDir } from "./test-preload.js";
-
-const flagDir = join(testWorkspaceDir, "flags");
+// Each test gets a fresh, uniquely-named flag directory. Reusing one path
+// across tests (rm + recreate) leaves fs.watch bound to a stale inode, so
+// file events on the recreated directory are silently dropped.
+let flagDir = "";
 
 mock.module("../feature-flag-store.js", () => ({
   clearFeatureFlagStoreCache: mock(() => {}),
@@ -21,6 +23,7 @@ const { FeatureFlagWatcher } = await import("../feature-flag-watcher.js");
 
 describe("FeatureFlagWatcher onChanged callback", () => {
   beforeEach(() => {
+    flagDir = mkdtempSync(join(tmpdir(), "ff-watcher-test-"));
     mkdirSync(flagDir, { recursive: true });
     writeFileSync(join(flagDir, "feature-flags.json"), "{}");
   });

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -498,6 +498,75 @@ describe("RemoteFeatureFlagSync", () => {
     expect(cached["unknown-flag"]).toBe(false);
   });
 
+  test("calls onChanged when remote flags change", async () => {
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "new-flag": true },
+      }),
+    );
+
+    const onChanged = mock(() => {});
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+      onChanged,
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call onChanged when remote flags have not changed", async () => {
+    // First sync to seed the file
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "stable-flag": true },
+      }),
+    );
+
+    const onChanged1 = mock(() => {});
+    const sync1 = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+      onChanged: onChanged1,
+    });
+    await sync1.start();
+    sync1.stop();
+    expect(onChanged1).toHaveBeenCalledTimes(1);
+
+    // Second sync with same data — onChanged should NOT fire
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "stable-flag": true },
+      }),
+    );
+
+    const onChanged2 = mock(() => {});
+    const sync2 = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+      onChanged: onChanged2,
+    });
+    await sync2.start();
+    sync2.stop();
+    expect(onChanged2).not.toHaveBeenCalled();
+  });
+
+  test("does not call onChanged on fetch failure", async () => {
+    fetchMock = mock(
+      async () => new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const onChanged = mock(() => {});
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+      onChanged,
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
   test("trims whitespace from credential values", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
 

--- a/gateway/src/feature-flag-watcher.ts
+++ b/gateway/src/feature-flag-watcher.ts
@@ -25,6 +25,10 @@ const log = getLogger("feature-flag-watcher");
 
 const DEBOUNCE_MS = 500;
 
+export interface FeatureFlagWatcherOptions {
+  onChanged?: () => void;
+}
+
 export class FeatureFlagWatcher {
   private watcher: FSWatcher | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -32,10 +36,12 @@ export class FeatureFlagWatcher {
   private remoteFlagFilename: string;
   /** Accumulates which files changed during the debounce window. */
   private pendingFilenames = new Set<string>();
+  private onChanged?: () => void;
 
-  constructor() {
+  constructor(options?: FeatureFlagWatcherOptions) {
     this.localFlagFilename = basename(getFeatureFlagStorePath());
     this.remoteFlagFilename = basename(getRemoteFeatureFlagStorePath());
+    this.onChanged = options?.onChanged;
   }
 
   start(): void {
@@ -106,6 +112,7 @@ export class FeatureFlagWatcher {
         { filenames: [...filenames] },
         "Feature flag cache invalidated due to file change",
       );
+      this.onChanged?.();
     }, DEBOUNCE_MS);
   }
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2214,11 +2214,16 @@ async function main() {
     assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
   });
 
-  const featureFlagWatcher = new FeatureFlagWatcher();
+  const emitFlagChanged = () => ipcServer.emit("feature_flags_changed");
+
+  const featureFlagWatcher = new FeatureFlagWatcher({
+    onChanged: emitFlagChanged,
+  });
   featureFlagWatcher.start();
 
   const remoteFeatureFlagSync = new RemoteFeatureFlagSync({
     credentials: credentialCache,
+    onChanged: emitFlagChanged,
   });
   // Intentionally fire-and-forget: remote flag fetch is best-effort;
   // the gateway continues with registry defaults if it fails.

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -42,6 +42,8 @@ export type RemoteFeatureFlagSyncConfig = {
   credentials: CredentialCache;
   /** Override the initial poll interval (ms) — useful for testing. Defaults to 10 000. */
   initialPollIntervalMs?: number;
+  /** Called when remote flags change on disk after a successful fetch. */
+  onChanged?: () => void;
 };
 
 /**
@@ -66,12 +68,14 @@ export class RemoteFeatureFlagSync {
   private currentIntervalMs: number;
   private readonly maxIntervalMs: number;
   private readonly credentials: CredentialCache;
+  private readonly onChanged?: () => void;
 
   constructor(config: RemoteFeatureFlagSyncConfig) {
     this.credentials = config.credentials;
     this.currentIntervalMs =
       config.initialPollIntervalMs ?? INITIAL_POLL_INTERVAL_MS;
     this.maxIntervalMs = getMaxPollIntervalMs();
+    this.onChanged = config.onChanged;
   }
 
   async start(): Promise<void> {
@@ -289,6 +293,7 @@ export class RemoteFeatureFlagSync {
     const meta = { count: Object.keys(result.values).length };
     if (changed) {
       log.info(meta, msg);
+      this.onChanged?.();
     } else {
       log.debug(meta, msg);
     }


### PR DESCRIPTION
## Summary
- Wire the gateway to push `feature_flags_changed` events over IPC when flag files change (local toggle or remote platform sync)
- Add a persistent IPC listener in the daemon that re-fetches flags on receiving the event
- Eliminates stale flag cache after startup — flags now propagate to the daemon within ~500ms of changing

## Test plan
- [x] Unit tests for gateway `onChanged` callbacks (FeatureFlagWatcher + RemoteFeatureFlagSync)
- [x] Unit test for daemon listener (event handling, reconnect, ignoring non-flag events)
- [ ] Manual: toggle flag in web UI, verify daemon picks up change without restart
- [x] Type-check passes in both assistant/ and gateway/

🤖 Generated with [Claude Code](https://claude.com/claude-code)