### PR TITLE
refactor(assistant): wrap v2 static memory in <info> instead of <memory>

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -379,7 +379,7 @@ describe("loadFromDb metadata injection rehydration", () => {
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           memoryV2StaticBlock:
-            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+            "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
           pkbSystemReminderBlock:
             "<system_reminder>\npkb payload\n</system_reminder>",
         }),
@@ -406,11 +406,52 @@ describe("loadFromDb metadata injection rehydration", () => {
       { type: "text", text: "<memory>\nmem payload\n</memory>" },
       {
         type: "text",
-        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+        text: "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
       },
       {
         type: "text",
         text: "<system_reminder>\npkb payload\n</system_reminder>",
+      },
+      { type: "text", text: "First turn" },
+    ]);
+  });
+
+  test("legacy <memory>-wrapped memoryV2StaticBlock rehydrates verbatim", async () => {
+    // `meta.memoryV2StaticBlock` may carry either `<info>…</info>` or
+    // legacy `<memory>…</memory>` wrappers depending on when the row was
+    // persisted. The rehydrate path replays the stored text verbatim,
+    // so both wrappers must round-trip unchanged.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
       },
       { type: "text", text: "First turn" },
     ]);
@@ -434,7 +475,7 @@ describe("loadFromDb metadata injection rehydration", () => {
         role: "user",
         content: JSON.stringify([{ type: "text", text: "Tail" }]),
         metadata: JSON.stringify({
-          memoryV2StaticBlock: "<memory>\n## Essentials\n\nleak\n</memory>",
+          memoryV2StaticBlock: "<info>\n## Essentials\n\nleak\n</info>",
         }),
       },
     ];
@@ -471,7 +512,7 @@ describe("loadFromDb metadata injection rehydration", () => {
           // survive the row-level filter for non-guardian views.
           provenanceTrustClass: "trusted_contact",
           memoryV2StaticBlock:
-            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+            "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
         }),
       },
       {
@@ -500,7 +541,7 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(messages[0].content).toEqual([
       {
         type: "text",
-        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+        text: "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
       },
       { type: "text", text: "First" },
     ]);
@@ -510,7 +551,7 @@ describe("loadFromDb metadata injection rehydration", () => {
     // Injection-time layout (per `applyRuntimeInjections` after-memory-
     // prefix splicing in ascending injector order: pkb-context 30,
     // pkb-reminder 35, memory-v2-static 38, now-md 40):
-    //   [<memory __injected>, <memory>v2static</memory>, <NOW.md>,
+    //   [<memory>dynamic</memory>, <info>v2static</info>, <NOW.md>,
     //    <system_reminder>, <knowledge_base>, ...original]
     // Rehydration must reproduce this exactly so Anthropic's prefix cache
     // matches msg[0] across daemon restarts.
@@ -523,7 +564,7 @@ describe("loadFromDb metadata injection rehydration", () => {
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           memoryV2StaticBlock:
-            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+            "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
           nowScratchpadBlock: "<NOW.md>\nnow body\n</NOW.md>",
           pkbSystemReminderBlock:
             "<system_reminder>\npkb reminder body\n</system_reminder>",
@@ -551,7 +592,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       { type: "text", text: "<memory>\nmem payload\n</memory>" },
       {
         type: "text",
-        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+        text: "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
       },
       { type: "text", text: "<NOW.md>\nnow body\n</NOW.md>" },
       {
@@ -575,7 +616,7 @@ describe("loadFromDb metadata injection rehydration", () => {
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV2StaticBlock:
-            "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+            "<info>\n## Essentials\n\nprivate memory\n</info>",
         }),
       },
       {
@@ -621,7 +662,7 @@ describe("loadFromDb metadata injection rehydration", () => {
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV2StaticBlock:
-            "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+            "<info>\n## Essentials\n\nprivate memory\n</info>",
         }),
       },
       {
@@ -649,7 +690,7 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(conversation.getMessages()[0].content).toEqual([
       {
         type: "text",
-        text: "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+        text: "<info>\n## Essentials\n\nprivate memory\n</info>",
       },
       { type: "text", text: "First" },
     ]);

--- a/assistant/src/__tests__/memory-v2-static-injector.test.ts
+++ b/assistant/src/__tests__/memory-v2-static-injector.test.ts
@@ -4,9 +4,9 @@
  * Covers:
  *   - Returns null when `memoryV2Static` is missing/empty.
  *   - Returns null when `mode === "minimal"`.
- *   - Wraps content in `<memory>...</memory>` and uses
+ *   - Wraps content in `<info>...</info>` and uses
  *     `after-memory-prefix` placement.
- *   - Escapes any `</memory>` substring inside the authored content so the
+ *   - Escapes any `</info>` substring inside the authored content so the
  *     wrapper cannot be broken out of.
  *
  * Hermetic: drives the injector's `produce()` directly with a synthesized
@@ -66,7 +66,7 @@ describe("memory-v2-static injector", () => {
     expect(await memoryV2StaticInjector.produce(ctx)).toBeNull();
   });
 
-  test("wraps content in <memory>...</memory> with after-memory-prefix placement", async () => {
+  test("wraps content in <info>...</info> with after-memory-prefix placement", async () => {
     const content =
       "## Essentials\n\nAlice prefers VS Code.\n\n## Threads\n\nOpen: ship PR.";
     const ctx = makeContext({
@@ -77,11 +77,11 @@ describe("memory-v2-static injector", () => {
     expect(block).not.toBeNull();
     expect(block!.id).toBe("memory-v2-static");
     expect(block!.placement).toBe("after-memory-prefix");
-    expect(block!.text).toBe(`<memory>\n${content}\n</memory>`);
+    expect(block!.text).toBe(`<info>\n${content}\n</info>`);
   });
 
-  test("escapes inner </memory> closing tags so the wrapper cannot be broken out of", async () => {
-    const content = "## Essentials\n\nText with </memory> embedded.";
+  test("escapes inner </info> closing tags so the wrapper cannot be broken out of", async () => {
+    const content = "## Essentials\n\nText with </info> embedded.";
     const ctx = makeContext({
       injectionInputs: { memoryV2Static: content },
     });
@@ -89,7 +89,7 @@ describe("memory-v2-static injector", () => {
     const block = await memoryV2StaticInjector.produce(ctx);
     expect(block).not.toBeNull();
     expect(block!.text).toBe(
-      "<memory>\n## Essentials\n\nText with &lt;/memory&gt; embedded.\n</memory>",
+      "<info>\n## Essentials\n\nText with &lt;/info&gt; embedded.\n</info>",
     );
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1645,7 +1645,7 @@ export async function runAgentLoopImpl(
     // V2 static memory block (essentials/threads/recent/buffer).
     // `currentMemoryV2Static` is the trust-gated content reused by every
     // re-injection path — it stays non-null on non-full-mode turns so
-    // that mid-turn reducer compaction (which strips the prior `<memory>`
+    // that mid-turn reducer compaction (which strips the prior `<info>`
     // block) can restore the freshest content. `memoryV2Static` is the
     // first-turn / post-compaction cadence-gated value for initial
     // injection only. `readMemoryV2StaticContent` self-gates on the v2

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -245,9 +245,12 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
         // (pkb-context 30, pkb-reminder 35, memory-v2-static 38,
         // now-md 40 — the v2 static block lands inside the memory
         // prefix, so now-md splices *after* it):
-        //   [<workspace>, <turn_context>, <memory __injected>,
-        //    <memory>\n…</memory>, <NOW.md>, <system_reminder>,
+        //   [<workspace>, <turn_context>, <memory>dynamic</memory>,
+        //    <info>v2static</info>, <NOW.md>, <system_reminder>,
         //    <knowledge_base>, ...original]
+        // The v2 static block is replayed verbatim from stored metadata,
+        // so rows may carry either `<info>…</info>` or `<memory>…</memory>`
+        // depending on when they were persisted.
         // Required so Anthropic's prefix cache keeps matching msg[0]
         // across daemon restart and conversation eviction. The tail
         // row only rehydrates `memoryInjectedBlock` — the next turn
@@ -274,11 +277,12 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
         }
 
         // The v2 static memory block (essentials/threads/recent/buffer
-        // wrapped in `<memory>…</memory>`) carries personal user memory.
-        // Trust-gated to mirror `shouldExposePersonalMemory` at injection
-        // time — untrusted-actor views must not read persisted personal
-        // memory back through metadata. Skipped on the tail row because
-        // the next turn re-injects fresh content on full-mode turns.
+        // wrapped in either `<info>…</info>` or `<memory>…</memory>`)
+        // carries personal user memory. Trust-gated to mirror
+        // `shouldExposePersonalMemory` at injection time — untrusted-actor
+        // views must not read persisted personal memory back through
+        // metadata. Skipped on the tail row because the next turn
+        // re-injects fresh content on full-mode turns.
         if (
           !isTail &&
           personalMemoryAllowed &&

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1734,15 +1734,16 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<background_turn>",
   "<memory_context __injected>",
   "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
-  // The static `memory-v2-static` block (opens `<memory>\n…`) IS stripped
-  // so each compaction re-injects the freshest essentials/threads/recent/
-  // buffer view, matching the `<knowledge_base>` cadence. The dynamic
-  // activation block (opens `<memory __injected>…`) is intentionally NOT
-  // stripped — `startsWith("<memory>\n")` does not match it — so per-turn
-  // memory activations persist in history. The activation pipeline dedupes
-  // via `everInjected`, and compaction handles aggregate growth, so
-  // accumulation does not cause unbounded context growth.
+  // The static `memory-v2-static` block (`<info>\n…</info>`) and the
+  // dynamic activation block (`<memory>\n…</memory>`, plus legacy
+  // `<memory __injected>…`) are both stripped so each compaction
+  // re-injects the freshest essentials/threads/recent/buffer view and
+  // re-runs the activation pipeline, matching the `<knowledge_base>`
+  // cadence. The activation pipeline dedupes via `everInjected`, and
+  // compaction handles aggregate growth, so accumulation does not cause
+  // unbounded context growth. Both wrappers may appear in persisted rows.
   "<memory>\n",
+  "<info>\n",
   "<voice_call_control>",
   "<workspace_top_level>", // backward-compat: strip legacy workspace blocks
   // NOTE: <workspace> is intentionally NOT stripped — workspace context
@@ -2037,7 +2038,7 @@ export interface RuntimeInjectionOptions {
   /**
    * Pre-rendered v2 static memory content (essentials/threads/recent/buffer
    * concatenated, header-wrapped). When non-null on full-mode turns the
-   * `memory-v2-static` injector wraps it in `<memory>` and splices it onto
+   * `memory-v2-static` injector wraps it in `<info>` and splices it onto
    * the user message; subsequent turns leave the prior block cached on its
    * original user message.
    */

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -808,16 +808,22 @@ export class ConversationGraphMemory {
 
 /**
  * Count the leading content blocks on a user message that were added by
- * `injectMemoryBlock`. Memory-injected images use a 3-block pattern
- * (opening `<memory_image>` text + image + closing `</memory_image>` text),
- * followed by a `<memory>…</memory>` text block (legacy `<memory __injected>` is also accepted).
- * The bare `<memory>` form is matched only when the block also ends with
- * `\n</memory>`, so user-authored content that happens to begin with
- * `<memory>` (for example, a message discussing the XML-like markup) is not
- * mistaken for an injected prefix and stripped on re-injection. A legacy
- * 2-block image pattern (no closing tag) is also accepted for backward
- * compatibility. The injection prefix is always contiguous at the start,
- * so we stop at the first non-memory block.
+ * `injectMemoryBlock` or the `memory-v2-static` injector. Memory-injected
+ * images use a 3-block pattern (opening `<memory_image>` text + image +
+ * closing `</memory_image>` text), followed by a `<memory>…</memory>` text
+ * block (legacy `<memory __injected>` is also accepted). The static
+ * memory-v2 block uses `<info>…</info>` and is also counted here so that
+ * `after-memory-prefix` splices for subsequent injectors (e.g. `now-md`)
+ * land after both the dynamic and static blocks.
+ *
+ * The bare `<memory>` and `<info>` forms are matched only when the block
+ * also ends with the corresponding closing tag, so user-authored content
+ * that happens to begin with `<memory>` or `<info>` (for example, a
+ * message discussing the XML-like markup) is not mistaken for an injected
+ * prefix and stripped on re-injection. A legacy 2-block image pattern (no
+ * closing tag) is also accepted for backward compatibility. The injection
+ * prefix is always contiguous at the start, so we stop at the first
+ * non-memory block.
  */
 export function countMemoryPrefixBlocks(content: ContentBlock[]): number {
   let firstNonMemory = 0;
@@ -829,6 +835,8 @@ export function countMemoryPrefixBlocks(content: ContentBlock[]): number {
       block.type === "text" &&
       ((block.text.startsWith("<memory>\n") &&
         block.text.endsWith("\n</memory>")) ||
+        (block.text.startsWith("<info>\n") &&
+          block.text.endsWith("\n</info>")) ||
         block.text.startsWith("<memory __injected>\n"))
     ) {
       firstNonMemory++;

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -387,17 +387,20 @@ async function buildPkbReminderWithHints(
  * `memory-v2-static` injector — order 38, after-memory-prefix.
  *
  * Injects the v2 static memory block (essentials/threads/recent/buffer
- * concatenated under markdown headings) wrapped in `<memory>...</memory>`
+ * concatenated under markdown headings) wrapped in `<info>...</info>`
  * onto the user message. The agent loop only forwards `memoryV2Static` on
  * full-mode turns (first turn / post-compaction), mirroring the PKB
  * auto-inject cadence — subsequent turns get `null` and the prior block
  * stays cached on its original user message.
  *
- * Sits between `pkb-reminder` (35) and `now-md` (40) so the rendered order
- * after the memory prefix is `[pkb-reminder, pkb-context, memory-v2-static,
- * now-md, ...user text]` when every PKB injector also fires (transitional
- * state). Once PKB is fully retired under v2 this is the only block
- * adjacent to the memory prefix.
+ * Sits between `pkb-reminder` (35) and `now-md` (40). Because every
+ * after-memory-prefix splice lands at the memory-prefix boundary in
+ * ascending `order`, higher-order blocks end up closer to the memory
+ * prefix. The rendered layout is therefore `[<memory>dynamic</memory>,
+ * <info>memory-v2-static</info>, <NOW.md>, <system_reminder>,
+ * <knowledge_base>, ...user text]` when every PKB injector also fires.
+ * `countMemoryPrefixBlocks` treats the `<info>` static block as part of
+ * the memory prefix so `now-md` (40) splices after it.
  *
  * Gating:
  *  - `mode === "full"`.
@@ -420,14 +423,18 @@ const memoryV2StaticInjector: Injector = {
   },
 };
 
+const INFO_CLOSE_TAG_RE = /<\/info\s*>/gi;
+
 /**
- * Wrap the static memory content in `<memory>...</memory>`. Escapes any
- * closing `</memory>` inside the content so authored memory files cannot
- * accidentally break out of the wrapper.
+ * Wrap the static memory content in `<info>...</info>`. Escapes any
+ * closing `</info>` inside the content so authored memory files cannot
+ * accidentally break out of the wrapper. Distinct from the dynamic
+ * activation block (which uses `<memory>...</memory>`) so downstream
+ * logic can address the two differently.
  */
 function buildMemoryV2StaticBlock(content: string): string {
-  const escaped = content.replace(/<\/memory\s*>/gi, "&lt;/memory&gt;");
-  return `<memory>\n${escaped}\n</memory>`;
+  const escaped = content.replace(INFO_CLOSE_TAG_RE, "&lt;/info&gt;");
+  return `<info>\n${escaped}\n</info>`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Static v2 memory block now wraps in `<info>...</info>` (essentials/threads/recent/buffer); the dynamic graph-memory activation block stays on `<memory>...</memory>`. Distinct tags so follow-up logic can address them independently.
- `countMemoryPrefixBlocks` and `RUNTIME_INJECTION_PREFIXES` accept both wrappers — preserves current `after-memory-prefix` splice ordering and lets legacy DB rows (whose persisted `memoryV2StaticBlock` still uses `<memory>`) rehydrate verbatim.
- Tests updated; added a dedicated regression for legacy `<memory>`-wrapped rehydration. No DB migration required — old rows replay as-is, new turns produce the new wrapper.

## Original prompt

The static memory injection block (essentials.md, threads.md, recent.md, buffer.md) and the dynamic per-turn graph-memory activation block were both wrapped in `<memory>...</memory>`, so the assistant couldn't tell them apart in the prompt. Rename the static wrapper to `<info>` now so a follow-up change can give the two blocks distinct downstream handling.