### PR TITLE
feat(playground): replace single query field with now/assistant/user

### DIFF
--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Card } from "@vellum/design-library";
@@ -6,6 +6,7 @@ import { Card } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
 import {
+  useCurrentNowText,
   useDefaultRouterPromptTemplate,
   useLlmProfiles,
   useSimulateMemoryRouter,
@@ -23,7 +24,8 @@ import { useAuthStore } from "@/stores/auth-store.js";
  * config overrides. Hits the daemon's read-only `simulate_memory_router`
  * route — no writes to the EMA event log or activation logs.
  *
- * Two independent result panes share one query input. Each pane carries
+ * Two independent result panes share one conversational context (now,
+ * prior assistant reply, just-arrived user message). Each pane carries
  * its own override fields and runs its own simulation; after both have
  * run, slugs are color-coded by whether they appear in both panes or
  * only one.
@@ -77,8 +79,26 @@ function PlaygroundView(): ReactNode {
   const mutationB = useSimulateMemoryRouter(assistantId);
   const profilesQuery = useLlmProfiles(assistantId);
   const promptTemplateQuery = useDefaultRouterPromptTemplate(assistantId);
+  const nowTextQuery = useCurrentNowText(assistantId);
 
-  const [query, setQuery] = useState("");
+  // Conversational context — shared between both panes so the comparison
+  // is about config knobs, not about which scenario the router saw.
+  const [nowText, setNowText] = useState("");
+  const [assistantMessage, setAssistantMessage] = useState("");
+  const [userMessage, setUserMessage] = useState("");
+  // Track which fields the user has touched so the live NOW.md autoload
+  // doesn't clobber an in-progress edit. The first time the fetch lands,
+  // we seed `nowText`; after that the user owns it.
+  const [nowTextDirty, setNowTextDirty] = useState(false);
+
+  useEffect(() => {
+    if (nowTextDirty) return;
+    const fetched = nowTextQuery.data?.nowText;
+    if (typeof fetched === "string" && nowText === "") {
+      setNowText(fetched);
+    }
+  }, [nowTextQuery.data?.nowText, nowText, nowTextDirty]);
+
   const [overridesA, setOverridesA] = useState<PaneOverrides>(EMPTY_OVERRIDES);
   const [overridesB, setOverridesB] = useState<PaneOverrides>(EMPTY_OVERRIDES);
   const [validationA, setValidationA] = useState<string | null>(null);
@@ -105,7 +125,9 @@ function PlaygroundView(): ReactNode {
         ? overrides.customPrompt
         : undefined;
     mutation.mutate({
-      query: query.trim(),
+      userMessage: userMessage.trim(),
+      assistantMessage,
+      nowText,
       ...(configOverrides ? { configOverrides } : {}),
       ...(profileOverride !== undefined ? { profileOverride } : {}),
       ...(routerPromptOverride !== undefined ? { routerPromptOverride } : {}),
@@ -117,15 +139,33 @@ function PlaygroundView(): ReactNode {
     runPane("B");
   };
 
-  const queryReady = query.trim().length > 0;
-  const canRunA = queryReady && !mutationA.isPending;
-  const canRunB = queryReady && !mutationB.isPending;
+  const userReady = userMessage.trim().length > 0;
+  const canRunA = userReady && !mutationA.isPending;
+  const canRunB = userReady && !mutationB.isPending;
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto">
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 p-6">
         <PageHeader />
-        <QuerySection query={query} onChange={setQuery} />
+        <ConversationContextSection
+          nowText={nowText}
+          onNowTextChange={(v) => {
+            setNowTextDirty(true);
+            setNowText(v);
+          }}
+          onReloadNowText={() => {
+            const fetched = nowTextQuery.data?.nowText;
+            if (typeof fetched === "string") {
+              setNowText(fetched);
+              setNowTextDirty(false);
+            }
+          }}
+          nowTextLoading={nowTextQuery.isLoading}
+          assistantMessage={assistantMessage}
+          onAssistantMessageChange={setAssistantMessage}
+          userMessage={userMessage}
+          onUserMessageChange={setUserMessage}
+        />
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <PaneConfigForm
             paneId="A"
@@ -153,7 +193,7 @@ function PlaygroundView(): ReactNode {
         <div className="flex justify-end">
           <RunBothButton
             onClick={runBoth}
-            disabled={!queryReady || mutationA.isPending || mutationB.isPending}
+            disabled={!userReady || mutationA.isPending || mutationB.isPending}
             isRunning={mutationA.isPending || mutationB.isPending}
           />
         </div>
@@ -163,14 +203,14 @@ function PlaygroundView(): ReactNode {
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <PaneOutputColumn
             paneId="A"
-            query={query}
+            userMessage={userMessage}
             mutation={mutationA}
             otherResult={mutationB.data?.response}
             validation={validationA}
           />
           <PaneOutputColumn
             paneId="B"
-            query={query}
+            userMessage={userMessage}
             mutation={mutationB}
             otherResult={mutationA.data?.response}
             validation={validationB}
@@ -235,39 +275,140 @@ function PageHeader(): ReactNode {
   );
 }
 
-function QuerySection({
-  query,
-  onChange,
+function ConversationContextSection({
+  nowText,
+  onNowTextChange,
+  onReloadNowText,
+  nowTextLoading,
+  assistantMessage,
+  onAssistantMessageChange,
+  userMessage,
+  onUserMessageChange,
 }: {
-  query: string;
-  onChange: (value: string) => void;
+  nowText: string;
+  onNowTextChange: (value: string) => void;
+  onReloadNowText: () => void;
+  nowTextLoading: boolean;
+  assistantMessage: string;
+  onAssistantMessageChange: (value: string) => void;
+  userMessage: string;
+  onUserMessageChange: (value: string) => void;
 }): ReactNode {
   return (
     <Card>
-      <div className="flex flex-col gap-1 p-4">
-        <label
-          htmlFor="memory-router-playground-query"
-          className="text-label-default"
-          style={{ color: "var(--content-secondary)" }}
+      <div className="flex flex-col gap-4 p-4">
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
         >
-          Query (shared by both panes)
-        </label>
-        <textarea
-          id="memory-router-playground-query"
-          value={query}
-          onChange={(e) => onChange(e.target.value)}
+          Conversational context (shared by both panes)
+        </span>
+        <ContextField
+          id="memory-router-playground-now"
+          label="<now> block"
+          value={nowText}
+          onChange={onNowTextChange}
+          rows={6}
+          monospace
+          placeholder={
+            nowTextLoading
+              ? "Loading current NOW.md…"
+              : "Pre-filled with the live NOW.md. Edit to test alternate states."
+          }
+          trailing={
+            <button
+              type="button"
+              onClick={onReloadNowText}
+              disabled={nowTextLoading}
+              className="rounded px-2 py-1 text-label-default"
+              style={{
+                background: "var(--surface-overlay)",
+                color: "var(--content-secondary)",
+                border: "none",
+                cursor: nowTextLoading ? "not-allowed" : "pointer",
+              }}
+            >
+              Reload live NOW.md
+            </button>
+          }
+        />
+        <ContextField
+          id="memory-router-playground-assistant"
+          label="Prior [assistant]: reply"
+          value={assistantMessage}
+          onChange={onAssistantMessageChange}
+          rows={3}
+          placeholder="Leave blank for a first-turn scenario (no prior assistant reply)."
+        />
+        <ContextField
+          id="memory-router-playground-user"
+          label="Just-arrived [user]: message"
+          value={userMessage}
+          onChange={onUserMessageChange}
           rows={3}
           placeholder="e.g. what should we ship next"
-          className="rounded-md border px-3 py-2 text-body-medium-default"
-          style={{
-            borderColor: "var(--border-base)",
-            background: "var(--surface-base)",
-            color: "var(--content-default)",
-            resize: "vertical",
-          }}
+          required
         />
       </div>
     </Card>
+  );
+}
+
+function ContextField({
+  id,
+  label,
+  value,
+  onChange,
+  rows,
+  placeholder,
+  monospace,
+  trailing,
+  required,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows: number;
+  placeholder?: string;
+  monospace?: boolean;
+  trailing?: ReactNode;
+  required?: boolean;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor={id}
+          className="text-label-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {label}
+          {required ? " *" : ""}
+        </label>
+        {trailing}
+      </div>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder}
+        className="rounded-md border px-3 py-2 text-body-medium-default"
+        style={{
+          borderColor: "var(--border-base)",
+          background: "var(--surface-base)",
+          color: "var(--content-default)",
+          resize: "vertical",
+          ...(monospace
+            ? {
+                fontFamily:
+                  "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              }
+            : {}),
+        }}
+      />
+    </div>
   );
 }
 
@@ -620,13 +761,13 @@ type SlugDiff = "both" | "only-here";
 
 function PaneOutputColumn({
   paneId,
-  query,
+  userMessage,
   mutation,
   otherResult,
   validation,
 }: {
   paneId: PaneId;
-  query: string;
+  userMessage: string;
   mutation: ReturnType<typeof useSimulateMemoryRouter>;
   otherResult: MemoryRouterSimulateResponse | undefined;
   validation: string | null;
@@ -649,7 +790,7 @@ function PaneOutputColumn({
         <>
           <ResultPanel
             paneId={paneId}
-            query={query}
+            userMessage={userMessage}
             result={data.response}
             otherResult={otherResult}
           />
@@ -755,12 +896,12 @@ function PaneHeader({ paneId }: { paneId: PaneId }): ReactNode {
 
 function ResultPanel({
   paneId,
-  query,
+  userMessage,
   result,
   otherResult,
 }: {
   paneId: PaneId;
-  query: string;
+  userMessage: string;
   result: MemoryRouterSimulateResponse;
   otherResult: MemoryRouterSimulateResponse | undefined;
 }): ReactNode {
@@ -774,7 +915,7 @@ function ResultPanel({
     <div className="flex flex-col gap-4">
       <SummaryCard
         result={result}
-        query={query}
+        userMessage={userMessage}
         otherResult={otherResult}
         counts={counts}
       />
@@ -834,17 +975,17 @@ function countDiff(diff: Map<string, SlugDiff>): DiffCounts {
 
 function SummaryCard({
   result,
-  query,
+  userMessage,
   otherResult,
   counts,
 }: {
   result: MemoryRouterSimulateResponse;
-  query: string;
+  userMessage: string;
   otherResult: MemoryRouterSimulateResponse | undefined;
   counts: DiffCounts;
 }): ReactNode {
   const rows: Array<{ label: string; value: string }> = [
-    { label: "Query", value: query },
+    { label: "User message", value: userMessage },
     {
       label: "Total candidate pages",
       value: result.totalCandidatePages.toLocaleString(),

--- a/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
+++ b/apps/web/src/domains/chat/inspector/memory-router-simulator-api.ts
@@ -16,7 +16,15 @@ import { client } from "@/generated/api/client.gen.js";
 export type RouterSource = "tier1" | "tier2" | `tier3:${number}`;
 
 export interface MemoryRouterSimulateRequest {
-  query: string;
+  /** Just-arrived user turn that would have triggered the router. Required. */
+  userMessage: string;
+  /** Prior assistant reply. Omit/empty for a first-turn scenario. */
+  assistantMessage?: string;
+  /**
+   * Verbatim `<now>` body. Omit to let the daemon load the workspace's live
+   * NOW.md (production-like default).
+   */
+  nowText?: string;
   configOverrides?: {
     tier1_size?: number | null;
     tier2_size?: number | null;
@@ -223,5 +231,50 @@ export function useDefaultRouterPromptTemplate(
     enabled: Boolean(assistantId),
     // The template only changes when the daemon ships, so cache aggressively.
     staleTime: 24 * 60 * 60 * 1000,
+  });
+}
+
+interface NowTextResponse {
+  nowText: string;
+}
+
+async function fetchCurrentNowText(
+  assistantId: string,
+  signal?: AbortSignal
+): Promise<NowTextResponse> {
+  const { data, response } = await client.get<NowTextResponse>({
+    url: "/v1/assistants/{assistant_id}/memory/v2/now-text/",
+    path: { assistant_id: assistantId },
+    signal,
+    throwOnError: false,
+  });
+  if (!response || !response.ok) {
+    throw new SimulateMemoryRouterError(
+      response?.status ?? 0,
+      response?.statusText ?? "Failed to load NOW.md"
+    );
+  }
+  if (!data) {
+    throw new SimulateMemoryRouterError(
+      response.status,
+      "Empty response from now-text endpoint"
+    );
+  }
+  return data;
+}
+
+export function useCurrentNowText(assistantId: string | undefined) {
+  return useQuery({
+    queryKey: ["memory-router-now-text", assistantId] as const,
+    queryFn: async ({ signal }): Promise<NowTextResponse> => {
+      if (!assistantId) {
+        throw new SimulateMemoryRouterError(0, "Missing assistantId");
+      }
+      return fetchCurrentNowText(assistantId, signal);
+    },
+    enabled: Boolean(assistantId),
+    // NOW.md only changes when the assistant rewrites it — refresh on
+    // navigation, not on a timer.
+    staleTime: Infinity,
   });
 }

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -469,7 +469,12 @@ Examples:
               "memory_v2_simulate_router",
               {
                 body: {
-                  query: opts.query,
+                  // The CLI flag is still named `--query` for backwards
+                  // compatibility, but maps to the route's `userMessage`
+                  // field. assistantMessage/nowText use server defaults
+                  // (empty + live NOW.md) so the CLI keeps its existing
+                  // single-turn semantics.
+                  userMessage: opts.query,
                   ...(configOverrides ? { configOverrides } : {}),
                 },
               },

--- a/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
@@ -210,7 +210,7 @@ describe("handleSimulateRouter", () => {
     providerStub = makeProvider([3, 1]);
 
     const result = await handleSimulateRouter({
-      body: { query: "what's relevant?" },
+      body: { userMessage: "what's relevant?" },
     });
 
     expect(result.failureReason).toBeNull();
@@ -228,7 +228,7 @@ describe("handleSimulateRouter", () => {
 
     const result = await handleSimulateRouter({
       body: {
-        query: "test",
+        userMessage: "test",
         configOverrides: {
           tier1_size: 50,
           batch_size: 25,
@@ -249,22 +249,22 @@ describe("handleSimulateRouter", () => {
     providerStub = makeProvider([1, 2]);
 
     await handleSimulateRouter({
-      body: { query: "should not record" },
+      body: { userMessage: "should not record" },
     });
 
     expect(recordCalls).toEqual([]);
   });
 
-  test("rejects an empty query at the schema layer", async () => {
+  test("rejects an empty userMessage at the schema layer", async () => {
     await expect(
-      handleSimulateRouter({ body: { query: "" } }),
+      handleSimulateRouter({ body: { userMessage: "" } }),
     ).rejects.toThrow();
   });
 
   test("rejects negative tier size at the schema layer", async () => {
     await expect(
       handleSimulateRouter({
-        body: { query: "test", configOverrides: { tier1_size: -5 } },
+        body: { userMessage: "test", configOverrides: { tier1_size: -5 } },
       }),
     ).rejects.toThrow();
   });

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -350,7 +350,26 @@ const SimulateRouterOverridesSchema = z
 
 const MemoryV2SimulateRouterParams = z
   .object({
-    query: z.string().min(1, "query must be non-empty"),
+    /**
+     * The just-arrived user turn — the message that would have triggered
+     * the router on a real turn. Required; the router has nothing to
+     * route against without at least a user message.
+     */
+    userMessage: z.string().min(1, "userMessage must be non-empty"),
+    /**
+     * The prior assistant reply. Empty/omitted means "first-turn scenario"
+     * — the router's `<last_turn>` block will skip the `[assistant]:` line
+     * entirely, matching how `runRouterBatch` serializes a conversation
+     * start.
+     */
+    assistantMessage: z.string().optional(),
+    /**
+     * Verbatim `<now>` body. When omitted, the daemon loads the workspace's
+     * live NOW.md so callers that don't care about per-call now context get
+     * production-like behavior for free. Pass an explicit string (including
+     * the empty string) to override.
+     */
+    nowText: z.string().optional(),
     configOverrides: SimulateRouterOverridesSchema.optional(),
     profileOverride: z.string().min(1).optional(),
     /**
@@ -437,7 +456,9 @@ export async function handleSimulateRouter({
 }: RouteHandlerArgs): Promise<MemoryV2SimulateRouterResult> {
   requireMemoryV2Enabled();
   const {
-    query,
+    userMessage,
+    assistantMessage,
+    nowText: rawNowText,
     configOverrides,
     profileOverride,
     routerPromptOverride: rawRouterPromptOverride,
@@ -476,12 +497,16 @@ export async function handleSimulateRouter({
   }
 
   const workspaceDir = getWorkspaceDir();
-  const nowText = await loadNowText(workspaceDir);
+  // Caller can override `<now>` explicitly; otherwise fall back to the
+  // live workspace NOW.md so a UI that doesn't supply nowText still
+  // exercises a production-like context.
+  const nowText =
+    rawNowText !== undefined ? rawNowText : await loadNowText(workspaceDir);
 
   const routerResult = await runRouter({
     workspaceDir,
-    userMessage: query,
-    assistantMessage: "",
+    userMessage,
+    assistantMessage: assistantMessage ?? "",
     nowText,
     priorEverInjected: [],
     config: mergedConfig,
@@ -553,6 +578,20 @@ export interface MemoryV2RouterPromptTemplateResult {
 async function handleGetRouterPromptTemplate(): Promise<MemoryV2RouterPromptTemplateResult> {
   requireMemoryV2Enabled();
   return { template: ROUTER_PROMPT };
+}
+
+// ── Current `<now>` body (default value for the playground editor) ──────
+
+export interface MemoryV2NowTextResult {
+  /** The current rendered NOW.md body (autoloaded essentials/threads/recent). */
+  nowText: string;
+}
+
+async function handleGetNowText(): Promise<MemoryV2NowTextResult> {
+  requireMemoryV2Enabled();
+  const workspaceDir = getWorkspaceDir();
+  const nowText = await loadNowText(workspaceDir);
+  return { nowText };
 }
 
 // ── Route definitions ───────────────────────────────────────────────────
@@ -654,6 +693,16 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Return the bundled router system-prompt template",
     description:
       "Returns the bundled `ROUTER_PROMPT` body with placeholders intact (`{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, `{{PAGE_INDEX}}`). Used by the memory router playground's 'Load default' affordance so users have a known-good starting point when authoring an inline prompt override.",
+    tags: ["memory"],
+  },
+  {
+    operationId: "memory_v2_now_text",
+    method: "GET",
+    endpoint: "memory/v2/now-text",
+    handler: handleGetNowText,
+    summary: "Return the current rendered `<now>` body",
+    description:
+      "Returns the current NOW.md (autoloaded essentials/threads/recent). Used by the memory router playground to seed its `<now>` text area with a production-like default so callers can edit from a realistic baseline.",
     tags: ["memory"],
   },
 ];

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsMemoryRouterPlaygroundTab.swift
@@ -23,8 +23,18 @@ struct SettingsMemoryRouterPlaygroundTab: View {
 
     private let client = MemoryRouterPlaygroundClient()
 
-    @State private var query: String = ""
-    @State private var lastQuery: String = ""
+    // Conversational context — shared between both panes so the comparison
+    // is about config knobs, not about which scenario the router saw.
+    @State private var nowText: String = ""
+    @State private var assistantMessage: String = ""
+    @State private var userMessage: String = ""
+    /// Echo of the user message used for the most recent successful run,
+    /// surfaced in the per-pane summary card.
+    @State private var lastUserMessage: String = ""
+    /// Tracks whether the live NOW.md fetch has already seeded `nowText`.
+    /// Subsequent successful fetches do NOT overwrite the field — the user
+    /// owns it after first load (or after their first edit).
+    @State private var nowTextSeeded: Bool = false
     @State private var paneA = PaneState()
     @State private var paneB = PaneState()
     @State private var availableProfiles: [String] = []
@@ -61,7 +71,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 header
-                queryCard
+                contextCard
                 runBothRow
                 if paneA.lastResult != nil && paneB.lastResult != nil {
                     diffLegend
@@ -75,11 +85,11 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .task {
-            await loadProfiles()
+            await loadInitialContext()
         }
     }
 
-    private func loadProfiles() async {
+    private func loadInitialContext() async {
         do {
             let response = try await client.fetchProfiles()
             availableProfiles = response.profiles
@@ -92,6 +102,21 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         if defaultPromptTemplate.isEmpty {
             if let template = try? await client.fetchDefaultRouterPrompt() {
                 defaultPromptTemplate = template
+            }
+        }
+        if !nowTextSeeded {
+            if let now = try? await client.fetchCurrentNowText() {
+                nowText = now
+                nowTextSeeded = true
+            }
+        }
+    }
+
+    private func reloadLiveNowText() {
+        Task {
+            if let now = try? await client.fetchCurrentNowText() {
+                nowText = now
+                nowTextSeeded = true
             }
         }
     }
@@ -112,19 +137,72 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Shared query
+    // MARK: - Shared conversational context
 
-    private var queryCard: some View {
+    private var contextCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Conversational context (shared by both panes)")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            contextField(
+                label: "<now> block",
+                binding: $nowText,
+                minHeight: 140,
+                monospace: true,
+                trailing: AnyView(
+                    Button("Reload live NOW.md") {
+                        reloadLiveNowText()
+                    }
+                    .buttonStyle(.plain)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                )
+            )
+            contextField(
+                label: "Prior [assistant]: reply",
+                binding: $assistantMessage,
+                minHeight: 80,
+                monospace: false,
+                trailing: nil
+            )
+            contextField(
+                label: "Just-arrived [user]: message *",
+                binding: $userMessage,
+                minHeight: 80,
+                monospace: false,
+                trailing: nil
+            )
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    private func contextField(
+        label: String,
+        binding: Binding<String>,
+        minHeight: CGFloat,
+        monospace: Bool,
+        trailing: AnyView?
+    ) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text("Query (shared by both panes)")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
-            TextEditor(text: $query)
-                .font(VFont.bodyMediumDefault)
+            HStack {
+                Text(label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                Spacer()
+                if let trailing = trailing {
+                    trailing
+                }
+            }
+            TextEditor(text: binding)
+                .font(monospace
+                    ? .system(.body, design: .monospaced)
+                    : VFont.bodyMediumDefault)
                 .foregroundStyle(VColor.contentDefault)
                 .scrollContentBackground(.hidden)
                 .padding(VSpacing.sm)
-                .frame(minHeight: 80)
+                .frame(minHeight: minHeight)
                 .background(VColor.surfaceBase)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
@@ -132,9 +210,6 @@ struct SettingsMemoryRouterPlaygroundTab: View {
                 )
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard()
     }
 
     private var runBothRow: some View {
@@ -406,7 +481,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             Text("Summary")
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
-            metaRow(label: "Query", value: lastQuery)
+            metaRow(label: "User message", value: lastUserMessage)
             metaRow(
                 label: "Total candidate pages",
                 value: "\(result.totalCandidatePages)"
@@ -602,12 +677,12 @@ struct SettingsMemoryRouterPlaygroundTab: View {
     }
 
     private func canRun(_ pane: PaneId) -> Bool {
-        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !userMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !paneState(pane).isRunning
     }
 
     private var canRunBoth: Bool {
-        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !userMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !paneA.isRunning && !paneB.isRunning
     }
 
@@ -624,8 +699,8 @@ struct SettingsMemoryRouterPlaygroundTab: View {
             paneB.clientError = nil
         }
 
-        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedQuery.isEmpty else { return }
+        let trimmedUser = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUser.isEmpty else { return }
 
         let state = paneState(pane)
         let tier1Override: MemoryRouterOverride
@@ -645,7 +720,9 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         let promptTrimmed = state.customPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let routerPromptOverride: String? = promptTrimmed.isEmpty ? nil : state.customPrompt
         let input = MemoryRouterSimulateInput(
-            query: trimmedQuery,
+            userMessage: trimmedUser,
+            assistantMessage: assistantMessage,
+            nowText: nowText,
             tier1Size: tier1Override,
             tier2Size: tier2Override,
             batchSize: batchOverride,
@@ -654,7 +731,7 @@ struct SettingsMemoryRouterPlaygroundTab: View {
         )
 
         setIsRunning(pane: pane, value: true)
-        lastQuery = trimmedQuery
+        lastUserMessage = trimmedUser
         Task {
             defer { setIsRunning(pane: pane, value: false) }
             do {

--- a/clients/shared/Network/MemoryRouterPlaygroundClient.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundClient.swift
@@ -108,11 +108,31 @@ public struct MemoryRouterPlaygroundClient: Sendable {
         return decoded.template
     }
 
+    /// Fetches the current `<now>` body (workspace NOW.md) so the playground
+    /// can seed its `<now>` text area with a production-like default.
+    public func fetchCurrentNowText() async throws -> String {
+        let path = "memory/v2/now-text/"
+        let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        struct NowTextResponse: Decodable { let nowText: String }
+        let decoded = try JSONDecoder().decode(
+            NowTextResponse.self,
+            from: response.data
+        )
+        return decoded.nowText
+    }
+
     /// Construct the JSON dict the daemon expects. Built by hand because the
     /// override fields have three states (inherit / value / explicit-null)
     /// and a plain Codable `Encodable` would conflate "absent" with "null".
     private func buildRequestBody(input: MemoryRouterSimulateInput) -> [String: Any] {
-        var body: [String: Any] = ["query": input.query]
+        var body: [String: Any] = ["userMessage": input.userMessage]
+        if let assistant = input.assistantMessage {
+            body["assistantMessage"] = assistant
+        }
+        if let now = input.nowText {
+            body["nowText"] = now
+        }
         var overrides: [String: Any] = [:]
         addOverride(input.tier1Size, key: "tier1_size", into: &overrides)
         addOverride(input.tier2Size, key: "tier2_size", into: &overrides)

--- a/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
+++ b/clients/shared/Network/MemoryRouterPlaygroundTypes.swift
@@ -21,7 +21,15 @@ public enum MemoryRouterOverride: Equatable, Sendable {
 /// ``MemoryRouterPlaygroundClient`` so the explicit-null branch is handled
 /// in one place instead of leaking through a custom Codable.
 public struct MemoryRouterSimulateInput: Equatable, Sendable {
-    public let query: String
+    /// The just-arrived user turn — what would have triggered the router on
+    /// a real turn. Required.
+    public let userMessage: String
+    /// Prior assistant reply. `nil` or empty means "first-turn scenario"
+    /// and the daemon renders `<last_turn>` without an `[assistant]:` line.
+    public let assistantMessage: String?
+    /// Verbatim `<now>` body. `nil` means "let the daemon load the live
+    /// NOW.md" (production-like default).
+    public let nowText: String?
     public let tier1Size: MemoryRouterOverride
     public let tier2Size: MemoryRouterOverride
     public let batchSize: MemoryRouterOverride
@@ -32,14 +40,18 @@ public struct MemoryRouterSimulateInput: Equatable, Sendable {
     public let routerPromptOverride: String?
 
     public init(
-        query: String,
+        userMessage: String,
+        assistantMessage: String? = nil,
+        nowText: String? = nil,
         tier1Size: MemoryRouterOverride = .inherit,
         tier2Size: MemoryRouterOverride = .inherit,
         batchSize: MemoryRouterOverride = .inherit,
         profileOverride: String? = nil,
         routerPromptOverride: String? = nil
     ) {
-        self.query = query
+        self.userMessage = userMessage
+        self.assistantMessage = assistantMessage
+        self.nowText = nowText
         self.tier1Size = tier1Size
         self.tier2Size = tier2Size
         self.batchSize = batchSize


### PR DESCRIPTION
## Summary

- Memory router playground now exposes the three conversational-context fields the production router uses — `<now>` body, prior `[assistant]:` reply, and just-arrived `[user]:` message — instead of a single `query`. The daemon serializes them the same way `runRouterBatch` does in prod.
- New `GET /v1/memory/v2/now-text` endpoint returns the current NOW.md; the playground pre-fills the `<now>` editor with it so callers start from a production-like default and can edit to test alternate states.
- Schema change: `simulate-router` now takes `userMessage` (required), `assistantMessage` (optional), `nowText` (optional, falls back to live NOW.md when omitted) instead of `query`. CLI `--query` flag preserved; it just maps to `userMessage` server-side.

## Test plan

- [ ] Web: open `/assistant/memory-router-playground`. The `<now>` field should pre-fill with the live NOW.md. Type a user message + (optionally) an assistant message, hit Run — pane should render selections.
- [ ] Web: edit `<now>` to a deliberately different state (e.g. wipe a thread), re-run, observe the slug set shift.
- [ ] Web: hit "Reload live NOW.md" to discard local edits.
- [ ] macOS: same flow in Settings → Memory Router Playground.
- [ ] CLI: \`assistant memory v2 simulate -q "test"\` still works (no flag changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)