### PR TITLE
chore(web): keep Safari sheet open on native-auth error for debugging

### DIFF
--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -119,7 +119,19 @@ export function ProviderCallbackPage() {
           }
           case "error":
             if (nativeParams) {
-              redirectToNativeApp(nativeParams, outcome.message);
+              // TEMPORARY DEBUG (revert once iOS sign-in cache-miss is
+              // diagnosed): suppress the redirect-back-to-native so the
+              // Safari sheet stays open and the actual getSession()
+              // failure mode is inspectable. Without this, ASWebAuth
+              // catches the scheme:// redirect, closes the sheet, and
+              // destroys the Web Inspector window before anything can
+              // be read.
+              console.log("[debug native auth] getSession result:", result);
+              console.log("[debug native auth] classification outcome:", outcome);
+              console.log("[debug native auth] nativeParams:", nativeParams);
+              setFallbackError(
+                `[debug] ${outcome.message} :: result=${JSON.stringify(result).slice(0, 800)}`,
+              );
               return;
             }
             setFallbackError(outcome.message);


### PR DESCRIPTION
## Why

**Temporary** — revert once iOS sign-in cache-miss is diagnosed.

iOS dev sign-in fails with a Capacitor bridge rejection `{ code: "AUTH_ERROR", data.authError: "Unexpected authentication state." }`. That string comes from `classifyCallbackFlows()` in `social-auth.ts:167`, which fires when `getSession()` returns `isAuthenticated === false` inside the Safari sheet. We need to see the actual `getSession()` response body and request cookies to know why it's coming back anonymous.

Problem: in `ProviderCallbackPage`, the native-flow `case "error"` branch immediately does `window.location.href = vellum-assistant-dev://auth/callback?error=...`. `ASWebAuthenticationSession` catches the scheme, closes the Safari sheet, **and destroys the attached Web Inspector window before any recorded Network / Console data can be read**.

## What

Suppress the redirect-back in the native error branch and instead:
- `console.log` the full `getSession()` result, classification outcome, and native params (visible in the now-persistent Web Inspector console).
- Set a `fallbackError` containing a truncated JSON dump of the result so the data is also rendered on screen.

The sheet stays open showing the SPA's "Authentication failed" page with the debug payload as subtitle, where it can be inspected at leisure.

## Behavioral diff

| Path | Before | After |
|---|---|---|
| Native error (this PR's target) | Bounce to `scheme://auth/callback?error=…`, sheet closes | Stay on SPA error page with debug subtitle; sheet stays open |
| Native authenticated / signup needed | Unchanged | Unchanged |
| Web (non-native) error | Render fallback error UI | Unchanged |

While this is deployed, real iOS sign-in failures on dev will land on the SPA error page instead of bouncing back to the app's login screen — but those users were already broken by the underlying bug. UX delta is just "Authentication failed page" vs "Something went wrong on login page." Acceptable for the short debug window.

## Checks

- `bun run typecheck` — clean
- `bun run lint src/domains/account/pages/provider-callback-page.tsx` — clean
- No tests exist for this file.

## Revert

Single revert commit once we have the answer.

## Related

- Investigation context: closed [`#31693`](https://github.com/vellum-ai/vellum-assistant/pull/31693), merged [`#31733`](https://github.com/vellum-ai/vellum-assistant/pull/31733) (cookie-flush; not the fix), platform-side instrumentation [`vellum-ai/vellum-assistant-platform#7662`](https://github.com/vellum-ai/vellum-assistant-platform/pull/7662) (also won't fire on the failed-attempt code path).

---
_Generated by [Claude Code](https://claude.ai/code/session_012B87vGYhbhfDCYnwQHr4Mh)_