### PR TITLE
feat(llm): route cost-optimized profile to gemini-3.1-flash-lite

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -65,8 +65,8 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "cost-optimized": {
     intent: "latency-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
+    provider: "gemini",
+    connectionName: "gemini-managed",
     source: "managed",
     label: "Speed",
     description: "Fastest responses at lower cost",


### PR DESCRIPTION
## Summary

- Switch the managed `cost-optimized` profile in `seed-inference-profiles.ts` from `provider: anthropic` / `anthropic-managed` to `provider: gemini` / `gemini-managed`. The `intent: latency-optimized` is unchanged, so `model-intents.ts` resolves it to `gemini-3.1-flash-lite` (already in the catalog).
- All ~20 call sites in `assistant/src/config/call-site-defaults.ts` that default to the `cost-optimized` profile (filing, memory extraction/retrieval, summarization, commit messages, classifiers, notification decisions, etc.) now route to Gemini Flash-Lite — cheaper input/output pricing and a 1M-token context window.
- No new connection or migration needed: `gemini-managed` is already seeded every boot by `seedCanonicalConnections()`. On daemon restart, `seedInferenceProfiles()` overwrites the existing managed profile row while preserving the user's `label` and `status` choices.

## Original prompt

Change the cost-optimized profile to default to `gemini-3.1-flash-lite`. The model and managed connection are already registered, so the implementation is a two-field provider/connectionName swap on the managed `cost-optimized` template — no migration, no test churn, no call-site edits, and the existing intent indirection (`latency-optimized` → `gemini-3.1-flash-lite`) picks up the new model automatically. Keep the PR open for manual review rather than auto-merging.