### PR TITLE
fix(macos): prevent duplicate self-signed cert creation on every build

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -316,8 +316,11 @@ if [ -z "${SIGN_IDENTITY:-}" ]; then
         # A self-signed cert satisfies this without Apple Developer enrollment.
         if [ -z "$SIGN_IDENTITY" ] && command -v openssl >/dev/null 2>&1; then
             _CERT_CN="Vellum Local Development"
-            # Check if we already created this cert in a previous build
-            if ! _valid_codesign_identities | grep -q "$_CERT_CN"; then
+            # Check if we already created this cert in a previous build.
+            # Use find-identity WITHOUT -v: self-signed certs are untrusted
+            # (CSSMERR_TP_NOT_TRUSTED) so -v filters them out, causing a new
+            # cert to be created on every build invocation.
+            if ! security find-identity -p codesigning 2>/dev/null | grep -q "$_CERT_CN"; then
                 echo ""
                 echo "No codesigning certificate found in keychain."
                 echo "Creating self-signed certificate '$_CERT_CN' for local development..."


### PR DESCRIPTION
## Summary
- The self-signed certificate existence check used `security find-identity -v` which only shows **trusted** identities. Self-signed certs are always `CSSMERR_TP_NOT_TRUSTED`, so the check always failed and a new cert was created on every `build.sh` invocation.
- Changed the check to use `security find-identity` without `-v` (matching the pattern already used at line 398), so existing self-signed certs are detected and no duplicates are created.

## Original prompt
The macOS app failed to launch because dozens of duplicate "Vellum Local Development" certificates accumulated in the login keychain, causing a `security` ambiguity error. The root cause was that `build.sh` used `-v` (valid/trusted only) when checking for existing self-signed certs, but self-signed certs are never trusted, so a new one was created on every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)