### PR TITLE
refactor(contacts): suppress per-row A2A setup button in channels section

### DIFF
--- a/apps/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/apps/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -316,13 +316,15 @@ function ChannelRow({
             {verifyLoading ? "Verifying…" : "Verify"}
           </Button>
         ) : actionState.kind === "setup" ? (
-          <Button
-            variant="outlined"
-            onClick={onSetup}
-            disabled={!onSetup}
-          >
-            {info.id === "a2a" ? "Connect" : setupLabel}
-          </Button>
+          info.id === "a2a" ? null : (
+            <Button
+              variant="outlined"
+              onClick={onSetup}
+              disabled={!onSetup}
+            >
+              {setupLabel}
+            </Button>
+          )
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Suppress the per-row setup button for A2A channels in contact channels section
- A2A connections are now managed via the Share Connection Link button at the detail-view level

Part of plan: a2a-invite-link-broker.md (PR 6 of 9)