### PR TITLE
fix(assistant): register route policy for config/llm/profiles endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -417,6 +417,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // LLM call site catalog
   { endpoint: "config/llm/call-sites:GET", scopes: ["settings.read"] },
+  { endpoint: "config/llm/profiles:GET", scopes: ["settings.read"] },
 
   // Conversation management
   { endpoint: "conversations:DELETE", scopes: ["chat.write"] },


### PR DESCRIPTION
## Summary
- Add `config/llm/profiles:GET` to `ACTOR_ENDPOINTS` in `route-policy.ts` with `settings.read` scope, matching the existing `config/llm/call-sites:GET` entry.
- Fixes the guard test failure in `src/runtime/auth/__tests__/guard-tests.test.ts` introduced by #31778 (per-pane `llm.profiles` override), which added the endpoint to `llm-call-sites-routes.ts` without a corresponding policy entry.

## Original prompt
Fix the specific CI failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/26307603724/job/77448187437 only — the guard test asserting every endpoint dispatched in `http-server.ts` has a policy entry in `route-policy.ts`.