### PR TITLE
fix(assistant): add route policy for memory/v2/router-prompt-template

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -473,6 +473,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/concept-frequency:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/ema-scores:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/simulate-router:POST", scopes: ["settings.read"] },
+  {
+    endpoint: "memory/v2/router-prompt-template:GET",
+    scopes: ["settings.read"],
+  },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary

- Add `memory/v2/router-prompt-template:GET` to `route-policy.ts` with `settings.read` scope, matching the read-only nature of this endpoint and consistent with sibling memory/v2 read routes.
- Fixes the `guard-tests.test.ts` route-policy-coverage failure from the Test CI job on main.

## Original prompt

Fix the specific CI issue in the failing Test job at run 26310402687: `guard-tests.test.ts` failed because `memory/v2/router-prompt-template` (introduced in #31795 for the playground's "Load default" affordance) was dispatched in `http-server.ts` without a matching entry in `route-policy.ts`. Add the missing policy entry only — no other changes.