### PR TITLE
fix(web): hide mainAgent row from Action Overrides modal

### DIFF
--- a/apps/web/src/domains/settings/ai/call-site-overrides-modal.tsx
+++ b/apps/web/src/domains/settings/ai/call-site-overrides-modal.tsx
@@ -180,8 +180,11 @@ function CallSiteOverridesModalInner({
     refetchOnWindowFocus: false,
   });
 
+  // mainAgent is controlled by the main inference card / Default Profile, not this
+  // modal. Filter it out here so we don't render a row whose edits we'd silently
+  // drop in Save/Reset (LUM-1830).
   const gatedCallSites = useMemo(() => {
-    const all = catalog?.callSites ?? [];
+    const all = (catalog?.callSites ?? []).filter((cs) => cs.id !== "mainAgent");
     if (analyzeConversationEnabled) return all;
     return all.filter((cs) => cs.id !== "analyzeConversation");
   }, [catalog, analyzeConversationEnabled]);
@@ -232,7 +235,6 @@ function CallSiteOverridesModalInner({
     () =>
       Object.entries(persistedOverrides).some(
         ([id, s]) =>
-          id !== "mainAgent" &&
           gatedCallSiteIdSet.has(id) &&
           (s?.profile != null || s?.provider != null || s?.model != null),
       ),
@@ -247,7 +249,6 @@ function CallSiteOverridesModalInner({
     // Use catalog IDs only (keys of drafts) — orphaned stale overrides in
     // persistedOverrides that aren't in the catalog stay untouched.
     for (const id of Object.keys(drafts)) {
-      if (id === "mainAgent") continue;
       if (!draftsEqual(drafts[id], persistedOverrides[id])) return true;
     }
     return false;
@@ -393,7 +394,6 @@ function CallSiteOverridesModalInner({
       // Use catalog IDs only (keys of drafts) — orphaned stale overrides stay untouched.
       const patch: Record<string, CallSiteOverrideDraft | null> = {};
       for (const id of Object.keys(drafts)) {
-        if (id === "mainAgent") continue; // managed by the main inference card, not this modal
         const d = drafts[id] ?? null;
         patch[id] = isDraftActive(d)
           ? { profile: d?.profile ?? null, provider: d?.provider ?? null, model: d?.model ?? null }
@@ -428,7 +428,6 @@ function CallSiteOverridesModalInner({
       // Use catalog IDs only (keys of drafts) — orphaned stale overrides stay untouched.
       const resetPatch: Record<string, null> = {};
       for (const id of Object.keys(drafts)) {
-        if (id === "mainAgent") continue; // managed by the main inference card, not this modal
         resetPatch[id] = null;
       }
       await client.patch({


### PR DESCRIPTION
## Summary

Fixes [LUM-1830](https://linear.app/vellum/issue/LUM-1830/bug-hide-or-persist-main-agent-in-action-overrides).

The Action Overrides modal showed a `Main Agent` row that looked editable but whose changes were silently dropped on Save and Reset. `mainAgent` is controlled by the main inference card / Default Profile, not by this modal, so the existing handlers explicitly skipped it when building the PATCH.

Filter `mainAgent` out at the source (`gatedCallSites`) so the modal only renders rows it actually persists. The now-redundant `id === "mainAgent"` skip checks in dirty-state, Save, and Reset are removed since drafts no longer contain that id.

Note: `ai-page.tsx`'s `overrideCount` still excludes `mainAgent` because `daemonConfig.llm.callSites` can legitimately carry a `mainAgent` entry (written by the main inference card) — that exclusion is about counting persisted overrides, not modal rendering.

## Test plan

- [ ] Open Action Overrides modal — `Main Agent` row no longer appears
- [ ] Change provider/model in the main inference card — still persists as before
- [ ] Toggle/edit other call-site overrides — Save and Reset still work
- [ ] Override count badge on the Overrides button still matches the number of non-`mainAgent` persisted overrides

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBMXKchxrGCz6ReZnVYkw6)_