### PR TITLE
[codex] Remove assistant-owned identity template guidance

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -111,8 +111,9 @@ describe("onboarding template contracts", () => {
       expect(identity).toContain("**Emoji:**");
     });
 
-    test("contains parsed field format guidance", () => {
-      expect(identity).toContain("parsed by the app");
+    test("does not invite assistant-owned identity restructuring", () => {
+      expect(identity).not.toContain("This file is yours");
+      expect(identity).not.toContain("parsed by the app");
     });
   });
 

--- a/assistant/src/prompts/templates/IDENTITY.md
+++ b/assistant/src/prompts/templates/IDENTITY.md
@@ -2,8 +2,6 @@ _ Lines starting with _ are comments - they won't appear in the system prompt
 
 # IDENTITY.md
 
-This file is yours. Add sections, restructure it, make it reflect who you are. Name, Emoji, Role, Personality are parsed by the app - keep their `- **Label:**` format. Everything else is freeform.
-
 - **Name:** _(not yet chosen)_
 - **Emoji:** _(not yet chosen)_
 - **Nature:** _(not yet established)_


### PR DESCRIPTION
## Summary

- Remove the `IDENTITY.md` scaffold sentence that tells the assistant the file is theirs to restructure.
- Update the onboarding template contract so the identity scaffold keeps canonical fields while guarding against the removed self-ownership guidance returning.

## Why

The old scaffold language encouraged the assistant to treat identity as self-owned, which contributed to assistant self-renaming behavior during onboarding. This keeps the existing markdown-backed identity flow intact while removing the most direct problematic instruction.

Fixes JARVIS-943

## Validation

- `cd assistant && bun test src/__tests__/onboarding-template-contract.test.ts`
- `cd assistant && bunx tsc --noEmit`