### PR TITLE
fix(web): wire up subagent detail fetching to populate timeline events

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -29,7 +29,8 @@ import {
 } from "@/domains/conversations/conversation-queries.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
 import { useDeployStore } from "@/domains/chat/deploy-store.js";
-import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
+import { useSubagentStore, type SubagentTimelineEvent } from "@/domains/subagents/subagent-store.js";
+import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store.js";
 import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store.js";
@@ -93,7 +94,7 @@ import { ConversationActionsMenu } from "@/domains/chat/components/conversation-
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill.js";
 import { CommandPalette } from "@/components/command-palette/command-palette.js";
 import { shouldHandleShortcut } from "@/domains/chat/chat-layout.js";
-import { abortSubagent } from "@/domains/chat/api/conversations.js";
+import { abortSubagent, fetchSubagentDetail } from "@/domains/chat/api/conversations.js";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay.js";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay.js";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay.js";
@@ -726,6 +727,106 @@ export function ChatPage() {
   useEffect(() => {
     useSubagentStore.getState().reset();
   }, [activeConversationKey]);
+
+  // -------------------------------------------------------------------------
+  // Subagent detail fetching
+  // -------------------------------------------------------------------------
+  const handleRequestSubagentDetail = useCallback(
+    async (subagentId: string) => {
+      if (!assistantId) return;
+      const entry = useSubagentStore.getState().byId[subagentId];
+      if (!entry?.conversationId) return;
+
+      const detail = await fetchSubagentDetail(assistantId, subagentId, entry.conversationId);
+      if (!detail) return;
+
+      let eventCounter = 0;
+      const events: SubagentTimelineEvent[] = [];
+
+      for (const evt of detail.events ?? []) {
+        const rawType = typeof evt.type === "string" ? evt.type : "unknown";
+        let type: SubagentTimelineEvent["type"];
+        switch (rawType) {
+          case "text":
+          case "assistant_text_delta":
+            type = "text";
+            break;
+          case "tool_use":
+          case "tool_use_start":
+            type = "tool_call";
+            break;
+          case "tool_result":
+            type = "tool_result";
+            break;
+          case "error":
+            type = "error";
+            break;
+          default:
+            continue;
+        }
+
+        const content =
+          typeof evt.content === "string"
+            ? evt.content
+            : typeof evt.text === "string"
+              ? evt.text
+              : typeof evt.result === "string"
+                ? evt.result
+                : "";
+
+        if (type === "text" && content === "") continue;
+
+        // Coalesce consecutive text events
+        const prev = events[events.length - 1];
+        if (type === "text" && prev && prev.type === "text") {
+          prev.content += "\n\n" + content;
+          continue;
+        }
+
+        events.push({
+          id: `detail-${++eventCounter}`,
+          type,
+          content,
+          toolName: typeof evt.toolName === "string" ? evt.toolName : undefined,
+          isError: typeof evt.isError === "boolean" ? evt.isError : undefined,
+          timestamp: typeof evt.timestamp === "number" ? evt.timestamp : Date.now(),
+        });
+      }
+
+      useSubagentStore.getState().loadDetail({
+        subagentId,
+        status: (detail.status as SubagentStatus) || undefined,
+        objective: detail.objective,
+        inputTokens: detail.usage?.inputTokens,
+        outputTokens: detail.usage?.outputTokens,
+        totalCost: detail.usage?.estimatedCost,
+        events,
+      });
+    },
+    [assistantId],
+  );
+
+  // Auto-fetch details for subagents reconstructed from history (mirrors macOS
+  // behavior of calling the detail endpoint on reload to get correct status,
+  // metrics, and events).
+  const fetchedSubagentsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    fetchedSubagentsRef.current.clear();
+  }, [activeConversationKey]);
+  useEffect(() => {
+    if (!assistantId) return;
+    const entries = Object.values(subagentState.byId);
+    for (const entry of entries) {
+      if (
+        entry.conversationId &&
+        entry.events.length === 0 &&
+        !fetchedSubagentsRef.current.has(entry.subagentId)
+      ) {
+        fetchedSubagentsRef.current.add(entry.subagentId);
+        handleRequestSubagentDetail(entry.subagentId);
+      }
+    }
+  }, [assistantId, subagentState.byId, handleRequestSubagentDetail]);
 
   // -------------------------------------------------------------------------
   // Interaction actions
@@ -1467,7 +1568,7 @@ export function ChatPage() {
         // Best-effort — the daemon may have already completed
       }
     },
-    onRequestSubagentDetail: async () => {},
+    onRequestSubagentDetail: handleRequestSubagentDetail,
     pushToAiSettings,
     checkAssistant,
     setRefreshEpoch,
@@ -1611,7 +1712,7 @@ export function ChatPage() {
                   // Best-effort — the daemon may have already completed
                 }
               }}
-              onRequestDetail={async () => {}}
+              onRequestDetail={handleRequestSubagentDetail}
             />
           </>,
           overlayTarget,

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -809,7 +809,10 @@ export function ChatPage() {
   // Auto-fetch details for subagents reconstructed from history (mirrors macOS
   // behavior of calling the detail endpoint on reload to get correct status,
   // metrics, and events).
-  const fetchedSubagentsRef = useRef<Set<string>>(new Set());
+  // Keyed by subagentId → spawnedAt at fetch time so that store rebuilds
+  // (e.g. background TanStack Query refetches that reset + respawn entries)
+  // produce a new spawnedAt and allow re-fetching.
+  const fetchedSubagentsRef = useRef<Map<string, number>>(new Map());
   useEffect(() => {
     fetchedSubagentsRef.current.clear();
   }, [activeConversationKey]);
@@ -817,12 +820,10 @@ export function ChatPage() {
     if (!assistantId) return;
     const entries = Object.values(subagentState.byId);
     for (const entry of entries) {
-      if (
-        entry.conversationId &&
-        entry.events.length === 0 &&
-        !fetchedSubagentsRef.current.has(entry.subagentId)
-      ) {
-        fetchedSubagentsRef.current.add(entry.subagentId);
+      if (entry.conversationId && entry.events.length === 0) {
+        const fetchedAt = fetchedSubagentsRef.current.get(entry.subagentId);
+        if (fetchedAt !== undefined && fetchedAt >= entry.spawnedAt) continue;
+        fetchedSubagentsRef.current.set(entry.subagentId, entry.spawnedAt);
         handleRequestSubagentDetail(entry.subagentId);
       }
     }

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -86,6 +86,16 @@ export interface SubagentActions {
     timestamp: number;
   }) => void;
 
+  loadDetail: (params: {
+    subagentId: string;
+    status?: SubagentStatus;
+    objective?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalCost?: number;
+    events: SubagentTimelineEvent[];
+  }) => void;
+
   setConversationId: (subagentId: string, conversationId: string) => void;
 
   reset: () => void;
@@ -267,6 +277,27 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         [params.subagentId]: {
           ...existing,
           events: [...existing.events, timelineEvent],
+        },
+      },
+    });
+  },
+
+  loadDetail: (params) => {
+    const { byId } = get();
+    const existing = byId[params.subagentId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.subagentId]: {
+          ...existing,
+          status: params.status ?? existing.status,
+          objective: params.objective ?? existing.objective,
+          inputTokens: params.inputTokens ?? existing.inputTokens,
+          outputTokens: params.outputTokens ?? existing.outputTokens,
+          totalCost: params.totalCost ?? existing.totalCost,
+          events: params.events.length > 0 ? params.events : existing.events,
         },
       },
     });

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -297,7 +297,10 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
           inputTokens: params.inputTokens ?? existing.inputTokens,
           outputTokens: params.outputTokens ?? existing.outputTokens,
           totalCost: params.totalCost ?? existing.totalCost,
-          events: params.events.length > 0 ? params.events : existing.events,
+          events:
+            params.events.length > 0 && existing.events.length === 0
+              ? params.events
+              : existing.events,
         },
       },
     });


### PR DESCRIPTION
## Summary

- Wire up the empty `onRequestSubagentDetail` callback stub in `chat-page.tsx` to actually fetch subagent detail from the daemon API
- Add `loadDetail` action to the Zustand subagent store for batch-loading fetched events and metadata
- Add auto-fetch effect that proactively fetches detail for history-reconstructed subagents with empty events

## Problem

The subagent detail panel showed "No events yet" in the Timeline section even after a subagent completed, because `onRequestSubagentDetail` was defined as `async () => {}` — a no-op. The `fetchSubagentDetail()` API function existed but was never called. This was a porting gap from the platform web implementation.

## Changes

**`apps/web/src/domains/subagents/subagent-store.ts`**
- Added `loadDetail` action that batch-updates an entry's events, status, objective, and usage metrics (only overrides when provided; only replaces events if incoming array is non-empty)

**`apps/web/src/domains/chat/chat-page.tsx`**
- Added `handleRequestSubagentDetail` callback that fetches detail from the daemon, transforms raw events into typed `SubagentTimelineEvent[]` (type mapping, text coalescing, empty-text filtering), and dispatches to the store
- Added auto-fetch effect with deduplication tracking that fetches detail for all subagents with `conversationId` but empty events on conversation load
- Replaced both empty stubs (desktop panel + mobile overlay) with the real callback

## Test plan

- [ ] Open a conversation with a completed subagent → click the subagent card → verify Timeline shows events (tool calls, text responses, etc.)
- [ ] Refresh the page → verify events auto-populate without opening the panel
- [ ] Verify usage metrics (Input/Output/Cost) display correct values
- [ ] Spawn a new subagent → verify live streaming events still work correctly in the panel
- [ ] On mobile: verify the subagent detail overlay also shows events

🤖 Generated with [Claude Code](https://claude.com/claude-code)