### PR TITLE
Run missed background wake work during drain

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1857,11 +1857,32 @@ paths:
                         type: number
                       total:
                         type: number
+                      completed:
+                        type: number
+                      failed:
+                        type: number
+                      skipped:
+                        type: number
+                      claimed:
+                        type: number
+                      stillPending:
+                        type: number
                     required:
                       - heartbeat
                       - scheduler
                       - total
+                      - completed
+                      - failed
+                      - skipped
+                      - claimed
+                      - stillPending
                     additionalProperties: false
+                  completed:
+                    type: number
+                  failed:
+                    type: number
+                  skipped:
+                    type: number
                   nextIntent:
                     anyOf:
                       - type: object
@@ -1894,6 +1915,8 @@ paths:
                           - sourcePayload
                         additionalProperties: false
                       - type: "null"
+                  dueWorkRemaining:
+                    type: boolean
                 required:
                   - leaseId
                   - reason
@@ -1901,7 +1924,11 @@ paths:
                   - startedAt
                   - deadlineAt
                   - counts
+                  - completed
+                  - failed
+                  - skipped
                   - nextIntent
+                  - dueWorkRemaining
                 additionalProperties: false
       requestBody:
         required: true

--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -400,6 +400,56 @@ describe("background wake runtime routes", () => {
     });
   });
 
+  test("drain-due runs due heartbeat even when schedule is the earliest intent source", async () => {
+    const now = Date.now();
+    const scheduleDueAt = now - 60_000;
+    const heartbeatDueAt = now - 1_000;
+    const recomputedIntent = intentFixture({
+      nextWakeAt: now + 60_000,
+      sourceGeneration: "after-mixed-backlog",
+    });
+    computedIntent = intentFixture({
+      nextWakeAt: scheduleDueAt,
+      actualNextDueAt: scheduleDueAt,
+      reason: "schedule",
+    });
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () => {
+      computedIntent = recomputedIntent;
+      return schedulerResultFixture({ claimed: 1, completed: 1 });
+    });
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: heartbeatDueAt,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({ reason: "schedule" }),
+    });
+
+    expect(heartbeatRunManaged).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduledFor: NOW }),
+    );
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    expect(response).toMatchObject({
+      completed: 2,
+      failed: 0,
+      skipped: 0,
+      dueWorkRemaining: false,
+    });
+  });
+
   test("drain-due does no work for refresh-only wakes with no due intent", async () => {
     const heartbeatRunManaged = mock(async () => ({
       due: true,

--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -38,6 +38,13 @@ function schedulerResultFixture(
   };
 }
 
+function firstCallArg(fn: {
+  mock: { calls: unknown[] };
+}): Record<string, unknown> {
+  const call = fn.mock.calls[0] as unknown[] | undefined;
+  return (call?.[0] ?? {}) as Record<string, unknown>;
+}
+
 describe("background wake runtime routes", () => {
   beforeEach(() => {
     clearBackgroundWakeRuntime();
@@ -96,27 +103,34 @@ describe("background wake runtime routes", () => {
   });
 
   test("drain-due invokes due heartbeat and scheduler work", async () => {
+    const dueAt = Date.now() - 1;
+    const recomputedIntent = intentFixture({
+      nextWakeAt: Date.now() + 60_000,
+      sourceGeneration: "next-generation",
+    });
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "mixed",
+    });
     const heartbeatRunManaged = mock(async () => ({
       due: true,
       completed: 1,
       skipped: 0,
     }));
-    const schedulerRunDue = mock(async () =>
-      schedulerResultFixture({ claimed: 2, completed: 2 }),
-    );
+    const schedulerRunDue = mock(async () => {
+      computedIntent = recomputedIntent;
+      return schedulerResultFixture({ claimed: 2, completed: 2 });
+    });
     registerBackgroundWakeRuntime({
       heartbeat: {
-        nextRunAt: Date.now() - 1,
+        nextRunAt: dueAt,
         runManagedWakeIfDue: heartbeatRunManaged,
       },
       scheduler: {
         runOnce: mock(async () => 2),
         runDueWorkOnce: schedulerRunDue,
       },
-    });
-    computedIntent = intentFixture({
-      nextWakeAt: NOW + 60_000,
-      sourceGeneration: "next-generation",
     });
     const handler = findHandler("drainDueBackgroundWake");
 
@@ -126,8 +140,9 @@ describe("background wake runtime routes", () => {
 
     expect(heartbeatRunManaged).toHaveBeenCalledTimes(1);
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
-      expect.objectContaining({ assumeDue: true }),
+      expect.objectContaining({ scheduledFor: NOW }),
     );
+    expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
     expect(response).toEqual({
       leaseId: "lease-123",
@@ -148,7 +163,7 @@ describe("background wake runtime routes", () => {
       completed: 3,
       failed: 0,
       skipped: 0,
-      nextIntent: computedIntent,
+      nextIntent: recomputedIntent,
       dueWorkRemaining: false,
     });
   });
@@ -231,7 +246,58 @@ describe("background wake runtime routes", () => {
     expect(response.nextIntent).toEqual(recomputedIntent);
   });
 
-  test("drain-due runs a heartbeat for daemon startup after sleep", async () => {
+  test("drain-due runs scheduler backlog on heartbeat-only drains", async () => {
+    const dueAt = Date.now() - 1;
+    const recomputedIntent = intentFixture({
+      nextWakeAt: Date.now() + 60_000,
+      sourceGeneration: "after-heartbeat-drain",
+    });
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "heartbeat",
+    });
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () => {
+      computedIntent = recomputedIntent;
+      return schedulerResultFixture({ claimed: 1, completed: 1 });
+    });
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: dueAt,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({ reason: "heartbeat" }),
+    });
+
+    expect(heartbeatRunManaged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledFor: NOW,
+      }),
+    );
+    expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    expect(response).toMatchObject({
+      completed: 2,
+      failed: 0,
+      skipped: 0,
+      dueWorkRemaining: false,
+    });
+  });
+
+  test("drain-due does not rerun heartbeat for stale heartbeat drain requests", async () => {
     const heartbeatRunManaged = mock(async () => ({
       due: true,
       completed: 1,
@@ -254,15 +320,10 @@ describe("background wake runtime routes", () => {
       body: drainBodyFixture({ reason: "heartbeat" }),
     });
 
-    expect(heartbeatRunManaged).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assumeDue: true,
-        scheduledFor: NOW,
-      }),
-    );
+    expect(heartbeatRunManaged).not.toHaveBeenCalled();
     expect(schedulerRunDue).not.toHaveBeenCalled();
     expect(response).toMatchObject({
-      completed: 1,
+      completed: 0,
       failed: 0,
       skipped: 0,
       dueWorkRemaining: false,
@@ -296,8 +357,9 @@ describe("background wake runtime routes", () => {
     await handler({ body: drainBodyFixture({ reason: "refresh" }) });
 
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
-      expect.objectContaining({ assumeDue: false }),
+      expect.objectContaining({ scheduledFor: NOW }),
     );
+    expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
   });
 
   test("drain-due runs scheduler when schedule work is due at wake", async () => {
@@ -374,6 +436,12 @@ describe("background wake runtime routes", () => {
   });
 
   test("drain-due honors deadline exhaustion before starting heartbeat work", async () => {
+    const dueAt = Date.now() - 1;
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "mixed",
+    });
     const heartbeatRunManaged = mock(async () => ({
       due: true,
       completed: 1,
@@ -384,7 +452,7 @@ describe("background wake runtime routes", () => {
     );
     registerBackgroundWakeRuntime({
       heartbeat: {
-        nextRunAt: Date.now() - 1,
+        nextRunAt: dueAt,
         runManagedWakeIfDue: heartbeatRunManaged,
       },
       scheduler: {

--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { SchedulerDueWorkResult } from "../schedule/scheduler.js";
 import type { BackgroundWakeIntent } from "./next-wake.js";
 import {
   clearBackgroundWakeRuntime,
@@ -23,6 +24,19 @@ function findHandler(operationId: string) {
 }
 
 const NOW = 1_800_000_000_000;
+
+function schedulerResultFixture(
+  overrides: Partial<SchedulerDueWorkResult> = {},
+): SchedulerDueWorkResult {
+  return {
+    claimed: 0,
+    completed: 0,
+    failed: 0,
+    skipped: 0,
+    stillPending: 0,
+    ...overrides,
+  };
+}
 
 describe("background wake runtime routes", () => {
   beforeEach(() => {
@@ -82,15 +96,22 @@ describe("background wake runtime routes", () => {
   });
 
   test("drain-due invokes due heartbeat and scheduler work", async () => {
-    const heartbeatRunOnce = mock(async () => true);
-    const schedulerRunOnce = mock(async () => 2);
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ claimed: 2, completed: 2 }),
+    );
     registerBackgroundWakeRuntime({
       heartbeat: {
         nextRunAt: Date.now() - 1,
-        runOnce: heartbeatRunOnce,
+        runManagedWakeIfDue: heartbeatRunManaged,
       },
       scheduler: {
-        runOnce: schedulerRunOnce,
+        runOnce: mock(async () => 2),
+        runDueWorkOnce: schedulerRunDue,
       },
     });
     computedIntent = intentFixture({
@@ -99,14 +120,18 @@ describe("background wake runtime routes", () => {
     });
     const handler = findHandler("drainDueBackgroundWake");
 
-    const response = await handler({ body: drainBodyFixture() });
+    const response = await handler({
+      body: drainBodyFixture({ reason: "mixed" }),
+    });
 
-    expect(heartbeatRunOnce).toHaveBeenCalledTimes(1);
-    expect(heartbeatRunOnce).toHaveBeenCalledWith();
-    expect(schedulerRunOnce).toHaveBeenCalledTimes(1);
+    expect(heartbeatRunManaged).toHaveBeenCalledTimes(1);
+    expect(heartbeatRunManaged).toHaveBeenCalledWith(
+      expect.objectContaining({ assumeDue: true }),
+    );
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
     expect(response).toEqual({
       leaseId: "lease-123",
-      reason: "schedule",
+      reason: "mixed",
       sourceGeneration: "source-generation",
       startedAt: NOW,
       deadlineAt: NOW + 30_000,
@@ -114,35 +139,63 @@ describe("background wake runtime routes", () => {
         heartbeat: 1,
         scheduler: 2,
         total: 3,
+        completed: 3,
+        failed: 0,
+        skipped: 0,
+        claimed: 2,
+        stillPending: 0,
       },
+      completed: 3,
+      failed: 0,
+      skipped: 0,
       nextIntent: computedIntent,
+      dueWorkRemaining: false,
     });
   });
 
   test("drain-due skips heartbeat when it is not due and reports no scheduler work", async () => {
-    const heartbeatRunOnce = mock(async () => true);
-    const schedulerRunOnce = mock(async () => 0);
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () => schedulerResultFixture());
     registerBackgroundWakeRuntime({
       heartbeat: {
         nextRunAt: Date.now() + 5 * 60_000,
-        runOnce: heartbeatRunOnce,
+        runManagedWakeIfDue: heartbeatRunManaged,
       },
       scheduler: {
-        runOnce: schedulerRunOnce,
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
       },
     });
     const handler = findHandler("drainDueBackgroundWake");
 
     const response = (await handler({ body: drainBodyFixture() })) as {
-      counts: { heartbeat: number; scheduler: number; total: number };
+      counts: {
+        heartbeat: number;
+        scheduler: number;
+        total: number;
+        completed: number;
+        failed: number;
+        skipped: number;
+        claimed: number;
+        stillPending: number;
+      };
     };
 
-    expect(heartbeatRunOnce).not.toHaveBeenCalled();
-    expect(schedulerRunOnce).toHaveBeenCalledTimes(1);
+    expect(heartbeatRunManaged).not.toHaveBeenCalled();
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
     expect(response.counts).toEqual({
       heartbeat: 0,
       scheduler: 0,
       total: 0,
+      completed: 0,
+      failed: 0,
+      skipped: 0,
+      claimed: 0,
+      stillPending: 0,
     });
   });
 
@@ -153,15 +206,20 @@ describe("background wake runtime routes", () => {
     });
     const schedulerRunOnce = mock(async () => {
       computedIntent = recomputedIntent;
-      return 1;
+      return schedulerResultFixture({ claimed: 1, completed: 1 });
     });
     registerBackgroundWakeRuntime({
       heartbeat: {
         nextRunAt: null,
-        runOnce: mock(async () => true),
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
       },
       scheduler: {
-        runOnce: schedulerRunOnce,
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunOnce,
       },
     });
     const handler = findHandler("drainDueBackgroundWake");
@@ -173,15 +231,232 @@ describe("background wake runtime routes", () => {
     expect(response.nextIntent).toEqual(recomputedIntent);
   });
 
+  test("drain-due runs a heartbeat for daemon startup after sleep", async () => {
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () => schedulerResultFixture());
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() + 30 * 60_000,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({ reason: "heartbeat" }),
+    });
+
+    expect(heartbeatRunManaged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assumeDue: true,
+        scheduledFor: NOW,
+      }),
+    );
+    expect(schedulerRunDue).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 0,
+      dueWorkRemaining: false,
+    });
+  });
+
+  test("drain-due runs heartbeat when the local intent is due at wake", async () => {
+    const dueAt = Date.now() - 1;
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "heartbeat",
+    });
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: dueAt,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: mock(async () => schedulerResultFixture()),
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    await handler({ body: drainBodyFixture({ reason: "refresh" }) });
+
+    expect(heartbeatRunManaged).toHaveBeenCalledWith(
+      expect.objectContaining({ assumeDue: false }),
+    );
+  });
+
+  test("drain-due runs scheduler when schedule work is due at wake", async () => {
+    const dueAt = Date.now() - 1;
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "schedule",
+    });
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ claimed: 1, completed: 1 }),
+    );
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() + 60_000,
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({ reason: "refresh" }),
+    });
+
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    expect(response).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 0,
+    });
+  });
+
+  test("drain-due does no work for refresh-only wakes with no due intent", async () => {
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ completed: 1 }),
+    );
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() + 60_000,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({ reason: "refresh" }),
+    });
+
+    expect(heartbeatRunManaged).not.toHaveBeenCalled();
+    expect(schedulerRunDue).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      completed: 0,
+      failed: 0,
+      skipped: 0,
+      dueWorkRemaining: false,
+    });
+  });
+
+  test("drain-due honors deadline exhaustion before starting heartbeat work", async () => {
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ skipped: 2, stillPending: 2 }),
+    );
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() - 1,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({
+        reason: "mixed",
+        deadlineAt: Date.now() + 1_000,
+      }),
+    });
+
+    expect(heartbeatRunManaged).not.toHaveBeenCalled();
+    expect(schedulerRunDue).toHaveBeenCalledWith(
+      expect.objectContaining({ minStartBudgetMs: 5_000 }),
+    );
+    expect(response).toMatchObject({
+      completed: 0,
+      failed: 0,
+      skipped: 3,
+      dueWorkRemaining: true,
+    });
+  });
+
+  test("drain-due reports due work remaining from scheduler counts", async () => {
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ claimed: 1, completed: 1, stillPending: 1 }),
+    );
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() + 60_000,
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({ body: drainBodyFixture() });
+
+    expect(response).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 0,
+      dueWorkRemaining: true,
+    });
+  });
+
   test("drain-due accepts vembda snake_case payload aliases", async () => {
-    const schedulerRunOnce = mock(async () => 0);
+    const schedulerRunDue = mock(async () => schedulerResultFixture());
     registerBackgroundWakeRuntime({
       heartbeat: {
         nextRunAt: null,
-        runOnce: mock(async () => false),
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
       },
       scheduler: {
-        runOnce: schedulerRunOnce,
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
       },
     });
     const handler = findHandler("drainDueBackgroundWake");
@@ -206,13 +481,22 @@ describe("background wake runtime routes", () => {
   });
 });
 
-function drainBodyFixture() {
+function drainBodyFixture(
+  overrides: Partial<{
+    leaseId: string;
+    reason: string;
+    sourceGeneration: string;
+    startedAt: number;
+    deadlineAt: number;
+  }> = {},
+) {
   return {
     leaseId: "lease-123",
     reason: "schedule",
     sourceGeneration: "source-generation",
     startedAt: NOW,
     deadlineAt: NOW + 30_000,
+    ...overrides,
   };
 }
 

--- a/assistant/src/background-wake/runtime-registry.ts
+++ b/assistant/src/background-wake/runtime-registry.ts
@@ -2,8 +2,8 @@ import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { SchedulerHandle } from "../schedule/scheduler.js";
 
 export interface BackgroundWakeRuntime {
-  scheduler: Pick<SchedulerHandle, "runOnce">;
-  heartbeat: Pick<HeartbeatService, "nextRunAt" | "runOnce">;
+  scheduler: Pick<SchedulerHandle, "runOnce" | "runDueWorkOnce">;
+  heartbeat: Pick<HeartbeatService, "nextRunAt" | "runManagedWakeIfDue">;
 }
 
 let runtime: BackgroundWakeRuntime | null = null;

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -107,6 +107,19 @@ export interface HeartbeatDeps {
   getCurrentHour?: () => number;
 }
 
+export interface ManagedWakeHeartbeatRunOptions {
+  now?: number;
+  toleranceMs?: number;
+  assumeDue?: boolean;
+  scheduledFor?: number;
+}
+
+export interface ManagedWakeHeartbeatRunResult {
+  due: boolean;
+  completed: number;
+  skipped: number;
+}
+
 export class HeartbeatService {
   private static instance?: HeartbeatService;
 
@@ -151,6 +164,40 @@ export class HeartbeatService {
   /** Epoch-ms timestamp of the next scheduled heartbeat run. */
   get nextRunAt(): number | null {
     return this._nextRunAt;
+  }
+
+  async runManagedWakeIfDue(
+    options: ManagedWakeHeartbeatRunOptions = {},
+  ): Promise<ManagedWakeHeartbeatRunResult> {
+    const now = options.now ?? Date.now();
+    const toleranceMs = options.toleranceMs ?? 0;
+    const dueByLocalTimer =
+      this._nextRunAt != null && this._nextRunAt <= now + toleranceMs;
+
+    if (!dueByLocalTimer && options.assumeDue !== true) {
+      return { due: false, completed: 0, skipped: 0 };
+    }
+
+    if (!dueByLocalTimer) {
+      if (this._pendingRunId) {
+        supersedePendingRun(this._pendingRunId);
+        this._pendingRunId = null;
+      }
+      this._nextRunAt = options.scheduledFor ?? now;
+      this._pendingRunId = insertPendingHeartbeatRun(this._nextRunAt);
+    }
+
+    const completed = await this.runOnce({ force: false });
+
+    if (this.cronMode && !this.stopped) {
+      this.scheduleNextCronRun(getConfig().heartbeat);
+    }
+
+    return {
+      due: true,
+      completed: completed ? 1 : 0,
+      skipped: completed ? 0 : 1,
+    };
   }
 
   start(): void {

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -109,7 +109,7 @@ async function handleDrainDue(body: Record<string, unknown>) {
 
   const now = Date.now();
   const currentIntent = computeWakeIntent(now);
-  const heartbeatDue = intentHasDueSource(currentIntent, "heartbeat", now);
+  const heartbeatDue = isHeartbeatTimerDue(runtime.heartbeat.nextRunAt, now);
   const schedulerDue =
     heartbeatDue ||
     reasonIncludesSource(request.reason, "schedule") ||
@@ -184,6 +184,10 @@ function reasonIncludesSource(
   source: "heartbeat" | "schedule",
 ): boolean {
   return reason === "mixed" || reason === source;
+}
+
+function isHeartbeatTimerDue(nextRunAt: number | null, now: number): boolean {
+  return nextRunAt != null && nextRunAt <= now + HEARTBEAT_DUE_TOLERANCE_MS;
 }
 
 function intentHasDueSource(

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-import { computeNextBackgroundWakeIntent } from "../../background-wake/next-wake.js";
+import {
+  type BackgroundWakeIntent,
+  computeNextBackgroundWakeIntent,
+} from "../../background-wake/next-wake.js";
 import { getBackgroundWakeRuntime } from "../../background-wake/runtime-registry.js";
+import type { SchedulerDueWorkResult } from "../../schedule/scheduler.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const PREPARE_SLEEP_DEFER_WINDOW_MS = 60_000;
 const HEARTBEAT_DUE_TOLERANCE_MS = 1_000;
+const MIN_DRAIN_START_BUDGET_MS = 5_000;
 
 let computeWakeIntent = computeNextBackgroundWakeIntent;
 const timestampInputSchema = z.union([z.number(), z.string()]);
@@ -103,11 +108,54 @@ async function handleDrainDue(body: Record<string, unknown>) {
   }
 
   const now = Date.now();
+  const currentIntent = computeWakeIntent(now);
   const heartbeatDue =
-    runtime.heartbeat.nextRunAt != null &&
-    runtime.heartbeat.nextRunAt <= now + HEARTBEAT_DUE_TOLERANCE_MS;
-  const heartbeatRan = heartbeatDue ? await runtime.heartbeat.runOnce() : false;
-  const scheduledCount = await runtime.scheduler.runOnce();
+    reasonIncludesSource(request.reason, "heartbeat") ||
+    intentHasDueSource(currentIntent, "heartbeat", now);
+  const schedulerDue =
+    reasonIncludesSource(request.reason, "schedule") ||
+    intentHasDueSource(currentIntent, "schedule", now);
+
+  let heartbeatCompleted = 0;
+  let heartbeatSkipped = 0;
+  let heartbeatDueRemaining = false;
+  if (heartbeatDue) {
+    if (hasStartBudget(request.deadlineAt)) {
+      const heartbeatResult = await runtime.heartbeat.runManagedWakeIfDue({
+        now,
+        toleranceMs: HEARTBEAT_DUE_TOLERANCE_MS,
+        assumeDue: reasonIncludesSource(request.reason, "heartbeat"),
+        scheduledFor: request.startedAt,
+      });
+      heartbeatCompleted = heartbeatResult.completed;
+      heartbeatSkipped = heartbeatResult.skipped;
+      heartbeatDueRemaining =
+        heartbeatResult.due && heartbeatResult.completed === 0;
+    } else {
+      heartbeatSkipped = 1;
+      heartbeatDueRemaining = true;
+    }
+  }
+
+  const schedulerResult = schedulerDue
+    ? await runtime.scheduler.runDueWorkOnce({
+        deadlineAt: request.deadlineAt,
+        minStartBudgetMs: MIN_DRAIN_START_BUDGET_MS,
+        includeStillPending: true,
+      })
+    : emptySchedulerDueWorkResult();
+  const nextIntent = computeWakeIntent();
+  const completed = heartbeatCompleted + schedulerResult.completed;
+  const failed = schedulerResult.failed;
+  const skipped = heartbeatSkipped + schedulerResult.skipped;
+  const schedulerProcessed =
+    schedulerResult.completed +
+    schedulerResult.failed +
+    schedulerResult.skipped;
+  const dueWorkRemaining =
+    heartbeatDueRemaining ||
+    schedulerResult.stillPending > 0 ||
+    intentIsDue(nextIntent);
 
   return {
     leaseId: request.leaseId,
@@ -116,11 +164,60 @@ async function handleDrainDue(body: Record<string, unknown>) {
     startedAt: request.startedAt,
     deadlineAt: request.deadlineAt,
     counts: {
-      heartbeat: heartbeatRan ? 1 : 0,
-      scheduler: scheduledCount,
-      total: (heartbeatRan ? 1 : 0) + scheduledCount,
+      heartbeat: heartbeatCompleted,
+      scheduler: schedulerProcessed,
+      total: heartbeatCompleted + schedulerProcessed,
+      completed,
+      failed,
+      skipped,
+      claimed: schedulerResult.claimed,
+      stillPending: schedulerResult.stillPending,
     },
-    nextIntent: computeWakeIntent(),
+    completed,
+    failed,
+    skipped,
+    nextIntent,
+    dueWorkRemaining,
+  };
+}
+
+function reasonIncludesSource(
+  reason: string,
+  source: "heartbeat" | "schedule",
+): boolean {
+  return reason === "mixed" || reason === source;
+}
+
+function intentHasDueSource(
+  intent: BackgroundWakeIntent | null,
+  source: "heartbeat" | "schedule",
+  now: number,
+): boolean {
+  return (
+    intent != null &&
+    intent.actualNextDueAt <= now + HEARTBEAT_DUE_TOLERANCE_MS &&
+    reasonIncludesSource(intent.reason, source)
+  );
+}
+
+function intentIsDue(intent: BackgroundWakeIntent | null): boolean {
+  return (
+    intent != null &&
+    intent.actualNextDueAt <= Date.now() + HEARTBEAT_DUE_TOLERANCE_MS
+  );
+}
+
+function hasStartBudget(deadlineAt: number): boolean {
+  return deadlineAt - Date.now() >= MIN_DRAIN_START_BUDGET_MS;
+}
+
+function emptySchedulerDueWorkResult(): SchedulerDueWorkResult {
+  return {
+    claimed: 0,
+    completed: 0,
+    failed: 0,
+    skipped: 0,
+    stillPending: 0,
   };
 }
 
@@ -180,8 +277,17 @@ export const ROUTES: RouteDefinition[] = [
         heartbeat: z.number(),
         scheduler: z.number(),
         total: z.number(),
+        completed: z.number(),
+        failed: z.number(),
+        skipped: z.number(),
+        claimed: z.number(),
+        stillPending: z.number(),
       }),
+      completed: z.number(),
+      failed: z.number(),
+      skipped: z.number(),
       nextIntent: wakeIntentSchema,
+      dueWorkRemaining: z.boolean(),
     }),
     handler: ({ body }: RouteHandlerArgs) => handleDrainDue(body ?? {}),
   },

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -109,10 +109,9 @@ async function handleDrainDue(body: Record<string, unknown>) {
 
   const now = Date.now();
   const currentIntent = computeWakeIntent(now);
-  const heartbeatDue =
-    reasonIncludesSource(request.reason, "heartbeat") ||
-    intentHasDueSource(currentIntent, "heartbeat", now);
+  const heartbeatDue = intentHasDueSource(currentIntent, "heartbeat", now);
   const schedulerDue =
+    heartbeatDue ||
     reasonIncludesSource(request.reason, "schedule") ||
     intentHasDueSource(currentIntent, "schedule", now);
 
@@ -124,7 +123,6 @@ async function handleDrainDue(body: Record<string, unknown>) {
       const heartbeatResult = await runtime.heartbeat.runManagedWakeIfDue({
         now,
         toleranceMs: HEARTBEAT_DUE_TOLERANCE_MS,
-        assumeDue: reasonIncludesSource(request.reason, "heartbeat"),
         scheduledFor: request.startedAt,
       });
       heartbeatCompleted = heartbeatResult.completed;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -22,6 +22,7 @@ import {
   createScheduleRun,
   failOneShotPermanently,
   getLastScheduleConversationId,
+  listSchedules,
   resetRetryCount,
   retryOneShot,
   type RoutingIntent,
@@ -48,7 +49,25 @@ type ScheduleConversationCreatedNotifier = (info: {
 
 export interface SchedulerHandle {
   runOnce(): Promise<number>;
+  runDueWorkOnce(
+    options?: SchedulerRunDueWorkOptions,
+  ): Promise<SchedulerDueWorkResult>;
   stop(): void;
+}
+
+export interface SchedulerRunDueWorkOptions {
+  now?: number;
+  deadlineAt?: number;
+  minStartBudgetMs?: number;
+  includeStillPending?: boolean;
+}
+
+export interface SchedulerDueWorkResult {
+  claimed: number;
+  completed: number;
+  failed: number;
+  skipped: number;
+  stillPending: number;
 }
 
 const TICK_INTERVAL_MS = 15_000;
@@ -140,6 +159,17 @@ export function startScheduler(
         onScheduleConversationCreated,
       );
     },
+    async runDueWorkOnce(
+      options?: SchedulerRunDueWorkOptions,
+    ): Promise<SchedulerDueWorkResult> {
+      return runScheduleDueWorkOnce(
+        processMessage,
+        notifyScheduleOneShot,
+        watcherNotifier,
+        onScheduleConversationCreated,
+        options,
+      );
+    },
     stop(): void {
       stopped = true;
       clearInterval(timer);
@@ -153,8 +183,45 @@ export async function runScheduleOnce(
   watcherNotifier?: WatcherNotifier,
   onScheduleConversationCreated?: ScheduleConversationCreatedNotifier,
 ): Promise<number> {
-  const now = Date.now();
-  let processed = 0;
+  const result = await runScheduleDueWorkOnce(
+    processMessage,
+    notifyScheduleOneShot,
+    watcherNotifier,
+    onScheduleConversationCreated,
+  );
+  return result.completed + result.failed + result.skipped;
+}
+
+export async function runScheduleDueWorkOnce(
+  processMessage: ScheduleMessageProcessor,
+  notifyScheduleOneShot: ScheduleNotifyModeNotifier,
+  watcherNotifier?: WatcherNotifier,
+  onScheduleConversationCreated?: ScheduleConversationCreatedNotifier,
+  options: SchedulerRunDueWorkOptions = {},
+): Promise<SchedulerDueWorkResult> {
+  const now = options.now ?? Date.now();
+  const minStartBudgetMs = options.minStartBudgetMs ?? 0;
+  const result: SchedulerDueWorkResult = {
+    claimed: 0,
+    completed: 0,
+    failed: 0,
+    skipped: 0,
+    stillPending: 0,
+  };
+  const mark = (status: "completed" | "failed" | "skipped") => {
+    result[status] += 1;
+  };
+
+  if (
+    options.deadlineAt != null &&
+    options.deadlineAt - Date.now() < minStartBudgetMs
+  ) {
+    result.stillPending = options.includeStillPending
+      ? countDueScheduleJobs(now)
+      : 0;
+    result.skipped = result.stillPending;
+    return result;
+  }
 
   const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
   if (diskPressureGate.action === "skip") {
@@ -167,16 +234,21 @@ export async function runScheduleOnce(
         "Schedule tick skipped during disk pressure cleanup mode",
       );
     }
-    return 0;
+    result.stillPending = options.includeStillPending
+      ? countDueScheduleJobs(now)
+      : 0;
+    return result;
   }
 
   // ── Schedules (recurring cron/RRULE + one-shot) ─────────────────────
   const jobs = claimDueSchedules(now);
+  result.claimed = jobs.length;
   for (const job of jobs) {
     const isOneShot = job.expression == null;
 
     // ── Notify mode (one-shot or recurring) ─────────────────────────
     if (job.mode === "notify") {
+      let failed = false;
       try {
         log.info(
           { jobId: job.id, name: job.name, isOneShot },
@@ -208,8 +280,9 @@ export async function runScheduleOnce(
         const errorRunId = createScheduleRun(job.id, `notify-error:${job.id}`);
         completeScheduleRun(errorRunId, { status: "error", error: errorMsg });
         handleExecutionFailure({ job, errorMsg, isOneShot });
+        failed = true;
       }
-      processed += 1;
+      mark(failed ? "failed" : "completed");
       continue;
     }
 
@@ -220,10 +293,11 @@ export async function runScheduleOnce(
           { jobId: job.id, name: job.name },
           "Script schedule has no script command — skipping",
         );
-        processed += 1;
+        mark("skipped");
         continue;
       }
       const runId = createScheduleRun(job.id, `script:${job.id}`);
+      let failed = false;
       try {
         log.info(
           { jobId: job.id, name: job.name, isOneShot },
@@ -241,6 +315,7 @@ export async function runScheduleOnce(
           const errorMsg =
             result.stderr || "Script exited with non-zero status";
           handleExecutionFailure({ job, errorMsg, isOneShot });
+          failed = true;
         }
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
@@ -250,8 +325,9 @@ export async function runScheduleOnce(
         );
         completeScheduleRun(runId, { status: "error", error: errorMsg });
         handleExecutionFailure({ job, errorMsg, isOneShot });
+        failed = true;
       }
-      processed += 1;
+      mark(failed ? "failed" : "completed");
       continue;
     }
 
@@ -264,10 +340,11 @@ export async function runScheduleOnce(
           "Wake schedule missing wakeConversationId — completing as no-op",
         );
         if (isOneShot) completeOneShot(job.id);
-        processed += 1;
+        mark("skipped");
         continue;
       }
 
+      let failed = false;
       try {
         log.info(
           { jobId: job.id, name: job.name, wakeConversationId, isOneShot },
@@ -305,7 +382,7 @@ export async function runScheduleOnce(
             );
             retryOneShot(job.id);
           }
-          processed += 1;
+          mark("skipped");
           continue;
         }
 
@@ -323,7 +400,7 @@ export async function runScheduleOnce(
             "Wake not invoked; skipping feed event",
           );
           if (isOneShot) completeOneShot(job.id);
-          processed += 1;
+          mark("skipped");
           continue;
         }
 
@@ -347,8 +424,9 @@ export async function runScheduleOnce(
           error: errorMsg,
         });
         handleExecutionFailure({ job, errorMsg, isOneShot });
+        failed = true;
       }
-      processed += 1;
+      mark(failed ? "failed" : "completed");
       continue;
     }
 
@@ -362,6 +440,7 @@ export async function runScheduleOnce(
         job.syntax === "rrule" &&
         job.expression != null &&
         hasSetConstructs(job.expression);
+      let failed = false;
       try {
         log.info(
           {
@@ -415,11 +494,11 @@ export async function runScheduleOnce(
             errorMsg: errorMessage,
             isOneShot,
           });
+          failed = true;
         } else {
           completeScheduleRun(runId, { status: "ok" });
           if (isOneShot) completeOneShot(job.id);
         }
-        processed += 1;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         log.warn(
@@ -461,7 +540,9 @@ export async function runScheduleOnce(
           errorMsg: message,
           isOneShot,
         });
+        failed = true;
       }
+      mark(failed ? "failed" : "completed");
       continue;
     }
 
@@ -567,7 +648,7 @@ export async function runScheduleOnce(
     if (ok) {
       completeScheduleRun(runId, { status: "ok" });
       if (isOneShot) completeOneShot(job.id);
-      processed += 1;
+      mark("completed");
     } else {
       log.warn(
         {
@@ -605,6 +686,7 @@ export async function runScheduleOnce(
           );
         }
       }
+      mark("failed");
     }
   }
 
@@ -612,7 +694,7 @@ export async function runScheduleOnce(
   if (watcherNotifier) {
     try {
       const watcherProcessed = await runWatchersOnce(watcherNotifier);
-      processed += watcherProcessed;
+      result.completed += watcherProcessed;
     } catch (err) {
       log.error({ err }, "Watcher tick failed");
     }
@@ -621,15 +703,29 @@ export async function runScheduleOnce(
   // ── Sequences (multi-step outreach) ──────────────────────────────
   try {
     const sequenceProcessed = await runSequencesOnce();
-    processed += sequenceProcessed;
+    result.completed += sequenceProcessed;
   } catch (err) {
     log.error({ err }, "Sequence engine tick failed");
   }
 
+  if (options.includeStillPending) {
+    result.stillPending = countDueScheduleJobs(Date.now());
+  }
+  const processed = result.completed + result.failed + result.skipped;
   if (processed > 0) {
     log.info({ processed }, "Schedule tick complete");
   }
-  return processed;
+  return result;
+}
+
+function countDueScheduleJobs(now: number): number {
+  return listSchedules({ enabledOnly: true }).filter(
+    (job) =>
+      job.status === "active" &&
+      Number.isFinite(job.nextRunAt) &&
+      job.nextRunAt > 0 &&
+      job.nextRunAt <= now,
+  ).length;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a managed-wake heartbeat drain helper that runs due work through normal heartbeat guards instead of force paths.
- Expose a scheduler due-work pass with claimed/completed/failed/skipped/still-pending counts and deadline-aware no-start behavior.
- Make `drain-due` skip refresh-only wakes, honor vembda `deadlineAt`, and return additive `completed`, `failed`, `skipped`, `nextIntent`, and `dueWorkRemaining` fields.

## Original prompt
This is companion assistant plan PR 4, "Make Drain Robust Across Startup And Missed Timers," building on the merged next-wake/runtime routes work from PR #31575. The request was to keep changes tightly scoped to heartbeat, scheduler, background wake runtime routes, and focused tests; handle startup/missed timers; honor vembda-supplied deadlines; and ship in default review mode without auto-merge.