### PR TITLE
[codex] Hide ask_question on macOS turns

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -558,9 +558,42 @@ describe("isToolActiveForContext — ask_question macOS gating", () => {
     ).toBe(false);
   });
 
+  test("ask_question is NOT active for macOS transport without channelCapabilities", () => {
+    expect(
+      isToolActiveForContext(
+        "ask_question",
+        makeCtx({
+          hasNoClient: false,
+          transportInterface: "macos",
+        }),
+      ),
+    ).toBe(false);
+  });
+
   test("ask_question is active when channelCapabilities is undefined (backwards-compat)", () => {
     expect(
       isToolActiveForContext("ask_question", makeCtx({ hasNoClient: false })),
+    ).toBe(true);
+  });
+
+  test("ask_question remains active for web and iOS transports", () => {
+    expect(
+      isToolActiveForContext(
+        "ask_question",
+        makeCtx({
+          hasNoClient: false,
+          transportInterface: "web",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isToolActiveForContext(
+        "ask_question",
+        makeCtx({
+          hasNoClient: false,
+          transportInterface: "ios",
+        }),
+      ),
     ).toBe(true);
   });
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -490,10 +490,13 @@ export function isToolActiveForContext(
     return !ctx.hasNoClient;
   }
   if (CLIENT_CAPABILITY_TOOL_NAMES.has(name)) {
-    if (
-      name === "ask_question" &&
-      ctx.channelCapabilities?.clientOS === "macos"
-    ) {
+    if (name === "ask_question") {
+      const isMacOSClientTurn =
+        ctx.channelCapabilities?.clientOS === "macos" ||
+        ctx.transportInterface === "macos";
+      if (!isMacOSClientTurn) {
+        return !ctx.hasNoClient;
+      }
       // macOS has no UI handler for question_request yet; hiding the tool
       // avoids a 5-minute prompter timeout when the LLM would otherwise call it.
       return false;


### PR DESCRIPTION
## Summary
- Hide `ask_question` whenever the active turn is from macOS, using either channel capabilities or the turn transport as the signal.
- Preserve `ask_question` support for connected web and iOS/mobile turns.
- Add regression coverage for macOS transport fallback and web/iOS support.

## Original prompt
The user asked for a PR that removes the `ask_question` tool only when the user is talking to their assistant on macOS, while keeping web and mobile supported.

## Validation
- `cd assistant && bun test src/daemon/__tests__/conversation-tool-setup.test.ts`
- `cd assistant && bunx tsc --noEmit`