### PR TITLE
fix(web): persist content automation initial message

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -44,7 +44,7 @@ import type { TranscriptHandle } from "@/domains/chat/transcript/transcript.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import { getThinkingStatusText, shouldShowThinkingIndicator, type UIContext } from "@/domains/messaging/turn-selectors.js";
-import { clearPendingInitialMessage, peekPendingInitialMessage, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
+import { peekPendingPreChatContext, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
 import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
@@ -161,7 +161,7 @@ export function ChatPage() {
   const [restoredDraftConversationKey, setRestoredDraftConversationKey] = useState<string | null>(null);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [autoGreetPending, setAutoGreetPending] = useState(
-    () => peekPendingInitialMessage() !== null,
+    () => peekPendingPreChatContext()?.initialMessage != null,
   );
   const [contextWindowUsage, setContextWindowUsage] = useState<ContextWindowUsage | null>(null);
   const [transcriptPagination, setTranscriptPagination] = useState<Omit<TranscriptPaginationState, "items">>({
@@ -651,7 +651,7 @@ export function ChatPage() {
   // getChatContext to trigger the unreachable-bus.
   useEffect(() => {
     if (!assistantId) return;
-    const message = peekPendingInitialMessage();
+    const message = peekPendingPreChatContext()?.initialMessage;
     if (!message) return;
     if (reachability.state.phase === "idle") {
       reachability.probe({ mode: "background" });
@@ -663,10 +663,9 @@ export function ChatPage() {
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationKey) return;
     if (reachability.state.phase !== "ready") return;
-    const message = peekPendingInitialMessage();
+    const message = peekPendingPreChatContext()?.initialMessage;
     if (!message) return;
     initialMessageConsumedRef.current = true;
-    clearPendingInitialMessage();
     void sendMessage(message);
   }, [activeConversationKey, assistantId, reachability.state.phase, sendMessage]);
 

--- a/apps/web/src/domains/onboarding/content-automation.test.ts
+++ b/apps/web/src/domains/onboarding/content-automation.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildContentAutomationPreChatContext,
+  CONTENT_AUTOMATION_INITIAL_MESSAGE,
+  persistContentAutomationPreChatHandoff,
+} from "@/domains/onboarding/content-automation.js";
+import {
+  INITIAL_MESSAGE_KEY,
+  STORAGE_KEY,
+} from "@/domains/onboarding/prechat.js";
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const ORIGINAL_SESSION_STORAGE = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "sessionStorage",
+);
+
+function installStorage(storage: Storage): void {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function uninstallStorage(): void {
+  if (ORIGINAL_SESSION_STORAGE) {
+    Object.defineProperty(globalThis, "sessionStorage", ORIGINAL_SESSION_STORAGE);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+}
+
+describe("content automation onboarding handoff", () => {
+  beforeEach(() => {
+    installStorage(new MemoryStorage());
+  });
+
+  afterAll(() => {
+    uninstallStorage();
+  });
+
+  test("builds the cohort context used by the auto-skip path", () => {
+    expect(buildContentAutomationPreChatContext()).toEqual({
+      tools: [],
+      tasks: ["writing", "research", "project-management"],
+      tone: "grounded",
+      googleConnected: false,
+      cohort: "content-automation",
+    });
+  });
+
+  test("persists both the pre-chat context and the chat auto-send key", () => {
+    persistContentAutomationPreChatHandoff();
+
+    const storage = (globalThis as { sessionStorage: Storage }).sessionStorage;
+    expect(storage.getItem(INITIAL_MESSAGE_KEY)).toBe(
+      CONTENT_AUTOMATION_INITIAL_MESSAGE,
+    );
+    expect(JSON.parse(storage.getItem(STORAGE_KEY) ?? "{}")).toEqual(
+      buildContentAutomationPreChatContext(),
+    );
+  });
+});

--- a/apps/web/src/domains/onboarding/content-automation.test.ts
+++ b/apps/web/src/domains/onboarding/content-automation.test.ts
@@ -5,10 +5,7 @@ import {
   CONTENT_AUTOMATION_INITIAL_MESSAGE,
   persistContentAutomationPreChatHandoff,
 } from "@/domains/onboarding/content-automation.js";
-import {
-  INITIAL_MESSAGE_KEY,
-  STORAGE_KEY,
-} from "@/domains/onboarding/prechat.js";
+import { STORAGE_KEY } from "@/domains/onboarding/prechat.js";
 
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();
@@ -68,25 +65,24 @@ describe("content automation onboarding handoff", () => {
     uninstallStorage();
   });
 
-  test("builds the cohort context used by the auto-skip path", () => {
-    expect(buildContentAutomationPreChatContext()).toEqual({
+  test("builds the cohort context with initialMessage", () => {
+    const context = buildContentAutomationPreChatContext();
+    expect(context).toEqual({
       tools: [],
       tasks: ["writing", "research", "project-management"],
       tone: "grounded",
       googleConnected: false,
       cohort: "content-automation",
+      initialMessage: CONTENT_AUTOMATION_INITIAL_MESSAGE,
     });
   });
 
-  test("persists both the pre-chat context and the chat auto-send key", () => {
+  test("persists context (including initialMessage) to a single storage key", () => {
     persistContentAutomationPreChatHandoff();
 
     const storage = (globalThis as { sessionStorage: Storage }).sessionStorage;
-    expect(storage.getItem(INITIAL_MESSAGE_KEY)).toBe(
-      CONTENT_AUTOMATION_INITIAL_MESSAGE,
-    );
-    expect(JSON.parse(storage.getItem(STORAGE_KEY) ?? "{}")).toEqual(
-      buildContentAutomationPreChatContext(),
-    );
+    const persisted = JSON.parse(storage.getItem(STORAGE_KEY) ?? "{}");
+    expect(persisted).toEqual(buildContentAutomationPreChatContext());
+    expect(persisted.initialMessage).toBe(CONTENT_AUTOMATION_INITIAL_MESSAGE);
   });
 });

--- a/apps/web/src/domains/onboarding/content-automation.ts
+++ b/apps/web/src/domains/onboarding/content-automation.ts
@@ -1,0 +1,25 @@
+import {
+  setPendingInitialMessage,
+  setPendingPreChatContext,
+  type PreChatOnboardingContext,
+} from "@/domains/onboarding/prechat.js";
+import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names.js";
+
+export const CONTENT_AUTOMATION_INITIAL_MESSAGE =
+  "I want to write articles that rank better for GEO.";
+
+export function buildContentAutomationPreChatContext(): PreChatOnboardingContext {
+  return {
+    tools: [],
+    tasks: ["writing", "research", "project-management"],
+    tone: DEFAULT_GROUP_ID,
+    googleConnected: false,
+    cohort: "content-automation",
+  };
+}
+
+export function persistContentAutomationPreChatHandoff(): void {
+  const context = buildContentAutomationPreChatContext();
+  setPendingPreChatContext(context);
+  setPendingInitialMessage(CONTENT_AUTOMATION_INITIAL_MESSAGE);
+}

--- a/apps/web/src/domains/onboarding/content-automation.ts
+++ b/apps/web/src/domains/onboarding/content-automation.ts
@@ -1,5 +1,4 @@
 import {
-  setPendingInitialMessage,
   setPendingPreChatContext,
   type PreChatOnboardingContext,
 } from "@/domains/onboarding/prechat.js";
@@ -15,11 +14,10 @@ export function buildContentAutomationPreChatContext(): PreChatOnboardingContext
     tone: DEFAULT_GROUP_ID,
     googleConnected: false,
     cohort: "content-automation",
+    initialMessage: CONTENT_AUTOMATION_INITIAL_MESSAGE,
   };
 }
 
 export function persistContentAutomationPreChatHandoff(): void {
-  const context = buildContentAutomationPreChatContext();
-  setPendingPreChatContext(context);
-  setPendingInitialMessage(CONTENT_AUTOMATION_INITIAL_MESSAGE);
+  setPendingPreChatContext(buildContentAutomationPreChatContext());
 }

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -7,6 +7,7 @@ import { useIsIOSWeb } from "@/domains/nudges/ios-app-platform.js";
 import { readIOSAppDownloaded } from "@/domains/nudges/ios-app-prefs.js";
 import { useIsMacOSWeb } from "@/domains/nudges/mac-app-platform.js";
 import { readMacOsAppDownloaded } from "@/domains/nudges/mac-app-prefs.js";
+import { persistContentAutomationPreChatHandoff } from "@/domains/onboarding/content-automation.js";
 import { GetIOSAppScreen } from "@/domains/onboarding/screens/get-ios-app-screen.js";
 import { GetMacOSAppScreen } from "@/domains/onboarding/screens/get-macos-app-screen.js";
 import { GoogleConnectScreen } from "@/domains/onboarding/screens/google-connect-screen.js";
@@ -190,15 +191,7 @@ export function PreChatFlow() {
     if (autoSkippedRef.current) return;
     autoSkippedRef.current = true;
 
-    const context: PreChatOnboardingContext = {
-      tools: [],
-      tasks: ["writing", "research", "project-management"],
-      tone: DEFAULT_GROUP_ID,
-      googleConnected: false,
-      cohort: "content-automation",
-      initialMessage: "I want to write articles that rank better for GEO.",
-    };
-    setPendingPreChatContext(context);
+    persistContentAutomationPreChatHandoff();
     try {
       setOnboardingCompleted(true);
     } catch (err) {

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -21,7 +21,6 @@ import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react
 import { usePrefilledInput } from "@/hooks/use-prefilled-input.js";
 import {
   setPendingAssistantName,
-  setPendingInitialMessage,
   setPendingPreChatContext,
   type PreChatOnboardingContext,
 } from "@/domains/onboarding/prechat.js";
@@ -229,7 +228,6 @@ export function PreChatFlow() {
 
     setPendingPreChatContext(context);
     if (trimmedAssistant) setPendingAssistantName(trimmedAssistant);
-    setPendingInitialMessage(context.initialMessage!);
     try {
       setOnboardingCompleted(true);
     } catch (err) {
@@ -305,7 +303,6 @@ export function PreChatFlow() {
       if (trimmedAssistant) {
         setPendingAssistantName(trimmedAssistant);
       }
-      setPendingInitialMessage(context.initialMessage);
       if (screenStorageKey) {
         try {
           sessionStorage.removeItem(screenStorageKey);

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -368,58 +368,33 @@ export function consumePendingAssistantName(): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// Initial-message handoff
-//
-// The initial message (e.g. "Wake up, my friend!") is stored in the full
-// PreChatOnboardingContext, but `ChatPage` unmounts and remounts during
-// the onboarding redirect (index route → /conversations/:key), losing
-// the ref that held the message. A separate sessionStorage key lets the
-// new mount pick it up.
+// Peek at pre-chat context (non-destructive)
 // ---------------------------------------------------------------------------
 
-export const INITIAL_MESSAGE_KEY = "onboarding.prechat.initialMessage";
-
-export function setPendingInitialMessage(message: string): void {
-  const trimmed = message.trim();
-  if (!trimmed) return;
-  const storage = getSessionStorage();
-  if (storage === null) return;
-  try {
-    storage.setItem(INITIAL_MESSAGE_KEY, trimmed);
-  } catch {
-    // Storage unavailable — degrade silently.
-  }
-}
-
-export function consumePendingInitialMessage(): string | null {
+/**
+ * Read the pending pre-chat onboarding context without removing it.
+ * Used by ChatPage to check for an `initialMessage` before the context
+ * is consumed during the first send.
+ */
+export function peekPendingPreChatContext(): PreChatOnboardingContext | null {
   const storage = getSessionStorage();
   if (storage === null) return null;
+
+  let raw: string | null;
   try {
-    const value = storage.getItem(INITIAL_MESSAGE_KEY);
-    storage.removeItem(INITIAL_MESSAGE_KEY);
-    return typeof value === "string" && value.length > 0 ? value : null;
+    raw = storage.getItem(STORAGE_KEY);
   } catch {
     return null;
   }
-}
+  if (raw === null) return null;
 
-export function peekPendingInitialMessage(): string | null {
-  const storage = getSessionStorage();
-  if (storage === null) return null;
+  let parsed: unknown;
   try {
-    const value = storage.getItem(INITIAL_MESSAGE_KEY);
-    return typeof value === "string" && value.length > 0 ? value : null;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
-}
 
-export function clearPendingInitialMessage(): void {
-  const storage = getSessionStorage();
-  if (storage === null) return;
-  try {
-    storage.removeItem(INITIAL_MESSAGE_KEY);
-  } catch {
-    // Storage unavailable — nothing to clear.
-  }
+  if (!isPreChatOnboardingContext(parsed)) return null;
+  return parsed;
 }


### PR DESCRIPTION
## Summary
- Persist the content-automation cohort onboarding context through a dedicated helper.
- Write the separate `onboarding.prechat.initialMessage` session key so ChatPage auto-sends the seeded GEO prompt after the pre-chat skip.
- Add a focused regression test for the content-automation handoff keys.

## Testing
- `cd apps/web && bun test src/domains/onboarding/content-automation.test.ts`
- `cd apps/web && bun run lint src/domains/onboarding/content-automation.ts src/domains/onboarding/content-automation.test.ts src/domains/onboarding/pages/pre-chat-flow.tsx`
- `cd apps/web && bunx tsc --noEmit` currently fails on unrelated generated billing API mismatch in `src/domains/settings/components/adjust-plan-modal.tsx` (`organizationsBillingSubscriptionChangeStorageTierCreateMutation` missing).

## Manual validation loop
- In staging DevTools, after `/assistant/onboarding/prechat` redirects for a content-automation user, verify `sessionStorage.getItem("onboarding.prechat.initialMessage")` equals `I want to write articles that rank better for GEO.` before the chat page consumes it.
- On the chat page, preserve the Network log and verify the first chat POST carries that prompt without typing in the composer.