### PR TITLE
[codex] fix onboarding account isolation

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -163,7 +163,6 @@ export function ChatPage() {
   const [autoGreetPending, setAutoGreetPending] = useState(
     () => peekPendingInitialMessage() !== null,
   );
-  const awaitingAutoGreetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
     hasMore: false,
@@ -476,12 +475,6 @@ export function ChatPage() {
     autoGreetRef.current = true;
     setDidOnboarding(true);
     setAutoGreetPending(true);
-    if (awaitingAutoGreetTimeoutRef.current) {
-      clearTimeout(awaitingAutoGreetTimeoutRef.current);
-    }
-    awaitingAutoGreetTimeoutRef.current = setTimeout(() => {
-      setAutoGreetPending(false);
-    }, 10_000);
     const onboardingDraftKey =
       onboardingDraftConversationKeyRef.current ?? createDraftConversationKey();
     onboardingDraftConversationKeyRef.current = onboardingDraftKey;
@@ -492,12 +485,6 @@ export function ChatPage() {
     // losing all refs. Leave the context in sessionStorage so the new
     // mount's sendMessage hook and auto-send effect can consume it.
     void navigate(routes.conversation(onboardingDraftKey), { replace: true });
-    return () => {
-      if (awaitingAutoGreetTimeoutRef.current) {
-        clearTimeout(awaitingAutoGreetTimeoutRef.current);
-        awaitingAutoGreetTimeoutRef.current = null;
-      }
-    };
   }, [searchParams, navigate]);
 
   // -------------------------------------------------------------------------
@@ -683,15 +670,26 @@ export function ChatPage() {
     void sendMessage(message);
   }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
 
-  // Clear the auto-greet loading gate once messages arrive (the assistant
-  // responded) or the 10-second safety timeout expires. Matches platform's
-  // awaitingAutoGreet pattern.
+  // Clear the post-onboarding loading gate once the first message appears.
   useEffect(() => {
     if (!autoGreetPending) return;
     if (messages.length > 0) {
       setAutoGreetPending(false);
     }
   }, [autoGreetPending, messages.length]);
+
+  // The onboarding redirect remounts ChatPage after leaving
+  // `/assistant?onboarding=1`; a timeout armed on the first mount is cancelled
+  // during that remount. Arm the safety timer from the actual mounted page
+  // that is rendering the loading gate so a failed auto-send cannot strand
+  // the user on "Connecting..." until refresh.
+  useEffect(() => {
+    if (!autoGreetPending) return;
+    const timeout = setTimeout(() => {
+      setAutoGreetPending(false);
+    }, 10_000);
+    return () => clearTimeout(timeout);
+  }, [autoGreetPending]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type MockSessionUser = {
+  id?: string;
+  username?: string;
+  email?: string;
+};
+
+let sessionUser: MockSessionUser | null = null;
+const syncOnboardingUserMock = mock((_userId: string | null) => {});
+const clearOrganizationMock = mock(() => {});
+const logoutMock = mock(async () => {});
+
+mock.module("@/lib/auth/allauth-client.js", () => ({
+  getSession: async () => {
+    if (!sessionUser) {
+      return { ok: false, status: 401, error: { detail: "Unauthorized" } };
+    }
+    return { ok: true, data: { user: sessionUser } };
+  },
+  logout: logoutMock,
+}));
+
+mock.module("@/domains/onboarding/prefs.js", () => ({
+  syncOnboardingUser: syncOnboardingUserMock,
+}));
+
+mock.module("@/stores/organization-store.js", () => ({
+  clearOrganization: clearOrganizationMock,
+}));
+
+mock.module("@/stores/event-bus-store.js", () => ({
+  useEventBusStore: {
+    getState: () => ({
+      subscribe: () => () => {},
+    }),
+  },
+}));
+
+const { useAuthStore } = await import("@/stores/auth-store.js");
+
+function resetAuthStore(): void {
+  useAuthStore.setState({
+    isLoggedIn: false,
+    isLoading: true,
+    user: null,
+  });
+}
+
+beforeEach(() => {
+  sessionUser = null;
+  syncOnboardingUserMock.mockClear();
+  clearOrganizationMock.mockClear();
+  logoutMock.mockClear();
+  resetAuthStore();
+});
+
+describe("auth store onboarding flag reconciliation", () => {
+  test("initSession reconciles onboarding flags for the signed-in user", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    expect(syncOnboardingUserMock).toHaveBeenCalledWith("user-1");
+    expect(useAuthStore.getState().isLoggedIn).toBe(true);
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+
+  test("refreshSession reconciles onboarding flags for a changed user", async () => {
+    sessionUser = { id: "user-2", email: "user@example.com" };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(syncOnboardingUserMock).toHaveBeenCalledWith("user-2");
+    expect(useAuthStore.getState().user?.id).toBe("user-2");
+  });
+
+  test("logout keeps onboarding reconciliation on the shared auth path", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(logoutMock).toHaveBeenCalled();
+    expect(syncOnboardingUserMock).toHaveBeenCalledWith(null);
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+});

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,6 +19,7 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
+import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
 
@@ -84,6 +85,11 @@ function broadcastAuthChange(): void {
   broadcastChannel?.postMessage("auth-changed");
 }
 
+function syncUserScopedState(nextUserId: string | null): void {
+  syncOnboardingUser(nextUserId);
+  syncOrganizationState(nextUserId);
+}
+
 const useAuthStoreBase = create<AuthStore>()((set) => ({
   isLoggedIn: false,
   isLoading: true,
@@ -94,14 +100,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       const result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
-        syncOrganizationState(user?.id ?? null);
+        syncUserScopedState(user?.id ?? null);
         set({ isLoggedIn: true, isLoading: false, user });
         return;
       }
     } catch (err) {
       console.error("auth.initSession failed", err);
     }
-    syncOrganizationState(null);
+    syncUserScopedState(null);
     set({ isLoggedIn: false, isLoading: false, user: null });
   },
 
@@ -110,14 +116,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       const result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
-        syncOrganizationState(user?.id ?? null);
+        syncUserScopedState(user?.id ?? null);
         set({ isLoggedIn: true, user });
         return true;
       }
     } catch (err) {
       console.warn("auth.refreshSession failed", err);
     }
-    syncOrganizationState(null);
+    syncUserScopedState(null);
     set({ isLoggedIn: false, user: null });
     return false;
   },
@@ -126,7 +132,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     try {
       await allauthLogout();
     } finally {
-      syncOrganizationState(null);
+      syncUserScopedState(null);
       set({ isLoggedIn: false, user: null });
       broadcastAuthChange();
     }


### PR DESCRIPTION
## Summary
- Restore per-user onboarding flag reconciliation in the web auth store so stale `onboarding.completed` state from another account cannot bypass onboarding.
- Move the post-onboarding auto-greet safety timeout onto the remounted chat page that actually renders `Connecting...`, preventing a failed/delayed auto-send from stranding the user until refresh.
- Add auth-store regression coverage for init, refresh, and logout paths.

## Root Cause
The React Router/Zustand auth migration dropped the platform auth provider call to `syncOnboardingUser()`. On a shared browser profile, a new signed-in user could inherit a previous account’s `onboarding.completed=true` localStorage flag.

Separately, the auto-greet timeout was armed during the `/assistant?onboarding=1` mount and then cancelled by the redirect/remount to `/assistant/conversations/:key`, so the loading gate could remain visible indefinitely if the first-message path did not complete.

## Validation
- `cd apps/web && bun test src/stores/auth-store.test.ts`
- `cd apps/web && bun run lint src/stores/auth-store.ts src/stores/auth-store.test.ts src/domains/chat/chat-page.tsx`
- `cd apps/web && bunx tsc --noEmit` currently fails on `origin/main` due to `adjust-plan-modal.tsx` importing missing generated API member `organizationsBillingSubscriptionChangeStorageTierCreateMutation`; this branch only changes auth/onboarding/chat files.
