### PR TITLE
feat(providers): add Gemini 3.1 Flash-Lite GA model

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.ts
+++ b/apps/web/src/assistant/llm-model-catalog.ts
@@ -162,6 +162,14 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
+      id: "gemini-3.1-flash-lite",
+      displayName: "Gemini 3.1 Flash-Lite",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 65_536,
+      supportsThinking: true,
+    },
+    {
       id: "gemini-2.5-flash",
       displayName: "Gemini 2.5 Flash",
       contextWindowTokens: 1_000_000,

--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -29,7 +29,7 @@ describe("model intents", () => {
       "gpt-5.4-nano",
     );
     expect(resolveModelIntent("gemini", "latency-optimized")).toBe(
-      "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite",
     );
     expect(resolveModelIntent("gemini", "quality-optimized")).toBe(
       "gemini-3.1-pro-preview",
@@ -44,9 +44,7 @@ describe("model intents", () => {
   });
 
   test("falls back to provider default for unknown providers", () => {
-    expect(getProviderDefaultModel("unknown-provider")).toBe(
-      "claude-opus-4-7",
-    );
+    expect(getProviderDefaultModel("unknown-provider")).toBe("claude-opus-4-7");
     expect(resolveModelIntent("unknown-provider", "quality-optimized")).toBe(
       "claude-opus-4-7",
     );

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -216,6 +216,17 @@ describe("resolvePricing", () => {
       expect(result.estimatedCostUsd).toBe(0.25 + 1.5);
     });
 
+    test("returns priced for gemini-3.1-flash-lite", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-flash-lite",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(0.25 + 1.5);
+    });
+
     test("prices gemini-2.5-pro at the low-context tier through 200k input tokens", () => {
       const result = resolvePricing(
         "gemini",
@@ -489,6 +500,7 @@ describe("resolvePricingForUsage", () => {
     const cases = [
       ["gemini-3-flash-preview", 0.05],
       ["gemini-3.1-flash-lite-preview", 0.025],
+      ["gemini-3.1-flash-lite", 0.025],
       ["gemini-2.5-flash", 0.03],
       ["gemini-2.5-flash-lite", 0.01],
       ["gemini-2.5-pro", 0.625],

--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -70,6 +70,7 @@ describe("projectProviderForWire", () => {
       "gemini-3.1-pro-preview-customtools",
       "gemini-3-flash-preview",
       "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite",
     ];
 
     expect(modelIds.filter((id) => id.startsWith("gemini-3"))).toEqual(

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -494,6 +494,21 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       {
+        id: "gemini-3.1-flash-lite",
+        displayName: "Gemini 3.1 Flash-Lite",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 65536,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 0.25,
+          outputPer1mTokens: 1.5,
+          cacheReadPer1mTokens: 0.025,
+        },
+      },
+      {
         id: "gemini-2.5-flash",
         displayName: "Gemini 2.5 Flash",
         contextWindowTokens: 1000000,

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -24,7 +24,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   gemini: {
     balanced: "gemini-3-flash-preview",
-    "latency-optimized": "gemini-3.1-flash-lite-preview",
+    "latency-optimized": "gemini-3.1-flash-lite",
     "quality-optimized": "gemini-3.1-pro-preview",
     "vision-optimized": "gemini-3-flash-preview",
   },

--- a/assistant/src/workspace/migrations/086-revert-stale-gemini-mis-rewrites.ts
+++ b/assistant/src/workspace/migrations/086-revert-stale-gemini-mis-rewrites.ts
@@ -140,6 +140,7 @@ const GEMINI_CATALOG_MODELS = new Set<string>([
   "gemini-3.1-pro-preview-customtools",
   "gemini-3-flash-preview",
   "gemini-3.1-flash-lite-preview",
+  "gemini-3.1-flash-lite",
   "gemini-2.5-flash",
   "gemini-2.5-flash-lite",
   "gemini-2.5-pro",

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -121,6 +121,10 @@ final class InferenceProfileEditorTests: XCTestCase {
                         id: "gemini-3.1-flash-lite-preview",
                         displayName: "Gemini 3.1 Flash-Lite Preview"
                     ),
+                    CatalogModel(
+                        id: "gemini-3.1-flash-lite",
+                        displayName: "Gemini 3.1 Flash-Lite"
+                    ),
                     CatalogModel(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
                     CatalogModel(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite"),
                     CatalogModel(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro"),
@@ -668,12 +672,13 @@ final class InferenceProfileEditorTests: XCTestCase {
     func testCanSelectGemini3ModelFromDynamicCatalog() {
         let geminiModels = store.dynamicProviderModels("gemini")
         XCTAssertEqual(
-            geminiModels.prefix(4).map(\.id),
+            geminiModels.prefix(5).map(\.id),
             [
                 "gemini-3.1-pro-preview",
                 "gemini-3.1-pro-preview-customtools",
                 "gemini-3-flash-preview",
                 "gemini-3.1-flash-lite-preview",
+                "gemini-3.1-flash-lite",
             ]
         )
         XCTAssertEqual(

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -395,6 +395,23 @@
           }
         },
         {
+          "id": "gemini-3.1-flash-lite",
+          "displayName": "Gemini 3.1 Flash-Lite",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.25,
+            "outputPer1mTokens": 1.5,
+            "cacheReadPer1mTokens": 0.025
+          }
+        },
+        {
           "id": "gemini-2.5-flash",
           "displayName": "Gemini 2.5 Flash",
           "contextWindowTokens": 1000000,

--- a/clients/shared/Tests/LLMProviderRegistryTests.swift
+++ b/clients/shared/Tests/LLMProviderRegistryTests.swift
@@ -38,19 +38,23 @@ final class LLMProviderRegistryTests: XCTestCase {
         XCTAssertEqual(
             gemini.models.map(\.id).filter { $0.hasPrefix("gemini-3") },
             [
+                "gemini-3.5-flash",
                 "gemini-3.1-pro-preview",
                 "gemini-3.1-pro-preview-customtools",
                 "gemini-3-flash-preview",
                 "gemini-3.1-flash-lite-preview",
+                "gemini-3.1-flash-lite",
             ]
         )
         XCTAssertEqual(
-            Array(gemini.models.prefix(7).map(\.id)),
+            Array(gemini.models.prefix(9).map(\.id)),
             [
+                "gemini-3.5-flash",
                 "gemini-3.1-pro-preview",
                 "gemini-3.1-pro-preview-customtools",
                 "gemini-3-flash-preview",
                 "gemini-3.1-flash-lite-preview",
+                "gemini-3.1-flash-lite",
                 "gemini-2.5-flash",
                 "gemini-2.5-flash-lite",
                 "gemini-2.5-pro",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -395,6 +395,23 @@
           }
         },
         {
+          "id": "gemini-3.1-flash-lite",
+          "displayName": "Gemini 3.1 Flash-Lite",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.25,
+            "outputPer1mTokens": 1.5,
+            "cacheReadPer1mTokens": 0.025
+          }
+        },
+        {
           "id": "gemini-2.5-flash",
           "displayName": "Gemini 2.5 Flash",
           "contextWindowTokens": 1000000,


### PR DESCRIPTION
## Summary

- Adds `gemini-3.1-flash-lite` to the provider catalog with the same shape and pricing as the preview entry (Google promoted the model out of preview — https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite).
- Switches the gemini `latency-optimized` intent from the preview ID to the GA ID. The preview entry stays in the catalog so existing user configs that hardcode it keep working.
- Regenerates the bundled catalog JSON mirrors via `bun run sync:llm-catalog` and updates the hand-maintained web/macOS/shared test catalogs to match.
- Adds the GA ID to `GEMINI_CATALOG_MODELS` in migration 086 (catalog inference). Intentionally **not** added to `REPLACEMENT_MODELS` — that set is "models migration 057 wrote", and 057 only ever wrote the preview ID; including GA there would falsely flag legitimate GA configs as revert candidates.
- Drive-by: updates \`LLMProviderRegistryTests.swift\` to also expect \`gemini-3.5-flash\`, which was added to the catalog in #31400 but never reflected in this assertion — the GA addition forces the count to change anyway, so it would otherwise leave the test broken.

## Original prompt

In a conversation about whether the codebase supports \`gemini-3.1-flash-lite\` vs \`gemini-3.1-flash-lite-preview\`, the user confirmed only the \`-preview\` ID exists and asked to add the GA model (linking to Google's docs). The decision was to add the GA entry alongside the preview and switch the latency-optimized intent to point at GA, keeping the preview entry for backward compatibility with existing user configs.