### PR TITLE
Add conversationId to inspector LLM context query

### DIFF
--- a/apps/web/src/domains/chat/inspector/inspector-api.test.ts
+++ b/apps/web/src/domains/chat/inspector/inspector-api.test.ts
@@ -79,10 +79,7 @@ beforeEach(() => {
   mockMessages = [];
 });
 
-function staticLog(
-  id: string,
-  createdAt: number,
-): LLMRequestLogEntry {
+function staticLog(id: string, createdAt: number): LLMRequestLogEntry {
   return {
     id,
     createdAt,
@@ -115,7 +112,10 @@ describe("fetchConversationLlmContext — happy path", () => {
       "/v1/assistants/{assistant_id}/conversations/llm-context/",
     );
     expect(requests[0]!.path).toEqual({ assistant_id: "asst-1" });
-    expect(requests[0]!.query).toEqual({ conversationKey: "conv-1" });
+    expect(requests[0]!.query).toEqual({
+      conversationId: "conv-1",
+      conversationKey: "conv-1",
+    });
     expect(result).toEqual(body);
   });
 

--- a/apps/web/src/domains/chat/inspector/inspector-api.ts
+++ b/apps/web/src/domains/chat/inspector/inspector-api.ts
@@ -1,4 +1,3 @@
-
 import { queryOptions, useQuery } from "@tanstack/react-query";
 
 import {
@@ -6,7 +5,10 @@ import {
   client,
   extractErrorMessage,
 } from "@/domains/chat/api/client.js";
-import { fetchConversationMessages, type RuntimeMessage } from "@/domains/chat/api/messages.js";
+import {
+  fetchConversationMessages,
+  type RuntimeMessage,
+} from "@/domains/chat/api/messages.js";
 
 import type {
   LlmContextResponse,
@@ -145,7 +147,7 @@ export async function fetchConversationLlmContext(
   const { data, error, response } = await client.get<LlmContextResponse>({
     url: "/v1/assistants/{assistant_id}/conversations/llm-context/",
     path: { assistant_id: assistantId },
-    query: { conversationKey },
+    query: { conversationId: conversationKey, conversationKey },
     signal,
     throwOnError: false,
   });
@@ -161,7 +163,11 @@ export async function fetchConversationLlmContext(
   }
 
   if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to load LLM context");
+    const msg = extractErrorMessage(
+      error,
+      response,
+      "Failed to load LLM context",
+    );
     throw new LlmContextRequestError(response.status, msg);
   }
 
@@ -194,7 +200,11 @@ export async function fetchMessageLlmContextOrThrow(
   });
   assertHasResponse(response, error, "Failed to fetch message LLM context");
   if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to load LLM context");
+    const msg = extractErrorMessage(
+      error,
+      response,
+      "Failed to load LLM context",
+    );
     throw new LlmContextRequestError(response.status, msg);
   }
   if (!data) {


### PR DESCRIPTION
## Summary
- Adds `conversationId` alongside `conversationKey` in the inspector's `fetchConversationLlmContext` query params
- Updates the corresponding test assertion

## Context
Follow-up to #31760 and #31774. The inspector's `/conversations/llm-context/` endpoint was still only sending `conversationKey`, which depends on the `conversation_keys` DB table. Adding `conversationId` lets the server resolve directly against the `conversations` table.

## Test plan
- [x] Updated inspector-api test
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)