### PR TITLE
attempt to reduce SPA chunk churn

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -163,6 +163,8 @@ jobs:
       #                              job's `environment:`)
       #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
       #                              are public, so embedding them is expected
+      #   - VITE_APP_VERSION         commit SHA baked into the browser bundle
+      #                              for Sentry event release tagging.
       #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
       #                              and Sentry release side effects.
       #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -130,6 +130,7 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
+          VITE_APP_VERSION: ${{ github.sha }}
         run: bun run build
 
   # Aggregator — preserves the "Lint, Type Check & Build" status check name

--- a/apps/web/src/lib/sentry/sentry-init.ts
+++ b/apps/web/src/lib/sentry/sentry-init.ts
@@ -28,6 +28,7 @@ import { sanitizeUrl } from "@/lib/sentry/url-sanitize.js";
 const options: BrowserOptions = {
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local",
+  release: import.meta.env.VITE_APP_VERSION,
   tracesSampleRate: 0,
   // Attach a synthetic JS stack to `Sentry.captureMessage` calls so events
   // emitted without a thrown exception still resolve to a source location

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig(({ mode }) => {
   if (sentryUploadEnabled && !env.SENTRY_AUTH_TOKEN) {
     throw new Error("SENTRY_AUTH_TOKEN is required to upload Sentry source maps.");
   }
+  if (sentryUploadEnabled) {
+    if (!env.VITE_APP_VERSION) {
+      throw new Error("VITE_APP_VERSION is required to upload Sentry source maps.");
+    }
+  }
 
   return {
     base: "/assistant/",
@@ -31,7 +36,8 @@ export default defineConfig(({ mode }) => {
         project: env.SENTRY_PROJECT || "vellum-assistant-web",
         authToken: env.SENTRY_AUTH_TOKEN,
         release: {
-          name: env.SENTRY_RELEASE,
+          name: env.VITE_APP_VERSION,
+          inject: false,
         },
         sourcemaps: {
           filesToDeleteAfterUpload: ["./dist/**/*.map"],


### PR DESCRIPTION
Our build process uploads source maps to Sentry via the sentry-via plugin.
This also creates a new Release in Sentry -- we don't explicitly set an ID, so by default Sentry will detect the `GITHUB_SHA` env var on GHA runners.

Very roughly, Sentry seems to inject this release ID into each chunk as follows:
1. creates a chunk named `_sentry-release-injection-file-XXXX.js`. This script contains the release ID from above and is content-hashed, so it changes each build job.
2. adds an import of the release injection file to the beginning of each chunk, which in turn updates content hash

(2) basically invalidates cache for otherwise unchanged files.

I'd like to reduce chunk churn for better caching.

Maybe we can avoid injecting release IDs?
My reading of Sentry docs isn't very clear: https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/debug-ids/ so I'm just gonna try something.
- AFAICT, Sentry already injects debug IDs (which are content hashed and stable) into these files.
- Maybe we can avoid release injection mechanism, and instead bake release ID into sentry SDK init

