### PR TITLE
feat(playground): per-pane llm.profiles override

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -5,7 +5,10 @@ import { Card } from "@vellum/design-library";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
-import { useSimulateMemoryRouter } from "@/domains/chat/inspector/memory-router-simulator-api.js";
+import {
+  useLlmProfiles,
+  useSimulateMemoryRouter,
+} from "@/domains/chat/inspector/memory-router-simulator-api.js";
 import type {
   MemoryRouterSimulateRequest,
   MemoryRouterSimulateResponse,
@@ -53,14 +56,22 @@ interface PaneOverrides {
   tier1: string;
   tier2: string;
   batch: string;
+  /** Profile name, or empty string for "inherit active". */
+  profile: string;
 }
 
-const EMPTY_OVERRIDES: PaneOverrides = { tier1: "", tier2: "", batch: "" };
+const EMPTY_OVERRIDES: PaneOverrides = {
+  tier1: "",
+  tier2: "",
+  batch: "",
+  profile: "",
+};
 
 function PlaygroundView(): ReactNode {
   const { assistantId } = useActiveAssistantContext();
   const mutationA = useSimulateMemoryRouter(assistantId);
   const mutationB = useSimulateMemoryRouter(assistantId);
+  const profilesQuery = useLlmProfiles(assistantId);
 
   const [query, setQuery] = useState("");
   const [overridesA, setOverridesA] = useState<PaneOverrides>(EMPTY_OVERRIDES);
@@ -82,9 +93,12 @@ function PlaygroundView(): ReactNode {
       );
       return;
     }
+    const profileOverride =
+      overrides.profile.trim().length > 0 ? overrides.profile : undefined;
     mutation.mutate({
       query: query.trim(),
       ...(configOverrides ? { configOverrides } : {}),
+      ...(profileOverride !== undefined ? { profileOverride } : {}),
     });
   };
 
@@ -110,6 +124,8 @@ function PlaygroundView(): ReactNode {
             onRun={() => runPane("A")}
             canRun={canRunA}
             isRunning={mutationA.isPending}
+            profiles={profilesQuery.data?.profiles ?? []}
+            activeProfile={profilesQuery.data?.activeProfile ?? null}
           />
           <PaneConfigForm
             paneId="B"
@@ -118,6 +134,8 @@ function PlaygroundView(): ReactNode {
             onRun={() => runPane("B")}
             canRun={canRunB}
             isRunning={mutationB.isPending}
+            profiles={profilesQuery.data?.profiles ?? []}
+            activeProfile={profilesQuery.data?.activeProfile ?? null}
           />
         </div>
         <div className="flex justify-end">
@@ -248,6 +266,8 @@ function PaneConfigForm({
   onRun,
   canRun,
   isRunning,
+  profiles,
+  activeProfile,
 }: {
   paneId: PaneId;
   overrides: PaneOverrides;
@@ -255,6 +275,8 @@ function PaneConfigForm({
   onRun: () => void;
   canRun: boolean;
   isRunning: boolean;
+  profiles: string[];
+  activeProfile: string | null;
 }): ReactNode {
   return (
     <Card>
@@ -285,6 +307,13 @@ function PaneConfigForm({
             onChange={(v) => onChange({ ...overrides, batch: v })}
           />
         </div>
+        <ProfileSelect
+          paneId={paneId}
+          value={overrides.profile}
+          onChange={(v) => onChange({ ...overrides, profile: v })}
+          profiles={profiles}
+          activeProfile={activeProfile}
+        />
         <div className="flex justify-end">
           <button
             type="button"
@@ -307,6 +336,55 @@ function PaneConfigForm({
         </div>
       </div>
     </Card>
+  );
+}
+
+function ProfileSelect({
+  paneId,
+  value,
+  onChange,
+  profiles,
+  activeProfile,
+}: {
+  paneId: PaneId;
+  value: string;
+  onChange: (value: string) => void;
+  profiles: string[];
+  activeProfile: string | null;
+}): ReactNode {
+  const inputId = `memory-router-playground-${paneId}-profile`;
+  const inheritLabel =
+    activeProfile !== null && activeProfile.length > 0
+      ? `inherit active (${activeProfile})`
+      : "inherit active";
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor={inputId}
+        className="text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        llm.profiles override
+      </label>
+      <select
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border px-3 py-2 text-body-medium-default"
+        style={{
+          borderColor: "var(--border-base)",
+          background: "var(--surface-base)",
+          color: "var(--content-default)",
+        }}
+      >
+        <option value="">{inheritLabel}</option>
+        {profiles.map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 }
 
@@ -608,7 +686,7 @@ function ConfigCard({
     "batch_size",
     "max_page_ids",
   ];
-  const rows = knobs.map((key) => {
+  const rows: Array<{ label: string; value: string }> = knobs.map((key) => {
     const eff = result.effectiveConfig[key];
     const overrideValue = (result.overrides as Record<
       string,
@@ -617,6 +695,13 @@ function ConfigCard({
     const effStr = eff === null ? "null" : String(eff);
     const suffix = overrideValue !== undefined ? "  (override)" : "";
     return { label: key, value: `${effStr}${suffix}` };
+  });
+  rows.push({
+    label: "llm.profiles override",
+    value:
+      result.profileOverride !== null
+        ? `${result.profileOverride}  (override)`
+        : "inherit active",
   });
   return (
     <Card>

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { client } from "@/generated/api/client.gen.js";
 
@@ -22,6 +22,8 @@ export interface MemoryRouterSimulateRequest {
     tier2_size?: number | null;
     batch_size?: number | null;
   };
+  /** Per-call `llm.profiles` override name. Omit to use the active profile. */
+  profileOverride?: string;
 }
 
 export interface MemoryRouterSimulateEffectiveConfig {
@@ -43,6 +45,13 @@ export interface MemoryRouterSimulateResponse {
     batch_size?: number | null;
   };
   totalCandidatePages: number;
+  /** Profile name passed as an override on this call, or null if none. */
+  profileOverride: string | null;
+}
+
+export interface LlmProfilesListResponse {
+  profiles: string[];
+  activeProfile: string | null;
 }
 
 export class SimulateMemoryRouterError extends Error {
@@ -96,5 +105,44 @@ export function useSimulateMemoryRouter(assistantId: string | undefined) {
       }
       return simulateMemoryRouter(assistantId, request);
     },
+  });
+}
+
+async function fetchLlmProfiles(
+  assistantId: string,
+  signal?: AbortSignal
+): Promise<LlmProfilesListResponse> {
+  const { data, response } = await client.get<LlmProfilesListResponse>({
+    url: "/v1/assistants/{assistant_id}/config/llm/profiles/",
+    path: { assistant_id: assistantId },
+    signal,
+    throwOnError: false,
+  });
+  if (!response || !response.ok) {
+    throw new SimulateMemoryRouterError(
+      response?.status ?? 0,
+      response?.statusText ?? "Failed to load LLM profiles"
+    );
+  }
+  if (!data) {
+    throw new SimulateMemoryRouterError(
+      response.status,
+      "Empty response from profile list endpoint"
+    );
+  }
+  return data;
+}
+
+export function useLlmProfiles(assistantId: string | undefined) {
+  return useQuery({
+    queryKey: ["llm-profiles", assistantId] as const,
+    queryFn: async ({ signal }): Promise<LlmProfilesListResponse> => {
+      if (!assistantId) {
+        throw new SimulateMemoryRouterError(0, "Missing assistantId");
+      }
+      return fetchLlmProfiles(assistantId, signal);
+    },
+    enabled: Boolean(assistantId),
+    staleTime: 60_000,
   });
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3652,6 +3652,19 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/config/llm/profiles:
+    get:
+      operationId: config_llm_profiles_get
+      summary: List defined LLM profiles
+      description:
+        Returns the sorted list of profile names defined in `llm.profiles` plus the workspace-wide active profile.
+        Used to populate per-call profile dropdowns (e.g. memory router playground) without requiring the caller to type
+        profile names.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
   /v1/config/llm/profiles/{name}:
     put:
       operationId: config_llm_profiles_by_name_put
@@ -11471,6 +11484,9 @@ paths:
                           maximum: 9007199254740991
                         - type: "null"
                   additionalProperties: false
+                profileOverride:
+                  type: string
+                  minLength: 1
               required:
                 - query
               additionalProperties: false

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -172,6 +172,14 @@ interface RunRouterParams {
    * only exercise tier 1 / tier 3 paths can omit it.
    */
   database?: DrizzleDb;
+  /**
+   * Per-call profile override forwarded to `getConfiguredProvider`. When
+   * set, the `memoryRouter` call site resolves against this profile name
+   * instead of the workspace active profile. The simulator route uses
+   * this to compare different profiles against the same query; live
+   * router callers leave it unset.
+   */
+  overrideProfile?: string;
 }
 
 /**
@@ -207,7 +215,11 @@ export async function runRouter(
     return emptyResult("empty_index");
   }
 
-  const provider = await getConfiguredProvider("memoryRouter");
+  const provider = await getConfiguredProvider("memoryRouter", {
+    ...(params.overrideProfile !== undefined
+      ? { overrideProfile: params.overrideProfile }
+      : {}),
+  });
   if (!provider) {
     log.warn("memoryRouter provider unavailable; router skipped");
     return emptyResult("no_provider");

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,6 +1,9 @@
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { loadConfig } from "../../config/loader.js";
-import { CALL_SITE_CATALOG, CALL_SITE_DOMAINS } from "../../config/schemas/call-site-catalog.js";
+import {
+  CALL_SITE_CATALOG,
+  CALL_SITE_DOMAINS,
+} from "../../config/schemas/call-site-catalog.js";
 import type { LLMCallSite } from "../../config/schemas/llm.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -10,11 +13,25 @@ async function handleGetCallSites() {
     domains: CALL_SITE_DOMAINS,
     callSites: CALL_SITE_CATALOG.map((entry) => ({
       ...entry,
-      defaultProfile: resolveDefaultProfileKey(
-        entry.id as LLMCallSite,
-        llm,
-      ),
+      defaultProfile: resolveDefaultProfileKey(entry.id as LLMCallSite, llm),
     })),
+  };
+}
+
+export interface LlmProfilesListResult {
+  /** Sorted list of profile names defined in `llm.profiles`. */
+  profiles: string[];
+  /** The workspace-wide active profile name, if one is set. */
+  activeProfile: string | null;
+}
+
+async function handleListProfiles(): Promise<LlmProfilesListResult> {
+  const { llm } = loadConfig();
+  const profiles = llm?.profiles ?? {};
+  return {
+    profiles: Object.keys(profiles).sort(),
+    activeProfile:
+      typeof llm?.activeProfile === "string" ? llm.activeProfile : null,
   };
 }
 
@@ -27,6 +44,16 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List LLM call sites",
     description:
       "Returns the full catalog of LLM call sites with display names, descriptions, and domain groupings. Used by clients to render the per-call-site override settings UI.",
+    tags: ["config"],
+  },
+  {
+    operationId: "llm_profiles_list",
+    method: "GET",
+    endpoint: "config/llm/profiles",
+    handler: handleListProfiles,
+    summary: "List defined LLM profiles",
+    description:
+      "Returns the sorted list of profile names defined in `llm.profiles` plus the workspace-wide active profile. Used to populate per-call profile dropdowns (e.g. memory router playground) without requiring the caller to type profile names.",
     tags: ["config"],
   },
 ];

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -351,6 +351,7 @@ const MemoryV2SimulateRouterParams = z
   .object({
     query: z.string().min(1, "query must be non-empty"),
     configOverrides: SimulateRouterOverridesSchema.optional(),
+    profileOverride: z.string().min(1).optional(),
   })
   .strict();
 
@@ -380,6 +381,8 @@ export interface MemoryV2SimulateRouterResult {
   };
   /** Page index size the router was given (post-tier-carve, all batches). */
   totalCandidatePages: number;
+  /** The profile name passed as a per-call override, if any. */
+  profileOverride: string | null;
 }
 
 /**
@@ -423,11 +426,32 @@ export async function handleSimulateRouter({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2SimulateRouterResult> {
   requireMemoryV2Enabled();
-  const { query, configOverrides } = MemoryV2SimulateRouterParams.parse(body);
+  const { query, configOverrides, profileOverride } =
+    MemoryV2SimulateRouterParams.parse(body);
 
   const liveConfig = loadConfig();
   const mergedConfig = applySimulateOverrides(liveConfig, configOverrides);
   const effectiveRouter = mergedConfig.memory.v2.router;
+
+  // Validate the requested profile name against the configured profile
+  // catalog so the caller gets a structured 400 instead of a silent fall-
+  // through (the resolver tolerates missing override-profile references by
+  // design, but the playground wants the user to know they typo'd).
+  if (profileOverride !== undefined) {
+    const profiles = liveConfig.llm?.profiles ?? {};
+    if (!Object.prototype.hasOwnProperty.call(profiles, profileOverride)) {
+      const available = Object.keys(profiles).sort();
+      const hint =
+        available.length > 0
+          ? ` Available profiles: ${available.join(", ")}.`
+          : " No profiles defined in llm.profiles.";
+      throw new RouteError(
+        `Profile "${profileOverride}" is not defined in llm.profiles.${hint}`,
+        "MEMORY_V2_SIMULATE_INVALID_PROFILE",
+        400,
+      );
+    }
+  }
 
   const workspaceDir = getWorkspaceDir();
   const nowText = await loadNowText(workspaceDir);
@@ -440,6 +464,9 @@ export async function handleSimulateRouter({
     priorEverInjected: [],
     config: mergedConfig,
     database: getDb(),
+    ...(profileOverride !== undefined
+      ? { overrideProfile: profileOverride }
+      : {}),
   });
 
   const pageIndex = await getPageIndex(workspaceDir);
@@ -482,6 +509,7 @@ export async function handleSimulateRouter({
         : {}),
     },
     totalCandidatePages: pageIndex.entries.length,
+    profileOverride: profileOverride ?? null,
   };
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -27,6 +27,8 @@ struct SettingsMemoryRouterPlaygroundTab: View {
     @State private var lastQuery: String = ""
     @State private var paneA = PaneState()
     @State private var paneB = PaneState()
+    @State private var availableProfiles: [String] = []
+    @State private var activeProfile: String?
 
     enum PaneId { case a, b }
 
@@ -34,6 +36,8 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         var tier1: String = ""
         var tier2: String = ""
         var batch: String = ""
+        /// Empty string means "inherit active profile".
+        var profile: String = ""
         var isRunning: Bool = false
         var validationError: String?
         var clientError: String?
@@ -58,6 +62,21 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task {
+            await loadProfiles()
+        }
+    }
+
+    private func loadProfiles() async {
+        do {
+            let response = try await client.fetchProfiles()
+            availableProfiles = response.profiles
+            activeProfile = response.activeProfile
+        } catch {
+            // Best-effort — leave the pickers empty. The user can still type
+            // an override into config.json directly or wait until profiles
+            // load on a later view appearance.
         }
     }
 
@@ -170,6 +189,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                 overrideField(label: "tier2_size", binding: tier2Binding(pane))
                 overrideField(label: "batch_size", binding: batchBinding(pane))
             }
+            profileField(pane: pane)
             HStack {
                 Spacer()
                 VButton(
@@ -184,6 +204,29 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
+    }
+
+    private func profileField(pane: PaneId) -> some View {
+        let inheritLabel: String
+        if let active = activeProfile, !active.isEmpty {
+            inheritLabel = "inherit active (\(active))"
+        } else {
+            inheritLabel = "inherit active"
+        }
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("llm.profiles override")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            Picker("", selection: profileBinding(pane)) {
+                Text(inheritLabel).tag("")
+                ForEach(availableProfiles, id: \.self) { name in
+                    Text(name).tag(name)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func overrideField(label: String, binding: Binding<String>) -> some View {
@@ -291,6 +334,10 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             metaRow(
                 label: "max_page_ids",
                 value: "\(result.effectiveConfig.maxPageIds)"
+            )
+            metaRow(
+                label: "llm.profiles override",
+                value: result.profileOverride.map { "\($0)  (override)" } ?? "inherit active"
             )
         }
         .padding(VSpacing.lg)
@@ -406,6 +453,10 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         pane == .a ? $paneA.batch : $paneB.batch
     }
 
+    private func profileBinding(_ pane: PaneId) -> Binding<String> {
+        pane == .a ? $paneA.profile : $paneB.profile
+    }
+
     private func canRun(_ pane: PaneId) -> Bool {
         !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !paneState(pane).isRunning
@@ -445,11 +496,14 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             return
         }
 
+        let profileTrimmed = state.profile.trimmingCharacters(in: .whitespacesAndNewlines)
+        let profileOverride: String? = profileTrimmed.isEmpty ? nil : profileTrimmed
         let input = MemoryRouterSimulateInput(
             query: trimmedQuery,
             tier1Size: tier1Override,
             tier2Size: tier2Override,
-            batchSize: batchOverride
+            batchSize: batchOverride,
+            profileOverride: profileOverride
         )
 
         setIsRunning(pane: pane, value: true)

--- a/clients/shared/Network/MemoryRouterPlaygroundClient.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundClient.swift
@@ -42,6 +42,18 @@ public struct MemoryRouterPlaygroundClient: Sendable {
         )
     }
 
+    /// Fetches the workspace's defined `llm.profiles` for populating the
+    /// playground's per-pane profile picker.
+    public func fetchProfiles() async throws -> LlmProfilesListResponse {
+        let path = "config/llm/profiles/"
+        let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(
+            LlmProfilesListResponse.self,
+            from: response.data
+        )
+    }
+
     /// Construct the JSON dict the daemon expects. Built by hand because the
     /// override fields have three states (inherit / value / explicit-null)
     /// and a plain Codable `Encodable` would conflate "absent" with "null".
@@ -53,6 +65,9 @@ public struct MemoryRouterPlaygroundClient: Sendable {
         addOverride(input.batchSize, key: "batch_size", into: &overrides)
         if !overrides.isEmpty {
             body["configOverrides"] = overrides
+        }
+        if let profile = input.profileOverride {
+            body["profileOverride"] = profile
         }
         return body
     }

--- a/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
@@ -25,17 +25,21 @@ public struct MemoryRouterSimulateInput: Equatable, Sendable {
     public let tier1Size: MemoryRouterOverride
     public let tier2Size: MemoryRouterOverride
     public let batchSize: MemoryRouterOverride
+    /// Per-call `llm.profiles` override name. `nil` means "inherit active".
+    public let profileOverride: String?
 
     public init(
         query: String,
         tier1Size: MemoryRouterOverride = .inherit,
         tier2Size: MemoryRouterOverride = .inherit,
-        batchSize: MemoryRouterOverride = .inherit
+        batchSize: MemoryRouterOverride = .inherit,
+        profileOverride: String? = nil
     ) {
         self.query = query
         self.tier1Size = tier1Size
         self.tier2Size = tier2Size
         self.batchSize = batchSize
+        self.profileOverride = profileOverride
     }
 }
 
@@ -118,4 +122,13 @@ public struct MemoryRouterSimulateResponse: Decodable, Sendable {
     public let overrides: MemoryRouterReportedOverrides
     /// Page index size the router was given (post-tier-carve, all batches).
     public let totalCandidatePages: Int
+    /// Profile name passed as an override on this call, or `nil` if none.
+    public let profileOverride: String?
+}
+
+/// Response from `GET /v1/assistants/{id}/config/llm/profiles/`. Used to
+/// populate per-pane profile dropdowns in the playground.
+public struct LlmProfilesListResponse: Decodable, Sendable {
+    public let profiles: [String]
+    public let activeProfile: String?
 }


### PR DESCRIPTION
## Summary

- Each memory-router-playground pane (web + macOS) can now pick which `llm.profiles.<name>` to resolve the `memoryRouter` call against. Lets you compare two profiles head-to-head on the same query.
- New `GET /v1/config/llm/profiles` populates the per-pane dropdown with the list of defined profile names (plus the active profile for the inherit label).
- `runRouter` accepts an optional `overrideProfile` threaded to `getConfiguredProvider`; live callers leave it unset, preserving today's behavior.

## Why

Profile tuning is the next dimension the playground needs to cover. The tier/batch knobs answer "what would the router pick"; profile selection answers "which provider+model is doing the picking". Together they let an operator validate both decisions side-by-side before flipping the live config.

## Test plan

- [x] `cd assistant && bunx tsc --noEmit` clean
- [x] `cd apps/web && bunx tsc --noEmit` clean for the playground files
- [x] `cd clients && swift build --target VellumAssistantLib` clean
- [x] Format / lint / pre-commit hooks pass
- [ ] Web smoke: open playground, pick different profiles in pane A vs B with the same query, confirm "Effective config" shows the override and diff coloring reflects any selection drift.
- [ ] macOS smoke: rebuild, repeat above scenario.
- [ ] Negative path: type a nonexistent profile in the web (you can do this via the simulator request directly) and confirm a 400 with the available-profile hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)