### PR TITLE
fix: consolidate invite types and remove dead senderGatewayUrl field

### DIFF
--- a/apps/web/src/domains/contacts/a2a-invite.ts
+++ b/apps/web/src/domains/contacts/a2a-invite.ts
@@ -10,10 +10,7 @@ export interface A2AInviteParams {
  * The link includes `senderAssistantId` and `token` so the recipient
  * can redeem the invite via the platform broker.
  */
-export function buildA2AInviteLink(params: {
-  senderAssistantId: string;
-  token: string;
-}): string {
+export function buildA2AInviteLink(params: A2AInviteParams): string {
   const origin =
     typeof window !== "undefined" ? window.location.origin : "";
   const search = new URLSearchParams({

--- a/apps/web/src/domains/contacts/api.ts
+++ b/apps/web/src/domains/contacts/api.ts
@@ -4,13 +4,13 @@ import {
   assertHasResponse,
   extractErrorMessage,
 } from "@/lib/api-errors.js";
+import type { A2AInviteParams } from "@/domains/contacts/a2a-invite.js";
 import type {
   ChannelInfo,
   ChannelReadinessSnapshot,
   ContactPayload,
   CreateA2AInviteResponse,
   CreateContactInput,
-  RedeemA2AInviteInput,
   RedeemA2AInviteResponse,
   SlackChannelConfig,
   TelegramConfig,
@@ -489,7 +489,6 @@ interface DaemonCreateInviteResponse {
   inviteId?: string;
   token?: string;
   expiresAt?: number;
-  senderGatewayUrl?: string;
   success?: boolean;
 }
 
@@ -542,7 +541,7 @@ interface DjangoRedeemInviteResponse {
 
 export async function redeemA2AInvite(
   receiverAssistantId: string,
-  input: RedeemA2AInviteInput,
+  input: A2AInviteParams,
 ): Promise<RedeemA2AInviteResponse> {
   const { data, error, response } = await client.post<
     DjangoRedeemInviteResponse,

--- a/apps/web/src/domains/contacts/types.ts
+++ b/apps/web/src/domains/contacts/types.ts
@@ -104,11 +104,6 @@ export interface CreateA2AInviteResponse {
   expiresAt: number;
 }
 
-export interface RedeemA2AInviteInput {
-  senderAssistantId: string;
-  token: string;
-}
-
 export interface RedeemA2AInviteResponse {
   success: boolean;
   alreadyConnected?: boolean;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for a2a-invite-link-broker.md.

- Remove dead senderGatewayUrl from DaemonCreateInviteResponse
- Use A2AInviteParams type in buildA2AInviteLink instead of inline type
- Remove duplicate RedeemA2AInviteInput, use A2AInviteParams instead