### PR TITLE
feat(gemini): make thinking config toggleable and configurable

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -75,6 +75,12 @@ mock.module("@google/genai", () => ({
     };
   },
   ApiError: FakeApiError,
+  ThinkingLevel: {
+    MINIMAL: "MINIMAL",
+    LOW: "LOW",
+    MEDIUM: "MEDIUM",
+    HIGH: "HIGH",
+  },
 }));
 
 // Import after mocking
@@ -221,6 +227,78 @@ describe("GeminiProvider", () => {
 
     const config = lastStreamParams!.config as Record<string, unknown>;
     expect(config.systemInstruction).toBe("You are a helpful assistant.");
+  });
+
+  // -----------------------------------------------------------------------
+  // Thinking config
+  // -----------------------------------------------------------------------
+  test("omits thinkingConfig when no thinking config is supplied", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toBeUndefined();
+  });
+
+  test("maps wire { type: 'adaptive', level, streamThinking } to Gemini thinkingConfig", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      {
+        config: {
+          thinking: {
+            type: "adaptive",
+            level: "high",
+            streamThinking: false,
+          },
+        },
+      },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "HIGH",
+      includeThoughts: false,
+    });
+  });
+
+  test("maps wire { type: 'disabled' } to MINIMAL thinking level", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { thinking: { type: "disabled" } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "MINIMAL",
+      includeThoughts: false,
+    });
+  });
+
+  test("omits thinkingConfig when wire shape is adaptive with no extras", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { thinking: { type: "adaptive" } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    // No level/streamThinking → omit so Google's per-model default applies
+    // (Gemini 3.x defaults to "medium" with dynamic thinking).
+    expect(config.thinkingConfig).toBeUndefined();
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -152,10 +152,18 @@ const TemperatureSchema = z.number().min(0).max(2).nullable();
 // defaulted (`ThinkingSchema`) and fragment (`ThinkingFragmentSchema`) views.
 const ThinkingEnabledSchema = z.boolean();
 const ThinkingStreamThinkingSchema = z.boolean();
+// Gemini-style thinking depth knob. Maps to Gemini's `thinkingLevel`. Other
+// providers (Anthropic, OpenRouter) ignore this field — they use `effort`
+// instead to size reasoning. Optional with no default so the underlying
+// provider can pick its own default (Gemini 3.x defaults to "medium").
+export const THINKING_LEVELS = ["minimal", "low", "medium", "high"] as const;
+export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+const ThinkingLevelSchema = z.enum(THINKING_LEVELS);
 
 const ThinkingSchema = z.object({
   enabled: ThinkingEnabledSchema.default(true),
   streamThinking: ThinkingStreamThinkingSchema.default(true),
+  level: ThinkingLevelSchema.optional(),
 });
 
 // Fragment view: every field optional, no defaults injected. Defining this
@@ -165,6 +173,7 @@ const ThinkingSchema = z.object({
 const ThinkingFragmentSchema = z.object({
   enabled: ThinkingEnabledSchema.optional(),
   streamThinking: ThinkingStreamThinkingSchema.optional(),
+  level: ThinkingLevelSchema.optional(),
 });
 
 // Leaf primitives for context-overflow recovery.

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -425,7 +425,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.temperature).toBe(0.5);
   });
 
-  test("strips effort/speed/thinking for providers that don't support them", async () => {
+  test("strips effort/speed for providers that don't support them (e.g. fireworks)", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -434,14 +434,14 @@ describe("RetryProvider — callSite resolution", () => {
         speed: "fast",
       },
       callSites: {
-        memoryRetrieval: { thinking: { enabled: true } },
+        memoryRetrieval: { thinking: { enabled: false } },
       },
     });
 
     let seen: SendMessageOptions | undefined;
-    // gemini does not support effort/speed/thinking — they must be stripped.
+    // fireworks does not support speed or thinking — they must be stripped.
     const wrapped = new RetryProvider(
-      makeProvider("gemini", (options) => {
+      makeProvider("fireworks", (options) => {
         seen = options;
       }),
     );
@@ -451,11 +451,91 @@ describe("RetryProvider — callSite resolution", () => {
     });
 
     const config = seen?.config as Record<string, unknown>;
-    expect(config.effort).toBeUndefined();
     expect(config.speed).toBeUndefined();
     expect(config.thinking).toBeUndefined();
     // Model still comes through.
     expect(config.model).toBe("claude-opus-4-7");
+  });
+
+  test("preserves thinking + level for Gemini provider", async () => {
+    setLlmConfig({
+      default: {
+        provider: "gemini",
+        model: "gemini-3.5-flash",
+        thinking: { enabled: true, streamThinking: true, level: "high" },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("gemini", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({
+      type: "adaptive",
+      level: "high",
+      streamThinking: true,
+    });
+  });
+
+  test("Gemini disabled thinking carries the wire `disabled` discriminator", async () => {
+    setLlmConfig({
+      default: {
+        provider: "gemini",
+        model: "gemini-3.5-flash",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("gemini", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("scrubs Gemini-only thinking extras (level, streamThinking) for Anthropic", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: true, streamThinking: true, level: "high" },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    // Anthropic's SDK rejects unknown keys inside the `thinking` object with
+    // "Extra inputs are not permitted" — must be exactly `{ type }`.
+    expect(config.thinking).toEqual({ type: "adaptive" });
   });
 
   test("explicit per-call config.model wins over resolved callSite model", async () => {

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,5 +1,5 @@
 import type * as genai from "@google/genai";
-import { ApiError, GoogleGenAI } from "@google/genai";
+import { ApiError, GoogleGenAI, ThinkingLevel } from "@google/genai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
@@ -32,6 +32,47 @@ const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
 
 function isGemini3Model(model: string): boolean {
   return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
+}
+
+const THINKING_LEVEL_BY_NAME: Record<string, ThinkingLevel> = {
+  minimal: ThinkingLevel.MINIMAL,
+  low: ThinkingLevel.LOW,
+  medium: ThinkingLevel.MEDIUM,
+  high: ThinkingLevel.HIGH,
+};
+
+/**
+ * Translate the resolved wire-shape `thinking` config into Gemini's
+ * `thinkingConfig`. Returns `undefined` when no thinking config was supplied,
+ * which lets Google's per-model default apply (e.g. `gemini-3.5-flash`
+ * defaults to dynamic medium-level thinking).
+ *
+ * `enabled: false` maps to `thinkingLevel: MINIMAL` because Gemini 3.x cannot
+ * fully disable thinking — `"minimal"` is the floor. `includeThoughts` is
+ * gated on `streamThinking` so callers that opted out of streaming thoughts
+ * don't pay for thought tokens in the response.
+ */
+function buildThinkingConfig(
+  thinking: Record<string, unknown> | undefined,
+): genai.ThinkingConfig | undefined {
+  if (!thinking) return undefined;
+  if (thinking.type === "disabled") {
+    return {
+      thinkingLevel: ThinkingLevel.MINIMAL,
+      includeThoughts: false,
+    };
+  }
+  if (thinking.type !== "adaptive") return undefined;
+
+  const result: genai.ThinkingConfig = {};
+  if (typeof thinking.level === "string") {
+    const mapped = THINKING_LEVEL_BY_NAME[thinking.level];
+    if (mapped) result.thinkingLevel = mapped;
+  }
+  if (typeof thinking.streamThinking === "boolean") {
+    result.includeThoughts = thinking.streamThinking;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function stripGeminiHttpOptions(
@@ -175,6 +216,9 @@ export class GeminiProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
+    const thinkingConfig = buildThinkingConfig(
+      configObj?.thinking as Record<string, unknown> | undefined,
+    );
     const activeModel = modelOverride ?? this.model;
 
     try {
@@ -190,6 +234,9 @@ export class GeminiProvider implements Provider {
       }
       if (maxTokens) {
         geminiConfig.maxOutputTokens = maxTokens;
+      }
+      if (thinkingConfig) {
+        geminiConfig.thinkingConfig = thinkingConfig;
       }
       if (tools && tools.length > 0) {
         geminiConfig.tools = [

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -47,9 +47,18 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
  * the wire; OpenRouter either forwards it to its Anthropic-compatible path or
- * translates it into the unified `reasoning` parameter on OpenAI-compat calls.
+ * translates it into the unified `reasoning` parameter on OpenAI-compat calls;
+ * Gemini reads `thinking.level` to populate `thinkingConfig.thinkingLevel`.
  */
-const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter"]);
+const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter", "gemini"]);
+
+/**
+ * Providers that consume Gemini-only thinking extras (`level`,
+ * `streamThinking`). For other thinking-aware providers, we scrub these from
+ * the normalized wire payload because Anthropic's SDK rejects unknown keys
+ * inside the `thinking` object with "Extra inputs are not permitted".
+ */
+const THINKING_EXTRA_FIELDS_AWARE_PROVIDERS = new Set(["gemini"]);
 
 /**
  * Providers that consume the `verbosity` config. Currently OpenAI (mapped to
@@ -289,12 +298,34 @@ function normalizeSendMessageOptions(
   }
 
   // thinking is Anthropic-specific on the wire; OpenRouter reads it as a
-  // signal for its unified reasoning parameter. Strip it for other providers.
+  // signal for its unified reasoning parameter; Gemini reads `level` from it.
+  // Strip it for other providers.
   if (
     !THINKING_AWARE_PROVIDERS.has(providerName) &&
     nextConfig.thinking !== undefined
   ) {
     delete nextConfig.thinking;
+  }
+
+  // Strip Gemini-only extras (`level`, `streamThinking`) from the wire
+  // `thinking` object for providers that don't read them. Anthropic in
+  // particular rejects unknown keys inside `thinking` with "Extra inputs are
+  // not permitted"; the OpenRouter Anthropic-compat path hits the same SDK.
+  if (
+    nextConfig.thinking !== undefined &&
+    !THINKING_EXTRA_FIELDS_AWARE_PROVIDERS.has(providerName) &&
+    typeof nextConfig.thinking === "object" &&
+    nextConfig.thinking !== null
+  ) {
+    const wire = nextConfig.thinking as Record<string, unknown>;
+    if (wire.level !== undefined || wire.streamThinking !== undefined) {
+      const scrubbed: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(wire)) {
+        if (key === "level" || key === "streamThinking") continue;
+        scrubbed[key] = value;
+      }
+      nextConfig.thinking = scrubbed;
+    }
   }
 
   // Anthropic (and OpenRouter fronting Anthropic) rejects requests that

--- a/assistant/src/providers/thinking-config.ts
+++ b/assistant/src/providers/thinking-config.ts
@@ -1,7 +1,28 @@
+import { THINKING_LEVELS, type ThinkingLevel } from "../config/schemas/llm.js";
+
 type ThinkingConfigRecord = Record<string, unknown>;
+
+const THINKING_LEVEL_SET: ReadonlySet<string> = new Set(THINKING_LEVELS);
 
 function isRecord(value: unknown): value is ThinkingConfigRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pickGeminiExtras(thinking: ThinkingConfigRecord): {
+  level?: ThinkingLevel;
+  streamThinking?: boolean;
+} {
+  const extras: { level?: ThinkingLevel; streamThinking?: boolean } = {};
+  if (
+    typeof thinking.level === "string" &&
+    THINKING_LEVEL_SET.has(thinking.level)
+  ) {
+    extras.level = thinking.level as ThinkingLevel;
+  }
+  if (typeof thinking.streamThinking === "boolean") {
+    extras.streamThinking = thinking.streamThinking;
+  }
+  return extras;
 }
 
 export function normalizeThinkingConfigForWire(
@@ -9,12 +30,16 @@ export function normalizeThinkingConfigForWire(
 ): ThinkingConfigRecord | undefined {
   if (!isRecord(thinking)) return undefined;
 
+  // Already in wire shape — preserve as-is so re-normalization is idempotent
+  // and Gemini-only fields stay attached for the Gemini provider to read.
   if (typeof thinking.type === "string") {
     return thinking;
   }
 
+  const extras = pickGeminiExtras(thinking);
+
   if (thinking.enabled === true) {
-    return { type: "adaptive" };
+    return { type: "adaptive", ...extras };
   }
 
   if (thinking.enabled === false) {


### PR DESCRIPTION
## Summary
- Add `level` field to `ThinkingSchema` (enum: minimal/low/medium/high) so callers can tune Gemini reasoning depth without touching SDK internals.
- Add `gemini` to `THINKING_AWARE_PROVIDERS`; translate the wire-shape `thinking` into `thinkingConfig` inside `GeminiProvider.sendMessage()`. `enabled: false` maps to `thinkingLevel: MINIMAL` (Gemini 3.x can't fully disable thinking).
- Scrub Gemini-only fields (`level`, `streamThinking`) from the wire `thinking` object for non-Gemini providers so Anthropic's SDK doesn't reject the request with "Extra inputs are not permitted".

## Original prompt
The Gemini provider was passing requests with no thinking config to Google, meaning Google's per-model default applied — `gemini-3.5-flash` defaults to dynamic "medium" thinking. Worse, the 13 call sites that explicitly set `thinking: { enabled: false }` (commitMessage, replySuggestion, notificationDecision, etc.) had their intent silently dropped because Gemini wasn't in `THINKING_AWARE_PROVIDERS`. This change makes the existing toggle actually work for Gemini and exposes the `thinkingLevel` knob through config.