### PR TITLE
feat(playground): side-by-side comparison view in web + macOS

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Card } from "@vellum/design-library";
@@ -18,6 +18,11 @@ import { useAuthStore } from "@/stores/auth-store.js";
  * Developer-only page for dry-running the v4 memory router with custom
  * config overrides. Hits the daemon's read-only `simulate_memory_router`
  * route — no writes to the EMA event log or activation logs.
+ *
+ * Two independent result panes share one query input. Each pane carries
+ * its own override fields and runs its own simulation; after both have
+ * run, slugs are color-coded by whether they appear in both panes or
+ * only one.
  *
  * Gated by:
  *   1. The `memoryRouterPlayground` client feature flag (default off).
@@ -42,30 +47,37 @@ export function MemoryRouterPlaygroundPage(): ReactNode {
   return <PlaygroundView />;
 }
 
+type PaneId = "A" | "B";
+
+interface PaneOverrides {
+  tier1: string;
+  tier2: string;
+  batch: string;
+}
+
+const EMPTY_OVERRIDES: PaneOverrides = { tier1: "", tier2: "", batch: "" };
+
 function PlaygroundView(): ReactNode {
   const { assistantId } = useActiveAssistantContext();
-  const mutation = useSimulateMemoryRouter(assistantId);
+  const mutationA = useSimulateMemoryRouter(assistantId);
+  const mutationB = useSimulateMemoryRouter(assistantId);
 
   const [query, setQuery] = useState("");
-  const [tier1Raw, setTier1Raw] = useState("");
-  const [tier2Raw, setTier2Raw] = useState("");
-  const [batchRaw, setBatchRaw] = useState("");
-  const [validationError, setValidationError] = useState<string | null>(null);
+  const [overridesA, setOverridesA] = useState<PaneOverrides>(EMPTY_OVERRIDES);
+  const [overridesB, setOverridesB] = useState<PaneOverrides>(EMPTY_OVERRIDES);
+  const [validationA, setValidationA] = useState<string | null>(null);
+  const [validationB, setValidationB] = useState<string | null>(null);
 
-  const runSimulation = () => {
-    setValidationError(null);
+  const runPane = (pane: PaneId) => {
+    const overrides = pane === "A" ? overridesA : overridesB;
+    const setValidation = pane === "A" ? setValidationA : setValidationB;
+    const mutation = pane === "A" ? mutationA : mutationB;
+    setValidation(null);
     let configOverrides: MemoryRouterSimulateRequest["configOverrides"];
     try {
-      configOverrides = {
-        ...maybeOverride("tier1_size", tier1Raw),
-        ...maybeOverride("tier2_size", tier2Raw),
-        ...maybeOverride("batch_size", batchRaw),
-      };
-      if (Object.keys(configOverrides).length === 0) {
-        configOverrides = undefined;
-      }
+      configOverrides = buildOverrides(overrides);
     } catch (err) {
-      setValidationError(
+      setValidation(
         err instanceof Error ? err.message : "Invalid override input"
       );
       return;
@@ -76,41 +88,80 @@ function PlaygroundView(): ReactNode {
     });
   };
 
-  const canRun = query.trim().length > 0 && !mutation.isPending;
+  const runBoth = () => {
+    runPane("A");
+    runPane("B");
+  };
+
+  const queryReady = query.trim().length > 0;
+  const canRunA = queryReady && !mutationA.isPending;
+  const canRunB = queryReady && !mutationB.isPending;
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto">
-      <div className="mx-auto flex w-full max-w-[940px] flex-col gap-6 p-6">
+      <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 p-6">
         <PageHeader />
-        <InputForm
-          query={query}
-          onQueryChange={setQuery}
-          tier1={tier1Raw}
-          onTier1Change={setTier1Raw}
-          tier2={tier2Raw}
-          onTier2Change={setTier2Raw}
-          batch={batchRaw}
-          onBatchChange={setBatchRaw}
-          onRun={runSimulation}
-          canRun={canRun}
-          isRunning={mutation.isPending}
-        />
-        {validationError !== null && <ErrorBanner message={validationError} />}
-        {mutation.isError && (
-          <ErrorBanner
-            message={
-              mutation.error instanceof Error
-                ? mutation.error.message
-                : "Failed to run simulation"
-            }
+        <QuerySection query={query} onChange={setQuery} />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <PaneConfigForm
+            paneId="A"
+            overrides={overridesA}
+            onChange={setOverridesA}
+            onRun={() => runPane("A")}
+            canRun={canRunA}
+            isRunning={mutationA.isPending}
           />
-        )}
-        {mutation.data !== undefined && (
-          <ResultPanel result={mutation.data} query={query} />
-        )}
+          <PaneConfigForm
+            paneId="B"
+            overrides={overridesB}
+            onChange={setOverridesB}
+            onRun={() => runPane("B")}
+            canRun={canRunB}
+            isRunning={mutationB.isPending}
+          />
+        </div>
+        <div className="flex justify-end">
+          <RunBothButton
+            onClick={runBoth}
+            disabled={!queryReady || mutationA.isPending || mutationB.isPending}
+            isRunning={mutationA.isPending || mutationB.isPending}
+          />
+        </div>
+        <DiffLegend
+          visible={mutationA.data !== undefined && mutationB.data !== undefined}
+        />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <PaneOutputColumn
+            paneId="A"
+            query={query}
+            mutation={mutationA}
+            otherResult={mutationB.data}
+            validation={validationA}
+          />
+          <PaneOutputColumn
+            paneId="B"
+            query={query}
+            mutation={mutationB}
+            otherResult={mutationA.data}
+            validation={validationB}
+          />
+        </div>
       </div>
     </div>
   );
+}
+
+// ── Input helpers ──────────────────────────────────────────────────────────
+
+function buildOverrides(
+  overrides: PaneOverrides
+): MemoryRouterSimulateRequest["configOverrides"] {
+  const merged = {
+    ...maybeOverride("tier1_size", overrides.tier1),
+    ...maybeOverride("tier2_size", overrides.tier2),
+    ...maybeOverride("batch_size", overrides.batch),
+  };
+  return Object.keys(merged).length === 0 ? undefined : merged;
 }
 
 function maybeOverride(
@@ -128,6 +179,8 @@ function maybeOverride(
   }
   return { [fieldName]: parsed };
 }
+
+// ── Layout components ──────────────────────────────────────────────────────
 
 function PageHeader(): ReactNode {
   return (
@@ -152,27 +205,53 @@ function PageHeader(): ReactNode {
   );
 }
 
-function InputForm({
+function QuerySection({
   query,
-  onQueryChange,
-  tier1,
-  onTier1Change,
-  tier2,
-  onTier2Change,
-  batch,
-  onBatchChange,
+  onChange,
+}: {
+  query: string;
+  onChange: (value: string) => void;
+}): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-1 p-4">
+        <label
+          htmlFor="memory-router-playground-query"
+          className="text-label-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          Query (shared by both panes)
+        </label>
+        <textarea
+          id="memory-router-playground-query"
+          value={query}
+          onChange={(e) => onChange(e.target.value)}
+          rows={3}
+          placeholder="e.g. what should we ship next"
+          className="rounded-md border px-3 py-2 text-body-medium-default"
+          style={{
+            borderColor: "var(--border-base)",
+            background: "var(--surface-base)",
+            color: "var(--content-default)",
+            resize: "vertical",
+          }}
+        />
+      </div>
+    </Card>
+  );
+}
+
+function PaneConfigForm({
+  paneId,
+  overrides,
+  onChange,
   onRun,
   canRun,
   isRunning,
 }: {
-  query: string;
-  onQueryChange: (value: string) => void;
-  tier1: string;
-  onTier1Change: (value: string) => void;
-  tier2: string;
-  onTier2Change: (value: string) => void;
-  batch: string;
-  onBatchChange: (value: string) => void;
+  paneId: PaneId;
+  overrides: PaneOverrides;
+  onChange: (next: PaneOverrides) => void;
   onRun: () => void;
   canRun: boolean;
   isRunning: boolean;
@@ -180,44 +259,30 @@ function InputForm({
   return (
     <Card>
       <div className="flex flex-col gap-4 p-4">
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor="memory-router-playground-query"
-            className="text-label-default"
-            style={{ color: "var(--content-secondary)" }}
-          >
-            Query
-          </label>
-          <textarea
-            id="memory-router-playground-query"
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
-            rows={3}
-            placeholder="e.g. what should we ship next"
-            className="rounded-md border px-3 py-2 text-body-medium-default"
-            style={{
-              borderColor: "var(--border-base)",
-              background: "var(--surface-base)",
-              color: "var(--content-default)",
-              resize: "vertical",
-            }}
-          />
+        <div
+          className="text-body-medium-default"
+          style={{ color: paneAccentColor(paneId) }}
+        >
+          Config {paneId}
         </div>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <OverrideInput
+            paneId={paneId}
             label="tier1_size"
-            value={tier1}
-            onChange={onTier1Change}
+            value={overrides.tier1}
+            onChange={(v) => onChange({ ...overrides, tier1: v })}
           />
           <OverrideInput
+            paneId={paneId}
             label="tier2_size"
-            value={tier2}
-            onChange={onTier2Change}
+            value={overrides.tier2}
+            onChange={(v) => onChange({ ...overrides, tier2: v })}
           />
           <OverrideInput
+            paneId={paneId}
             label="batch_size"
-            value={batch}
-            onChange={onBatchChange}
+            value={overrides.batch}
+            onChange={(v) => onChange({ ...overrides, batch: v })}
           />
         </div>
         <div className="flex justify-end">
@@ -237,7 +302,7 @@ function InputForm({
               cursor: canRun ? "pointer" : "not-allowed",
             }}
           >
-            {isRunning ? "Running…" : "Run simulation"}
+            {isRunning ? "Running…" : `Run ${paneId}`}
           </button>
         </div>
       </div>
@@ -246,25 +311,28 @@ function InputForm({
 }
 
 function OverrideInput({
+  paneId,
   label,
   value,
   onChange,
 }: {
+  paneId: PaneId;
   label: string;
   value: string;
   onChange: (value: string) => void;
 }): ReactNode {
+  const inputId = `memory-router-playground-${paneId}-${label}`;
   return (
     <div className="flex flex-col gap-1">
       <label
-        htmlFor={`memory-router-playground-${label}`}
+        htmlFor={inputId}
         className="text-label-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {label}
       </label>
       <input
-        id={`memory-router-playground-${label}`}
+        id={inputId}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="inherit"
@@ -279,17 +347,159 @@ function OverrideInput({
   );
 }
 
-function ResultPanel({
-  result,
-  query,
+function RunBothButton({
+  onClick,
+  disabled,
+  isRunning,
 }: {
-  result: MemoryRouterSimulateResponse;
-  query: string;
+  onClick: () => void;
+  disabled: boolean;
+  isRunning: boolean;
 }): ReactNode {
-  const groups = groupSlugsBySource(result);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md px-4 py-2 text-body-medium-default transition-colors"
+      style={{
+        background: disabled ? "var(--surface-overlay)" : "var(--primary-base)",
+        color: disabled
+          ? "var(--content-disabled)"
+          : "var(--content-on-primary)",
+        border: "none",
+        cursor: disabled ? "not-allowed" : "pointer",
+      }}
+    >
+      {isRunning ? "Running…" : "Run both"}
+    </button>
+  );
+}
+
+function DiffLegend({ visible }: { visible: boolean }): ReactNode {
+  if (!visible) return null;
+  return (
+    <div
+      className="flex flex-wrap items-center gap-4 rounded-md px-4 py-2 text-label-default"
+      style={{
+        background: "var(--surface-overlay)",
+        color: "var(--content-secondary)",
+      }}
+    >
+      <LegendItem
+        marker="●"
+        markerColor="var(--content-default)"
+        label="in both"
+      />
+      <LegendItem
+        marker="◆"
+        markerColor={paneAccentColor("A")}
+        label="A only"
+      />
+      <LegendItem
+        marker="◇"
+        markerColor={paneAccentColor("B")}
+        label="B only"
+      />
+    </div>
+  );
+}
+
+function LegendItem({
+  marker,
+  markerColor,
+  label,
+}: {
+  marker: string;
+  markerColor: string;
+  label: string;
+}): ReactNode {
+  return (
+    <span className="flex items-center gap-1">
+      <span style={{ color: markerColor }}>{marker}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+// ── Result rendering ───────────────────────────────────────────────────────
+
+type SlugDiff = "both" | "only-here";
+
+function PaneOutputColumn({
+  paneId,
+  query,
+  mutation,
+  otherResult,
+  validation,
+}: {
+  paneId: PaneId;
+  query: string;
+  mutation: ReturnType<typeof useSimulateMemoryRouter>;
+  otherResult: MemoryRouterSimulateResponse | undefined;
+  validation: string | null;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-3">
+      <PaneHeader paneId={paneId} />
+      {validation !== null && <ErrorBanner message={validation} />}
+      {mutation.isError && (
+        <ErrorBanner
+          message={
+            mutation.error instanceof Error
+              ? mutation.error.message
+              : "Failed to run simulation"
+          }
+        />
+      )}
+      {mutation.data !== undefined && (
+        <ResultPanel
+          paneId={paneId}
+          query={query}
+          result={mutation.data}
+          otherResult={otherResult}
+        />
+      )}
+    </div>
+  );
+}
+
+function PaneHeader({ paneId }: { paneId: PaneId }): ReactNode {
+  return (
+    <div
+      className="text-body-medium-default"
+      style={{ color: paneAccentColor(paneId) }}
+    >
+      Pane {paneId}
+    </div>
+  );
+}
+
+function ResultPanel({
+  paneId,
+  query,
+  result,
+  otherResult,
+}: {
+  paneId: PaneId;
+  query: string;
+  result: MemoryRouterSimulateResponse;
+  otherResult: MemoryRouterSimulateResponse | undefined;
+}): ReactNode {
+  const diff = useMemo(() => classifySlugs(result, otherResult), [
+    result,
+    otherResult,
+  ]);
+  const groups = useMemo(() => groupSlugsBySource(result), [result]);
+  const counts = useMemo(() => countDiff(diff), [diff]);
   return (
     <div className="flex flex-col gap-4">
-      <SummaryCard result={result} query={query} />
+      <SummaryCard
+        result={result}
+        query={query}
+        otherResult={otherResult}
+        counts={counts}
+      />
       <ConfigCard result={result} />
       {result.failureReason !== null && (
         <ErrorBanner message={`Router failure: ${result.failureReason}`} />
@@ -300,9 +510,11 @@ function ResultPanel({
         groups.map((group) => (
           <TierSectionCard
             key={group.source}
+            paneId={paneId}
             source={group.source}
             slugs={group.slugs}
             scores={result.scores}
+            diff={diff}
           />
         ))
       )}
@@ -310,13 +522,66 @@ function ResultPanel({
   );
 }
 
+function classifySlugs(
+  own: MemoryRouterSimulateResponse,
+  other: MemoryRouterSimulateResponse | undefined
+): Map<string, SlugDiff> {
+  const out = new Map<string, SlugDiff>();
+  if (other === undefined) {
+    for (const slug of own.selectedSlugs) out.set(slug, "both");
+    return out;
+  }
+  const otherSet = new Set(other.selectedSlugs);
+  for (const slug of own.selectedSlugs) {
+    out.set(slug, otherSet.has(slug) ? "both" : "only-here");
+  }
+  return out;
+}
+
+interface DiffCounts {
+  total: number;
+  shared: number;
+  unique: number;
+}
+
+function countDiff(diff: Map<string, SlugDiff>): DiffCounts {
+  let shared = 0;
+  let unique = 0;
+  for (const cls of diff.values()) {
+    if (cls === "both") shared++;
+    else unique++;
+  }
+  return { total: diff.size, shared, unique };
+}
+
 function SummaryCard({
   result,
   query,
+  otherResult,
+  counts,
 }: {
   result: MemoryRouterSimulateResponse;
   query: string;
+  otherResult: MemoryRouterSimulateResponse | undefined;
+  counts: DiffCounts;
 }): ReactNode {
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "Query", value: query },
+    {
+      label: "Total candidate pages",
+      value: result.totalCandidatePages.toLocaleString(),
+    },
+    {
+      label: "Selected",
+      value: `${result.selectedSlugs.length} / ${result.effectiveConfig.max_page_ids}`,
+    },
+  ];
+  if (otherResult !== undefined) {
+    rows.push({
+      label: "Diff",
+      value: `${counts.shared} shared · ${counts.unique} unique to this pane`,
+    });
+  }
   return (
     <Card>
       <div className="flex flex-col gap-3 p-4">
@@ -326,19 +591,7 @@ function SummaryCard({
         >
           Summary
         </span>
-        <MetaGrid
-          rows={[
-            { label: "Query", value: query },
-            {
-              label: "Total candidate pages",
-              value: result.totalCandidatePages.toLocaleString(),
-            },
-            {
-              label: "Selected",
-              value: `${result.selectedSlugs.length} / ${result.effectiveConfig.max_page_ids}`,
-            },
-          ]}
-        />
+        <MetaGrid rows={rows} />
       </div>
     </Card>
   );
@@ -423,14 +676,35 @@ function formatSourceLabel(source: RouterSource): string {
   return source;
 }
 
+function paneAccentColor(paneId: PaneId): string {
+  return paneId === "A" ? "var(--system-mid-strong)" : "var(--primary-base)";
+}
+
+function slugStyle(
+  paneId: PaneId,
+  diff: SlugDiff
+): { color: string; marker: string } {
+  if (diff === "both") {
+    return { color: "var(--content-default)", marker: "●" };
+  }
+  return {
+    color: paneAccentColor(paneId),
+    marker: paneId === "A" ? "◆" : "◇",
+  };
+}
+
 function TierSectionCard({
+  paneId,
   source,
   slugs,
   scores,
+  diff,
 }: {
+  paneId: PaneId;
   source: RouterSource;
   slugs: string[];
   scores: Record<string, number>;
+  diff: Map<string, SlugDiff>;
 }): ReactNode {
   return (
     <Card>
@@ -450,27 +724,31 @@ function TierSectionCard({
           </span>
         </div>
         <ul className="flex flex-col gap-1">
-          {slugs.map((slug) => (
-            <li
-              key={slug}
-              className="flex items-baseline justify-between gap-3"
-            >
-              <code
-                className="text-body-medium-default"
-                style={{ color: "var(--content-default)" }}
+          {slugs.map((slug) => {
+            const slugClass = diff.get(slug) ?? "only-here";
+            const { color, marker } = slugStyle(paneId, slugClass);
+            return (
+              <li
+                key={slug}
+                className="flex items-baseline justify-between gap-3"
               >
-                {slug}
-              </code>
-              {source === "tier2" && (
-                <span
-                  className="tabular-nums text-label-default"
-                  style={{ color: "var(--content-secondary)" }}
-                >
-                  EMA {(scores[slug] ?? 0).toFixed(3)}
+                <span className="flex items-baseline gap-2">
+                  <span style={{ color }}>{marker}</span>
+                  <code className="text-body-medium-default" style={{ color }}>
+                    {slug}
+                  </code>
                 </span>
-              )}
-            </li>
-          ))}
+                {source === "tier2" && (
+                  <span
+                    className="tabular-nums text-label-default"
+                    style={{ color: "var(--content-secondary)" }}
+                  >
+                    EMA {(scores[slug] ?? 0).toFixed(3)}
+                  </span>
+                )}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </Card>

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -6,6 +6,11 @@ import VellumAssistantShared
 /// under custom `tier1_size`, `tier2_size`, and `batch_size` overrides —
 /// without touching the live EMA event log or activation log.
 ///
+/// Two independent result panes share one query input. Each pane carries
+/// its own override fields and runs its own simulation; after both have
+/// run, slugs are color-coded by whether they appear in both panes or
+/// only one.
+///
 /// Gated by:
 ///   1. `settings-developer-nav` (developer-nav visibility)
 ///   2. `memory-router-playground` (this tab)
@@ -19,25 +24,36 @@ struct SettingsMemoryRouterPlaygroundTab: View {
     private let client = MemoryRouterPlaygroundClient()
 
     @State private var query: String = ""
-    @State private var tier1Raw: String = ""
-    @State private var tier2Raw: String = ""
-    @State private var batchRaw: String = ""
-    @State private var isRunning: Bool = false
-    @State private var validationError: String?
-    @State private var clientError: String?
-    @State private var lastResult: MemoryRouterSimulateResponse?
     @State private var lastQuery: String = ""
+    @State private var paneA = PaneState()
+    @State private var paneB = PaneState()
+
+    enum PaneId { case a, b }
+
+    struct PaneState {
+        var tier1: String = ""
+        var tier2: String = ""
+        var batch: String = ""
+        var isRunning: Bool = false
+        var validationError: String?
+        var clientError: String?
+        var lastResult: MemoryRouterSimulateResponse?
+    }
+
+    enum SlugDiff { case both, onlyHere }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 header
-                formCard
-                if let err = validationError ?? clientError {
-                    errorBanner(err)
+                queryCard
+                runBothRow
+                if paneA.lastResult != nil && paneB.lastResult != nil {
+                    diffLegend
                 }
-                if let result = lastResult {
-                    resultSection(result)
+                HStack(alignment: .top, spacing: VSpacing.md) {
+                    paneColumn(pane: .a)
+                    paneColumn(pane: .b)
                 }
             }
             .padding(VSpacing.lg)
@@ -61,42 +77,107 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Form
+    // MARK: - Shared query
 
-    private var formCard: some View {
+    private var queryCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Query (shared by both panes)")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            TextEditor(text: $query)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .scrollContentBackground(.hidden)
+                .padding(VSpacing.sm)
+                .frame(minHeight: 80)
+                .background(VColor.surfaceBase)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private var runBothRow: some View {
+        HStack {
+            Spacer()
+            VButton(
+                label: (paneA.isRunning || paneB.isRunning) ? "Running…" : "Run both",
+                style: .primary,
+                isDisabled: !canRunBoth
+            ) {
+                runPane(.a)
+                runPane(.b)
+            }
+        }
+    }
+
+    private var diffLegend: some View {
+        HStack(spacing: VSpacing.md) {
+            legendItem(marker: "●", color: VColor.contentDefault, label: "in both")
+            legendItem(marker: "◆", color: paneAccentColor(.a), label: "A only")
+            legendItem(marker: "◇", color: paneAccentColor(.b), label: "B only")
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    private func legendItem(marker: String, color: Color, label: String) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(marker).foregroundStyle(color)
+            Text(label).foregroundStyle(VColor.contentSecondary)
+        }
+        .font(VFont.labelDefault)
+    }
+
+    // MARK: - Per-pane column
+
+    @ViewBuilder
+    private func paneColumn(pane: PaneId) -> some View {
+        let state = paneState(pane)
+        let otherState = paneState(otherPane(pane))
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Query")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                TextEditor(text: $query)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
-                    .scrollContentBackground(.hidden)
-                    .padding(VSpacing.sm)
-                    .frame(minHeight: 80)
-                    .background(VColor.surfaceBase)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.borderBase, lineWidth: 1)
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            Text("Pane \(paneLabel(pane))")
+                .font(VFont.titleSmall)
+                .foregroundStyle(paneAccentColor(pane))
+            paneFormCard(pane: pane)
+            if let err = state.validationError ?? state.clientError {
+                errorBanner(err)
             }
-
-            HStack(alignment: .top, spacing: VSpacing.md) {
-                overrideField(label: "tier1_size", value: $tier1Raw)
-                overrideField(label: "tier2_size", value: $tier2Raw)
-                overrideField(label: "batch_size", value: $batchRaw)
+            if let result = state.lastResult {
+                paneResultSection(
+                    result: result,
+                    pane: pane,
+                    otherResult: otherState.lastResult
+                )
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
 
+    private func paneFormCard(pane: PaneId) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                overrideField(label: "tier1_size", binding: tier1Binding(pane))
+                overrideField(label: "tier2_size", binding: tier2Binding(pane))
+                overrideField(label: "batch_size", binding: batchBinding(pane))
+            }
             HStack {
                 Spacer()
                 VButton(
-                    label: isRunning ? "Running…" : "Run simulation",
-                    style: .primary,
-                    isDisabled: !canRun
+                    label: paneState(pane).isRunning ? "Running…" : "Run \(paneLabel(pane))",
+                    style: .outlined,
+                    isDisabled: !canRun(pane)
                 ) {
-                    runSimulation()
+                    runPane(pane)
                 }
             }
         }
@@ -105,12 +186,12 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .vCard()
     }
 
-    private func overrideField(label: String, value: Binding<String>) -> some View {
+    private func overrideField(label: String, binding: Binding<String>) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text(label)
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentSecondary)
-            TextField("inherit", text: value)
+            TextField("inherit", text: binding)
                 .textFieldStyle(.plain)
                 .font(VFont.bodyMediumDefault)
                 .foregroundStyle(VColor.contentDefault)
@@ -126,11 +207,16 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Result Section
+    // MARK: - Result section
 
     @ViewBuilder
-    private func resultSection(_ result: MemoryRouterSimulateResponse) -> some View {
-        summaryCard(result)
+    private func paneResultSection(
+        result: MemoryRouterSimulateResponse,
+        pane: PaneId,
+        otherResult: MemoryRouterSimulateResponse?
+    ) -> some View {
+        let diff = classifySlugs(own: result, other: otherResult)
+        summaryCard(result: result, otherResult: otherResult, diff: diff)
         configCard(result)
         if let reason = result.failureReason {
             errorBanner("Router failure: \(reason)")
@@ -140,13 +226,18 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             emptyResultCard
         } else {
             ForEach(groups, id: \.source) { group in
-                tierCard(group: group, scores: result.scores)
+                tierCard(group: group, scores: result.scores, pane: pane, diff: diff)
             }
         }
     }
 
-    private func summaryCard(_ result: MemoryRouterSimulateResponse) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+    private func summaryCard(
+        result: MemoryRouterSimulateResponse,
+        otherResult: MemoryRouterSimulateResponse?,
+        diff: [String: SlugDiff]
+    ) -> some View {
+        let counts = countDiff(diff)
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Summary")
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
@@ -159,6 +250,12 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                 label: "Selected",
                 value: "\(result.selectedSlugs.count) / \(result.effectiveConfig.maxPageIds)"
             )
+            if otherResult != nil {
+                metaRow(
+                    label: "Diff",
+                    value: "\(counts.shared) shared · \(counts.unique) unique to this pane"
+                )
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -203,7 +300,9 @@ struct SettingsMemoryRouterPlaygroundTab: View {
 
     private func tierCard(
         group: SourceGroup,
-        scores: [String: Double]
+        scores: [String: Double],
+        pane: PaneId,
+        diff: [String: SlugDiff]
     ) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack {
@@ -217,24 +316,38 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             }
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(group.slugs, id: \.self) { slug in
-                    HStack {
-                        Text(slug)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentDefault)
-                            .textSelection(.enabled)
-                        Spacer()
-                        if group.source == "tier2" {
-                            Text("EMA \(formatScore(scores[slug] ?? 0))")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentSecondary)
-                        }
-                    }
+                    slugRow(slug: slug, pane: pane, diff: diff, source: group.source, scores: scores)
                 }
             }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
+    }
+
+    private func slugRow(
+        slug: String,
+        pane: PaneId,
+        diff: [String: SlugDiff],
+        source: String,
+        scores: [String: Double]
+    ) -> some View {
+        let cls = diff[slug] ?? .onlyHere
+        let color: Color = cls == .both ? VColor.contentDefault : paneAccentColor(pane)
+        let marker: String = cls == .both ? "●" : (pane == .a ? "◆" : "◇")
+        return HStack(alignment: .firstTextBaseline, spacing: VSpacing.xs) {
+            Text(marker).foregroundStyle(color)
+            Text(slug)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(color)
+                .textSelection(.enabled)
+            Spacer()
+            if source == "tier2" {
+                Text("EMA \(formatScore(scores[slug] ?? 0))")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
     }
 
     private var emptyResultCard: some View {
@@ -263,11 +376,144 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
-    // MARK: - Helpers
+    // MARK: - Pane state helpers
 
-    private var canRun: Bool {
-        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunning
+    private func paneState(_ pane: PaneId) -> PaneState {
+        pane == .a ? paneA : paneB
     }
+
+    private func otherPane(_ pane: PaneId) -> PaneId {
+        pane == .a ? .b : .a
+    }
+
+    private func paneLabel(_ pane: PaneId) -> String {
+        pane == .a ? "A" : "B"
+    }
+
+    private func paneAccentColor(_ pane: PaneId) -> Color {
+        pane == .a ? VColor.systemMidStrong : VColor.primaryBase
+    }
+
+    private func tier1Binding(_ pane: PaneId) -> Binding<String> {
+        pane == .a ? $paneA.tier1 : $paneB.tier1
+    }
+
+    private func tier2Binding(_ pane: PaneId) -> Binding<String> {
+        pane == .a ? $paneA.tier2 : $paneB.tier2
+    }
+
+    private func batchBinding(_ pane: PaneId) -> Binding<String> {
+        pane == .a ? $paneA.batch : $paneB.batch
+    }
+
+    private func canRun(_ pane: PaneId) -> Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !paneState(pane).isRunning
+    }
+
+    private var canRunBoth: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !paneA.isRunning && !paneB.isRunning
+    }
+
+    // MARK: - Run
+
+    private func runPane(_ pane: PaneId) {
+        // Clear per-pane error state on entry.
+        switch pane {
+        case .a:
+            paneA.validationError = nil
+            paneA.clientError = nil
+        case .b:
+            paneB.validationError = nil
+            paneB.clientError = nil
+        }
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { return }
+
+        let state = paneState(pane)
+        let tier1Override: MemoryRouterOverride
+        let tier2Override: MemoryRouterOverride
+        let batchOverride: MemoryRouterOverride
+        do {
+            tier1Override = try parseOverride(field: "tier1_size", raw: state.tier1)
+            tier2Override = try parseOverride(field: "tier2_size", raw: state.tier2)
+            batchOverride = try parseOverride(field: "batch_size", raw: state.batch)
+        } catch {
+            setValidationError(pane: pane, message: error.localizedDescription)
+            return
+        }
+
+        let input = MemoryRouterSimulateInput(
+            query: trimmedQuery,
+            tier1Size: tier1Override,
+            tier2Size: tier2Override,
+            batchSize: batchOverride
+        )
+
+        setIsRunning(pane: pane, value: true)
+        lastQuery = trimmedQuery
+        Task {
+            defer { setIsRunning(pane: pane, value: false) }
+            do {
+                let result = try await client.simulate(input: input)
+                setLastResult(pane: pane, result: result)
+                setClientError(pane: pane, message: nil)
+            } catch MemoryRouterPlaygroundError.memoryV2Disabled {
+                setClientError(
+                    pane: pane,
+                    message: "Memory v2 is not enabled on this assistant — set memory.v2.enabled to true in workspace config."
+                )
+                setLastResult(pane: pane, result: nil)
+            } catch MemoryRouterPlaygroundError.notAvailable {
+                setClientError(
+                    pane: pane,
+                    message: "Simulate route is not available — the daemon may need to be updated."
+                )
+                setLastResult(pane: pane, result: nil)
+            } catch let MemoryRouterPlaygroundError.http(statusCode, body) {
+                setClientError(
+                    pane: pane,
+                    message: "HTTP \(statusCode): \(body.isEmpty ? "Failed to run simulation" : body)"
+                )
+                setLastResult(pane: pane, result: nil)
+            } catch {
+                setClientError(pane: pane, message: error.localizedDescription)
+                setLastResult(pane: pane, result: nil)
+            }
+        }
+    }
+
+    private func setIsRunning(pane: PaneId, value: Bool) {
+        switch pane {
+        case .a: paneA.isRunning = value
+        case .b: paneB.isRunning = value
+        }
+    }
+
+    private func setLastResult(pane: PaneId, result: MemoryRouterSimulateResponse?) {
+        switch pane {
+        case .a: paneA.lastResult = result
+        case .b: paneB.lastResult = result
+        }
+    }
+
+    private func setValidationError(pane: PaneId, message: String?) {
+        switch pane {
+        case .a: paneA.validationError = message
+        case .b: paneB.validationError = message
+        }
+    }
+
+    private func setClientError(pane: PaneId, message: String?) {
+        switch pane {
+        case .a: paneA.clientError = message
+        case .b: paneB.clientError = message
+        }
+    }
+
+    // MARK: - Helpers (shared)
 
     private func metaRow(label: String, value: String) -> some View {
         HStack(alignment: .firstTextBaseline) {
@@ -296,56 +542,6 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         String(format: "%.3f", value)
     }
 
-    private func runSimulation() {
-        validationError = nil
-        clientError = nil
-
-        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedQuery.isEmpty else { return }
-
-        let tier1Override: MemoryRouterOverride
-        let tier2Override: MemoryRouterOverride
-        let batchOverride: MemoryRouterOverride
-        do {
-            tier1Override = try parseOverride(field: "tier1_size", raw: tier1Raw)
-            tier2Override = try parseOverride(field: "tier2_size", raw: tier2Raw)
-            batchOverride = try parseOverride(field: "batch_size", raw: batchRaw)
-        } catch {
-            validationError = error.localizedDescription
-            return
-        }
-
-        let input = MemoryRouterSimulateInput(
-            query: trimmedQuery,
-            tier1Size: tier1Override,
-            tier2Size: tier2Override,
-            batchSize: batchOverride
-        )
-
-        isRunning = true
-        lastQuery = trimmedQuery
-        Task {
-            defer { isRunning = false }
-            do {
-                let result = try await client.simulate(input: input)
-                lastResult = result
-                clientError = nil
-            } catch MemoryRouterPlaygroundError.memoryV2Disabled {
-                clientError = "Memory v2 is not enabled on this assistant — set memory.v2.enabled to true in workspace config."
-                lastResult = nil
-            } catch MemoryRouterPlaygroundError.notAvailable {
-                clientError = "Simulate route is not available — the daemon may need to be updated."
-                lastResult = nil
-            } catch let MemoryRouterPlaygroundError.http(statusCode, body) {
-                clientError = "HTTP \(statusCode): \(body.isEmpty ? "Failed to run simulation" : body)"
-                lastResult = nil
-            } catch {
-                clientError = error.localizedDescription
-                lastResult = nil
-            }
-        }
-    }
-
     private func parseOverride(field: String, raw: String) throws -> MemoryRouterOverride {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return .inherit }
@@ -354,6 +550,28 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             throw MemoryRouterPlaygroundInputError.invalidOverride(field: field, raw: trimmed)
         }
         return .value(parsed)
+    }
+
+    private func classifySlugs(
+        own: MemoryRouterSimulateResponse,
+        other: MemoryRouterSimulateResponse?
+    ) -> [String: SlugDiff] {
+        guard let other = other else {
+            return Dictionary(uniqueKeysWithValues: own.selectedSlugs.map { ($0, .both) })
+        }
+        let otherSet = Set(other.selectedSlugs)
+        return Dictionary(uniqueKeysWithValues: own.selectedSlugs.map {
+            ($0, otherSet.contains($0) ? .both : .onlyHere)
+        })
+    }
+
+    private func countDiff(_ diff: [String: SlugDiff]) -> (shared: Int, unique: Int) {
+        var shared = 0
+        var unique = 0
+        for cls in diff.values {
+            if cls == .both { shared += 1 } else { unique += 1 }
+        }
+        return (shared, unique)
     }
 
     private struct SourceGroup {


### PR DESCRIPTION
## Summary

- Adds a second result pane to the memory router playground (web and macOS) so two configs can be compared against the same query in one shot.
- Shared query input + two independent override sets (`tier1_size`, `tier2_size`, `batch_size` per pane) + per-pane Run buttons + "Run both".
- Slugs are diff-colored: neutral when present in both panes, amber when only in A, primary brand when only in B. Leading marker (●/◆/◇) for accessibility. A legend appears once both panes have run.
- Single-pane behavior unchanged when pane B hasn't run yet.

## Why

Tuning router knobs is faster when you can see what a config change does relative to the baseline. Side-by-side removes the "ran A, jotted down slugs, ran B, alt-tabbed" loop.

## Test plan

- [x] \`cd apps/web && bunx tsc --noEmit\` — zero new errors in \`memory-router-playground-page.tsx\`
- [x] \`bunx prettier --write\` / \`bunx eslint --fix\` clean
- [x] \`cd clients && swift build --target VellumAssistantLib\` clean
- [ ] Web smoke after merge: open playground, enter query, A: \`tier1=100, batch=50\`, B: blank, Run both. Slug overlap should be neutral; tier-1 picks should color as A-only.
- [ ] macOS smoke after merge: rebuild + open Settings → Memory Router Playground. Same scenario as web.
- [ ] Read-only guard: confirm \`memory_v2_injection_events\` + \`memory_v2_activation_logs\` row counts unchanged pre/post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)