### PR TITLE
refactor(contacts): remove a2a setup redirect from contacts page

### DIFF
--- a/apps/web/src/domains/contacts/contacts-page.tsx
+++ b/apps/web/src/domains/contacts/contacts-page.tsx
@@ -367,10 +367,6 @@ function ContactsPageInner({
 
   const handleContactSetupChannel = useCallback(
     (type: string) => {
-      if (type === "a2a") {
-        setInviteDialogOpen(true);
-        return;
-      }
       if (!onStartSetupConversation) {
         return;
       }


### PR DESCRIPTION
## Summary
- Remove a2a type interception from handleContactSetupChannel
- A2A setup is now handled by ShareConnectionLinkButton on detail views

Part of plan: a2a-invite-link-broker.md (PR 9 of 9)