### PR TITLE
feat(web): add 7-click version unlock for developer settings

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -14,6 +14,7 @@ import {
 import { useAuthStore } from "@/stores/auth-store.js";
 import { reportError } from "@/lib/errors/report.js";
 import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
+import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock.js";
 
 const CURRENT_ASSISTANT_QUERY_KEY = ["currentAssistant"] as const;
 
@@ -166,20 +167,10 @@ export function AssistantStatusPanel({
       <Value>{new Date(assistant.created).toLocaleDateString()}</Value>
 
       <Label>Version</Label>
-      {healthzLoading && !assistant.current_release_version ? (
-        <span className="flex items-center gap-2 text-body-medium-lighter text-[var(--content-tertiary)]">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading version...
-        </span>
-      ) : version ? (
-        <span className="break-all text-body-medium-lighter text-[var(--content-default)]">
-          {version}
-        </span>
-      ) : (
-        <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
-          —
-        </span>
-      )}
+      <DevModeVersionUnlock
+        version={version ?? null}
+        loading={healthzLoading && !assistant.current_release_version}
+      />
     </div>
   );
 }

--- a/apps/web/src/domains/settings/components/dev-mode-version-unlock.tsx
+++ b/apps/web/src/domains/settings/components/dev-mode-version-unlock.tsx
@@ -1,0 +1,76 @@
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store.js";
+
+const TAP_THRESHOLD = 7;
+const MESSAGE_DURATION_MS = 2000;
+
+export interface DevModeVersionUnlockProps {
+  version: string | null;
+  loading: boolean;
+}
+
+export function DevModeVersionUnlock({
+  version,
+  loading,
+}: DevModeVersionUnlockProps) {
+  const setFlag = useAssistantFeatureFlagStore.use.setFlag();
+  const tapCountRef = useRef(0);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleClick = useCallback(() => {
+    tapCountRef.current += 1;
+    if (tapCountRef.current >= TAP_THRESHOLD) {
+      tapCountRef.current = 0;
+      const nowEnabled =
+        !useAssistantFeatureFlagStore.getState().settingsDeveloperNav;
+      setFlag("settingsDeveloperNav", nowEnabled);
+      setMessage(
+        nowEnabled ? "Developer mode enabled" : "Developer mode disabled",
+      );
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = setTimeout(
+        () => setMessage(null),
+        MESSAGE_DURATION_MS,
+      );
+    }
+  }, [setFlag]);
+
+  useEffect(() => () => clearTimeout(dismissTimerRef.current), []);
+
+  if (loading) {
+    return (
+      <span className="flex items-center gap-2 text-body-medium-lighter text-[var(--content-tertiary)]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading version...
+      </span>
+    );
+  }
+
+  if (!version) {
+    return (
+      <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
+        —
+      </span>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="break-all text-left text-body-medium-lighter text-[var(--content-default)]"
+        onClick={handleClick}
+      >
+        {version}
+      </button>
+      {message && (
+        <p className="mt-1 text-body-small-default text-[var(--content-accent)]">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/settings/components/dev-mode-version-unlock.tsx
+++ b/apps/web/src/domains/settings/components/dev-mode-version-unlock.tsx
@@ -15,7 +15,6 @@ export function DevModeVersionUnlock({
   version,
   loading,
 }: DevModeVersionUnlockProps) {
-  const setFlag = useAssistantFeatureFlagStore.use.setFlag();
   const tapCountRef = useRef(0);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const [message, setMessage] = useState<string | null>(null);
@@ -24,9 +23,9 @@ export function DevModeVersionUnlock({
     tapCountRef.current += 1;
     if (tapCountRef.current >= TAP_THRESHOLD) {
       tapCountRef.current = 0;
-      const nowEnabled =
-        !useAssistantFeatureFlagStore.getState().settingsDeveloperNav;
-      setFlag("settingsDeveloperNav", nowEnabled);
+      const store = useAssistantFeatureFlagStore.getState();
+      const nowEnabled = !store.settingsDeveloperNav;
+      store.setFlag("settingsDeveloperNav", nowEnabled);
       setMessage(
         nowEnabled ? "Developer mode enabled" : "Developer mode disabled",
       );
@@ -36,7 +35,7 @@ export function DevModeVersionUnlock({
         MESSAGE_DURATION_MS,
       );
     }
-  }, [setFlag]);
+  }, []);
 
   useEffect(() => () => clearTimeout(dismissTimerRef.current), []);
 


### PR DESCRIPTION
## Summary
- Adds a secret 7-click unlock on the version number in Settings > General that toggles the `settingsDeveloperNav` feature flag, mirroring the Mac app's 7-tap pattern on Assistant ID
- Extracted into a standalone `DevModeVersionUnlock` component with ref-based tap counting (no unnecessary re-renders) and `getState()` reads (stable callback)
- Shows a temporary "Developer mode enabled/disabled" message that auto-dismisses after 2 seconds

## Original prompt
The web UI had no way to unlock the Developer settings tab — the Mac app uses a 7-tap on the Assistant ID row, but the web UI required the `settingsDeveloperNav` feature flag to already be enabled. The user asked to add an equivalent secret unlock pattern in the web UI so developers can toggle the Developer tab without needing to set the flag externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)