### PR TITLE
feat(contacts): add Share Connection Link to assistant and guardian detail views

### DIFF
--- a/apps/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/apps/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog"
 import { Input } from "@vellum/design-library/components/input";
 
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge.js";
+import { ShareConnectionLinkButton } from "@/domains/contacts/components/share-connection-link-button.js";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 import type { AssistantChannelState } from "@/domains/contacts/types.js";
 
@@ -20,6 +21,7 @@ interface AssistantChannelsDetailProps {
   onSaveTelegramToken?: (botToken: string) => Promise<void>;
   onSaveSlackConfig?: (botToken: string, appToken: string) => Promise<void>;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
+  onGenerateInviteLink?: () => void;
 }
 
 const CHANNEL_META: Record<
@@ -55,6 +57,7 @@ export function AssistantChannelsDetail({
   onSaveTelegramToken,
   onSaveSlackConfig,
   onSaveTwilioCredentials,
+  onGenerateInviteLink,
 }: AssistantChannelsDetailProps) {
   const displayName = assistantName.trim() || "your assistant";
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
@@ -112,6 +115,8 @@ export function AssistantChannelsDetail({
           ))}
         </div>
       </SettingsCard>
+
+      {onGenerateInviteLink ? <ShareConnectionLinkButton onClick={onGenerateInviteLink} /> : null}
 
       <ConfirmDialog
         open={pendingDisconnect !== null}

--- a/apps/web/src/domains/contacts/components/guardian-detail-view.tsx
+++ b/apps/web/src/domains/contacts/components/guardian-detail-view.tsx
@@ -5,6 +5,7 @@ import { Input } from "@vellum/design-library/components/input";
 
 import { ContactChannelsSection } from "@/domains/contacts/components/contact-channels-section.js";
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge.js";
+import { ShareConnectionLinkButton } from "@/domains/contacts/components/share-connection-link-button.js";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 import type { ChannelInfo, ContactPayload } from "@/domains/contacts/types.js";
 
@@ -21,6 +22,7 @@ interface GuardianDetailViewProps {
   onSetupChannel?: (type: string) => void;
   onVerifyChannel?: (type: string) => void;
   onRevokeChannel?: (channelId: string, type: string) => void;
+  onGenerateInviteLink?: () => void;
 }
 
 export function GuardianDetailView(props: GuardianDetailViewProps) {
@@ -40,6 +42,7 @@ function GuardianDetailViewInner({
   onSetupChannel,
   onVerifyChannel,
   onRevokeChannel,
+  onGenerateInviteLink,
 }: GuardianDetailViewProps) {
   const principalId = contact.displayName.startsWith("vellum-principal-");
   const initialName = principalId ? "" : contact.displayName;
@@ -135,6 +138,8 @@ function GuardianDetailViewInner({
           onRevokeChannel={onRevokeChannel}
         />
       </SettingsCard>
+
+      {onGenerateInviteLink ? <ShareConnectionLinkButton onClick={onGenerateInviteLink} /> : null}
     </div>
   );
 }

--- a/apps/web/src/domains/contacts/contacts-page.tsx
+++ b/apps/web/src/domains/contacts/contacts-page.tsx
@@ -339,7 +339,7 @@ function ContactsPageInner({
     createMutation.mutate();
   }, [createMutation]);
 
-  const handleAddAssistant = useCallback(() => {
+  const handleOpenInviteLink = useCallback(() => {
     setInviteDialogOpen(true);
   }, []);
 
@@ -449,8 +449,6 @@ function ContactsPageInner({
     selection,
     onAddContact: handleAddContact,
     addingContact: createMutation.isPending,
-    a2aEnabled: a2aChannel,
-    onAddAssistant: handleAddAssistant,
   };
 
   return (
@@ -482,6 +480,7 @@ function ContactsPageInner({
             onSaveTelegramToken={handleSaveTelegramToken}
             onSaveSlackConfig={handleSaveSlackConfig}
             onSaveTwilioCredentials={handleSaveTwilioCredentials}
+            onGenerateInviteLink={a2aChannel ? handleOpenInviteLink : undefined}
           />
         ) : selectedContact ? (
           selectedContact.role === "guardian" ? (
@@ -505,6 +504,7 @@ function ContactsPageInner({
               }
               onVerifyChannel={handleGuardianVerifyChannel}
               onRevokeChannel={handleRevokeChannel}
+              onGenerateInviteLink={a2aChannel ? handleOpenInviteLink : undefined}
             />
           ) : (
             <ContactDetailView


### PR DESCRIPTION
## Summary
- Wire ShareConnectionLinkButton into AssistantChannelsDetail and GuardianDetailView
- Pass onGenerateInviteLink from contacts page when a2a is enabled
- Remove onAddAssistant and a2aEnabled from contactsListProps

Part of plan: a2a-invite-link-broker.md (PR 4 of 9)