### PR TITLE
test: add ingress disabled + platform mode coverage

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -124,6 +124,14 @@ describe("platform fallback", () => {
     expect(result).toBe("https://tunnel.example.com");
   });
 
+  test("throws when ingress is explicitly disabled even in platform mode", () => {
+    expect(() =>
+      getPublicBaseUrl({
+        ingress: { enabled: false, publicBaseUrl: "" },
+      }),
+    ).toThrow(/Public ingress is disabled/);
+  });
+
   test("throws when IS_PLATFORM is not set", () => {
     delete process.env.IS_PLATFORM;
     setPlatformAssistantId(undefined);


### PR DESCRIPTION
## Summary
- Add test verifying that `ingress.enabled === false` blocks URL resolution even when IS_PLATFORM=true

Part of plan: a2a-platform-public-url.md (review fix)