### PR TITLE
Add vellum roadmap create CLI command

### DIFF
--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -1,0 +1,116 @@
+import { readPlatformToken, getWebUrl } from "../lib/platform-client.js";
+
+function printUsage(): void {
+  console.log("Usage: vellum roadmap <subcommand>");
+  console.log("");
+  console.log("Manage roadmap items.");
+  console.log("");
+  console.log("Subcommands:");
+  console.log(
+    "  create --title <title> [--description <desc>] [--tag <slug>...]",
+  );
+  console.log("");
+  console.log("Examples:");
+  console.log('  $ vellum roadmap create --title "Add dark mode"');
+  console.log(
+    '  $ vellum roadmap create --title "OAuth support" --description "Support for Google and GitHub" --tag integrations',
+  );
+}
+
+function parseCreateArgs(args: string[]): {
+  title: string | undefined;
+  description: string | undefined;
+  tags: string[];
+} {
+  let title: string | undefined;
+  let description: string | undefined;
+  const tags: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--title":
+        title = args[++i];
+        break;
+      case "--description":
+        description = args[++i];
+        break;
+      case "--tag":
+        tags.push(args[++i]!);
+        break;
+    }
+  }
+
+  return { title, description, tags };
+}
+
+async function roadmapCreate(args: string[]): Promise<void> {
+  const { title, description, tags } = parseCreateArgs(args);
+
+  if (!title) {
+    console.error("Error: --title is required.");
+    console.error('Usage: vellum roadmap create --title "My feature request"');
+    process.exitCode = 1;
+    return;
+  }
+
+  const token = readPlatformToken();
+  if (!token) {
+    console.error("Not logged in. Run `vellum login` first.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const webUrl = getWebUrl();
+  const url = `${webUrl}/api/marketing/v1/roadmap`;
+
+  const body: Record<string, unknown> = { title };
+  if (description) body.description = description;
+  if (tags.length > 0) body.tags = tags;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-Token": token,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    console.error(`Failed to create roadmap item (${response.status}): ${text}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const item = (await response.json()) as {
+    slug: string;
+    title: string;
+    status: string;
+  };
+
+  console.log(`Created roadmap item: ${item.title}`);
+  console.log(`  slug:   ${item.slug}`);
+  console.log(`  status: ${item.status}`);
+  console.log(`  url:    ${webUrl}/roadmap/${item.slug}`);
+}
+
+export async function roadmap(): Promise<void> {
+  const args = process.argv.slice(3);
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    printUsage();
+    return;
+  }
+
+  switch (sub) {
+    case "create":
+      await roadmapCreate(args.slice(1));
+      break;
+    default:
+      console.error(`Unknown subcommand: ${sub}`);
+      printUsage();
+      process.exitCode = 1;
+  }
+}

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -17,6 +17,15 @@ function printUsage(): void {
   );
 }
 
+function consumeValue(args: string[], i: number, flag: string): string {
+  const next = args[i + 1];
+  if (next === undefined || next.startsWith("--")) {
+    console.error(`Error: ${flag} requires a value.`);
+    process.exit(1);
+  }
+  return next;
+}
+
 function parseCreateArgs(args: string[]): {
   title: string | undefined;
   description: string | undefined;
@@ -29,13 +38,16 @@ function parseCreateArgs(args: string[]): {
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case "--title":
-        title = args[++i];
+        title = consumeValue(args, i, "--title");
+        i++;
         break;
       case "--description":
-        description = args[++i];
+        description = consumeValue(args, i, "--description");
+        i++;
         break;
       case "--tag":
-        tags.push(args[++i]!);
+        tags.push(consumeValue(args, i, "--tag"));
+        i++;
         break;
     }
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import { message } from "./commands/message";
 import { ps } from "./commands/ps";
 import { recover } from "./commands/recover";
 import { restore } from "./commands/restore";
+import { roadmap } from "./commands/roadmap";
 import { retire } from "./commands/retire";
 import { rollback } from "./commands/rollback";
 import { setup } from "./commands/setup";
@@ -45,6 +46,7 @@ const commands = {
   recover,
   restore,
   retire,
+  roadmap,
   rollback,
   setup,
   sleep,
@@ -83,6 +85,7 @@ function printHelp(): void {
     "  restore  Restore data (and optionally version) from a .vbundle backup",
   );
   console.log("  retire   Delete an assistant instance");
+  console.log("  roadmap  Manage roadmap items");
   console.log("  rollback  Roll back an assistant to a previous version");
   console.log("  setup    Configure API keys interactively");
   console.log("  sleep    Stop the assistant process");


### PR DESCRIPTION
## Summary
- Adds a `vellum roadmap create` subcommand that creates a new roadmap item via the marketing API
- Authenticates using the session token from `vellum login`, sent as `X-Session-Token` through the Next.js marketing proxy
- Supports `--title` (required), `--description`, and `--tag` flags

Usage:
```
vellum roadmap create --title "Add dark mode"
vellum roadmap create --title "OAuth support" --description "Support for Google and GitHub" --tag integrations
```

**Depends on:** vellum-ai/vellum-assistant-platform#TBD (adds `X-Session-Token` support to the marketing proxy)

## Test plan
- [ ] `vellum roadmap create --title "test"` creates a roadmap item
- [ ] `vellum roadmap create` without `--title` shows usage error
- [ ] Running without `vellum login` shows login prompt
- [ ] `vellum roadmap --help` shows usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)