### PR TITLE
remove redundant build step for main web CI

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -96,36 +96,9 @@ jobs:
       - name: Test
         run: bun run test:ci
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/web
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: '1.3.11'
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Generate API clients
-        run: bun run openapi-ts
-
-      - name: Build
-        env:
-          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
-        run: bun run build
-
   checks:
-    name: Lint, Type Check & Build
-    needs: [lint, typecheck, test, build]
+    name: Lint, Type Check & Test
+    needs: [lint, typecheck, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -134,13 +107,11 @@ jobs:
           LINT: ${{ needs.lint.result }}
           TYPECHECK: ${{ needs.typecheck.result }}
           TEST: ${{ needs.test.result }}
-          BUILD: ${{ needs.build.result }}
         run: |
           echo "Lint:       $LINT"
           echo "Type Check: $TYPECHECK"
           echo "Test:       $TEST"
-          echo "Build:      $BUILD"
-          for r in "$LINT" "$TYPECHECK" "$TEST" "$BUILD"; do
+          for r in "$LINT" "$TYPECHECK" "$TEST"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one web CI job failed."
               exit 1


### PR DESCRIPTION
We're already building as part of `deploy` step.
