### PR TITLE
fix(web): replace dark: pairs with semantic tokens on integrations page (LUM-1768)

### DIFF
--- a/apps/web/src/domains/settings/pages/integrations-page.tsx
+++ b/apps/web/src/domains/settings/pages/integrations-page.tsx
@@ -1,23 +1,20 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { useQuery } from "@tanstack/react-query";
 import {
   ChevronDown,
   Loader2,
   Search,
   Sparkles,
-  X,
 } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { useSearchParams, useNavigate } from "react-router";
 
+import { Input } from "@vellum/design-library/components/input";
+import { Notice } from "@vellum/design-library/components/notice";
 import { Popover } from "@vellum/design-library/components/popover";
 import { toast } from "@vellum/design-library/components/toast";
 import { IntegrationDetailModal } from "@/domains/settings/components/integration-detail-modal.js";
 import { IntegrationRow } from "@/domains/settings/components/integration-row.js";
-import { Button } from "@vellum/design-library/components/button";
-import { Input } from "@vellum/design-library/components/input";
 import { assistantsOauthConnectionsListOptions } from "@/generated/api/@tanstack/react-query.gen.js";
 import type { OAuthConnection } from "@/generated/api/types.gen.js";
 import { type Assistant, getAssistant } from "@/assistant/api.js";
@@ -240,21 +237,14 @@ function IntegrationsPanelInner() {
   return (
     <div className="space-y-4">
       {!bannerDismissed && (
-        <div className="flex items-center gap-2 rounded-md border border-sky-200/70 bg-sky-50 px-3 py-2 text-body-medium-lighter text-[var(--content-default)] dark:border-sky-900/60 dark:bg-sky-950/30">
-          <Sparkles className="h-3.5 w-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
-          <span className="flex-1">
-            <span className="text-body-medium-default">Tip:</span> You can enable
-            integrations by mentioning them in chat.
-          </span>
-          <Button
-            variant="ghost"
-            size="compact"
-            iconOnly={<X />}
-            onClick={dismissBanner}
-            aria-label="Dismiss tip"
-            className="shrink-0"
-          />
-        </div>
+        <Notice
+          tone="info"
+          icon={<Sparkles className="h-3.5 w-3.5" />}
+          onDismiss={dismissBanner}
+        >
+          <span className="text-body-medium-default">Tip:</span> You can enable
+          integrations by mentioning them in chat.
+        </Notice>
       )}
 
       <div className="flex items-center gap-2">
@@ -274,7 +264,7 @@ function IntegrationsPanelInner() {
               type="button"
               aria-haspopup="listbox"
               aria-expanded={filterMenuOpen}
-              className="flex w-36 cursor-pointer items-center justify-between gap-2 rounded-md border border-[var(--border-element)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] transition-colors hover:bg-[var(--surface-base)] dark:border-[var(--border-base)] dark:bg-[var(--surface-lift)] dark:text-[var(--content-default)] dark:hover:bg-[var(--ghost-hover)]"
+              className="flex w-36 cursor-pointer items-center justify-between gap-2 rounded-md border border-[var(--border-element)] bg-[var(--surface-lift)] px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] transition-colors hover:bg-[var(--ghost-hover)]"
             >
               <span>{selectedFilterLabel}</span>
               <ChevronDown className="h-3.5 w-3.5" />
@@ -328,7 +318,7 @@ function IntegrationsPanelInner() {
             No assistant found. Hatch an assistant to connect integrations.
           </p>
         ) : filteredProviders.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center dark:border-[var(--border-base)]">
+          <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center">
             <Search className="h-6 w-6 text-[var(--content-disabled)]" />
             <p className="text-body-medium-default text-[var(--content-default)]">
               {emptyStateTitle}


### PR DESCRIPTION
The integrations page tip banner and filter button use `dark:` Tailwind variant pairs (`bg-sky-50 dark:bg-sky-950/30`, `bg-white dark:bg-[var(--surface-lift)]`, etc.) that don't activate in velvet theme because the `@custom-variant dark` selector only matches `data-theme="dark"`, not `data-theme="velvet"`. This leaves the banner with a white/light background in velvet mode.

Replaces all `dark:` pairs in the file with semantic tokens and design-library components:

- **Tip banner** → replaced with the `<Notice tone="info">` component, which uses `--surface-overlay` / `--border-element` tokens that switch correctly across all three themes
- **Filter dropdown trigger** → `bg-white dark:bg-[var(--surface-lift)]` collapsed to `bg-[var(--surface-lift)]` (light=#FFFFFF, dark=#24292E, velvet=#211D22); hover collapsed to `hover:bg-[var(--ghost-hover)]`
- **Empty state border** → removed redundant `dark:border-[var(--border-base)]` since `border-[var(--border-element)]` already adapts per theme

With all `dark:` pairs eliminated, the `eslint-disable no-restricted-syntax` comment at the top of the file is also removed.

## Root cause analysis

1. **How did the code get into this state?** The integrations page was ported from the platform repo with hardcoded light/dark color pairs. The velvet theme was added later and the `@custom-variant dark` was intentionally kept scoped to `data-theme="dark"` only, to force migration to semantic tokens rather than silently extending `dark:` to velvet.
2. **What decisions led to it?** Using raw Tailwind color-scale utilities (`bg-sky-50`, `bg-white`) with `dark:` overrides rather than semantic design tokens.
3. **Warning signs?** The file already had `/* eslint-disable no-restricted-syntax -- LUM-1768 */` flagging these pairs for migration.
4. **Prevention?** The ESLint `no-restricted-syntax` rule added in [#31403](https://github.com/vellum-ai/vellum-assistant/pull/31403) already catches new `dark:` + raw-color pairs. Continuing the LUM-1768 migration across remaining files will eliminate the pattern.

## Prompt / plan

Fix white background on integrations page tip banner in velvet theme by migrating `dark:` pairs to semantic tokens per the team's established LUM-1768 migration strategy.

## Test plan

- `bunx tsc --noEmit` passes
- `bun run lint` passes (no remaining `dark:` pairs, eslint-disable removed)
- Manual verification: open Settings → Integrations in velvet theme and confirm the tip banner, filter button, and empty state all use dark backgrounds consistent with the velvet palette

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/73ada537aa294d4bbc93b1bba7371809