### PR TITLE
feat(playground): per-pane router system prompt override

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -6,6 +6,7 @@ import { Card } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
 import {
+  useDefaultRouterPromptTemplate,
   useLlmProfiles,
   useSimulateMemoryRouter,
 } from "@/domains/chat/inspector/memory-router-simulator-api.js";
@@ -58,6 +59,8 @@ interface PaneOverrides {
   batch: string;
   /** Profile name, or empty string for "inherit active". */
   profile: string;
+  /** Inline router prompt override; empty = use bundled. */
+  customPrompt: string;
 }
 
 const EMPTY_OVERRIDES: PaneOverrides = {
@@ -65,6 +68,7 @@ const EMPTY_OVERRIDES: PaneOverrides = {
   tier2: "",
   batch: "",
   profile: "",
+  customPrompt: "",
 };
 
 function PlaygroundView(): ReactNode {
@@ -72,6 +76,7 @@ function PlaygroundView(): ReactNode {
   const mutationA = useSimulateMemoryRouter(assistantId);
   const mutationB = useSimulateMemoryRouter(assistantId);
   const profilesQuery = useLlmProfiles(assistantId);
+  const promptTemplateQuery = useDefaultRouterPromptTemplate(assistantId);
 
   const [query, setQuery] = useState("");
   const [overridesA, setOverridesA] = useState<PaneOverrides>(EMPTY_OVERRIDES);
@@ -95,10 +100,15 @@ function PlaygroundView(): ReactNode {
     }
     const profileOverride =
       overrides.profile.trim().length > 0 ? overrides.profile : undefined;
+    const routerPromptOverride =
+      overrides.customPrompt.trim().length > 0
+        ? overrides.customPrompt
+        : undefined;
     mutation.mutate({
       query: query.trim(),
       ...(configOverrides ? { configOverrides } : {}),
       ...(profileOverride !== undefined ? { profileOverride } : {}),
+      ...(routerPromptOverride !== undefined ? { routerPromptOverride } : {}),
     });
   };
 
@@ -126,6 +136,7 @@ function PlaygroundView(): ReactNode {
             isRunning={mutationA.isPending}
             profiles={profilesQuery.data?.profiles ?? []}
             activeProfile={profilesQuery.data?.activeProfile ?? null}
+            defaultPromptTemplate={promptTemplateQuery.data?.template ?? ""}
           />
           <PaneConfigForm
             paneId="B"
@@ -136,6 +147,7 @@ function PlaygroundView(): ReactNode {
             isRunning={mutationB.isPending}
             profiles={profilesQuery.data?.profiles ?? []}
             activeProfile={profilesQuery.data?.activeProfile ?? null}
+            defaultPromptTemplate={promptTemplateQuery.data?.template ?? ""}
           />
         </div>
         <div className="flex justify-end">
@@ -268,6 +280,7 @@ function PaneConfigForm({
   isRunning,
   profiles,
   activeProfile,
+  defaultPromptTemplate,
 }: {
   paneId: PaneId;
   overrides: PaneOverrides;
@@ -277,6 +290,7 @@ function PaneConfigForm({
   isRunning: boolean;
   profiles: string[];
   activeProfile: string | null;
+  defaultPromptTemplate: string;
 }): ReactNode {
   return (
     <Card>
@@ -314,6 +328,12 @@ function PaneConfigForm({
           profiles={profiles}
           activeProfile={activeProfile}
         />
+        <PromptEditor
+          paneId={paneId}
+          value={overrides.customPrompt}
+          onChange={(v) => onChange({ ...overrides, customPrompt: v })}
+          defaultTemplate={defaultPromptTemplate}
+        />
         <div className="flex justify-end">
           <button
             type="button"
@@ -336,6 +356,100 @@ function PaneConfigForm({
         </div>
       </div>
     </Card>
+  );
+}
+
+function PromptEditor({
+  paneId,
+  value,
+  onChange,
+  defaultTemplate,
+}: {
+  paneId: PaneId;
+  value: string;
+  onChange: (value: string) => void;
+  defaultTemplate: string;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const inputId = `memory-router-playground-${paneId}-prompt`;
+  const usingCustom = value.trim().length > 0;
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="text-label-default"
+          style={{
+            color: "var(--content-secondary)",
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          {open ? "▾" : "▸"} System prompt{" "}
+          <span style={{ color: "var(--content-tertiary)" }}>
+            ({usingCustom ? "custom" : "bundled"})
+          </span>
+        </button>
+        {open && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onChange(defaultTemplate)}
+              disabled={defaultTemplate.length === 0}
+              className="rounded px-2 py-1 text-label-default"
+              style={{
+                background: "var(--surface-overlay)",
+                color: "var(--content-secondary)",
+                border: "none",
+                cursor:
+                  defaultTemplate.length === 0 ? "not-allowed" : "pointer",
+              }}
+            >
+              Load default
+            </button>
+            <button
+              type="button"
+              onClick={() => onChange("")}
+              disabled={!usingCustom}
+              className="rounded px-2 py-1 text-label-default"
+              style={{
+                background: "var(--surface-overlay)",
+                color: "var(--content-secondary)",
+                border: "none",
+                cursor: usingCustom ? "pointer" : "not-allowed",
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        )}
+      </div>
+      {open && (
+        <textarea
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={12}
+          placeholder={
+            'Custom router system prompt. Available placeholders:\n  {{ASSISTANT_NAME}}, {{USER_NAME}}, {{PAGE_INDEX}}\nLeave blank to use the bundled template. "Load default" seeds the textarea with the bundled body for editing.'
+          }
+          className="rounded-md border px-3 py-2 text-body-small-default"
+          style={{
+            borderColor: "var(--border-base)",
+            background: "var(--surface-base)",
+            color: "var(--content-default)",
+            fontFamily:
+              "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            resize: "vertical",
+            minHeight: "120px",
+          }}
+        />
+      )}
+    </div>
   );
 }
 
@@ -702,6 +816,10 @@ function ConfigCard({
       result.profileOverride !== null
         ? `${result.profileOverride}  (override)`
         : "inherit active",
+  });
+  rows.push({
+    label: "system prompt",
+    value: result.routerPromptOverridden ? "custom" : "bundled",
   });
   return (
     <Card>

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -24,6 +24,11 @@ export interface MemoryRouterSimulateRequest {
   };
   /** Per-call `llm.profiles` override name. Omit to use the active profile. */
   profileOverride?: string;
+  /**
+   * Inline router system-prompt override. Empty / whitespace-only strings
+   * are treated as no-override server-side.
+   */
+  routerPromptOverride?: string;
 }
 
 export interface MemoryRouterSimulateEffectiveConfig {
@@ -47,6 +52,8 @@ export interface MemoryRouterSimulateResponse {
   totalCandidatePages: number;
   /** Profile name passed as an override on this call, or null if none. */
   profileOverride: string | null;
+  /** True when an inline router prompt override was applied this call. */
+  routerPromptOverridden: boolean;
 }
 
 export interface LlmProfilesListResponse {
@@ -144,5 +151,51 @@ export function useLlmProfiles(assistantId: string | undefined) {
     },
     enabled: Boolean(assistantId),
     staleTime: 60_000,
+  });
+}
+
+interface RouterPromptTemplateResponse {
+  template: string;
+}
+
+async function fetchRouterPromptTemplate(
+  assistantId: string,
+  signal?: AbortSignal
+): Promise<RouterPromptTemplateResponse> {
+  const { data, response } = await client.get<RouterPromptTemplateResponse>({
+    url: "/v1/assistants/{assistant_id}/memory/v2/router-prompt-template/",
+    path: { assistant_id: assistantId },
+    signal,
+    throwOnError: false,
+  });
+  if (!response || !response.ok) {
+    throw new SimulateMemoryRouterError(
+      response?.status ?? 0,
+      response?.statusText ?? "Failed to load router prompt template"
+    );
+  }
+  if (!data) {
+    throw new SimulateMemoryRouterError(
+      response.status,
+      "Empty response from router prompt template endpoint"
+    );
+  }
+  return data;
+}
+
+export function useDefaultRouterPromptTemplate(
+  assistantId: string | undefined
+) {
+  return useQuery({
+    queryKey: ["router-prompt-template", assistantId] as const,
+    queryFn: async ({ signal }): Promise<RouterPromptTemplateResponse> => {
+      if (!assistantId) {
+        throw new SimulateMemoryRouterError(0, "Missing assistantId");
+      }
+      return fetchRouterPromptTemplate(assistantId, signal);
+    },
+    enabled: Boolean(assistantId),
+    // The template only changes when the daemon ships, so cache aggressively.
+    staleTime: 24 * 60 * 60 * 1000,
   });
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11438,6 +11438,19 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v2/router-prompt-template:
+    get:
+      operationId: memory_v2_routerprompttemplate_get
+      summary: Return the bundled router system-prompt template
+      description:
+        Returns the bundled `ROUTER_PROMPT` body with placeholders intact (`{{ASSISTANT_NAME}}`, `{{USER_NAME}}`,
+        `{{PAGE_INDEX}}`). Used by the memory router playground's 'Load default' affordance so users have a known-good
+        starting point when authoring an inline prompt override.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
   /v1/memory/v2/simulate-router:
     post:
       operationId: memory_v2_simulaterouter_post
@@ -11487,6 +11500,9 @@ paths:
                 profileOverride:
                   type: string
                   minLength: 1
+                routerPromptOverride:
+                  type: string
+                  maxLength: 1000000
               required:
                 - query
               additionalProperties: false

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -56,8 +56,11 @@ const PAGE_INDEX_PLACEHOLDER = "{{PAGE_INDEX}}";
  * Recent message context and `<now>` / `<already_injected_ids>` blocks are
  * appended at the call site so we don't inadvertently expand `{{` inside
  * dynamic content.
+ *
+ * Exported so the simulator route can return the bundled template verbatim
+ * for the playground's "Load default" affordance.
  */
-const ROUTER_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOLDER}. Your job is to route memory pages for the next assistant turn between ${ASSISTANT_NAME_PLACEHOLDER} and ${USER_NAME_PLACEHOLDER}.
+export const ROUTER_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOLDER}. Your job is to route memory pages for the next assistant turn between ${ASSISTANT_NAME_PLACEHOLDER} and ${USER_NAME_PLACEHOLDER}.
 
 You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
 
@@ -112,7 +115,29 @@ export function resolveRouterPrompt(
   overridePath: string | null,
   workspaceDir: string,
   opts: RenderRouterPromptOpts,
+  inlineOverride?: string | null,
 ): string {
+  // Inline override (e.g. simulator playground) takes precedence over the
+  // configured file path and the bundled prompt. Same placeholder
+  // substitution + size guard as the file-path branch; empty/whitespace
+  // bodies fall through to file/bundled resolution so a "cleared" textarea
+  // is treated as no override.
+  if (inlineOverride !== undefined && inlineOverride !== null) {
+    if (inlineOverride.length > MAX_PROMPT_BYTES) {
+      log.warn(
+        {
+          size: inlineOverride.length,
+          limit: MAX_PROMPT_BYTES,
+          reason: "oversized_inline_override",
+          fallback: "path_or_bundled",
+        },
+        "inline router prompt override exceeds size limit; falling back",
+      );
+    } else if (inlineOverride.trim().length > 0) {
+      return substitutePlaceholders(inlineOverride, opts);
+    }
+  }
+
   if (overridePath === null) return renderRouterPrompt(opts);
 
   const resolvedPath = resolveOverridePath(overridePath, workspaceDir);

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -187,6 +187,13 @@ interface RunRouterParams {
    * this unset so the bounded-injection contract holds.
    */
   disableUnionCap?: boolean;
+  /**
+   * Per-call inline router system-prompt override. Takes precedence
+   * over `memory.v2.router.router_prompt_path` and the bundled body.
+   * Used by the simulator playground for ad-hoc prompt comparisons.
+   * Live callers leave this unset.
+   */
+  routerPromptOverride?: string;
 }
 
 /**
@@ -371,6 +378,7 @@ async function runRouterBatch(
       userName: resolveUserName(workspaceDir),
       pageIndexBlock: batchIndex.rendered,
     },
+    params.routerPromptOverride ?? null,
   );
 
   // Filter prior-injected to slugs present in THIS batch and map to

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -32,6 +32,7 @@ import {
   readPage,
   renderPageContent,
 } from "../../memory/v2/page-store.js";
+import { ROUTER_PROMPT } from "../../memory/v2/prompts/router.js";
 import { type RouterSource, runRouter } from "../../memory/v2/router.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -352,6 +353,13 @@ const MemoryV2SimulateRouterParams = z
     query: z.string().min(1, "query must be non-empty"),
     configOverrides: SimulateRouterOverridesSchema.optional(),
     profileOverride: z.string().min(1).optional(),
+    /**
+     * Inline router system-prompt override (simulator only). Empty /
+     * whitespace-only strings are normalized to "no override" so a
+     * cleared textarea behaves the same as never opening it. The 1 MiB
+     * cap mirrors the file-path size guard in `resolveRouterPrompt`.
+     */
+    routerPromptOverride: z.string().max(1_000_000).optional(),
   })
   .strict();
 
@@ -383,6 +391,8 @@ export interface MemoryV2SimulateRouterResult {
   totalCandidatePages: number;
   /** The profile name passed as a per-call override, if any. */
   profileOverride: string | null;
+  /** `true` when an inline `routerPromptOverride` was applied this call. */
+  routerPromptOverridden: boolean;
 }
 
 /**
@@ -426,8 +436,20 @@ export async function handleSimulateRouter({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2SimulateRouterResult> {
   requireMemoryV2Enabled();
-  const { query, configOverrides, profileOverride } =
-    MemoryV2SimulateRouterParams.parse(body);
+  const {
+    query,
+    configOverrides,
+    profileOverride,
+    routerPromptOverride: rawRouterPromptOverride,
+  } = MemoryV2SimulateRouterParams.parse(body);
+
+  // Normalize whitespace-only strings to "no override" so the
+  // bundled/file prompt resolution behaves the same as a cleared editor.
+  const routerPromptOverride =
+    rawRouterPromptOverride !== undefined &&
+    rawRouterPromptOverride.trim().length > 0
+      ? rawRouterPromptOverride
+      : undefined;
 
   const liveConfig = loadConfig();
   const mergedConfig = applySimulateOverrides(liveConfig, configOverrides);
@@ -467,6 +489,7 @@ export async function handleSimulateRouter({
     ...(profileOverride !== undefined
       ? { overrideProfile: profileOverride }
       : {}),
+    ...(routerPromptOverride !== undefined ? { routerPromptOverride } : {}),
     // Always return the full union — the simulator's job is to surface
     // what the router actually picked across all batches, not what
     // injection.ts would have trimmed it to. The `max_page_ids` knob is
@@ -516,7 +539,20 @@ export async function handleSimulateRouter({
     },
     totalCandidatePages: pageIndex.entries.length,
     profileOverride: profileOverride ?? null,
+    routerPromptOverridden: routerPromptOverride !== undefined,
   };
+}
+
+// ── Router prompt template (bundled default for the playground editor) ──
+
+export interface MemoryV2RouterPromptTemplateResult {
+  /** The bundled router prompt body, placeholders intact. */
+  template: string;
+}
+
+async function handleGetRouterPromptTemplate(): Promise<MemoryV2RouterPromptTemplateResult> {
+  requireMemoryV2Enabled();
+  return { template: ROUTER_PROMPT };
 }
 
 // ── Route definitions ───────────────────────────────────────────────────
@@ -609,5 +645,15 @@ export const ROUTES: RouteDefinition[] = [
       "Runs the memory router against the live page index + EMA scores with optional tier_size / batch_size overrides, without recording an injection event or writing an activation log. Returns the slugs that would have been selected, per-slug tier provenance, EMA scores, and the effective router config so operators can validate knob changes before flipping them in workspace config.",
     tags: ["memory"],
     requestBody: MemoryV2SimulateRouterParams,
+  },
+  {
+    operationId: "memory_v2_router_prompt_template",
+    method: "GET",
+    endpoint: "memory/v2/router-prompt-template",
+    handler: handleGetRouterPromptTemplate,
+    summary: "Return the bundled router system-prompt template",
+    description:
+      "Returns the bundled `ROUTER_PROMPT` body with placeholders intact (`{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, `{{PAGE_INDEX}}`). Used by the memory router playground's 'Load default' affordance so users have a known-good starting point when authoring an inline prompt override.",
+    tags: ["memory"],
   },
 ];

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -29,6 +29,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
     @State private var paneB = PaneState()
     @State private var availableProfiles: [String] = []
     @State private var activeProfile: String?
+    @State private var defaultPromptTemplate: String = ""
 
     enum PaneId { case a, b }
 
@@ -38,6 +39,10 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         var batch: String = ""
         /// Empty string means "inherit active profile".
         var profile: String = ""
+        /// Empty string means "use bundled template".
+        var customPrompt: String = ""
+        /// Disclosure state for the per-pane prompt editor.
+        var showPromptEditor: Bool = false
         var isRunning: Bool = false
         var validationError: String?
         var clientError: String?
@@ -77,6 +82,11 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             // Best-effort — leave the pickers empty. The user can still type
             // an override into config.json directly or wait until profiles
             // load on a later view appearance.
+        }
+        if defaultPromptTemplate.isEmpty {
+            if let template = try? await client.fetchDefaultRouterPrompt() {
+                defaultPromptTemplate = template
+            }
         }
     }
 
@@ -190,6 +200,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                 overrideField(label: "batch_size", binding: batchBinding(pane))
             }
             profileField(pane: pane)
+            promptEditorField(pane: pane)
             HStack {
                 Spacer()
                 VButton(
@@ -204,6 +215,56 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
+    }
+
+    private func promptEditorField(pane: PaneId) -> some View {
+        let state = paneState(pane)
+        let usingCustom = !state.customPrompt
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack {
+                Button {
+                    showPromptEditorToggle(pane)
+                } label: {
+                    Text("\(state.showPromptEditor ? "▾" : "▸") System prompt (\(usingCustom ? "custom" : "bundled"))")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                if state.showPromptEditor {
+                    Button("Load default") {
+                        setCustomPrompt(pane: pane, value: defaultPromptTemplate)
+                    }
+                    .buttonStyle(.plain)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .disabled(defaultPromptTemplate.isEmpty)
+                    Button("Reset") {
+                        setCustomPrompt(pane: pane, value: "")
+                    }
+                    .buttonStyle(.plain)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .disabled(!usingCustom)
+                }
+            }
+            if state.showPromptEditor {
+                TextEditor(text: customPromptBinding(pane))
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(VColor.contentDefault)
+                    .scrollContentBackground(.hidden)
+                    .padding(VSpacing.sm)
+                    .frame(minHeight: 180)
+                    .background(VColor.surfaceBase)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+        }
     }
 
     private func profileField(pane: PaneId) -> some View {
@@ -339,6 +400,10 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                 label: "llm.profiles override",
                 value: result.profileOverride.map { "\($0)  (override)" } ?? "inherit active"
             )
+            metaRow(
+                label: "system prompt",
+                value: result.routerPromptOverridden ? "custom" : "bundled"
+            )
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -457,6 +522,24 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         pane == .a ? $paneA.profile : $paneB.profile
     }
 
+    private func customPromptBinding(_ pane: PaneId) -> Binding<String> {
+        pane == .a ? $paneA.customPrompt : $paneB.customPrompt
+    }
+
+    private func setCustomPrompt(pane: PaneId, value: String) {
+        switch pane {
+        case .a: paneA.customPrompt = value
+        case .b: paneB.customPrompt = value
+        }
+    }
+
+    private func showPromptEditorToggle(_ pane: PaneId) {
+        switch pane {
+        case .a: paneA.showPromptEditor.toggle()
+        case .b: paneB.showPromptEditor.toggle()
+        }
+    }
+
     private func canRun(_ pane: PaneId) -> Bool {
         !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !paneState(pane).isRunning
@@ -498,12 +581,15 @@ struct SettingsMemoryRouterPlaygroundTab: View {
 
         let profileTrimmed = state.profile.trimmingCharacters(in: .whitespacesAndNewlines)
         let profileOverride: String? = profileTrimmed.isEmpty ? nil : profileTrimmed
+        let promptTrimmed = state.customPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let routerPromptOverride: String? = promptTrimmed.isEmpty ? nil : state.customPrompt
         let input = MemoryRouterSimulateInput(
             query: trimmedQuery,
             tier1Size: tier1Override,
             tier2Size: tier2Override,
             batchSize: batchOverride,
-            profileOverride: profileOverride
+            profileOverride: profileOverride,
+            routerPromptOverride: routerPromptOverride
         )
 
         setIsRunning(pane: pane, value: true)

--- a/clients/shared/Network/MemoryRouterPlaygroundClient.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundClient.swift
@@ -54,6 +54,20 @@ public struct MemoryRouterPlaygroundClient: Sendable {
         )
     }
 
+    /// Fetches the bundled router system-prompt template so the playground
+    /// "Load default" affordance can seed the per-pane prompt editor.
+    public func fetchDefaultRouterPrompt() async throws -> String {
+        let path = "memory/v2/router-prompt-template/"
+        let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        struct TemplateResponse: Decodable { let template: String }
+        let decoded = try JSONDecoder().decode(
+            TemplateResponse.self,
+            from: response.data
+        )
+        return decoded.template
+    }
+
     /// Construct the JSON dict the daemon expects. Built by hand because the
     /// override fields have three states (inherit / value / explicit-null)
     /// and a plain Codable `Encodable` would conflate "absent" with "null".
@@ -68,6 +82,9 @@ public struct MemoryRouterPlaygroundClient: Sendable {
         }
         if let profile = input.profileOverride {
             body["profileOverride"] = profile
+        }
+        if let prompt = input.routerPromptOverride, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            body["routerPromptOverride"] = prompt
         }
         return body
     }

--- a/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
@@ -27,19 +27,24 @@ public struct MemoryRouterSimulateInput: Equatable, Sendable {
     public let batchSize: MemoryRouterOverride
     /// Per-call `llm.profiles` override name. `nil` means "inherit active".
     public let profileOverride: String?
+    /// Inline router system-prompt override. `nil` or whitespace-only means
+    /// "use the bundled template" — the daemon normalizes either way.
+    public let routerPromptOverride: String?
 
     public init(
         query: String,
         tier1Size: MemoryRouterOverride = .inherit,
         tier2Size: MemoryRouterOverride = .inherit,
         batchSize: MemoryRouterOverride = .inherit,
-        profileOverride: String? = nil
+        profileOverride: String? = nil,
+        routerPromptOverride: String? = nil
     ) {
         self.query = query
         self.tier1Size = tier1Size
         self.tier2Size = tier2Size
         self.batchSize = batchSize
         self.profileOverride = profileOverride
+        self.routerPromptOverride = routerPromptOverride
     }
 }
 
@@ -124,6 +129,36 @@ public struct MemoryRouterSimulateResponse: Decodable, Sendable {
     public let totalCandidatePages: Int
     /// Profile name passed as an override on this call, or `nil` if none.
     public let profileOverride: String?
+    /// `true` when an inline router prompt override was applied this call.
+    public let routerPromptOverridden: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case selectedSlugs
+        case sourceBySlug
+        case scores
+        case failureReason
+        case effectiveConfig
+        case overrides
+        case totalCandidatePages
+        case profileOverride
+        case routerPromptOverridden
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.selectedSlugs = try container.decode([String].self, forKey: .selectedSlugs)
+        self.sourceBySlug = try container.decode([String: String].self, forKey: .sourceBySlug)
+        self.scores = try container.decode([String: Double].self, forKey: .scores)
+        self.failureReason = try container.decodeIfPresent(String.self, forKey: .failureReason)
+        self.effectiveConfig = try container.decode(MemoryRouterEffectiveConfig.self, forKey: .effectiveConfig)
+        self.overrides = try container.decode(MemoryRouterReportedOverrides.self, forKey: .overrides)
+        self.totalCandidatePages = try container.decode(Int.self, forKey: .totalCandidatePages)
+        self.profileOverride = try container.decodeIfPresent(String.self, forKey: .profileOverride)
+        // Forward-compat: an older daemon won't send this field. Default
+        // to `false` rather than failing the decode for the entire response.
+        self.routerPromptOverridden =
+            try container.decodeIfPresent(Bool.self, forKey: .routerPromptOverridden) ?? false
+    }
 }
 
 /// Response from `GET /v1/assistants/{id}/config/llm/profiles/`. Used to


### PR DESCRIPTION
## Summary

- Each memory-router-playground pane (web + macOS) can now override the router system prompt inline. Edit pane A, edit pane B differently, compare against the same query.
- Backend: \`runRouter\` accepts an optional \`routerPromptOverride\` threaded through to \`resolveRouterPrompt\` (precedence: inline > file path > bundled). The simulate route exposes it as a top-level field; live callers leave it unset.
- New \`GET /v1/memory/v2/router-prompt-template\` returns the bundled body verbatim so the UI's "Load default" button can seed the textarea.
- Effective-config card surfaces \`system prompt: bundled / custom\` per pane.

## Why

Tier knobs, batch size, and profile cover *what* the router sees and *how* it's called; the prompt covers *what it's asked to do*. Letting users iterate on the prompt inline is the natural completion of the playground.

## Test plan

- [x] \`cd assistant && bunx tsc --noEmit\` clean
- [x] \`cd apps/web && bunx tsc --noEmit\` clean for playground files
- [x] \`cd clients && swift build --target VellumAssistantLib\` clean
- [x] Format / lint pre-commit hooks pass
- [ ] Web smoke: open System prompt for pane B, click Load default, edit "lean toward inclusion" → "be conservative". Run B. Confirm Effective-config shows \`system prompt: custom\` and selection count shifts.
- [ ] macOS smoke: same scenario inside Settings → Memory Router Playground.
- [ ] Negative path: whitespace-only override → response \`routerPromptOverridden: false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)