### PR TITLE
fix(web): create new conversation when suggestion chip is clicked

### DIFF
--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -61,6 +61,9 @@ import { TracePage } from "@/domains/logs/pages/trace-page.js";
 import { UsagePage } from "@/domains/logs/pages/usage-page.js";
 import { SystemEventsPage } from "@/domains/logs/pages/system-events-page.js";
 import { EmailsPage } from "@/domains/logs/pages/emails-page.js";
+import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
 import { routes } from "@/utils/routes.js";
 
 /**
@@ -95,9 +98,14 @@ function HomePageRoute() {
       onOpenConversation={(conversationId) =>
         navigate(routes.conversation(conversationId))
       }
-      onSuggestionSelected={(prompt) =>
-        navigate(`${routes.assistant}?prompt=${encodeURIComponent(prompt)}`)
-      }
+      onSuggestionSelected={(prompt) => {
+        useViewerStore.getState().setMainView("chat");
+        const draftKey = createDraftConversationKey();
+        useConversationStore.getState().setActiveKey(draftKey);
+        navigate(
+          `${routes.conversation(draftKey)}?prompt=${encodeURIComponent(prompt)}`,
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Home page suggestion chips were sending the prompt into the last-viewed conversation instead of creating a new one
- Root cause: `onSuggestionSelected` navigated to `/assistant?prompt=...` which resolved to an existing conversation via `resolveBootstrappedConversationKey`
- Fix: create a fresh draft conversation key, set it as active in the Zustand store, and navigate to `/assistant/conversations/:draftKey?prompt=...` — matching platform web's `startNewConversation({ initialMessage })` behavior

## Test plan
- [ ] Go to the home page, click a suggestion chip → should open a **new** conversation and send the prompt
- [ ] Verify the prompt appears as a user message in the new conversation
- [ ] Verify the assistant responds to the prompt
- [ ] Verify clicking "New Chat" from the home page still works correctly
- [ ] Verify opening an existing conversation from the home feed still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)