### PR TITLE
test(workspace-git): read concurrent-commit log through service

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -421,11 +421,12 @@ describe("WorkspaceGitService", () => {
 
       await Promise.all(commits);
 
-      // All commits should have succeeded
-      const log = execFileSync("git", ["log", "--oneline"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      });
+      // Read through the service so GIT_* vars set by CI runners are stripped
+      // (matches the env used for the commits themselves).
+      const { stdout: log } = await service.runReadOnlyGit([
+        "log",
+        "--oneline",
+      ]);
 
       for (let i = 0; i < 10; i++) {
         expect(log).toContain(`Add file ${i}`);


### PR DESCRIPTION
## Summary
- Replace direct \`execFileSync(\"git\", [\"log\", ...])\` in the \`serializes concurrent commit operations\` test with \`service.runReadOnlyGit\`, so the log read uses the same \`cleanGitEnv\` (strips \`GIT_*\` vars) and \`GIT_CEILING_DIRECTORIES\` setup that the commits themselves used.
- Aimed at the recurring CI flake where the test sees only the final commit (\`Add file 9\`) in the log — observed in [runs/26310785161](https://github.com/vellum-ai/vellum-assistant/actions/runs/26310785161/job/77458699404) and [runs/26294962213](https://github.com/vellum-ai/vellum-assistant/actions/runs/26294962213).

## Original prompt
Fix the CI failure in [job 77458699404](https://github.com/vellum-ai/vellum-assistant/actions/runs/26310785161/job/77458699404): the workspace-git-service \"serializes concurrent commit operations\" test fails on CI showing only the last commit in the log. Same symptom appeared in at least one earlier run, so it's a recurring flake worth addressing rather than a one-off retry.