### PR TITLE
only upload sentry source maps in deploy build

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -121,7 +121,6 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 
   checks:
@@ -193,6 +192,8 @@ jobs:
       #                              job's `environment:`)
       #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
       #                              are public, so embedding them is expected
+      #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
+      #                              and Sentry release side effects.
       #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
       #                              inlines it — it only authenticates the
       #                              build-time source-map upload and is not
@@ -205,6 +206,7 @@ jobs:
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_APP_VERSION: ${{ github.sha }}
+          SENTRY_UPLOAD_SOURCE_MAPS: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -130,7 +130,6 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 
   # Aggregator — preserves the "Lint, Type Check & Build" status check name

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,10 +13,12 @@ export default defineConfig(({ mode }) => {
   // Reference: https://vite.dev/config/server-options#server-proxy
   const apiProxyTarget = env.API_PROXY_TARGET || "http://localhost:8000";
 
-  // Sentry source map upload is opt-in — only runs when SENTRY_AUTH_TOKEN
-  // is provided (CI/CD build pipeline). Local dev builds skip it.
+  // Only enable Sentry source map upload for deploy builds.
   // Reference: https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/uploading/vite/
-  const sentryUploadEnabled = !!env.SENTRY_AUTH_TOKEN;
+  const sentryUploadEnabled = env.SENTRY_UPLOAD_SOURCE_MAPS === "true";
+  if (sentryUploadEnabled && !env.SENTRY_AUTH_TOKEN) {
+    throw new Error("SENTRY_AUTH_TOKEN is required to upload Sentry source maps.");
+  }
 
   return {
     base: "/assistant/",


### PR DESCRIPTION
Currently we upload source maps / create releases in Sentry
1. during CI for PRs
2. during main CI/CD workflow (twice...)

AFAICT, the autogenerated release IDs will use the `GITHUB_SHA` env var: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#:~:text=github.com.-,GITHUB_SHA,-The%20commit%20SHA
This value depends on how the GHA workflow was trigged. For a PR target this is a synthentic merge commit, which is basically invisible and not particularly helpful.

I split out a `SENTRY_UPLOAD_SOURCE_MAPS` env var so that we're more explicit about our intentions. Without preview environments, we should only upload source maps as part of the production build.
