### PR TITLE
fix(ios): await safe-area bridge before first render

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -13,18 +13,23 @@ import "./index.css";
 
 import { initSafeAreaBridge } from "@/runtime/native-safe-area.js";
 
-initSafeAreaBridge();
-setupOrganizationStore();
-useAuthStore.getState().initSession();
-setupAuthListeners();
+async function boot() {
+  await initSafeAreaBridge();
 
-const rootEl = document.getElementById("root");
-if (!rootEl) throw new Error("Root element #root not found");
+  setupOrganizationStore();
+  useAuthStore.getState().initSession();
+  setupAuthListeners();
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <AppProviders>
-      <RouterProvider router={router} />
-    </AppProviders>
-  </StrictMode>,
-);
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("Root element #root not found");
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <AppProviders>
+        <RouterProvider router={router} />
+      </AppProviders>
+    </StrictMode>,
+  );
+}
+
+boot();

--- a/apps/web/src/runtime/native-safe-area.ts
+++ b/apps/web/src/runtime/native-safe-area.ts
@@ -34,8 +34,12 @@ export async function initSafeAreaBridge(): Promise<void> {
   try {
     const { SafeArea } = await import("capacitor-plugin-safe-area");
 
-    const { insets } = await SafeArea.getSafeAreaInsets();
-    applyInsets(insets);
+    try {
+      const { insets } = await SafeArea.getSafeAreaInsets();
+      applyInsets(insets);
+    } catch {
+      // Initial read failed — listener below may still deliver insets.
+    }
 
     await SafeArea.addListener("safeAreaChanged", ({ insets: next }) => {
       applyInsets(next);

--- a/apps/web/src/runtime/native-safe-area.ts
+++ b/apps/web/src/runtime/native-safe-area.ts
@@ -1,5 +1,4 @@
 import { Capacitor } from "@capacitor/core";
-import { SafeArea } from "capacitor-plugin-safe-area";
 
 function applyInsets(insets: {
   top: number;
@@ -16,23 +15,32 @@ function applyInsets(insets: {
 
 let initialized = false;
 
+/**
+ * Read device safe-area insets from the native layer via
+ * `capacitor-plugin-safe-area` and expose them as CSS custom properties
+ * on `<html>`. Must be awaited before first render so the layout never
+ * paints with zero-inset padding.
+ *
+ * No-op outside the Capacitor shell — browser consumers fall through to
+ * `env(safe-area-inset-*)` which works correctly in Safari / Chrome.
+ *
+ * Ported from vellum-assistant-platform's SafeAreaBridge.tsx.
+ */
 export async function initSafeAreaBridge(): Promise<void> {
   if (initialized) return;
   if (typeof window === "undefined" || !Capacitor.isNativePlatform()) return;
   initialized = true;
 
   try {
+    const { SafeArea } = await import("capacitor-plugin-safe-area");
+
     const { insets } = await SafeArea.getSafeAreaInsets();
     applyInsets(insets);
-  } catch {
-    // Plugin unavailable or not registered — fall through to env() fallback.
-  }
 
-  try {
-    await SafeArea.addListener("safeAreaChanged", ({ insets }) => {
-      applyInsets(insets);
+    await SafeArea.addListener("safeAreaChanged", ({ insets: next }) => {
+      applyInsets(next);
     });
   } catch {
-    // Listener registration failed — initial insets are still applied.
+    // Plugin unavailable — fall through to env() fallback.
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #31794. The initial fix wired up the safe-area bridge but called it fire-and-forget — React rendered before the async native bridge responded, so the first paint still had zero-inset padding.

- Wrap app bootstrap in `async boot()` that **awaits** `initSafeAreaBridge()` before `createRoot().render()`, eliminating the flash of content behind the status bar
- Switch to **dynamic import** for `capacitor-plugin-safe-area` (matches platform web's `SafeAreaBridge.tsx` pattern) so the plugin stub doesn't execute in browser bundles
- No-op in browser — `Capacitor.isNativePlatform()` returns false, the async function returns immediately, and boot continues synchronously

**Important**: The iOS app loads web content from a remote URL (dev/staging/prod), NOT the local bundle. This fix takes effect once deployed to the server, not just by rebuilding Xcode.

## Test plan

- [ ] Deploy to dev-assistant.vellum.ai
- [ ] Open iOS app — header should sit below status bar on first paint (no flash)
- [ ] Rotate device — safe area adjusts correctly
- [ ] Verify web app still loads normally in browser (bridge is a no-op)
- [ ] Verify no delay in app boot time on web (bridge short-circuits before dynamic import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)