### PR TITLE
feat(playground): surface full router union without max_page_ids truncation

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -651,7 +651,7 @@ function SummaryCard({
     },
     {
       label: "Selected",
-      value: `${result.selectedSlugs.length} / ${result.effectiveConfig.max_page_ids}`,
+      value: `${result.selectedSlugs.length}  (live max_page_ids: ${result.effectiveConfig.max_page_ids})`,
     },
   ];
   if (otherResult !== undefined) {

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -180,6 +180,13 @@ interface RunRouterParams {
    * router callers leave it unset.
    */
   overrideProfile?: string;
+  /**
+   * Skip the post-union truncation to `max_page_ids`. Used by the
+   * simulator so the playground can show the full untruncated router
+   * output across all batches. Live callers (`injectViaRouter`) leave
+   * this unset so the bounded-injection contract holds.
+   */
+  disableUnionCap?: boolean;
 }
 
 /**
@@ -314,15 +321,18 @@ export async function runRouter(
   // exceed it (e.g. 10 batches × 10 selections each ≫ 25 cap). Apply a final
   // truncation so RouterResult honors the contract that injection.ts trusts.
   // Iteration order above is tier 1 → tier 2 → tier 3:0 → … so earlier-tier
-  // slugs win the truncation.
-  const maxPageIds = config.memory?.v2?.router?.max_page_ids ?? 25;
-  if (selectedSlugs.length > maxPageIds) {
-    log.warn(
-      { unionSize: selectedSlugs.length, max: maxPageIds },
-      "Router union across batches exceeded max_page_ids; truncating",
-    );
-    const dropped = selectedSlugs.splice(maxPageIds);
-    for (const slug of dropped) sourceBySlug.delete(slug);
+  // slugs win the truncation. The simulator passes `disableUnionCap` so the
+  // playground can show the full untruncated union for analysis.
+  if (!params.disableUnionCap) {
+    const maxPageIds = config.memory?.v2?.router?.max_page_ids ?? 25;
+    if (selectedSlugs.length > maxPageIds) {
+      log.warn(
+        { unionSize: selectedSlugs.length, max: maxPageIds },
+        "Router union across batches exceeded max_page_ids; truncating",
+      );
+      const dropped = selectedSlugs.splice(maxPageIds);
+      for (const slug of dropped) sourceBySlug.delete(slug);
+    }
   }
   return { selectedSlugs, sourceBySlug, failureReason: null };
 }

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -467,6 +467,12 @@ export async function handleSimulateRouter({
     ...(profileOverride !== undefined
       ? { overrideProfile: profileOverride }
       : {}),
+    // Always return the full union — the simulator's job is to surface
+    // what the router actually picked across all batches, not what
+    // injection.ts would have trimmed it to. The `max_page_ids` knob is
+    // still echoed in `effectiveConfig` so the UI can show the live cap
+    // as informational context.
+    disableUnionCap: true,
   });
 
   const pageIndex = await getPageIndex(workspaceDir);

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -291,7 +291,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             )
             metaRow(
                 label: "Selected",
-                value: "\(result.selectedSlugs.count) / \(result.effectiveConfig.maxPageIds)"
+                value: "\(result.selectedSlugs.count)  (live max_page_ids: \(result.effectiveConfig.maxPageIds))"
             )
             if otherResult != nil {
                 metaRow(


### PR DESCRIPTION
## Summary

- Simulator route passes `disableUnionCap: true` to `runRouter`, skipping the post-union truncation.
- The playground now shows the complete set of slugs every batch picked. No more "tier3:b0 filled the budget, the rest of the batches are silently dropped" confusion.
- Live behavior unchanged: `injectViaRouter` doesn't set the flag, so the bounded-injection contract still holds for the real router.
- UI summary updated: "Selected: N  (live max_page_ids: M)" — the cap is still surfaced as informational context.

## Why

With `batch_size` set, the orchestrator unions per-batch results in tier-then-batch-index order and truncates to `max_page_ids`. Batches with low indices win the truncation regardless of relevance — a quality slug in `tier3:b14` can be dropped entirely if `tier3:b0..b8` already filled the budget. Hiding that drop made it impossible to compare batched configs honestly in the playground.

## Test plan

- [x] `cd assistant && bunx tsc --noEmit` clean
- [x] `cd apps/web && bunx tsc --noEmit` clean for playground files
- [x] `cd clients && swift build --target VellumAssistantLib` clean
- [ ] Run the same "tell me about everyone in my life" query in both panes (A: `batch_size=inherit`, B: `batch_size=100`); pane B should now show the full ~450 slug union instead of being capped at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)