### PR TITLE
[codex] Add conversationId terminal runtime client support

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2812,14 +2812,16 @@ paths:
             schema:
               type: object
               properties:
-                conversationKey:
+                conversationId:
+                  description: Conversation ID to scope the call
                   type: string
+                conversationKey:
                   description: Conversation key to scope the call
+                  type: string
                 content:
                   type: string
                   description: User prompt content
               required:
-                - conversationKey
                 - content
               additionalProperties: false
   /v1/cache/delete:
@@ -7651,12 +7653,18 @@ paths:
         "200":
           description: Successful response
       parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Scope to a single conversation by ID
         - name: conversationKey
           in: query
           required: false
           schema:
             type: string
-          description: Scope to a single conversation
+          description: Scope to a single conversation by legacy key
   /v1/events/emit:
     post:
       operationId: events_emit_post
@@ -11579,6 +11587,8 @@ paths:
             schema:
               type: object
               properties:
+                conversationId:
+                  type: string
                 conversationKey:
                   type: string
                 content:

--- a/assistant/src/__tests__/assistant-events-sse-shed.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-shed.test.ts
@@ -193,6 +193,7 @@ describe("buildSseShedSentryContext", () => {
     heartbeatsSent: 3,
     clientId: "client-xyz",
     interfaceId: "macos",
+    conversationId: null,
     // Channel-backed conversation key embedding a phone number.
     conversationKey: "asst:self:whatsapp:447123456789",
   };

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -225,6 +225,16 @@ describe("POST /v1/btw", () => {
     expect((error as BadRequestError).message).toContain("conversationKey");
   });
 
+  test("throws BadRequestError when conversationId and conversationKey are both provided", async () => {
+    const { error } = await callHandler({
+      conversationId: "conv-test-123",
+      conversationKey: "key",
+      content: "hello",
+    });
+    expect(error).toBeInstanceOf(BadRequestError);
+    expect((error as BadRequestError).message).toContain("mutually exclusive");
+  });
+
   test("throws BadRequestError for missing content", async () => {
     const { error } = await callHandler({ conversationKey: "key" });
     expect(error).toBeInstanceOf(BadRequestError);
@@ -267,6 +277,23 @@ describe("POST /v1/btw", () => {
 
     const text = await readStream(result as ReadableStream<Uint8Array>);
     expect(text).toContain(`event: btw_text_delta\ndata: {"text":"hello"}`);
+  });
+
+  test("accepts conversationId without looking up a conversationKey", async () => {
+    mockGetConversationByKey.mockClear();
+    mockGetOrCreateConversation.mockClear();
+    const session = makeMockSession();
+    mockGetOrCreateConversation.mockImplementationOnce(async () => session);
+
+    const { result } = await callHandler({
+      conversationId: "conv-direct-123",
+      content: "hello",
+    });
+    expect(result).toBeInstanceOf(ReadableStream);
+    await readStream(result as ReadableStream<Uint8Array>);
+
+    expect(mockGetConversationByKey).not.toHaveBeenCalled();
+    expect(mockGetOrCreateConversation).toHaveBeenCalledWith("conv-direct-123");
   });
 
   test("response ends with btw_complete", async () => {

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -41,6 +41,15 @@ const addMessageMock = mock(
     id: role === "user" ? "persisted-user-id" : "persisted-assistant-id",
   }),
 );
+const getConversationMock = mock((conversationId: string) => ({
+  id: conversationId,
+  conversationType: "standard",
+}));
+const getOrCreateConversationByKeyMock = mock(() => ({
+  conversationId: "conv-parity-test",
+  conversationType: "standard",
+  created: false,
+}));
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -50,7 +59,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../memory/conversation-key-store.js", () => ({
-  getOrCreateConversation: () => ({ conversationId: "conv-parity-test" }),
+  getOrCreateConversation: getOrCreateConversationByKeyMock,
   getConversationByKey: () => null,
 }));
 
@@ -100,6 +109,8 @@ mock.module("../memory/conversation-crud.js", () => ({
     content: string,
     metadata?: Record<string, unknown>,
   ) => addMessageMock(conversationId, role, content, metadata),
+  getConversation: getConversationMock,
+  hasMessages: () => false,
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
@@ -198,6 +209,11 @@ const _testAuthContext: AuthContext = {
   ]),
   policyEpoch: 1,
 };
+
+beforeEach(() => {
+  getConversationMock.mockClear();
+  getOrCreateConversationByKeyMock.mockClear();
+});
 
 // ── Helper: create a minimal mock conversation ─────────────────────────────
 function makeConversation(overrides: Record<string, unknown> = {}) {
@@ -336,6 +352,55 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     expect(res.status).toBe(202);
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("HTTP POST /v1/messages conversation identifiers", () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  test("uses conversationId directly without treating it as a conversationKey", async () => {
+    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+    let capturedConversationId: string | undefined;
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      {
+        conversationKey: undefined,
+        conversationId: "conv-direct-123",
+      },
+      {
+        onGetOrCreateConversation: (conversationId) => {
+          capturedConversationId = conversationId;
+        },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedConversationId).toBe("conv-direct-123");
+    expect(getConversationMock).toHaveBeenCalledWith("conv-direct-123");
+    expect(getOrCreateConversationByKeyMock).not.toHaveBeenCalled();
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects requests that provide both conversationId and conversationKey", async () => {
+    const conversation = makeConversation();
+
+    const res = await sendMessage("hello", conversation, {
+      conversationId: "conv-direct-123",
+    });
+
+    expect(res.status).toBe(400);
+    expect(getConversationMock).not.toHaveBeenCalled();
+    expect(getOrCreateConversationByKeyMock).not.toHaveBeenCalled();
   });
 });
 

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -151,6 +151,42 @@ describe("SSE assistant-events endpoint", () => {
     expect(frame).toContain('"type":"pong"');
   });
 
+  test("stream can be scoped directly by conversationId", async () => {
+    const conversationId = "conversation-id-sse";
+    const ac = new AbortController();
+
+    const { AssistantEventHub } =
+      await import("../runtime/assistant-event-hub.js");
+    const testHub = new AssistantEventHub();
+
+    const { handleSubscribeAssistantEvents } =
+      await import("../runtime/routes/events-routes.js");
+    const stream = handleSubscribeAssistantEvents(
+      {
+        queryParams: { conversationId },
+        abortSignal: ac.signal,
+      },
+      { hub: testHub },
+    );
+
+    const reader = stream.getReader();
+    const heartbeat = await reader.read();
+    expect(heartbeat.done).toBe(false);
+    expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
+
+    await testHub.publish(
+      buildAssistantEvent({ type: "pong" }, conversationId),
+    );
+
+    const { value, done } = await reader.read();
+    ac.abort();
+
+    expect(done).toBe(false);
+    const frame = new TextDecoder().decode(value);
+    expect(frame).toContain(`"conversationId":"${conversationId}"`);
+    expect(frame).toContain('"type":"pong"');
+  });
+
   // ── Unfiltered subscription ──────────────────────────────────────────────
 
   test("streams all events when conversationKey is omitted", async () => {

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -56,11 +56,29 @@ async function handleBtw({
   body,
   abortSignal,
 }: RouteHandlerArgs): Promise<ReadableStream<Uint8Array>> {
-  const conversationKey = body?.conversationKey as string | undefined;
-  const content = body?.content as string | undefined;
+  const requestBody =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const conversationId =
+    typeof requestBody.conversationId === "string"
+      ? requestBody.conversationId.trim()
+      : undefined;
+  const conversationKey =
+    typeof requestBody.conversationKey === "string"
+      ? requestBody.conversationKey
+      : undefined;
+  const content =
+    typeof requestBody.content === "string" ? requestBody.content : undefined;
 
-  if (!conversationKey) {
-    throw new BadRequestError("conversationKey is required");
+  if ("conversationId" in requestBody && !conversationId) {
+    throw new BadRequestError("conversationId must not be empty");
+  }
+  if (conversationId && conversationKey) {
+    throw new BadRequestError(
+      "conversationId and conversationKey are mutually exclusive",
+    );
+  }
+  if (!conversationId && !conversationKey) {
+    throw new BadRequestError("conversationId or conversationKey is required");
   }
   if (!content || typeof content !== "string") {
     throw new BadRequestError("content must be a non-empty string");
@@ -104,12 +122,15 @@ async function handleBtw({
   }
 
   // Look up an existing conversation or create an ephemeral one.
-  const mapping = getConversationByKey(conversationKey);
-  const conversationId = mapping?.conversationId ?? conversationKey;
+  const mapping = conversationKey
+    ? getConversationByKey(conversationKey)
+    : null;
+  const resolvedConversationId =
+    conversationId ?? mapping?.conversationId ?? conversationKey!;
 
   let conversation;
   try {
-    conversation = await getOrCreateConversation(conversationId);
+    conversation = await getOrCreateConversation(resolvedConversationId);
   } catch {
     throw new ServiceUnavailableError("Message processing is not available");
   }
@@ -144,6 +165,7 @@ async function handleBtw({
             log.warn(
               {
                 conversationKey,
+                conversationId: resolvedConversationId,
                 messageCount: conversation.getMessages().length + 1,
               },
               "btw side-chain completed with no text deltas",
@@ -196,8 +218,13 @@ export const ROUTES: RouteDefinition[] = [
       Connection: "keep-alive",
     },
     requestBody: z.object({
+      conversationId: z
+        .string()
+        .optional()
+        .describe("Conversation ID to scope the call"),
       conversationKey: z
         .string()
+        .optional()
         .describe("Conversation key to scope the call"),
       content: z.string().describe("User prompt content"),
     }),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -121,7 +121,12 @@ import {
   resolveTrustContext,
   withSourceChannel,
 } from "../trust-context-resolver.js";
-import { BadRequestError, InternalError, RouteError } from "./errors.js";
+import {
+  BadRequestError,
+  InternalError,
+  NotFoundError,
+  RouteError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
 
@@ -1239,6 +1244,7 @@ export async function handleSendMessage(
   },
 ): Promise<unknown> {
   const body = (rawBody ?? {}) as {
+    conversationId?: string;
     conversationKey?: string;
     content?: string;
     attachmentIds?: string[];
@@ -1273,6 +1279,18 @@ export async function handleSendMessage(
   const principalType = headers?.["x-vellum-principal-type"];
 
   const { conversationKey, content, attachmentIds } = body;
+  const requestedConversationId =
+    typeof body.conversationId === "string"
+      ? body.conversationId.trim()
+      : undefined;
+  if ("conversationId" in body && !requestedConversationId) {
+    throw new BadRequestError("conversationId must not be empty");
+  }
+  if (requestedConversationId && conversationKey) {
+    throw new BadRequestError(
+      "conversationId and conversationKey are mutually exclusive",
+    );
+  }
   const clientMessageId =
     typeof body.clientMessageId === "string" ? body.clientMessageId : undefined;
   const requestedInferenceProfile =
@@ -1340,12 +1358,6 @@ export async function handleSendMessage(
       ? (canonicalizeTimeZone(body.clientTimezone) ?? undefined)
       : undefined;
 
-  // When conversationKey is omitted, derive a stable default from
-  // sourceChannel + sourceInterface so that repeated calls from the same
-  // channel/interface pair share a single conversation thread.
-  const resolvedConversationKey =
-    conversationKey ?? `default:${sourceChannel}:${sourceInterface}`;
-
   // Reject non-string content values (numbers, objects, etc.)
   if (content != null && typeof content !== "string") {
     throw new BadRequestError("content must be a string");
@@ -1409,9 +1421,33 @@ export async function handleSendMessage(
   // timer so the next heartbeat is a full interval after this interaction.
   HeartbeatService.getInstance()?.resetTimer();
 
-  const mapping = getOrCreateConversation(resolvedConversationKey, {
-    conversationType: "standard",
-  });
+  let mapping: {
+    conversationId: string;
+    conversationType: string;
+    created: boolean;
+  };
+  if (requestedConversationId) {
+    const existingConversation = getConversation(requestedConversationId);
+    if (!existingConversation) {
+      throw new NotFoundError(
+        `Conversation ${requestedConversationId} not found`,
+      );
+    }
+    mapping = {
+      conversationId: requestedConversationId,
+      conversationType: existingConversation.conversationType,
+      created: false,
+    };
+  } else {
+    // When conversationKey is omitted, derive a stable default from
+    // sourceChannel + sourceInterface so repeated calls from the same
+    // channel/interface pair share a single conversation thread.
+    const resolvedConversationKey =
+      conversationKey ?? `default:${sourceChannel}:${sourceInterface}`;
+    mapping = getOrCreateConversation(resolvedConversationKey, {
+      conversationType: "standard",
+    });
+  }
 
   if (requestedRiskThreshold !== undefined) {
     const result = await ipcCall("set_conversation_threshold", {
@@ -2599,6 +2635,7 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["messages"],
     responseStatus: "202",
     requestBody: z.object({
+      conversationId: z.string().optional(),
       conversationKey: z.string().optional(),
       content: z.string().describe("Message text content"),
       attachments: z

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -1,15 +1,15 @@
 /**
  * Route handler for the assistant-events SSE endpoint.
  *
- * GET /v1/events?conversationKey=...
+ * GET /v1/events?conversationId=... or /v1/events?conversationKey=...
  *
  * JWT bearer auth is enforced by RuntimeHttpServer before this handler
  * is called. The AuthContext is threaded through from the HTTP server
  * layer, so no additional actor-token verification is needed here.
  *
- * When `conversationKey` is provided, subscribers receive events scoped to
- * that conversation. When omitted, subscribers receive events from ALL
- * conversations for this assistant (unfiltered).
+ * When `conversationId` or `conversationKey` is provided, subscribers receive
+ * events scoped to that conversation. When omitted, subscribers receive events
+ * from ALL conversations for this assistant (unfiltered).
  *
  * Client registration:
  *   Clients may send `X-Vellum-Client-Id` and `X-Vellum-Interface-Id`
@@ -134,6 +134,7 @@ export interface SseSubscriberInstrumentation {
   heartbeatsSent: number;
   clientId: string | null;
   interfaceId: string | null;
+  conversationId: string | null;
   conversationKey: string | null;
 }
 
@@ -198,7 +199,11 @@ const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
     Date.now(),
   );
   log.warn(
-    { ...sentryContext, conversation_key: inst.conversationKey },
+    {
+      ...sentryContext,
+      conversation_id: inst.conversationId,
+      conversation_key: inst.conversationKey,
+    },
     "sse subscriber shed under backpressure",
   );
 
@@ -220,9 +225,12 @@ const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
  * Stream assistant events as Server-Sent Events.
  *
  * Query params:
- *   conversationKey -- optional; when provided, scopes the stream to one
- *                      conversation. When omitted, the stream delivers events
- *                      from ALL conversations for this assistant.
+ *   conversationId -- optional; when provided, scopes the stream directly to
+ *                     one conversation by ID.
+ *   conversationKey -- optional legacy key lookup; when provided, scopes the
+ *                      stream to the mapped conversation.
+ *   When both are omitted, the stream delivers events from ALL conversations
+ *   for this assistant.
  *
  * Headers (optional):
  *   X-Vellum-Client-Id    -- stable per-install UUID identifying this client.
@@ -248,9 +256,18 @@ export function handleSubscribeAssistantEvents(
 ): ReadableStream<Uint8Array> {
   const { queryParams, headers, abortSignal } = args;
 
+  const conversationId = queryParams?.conversationId;
   const conversationKey = queryParams?.conversationKey;
+  if ("conversationId" in (queryParams ?? {}) && !conversationId?.trim()) {
+    throw new BadRequestError("conversationId must not be empty");
+  }
   if ("conversationKey" in (queryParams ?? {}) && !conversationKey?.trim()) {
     throw new BadRequestError("conversationKey must not be empty");
+  }
+  if (conversationId && conversationKey) {
+    throw new BadRequestError(
+      "conversationId and conversationKey are mutually exclusive",
+    );
   }
 
   // ── Client identity from headers ──────────────────────────────────────
@@ -294,7 +311,9 @@ export function handleSubscribeAssistantEvents(
   ];
 
   const filter: AssistantEventFilter = {};
-  if (conversationKey) {
+  if (conversationId) {
+    filter.conversationId = conversationId;
+  } else if (conversationKey) {
     const mapping = getOrCreateConversation(conversationKey);
     filter.conversationId = mapping.conversationId;
   }
@@ -316,6 +335,7 @@ export function handleSubscribeAssistantEvents(
     heartbeatsSent: 0,
     clientId,
     interfaceId,
+    conversationId: conversationId ?? null,
     conversationKey: conversationKey ?? null,
   };
 
@@ -471,8 +491,12 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["events"],
     queryParams: [
       {
+        name: "conversationId",
+        description: "Scope to a single conversation by ID",
+      },
+      {
         name: "conversationKey",
-        description: "Scope to a single conversation",
+        description: "Scope to a single conversation by legacy key",
       },
     ],
     responseHeaders: {

--- a/cli/src/__tests__/conversation-client.test.ts
+++ b/cli/src/__tests__/conversation-client.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ConversationClient,
+  getEffectiveOriginChannel,
+  isExternalChannelReadOnly,
+  type ConversationSummary,
+} from "../lib/conversation-client.js";
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({ url: String(input), init: init ?? {} });
+    return makeJsonResponse({ ok: true, conversations: [], messages: [] });
+  };
+
+  const client = new ConversationClient({
+    baseUrl: "https://runtime.example.com/",
+    assistantId: "assistant-123",
+    auth: { Authorization: "Bearer token" },
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+
+  return { client, calls };
+}
+
+function lastJsonBody(calls: Array<{ init: RequestInit }>): unknown {
+  const body = calls[calls.length - 1]?.init.body;
+  expect(typeof body).toBe("string");
+  return JSON.parse(body as string);
+}
+
+describe("ConversationClient", () => {
+  test("builds event URLs with conversationId", () => {
+    const { client } = makeClient();
+
+    expect(client.buildEventsUrl("conv-123")).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/events?conversationId=conv-123",
+    );
+  });
+
+  test("sends messages with conversationId, not conversationKey", async () => {
+    const { client, calls } = makeClient();
+
+    await client.sendMessage({
+      conversationId: "conv-123",
+      content: "hello",
+      clientMessageId: "client-message-1",
+    });
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/messages",
+    );
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].init.headers).toMatchObject({
+      Authorization: "Bearer token",
+      "Content-Type": "application/json",
+    });
+    expect(lastJsonBody(calls)).toEqual({
+      conversationId: "conv-123",
+      content: "hello",
+      sourceChannel: "vellum",
+      interface: "cli",
+      clientMessageId: "client-message-1",
+    });
+  });
+
+  test("runs btw with conversationId, not conversationKey", async () => {
+    const { client, calls } = makeClient();
+
+    await client.runBtw({ conversationId: "conv-123", content: "side note" });
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/btw",
+    );
+    expect(calls[0].init.headers).toMatchObject({
+      Accept: "text/event-stream",
+      Authorization: "Bearer token",
+      "Content-Type": "application/json",
+    });
+    expect(lastJsonBody(calls)).toEqual({
+      conversationId: "conv-123",
+      content: "side note",
+    });
+  });
+
+  test("lists messages by conversationId", async () => {
+    const { client, calls } = makeClient();
+
+    await client.listMessages("conv-123", {
+      page: "latest",
+      limit: 50,
+      beforeTimestamp: 123456,
+    });
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/messages?conversationId=conv-123&limit=50&page=latest&beforeTimestamp=123456",
+    );
+    expect(calls[0].init.method).toBe("GET");
+  });
+
+  test("switches conversations without sending a conversationKey", async () => {
+    const { client, calls } = makeClient();
+
+    await client.switchConversation("conv-123");
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/conversations/switch",
+    );
+    expect(lastJsonBody(calls)).toEqual({ conversationId: "conv-123" });
+  });
+
+  test("creates conversations without client-side conversation keys", async () => {
+    const { client, calls } = makeClient();
+
+    await client.createConversation();
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/conversations",
+    );
+    expect(lastJsonBody(calls)).toEqual({});
+  });
+
+  test("searches conversations with encoded query params", async () => {
+    const { client, calls } = makeClient();
+
+    await client.searchConversations({
+      query: "hello world",
+      limit: 10,
+      maxMessagesPerConversation: 2,
+    });
+
+    expect(calls[0].url).toBe(
+      "https://runtime.example.com/v1/assistants/assistant-123/conversations/search?q=hello+world&limit=10&maxMessagesPerConversation=2",
+    );
+  });
+});
+
+describe("conversation origin helpers", () => {
+  function summary(
+    conversation: Partial<ConversationSummary>,
+  ): ConversationSummary {
+    return { id: "conv-123", ...conversation };
+  }
+
+  test("prefers channelBinding.sourceChannel over conversationOriginChannel", () => {
+    expect(
+      getEffectiveOriginChannel(
+        summary({
+          channelBinding: { sourceChannel: "slack" },
+          conversationOriginChannel: "vellum",
+        }),
+      ),
+    ).toBe("slack");
+  });
+
+  test("treats absent, vellum, and notification origins as writable", () => {
+    expect(isExternalChannelReadOnly(summary({}))).toBe(false);
+    expect(
+      isExternalChannelReadOnly(
+        summary({ conversationOriginChannel: "vellum" }),
+      ),
+    ).toBe(false);
+    expect(
+      isExternalChannelReadOnly(
+        summary({ conversationOriginChannel: "notification:daily" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("treats external origins as read-only", () => {
+    for (const channel of ["slack", "telegram", "phone", "email", "whatsapp"]) {
+      expect(
+        isExternalChannelReadOnly(
+          summary({ conversationOriginChannel: channel }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("ignores conversationOriginInterface for writeability", () => {
+    expect(
+      isExternalChannelReadOnly(
+        summary({
+          conversationOriginChannel: "vellum",
+          conversationOriginInterface: "slack",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/cli/src/lib/conversation-client.ts
+++ b/cli/src/lib/conversation-client.ts
@@ -1,0 +1,362 @@
+export type RuntimeAuthHeaders = Record<string, string>;
+
+export interface ConversationClientOptions {
+  baseUrl: string;
+  assistantId: string;
+  auth?: RuntimeAuthHeaders;
+  fetchImpl?: typeof fetch;
+}
+
+export interface ChannelBinding {
+  sourceChannel?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ConversationSummary {
+  id: string;
+  title?: string | null;
+  createdAt?: number;
+  updatedAt?: number;
+  lastMessageAt?: number | null;
+  conversationType?: string;
+  source?: string;
+  channelBinding?: ChannelBinding | null;
+  conversationOriginChannel?: string | null;
+  conversationOriginInterface?: string | null;
+  archivedAt?: number | null;
+  inferenceProfile?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummary[];
+  nextOffset?: number;
+  hasMore?: boolean;
+  groups?: unknown[];
+}
+
+export interface ConversationSearchResult {
+  conversation: ConversationSummary;
+  messages?: RuntimeMessage[];
+  score?: number;
+  [key: string]: unknown;
+}
+
+export interface ConversationSearchResponse {
+  query: string;
+  results: ConversationSearchResult[];
+}
+
+export interface ConversationCreateResponse {
+  id: string;
+  conversationId?: string;
+  conversationKey?: string;
+  conversationType?: string;
+  created?: boolean;
+}
+
+export interface ConversationSwitchResponse {
+  conversationId: string;
+  title?: string | null;
+  conversationType?: string;
+  inferenceProfile?: string | null;
+}
+
+export interface RuntimeMessage {
+  id?: string;
+  role?: string;
+  text?: string;
+  content?: unknown;
+  createdAt?: number;
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+export interface ListMessagesOptions {
+  limit?: number;
+  page?: "latest";
+  beforeTimestamp?: number;
+}
+
+export interface ListMessagesResponse {
+  messages: RuntimeMessage[];
+  hasMore?: boolean;
+  oldestTimestamp?: number | null;
+  oldestMessageId?: string | null;
+}
+
+export interface SendMessageResponse {
+  accepted: boolean;
+  messageId?: string;
+  conversationId?: string;
+  queued?: boolean;
+  requestId?: string;
+}
+
+export interface ModelInfoResponse {
+  model?: string;
+  provider?: string;
+  configuredProviders?: unknown;
+  availableModels?: unknown;
+  allProviders?: unknown;
+  [key: string]: unknown;
+}
+
+export interface SendMessageOptions {
+  content: string;
+  conversationId: string;
+  signal?: AbortSignal;
+  clientMessageId?: string;
+  inferenceProfile?: string | null;
+  riskThreshold?: string;
+}
+
+export interface RunBtwOptions {
+  content: string;
+  conversationId: string;
+  signal?: AbortSignal;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function friendlyErrorMessage(status: number, body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } };
+    if (parsed?.error?.message) {
+      return parsed.error.message;
+    }
+  } catch {
+    // Fall through to status text.
+  }
+  return `HTTP ${status}: ${body || "Unknown error"}`;
+}
+
+function appendQuery(path: string, query: Record<string, string>): string {
+  const params = new URLSearchParams(query);
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+export function getEffectiveOriginChannel(
+  conversation: Pick<
+    ConversationSummary,
+    "channelBinding" | "conversationOriginChannel"
+  >,
+): string | null {
+  return (
+    conversation.channelBinding?.sourceChannel ??
+    conversation.conversationOriginChannel ??
+    null
+  );
+}
+
+export function isExternalChannelReadOnly(
+  conversation: Pick<
+    ConversationSummary,
+    "channelBinding" | "conversationOriginChannel"
+  >,
+): boolean {
+  const originChannel = getEffectiveOriginChannel(conversation);
+  if (!originChannel) return false;
+  if (originChannel === "vellum") return false;
+  if (originChannel.startsWith("notification:")) return false;
+  return true;
+}
+
+export class ConversationClient {
+  private readonly baseUrl: string;
+  private readonly assistantId: string;
+  private readonly auth: RuntimeAuthHeaders | undefined;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ConversationClientOptions) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.assistantId = options.assistantId;
+    this.auth = options.auth;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  buildEventsUrl(conversationId: string): string {
+    return this.url(
+      appendQuery("/events", {
+        conversationId,
+      }),
+    );
+  }
+
+  async listConversations(options?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<ConversationListResponse> {
+    const query: Record<string, string> = {};
+    if (options?.limit !== undefined) query.limit = String(options.limit);
+    if (options?.offset !== undefined) query.offset = String(options.offset);
+    return this.request<ConversationListResponse>(
+      "GET",
+      appendQuery("/conversations", query),
+    );
+  }
+
+  async searchConversations(options: {
+    query: string;
+    limit?: number;
+    maxMessagesPerConversation?: number;
+  }): Promise<ConversationSearchResponse> {
+    const query: Record<string, string> = { q: options.query };
+    if (options.limit !== undefined) query.limit = String(options.limit);
+    if (options.maxMessagesPerConversation !== undefined) {
+      query.maxMessagesPerConversation = String(
+        options.maxMessagesPerConversation,
+      );
+    }
+    return this.request<ConversationSearchResponse>(
+      "GET",
+      appendQuery("/conversations/search", query),
+    );
+  }
+
+  async createConversation(): Promise<ConversationCreateResponse> {
+    return this.request<ConversationCreateResponse>(
+      "POST",
+      "/conversations",
+      {},
+    );
+  }
+
+  async switchConversation(
+    conversationId: string,
+  ): Promise<ConversationSwitchResponse> {
+    return this.request<ConversationSwitchResponse>(
+      "POST",
+      "/conversations/switch",
+      { conversationId },
+    );
+  }
+
+  async getConversation(conversationId: string): Promise<ConversationSummary> {
+    return this.request<ConversationSummary>(
+      "GET",
+      `/conversations/${encodeURIComponent(conversationId)}`,
+    );
+  }
+
+  async renameConversation(
+    conversationId: string,
+    name: string,
+  ): Promise<unknown> {
+    return this.request(
+      "PATCH",
+      `/conversations/${encodeURIComponent(conversationId)}/name`,
+      { name },
+    );
+  }
+
+  async archiveConversation(conversationId: string): Promise<unknown> {
+    return this.request(
+      "POST",
+      `/conversations/${encodeURIComponent(conversationId)}/archive`,
+      {},
+    );
+  }
+
+  async listMessages(
+    conversationId: string,
+    options?: ListMessagesOptions,
+  ): Promise<ListMessagesResponse> {
+    const query: Record<string, string> = { conversationId };
+    if (options?.limit !== undefined) query.limit = String(options.limit);
+    if (options?.page !== undefined) query.page = options.page;
+    if (options?.beforeTimestamp !== undefined) {
+      query.beforeTimestamp = String(options.beforeTimestamp);
+    }
+    return this.request<ListMessagesResponse>(
+      "GET",
+      appendQuery("/messages", query),
+    );
+  }
+
+  async sendMessage(options: SendMessageOptions): Promise<SendMessageResponse> {
+    return this.request<SendMessageResponse>(
+      "POST",
+      "/messages",
+      {
+        conversationId: options.conversationId,
+        content: options.content,
+        sourceChannel: "vellum",
+        interface: "cli",
+        ...(options.clientMessageId
+          ? { clientMessageId: options.clientMessageId }
+          : {}),
+        ...(options.inferenceProfile !== undefined
+          ? { inferenceProfile: options.inferenceProfile }
+          : {}),
+        ...(options.riskThreshold
+          ? { riskThreshold: options.riskThreshold }
+          : {}),
+      },
+      options.signal,
+    );
+  }
+
+  async runBtw(options: RunBtwOptions): Promise<Response> {
+    return this.rawRequest(
+      "POST",
+      "/btw",
+      {
+        conversationId: options.conversationId,
+        content: options.content,
+      },
+      options.signal,
+      { Accept: "text/event-stream" },
+    );
+  }
+
+  async getModelInfo(): Promise<ModelInfoResponse> {
+    return this.request<ModelInfoResponse>("GET", "/model");
+  }
+
+  private url(path: string): string {
+    return `${this.baseUrl}/v1/assistants/${encodeURIComponent(
+      this.assistantId,
+    )}${path}`;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const response = await this.rawRequest(method, path, body, signal);
+    if (response.status === 204) return undefined as T;
+    return response.json() as Promise<T>;
+  }
+
+  private async rawRequest(
+    method: string,
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+    headers?: Record<string, string>,
+  ): Promise<Response> {
+    const response = await this.fetchImpl(this.url(path), {
+      method,
+      signal,
+      headers: {
+        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        ...this.auth,
+        ...headers,
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(friendlyErrorMessage(response.status, text));
+    }
+
+    return response;
+  }
+}


### PR DESCRIPTION
Summary
- Extend existing /events, /messages, and /btw handlers to accept conversationId while keeping conversationKey behavior for existing callers.
- Add a CLI conversation runtime client that sends conversationId, not conversationKey, for terminal conversation operations.
- Add read-only origin-channel helpers matching the macOS/web effective-origin rule.

Validation
- cd assistant && bun test src/__tests__/http-user-message-parity.test.ts
- cd assistant && bun test src/__tests__/btw-routes.test.ts
- cd assistant && bun test src/__tests__/runtime-events-sse.test.ts --grep "conversationId"
- cd assistant && bun test src/__tests__/assistant-events-sse-shed.test.ts
- cd assistant && bunx tsc --noEmit
- cd cli && bun test src/__tests__/conversation-client.test.ts
- cd cli && bunx tsc --noEmit