### PR TITLE
[codex] LUM-1827 extend inference CLI timeout

### DIFF
--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -6,8 +6,8 @@
  * rendering, argument validation, and the no-message guard. They run
  * entirely inside the CLI process and need no daemon stub.
  *
- * Follow-up opportunity: mock `../../../ipc/cli-client.js` with canned
- * responses to cover the deeper send-message paths against the IPC contract.
+ * The IPC client is mocked with canned responses so tests can assert the
+ * request contract without opening an assistant socket.
  */
 
 import {
@@ -23,6 +23,34 @@ import { Command } from "commander";
 // ---------------------------------------------------------------------------
 
 let mockStdinContent: string | null = null;
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: { timeoutMs?: number };
+} | null = null;
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = {
+  ok: true,
+  result: {
+    response: "Hello from the model.",
+    model: "test-model",
+    usage: { inputTokens: 3, outputTokens: 4 },
+  },
+};
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
 
 mock.module("../../../providers/provider-send-message.js", () => ({
   // The handler under test calls getConfiguredProvider before any of the
@@ -30,7 +58,10 @@ mock.module("../../../providers/provider-send-message.js", () => ({
   // loads cleanly even though no test actually drives a request.
   getConfiguredProvider: async () => null,
   extractAllText: () => "",
-  userMessage: (text: string) => ({ role: "user", content: [{ type: "text", text }] }),
+  userMessage: (text: string) => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
 }));
 
 mock.module("../../../config/loader.js", () => ({
@@ -44,8 +75,18 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 mock.module("../../../util/logger.js", () => ({
-  getLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
-  getCliLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
 }));
 
 mock.module("node:fs", () => ({
@@ -127,6 +168,15 @@ async function runCommand(
 
 beforeEach(() => {
   mockStdinContent = null;
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: {
+      response: "Hello from the model.",
+      model: "test-model",
+      usage: { inputTokens: 3, outputTokens: 4 },
+    },
+  };
   process.exitCode = 0;
 });
 
@@ -142,6 +192,7 @@ describe("help text", () => {
     expect(stdout).toContain("--model");
     expect(stdout).toContain("--profile");
     expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--timeout-seconds");
     expect(stdout).toContain("--json");
     expect(stdout).toContain("[message...]");
   });
@@ -153,6 +204,7 @@ describe("help text", () => {
     expect(stdout).toContain("--model");
     expect(stdout).toContain("--profile");
     expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--timeout-seconds");
     expect(stdout).toContain("--json");
     expect(stdout).toContain("[message...]");
   });
@@ -223,5 +275,56 @@ describe("--max-tokens", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --max-tokens");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IPC timeout
+// ---------------------------------------------------------------------------
+
+describe("--timeout-seconds", () => {
+  test("uses a long default IPC timeout for inference calls", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).ok).toBe(true);
+    expect(lastIpcCall!.method).toBe("inference_send");
+    expect(lastIpcCall!.options!.timeoutMs).toBe(32 * 60 * 1000);
+  });
+
+  test("passes custom timeout to IPC call", async () => {
+    const { exitCode } = await runCommand([
+      "llm",
+      "send",
+      "--timeout-seconds",
+      "300",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("inference_send");
+    expect(lastIpcCall!.options!.timeoutMs).toBe(300_000);
+  });
+
+  test("errors on invalid timeout value", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--timeout-seconds",
+      "0",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout-seconds");
   });
 });

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -30,6 +30,54 @@ interface InferenceSendResult {
   };
 }
 
+const DEFAULT_INFERENCE_IPC_TIMEOUT_MS = 32 * 60 * 1000;
+const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
+const MAX_INFERENCE_TIMEOUT_SECONDS = Math.floor(MAX_TIMER_TIMEOUT_MS / 1000);
+
+function parsePositiveIntegerOption(
+  raw: string | undefined,
+  flagName: string,
+  options: { max?: number } = {},
+): { ok: true; value: number | undefined } | { ok: false; error: string } {
+  if (raw === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      ok: false,
+      error: `Invalid ${flagName} value. Must be a positive integer.`,
+    };
+  }
+
+  const value = Number(trimmed);
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    (options.max !== undefined && value > options.max)
+  ) {
+    return {
+      ok: false,
+      error:
+        `Invalid ${flagName} value. Must be a positive integer` +
+        (options.max !== undefined ? ` no greater than ${options.max}` : "") +
+        ".",
+    };
+  }
+
+  return { ok: true, value };
+}
+
+function writeCliError(message: string, jsonOutput?: boolean): void {
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
 // ── Send subcommand ──────────────────────────────────────────────────
 
 /**
@@ -47,6 +95,11 @@ function attachSendSubcommand(group: Command): void {
       "Apply a named inference profile from llm.profiles for this single call",
     )
     .option("--max-tokens <n>", "Max response tokens", undefined)
+    .option(
+      "--timeout-seconds <seconds>",
+      "Maximum time to wait for the inference response",
+      undefined,
+    )
     .option("--json", "Output structured JSON")
     .argument("[message...]", "User message (joined with spaces)")
     .addHelpText(
@@ -59,12 +112,15 @@ Behavioral notes:
     only. It does NOT open a session — to pin a profile to a conversation,
     use 'assistant inference profile open <name>'.
   - --profile layers below --model: --model still wins on the model field.
+  - Long-running requests wait up to 32 minutes by default. Use
+    --timeout-seconds to adjust the wait budget for this call.
   - Requires a configured LLM provider (see 'assistant config set').
 
 Examples:
   $ assistant inference send "What is 2+2?"
   $ echo "Summarize this" | assistant inference send
   $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
+  $ assistant inference send --timeout-seconds 300 "Draft a long memo"
   $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
   $ assistant inference send --profile balanced "Explain RFC 1149"`,
     )
@@ -76,29 +132,36 @@ Examples:
           model?: string;
           profile?: string;
           maxTokens?: string;
+          timeoutSeconds?: string;
           json?: boolean;
         },
       ) => {
         const { systemPrompt, model, profile, json: jsonOutput } = opts;
-        const maxTokens = opts.maxTokens
-          ? parseInt(opts.maxTokens, 10)
-          : undefined;
+        const parsedMaxTokens = parsePositiveIntegerOption(
+          opts.maxTokens,
+          "--max-tokens",
+        );
+        const parsedTimeoutSeconds = parsePositiveIntegerOption(
+          opts.timeoutSeconds,
+          "--timeout-seconds",
+          { max: MAX_INFERENCE_TIMEOUT_SECONDS },
+        );
 
-        if (
-          opts.maxTokens !== undefined &&
-          (!Number.isFinite(maxTokens) || maxTokens! < 1)
-        ) {
-          const msg = "Invalid --max-tokens value. Must be a positive integer.";
-          if (jsonOutput) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: msg }) + "\n",
-            );
-          } else {
-            log.error(msg);
-          }
-          process.exitCode = 1;
+        if (!parsedMaxTokens.ok) {
+          writeCliError(parsedMaxTokens.error, jsonOutput);
           return;
         }
+
+        if (!parsedTimeoutSeconds.ok) {
+          writeCliError(parsedTimeoutSeconds.error, jsonOutput);
+          return;
+        }
+
+        const maxTokens = parsedMaxTokens.value;
+        const timeoutMs =
+          parsedTimeoutSeconds.value !== undefined
+            ? parsedTimeoutSeconds.value * 1000
+            : DEFAULT_INFERENCE_IPC_TIMEOUT_MS;
 
         // Determine user message: positional args or stdin.
         let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
@@ -114,14 +177,7 @@ Examples:
         if (!messageText) {
           const msg =
             "No message provided. Pass a message as an argument or pipe via stdin.";
-          if (jsonOutput) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: msg }) + "\n",
-            );
-          } else {
-            log.error(msg);
-          }
-          process.exitCode = 1;
+          writeCliError(msg, jsonOutput);
           return;
         }
 
@@ -135,17 +191,14 @@ Examples:
         const ipcResult = await cliIpcCall<InferenceSendResult>(
           "inference_send",
           { body },
+          { timeoutMs },
         );
 
         if (!ipcResult.ok) {
-          if (jsonOutput) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
-            );
-          } else {
-            log.error(ipcResult.error ?? "Unknown error occurred");
-          }
-          process.exitCode = 1;
+          writeCliError(
+            ipcResult.error ?? "Unknown error occurred",
+            jsonOutput,
+          );
           return;
         }
 
@@ -179,9 +232,9 @@ export function registerInferenceCommand(program: Command): void {
     transport: "ipc",
     description: "LLM inference operations",
     build: (inference) => {
-  inference.addHelpText(
-    "after",
-    `
+      inference.addHelpText(
+        "after",
+        `
 The inference command group sends requests to your configured LLM provider.
 The provider is resolved from your assistant config (llm.default.provider).
 
@@ -191,11 +244,11 @@ Examples:
   $ assistant llm send --system-prompt "Be concise" "What is TCP?"
   $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
   $ assistant inference send --profile balanced "Explain RFC 1149"`,
-  );
+      );
 
-  attachSendSubcommand(inference);
-  attachSessionSubcommand(inference);
-  attachProvidersSubcommand(inference);
+      attachSendSubcommand(inference);
+      attachSessionSubcommand(inference);
+      attachProvidersSubcommand(inference);
     },
   });
 


### PR DESCRIPTION
## Summary

Related to LUM-1827. Follow-up to #31757 after the feedback logs became readable.

- Raise `assistant inference send` / `assistant llm send` IPC wait budget from the generic 60s default to 32 minutes.
- Add `--timeout-seconds` so long synchronous inference calls can opt into a different CLI wait budget.
- Add CLI coverage for the default timeout, custom timeout, invalid timeout, and help text.

## Root Cause

The feedback bundle showed `assistant inference send` returning `Request timed out` at about 60 seconds. The provider connection was a direct OpenAI API-key connection, and the full-model request did not appear as a completed provider request log. That points to the CLI IPC client default timeout, not only the provider SDK or gateway runtime timeout addressed in #31757.

## Validation

- `cd assistant && bun test src/cli/commands/__tests__/inference-send.test.ts`
- `cd assistant && bunx tsc --noEmit`
- Commit hook: Prettier, ESLint, assistant typecheck
- Pre-push hook: assistant typecheck and ESLint for changed files