### PR TITLE
feat(playground): show raw API request/response per pane

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -165,14 +165,14 @@ function PlaygroundView(): ReactNode {
             paneId="A"
             query={query}
             mutation={mutationA}
-            otherResult={mutationB.data}
+            otherResult={mutationB.data?.response}
             validation={validationA}
           />
           <PaneOutputColumn
             paneId="B"
             query={query}
             mutation={mutationB}
-            otherResult={mutationA.data}
+            otherResult={mutationA.data?.response}
             validation={validationB}
           />
         </div>
@@ -631,6 +631,7 @@ function PaneOutputColumn({
   otherResult: MemoryRouterSimulateResponse | undefined;
   validation: string | null;
 }): ReactNode {
+  const data = mutation.data;
   return (
     <div className="flex flex-col gap-3">
       <PaneHeader paneId={paneId} />
@@ -644,14 +645,99 @@ function PaneOutputColumn({
           }
         />
       )}
-      {mutation.data !== undefined && (
-        <ResultPanel
-          paneId={paneId}
-          query={query}
-          result={mutation.data}
-          otherResult={otherResult}
-        />
+      {data !== undefined && (
+        <>
+          <ResultPanel
+            paneId={paneId}
+            query={query}
+            result={data.response}
+            otherResult={otherResult}
+          />
+          <RawExchangePanel
+            paneId={paneId}
+            rawRequest={data.rawRequest}
+            rawResponse={data.rawResponse}
+          />
+        </>
       )}
+    </div>
+  );
+}
+
+function RawExchangePanel({
+  paneId,
+  rawRequest,
+  rawResponse,
+}: {
+  paneId: PaneId;
+  rawRequest: string;
+  rawResponse: string;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  return (
+    <Card>
+      <div className="flex flex-col gap-2 p-4">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="text-label-default"
+          style={{
+            color: "var(--content-secondary)",
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          {open ? "▾" : "▸"} Raw API exchange
+        </button>
+        {open && (
+          <div className="flex flex-col gap-3">
+            <RawExchangeBlock
+              label={`Request (Pane ${paneId})`}
+              body={rawRequest}
+            />
+            <RawExchangeBlock
+              label={`Response (Pane ${paneId})`}
+              body={rawResponse}
+            />
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function RawExchangeBlock({
+  label,
+  body,
+}: {
+  label: string;
+  body: string;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <span
+        className="text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {label}
+      </span>
+      <pre
+        className="overflow-auto rounded-md border px-3 py-2 text-body-small-default"
+        style={{
+          borderColor: "var(--border-base)",
+          background: "var(--surface-base)",
+          color: "var(--content-default)",
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+          maxHeight: "320px",
+          whiteSpace: "pre",
+        }}
+      >
+        {body.length === 0 ? "(empty)" : body}
+      </pre>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -56,6 +56,17 @@ export interface MemoryRouterSimulateResponse {
   routerPromptOverridden: boolean;
 }
 
+/**
+ * Result of a successful simulate call, including the pretty-printed
+ * request body that was sent and the raw response body returned. Surfaced
+ * in the playground's "Raw API exchange" disclosure for debugging.
+ */
+export interface MemoryRouterSimulateResult {
+  response: MemoryRouterSimulateResponse;
+  rawRequest: string;
+  rawResponse: string;
+}
+
 export interface LlmProfilesListResponse {
   profiles: string[];
   activeProfile: string | null;
@@ -75,7 +86,7 @@ export async function simulateMemoryRouter(
   assistantId: string,
   request: MemoryRouterSimulateRequest,
   signal?: AbortSignal
-): Promise<MemoryRouterSimulateResponse> {
+): Promise<MemoryRouterSimulateResult> {
   const { data, response } = await client.post<MemoryRouterSimulateResponse>({
     url: "/v1/assistants/{assistant_id}/memory/v2/simulate-router/",
     path: { assistant_id: assistantId },
@@ -83,14 +94,16 @@ export async function simulateMemoryRouter(
     signal,
     throwOnError: false,
   });
+  const rawResponse = response
+    ? await response
+        .clone()
+        .text()
+        .catch(() => "")
+    : "";
   if (!response || !response.ok) {
-    const text = await response
-      ?.clone()
-      .text()
-      .catch(() => "");
     throw new SimulateMemoryRouterError(
       response?.status ?? 0,
-      text || response?.statusText || "Failed to simulate memory router"
+      rawResponse || response?.statusText || "Failed to simulate memory router"
     );
   }
   if (!data) {
@@ -99,14 +112,27 @@ export async function simulateMemoryRouter(
       "Empty response from memory router simulator endpoint"
     );
   }
-  return data;
+  return {
+    response: data,
+    rawRequest: JSON.stringify(request, null, 2),
+    rawResponse: prettyJson(rawResponse),
+  };
+}
+
+function prettyJson(raw: string): string {
+  if (raw.length === 0) return raw;
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
 }
 
 export function useSimulateMemoryRouter(assistantId: string | undefined) {
   return useMutation({
     mutationFn: async (
       request: MemoryRouterSimulateRequest
-    ): Promise<MemoryRouterSimulateResponse> => {
+    ): Promise<MemoryRouterSimulateResult> => {
       if (!assistantId) {
         throw new SimulateMemoryRouterError(0, "Missing assistantId");
       }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -47,6 +47,12 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         var validationError: String?
         var clientError: String?
         var lastResult: MemoryRouterSimulateResponse?
+        /// Pretty-printed request body from the most recent successful run.
+        var rawRequest: String?
+        /// Pretty-printed response body from the most recent successful run.
+        var rawResponse: String?
+        /// Disclosure state for the raw API exchange panel.
+        var showRawExchange: Bool = false
     }
 
     enum SlugDiff { case both, onlyHere }
@@ -187,9 +193,64 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                     pane: pane,
                     otherResult: otherState.lastResult
                 )
+                if let req = state.rawRequest, let resp = state.rawResponse {
+                    rawExchangeCard(
+                        pane: pane,
+                        rawRequest: req,
+                        rawResponse: resp
+                    )
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func rawExchangeCard(
+        pane: PaneId,
+        rawRequest: String,
+        rawResponse: String
+    ) -> some View {
+        let state = paneState(pane)
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Button {
+                toggleRawExchange(pane)
+            } label: {
+                Text("\(state.showRawExchange ? "▾" : "▸") Raw API exchange")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+            if state.showRawExchange {
+                rawExchangeBlock(label: "Request (Pane \(paneLabel(pane)))", body: rawRequest)
+                rawExchangeBlock(label: "Response (Pane \(paneLabel(pane)))", body: rawResponse)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func rawExchangeBlock(label: String, body: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            ScrollView(.vertical) {
+                Text(body.isEmpty ? "(empty)" : body)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(VColor.contentDefault)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VSpacing.sm)
+            }
+            .frame(minHeight: 120, maxHeight: 320)
+            .background(VColor.surfaceBase)
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.borderBase, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
     }
 
     private func paneFormCard(pane: PaneId) -> some View {
@@ -598,7 +659,12 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             defer { setIsRunning(pane: pane, value: false) }
             do {
                 let result = try await client.simulate(input: input)
-                setLastResult(pane: pane, result: result)
+                setLastResult(pane: pane, result: result.response)
+                setRawExchange(
+                    pane: pane,
+                    request: result.rawRequest,
+                    response: result.rawResponse
+                )
                 setClientError(pane: pane, message: nil)
             } catch MemoryRouterPlaygroundError.memoryV2Disabled {
                 setClientError(
@@ -606,21 +672,25 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                     message: "Memory v2 is not enabled on this assistant — set memory.v2.enabled to true in workspace config."
                 )
                 setLastResult(pane: pane, result: nil)
+                setRawExchange(pane: pane, request: nil, response: nil)
             } catch MemoryRouterPlaygroundError.notAvailable {
                 setClientError(
                     pane: pane,
                     message: "Simulate route is not available — the daemon may need to be updated."
                 )
                 setLastResult(pane: pane, result: nil)
+                setRawExchange(pane: pane, request: nil, response: nil)
             } catch let MemoryRouterPlaygroundError.http(statusCode, body) {
                 setClientError(
                     pane: pane,
                     message: "HTTP \(statusCode): \(body.isEmpty ? "Failed to run simulation" : body)"
                 )
                 setLastResult(pane: pane, result: nil)
+                setRawExchange(pane: pane, request: nil, response: nil)
             } catch {
                 setClientError(pane: pane, message: error.localizedDescription)
                 setLastResult(pane: pane, result: nil)
+                setRawExchange(pane: pane, request: nil, response: nil)
             }
         }
     }
@@ -650,6 +720,24 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         switch pane {
         case .a: paneA.clientError = message
         case .b: paneB.clientError = message
+        }
+    }
+
+    private func setRawExchange(pane: PaneId, request: String?, response: String?) {
+        switch pane {
+        case .a:
+            paneA.rawRequest = request
+            paneA.rawResponse = response
+        case .b:
+            paneB.rawRequest = request
+            paneB.rawResponse = response
+        }
+    }
+
+    private func toggleRawExchange(_ pane: PaneId) {
+        switch pane {
+        case .a: paneA.showRawExchange.toggle()
+        case .b: paneB.showRawExchange.toggle()
         }
     }
 

--- a/clients/shared/Network/MemoryRouterPlaygroundClient.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundClient.swift
@@ -27,7 +27,7 @@ public struct MemoryRouterPlaygroundClient: Sendable {
 
     public func simulate(
         input: MemoryRouterSimulateInput
-    ) async throws -> MemoryRouterSimulateResponse {
+    ) async throws -> MemoryRouterSimulateResult {
         let path = "memory/v2/simulate-router/"
         let body = buildRequestBody(input: input)
         let response = try await GatewayHTTPClient.post(
@@ -35,11 +35,51 @@ public struct MemoryRouterPlaygroundClient: Sendable {
             json: body,
             timeout: 120
         )
+        let rawRequest = Self.prettyJsonString(fromObject: body)
+        let rawResponse = Self.prettyJsonString(fromData: response.data)
         try throwIfUnsuccessful(response, path: path)
-        return try JSONDecoder().decode(
+        let decoded = try JSONDecoder().decode(
             MemoryRouterSimulateResponse.self,
             from: response.data
         )
+        return MemoryRouterSimulateResult(
+            response: decoded,
+            rawRequest: rawRequest,
+            rawResponse: rawResponse
+        )
+    }
+
+    /// Pretty-print a JSON-compatible object (the same dict we POSTed) for
+    /// display in the playground's raw-exchange disclosure. Falls back to a
+    /// short sentinel if the object isn't JSON-encodable — we'd already
+    /// have failed the POST in that case, so the fallback is just defensive.
+    private static func prettyJsonString(fromObject object: Any) -> String {
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys]
+            ),
+            let text = String(data: data, encoding: .utf8)
+        else {
+            return "<unable to serialize request body>"
+        }
+        return text
+    }
+
+    /// Pretty-print response bytes if they parse as JSON; otherwise return
+    /// the UTF-8 text as-is so error bodies remain inspectable.
+    private static func prettyJsonString(fromData data: Data) -> String {
+        if
+            let parsed = try? JSONSerialization.jsonObject(with: data),
+            let pretty = try? JSONSerialization.data(
+                withJSONObject: parsed,
+                options: [.prettyPrinted, .sortedKeys]
+            ),
+            let text = String(data: pretty, encoding: .utf8)
+        {
+            return text
+        }
+        return String(data: data, encoding: .utf8) ?? "<binary>"
     }
 
     /// Fetches the workspace's defined `llm.profiles` for populating the

--- a/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
@@ -167,3 +167,22 @@ public struct LlmProfilesListResponse: Decodable, Sendable {
     public let profiles: [String]
     public let activeProfile: String?
 }
+
+/// Decoded simulate response paired with the pretty-printed request body
+/// that was sent and the raw response body that came back. The playground
+/// surfaces both strings in a "Raw API exchange" disclosure for debugging.
+public struct MemoryRouterSimulateResult: Sendable {
+    public let response: MemoryRouterSimulateResponse
+    public let rawRequest: String
+    public let rawResponse: String
+
+    public init(
+        response: MemoryRouterSimulateResponse,
+        rawRequest: String,
+        rawResponse: String
+    ) {
+        self.response = response
+        self.rawRequest = rawRequest
+        self.rawResponse = rawResponse
+    }
+}


### PR DESCRIPTION
## Summary

- Add a collapsible **Raw API exchange** disclosure at the bottom of each memory router playground pane.
- Surfaces the pretty-printed JSON request body that was POSTed and the response body that came back.
- Useful when a config or prompt override produces unexpected results and you want to confirm exactly what crossed the wire.

The simulate client now returns `{ response, rawRequest, rawResponse }` on both surfaces. Request is `JSON.stringify(req, null, 2)`; response is parsed-then-restringified when it's valid JSON, raw text otherwise. The disclosure is closed by default and renders two monospace, scrollable, copy-selectable blocks when expanded.

## Test plan

- [ ] Web: open `/assistant/memory-router-playground`, run a pane, expand "Raw API exchange", confirm request shows the typed query/overrides and response shows the daemon's output JSON.
- [ ] Web: enter an override (e.g. `tier1_size: 30`) and confirm it appears in the request's `configOverrides`.
- [ ] Web: paste a custom router prompt and confirm it appears verbatim under `routerPromptOverride`.
- [ ] macOS: same flow in Settings → Memory Router Playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)