### PR TITLE
chore(assistant): regenerate openapi.yaml for memory-router schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11484,11 +11484,20 @@ paths:
             schema:
               type: object
               properties:
-                userMessage:
-                  type: string
-                  minLength: 1
-                assistantMessage:
-                  type: string
+                recentTurnPairs:
+                  minItems: 1
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      assistantMessage:
+                        type: string
+                      userMessage:
+                        type: string
+                    required:
+                      - assistantMessage
+                      - userMessage
+                    additionalProperties: false
                 nowText:
                   type: string
                 configOverrides:
@@ -11520,7 +11529,7 @@ paths:
                   type: string
                   maxLength: 1000000
               required:
-                - userMessage
+                - recentTurnPairs
               additionalProperties: false
   /v1/memory/v2/validate:
     post:


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to match the current schema, fixing the failing `OpenAPI Spec Check` CI job.
- The diff reflects the memory-router endpoint change to `recentTurnPairs` (from #31844-#31846), which updated the source schema but did not refresh the generated spec.

## Original prompt
Fix the failing `OpenAPI Spec Check` CI job on main (run 26320001972, job 77487033448). The job reports `openapi.yaml is stale` with the first divergence around the memory-router endpoint that recently switched from `userMessage`/`assistantMessage` to `recentTurnPairs`. Regenerate with `bun run generate:openapi` and ship the result.