### PR TITLE
fix(web): make OverflowChip visually match FaviconChip in size + weight

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -210,7 +210,7 @@ export function PhaseGroupedStepList({
               durationLabel={totalDuration}
               status={status}
             />
-            <div className="flex flex-col gap-1 pl-[24px]">
+            <div className="flex min-w-0 flex-wrap items-start gap-1 pl-[24px]">
               {section.steps.map((step) => {
                 const key = stepKey(step, globalIndex);
                 globalIndex += 1;
@@ -300,30 +300,69 @@ function PhaseHeaderRow({
  */
 export function DefaultStepPill({ step }: { step: ToolCallCardStep }) {
   if (step.kind === "thinking") {
-    return <StepPill>{step.text}</StepPill>;
+    return (
+      <StepPill>
+        <PillText>{step.text}</PillText>
+      </StepPill>
+    );
   }
   if (step.kind === "tool") {
     const Glyph = ICON_MAP[step.iconName] ?? Bolt;
-    const text = step.info || step.title;
+    // `info` is the canonical per-tool detail (file basename, bash command,
+    // skill name, etc). When the labeler couldn't extract one, suppress the
+    // pill entirely rather than duplicating the phase header's title — e.g.
+    // a skill call with no skill name shouldn't render a literal "Using a
+    // skill" pill underneath a "Using a skill" phase header.
+    if (!step.info) return null;
     return (
       <StepPill>
         <Glyph
           aria-hidden="true"
           className="h-3.5 w-3.5 shrink-0 text-[var(--content-secondary)]"
         />
-        <span className="min-w-0 truncate">{text}</span>
+        <PillText>{step.info}</PillText>
       </StepPill>
     );
   }
   if (step.kind === "tool_error") {
-    return <StepPill tone="error">{step.message}</StepPill>;
+    return (
+      <StepPill tone="error">
+        <PillText>{step.message}</PillText>
+      </StepPill>
+    );
   }
   if (step.kind === "web_search_error") {
-    return <StepPill tone="error">{step.errorMessage}</StepPill>;
+    return (
+      <StepPill tone="error">
+        <PillText>{step.errorMessage}</PillText>
+      </StepPill>
+    );
   }
   // step.kind === "web_search" — default rendering just shows the title;
   // consumers that need favicons supply a `renderStep` override.
-  return <StepPill>{step.title}</StepPill>;
+  return (
+    <StepPill>
+      <PillText>{step.title}</PillText>
+    </StepPill>
+  );
+}
+
+/**
+ * Wrap a string in a Typography element configured to truncate when its
+ * surrounding pill is narrower than the text. The truncate utility requires
+ * `display: block | inline-block` to fire, so the Typography variant here
+ * stays default-display rather than inline-flex (which a previous version
+ * tried, suppressing ellipsis entirely).
+ */
+function PillText({ children }: { children: ReactNode }) {
+  return (
+    <Typography
+      variant="body-small-default"
+      className="min-w-0 truncate text-inherit"
+    >
+      {children}
+    </Typography>
+  );
 }
 
 function StepPill({
@@ -340,14 +379,9 @@ function StepPill({
   return (
     <div
       data-testid="phase-step-pill"
-      className={`inline-flex max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] ${toneClasses}`}
+      className={`inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] ${toneClasses}`}
     >
-      <Typography
-        variant="body-small-default"
-        className="inline-flex min-w-0 items-center gap-1 truncate"
-      >
-        {children}
-      </Typography>
+      {children}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/web-search/web-search-step-row.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-step-row.tsx
@@ -19,19 +19,23 @@ import type { ToolCallCardStep } from "@/domains/chat/hooks/use-tool-call-card-d
 
 /**
  * Small "+N more" pill used at the tail of a `web_search` row's result list.
- * Mirrors Figma node 4922:104082 — filled `--surface-base` pill with the
- * `body-small-emphasised` (Semi Bold 12) typography variant.
+ * Visually matches `FaviconChip` so the overflow pill sits flush in the same
+ * row: identical outer geometry (`inline-flex items-center`, 10/6 padding,
+ * pill radius, `--surface-base` fill), identical Inter Medium 12 typography
+ * (`body-small-default`), and a `min-h-[26px]` floor so the chip matches the
+ * favicon chips' natural height (which is dictated by their 14×14 favicon
+ * slot inside the same padding).
  */
 export function OverflowChip({ count }: { count: number }) {
   return (
-    <div className="rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
+    <span className="inline-flex min-h-[26px] items-center rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[10px] py-[6px]">
       <Typography
-        variant="body-small-emphasised"
+        variant="body-small-default"
         className="text-[var(--content-default)]"
       >
         +{count} more
       </Typography>
-    </div>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

QA feedback on PR #31739 — the `+N more` pill at the end of a `web_search` row was visibly shorter and bolder than the favicon chips beside it.

- Switch Typography variant from `body-small-emphasised` (Semi Bold 12) to `body-small-default` (Inter Medium 12) to match `FaviconChip`'s weight.
- Switch outer container from a `<div>` to `<span class="inline-flex items-center min-h-[26px]">` so the chip's height matches FaviconChip's natural height (which is dictated by the 14×14 favicon slot inside the same 10/6 padding).

Part of plan: unify-tool-progress-cards.md (post-merge QA tweak)