### PR TITLE
[codex] LUM-1827 fix OpenAI timeout handling

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -56,6 +56,7 @@ let lastCreateParams: Record<string, unknown> | null = null;
 let lastCreateOptions: Record<string, unknown> | null = null;
 let lastConstructorOptions: Record<string, unknown> | null = null;
 let shouldThrow: Error | null = null;
+const DEFAULT_SDK_TIMEOUT_MS = 1_860_000;
 
 function userMsg(text: string): Message {
   return { role: "user", content: [{ type: "text", text }] };
@@ -307,6 +308,7 @@ describe("OpenAIProvider", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "sk-local",
       baseURL: "http://127.0.0.1:11434/v1",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 
@@ -319,6 +321,7 @@ describe("OpenAIProvider", () => {
       expect(lastConstructorOptions).toEqual({
         apiKey: "ollama",
         baseURL: "http://127.0.0.1:11434/v1",
+        timeout: DEFAULT_SDK_TIMEOUT_MS,
       });
     } finally {
       if (previousBaseUrl !== undefined) {
@@ -338,6 +341,7 @@ describe("OpenAIProvider", () => {
       expect(lastConstructorOptions).toEqual({
         apiKey: "ollama",
         baseURL: "http://127.0.0.1:11434/v1",
+        timeout: DEFAULT_SDK_TIMEOUT_MS,
       });
     } finally {
       if (previousBaseUrl !== undefined) {
@@ -1280,6 +1284,7 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/openai",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 
@@ -1289,6 +1294,19 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "sk-user-key",
       baseURL: undefined,
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
+    });
+  });
+
+  test("OpenAIProvider passes configured stream timeout plus buffer to SDK", () => {
+    new OpenAIProvider("sk-user-key", "gpt-4o", {
+      streamTimeoutMs: 300_000,
+    });
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "sk-user-key",
+      baseURL: undefined,
+      timeout: 360_000,
     });
   });
 
@@ -1305,6 +1323,7 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/fireworks",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 
@@ -1317,6 +1336,7 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "fw-user-key",
       baseURL: "https://api.fireworks.ai/inference/v1",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 
@@ -1329,6 +1349,7 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 
@@ -1338,6 +1359,7 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "or-user-key",
       baseURL: "https://openrouter.ai/api/v1",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
 });

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -22,6 +22,7 @@ let lastStreamParams: Record<string, unknown> | null = null;
 let lastStreamOptions: Record<string, unknown> | null = null;
 let lastConstructorOptions: Record<string, unknown> | null = null;
 let shouldThrow: Error | null = null;
+const DEFAULT_SDK_TIMEOUT_MS = 1_860_000;
 
 // Simulate OpenAI.APIError
 class FakeAPIError extends Error {
@@ -200,6 +201,19 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "sk-custom",
       baseURL: "https://proxy.example.com/v1",
+      timeout: DEFAULT_SDK_TIMEOUT_MS,
+    });
+  });
+
+  test("passes configured stream timeout plus buffer to OpenAI client", () => {
+    new OpenAIResponsesProvider("sk-custom", "gpt-5.4", {
+      streamTimeoutMs: 300_000,
+    });
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "sk-custom",
+      baseURL: undefined,
+      timeout: 360_000,
     });
   });
 

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -155,12 +155,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
   ) {
     this.name = options.providerName ?? "openai";
     this.providerLabel = options.providerLabel ?? "OpenAI";
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
+    // Keep the SDK deadline behind our provider stream timeout so
+    // createStreamTimeout owns the user-facing timeout error.
+    const sdkTimeoutMs = this.streamTimeoutMs + 60_000;
     this.client = new OpenAI({
       apiKey,
       baseURL: options.baseURL,
+      timeout: sdkTimeoutMs,
     });
     this.model = model;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     this.extraCreateParams = options.extraCreateParams ?? {};
     this.maxReasoningEffort = options.maxReasoningEffort ?? "xhigh";
     this.requestHeaders = options.requestHeaders ?? {};

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -116,14 +116,18 @@ export class OpenAIResponsesProvider implements Provider {
     this.name = options.providerName ?? "openai";
     this.providerLabel = options.providerLabel ?? "OpenAI";
     this.codexSubscription = options.codexSubscription ?? false;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
+    // Keep the SDK deadline behind our provider stream timeout so
+    // createStreamTimeout owns the user-facing timeout error.
+    const sdkTimeoutMs = this.streamTimeoutMs + 60_000;
     this.client = new OpenAI({
       apiKey,
       baseURL: this.codexSubscription
         ? "https://chatgpt.com/backend-api/codex"
         : options.baseURL,
+      timeout: sdkTimeoutMs,
     });
     this.model = model;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
   }
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -1,4 +1,9 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, test, expect } from "bun:test";
+
+import { testWorkspaceDir } from "./test-preload.js";
 import { loadConfig } from "../config.js";
 
 describe("config: hardcoded defaults", () => {
@@ -83,6 +88,25 @@ describe("config: hardcoded defaults", () => {
     } finally {
       if (saved !== undefined) process.env.RUNTIME_TIMEOUT_MS = saved;
       else delete process.env.RUNTIME_TIMEOUT_MS;
+    }
+  });
+
+  test("runtimeTimeoutMs rejects non-numeric workspace config values", () => {
+    const saved = process.env.RUNTIME_TIMEOUT_MS;
+    delete process.env.RUNTIME_TIMEOUT_MS;
+    writeFileSync(
+      join(testWorkspaceDir, "config.json"),
+      JSON.stringify({ gateway: { runtimeTimeoutMs: true } }),
+    );
+
+    try {
+      expect(() => loadConfig()).toThrow(
+        "gateway.runtimeTimeoutMs must be a positive integer",
+      );
+    } finally {
+      if (saved !== undefined) process.env.RUNTIME_TIMEOUT_MS = saved;
+      else delete process.env.RUNTIME_TIMEOUT_MS;
+      writeFileSync(join(testWorkspaceDir, "config.json"), "{}");
     }
   });
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -61,6 +61,31 @@ describe("config: hardcoded defaults", () => {
     }
   });
 
+  test("runtimeTimeoutMs is configurable via env var", () => {
+    const saved = process.env.RUNTIME_TIMEOUT_MS;
+    process.env.RUNTIME_TIMEOUT_MS = "300000";
+    try {
+      const config = loadConfig();
+      expect(config.runtimeTimeoutMs).toBe(300000);
+    } finally {
+      if (saved !== undefined) process.env.RUNTIME_TIMEOUT_MS = saved;
+      else delete process.env.RUNTIME_TIMEOUT_MS;
+    }
+  });
+
+  test("runtimeTimeoutMs rejects invalid env var", () => {
+    const saved = process.env.RUNTIME_TIMEOUT_MS;
+    process.env.RUNTIME_TIMEOUT_MS = "0";
+    try {
+      expect(() => loadConfig()).toThrow(
+        "RUNTIME_TIMEOUT_MS must be a positive integer",
+      );
+    } finally {
+      if (saved !== undefined) process.env.RUNTIME_TIMEOUT_MS = saved;
+      else delete process.env.RUNTIME_TIMEOUT_MS;
+    }
+  });
+
   test("gatewayInternalBaseUrl derives from port", () => {
     const saved = process.env.GATEWAY_PORT;
     process.env.GATEWAY_PORT = "8080";

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -77,6 +77,18 @@ function parseRoutingEntries(raw: unknown): RoutingEntry[] {
   return entries;
 }
 
+function parsePositiveInteger(
+  value: unknown,
+  name: string,
+): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
 export function loadConfig(): GatewayConfig {
   const portRaw = process.env.GATEWAY_PORT || "7830";
   const port = Number(portRaw);
@@ -119,6 +131,13 @@ export function loadConfig(): GatewayConfig {
     (typeof gw.defaultAssistantId === "string" && gw.defaultAssistantId
       ? gw.defaultAssistantId
       : undefined);
+  const runtimeTimeoutMs =
+    parsePositiveInteger(
+      process.env.RUNTIME_TIMEOUT_MS,
+      "RUNTIME_TIMEOUT_MS",
+    ) ??
+    parsePositiveInteger(gw.runtimeTimeoutMs, "gateway.runtimeTimeoutMs") ??
+    30000;
   let routingEntries: RoutingEntry[] = [];
   if (process.env.ROUTING_ENTRIES) {
     try {
@@ -147,6 +166,7 @@ export function loadConfig(): GatewayConfig {
       hasVelayBaseUrl: !!velayBaseUrl,
       port,
       runtimeProxyRequireAuth,
+      runtimeTimeoutMs,
       trustProxy: false,
     },
     "Configuration loaded",
@@ -172,7 +192,7 @@ export function loadConfig(): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     runtimeMaxRetries: 2,
     runtimeProxyRequireAuth,
-    runtimeTimeoutMs: 30000,
+    runtimeTimeoutMs,
     shutdownDrainMs: 5000,
     unmappedPolicy,
     trustProxy: false,

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -81,8 +81,22 @@ function parsePositiveInteger(
   value: unknown,
   name: string,
 ): number | undefined {
-  if (value === undefined || value === null || value === "") return undefined;
-  const parsed = typeof value === "number" ? value : Number(value);
+  if (value === undefined || value === null) return undefined;
+
+  let parsed: number;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+    parsed = Number(trimmed);
+  } else {
+    throw new Error(`${name} must be a positive integer`);
+  }
+
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`${name} must be a positive integer`);
   }


### PR DESCRIPTION
## Summary

Fixes LUM-1827.

- Pass the configured provider stream timeout plus a 60s buffer into the OpenAI SDK for both Responses and Chat Completions transports.
- Make the gateway runtime request timeout configurable via `RUNTIME_TIMEOUT_MS` or `gateway.runtimeTimeoutMs` while preserving the existing 30s default.
- Add focused coverage for the OpenAI SDK timeout wiring and gateway timeout config parsing.

## Root Cause

The OpenAI provider path used the assistant's stream timeout for our own abort controller, but did not pass the same longer deadline into the OpenAI SDK. Separately, the gateway runtime timeout was hardcoded, so request-layer timeouts could not be increased for deployments that need longer synchronous waits.

## Validation

- `cd assistant && bun test src/__tests__/openai-provider.test.ts src/__tests__/openai-responses-provider.test.ts`
- `cd gateway && bun test src/__tests__/config.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd gateway && bunx tsc --noEmit`

## Notes

The feedback log bundle referenced from Downloads was not readable from this environment because macOS denied access, so this patch is based on code-path tracing and the reported timeout behavior.