### PR TITLE
chore(assistant): regenerate openapi.yaml for memory v2 now-text endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11420,6 +11420,18 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v2/now-text:
+    get:
+      operationId: memory_v2_nowtext_get
+      summary: Return the current rendered `<now>` body
+      description:
+        Returns the current NOW.md (autoloaded essentials/threads/recent). Used by the memory router playground to
+        seed its `<now>` text area with a production-like default so callers can edit from a realistic baseline.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
   /v1/memory/v2/reembed-skills:
     post:
       operationId: memory_v2_reembedskills_post
@@ -11472,9 +11484,13 @@ paths:
             schema:
               type: object
               properties:
-                query:
+                userMessage:
                   type: string
                   minLength: 1
+                assistantMessage:
+                  type: string
+                nowText:
+                  type: string
                 configOverrides:
                   type: object
                   properties:
@@ -11504,7 +11520,7 @@ paths:
                   type: string
                   maxLength: 1000000
               required:
-                - query
+                - userMessage
               additionalProperties: false
   /v1/memory/v2/validate:
     post:


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to include the new `/v1/memory/v2/now-text` GET endpoint and the updated playground POST schema (`userMessage`/`assistantMessage`/`nowText`) introduced in #31835.
- Fixes the `OpenAPI Spec Check` job on main, which had been failing because the spec was stale after #31835 merged without a regenerated yaml.

## Original prompt
Fix the specific CI issue in the failing `OpenAPI Spec Check` job on the post-merge run for #31835. The check exited with `openapi.yaml is stale. Run: bun run generate:openapi` and reported one missing path (`/v1/memory/v2/now-text`). Scope is strictly the regeneration — no other changes.