### PR TITLE
docs(ios): add debugging guide and fix stale web/ios paths

### DIFF
--- a/apps/ios/.gitignore
+++ b/apps/ios/.gitignore
@@ -14,10 +14,9 @@ App/App/config.xml
 
 # Generated Xcode project. `App.xcodeproj/` is regenerated from
 # `App/project.yml` on every CI run via `xcodegen generate` (see
-# `.github/workflows/release-ios.yaml` and
-# `.github/workflows/build-ios-slot.yaml`). Local devs run
+# `.github/workflows/release-ios.yaml`). Local devs run
 # `xcodegen generate` after `cap sync ios` and before
-# `open App.xcodeproj` — see `web/ios/README.md`. Nothing inside this
+# `open App.xcodeproj` — see `apps/ios/README.md`. Nothing inside this
 # tree should ever be committed; the SPM lockfile that Xcode normally
 # writes here is unnecessary because `CapApp-SPM/Package.swift`
 # already pins `capacitor-swift-pm` with `exact:`.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -89,6 +89,94 @@ In the Xcode toolbar:
 Apple's reference for the toolbar controls:
 [Running your app in Simulator or on a device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device).
 
+## Debugging
+
+The app has two layers — the **WKWebView contents** (the React app loaded
+from `dev-assistant.vellum.ai`) and the **native Swift shell** (Capacitor
+bridge, `MyViewController`, the two native plugins). Each has its own
+debugger.
+
+### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
+
+This is the one you'll use most. It's full Safari devtools attached to
+the WKWebView, so the Elements panel, Console, Network, Sources,
+debugger, and `console.log` output all work the way they do in a normal
+browser tab.
+
+One-time Safari setup on your Mac:
+
+1. Safari → Settings → **Advanced** → check **"Show features for web
+   developers"** (older macOS: "Show Develop menu in menu bar").
+
+Per-session, with the app running in the simulator (or on a tethered
+device):
+
+1. Safari → **Develop** menu → pick the simulator (e.g. "Simulator —
+   iPhone 16 Pro") or your connected device → click the entry under the
+   app's bundle ID (`…vellum-assistant-ios.dev` for App Dev).
+2. The Web Inspector window opens against the live WebView. Reloading the
+   app, navigating, or `cmd+R`-ing in Xcode all keep working — just
+   reopen the inspector entry from the Develop menu when the WebView
+   reloads.
+
+This works because Capacitor enables `WKWebView.isInspectable` on Debug
+builds automatically ([Capacitor 6+ default](https://capacitorjs.com/docs/ios/troubleshooting#using-safari-web-inspector));
+Release / TestFlight builds are not inspectable, which is intentional.
+
+For a **physical iPhone**:
+
+1. On the phone: Settings → Apps → Safari → Advanced → toggle **Web
+   Inspector** on.
+2. Plug it in via USB and trust the Mac.
+3. The device shows up in Safari's Develop menu the same way the
+   simulator does.
+
+> If the simulator/device shows up in the Develop menu but the app's
+> entry doesn't, the WebView hasn't loaded yet — wait for the splash
+> screen to dismiss, or you're running a Release build (only Debug is
+> inspectable).
+
+### Xcode debugger — for native Swift code
+
+⌘R runs with `lldb` already attached. Click in the gutter next to any
+line in `AppDelegate.swift`, `MyViewController.swift`,
+`NativeAuthPlugin.swift`, or `NativeBiometricPlugin.swift` to set a
+breakpoint.
+
+- **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
+  or click the bottom-right console toggle. `print()` and `NSLog()` from
+  Swift show up here, as do Capacitor's plugin-bridge logs.
+- **`console.log` from the web side does NOT appear in the Xcode
+  console** — it goes to Safari Web Inspector only. Don't waste time
+  looking for it here.
+- **Pause on first load**: breakpoint on `capacitorDidLoad()` in
+  `MyViewController.swift` to inspect the bridge state before any plugin
+  has been called.
+- **View hierarchy**: Debug → View Debugging → Capture View Hierarchy
+  shows the native view tree (useful for confirming the WebView is
+  laid out correctly under the notch — though most layout debugging
+  belongs in the Web Inspector, not here).
+
+### Common debugging recipes
+
+- **A native plugin call (`NativeAuth`, `NativeBiometric`) seems broken**:
+  set a Swift breakpoint in the relevant `@objc func` inside the plugin
+  file and trigger the action from the web app. If the breakpoint never
+  hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
+  `src/runtime/native-auth.ts` / `native-biometric.ts`). If it hits but
+  doesn't return, step through and check `call.resolve` / `call.reject`.
+- **A streaming/SSE bug only reproduces in the iOS shell**: open Safari
+  Web Inspector → Network → filter for `text/event-stream`. You should
+  see the connection stay open with `data:` frames arriving. If you see
+  the whole response delivered in one chunk, CapacitorHttp has been
+  enabled somewhere (it shouldn't be — see the
+  [CapacitorHttp section](#capacitorhttp-is-deliberately-off)).
+- **The WebView never loads, just a blank green screen**: check the
+  Xcode console for a failed navigation. Common cause is a typo'd
+  `server.url` in `capacitor.config.ts` or `cleartext: true` missing for
+  an HTTP target. The placeholder `capacitor-shell/index.html` is also
+  what flashes briefly before the remote URL paints.
+
 ## How it's set up
 
 > **Web-side conventions for iOS code paths**: any change to the web app

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -12,8 +12,8 @@ import { routes } from "@/utils/routes.js";
 
 /**
  * JS ↔ native bridge for the `NativeAuth` Capacitor plugin registered by
- * `web/ios/App/App/MyViewController.swift` +
- * `web/ios/App/App/NativeAuthPlugin.swift`.
+ * `apps/ios/App/App/MyViewController.swift` +
+ * `apps/ios/App/App/NativeAuthPlugin.swift`.
  *
  * The plugin opens an `ASWebAuthenticationSession` pointed at
  * `{baseURL}/accounts/native/start?state={nonce}`, which initiates the

--- a/apps/web/src/runtime/native-biometric.ts
+++ b/apps/web/src/runtime/native-biometric.ts
@@ -4,8 +4,8 @@ import { isNativePlatform } from "@/runtime/native-auth.js";
 
 /**
  * JS ↔ native bridge for the `NativeBiometric` Capacitor plugin registered by
- * `web/ios/App/App/MyViewController.swift` +
- * `web/ios/App/App/NativeBiometricPlugin.swift`.
+ * `apps/ios/App/App/MyViewController.swift` +
+ * `apps/ios/App/App/NativeBiometricPlugin.swift`.
  *
  * The plugin provides biometric-protected Keychain storage for session tokens,
  * enabling Face ID / Touch ID session recovery without a full WorkOS login.


### PR DESCRIPTION
## Summary

- Adds a **Debugging** section to `apps/ios/README.md` covering Safari Web Inspector (for the WKWebView — JS / CSS / network / `console.log`) and the Xcode debugger (for native Swift code), with common recipes for plugin, streaming, and load-failure debugging.
- Fixes three stale `web/ios/...` path references left over from the relocation to `apps/ios/` (#31302):
  - `apps/ios/.gitignore` — drops reference to a `build-ios-slot.yaml` workflow that no longer exists; updates `web/ios/README.md` → `apps/ios/README.md`.
  - `apps/web/src/runtime/native-auth.ts` — updates the plugin file path in the doc comment.
  - `apps/web/src/runtime/native-biometric.ts` — updates the plugin file path in the doc comment.

## Why these specifics

- **Safari Web Inspector vs Xcode console**: a frequent debugging trip-up is `console.log` from the web side not showing up in the Xcode console — it goes to Safari Web Inspector only. The README now calls this out explicitly.
- **Capacitor 6+ behaviour**: Web Inspector works on Debug builds because Capacitor auto-enables `WKWebView.isInspectable`; Release / TestFlight builds are intentionally not inspectable. Linked to the upstream Capacitor docs.
- **Common recipes**: covers the three failure modes most likely to land on iOS-shell debugging — a native plugin not responding (Swift breakpoint), an SSE / streaming regression (filter for `text/event-stream` in Network), and a blank-green-screen WebView load failure (Xcode console for the navigation error).

## Test plan

- [ ] Read through the new Debugging section in `apps/ios/README.md` and confirm the Safari steps match current macOS (Settings → Advanced → "Show features for web developers").
- [ ] Confirm Safari → Develop menu lists the simulator and the app's bundle ID entry when an App Dev Debug build is running.
- [ ] `grep -rn "web/ios" apps/ .github/` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)