### PR TITLE
Cherry-pick fixes for v0.8.4

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -338,8 +338,8 @@ References:
 
 - **Asynchronous loading.** Load data (network responses, file contents, images) asynchronously off the main thread. Show loading states while data is in flight. Never block the main thread waiting for data.
 - **Image loading must be async.** Use `AsyncImage` (built-in) or a library like Kingfisher for image loading. Never decode or resize images synchronously on the main thread — this is a common source of scroll jank in image-heavy views.
-- **(macOS) `NSImage` is NOT thread-safe.** Prefer thread-safe CoreGraphics/ImageIO APIs (`CGImageSource`, `CGContext`, `CGImageDestination`) for image processing off the main thread. See:
-  - [Apple — NSImage](https://developer.apple.com/documentation/appkit/nsimage) (thread safety limitations)
+- **(macOS) `NSImage` is thread-safe since macOS 10.6** — you may create, draw, and access instances from any thread. The archived [Threading Programming Guide](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html) lists NSImage as "Thread-Unsafe," but this predates the 10.6 thread-safety improvements and was never updated. For performance-sensitive image processing off the main thread, CoreGraphics/ImageIO APIs (`CGImageSource`, `CGContext`, `CGImageDestination`) avoid `NSGraphicsContext` overhead and may be faster for batch encoding. See:
+  - [Apple — NSImage](https://developer.apple.com/documentation/appkit/nsimage)
   - [Apple — CGImageSource](https://developer.apple.com/documentation/imageio/cgimagesource) (thread-safe image loading)
   - [Apple — CGImageDestination](https://developer.apple.com/documentation/imageio/cgimagedestination) (thread-safe JPEG/PNG encoding)
 - **Profile before optimizing, but follow known patterns.** Use Instruments to validate — specifically Time Profiler for main-thread spikes, Core Animation instrument for frame drops, and Allocations for memory. Launch Instruments directly from `/Applications/Instruments.app` or via `xcrun instruments`. However, the patterns above are established project standards — follow them proactively rather than waiting for a performance regression.

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -325,10 +325,6 @@ final class AvatarAppearanceManager {
     func saveAvatar(_ image: NSImage, bodyShape: AvatarBodyShape? = nil, eyeStyle: AvatarEyeStyle? = nil, color: AvatarColor? = nil, skipWorkspaceSync: Bool = false) {
         let isCharacter = bodyShape != nil
 
-        guard let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
-
         cachedChatAvatar = nil
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
@@ -350,24 +346,34 @@ final class AvatarAppearanceManager {
         }
         updateDockIcon()
 
-        // Update the local client-side cache so the next cold launch can
-        // hydrate the dock icon before the daemon is ready.
+        // Character traits are small JSON — persist synchronously.
         if isCharacter, let body = bodyShape, let eyes = eyeStyle, let color = color {
             AvatarCache.saveTraits(bodyShape: body, eyeStyle: eyes, color: color)
             AvatarCache.clearImage()
-        } else {
-            AvatarCache.saveImage(pngData)
-            AvatarCache.clearTraits()
         }
 
-        guard !skipWorkspaceSync else { return }
+        // PNG encoding (tiffRepresentation → NSBitmapImageRep → .png) is
+        // CPU-bound. Run off-main so it doesn't block the UI while the
+        // image is persisted to the local cache and the workspace.
+        let syncToWorkspace = !skipWorkspaceSync
+        Task.detached(priority: .utility) { [weak self] in
+            guard let tiffData = image.tiffRepresentation,
+                  let bitmap = NSBitmapImageRep(data: tiffData),
+                  let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
 
-        // Persist to the assistant's workspace via the gateway.
-        Task {
+            if !isCharacter {
+                AvatarCache.saveImage(pngData)
+                AvatarCache.clearTraits()
+            }
+
+            guard syncToWorkspace else { return }
+
             let workspaceClient = WorkspaceClient()
             _ = await workspaceClient.createWorkspaceDirectory(path: "data/avatar")
             _ = await workspaceClient.writeWorkspaceFile(path: "data/avatar/avatar-image.png", content: pngData)
-            saveAvatarComponentsViaGateway()
+            await MainActor.run { [weak self] in
+                self?.saveAvatarComponentsViaGateway()
+            }
         }
     }
 
@@ -555,6 +561,11 @@ final class AvatarAppearanceManager {
     /// Posted whenever the avatar changes so other components (e.g. menu bar icon) can update.
     static let avatarDidChangeNotification = Notification.Name("AvatarAppearanceManager.avatarDidChange")
 
+    /// Monotonically increasing generation counter for dock icon updates.
+    /// Prevents a slow background rasterization from overwriting a newer
+    /// icon when multiple `updateDockIcon()` calls overlap.
+    @ObservationIgnored private var dockIconGeneration: Int = 0
+
     /// The original bundle icon resolved from the `.app` bundle on disk.
     /// Uses `NSWorkspace` so the result is independent of whatever
     /// `applicationIconImage` is set at runtime and already includes all
@@ -596,9 +607,18 @@ final class AvatarAppearanceManager {
     ///
     /// Reference: https://developer.apple.com/documentation/appkit/nsapplication/applicationiconimage
     func restoreBundleIcon() {
+        dockIconGeneration += 1
+        let generation = dockIconGeneration
         NSApplication.shared.applicationIconImage = Self.bundledAppIcon
         NSApp.dockTile.display()
-        NSWorkspace.shared.setIcon(nil, forFile: Bundle.main.bundlePath, options: [])
+        let bundlePath = Bundle.main.bundlePath
+        Task.detached(priority: .utility) { [weak self] in
+            let isCurrent = await MainActor.run { [weak self] in
+                self?.dockIconGeneration == generation
+            }
+            guard isCurrent else { return }
+            NSWorkspace.shared.setIcon(nil, forFile: bundlePath, options: [])
+        }
     }
 
     /// Updates the application dock icon to match the current avatar.
@@ -610,6 +630,15 @@ final class AvatarAppearanceManager {
     /// pick up the avatar. `applicationIconImage` only affects the
     /// in-process Dock tile, which is why notifications would otherwise
     /// keep showing the bundled green V.
+    ///
+    /// Image processing (resize, squircle mask, compositing, rasterization)
+    /// and the `NSWorkspace.setIcon` write (which internally encodes PNG at
+    /// every icon size) run in a detached task so the main thread is never
+    /// blocked. A monotonic generation counter ensures that only the most
+    /// recent invocation's result is applied to the dock tile.
+    ///
+    /// Reference: https://developer.apple.com/documentation/appkit/nsimage
+    /// — "You may create, use, and destroy NSImage objects from any thread."
     private func updateDockIcon() {
         NotificationCenter.default.post(name: Self.avatarDidChangeNotification, object: nil)
 
@@ -624,23 +653,62 @@ final class AvatarAppearanceManager {
             return
         }
 
+        dockIconGeneration += 1
+        let generation = dockIconGeneration
+        let bundlePath = Bundle.main.bundlePath
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let icon = Self.composeDockIcon(from: avatar)
+
+            // Check generation before the expensive disk write so a
+            // superseded task doesn't overwrite a newer icon's .icns.
+            let isCurrent = await MainActor.run { [weak self] in
+                self?.dockIconGeneration == generation
+            }
+            guard isCurrent else { return }
+
+            // Write .icns to disk — the heaviest single operation (PNG
+            // encoding at multiple resolutions). Safe off main thread:
+            // NSWorkspace.setIcon writes to the file system.
+            NSWorkspace.shared.setIcon(icon, forFile: bundlePath, options: [])
+
+            await MainActor.run { [weak self] in
+                guard let self, self.dockIconGeneration == generation else { return }
+                NSApplication.shared.applicationIconImage = icon
+                NSApp.dockTile.display()
+            }
+        }
+    }
+
+    /// Composes the padded squircle dock icon from a source avatar and forces
+    /// rasterization so the result is a flat bitmap with no deferred drawing
+    /// handlers. Callers receive an image that can be displayed or encoded
+    /// without triggering further computation.
+    nonisolated private static func composeDockIcon(from avatar: NSImage) -> NSImage {
         // Standard macOS icons have ~10% padding so the artwork doesn't crowd
         // the dock running-indicator dot or produce edge fringe artifacts.
         let canvasSize: CGFloat = 512
         let iconSize: CGFloat = 418  // ~82% of canvas, matching Apple icon grid
         let padding = (canvasSize - iconSize) / 2
-        let squircle = Self.squircleIcon(avatar, size: iconSize)
+        let squircle = squircleIcon(avatar, size: iconSize)
 
-        let icon = NSImage(size: NSSize(width: canvasSize, height: canvasSize), flipped: false) { _ in
+        let composed = NSImage(size: NSSize(width: canvasSize, height: canvasSize), flipped: false) { _ in
             let iconRect = NSRect(x: padding, y: padding, width: iconSize, height: iconSize)
             squircle.draw(in: iconRect, from: NSRect(origin: .zero, size: squircle.size),
                           operation: .copy, fraction: 1.0)
             return true
         }
 
-        NSApplication.shared.applicationIconImage = icon
-        NSApp.dockTile.display()
-        NSWorkspace.shared.setIcon(icon, forFile: Bundle.main.bundlePath, options: [])
+        // Force rasterization: tiffRepresentation executes all deferred
+        // drawing handlers (resize → squircle mask → compositing) and
+        // produces a bitmap. Re-creating from that data gives an NSImage
+        // backed by NSBitmapImageRep, so dockTile.display() on the main
+        // thread just blits pixels instead of running the full pipeline.
+        guard let tiffData = composed.tiffRepresentation,
+              let rasterized = NSImage(data: tiffData) else {
+            return composed
+        }
+        return rasterized
     }
 
     /// Renders the source image inside a macOS-style squircle mask at the given point size.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -214,7 +214,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-21T13:10:14-04:00"
+      "updatedAt": "2026-05-21T20:10:42-04:00"
     },
     {
       "id": "gmail",
@@ -464,7 +464,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-18T03:34:58-04:00"
+      "updatedAt": "2026-05-21T18:28:55-04:00"
     },
     {
       "id": "notion",

--- a/skills/geo-writing/SKILL.md
+++ b/skills/geo-writing/SKILL.md
@@ -162,12 +162,12 @@ Load the QC checklist from `references/qc-checklist.md`.
 
 ## PHASE 5 — OUTPUT
 
-Write the completed article as a markdown file to `Articles/Articles/<slug>.md`. Use kebab-case. Do not include the year in the slug.
+1. Save a copy of the completed article to `Articles/<slug>.md` (kebab-case, no year in slug) as an archival record.
+2. Open the article in the **Document Writer** skill so the user can review and edit it inline. Use `document_create` with the article title, then stream the full article content via `document_update` with `mode: "append"`.
 
 Report back with:
 
-1. File path where the article was written
-2. 2-3 sentence summary: length, tools ranked, any notable judgment calls
-3. Any gaps or uncertainty flagged during research
+1. 2-3 sentence summary: length, tools ranked, any notable judgment calls
+2. Any gaps or uncertainty flagged during research
 
 Do NOT auto-publish to your CMS. Publishing is a separate manual step.


### PR DESCRIPTION
## Summary
- Cherry-pick fix for skills: use Document Writer for GEO article output and fix nested path (#31608)
- Cherry-pick fix for macOS: move dock icon image processing off main thread to eliminate 2s+ hangs (#31773)

## Test plan
- [ ] Verify GEO article output uses Document Writer correctly
- [ ] Verify macOS dock icon updates don't cause UI hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)