### PR TITLE
Refresh tier-ceiling cache after plan change so Storage & Resources shows new limits

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -6,6 +6,7 @@ import { Modal } from "@vellum/design-library/components/modal";
 import type { MachineTierEnum } from "@/generated/api/types.gen.js";
 import {
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen.js";
@@ -38,6 +39,13 @@ export function BillingOnboardingModal({
     if (!open) return;
     void queryClient.invalidateQueries({
       queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+    });
+    // Refresh the tier-ceiling cache (`max_machine_tier`,
+    // `selected_storage_gib`) the wizard's SetupStep and the shared Storage &
+    // Resources ResizeCard read from, so neither renders pre-upgrade limits
+    // once the new subscription is confirmed.
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
     });
   }, [open, queryClient]);
 

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -23,6 +23,7 @@ import type {
 import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
   organizationsBillingSubscriptionUpgradeCreateMutation,
@@ -133,6 +134,14 @@ export function AdjustPlanModal({ open, onClose }: AdjustPlanModalProps) {
       });
       void queryClient.invalidateQueries({
         queryKey: organizationsBillingPlansRetrieveQueryKey(),
+      });
+      // The onboarding endpoint carries the per-org tier ceilings
+      // (`max_machine_tier`, `selected_storage_gib`) that the Storage &
+      // Resources ResizeCard renders as its limits. A tier change updates those
+      // ceilings server-side, so its cache must be invalidated too — otherwise
+      // the card keeps showing the pre-upgrade limits until a hard reload.
+      void queryClient.invalidateQueries({
+        queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
       });
       onClose();
     });


### PR DESCRIPTION
## Symptom

After upgrading a plan/tier on Pro, the resize **goes through** but the **Storage & Resources** card keeps showing the **old limits** until a hard reload.

## Root cause

The `ResizeCard` (`settings/components/resize-card.tsx`) reads its ceilings — `max_machine_tier` and `selected_storage_gib` — from the **`organizationsBillingSubscriptionOnboardingRetrieve`** query.

The billing modals invalidate the **subscription** and **plans** caches after a plan change, but **never the onboarding cache**. So once a tier change updates the ceiling server-side (`change_storage_tier`/`change_machine_tier` persist `selected_storage_tier`/`max_machine_tier` synchronously; the resize endpoint gates on those same columns — which is why the resize succeeds), the card still serves its stale cached onboarding data. With the global `staleTime` of 10s and no invalidation, nothing forces a refetch on the mounted settings page.

## Fix

Invalidate the onboarding query key alongside the existing subscription invalidations:

- **`adjust-plan-modal.tsx`** — in the `openUrlFinishedListener` (Stripe checkout / billing-portal return), the primary upgrade path.
- **`billing-onboarding-modal.tsx`** — in the open effect, so the post-checkout wizard's SetupStep and the shared `ResizeCard` cache both refresh once the new subscription is confirmed.

## Checks

- `eslint` passes on both changed files (exit 0).
- No new type errors attributable to these files (the `tsc` output is all pre-existing duplicate-`@types/react` errors inside `node_modules/@vellum/design-library`).

## Note / follow-up

The ceilings are stamped into the DB by the async Stripe webhook, so on the immediate checkout-return there's still a small race where the refetch could read pre-webhook data (the same race the existing subscription-query poll already tolerates). A fully robust version would poll the onboarding query until `selected_storage_gib` reflects the purchased tier — larger than this missing-invalidation fix, noted for follow-up. No regression test added: these modals have no existing coverage and a real test needs interactive-render scaffolding (mock generated API + Capacitor runtime listener + queryClient spy) — happy to add if desired.