### PR TITLE
[codex] Add terminal clipboard helper

### DIFF
--- a/cli/src/__tests__/terminal-clipboard.test.ts
+++ b/cli/src/__tests__/terminal-clipboard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  copyTextToClipboard,
+  type ClipboardWriter,
+  type CommandRunner,
+} from "../lib/terminal-clipboard.js";
+
+describe("terminal clipboard", () => {
+  test("copies with OSC 52 when stdout is an interactive terminal", async () => {
+    let written = "";
+    const stdout: ClipboardWriter = {
+      isTTY: true,
+      write: (chunk) => {
+        written += chunk;
+      },
+    };
+
+    const result = await copyTextToClipboard("hello", {
+      stdout,
+      env: { TERM: "xterm-256color" },
+      platform: "linux",
+    });
+
+    expect(result).toEqual({ copied: true, method: "osc52" });
+    expect(written).toBe(
+      `\x1b]52;c;${Buffer.from("hello").toString("base64")}\x07`,
+    );
+  });
+
+  test("falls back to pbcopy on macOS", async () => {
+    let captured:
+      | { command: string; args: string[]; input: string }
+      | undefined;
+    const runCommand: CommandRunner = async (command, args, input) => {
+      captured = { command, args, input };
+      return { success: true };
+    };
+
+    const result = await copyTextToClipboard("hello", {
+      stdout: { isTTY: false, write: () => {} },
+      env: { TERM: "dumb" },
+      platform: "darwin",
+      runCommand,
+    });
+
+    expect(result).toEqual({ copied: true, method: "pbcopy" });
+    expect(captured).toEqual({
+      command: "pbcopy",
+      args: [],
+      input: "hello",
+    });
+  });
+
+  test("reports unsupported terminals when no strategy works", async () => {
+    const result = await copyTextToClipboard("hello", {
+      stdout: { isTTY: false, write: () => {} },
+      env: { TERM: "dumb" },
+      platform: "linux",
+    });
+
+    expect(result).toEqual({ copied: false, reason: "unsupported" });
+  });
+
+  test("reports empty input without writing", async () => {
+    let wrote = false;
+    const result = await copyTextToClipboard("", {
+      stdout: {
+        isTTY: true,
+        write: () => {
+          wrote = true;
+        },
+      },
+      env: { TERM: "xterm-256color" },
+      platform: "linux",
+    });
+
+    expect(result).toEqual({ copied: false, reason: "empty" });
+    expect(wrote).toBe(false);
+  });
+});

--- a/cli/src/lib/terminal-clipboard.ts
+++ b/cli/src/lib/terminal-clipboard.ts
@@ -1,0 +1,91 @@
+export type ClipboardMethod = "osc52" | "pbcopy";
+export type ClipboardFailureReason = "empty" | "unsupported";
+
+export interface ClipboardResult {
+  copied: boolean;
+  method?: ClipboardMethod;
+  reason?: ClipboardFailureReason;
+}
+
+export interface ClipboardWriter {
+  isTTY?: boolean;
+  write(chunk: string): unknown;
+}
+
+export interface CommandRunnerResult {
+  success: boolean;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  input: string,
+) => Promise<CommandRunnerResult>;
+
+export interface CopyTextOptions {
+  stdout?: ClipboardWriter;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  runCommand?: CommandRunner;
+}
+
+const OSC52_CLIPBOARD = "c";
+
+function osc52Sequence(text: string): string {
+  const encoded = Buffer.from(text, "utf-8").toString("base64");
+  return `\x1b]52;${OSC52_CLIPBOARD};${encoded}\x07`;
+}
+
+function supportsOsc52(
+  stdout: ClipboardWriter | undefined,
+  env: NodeJS.ProcessEnv,
+): stdout is ClipboardWriter {
+  if (!stdout?.isTTY) return false;
+  if ((env.TERM ?? "").toLowerCase() === "dumb") return false;
+  if (env.VELLUM_DISABLE_OSC52 === "1") return false;
+  return true;
+}
+
+async function defaultRunCommand(
+  command: string,
+  args: string[],
+  input: string,
+): Promise<CommandRunnerResult> {
+  const proc = Bun.spawn([command, ...args], {
+    stdin: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  proc.stdin.write(input);
+  proc.stdin.end();
+  const exitCode = await proc.exited;
+  return { success: exitCode === 0 };
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  options: CopyTextOptions = {},
+): Promise<ClipboardResult> {
+  if (text.length === 0) {
+    return { copied: false, reason: "empty" };
+  }
+
+  const env = options.env ?? process.env;
+  const stdout = options.stdout ?? process.stdout;
+
+  if (supportsOsc52(stdout, env)) {
+    stdout.write(osc52Sequence(text));
+    return { copied: true, method: "osc52" };
+  }
+
+  const platform = options.platform ?? process.platform;
+  if (platform === "darwin") {
+    const runner = options.runCommand ?? defaultRunCommand;
+    const result = await runner("pbcopy", [], text);
+    if (result.success) {
+      return { copied: true, method: "pbcopy" };
+    }
+  }
+
+  return { copied: false, reason: "unsupported" };
+}


### PR DESCRIPTION
Summary
- Add dependency-free terminal clipboard support for future /copy flows.
- Prefer OSC 52 when available and fall back to pbcopy on macOS.
- Return structured copy results so the TUI can show clear unsupported/empty statuses.

Validation
- cd cli && bun test src/__tests__/terminal-clipboard.test.ts
- cd cli && bunx tsc --noEmit