### PR TITLE
feat(avatar): add Generate with AI and Reset to default options

### DIFF
--- a/apps/web/src/components/avatar/avatar-management-modal.tsx
+++ b/apps/web/src/components/avatar/avatar-management-modal.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Image as ImageIcon, Wrench, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Image as ImageIcon, Sparkles, Trash2, Wrench, X } from "lucide-react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -27,6 +27,8 @@ interface AvatarManagementModalProps {
   customImageUrl: string | null;
   onSaveCharacter: (traits: CharacterTraits) => void;
   onUploadImage: () => void;
+  onGenerateWithAI?: () => void;
+  onDeleteAvatar?: () => void;
 }
 
 export function AvatarManagementModal({
@@ -38,6 +40,8 @@ export function AvatarManagementModal({
   customImageUrl,
   onSaveCharacter,
   onUploadImage,
+  onGenerateWithAI,
+  onDeleteAvatar,
 }: AvatarManagementModalProps) {
   const titleId = useId();
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -123,6 +127,16 @@ export function AvatarManagementModal({
   const handleUploadClick = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
+
+  const handleGenerateWithAI = useCallback(() => {
+    handleClose();
+    onGenerateWithAI?.();
+  }, [handleClose, onGenerateWithAI]);
+
+  const handleDeleteAvatar = useCallback(() => {
+    handleClose();
+    onDeleteAvatar?.();
+  }, [handleClose, onDeleteAvatar]);
 
   const handleCharacterSave = useCallback(
     (savedTraits: CharacterTraits) => {
@@ -264,7 +278,53 @@ export function AvatarManagementModal({
                   </div>
                   <ChevronRight className="h-4 w-4 shrink-0" style={{ color: "var(--content-tertiary)" }} />
                 </button>
+
+                {onGenerateWithAI && (
+                  <button
+                    type="button"
+                    onClick={handleGenerateWithAI}
+                    className="flex w-full cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors hover:opacity-80"
+                    style={{
+                      borderColor: "var(--border-base)",
+                      backgroundColor: "var(--surface-lift)",
+                    }}
+                  >
+                    <div
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                      style={{ backgroundColor: "color-mix(in oklab, var(--content-tertiary) 16%, transparent)" }}
+                    >
+                      <Sparkles className="h-4 w-4" style={{ color: "var(--content-secondary)" }} />
+                    </div>
+                    <div className="flex-1 text-left">
+                      <p
+                        className="text-body-medium-default"
+                        style={{ color: "var(--content-default)" }}
+                      >
+                        Generate with AI
+                      </p>
+                      <p
+                        className="text-body-small-default"
+                        style={{ color: "var(--content-tertiary)" }}
+                      >
+                        Create an avatar through chat
+                      </p>
+                    </div>
+                    <ChevronRight className="h-4 w-4 shrink-0" style={{ color: "var(--content-tertiary)" }} />
+                  </button>
+                )}
               </div>
+
+              {onDeleteAvatar && (
+                <button
+                  type="button"
+                  onClick={handleDeleteAvatar}
+                  className="flex items-center gap-1.5 text-body-small-default transition-colors hover:opacity-70"
+                  style={{ color: "var(--content-tertiary)" }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Reset to default
+                </button>
+              )}
             </div>
           ) : (
             <AvatarCustomizationPanel

--- a/apps/web/src/domains/avatar/api.ts
+++ b/apps/web/src/domains/avatar/api.ts
@@ -107,6 +107,28 @@ export async function uploadAvatarImage(
   }
 }
 
+export async function deleteAvatar(assistantId: string): Promise<boolean> {
+  try {
+    const [imageResult, traitsResult] = await Promise.all([
+      client.post({
+        url: "/v1/assistants/{assistant_id}/workspace/delete/",
+        path: { assistant_id: assistantId },
+        body: { path: "data/avatar/avatar-image.png" },
+        headers: { "Content-Type": "application/json" },
+      }),
+      client.post({
+        url: "/v1/assistants/{assistant_id}/workspace/delete/",
+        path: { assistant_id: assistantId },
+        body: { path: "data/avatar/character-traits.json" },
+        headers: { "Content-Type": "application/json" },
+      }),
+    ]);
+    return (imageResult.response?.ok ?? false) || (traitsResult.response?.ok ?? false);
+  } catch {
+    return false;
+  }
+}
+
 export async function fetchAvatarImageUrl(
   assistantId: string,
 ): Promise<string | null> {

--- a/apps/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/identity-tab.tsx
@@ -7,6 +7,7 @@ import { ConstellationView } from "@/domains/intelligence/components/constellati
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail.js";
 import { AvatarManagementModal } from "@/components/avatar/avatar-management-modal.js";
 import { ChatAvatar } from "@/components/avatar/chat-avatar.js";
+import { deleteAvatar } from "@/domains/avatar/api.js";
 import { useAssistantAvatar } from "@/domains/avatar/use-assistant-avatar.js";
 import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
 import { fetchSkills, installSkill, uninstallSkill } from "@/domains/intelligence/skills/api.js";
@@ -230,6 +231,17 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
     setModalOpen(false);
   }, []);
 
+  const handleGenerateWithAI = useCallback(() => {
+    onOpenThread?.("I'd like to create a custom AI-generated avatar.");
+  }, [onOpenThread]);
+
+  const handleDeleteAvatar = useCallback(async () => {
+    const ok = await deleteAvatar(assistantId);
+    if (ok) {
+      invalidateAvatar();
+    }
+  }, [assistantId, invalidateAvatar]);
+
   const invalidateSkills = useCallback(() => {
     void queryClient.invalidateQueries({
       queryKey: ["assistantSkills", assistantId],
@@ -380,6 +392,8 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
         customImageUrl={customImageUrl}
         onSaveCharacter={handleAvatarChange}
         onUploadImage={handleAvatarChange}
+        onGenerateWithAI={onOpenThread ? handleGenerateWithAI : undefined}
+        onDeleteAvatar={handleDeleteAvatar}
       />
       {removalDialog}
     </div>

--- a/apps/web/src/domains/intelligence/identity-page.tsx
+++ b/apps/web/src/domains/intelligence/identity-page.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
-import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
-import { useConversationStore } from "@/domains/conversations/conversation-store.js";
 import { IdentityTab } from "@/domains/intelligence/components/identity-tab.js";
 import { routes } from "@/utils/routes.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
@@ -15,8 +13,7 @@ export function IdentityPage() {
   const handleOpenThread = useCallback(
     (message: string) => {
       useViewerStore.getState().setMainView("chat");
-      const draftKey = createDraftConversationKey();
-      useConversationStore.getState().setActiveKey(draftKey);
+      const draftKey = crypto.randomUUID();
       navigate(
         `${routes.conversation(draftKey)}?prompt=${encodeURIComponent(message)}`,
       );

--- a/apps/web/src/domains/intelligence/identity-page.tsx
+++ b/apps/web/src/domains/intelligence/identity-page.tsx
@@ -1,7 +1,28 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
+import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
 import { IdentityTab } from "@/domains/intelligence/components/identity-tab.js";
+import { routes } from "@/utils/routes.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
 
 export function IdentityPage() {
   const { assistantId } = useActiveAssistantContext();
-  return <IdentityTab assistantId={assistantId} />;
+  const navigate = useNavigate();
+
+  const handleOpenThread = useCallback(
+    (message: string) => {
+      useViewerStore.getState().setMainView("chat");
+      const draftKey = createDraftConversationKey();
+      useConversationStore.getState().setActiveKey(draftKey);
+      navigate(
+        `${routes.conversation(draftKey)}?prompt=${encodeURIComponent(message)}`,
+      );
+    },
+    [navigate],
+  );
+
+  return <IdentityTab assistantId={assistantId} onOpenThread={handleOpenThread} />;
 }


### PR DESCRIPTION
## Summary

- Adds a **"Generate with AI"** button (Sparkles icon) to the avatar management modal that closes the modal, navigates to a new chat conversation, and auto-sends "I'd like to create a custom AI-generated avatar." — leveraging the existing `media-generate-image` bundled tool.
- Adds a **"Reset to default"** subtle text link (Trash2 icon) below the main options that deletes both the custom avatar image and character traits, reverting to the default avatar.
- Wires up `onOpenThread` in `IdentityPage` using the same `?prompt=` query param pattern as `HomePage`, which also enables the existing edit pencil buttons (name, role, personality) that were previously disabled on the standalone identity page.

Closes JARVIS-856

## Test plan

- [ ] Open the identity page → click "Update Avatar" → verify three buttons appear: Build a Character, Upload Image, Generate with AI
- [ ] Click "Generate with AI" → verify it navigates to a new chat conversation with the prompt auto-sent
- [ ] Verify the assistant responds with image generation flow
- [ ] Click "Reset to default" → verify avatar reverts to the default character
- [ ] Verify the edit pencil buttons (name, role, personality) now work from the identity page
- [ ] Verify existing Build a Character and Upload Image flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)