### PR TITLE
refactor(contacts): strip senderGatewayUrl from invite link params

### DIFF
--- a/apps/web/src/domains/contacts/a2a-invite.ts
+++ b/apps/web/src/domains/contacts/a2a-invite.ts
@@ -3,21 +3,22 @@ import { routes } from "@/utils/routes.js";
 export interface A2AInviteParams {
   senderAssistantId: string;
   token: string;
-  senderGatewayUrl: string;
 }
 
 /**
  * Build a shareable A2A invite link that routes to the connect page.
- * The link includes `senderGatewayUrl` so the recipient can reach the
- * sender's gateway directly, without a central broker.
+ * The link includes `senderAssistantId` and `token` so the recipient
+ * can redeem the invite via the platform broker.
  */
-export function buildA2AInviteLink(params: A2AInviteParams): string {
+export function buildA2AInviteLink(params: {
+  senderAssistantId: string;
+  token: string;
+}): string {
   const origin =
     typeof window !== "undefined" ? window.location.origin : "";
   const search = new URLSearchParams({
     senderAssistantId: params.senderAssistantId,
     token: params.token,
-    senderGatewayUrl: params.senderGatewayUrl,
   });
   return `${origin}${routes.connect}?${search.toString()}`;
 }
@@ -29,11 +30,10 @@ export function buildA2AInviteLink(params: A2AInviteParams): string {
 export function parseA2AInviteParams(
   search: URLSearchParams,
 ): A2AInviteParams | null {
-  const senderAssistantId = search.get("senderAssistantId");
-  const token = search.get("token");
-  const senderGatewayUrl = search.get("senderGatewayUrl");
-  if (!senderAssistantId || !token || !senderGatewayUrl) {
+  const senderAssistantId = search.get("senderAssistantId")?.trim();
+  const token = search.get("token")?.trim();
+  if (!senderAssistantId || !token) {
     return null;
   }
-  return { senderAssistantId, token, senderGatewayUrl };
+  return { senderAssistantId, token };
 }

--- a/apps/web/src/domains/contacts/types.ts
+++ b/apps/web/src/domains/contacts/types.ts
@@ -102,13 +102,18 @@ export interface CreateA2AInviteResponse {
   inviteId: string;
   token: string;
   expiresAt: number;
-  senderGatewayUrl: string;
 }
 
-export interface AcceptA2AInviteResponse {
+export interface RedeemA2AInviteInput {
+  senderAssistantId: string;
+  token: string;
+}
+
+export interface RedeemA2AInviteResponse {
   success: boolean;
-  contactId?: string;
   alreadyConnected?: boolean;
+  error?: string;
+  errorCode?: string;
 }
 
 export type ContactSelection =


### PR DESCRIPTION
## Summary
- Remove senderGatewayUrl from A2AInviteParams and invite link construction
- Remove AcceptA2AInviteResponse, add RedeemA2AInviteInput and RedeemA2AInviteResponse types
- Strip senderGatewayUrl from CreateA2AInviteResponse

Part of plan: a2a-invite-link-broker.md (PR 1 of 9)