### PR TITLE
fix(memory-router): chronological <last_turn> + suppress wasted turn-start cache

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -432,6 +432,31 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(lastBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
+  test("disableTurnStartCache suppresses the 1h breakpoint on the turn-starting user message", async () => {
+    // One-shot callers (e.g. the memory router) send a single user message
+    // per call with content that changes every time. Caching the turn-start
+    // block would create unused entries — `disableTurnStartCache: true`
+    // opts out.
+    await provider.sendMessage(
+      [userMsg("Pick relevant pages")],
+      undefined,
+      undefined,
+      {
+        config: { disableTurnStartCache: true },
+      },
+    );
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const lastBlock = sent[0].content[sent[0].content.length - 1];
+    expect(lastBlock.cache_control).toBeUndefined();
+  });
+
   test("previous-turn anchor is NOT applied during a tool-use loop", async () => {
     // When the request is mid tool-use (last msg is a tool_result), the
     // turn-start anchor already covers the long prefix, so we must not

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -21,9 +21,11 @@
  *      since NOW.md only changes when the model rewrites it. We set the 1h
  *      TTL explicitly here to match the provider-side breakpoints; the
  *      default 5m would force unnecessary cache re-creation.
- * The Anthropic provider also auto-applies a 1h breakpoint on the last text
- * block of a turn-starting user message, so the trailing uncached block does
- * not need an explicit `cache_control`.
+ * The trailing user-message block holds `<last_turn>` content that changes
+ * every call (new user turn + new prior assistant reply), so we pass
+ * `disableTurnStartCache: true` to the provider to suppress its auto-applied
+ * 1h breakpoint there — caching it would create unused cache entries (pure
+ * cache_creation cost with no future hit).
  *
  * This module is pure orchestration — it does not mutate activation state,
  * write any files, or update the conversation. PR 10 wires it into
@@ -390,6 +392,17 @@ async function runRouterBatch(
     if (local) priorIds.push(local.id);
   }
 
+  // Render `<last_turn>` chronologically: the prior assistant reply came
+  // first, then the just-arrived user message that triggered this call.
+  // On conversation start `assistantMessage` is the empty string — skip the
+  // assistant line in that case so we don't emit a dangling `[assistant]:`.
+  const lastTurnLines: string[] = [];
+  if (assistantMessage.trim().length > 0) {
+    lastTurnLines.push(`[assistant]: ${assistantMessage}`);
+  }
+  lastTurnLines.push(`[user]: ${userMessage}`);
+  const lastTurnBlock = `<last_turn>\n${lastTurnLines.join("\n")}\n</last_turn>`;
+
   const userMsg: Message = {
     role: "user",
     content: [
@@ -398,7 +411,7 @@ async function runRouterBatch(
         type: "text",
         text:
           `<already_injected_ids>\n${priorIds.join(", ")}\n</already_injected_ids>\n\n` +
-          `<last_turn>\n[user]: ${userMessage}\n[assistant]: ${assistantMessage}\n</last_turn>`,
+          lastTurnBlock,
       },
     ],
   };
@@ -416,6 +429,7 @@ async function runRouterBatch(
         config: {
           callSite: "memoryRouter" as const,
           tool_choice: { type: "tool" as const, name: ROUTER_TOOL_NAME },
+          disableTurnStartCache: true,
         },
         ...(signal ? { signal } : {}),
       },

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -819,6 +819,15 @@ export class AnthropicProvider implements Provider {
       ((config as Record<string, unknown> | undefined)?.cacheTtl as
         | "5m"
         | "1h") ?? "1h";
+    // Opt-out for callers (e.g. the memory router) that send a single
+    // user message per call with content that changes every time. The
+    // turn-start cache breakpoint below is only useful when the same
+    // prefix is re-sent on a subsequent call (typical for the main agent
+    // loop's tool-use iterations); one-shot callers pay cache_creation
+    // cost without a future hit.
+    const disableTurnStartCache =
+      (config as Record<string, unknown> | undefined)?.disableTurnStartCache ===
+      true;
     let sentMessages: Anthropic.MessageParam[] | undefined;
     const startedAt = Date.now();
     // Hoisted so the catch block can distinguish our inner stream timeout
@@ -980,14 +989,11 @@ export class AnthropicProvider implements Provider {
       // followed by user tool_result). Replaying stale thinking blocks from
       // earlier turns causes 400 errors when the signature is no longer
       // valid (e.g. after a provider/model/profile switch).
-      const activeToolUseStart =
-        findActiveToolUseContinuationStart(formatted);
+      const activeToolUseStart = findActiveToolUseContinuationStart(formatted);
       for (let i = 0; i < activeToolUseStart; i++) {
         const msg = formatted[i];
         if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
-        const stripped = (
-          msg.content as Anthropic.ContentBlockParam[]
-        ).filter(
+        const stripped = (msg.content as Anthropic.ContentBlockParam[]).filter(
           (b) =>
             typeof b === "string" ||
             (b.type !== "thinking" && b.type !== "redacted_thinking"),
@@ -1009,6 +1015,7 @@ export class AnthropicProvider implements Provider {
         speed,
         output_config,
         cacheTtl: _cacheTtl,
+        disableTurnStartCache: _disableTurnStartCache,
         max_tokens: callerMaxTokens,
         usageAttributionHeaders,
         ...restConfig
@@ -1160,7 +1167,9 @@ export class AnthropicProvider implements Provider {
         }
       };
       const turnStartIdx = findUserTextMsgIdx(msgs.length - 1);
-      if (turnStartIdx >= 0) applyCacheControlToLastBlock(turnStartIdx);
+      if (turnStartIdx >= 0 && !disableTurnStartCache) {
+        applyCacheControlToLastBlock(turnStartIdx);
+      }
 
       // Previous-turn anchor: when this request is the first of a new turn
       // (turn-start is the very last message — no tool-use loop yet), also


### PR DESCRIPTION
## Summary

- `<last_turn>` now renders in chronological order: prior assistant reply first, then the just-arrived user message. First-turn case (no prior assistant reply) skips the `[assistant]:` line entirely instead of emitting a dangling empty value.
- Suppress the Anthropic provider's auto-applied 1h cache breakpoint on the trailing user-message block for the memory router via a new `disableTurnStartCache` config flag. The router is a one-shot-per-turn call whose `<last_turn>` content changes every call, so the breakpoint never produces a future cache hit — pure cache_creation cost. The useful `<now>` breakpoint (set explicitly by the router) is unaffected.

## Original prompt

Two related concerns about the production router call: (1) the previous `<last_turn>` rendering placed the user line before the assistant line, which reverses real chronology since the user message is the just-arrived turn and the assistant message is from the prior turn; (2) the Anthropic provider auto-applies a 1h cache breakpoint to the trailing user block, which was useful for the main agent loop but wasted for the router because the router fires once per turn with a fresh trailing block — the cache entry never re-hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)