### PR TITLE
[codex] Add terminal command catalog and transcripts

### DIFF
--- a/cli/src/__tests__/client-command-catalog.test.ts
+++ b/cli/src/__tests__/client-command-catalog.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CLIENT_COMMANDS,
+  allCommandNames,
+  filterCommandSuggestions,
+  groupCommandsForHelp,
+  parseClientCommand,
+} from "../lib/client-command-catalog.js";
+
+describe("client command catalog", () => {
+  test("contains the full M2 command set with descriptions", () => {
+    expect(allCommandNames().sort()).toEqual(
+      [
+        "?",
+        "/archive",
+        "/btw",
+        "/clear",
+        "/copy",
+        "/exit",
+        "/export",
+        "/help",
+        "/new",
+        "/q",
+        "/quit",
+        "/rename",
+        "/resume",
+      ].sort(),
+    );
+
+    for (const command of CLIENT_COMMANDS) {
+      expect(command.description.length).toBeGreaterThan(0);
+      expect(command.usage.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("parses command aliases and trims arguments", () => {
+    expect(parseClientCommand("  /rename   Project Alpha  ")).toMatchObject({
+      command: "/rename",
+      args: "Project Alpha",
+    });
+
+    const quit = parseClientCommand("/q");
+    expect(quit?.entry.name).toBe("/exit");
+    expect(quit?.command).toBe("/q");
+
+    const help = parseClientCommand("?");
+    expect(help?.entry.name).toBe("/help");
+  });
+
+  test("returns null for non-command input and unknown commands", () => {
+    expect(parseClientCommand("hello")).toBeNull();
+    expect(parseClientCommand("/missing")).toBeNull();
+  });
+
+  test("filters slash command suggestions by prefix", () => {
+    expect(
+      filterCommandSuggestions("/re").map((command) => command.name),
+    ).toEqual(["/resume", "/rename"]);
+    expect(
+      filterCommandSuggestions("/q").map((command) => command.name),
+    ).toEqual(["/exit"]);
+    expect(filterCommandSuggestions("hello")).toEqual([]);
+  });
+
+  test("groups commands for compact help output", () => {
+    const grouped = groupCommandsForHelp();
+
+    expect(grouped.conversation.map((command) => command.name)).toEqual([
+      "/new",
+      "/resume",
+      "/rename",
+      "/archive",
+    ]);
+    expect(grouped.message.map((command) => command.name)).toEqual([
+      "/btw",
+      "/copy",
+      "/export",
+    ]);
+    expect(grouped.utility.map((command) => command.name)).toEqual([
+      "/clear",
+      "/help",
+      "/exit",
+    ]);
+  });
+});

--- a/cli/src/__tests__/conversation-transcript.test.ts
+++ b/cli/src/__tests__/conversation-transcript.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatConversationTranscript,
+  lastAssistantResponseText,
+  messageText,
+} from "../lib/conversation-transcript.js";
+
+describe("conversation transcript helpers", () => {
+  test("extracts text from common runtime message shapes", () => {
+    expect(messageText({ role: "assistant", text: "hello" })).toBe("hello");
+    expect(
+      messageText({
+        role: "assistant",
+        content: [{ type: "text", text: "block text" }],
+      }),
+    ).toBe("block text");
+    expect(
+      messageText({
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "json block" }]),
+      }),
+    ).toBe("json block");
+  });
+
+  test("finds the last assistant response", () => {
+    expect(
+      lastAssistantResponseText([
+        { role: "assistant", text: "first" },
+        { role: "user", text: "question" },
+        { role: "assistant", text: "second" },
+      ]),
+    ).toBe("second");
+  });
+
+  test("returns null when no assistant response has text", () => {
+    expect(lastAssistantResponseText([{ role: "user", text: "hello" }])).toBe(
+      null,
+    );
+  });
+
+  test("formats a Markdown transcript", () => {
+    const transcript = formatConversationTranscript({
+      conversationId: "conv-123",
+      title: "Project Alpha",
+      exportedAt: new Date("2026-01-02T03:04:05.000Z"),
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+          createdAt: Date.parse("2026-01-02T03:04:00.000Z"),
+        },
+        {
+          role: "assistant",
+          text: "Hi there",
+          createdAt: Date.parse("2026-01-02T03:04:01.000Z"),
+        },
+        {
+          role: "tool",
+          content: [{ type: "text", text: "Tool summary" }],
+        },
+      ],
+    });
+
+    expect(transcript).toContain("# Project Alpha");
+    expect(transcript).toContain("Conversation ID: conv-123");
+    expect(transcript).toContain("Exported: 2026-01-02T03:04:05.000Z");
+    expect(transcript).toContain(
+      "### User - 2026-01-02T03:04:00.000Z\n\nHello",
+    );
+    expect(transcript).toContain(
+      "### Assistant - 2026-01-02T03:04:01.000Z\n\nHi there",
+    );
+    expect(transcript).toContain("### Tool\n\nTool summary");
+  });
+
+  test("formats empty conversations", () => {
+    expect(
+      formatConversationTranscript({
+        conversationId: "conv-empty",
+        exportedAt: new Date("2026-01-02T03:04:05.000Z"),
+        messages: [],
+      }),
+    ).toContain("_No messages yet._");
+  });
+});

--- a/cli/src/lib/client-command-catalog.ts
+++ b/cli/src/lib/client-command-catalog.ts
@@ -1,0 +1,153 @@
+export type ClientCommandGroup = "conversation" | "message" | "utility";
+
+export interface ClientCommandEntry {
+  name: string;
+  aliases?: string[];
+  usage: string;
+  description: string;
+  group: ClientCommandGroup;
+}
+
+export interface ParsedClientCommand {
+  entry: ClientCommandEntry;
+  command: string;
+  args: string;
+}
+
+export const CLIENT_COMMANDS: ClientCommandEntry[] = [
+  {
+    name: "/new",
+    usage: "/new [title]",
+    description: "Start a new conversation",
+    group: "conversation",
+  },
+  {
+    name: "/resume",
+    usage: "/resume [search]",
+    description: "Search and resume an earlier conversation",
+    group: "conversation",
+  },
+  {
+    name: "/rename",
+    usage: "/rename <title>",
+    description: "Rename the current conversation",
+    group: "conversation",
+  },
+  {
+    name: "/archive",
+    usage: "/archive",
+    description: "Archive the current conversation",
+    group: "conversation",
+  },
+  {
+    name: "/btw",
+    usage: "/btw <question>",
+    description: "Ask a side question in the current conversation",
+    group: "message",
+  },
+  {
+    name: "/copy",
+    usage: "/copy [all]",
+    description: "Copy the last response or full conversation",
+    group: "message",
+  },
+  {
+    name: "/export",
+    usage: "/export [path]",
+    description: "Export the current conversation as Markdown",
+    group: "message",
+  },
+  {
+    name: "/clear",
+    usage: "/clear",
+    description: "Clear the current screen",
+    group: "utility",
+  },
+  {
+    name: "/help",
+    aliases: ["?"],
+    usage: "/help",
+    description: "Show commands and keyboard shortcuts",
+    group: "utility",
+  },
+  {
+    name: "/exit",
+    aliases: ["/quit", "/q"],
+    usage: "/exit",
+    description: "Exit the terminal client",
+    group: "utility",
+  },
+];
+
+export const KEYBOARD_SHORTCUTS = [
+  { keys: "Enter", description: "Send message or confirm selection" },
+  { keys: "Tab", description: "Accept or cycle command completion" },
+  { keys: "Shift+Tab", description: "Cycle command completion backward" },
+  { keys: "Up/Down", description: "Navigate history or picker options" },
+  { keys: "Shift+Up/Down", description: "Scroll conversation" },
+  { keys: "Cmd+Up/Down", description: "Jump to top or bottom" },
+  { keys: "Esc", description: "Cancel an open modal" },
+  { keys: "Ctrl+C", description: "Exit" },
+] as const;
+
+export function allCommandNames(
+  commands: readonly ClientCommandEntry[] = CLIENT_COMMANDS,
+): string[] {
+  return commands.flatMap((command) => [
+    command.name,
+    ...(command.aliases ?? []),
+  ]);
+}
+
+export function parseClientCommand(
+  input: string,
+  commands: readonly ClientCommandEntry[] = CLIENT_COMMANDS,
+): ParsedClientCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const firstSpace = trimmed.search(/\s/);
+  const command =
+    firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace).trim();
+  if (!command.startsWith("/") && command !== "?") return null;
+
+  const entry = commands.find(
+    (candidate) =>
+      candidate.name === command || candidate.aliases?.includes(command),
+  );
+  if (!entry) return null;
+
+  return {
+    entry,
+    command,
+    args: firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1).trim(),
+  };
+}
+
+export function filterCommandSuggestions(
+  input: string,
+  commands: readonly ClientCommandEntry[] = CLIENT_COMMANDS,
+): ClientCommandEntry[] {
+  const trimmed = input.trimStart();
+  if (!trimmed.startsWith("/") && trimmed !== "?") return [];
+
+  const query = trimmed.split(/\s/, 1)[0] ?? "";
+  if (query === "/") return [...commands];
+
+  return commands.filter((command) => {
+    if (command.name.startsWith(query)) return true;
+    return command.aliases?.some((alias) => alias.startsWith(query)) ?? false;
+  });
+}
+
+export function groupCommandsForHelp(
+  commands: readonly ClientCommandEntry[] = CLIENT_COMMANDS,
+): Record<ClientCommandGroup, ClientCommandEntry[]> {
+  return {
+    conversation: commands.filter(
+      (command) => command.group === "conversation",
+    ),
+    message: commands.filter((command) => command.group === "message"),
+    utility: commands.filter((command) => command.group === "utility"),
+  };
+}

--- a/cli/src/lib/conversation-transcript.ts
+++ b/cli/src/lib/conversation-transcript.ts
@@ -1,0 +1,112 @@
+export interface TranscriptMessage {
+  id?: string;
+  role?: string;
+  text?: string;
+  content?: unknown;
+  createdAt?: number;
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+export interface FormatTranscriptOptions {
+  conversationId: string;
+  title?: string | null;
+  messages: TranscriptMessage[];
+  exportedAt?: Date;
+}
+
+function blockText(block: unknown): string {
+  if (typeof block === "string") return block;
+  if (!block || typeof block !== "object") return "";
+
+  const record = block as Record<string, unknown>;
+  if (typeof record.text === "string") return record.text;
+  if (typeof record.content === "string") return record.content;
+  if (Array.isArray(record.content)) {
+    return record.content.map(blockText).filter(Boolean).join("\n");
+  }
+  return "";
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") {
+    try {
+      const parsed = JSON.parse(content) as unknown;
+      const parsedText = contentText(parsed);
+      return parsedText || content;
+    } catch {
+      return content;
+    }
+  }
+  if (Array.isArray(content)) {
+    return content.map(blockText).filter(Boolean).join("\n");
+  }
+  return blockText(content);
+}
+
+export function messageText(message: TranscriptMessage): string {
+  if (typeof message.text === "string") return message.text;
+  return contentText(message.content).trim();
+}
+
+export function lastAssistantResponseText(
+  messages: readonly TranscriptMessage[],
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== "assistant") continue;
+    const text = messageText(message);
+    if (text) return text;
+  }
+  return null;
+}
+
+function roleLabel(role: unknown): string {
+  if (role === "assistant") return "Assistant";
+  if (role === "user") return "User";
+  if (role === "tool") return "Tool";
+  if (typeof role === "string" && role.length > 0) return role;
+  return "Message";
+}
+
+function messageTimestamp(message: TranscriptMessage): string | null {
+  const value = message.createdAt ?? message.timestamp;
+  if (typeof value !== "number") return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function formatConversationTranscript(
+  options: FormatTranscriptOptions,
+): string {
+  const title = options.title?.trim() || "Untitled conversation";
+  const exportedAt = options.exportedAt ?? new Date();
+  const lines = [
+    `# ${title}`,
+    "",
+    `Conversation ID: ${options.conversationId}`,
+    `Exported: ${exportedAt.toISOString()}`,
+    "",
+    "## Transcript",
+  ];
+
+  if (options.messages.length === 0) {
+    lines.push("", "_No messages yet._");
+    return `${lines.join("\n")}\n`;
+  }
+
+  for (const message of options.messages) {
+    const text = messageText(message);
+    if (!text) continue;
+    const timestamp = messageTimestamp(message);
+    lines.push(
+      "",
+      `### ${roleLabel(message.role)}${timestamp ? ` - ${timestamp}` : ""}`,
+      "",
+      text,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}


### PR DESCRIPTION
Summary
- Add a terminal command catalog for the M2 slash command set with aliases, usage strings, descriptions, and help grouping.
- Add keyboard shortcut metadata for later TUI help rendering.
- Add pure transcript helpers for last-response copy and Markdown conversation export.

Validation
- cd cli && bun test src/__tests__/client-command-catalog.test.ts src/__tests__/conversation-transcript.test.ts
- cd cli && bunx tsc --noEmit