### PR TITLE
fix(sse): add conversationKey to event envelope for bus-owned routing

### DIFF
--- a/assistant/src/__tests__/broadcast-conversation-key.test.ts
+++ b/assistant/src/__tests__/broadcast-conversation-key.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Verifies that `broadcastMessage` sets `conversationKey` on conversation-scoped
+ * events and leaves it `undefined` on global events (e.g.
+ * `conversation_list_invalidated`).
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../signals/event-stream.js", () => ({
+  appendEventToStream: () => {},
+}));
+
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  assistantEventHub,
+  broadcastMessage,
+} from "../runtime/assistant-event-hub.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Collect events published to the hub during a callback. */
+async function collectEvents(
+  fn: () => void,
+): Promise<AssistantEvent[]> {
+  const events: AssistantEvent[] = [];
+  const sub = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      events.push(event);
+    },
+  });
+  fn();
+  // broadcastMessage chains publishes on a promise; wait for the microtask queue.
+  await new Promise((r) => setTimeout(r, 50));
+  sub.dispose();
+  return events;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("broadcastMessage — conversationKey", () => {
+  test("sets conversationKey on conversation-scoped events", async () => {
+    const conversationId = "conv-abc-123";
+    const events = await collectEvents(() => {
+      broadcastMessage(
+        { type: "assistant_text_delta", text: "hello" },
+        conversationId,
+      );
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.conversationId).toBe(conversationId);
+    expect(events[0]!.conversationKey).toBe(conversationId);
+  });
+
+  test("does not set conversationKey on global events", async () => {
+    const events = await collectEvents(() => {
+      broadcastMessage({
+        type: "conversation_list_invalidated",
+        reason: "created",
+      });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.conversationId).toBeUndefined();
+    expect(events[0]!.conversationKey).toBeUndefined();
+  });
+
+  test("auto-extracts conversationId from message and sets conversationKey", async () => {
+    const conversationId = "conv-xyz-789";
+    const events = await collectEvents(() => {
+      // No explicit conversationId arg — broadcastMessage extracts it from msg.
+      broadcastMessage({
+        type: "assistant_text_delta",
+        text: "world",
+        conversationId,
+      });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.conversationId).toBe(conversationId);
+    expect(events[0]!.conversationKey).toBe(conversationId);
+  });
+});

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -538,6 +538,7 @@ export function broadcastMessage(
       ? undefined
       : resolvedConversationId;
   const event = buildAssistantEvent(msg, scopedConversationId);
+  event.conversationKey = scopedConversationId;
   const targetCapability = capabilityForMessageType(msg.type);
   const publishOptions =
     targetCapability != null || targetClientId != null

--- a/packages/skill-host-contracts/src/assistant-event.ts
+++ b/packages/skill-host-contracts/src/assistant-event.ts
@@ -30,6 +30,8 @@ export interface AssistantEvent<TMessage = unknown> {
   id: string;
   /** Resolved conversation id when available. */
   conversationId?: string;
+  /** Conversation routing key for client-side event filtering. */
+  conversationKey?: string;
   /** ISO-8601 timestamp of when the event was emitted. */
   emittedAt: string;
   /** Outbound message payload. */


### PR DESCRIPTION
## Summary

- Adds `conversationKey` to the `AssistantEvent` envelope so the web client's bus-owned SSE connection can route conversation-scoped events correctly.
- After the bus migration (LUM-1812), a single unfiltered SSE stream serves all conversations. Each event must carry its own `conversationKey` for client-side filtering — but the daemon only set `conversationId`, never `conversationKey`.
- Hotfix #31726 tightened the client filter to reject events without `conversationKey`, which silently drops all conversation-scoped events (text deltas, activity state, tool progress, queue events). This fix closes the gap.

## `conversationKey` vs `conversationId`

This fix sets `conversationKey = conversationId` on the event envelope. This works because for web-originated conversations, the client's `conversationKey` is the same UUID as the daemon's `conversationId` — they coincide today. Channel-originated conversations (Slack, Telegram) use composite keys like `default:slack:C0123` but don't flow through the web SSE path, so the coincidence holds for all web clients.

If `conversationKey` and `conversationId` diverge for web conversations in the future, this mapping will need to be updated — but that would be a larger architectural change with its own migration.

Related: LUM-1825 (Vargas) found the same `conversationKey`/`conversationId` confusion on the platform backend side.

## Changes

- `packages/skill-host-contracts/src/assistant-event.ts`: Added `conversationKey?: string` to the `AssistantEvent` interface
- `assistant/src/runtime/assistant-event-hub.ts`: Set `event.conversationKey = scopedConversationId` in `broadcastMessage()` — conversation-scoped events get `conversationKey === conversationId` (they coincide for web today), global events stay `undefined`
- `assistant/src/__tests__/broadcast-conversation-key.test.ts`: Tests covering both cases

## Test plan

- [x] `bun test assistant/src/__tests__/broadcast-conversation-key.test.ts` — 3 tests pass
- [x] `bunx tsc --noEmit` — both `packages/skill-host-contracts` and `assistant` typecheck clean
- [ ] Manual: verify web streaming works (text deltas stream token-by-token, not all-at-once)
- [ ] Manual: verify queue steer transitions complete correctly (no stuck loading state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)