### PR TITLE
fix(assistant): add route policy for memory/v2/now-text

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -477,6 +477,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "memory/v2/router-prompt-template:GET",
     scopes: ["settings.read"],
   },
+  { endpoint: "memory/v2/now-text:GET", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Add missing route policy entry for the `memory/v2/now-text` GET endpoint so the guard test in `guard-tests.test.ts` passes.
- Scoped to `settings.read`, matching the adjacent `router-prompt-template` entry (both are memory-router playground reads).

## Original prompt
CI job https://github.com/vellum-ai/vellum-assistant/actions/runs/26317309824/job/77479132170 was failing because `memory/v2/now-text` was dispatched in `http-server.ts` (added in #31835/#31836 for the playground) without a corresponding entry in `assistant/src/runtime/auth/route-policy.ts`. This PR adds that entry to satisfy the route-policy coverage guard.