### PR TITLE
fix(web): add viewport-fit=cover so iOS Capacitor exposes safe-area insets

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- viewport-fit=cover is required for iOS WKWebView to expose env(safe-area-inset-*);
+       without it the Capacitor shell renders under the notch / home indicator. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <link rel="icon" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>


### PR DESCRIPTION
## Summary

- The main `apps/web/index.html` was missing `viewport-fit=cover` on its viewport meta tag. Without it, iOS WKWebView does not expose `env(safe-area-inset-*)` — they all resolve to `0`.
- That made the safe-area padding on `root-layout.tsx` (bottom/left/right) and the `safe-area-inset-top` compensation in `chat-layout-header.tsx`, `settings-shell.tsx`, onboarding screens, etc. all no-ops in the Capacitor iOS shell.
- Result: routes like `/assistant/home` rendered under the notch / home indicator on iOS.
- The Capacitor shell (`capacitor-shell/index.html`) already had `viewport-fit=cover`, but Capacitor loads the deployed web app via `server.url`, so the main `index.html` is what actually ships to the iOS app.

## Test plan

- [ ] Build/sync the iOS app (`bunx cap sync ios`) against a deploy that includes this change and open `/assistant/home` on a device with a notch — header content sits below the status bar, content sits above the home indicator.
- [ ] Verify other safe-area consumers still look right: `SettingsLayout` top bar, onboarding screens (name-step, vibe-step), mobile sidebar drawer, attachment preview modal.
- [ ] Confirm desktop / non-notch browsers are unaffected (env() values are already 0 there).

https://claude.ai/code/session_01ET9ezsQqDnfV46fPEUTToa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ET9ezsQqDnfV46fPEUTToa)_