### PR TITLE
feat(assistant): add --email-username option to domain register

### DIFF
--- a/assistant/src/cli/commands/__tests__/domain-register.test.ts
+++ b/assistant/src/cli/commands/__tests__/domain-register.test.ts
@@ -204,4 +204,114 @@ describe("assistant domain register", () => {
     await runDomainCommand("domain", "register", "velly");
     expect(process.exitCode).not.toBe(0);
   });
+
+  test("--email-username is included in IPC body", async () => {
+    mockIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          domain: "velly.vellum.me",
+          status: "active",
+          verified: true,
+        },
+      }),
+    );
+
+    await runDomainCommand(
+      "domain",
+      "register",
+      "velly",
+      "--email-username",
+      "hello",
+    );
+
+    expect(mockIpcCallFn).toHaveBeenCalledWith("domain_register", {
+      body: { subdomain: "velly", email_username: "hello" },
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("email error in response is surfaced as warning", async () => {
+    mockIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          domain: "velly.vellum.me",
+          status: "active",
+          verified: true,
+          email_error: {
+            detail: "MX records not ready",
+            code: "email_setup_failed",
+          },
+        },
+      }),
+    );
+
+    await runDomainCommand(
+      "domain",
+      "register",
+      "velly",
+      "--email-username",
+      "hello",
+    );
+
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("--json includes email_error in output", async () => {
+    mockIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          domain: "velly.vellum.me",
+          status: "active",
+          verified: true,
+          email_error: {
+            detail: "MX records not ready",
+            code: "email_setup_failed",
+          },
+        },
+      }),
+    );
+
+    const output = await runDomainCommand(
+      "domain",
+      "--json",
+      "register",
+      "velly",
+      "--email-username",
+      "hello",
+    );
+
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.email_error).toEqual({
+      detail: "MX records not ready",
+      code: "email_setup_failed",
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("without --email-username behavior is unchanged", async () => {
+    mockIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          domain: "velly.vellum.me",
+          status: "active",
+          verified: true,
+        },
+      }),
+    );
+
+    await runDomainCommand("domain", "register", "velly");
+
+    expect(mockIpcCallFn).toHaveBeenCalledWith("domain_register", {
+      body: { subdomain: "velly" },
+    });
+    expect(process.exitCode).toBe(0);
+  });
 });

--- a/assistant/src/cli/commands/domain.ts
+++ b/assistant/src/cli/commands/domain.ts
@@ -38,12 +38,17 @@ for email and web presence. DNS managed by the Vellum platform.
 
 Examples:
   $ assistant domain register velly
+  $ assistant domain register velly --email-username hello
   $ assistant domain register --json
   $ assistant domain status`,
       );
 
       domain
         .command("register [subdomain]")
+        .option(
+          "--email-username <username>",
+          "Also register an email address (e.g. --email-username hello → hello@<subdomain>.domain)",
+        )
         .description(
           `Register a custom subdomain on ${baseDomain} for this assistant`,
         )
@@ -54,12 +59,19 @@ Arguments:
   subdomain   The subdomain to register (e.g. "velly" → velly.${baseDomain}).
               If omitted, the platform derives it from the assistant's name.
 
+Options:
+  --email-username <username>  Also register an email address for the domain
+                               (e.g. --email-username hello → hello@velly.${baseDomain})
+
 Registers a subdomain at <subdomain>.${baseDomain}. DNS managed by the
 Vellum platform — no manual DNS changes needed.
 
 Examples:
   $ assistant domain register velly
   ✓ Registered velly.${baseDomain}
+
+  $ assistant domain register velly --email-username hello
+  ✓ Registered velly.${baseDomain} (email: hello@velly.${baseDomain})
 
   $ assistant domain register
   ✓ Registered my-assistant.${baseDomain}
@@ -68,10 +80,17 @@ Examples:
   {"domain":"velly.${baseDomain}","id":"...","status":"active","verified":true}`,
         )
         .action(
-          async (subdomain: string | undefined, _opts: unknown, cmd: Command) => {
+          async (
+            subdomain: string | undefined,
+            opts: { emailUsername?: string },
+            cmd: Command,
+          ) => {
             const body: Record<string, string> = {};
             if (subdomain) {
               body.subdomain = subdomain;
+            }
+            if (opts.emailUsername) {
+              body.email_username = opts.emailUsername;
             }
 
             const r = await cliIpcCall<{
@@ -82,6 +101,7 @@ Examples:
               verified?: boolean;
               created_at?: string;
               created?: string;
+              email_error?: { detail: string; code: string };
             }>("domain_register", { body });
 
             if (!r.ok)
@@ -104,7 +124,18 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, data);
             } else {
-              log.info(`✓ Registered ${displayDomain}`);
+              if (opts.emailUsername && !data.email_error) {
+                log.info(
+                  `✓ Registered ${displayDomain} (email: ${opts.emailUsername}@${displayDomain})`,
+                );
+              } else {
+                log.info(`✓ Registered ${displayDomain}`);
+              }
+              if (data.email_error) {
+                log.warn(
+                  `⚠ Email registration failed: ${data.email_error.detail}`,
+                );
+              }
               if (data.verified === false) {
                 log.info(
                   "  ⚠ Domain verification pending — this usually resolves within a few seconds.",

--- a/assistant/src/runtime/routes/domain-routes.ts
+++ b/assistant/src/runtime/routes/domain-routes.ts
@@ -35,13 +35,19 @@ async function requireClient(): Promise<VellumPlatformClient> {
 // ── Handlers ──────────────────────────────────────────────────────────
 
 async function handleDomainRegister({ body = {} }: RouteHandlerArgs) {
-  const { subdomain } = body as { subdomain?: string };
+  const { subdomain, email_username } = body as {
+    subdomain?: string;
+    email_username?: string;
+  };
   const client = await requireClient();
   const apexDomain = getApexDomain();
 
   const reqBody: Record<string, string> = {};
   if (subdomain) {
     reqBody.subdomain = subdomain;
+  }
+  if (email_username) {
+    reqBody.email_username = email_username;
   }
 
   const response = await client.fetch(
@@ -75,6 +81,7 @@ async function handleDomainRegister({ body = {} }: RouteHandlerArgs) {
     verified?: boolean;
     created_at?: string;
     created?: string;
+    email_error?: { detail: string; code: string };
   };
 
   // Persist the subdomain to config so getAssistantDomain() can use it

--- a/assistant/src/runtime/routes/domain-routes.ts
+++ b/assistant/src/runtime/routes/domain-routes.ts
@@ -64,12 +64,18 @@ async function handleDomainRegister({ body = {} }: RouteHandlerArgs) {
       string,
       unknown
     >;
+    const firstFieldError = ["subdomain", "email_username"].reduce<
+      string | undefined
+    >(
+      (found, field) =>
+        found ??
+        (Array.isArray(respBody[field])
+          ? (respBody[field][0] as string)
+          : undefined),
+      undefined,
+    );
     const detail =
-      respBody.detail ??
-      (Array.isArray(respBody.subdomain)
-        ? respBody.subdomain[0]
-        : undefined) ??
-      `HTTP ${response.status}`;
+      respBody.detail ?? firstFieldError ?? `HTTP ${response.status}`;
     throw new BadRequestError(String(detail));
   }
 


### PR DESCRIPTION
## Summary
- Add `--email-username <username>` option to `assistant domain register` that passes `email_username` to the platform API's domain creation endpoint
- On success, log the registered email alongside the domain; on email failure, log domain success with a warning about the email error
- Add tests for the new option: IPC body inclusion, email error surfacing, JSON passthrough, and unchanged behavior without the flag

## Original prompt
Add an `--email-username` option to `assistant domain register` that passes `email_username` to the platform API's domain creation endpoint, enabling one-step domain + email registration. The platform API accepts an optional `email_username` field on `POST /v1/assistants/{id}/domains/` and returns `email_error` on partial failure. The CLI should surface email errors as warnings (not failures) and pass through the full response in `--json` mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)