### PR TITLE
refactor(contacts): strip senderGatewayUrl from generate invite dialog

### DIFF
--- a/apps/web/src/domains/contacts/components/generate-invite-link-dialog.tsx
+++ b/apps/web/src/domains/contacts/components/generate-invite-link-dialog.tsx
@@ -79,7 +79,6 @@ export function GenerateInviteLinkDialog({
       ? buildA2AInviteLink({
           senderAssistantId: assistantId,
           token: mutation.data.token,
-          senderGatewayUrl: mutation.data.senderGatewayUrl,
         })
       : "";
 


### PR DESCRIPTION
## Summary
- Remove senderGatewayUrl from buildA2AInviteLink call in GenerateInviteLinkDialog

Part of plan: a2a-invite-link-broker.md (PR 8 of 9)