### PR TITLE
fix(a2a): derive public base URL automatically for platform-hosted assistants

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -25,10 +25,14 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeLoggerStub(),
 }));
 
-import { setIngressPublicBaseUrl } from "../config/env.js";
+import {
+  setIngressPublicBaseUrl,
+  setPlatformAssistantId,
+} from "../config/env.js";
 import { IngressConfigSchema } from "../config/schemas/ingress.js";
 import {
   getOAuthCallbackUrl,
+  getPlatformPublicCallbackBase,
   getPublicBaseUrl,
   getTelegramWebhookUrl,
   getTwilioConnectActionUrl,
@@ -37,6 +41,107 @@ import {
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
 } from "../inbound/public-ingress-urls.js";
+
+// ---------------------------------------------------------------------------
+// getPlatformPublicCallbackBase
+// ---------------------------------------------------------------------------
+
+describe("getPlatformPublicCallbackBase", () => {
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_PLATFORM_URL;
+    setPlatformAssistantId(undefined);
+  });
+
+  test("returns the correct URL when IS_PLATFORM=true with valid platform URL and assistant ID", () => {
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("ast_test123");
+
+    const result = getPlatformPublicCallbackBase();
+    expect(result).toBe(
+      "https://test-platform.vellum.ai/v1/gateway/callbacks/ast_test123",
+    );
+  });
+
+  test("returns undefined when IS_PLATFORM is not set", () => {
+    delete process.env.IS_PLATFORM;
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("ast_test123");
+
+    expect(getPlatformPublicCallbackBase()).toBeUndefined();
+  });
+
+  test("returns undefined when assistant ID is empty", () => {
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("");
+
+    expect(getPlatformPublicCallbackBase()).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// platform fallback in getPublicBaseUrl
+// ---------------------------------------------------------------------------
+
+describe("platform fallback", () => {
+  beforeEach(() => {
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("ast_test123");
+    setIngressPublicBaseUrl(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_PLATFORM_URL;
+    setPlatformAssistantId(undefined);
+    setIngressPublicBaseUrl(undefined);
+  });
+
+  test("getPublicBaseUrl returns platform-derived URL when ingress.publicBaseUrl is empty", () => {
+    const result = getPublicBaseUrl({
+      ingress: { publicBaseUrl: "" },
+    });
+    expect(result).toBe(
+      "https://test-platform.vellum.ai/v1/gateway/callbacks/ast_test123",
+    );
+  });
+
+  test("explicit ingress.publicBaseUrl takes precedence over platform derivation", () => {
+    const result = getPublicBaseUrl({
+      ingress: { publicBaseUrl: "https://custom.example.com" },
+    });
+    expect(result).toBe("https://custom.example.com");
+  });
+
+  test("module-level ingress state takes precedence over platform derivation", () => {
+    setIngressPublicBaseUrl("https://tunnel.example.com");
+    const result = getPublicBaseUrl({
+      ingress: { publicBaseUrl: "" },
+    });
+    expect(result).toBe("https://tunnel.example.com");
+  });
+
+  test("throws when IS_PLATFORM is not set", () => {
+    delete process.env.IS_PLATFORM;
+    setPlatformAssistantId(undefined);
+
+    expect(() => getPublicBaseUrl({ ingress: { publicBaseUrl: "" } })).toThrow(
+      /No public base URL configured/,
+    );
+  });
+
+  test("throws when getPlatformAssistantId() returns empty string even though IS_PLATFORM=true", () => {
+    process.env.IS_PLATFORM = "true";
+    setPlatformAssistantId("");
+
+    expect(() => getPublicBaseUrl({ ingress: { publicBaseUrl: "" } })).toThrow(
+      /No public base URL configured/,
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // IngressConfigSchema
@@ -66,7 +171,6 @@ describe("IngressConfigSchema", () => {
       }),
     ).toThrow(/ingress\.publicBaseUrl must be an absolute URL/);
   });
-
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -82,10 +82,10 @@ describe("getPlatformPublicCallbackBase", () => {
 });
 
 // ---------------------------------------------------------------------------
-// platform fallback in getPublicBaseUrl
+// getPublicBaseUrl does NOT fall back to platform callback base
 // ---------------------------------------------------------------------------
 
-describe("platform fallback", () => {
+describe("getPublicBaseUrl platform isolation", () => {
   beforeEach(() => {
     process.env.IS_PLATFORM = "true";
     process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
@@ -100,54 +100,17 @@ describe("platform fallback", () => {
     setIngressPublicBaseUrl(undefined);
   });
 
-  test("getPublicBaseUrl returns platform-derived URL when ingress.publicBaseUrl is empty", () => {
-    const result = getPublicBaseUrl({
-      ingress: { publicBaseUrl: "" },
-    });
-    expect(result).toBe(
-      "https://test-platform.vellum.ai/v1/gateway/callbacks/ast_test123",
+  test("throws even in platform mode when no ingress URL is configured", () => {
+    expect(() => getPublicBaseUrl({ ingress: { publicBaseUrl: "" } })).toThrow(
+      /No public base URL configured/,
     );
   });
 
-  test("explicit ingress.publicBaseUrl takes precedence over platform derivation", () => {
+  test("returns explicit ingress.publicBaseUrl in platform mode", () => {
     const result = getPublicBaseUrl({
       ingress: { publicBaseUrl: "https://custom.example.com" },
     });
     expect(result).toBe("https://custom.example.com");
-  });
-
-  test("module-level ingress state takes precedence over platform derivation", () => {
-    setIngressPublicBaseUrl("https://tunnel.example.com");
-    const result = getPublicBaseUrl({
-      ingress: { publicBaseUrl: "" },
-    });
-    expect(result).toBe("https://tunnel.example.com");
-  });
-
-  test("throws when ingress is explicitly disabled even in platform mode", () => {
-    expect(() =>
-      getPublicBaseUrl({
-        ingress: { enabled: false, publicBaseUrl: "" },
-      }),
-    ).toThrow(/Public ingress is disabled/);
-  });
-
-  test("throws when IS_PLATFORM is not set", () => {
-    delete process.env.IS_PLATFORM;
-    setPlatformAssistantId(undefined);
-
-    expect(() => getPublicBaseUrl({ ingress: { publicBaseUrl: "" } })).toThrow(
-      /No public base URL configured/,
-    );
-  });
-
-  test("throws when getPlatformAssistantId() returns empty string even though IS_PLATFORM=true", () => {
-    process.env.IS_PLATFORM = "true";
-    setPlatformAssistantId("");
-
-    expect(() => getPublicBaseUrl({ ingress: { publicBaseUrl: "" } })).toThrow(
-      /No public base URL configured/,
-    );
   });
 });
 

--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -124,6 +124,14 @@ describe("platform fallback", () => {
     expect(result).toBe("https://tunnel.example.com");
   });
 
+  test("throws when ingress is explicitly disabled even in platform mode", () => {
+    expect(() =>
+      getPublicBaseUrl({
+        ingress: { enabled: false, publicBaseUrl: "" },
+      }),
+    ).toThrow(/Public ingress is disabled/);
+  });
+
   test("throws when IS_PLATFORM is not set", () => {
     delete process.env.IS_PLATFORM;
     setPlatformAssistantId(undefined);

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -5,7 +5,7 @@
  * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -14,6 +14,7 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
+import { setPlatformAssistantId } from "../../../config/env.js";
 import {
   invalidateConfigCache,
   loadRawConfig,
@@ -244,5 +245,41 @@ describe("completeA2AInvite", () => {
     const invite = findById(created.inviteId!);
     expect(invite!.status).toBe("active");
     expect(invite!.useCount).toBe(0);
+  });
+});
+
+describe("completeA2AInvite — platform mode", () => {
+  beforeEach(() => {
+    resetTables();
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("ast_platform_test");
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "",
+      ingressEnabled: undefined,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_PLATFORM_URL;
+    setPlatformAssistantId(undefined);
+  });
+
+  test("resolves sender gateway URL automatically in platform mode", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sender?.gatewayUrl).toBe(
+      "https://test-platform.vellum.ai/v1/gateway/callbacks/ast_platform_test",
+    );
   });
 });

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
@@ -5,7 +5,7 @@
  * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -14,6 +14,7 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
+import { setPlatformAssistantId } from "../../../config/env.js";
 import {
   invalidateConfigCache,
   loadRawConfig,
@@ -150,5 +151,33 @@ describe("createA2AInvite", () => {
     const expectedMaxMs = after + 72 * 60 * 60 * 1000;
     expect(invite!.expiresAt).toBeGreaterThanOrEqual(expectedMinMs);
     expect(invite!.expiresAt).toBeLessThanOrEqual(expectedMaxMs);
+  });
+});
+
+describe("createA2AInvite — platform mode", () => {
+  beforeEach(() => {
+    resetTables();
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
+    setPlatformAssistantId("ast_platform_test");
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "",
+      ingressEnabled: undefined,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_PLATFORM_URL;
+    setPlatformAssistantId(undefined);
+  });
+
+  test("succeeds and senderGatewayUrl equals the platform callback base URL", () => {
+    const result = createA2AInvite({});
+    expect(result.success).toBe(true);
+    expect(result.senderGatewayUrl).toBe(
+      "https://test-platform.vellum.ai/v1/gateway/callbacks/ast_platform_test",
+    );
   });
 });

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -23,7 +23,10 @@ import {
   upsertContact,
 } from "../../contacts/contact-store.js";
 import type { VellumAssistantMetadata } from "../../contacts/types.js";
-import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import {
+  getPlatformPublicCallbackBase,
+  getPublicBaseUrl,
+} from "../../inbound/public-ingress-urls.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
   claimA2AInvite,
@@ -112,6 +115,16 @@ export function clearA2AConfig(): A2AConfigResult {
   return { success: true, enabled: false, activeConnections: 0 };
 }
 
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function resolveA2AGatewayUrl(): string | undefined {
+  try {
+    return getPublicBaseUrl(getConfig());
+  } catch {
+    return getPlatformPublicCallbackBase();
+  }
+}
+
 // ── A2A invite creation ────────────────────────────────────────────
 
 export function createA2AInvite(params: {
@@ -123,11 +136,9 @@ export function createA2AInvite(params: {
     setA2AConfig();
   }
 
-  // 2. Resolve public base URL
-  let publicBaseUrl: string;
-  try {
-    publicBaseUrl = getPublicBaseUrl(getConfig());
-  } catch {
+  // 2. Resolve gateway URL (ingress URL or platform callback base)
+  const gatewayUrl = resolveA2AGatewayUrl();
+  if (!gatewayUrl) {
     return {
       success: false,
       error:
@@ -156,7 +167,7 @@ export function createA2AInvite(params: {
     inviteId: invite.id,
     token: rawToken,
     expiresAt: invite.expiresAt,
-    senderGatewayUrl: publicBaseUrl,
+    senderGatewayUrl: gatewayUrl,
   };
 }
 
@@ -173,10 +184,8 @@ export function completeA2AInvite(params: {
 }): CompleteA2AInviteResult {
   // Resolve sender identity before any mutations so we fail cleanly
   const displayName = getAssistantName() ?? "Vellum Assistant";
-  let gatewayUrl: string;
-  try {
-    gatewayUrl = getPublicBaseUrl(getConfig());
-  } catch {
+  const gatewayUrl = resolveA2AGatewayUrl();
+  if (!gatewayUrl) {
     return {
       success: false,
       error:
@@ -345,10 +354,8 @@ export async function acceptA2AInvite(params: {
 
   // 1. Validate local config
   const displayName = getAssistantName() ?? "Vellum Assistant";
-  let localGatewayUrl: string;
-  try {
-    localGatewayUrl = getPublicBaseUrl(getConfig());
-  } catch {
+  const localGatewayUrl = resolveA2AGatewayUrl();
+  if (!localGatewayUrl) {
     return {
       success: false,
       error:

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -1,13 +1,10 @@
 import { updatePhoneNumberWebhooks } from "../../calls/twilio-rest.js";
-import {
-  getGatewayInternalBaseUrl,
-  getPlatformAssistantId,
-  getPlatformBaseUrl,
-} from "../../config/env.js";
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
 import { getIsPlatform } from "../../config/env-registry.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { resolveCallbackUrl } from "../../inbound/platform-callback-registration.js";
 import {
+  getPlatformPublicCallbackBase,
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
   type IngressConfig,
@@ -35,12 +32,11 @@ export function getIngressConfigResult(): {
   // platform callback URL and flag managedCallbacks so consumers (including
   // the assistant LLM) don't mistakenly try to set up ngrok or a tunnel.
   if (getIsPlatform()) {
-    const platformBase = getPlatformBaseUrl().replace(/\/+$/, "");
-    const assistantId = getPlatformAssistantId();
-    if (assistantId) {
+    const callbackBase = getPlatformPublicCallbackBase();
+    if (callbackBase) {
       return {
         enabled: true,
-        publicBaseUrl: `${platformBase}/gateway/callbacks/${assistantId}`,
+        publicBaseUrl: callbackBase,
         localGatewayTarget: computeGatewayTarget(),
         managedCallbacks: true,
         success: true,

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -3,7 +3,7 @@
  *
  * ## Source-of-truth precedence
  *
- * The canonical public base URL is resolved through a three-level chain:
+ * The canonical public base URL is resolved through a two-level chain:
  *
  *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via
  *      the in-chat config flow, the Settings UI, or `config set ingress.publicBaseUrl`. This is the
@@ -16,20 +16,10 @@
  *      tunnels start or stop, `setIngressPublicBaseUrl()` updates this
  *      value in-process.
  *
- *   3. **Platform derivation** (`getPlatformPublicCallbackBase()`) — for
- *      platform-hosted assistants (`IS_PLATFORM=true`), derives the URL
- *      from the platform base URL and assistant ID as
- *      `${platformBase}/v1/gateway/callbacks/${assistantId}`.
- *
- * This chain ensures that:
- *   - The assistant's outbound callback URLs (Twilio webhooks, OAuth
- *     redirect URIs, etc.) match the gateway's inbound signature
- *     reconstruction URL.
- *   - Changing the URL in Settings immediately updates outbound callback
- *     registration, while the gateway can validate inbound Twilio signatures
- *     using forwarded public URL headers from tunnels/proxies.
- *   - Platform-hosted assistants automatically resolve their public URL
- *     without manual configuration.
+ * Platform-hosted assistants use `getPlatformPublicCallbackBase()` for
+ * registration-gated callback surfaces (A2A, ingress config display) but
+ * NOT as a generic `getPublicBaseUrl()` fallback — the callback prefix
+ * only routes paths that are registered in `AssistantCallbackRoute`.
  *
  * All public-facing ingress URL construction is centralized here.
  */
@@ -106,9 +96,6 @@ export function getPublicBaseUrl(config: IngressConfig): string {
   const ingressEnvValue = getIngressPublicBaseUrl();
   const normalizedIngressEnvValue = normalizePublicBaseUrl(ingressEnvValue);
   if (normalizedIngressEnvValue) return normalizedIngressEnvValue;
-
-  const platformBase = getPlatformPublicCallbackBase();
-  if (platformBase) return platformBase;
 
   throw new Error(
     "No public base URL configured. Set ingress.publicBaseUrl in config.",

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -3,7 +3,7 @@
  *
  * ## Source-of-truth precedence
  *
- * The canonical public base URL is resolved through a two-level chain:
+ * The canonical public base URL is resolved through a three-level chain:
  *
  *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via
  *      the in-chat config flow, the Settings UI, or `config set ingress.publicBaseUrl`. This is the
@@ -16,6 +16,11 @@
  *      tunnels start or stop, `setIngressPublicBaseUrl()` updates this
  *      value in-process.
  *
+ *   3. **Platform derivation** (`getPlatformPublicCallbackBase()`) — for
+ *      platform-hosted assistants (`IS_PLATFORM=true`), derives the URL
+ *      from the platform base URL and assistant ID as
+ *      `${platformBase}/v1/gateway/callbacks/${assistantId}`.
+ *
  * This chain ensures that:
  *   - The assistant's outbound callback URLs (Twilio webhooks, OAuth
  *     redirect URIs, etc.) match the gateway's inbound signature
@@ -23,6 +28,8 @@
  *   - Changing the URL in Settings immediately updates outbound callback
  *     registration, while the gateway can validate inbound Twilio signatures
  *     using forwarded public URL headers from tunnels/proxies.
+ *   - Platform-hosted assistants automatically resolve their public URL
+ *     without manual configuration.
  *
  * All public-facing ingress URL construction is centralized here.
  */
@@ -36,13 +43,39 @@ import {
   normalizePublicBaseUrl,
 } from "@vellumai/service-contracts/twilio-ingress";
 
-import { getIngressPublicBaseUrl } from "../config/env.js";
+import {
+  getIngressPublicBaseUrl,
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+} from "../config/env.js";
+import { getIsPlatform } from "../config/env-registry.js";
 
 export interface IngressConfig {
   ingress?: {
     enabled?: boolean;
     publicBaseUrl?: string;
   };
+}
+
+/**
+ * Derive the platform callback base URL for platform-hosted assistants.
+ *
+ * Returns `https://<platformBase>/v1/gateway/callbacks/<assistantId>` when
+ * `IS_PLATFORM=true` and both the platform base URL and assistant ID are
+ * available. The `/v1` prefix matches the Django URL pattern at
+ * `django/config/api_router.py` (`gateway/callbacks/<path:callback_path>/`).
+ *
+ * Returns `undefined` when not in platform mode or when the required
+ * identifiers are missing.
+ */
+export function getPlatformPublicCallbackBase(): string | undefined {
+  if (!getIsPlatform()) return undefined;
+
+  const platformBase = getPlatformBaseUrl().replace(/\/+$/, "");
+  const assistantId = getPlatformAssistantId();
+  if (!platformBase || !assistantId) return undefined;
+
+  return `${platformBase}/v1/gateway/callbacks/${assistantId}`;
 }
 
 function assertPublicIngressEnabled(config: IngressConfig): void {
@@ -74,6 +107,9 @@ export function getPublicBaseUrl(config: IngressConfig): string {
   const normalizedIngressEnvValue = normalizePublicBaseUrl(ingressEnvValue);
   if (normalizedIngressEnvValue) return normalizedIngressEnvValue;
 
+  const platformBase = getPlatformPublicCallbackBase();
+  if (platformBase) return platformBase;
+
   throw new Error(
     "No public base URL configured. Set ingress.publicBaseUrl in config.",
   );
@@ -92,10 +128,7 @@ export function getTwilioVoiceWebhookUrl(
   config: IngressConfig,
   callSessionId?: string,
 ): string {
-  return buildTwilioVoiceWebhookUrl(
-    getPublicBaseUrl(config),
-    callSessionId,
-  );
+  return buildTwilioVoiceWebhookUrl(getPublicBaseUrl(config), callSessionId);
 }
 
 /**


### PR DESCRIPTION
## Summary
Platform-hosted assistants fail to create A2A invite links with "No public base URL configured" because `getPublicBaseUrl()` only checks config and module-level state. This adds a platform-aware fallback that derives the URL from `IS_PLATFORM` + `getPlatformBaseUrl()` + `getPlatformAssistantId()`, and fixes the existing `getIngressConfigResult()` which was missing the `/v1` prefix.

## Self-review result
GAPS FOUND — 1 gap fixed across 1 fix PR (missing test for `ingress.enabled === false` + platform mode)

## PRs merged into feature branch
- #31825: fix(a2a): derive public base URL automatically for platform-hosted assistants

### Fix PRs
- #31831: test: add ingress disabled + platform mode coverage

Part of plan: a2a-platform-public-url.md