### PR TITLE
fix(ios): wire up safe-area bridge so content clears the status bar

### DIFF
--- a/apps/ios/App/App/MyViewController.swift
+++ b/apps/ios/App/App/MyViewController.swift
@@ -44,13 +44,13 @@ class MyViewController: CAPBridgeViewController {
     /// Note: this alone does not make `env(safe-area-inset-*)` return
     /// non-zero values inside Capacitor's WKWebView (WebKit bug #191872,
     /// plus the `contentInset: "never"` interaction documented in
-    /// Capacitor issue #2149). That's why we also ship
-    /// `capacitor-plugin-safe-area` + `<SafeAreaBridge>` on the web side,
-    /// which reads `window.safeAreaInsets` natively and injects it as
-    /// `--safe-area-inset-*` CSS custom properties. This user script is
-    /// still useful because `viewport-fit=cover` is what lets the
-    /// WKWebView extend its surface under the notch and home indicator
-    /// in the first place.
+    /// Capacitor issue #2149). The web side bridges this gap via
+    /// `initSafeAreaBridge()` (`runtime/native-safe-area.ts`), which
+    /// calls `capacitor-plugin-safe-area` to read insets natively and
+    /// injects them as `--safe-area-inset-*` CSS custom properties.
+    /// This user script is still useful because `viewport-fit=cover` is
+    /// what lets the WKWebView extend its surface under the notch and
+    /// home indicator in the first place.
     private func installViewportFitCoverUserScript() {
         guard let contentController = webView?.configuration.userContentController else { return }
         let source = """

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,9 @@ import "@/lib/sentry/sentry-init.js";
 import "@/lib/api-interceptors.js";
 import "./index.css";
 
+import { initSafeAreaBridge } from "@/runtime/native-safe-area.js";
+
+initSafeAreaBridge();
 setupOrganizationStore();
 useAuthStore.getState().initSession();
 setupAuthListeners();

--- a/apps/web/src/runtime/native-safe-area.ts
+++ b/apps/web/src/runtime/native-safe-area.ts
@@ -1,0 +1,38 @@
+import { Capacitor } from "@capacitor/core";
+import { SafeArea } from "capacitor-plugin-safe-area";
+
+function applyInsets(insets: {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}) {
+  const style = document.documentElement.style;
+  style.setProperty("--safe-area-inset-top", `${insets.top}px`);
+  style.setProperty("--safe-area-inset-right", `${insets.right}px`);
+  style.setProperty("--safe-area-inset-bottom", `${insets.bottom}px`);
+  style.setProperty("--safe-area-inset-left", `${insets.left}px`);
+}
+
+let initialized = false;
+
+export async function initSafeAreaBridge(): Promise<void> {
+  if (initialized) return;
+  if (typeof window === "undefined" || !Capacitor.isNativePlatform()) return;
+  initialized = true;
+
+  try {
+    const { insets } = await SafeArea.getSafeAreaInsets();
+    applyInsets(insets);
+  } catch {
+    // Plugin unavailable or not registered — fall through to env() fallback.
+  }
+
+  try {
+    await SafeArea.addListener("safeAreaChanged", ({ insets }) => {
+      applyInsets(insets);
+    });
+  } catch {
+    // Listener registration failed — initial insets are still applied.
+  }
+}


### PR DESCRIPTION
## Summary

- The `capacitor-plugin-safe-area` native plugin was installed and registered in the iOS project but **never called from the web side**. `env(safe-area-inset-*)` returns `0` in Capacitor's WKWebView when `contentInset: "never"` is set (WebKit bug #191872), so all safe-area padding resolved to `0px` and content rendered behind the status bar / Dynamic Island.
- Added `initSafeAreaBridge()` in `runtime/native-safe-area.ts` — reads native insets via the plugin and sets `--safe-area-inset-*` CSS custom properties on `:root`. All 8 existing consumers already use `var(--safe-area-inset-*, env(safe-area-inset-*, 0px))` and pick up the values automatically with zero UI changes.
- Listens for `safeAreaChanged` events to handle device rotation.

## Test plan

- [ ] Build and run on iOS device (iPhone with notch or Dynamic Island)
- [ ] Verify header content (settings gear, title, "Go to Convo" button) sits below the status bar
- [ ] Rotate device — verify safe area adjusts correctly
- [ ] Verify no regression on web (bridge is a no-op when `Capacitor.isNativePlatform()` is false)
- [ ] Check onboarding screens, settings, mobile sidebar drawer all respect safe area

🤖 Generated with [Claude Code](https://claude.com/claude-code)