### PR TITLE
feat(web): improve DomainField with error display, locked state, and env-aware domain

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -23,6 +23,7 @@ import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Input } from "@vellum/design-library/components/input";
 import { Notice } from "@vellum/design-library/components/notice";
 import { SegmentControl } from "@vellum/design-library/components/segment-control";
+import { DomainField } from "@/domains/settings/components/domain-field.js";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 import { Typography } from "@vellum/design-library/components/typography";
 
@@ -854,9 +855,10 @@ const EMAIL_BYO_PROVIDERS: readonly EmailByoProvider[] = [
 
 interface EmailServiceCardProps {
   assistantId: string | undefined;
+  assistantHandle: string | undefined;
 }
 
-function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
+function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
@@ -871,8 +873,16 @@ function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
       ) as EmailByoProvider["id"],
   );
   const [subdomainDraft, setSubdomainDraft] = useState("");
+  const [subdomainPrefilled, setSubdomainPrefilled] = useState(false);
+  const [subdomainError, setSubdomainError] = useState<string | null>(null);
   const [usernameDraft, setUsernameDraft] = useState("");
   const [savingMode, setSavingMode] = useState(false);
+
+  useEffect(() => {
+    if (subdomainPrefilled || !assistantHandle || subdomainDraft) return;
+    setSubdomainDraft(assistantHandle);
+    setSubdomainPrefilled(true);
+  }, [assistantHandle, subdomainPrefilled, subdomainDraft]);
 
   // -- Subscription gate (managed mode requires Pro) -------------------------
   // We separate "definitely not Pro" from "unknown" so a failed subscription
@@ -949,7 +959,7 @@ function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
     if (!assistantId) return;
     const trimmed = subdomainDraft.trim().toLowerCase();
     if (!trimmed) {
-      toast.error("Enter a subdomain.");
+      setSubdomainError("Enter a subdomain.");
       return;
     }
     try {
@@ -958,14 +968,14 @@ function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
         body: { subdomain: trimmed },
       });
       setSubdomainDraft("");
+      setSubdomainError(null);
       invalidateEmailQueries();
       toast.success(`Domain ${trimmed}.${emailRootDomain} registered.`);
     } catch (err) {
-      const message =
-        err instanceof Error && err.message
-          ? err.message
-          : "Failed to register domain.";
-      toast.error(message);
+      const rec = err as Record<string, unknown> | undefined;
+      const detail = rec && typeof rec.detail === "string" ? rec.detail : null;
+      const message = detail ?? (err instanceof Error && err.message ? err.message : "Failed to register domain.");
+      setSubdomainError(message);
     }
   }, [
     assistantId,
@@ -1117,22 +1127,23 @@ function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
             </p>
           ) : !domain ? (
             <div className="space-y-3">
-              <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              <Typography
+                variant="body-small-default"
+                as="label"
+                className="text-[var(--content-secondary)]"
+              >
                 Subdomain
-              </label>
-              <div className="flex items-center gap-2">
-                <Input
-                  value={subdomainDraft}
-                  onChange={(e) =>
-                    setSubdomainDraft(e.target.value.toLowerCase())
-                  }
-                  placeholder="myassistant"
-                  fullWidth
-                />
-                <span className="shrink-0 text-body-small-default text-[var(--content-tertiary)]">
-                  .{emailRootDomain}
-                </span>
-              </div>
+              </Typography>
+              <DomainField
+                subdomain={subdomainDraft}
+                onSubdomainChange={(v) => {
+                  setSubdomainDraft(v);
+                  if (subdomainError) setSubdomainError(null);
+                }}
+                domainSuffix={emailRootDomain}
+                subdomainPlaceholder="my-assistant"
+                error={subdomainError}
+              />
               <p className="text-body-small-default text-[var(--content-tertiary)]">
                 Each assistant gets its own subdomain. Lowercase letters,
                 numbers, and hyphens only.
@@ -1146,24 +1157,27 @@ function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
             </div>
           ) : !address ? (
             <div className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <div className="space-y-0.5">
+              <div className="space-y-0.5">
+                <div className="flex items-center justify-between gap-3">
                   <label className="block text-body-small-default text-[var(--content-tertiary)]">
                     Domain
                   </label>
-                  <span className="inline-flex items-center gap-1 rounded-full bg-[var(--system-positive-weak)] px-2.5 py-0.5 text-body-small-default text-[var(--system-positive-strong)]">
-                    <Check className="h-3 w-3" />
-                    {fullDomain}
-                  </span>
+                  <Button
+                    variant="dangerGhost"
+                    size="compact"
+                    onClick={handleDeleteDomain}
+                    disabled={deleteDomain.isPending}
+                  >
+                    Release
+                  </Button>
                 </div>
-                <Button
-                  variant="dangerGhost"
-                  size="compact"
-                  onClick={handleDeleteDomain}
-                  disabled={deleteDomain.isPending}
-                >
-                  Release
-                </Button>
+                <DomainField
+                  subdomain={domain.subdomain}
+                  onSubdomainChange={() => {}}
+                  domainSuffix={emailRootDomain}
+                  locked
+                  lockedMessage="This domain has been set and cannot be changed."
+                />
               </div>
 
               <div className="space-y-1">
@@ -1926,7 +1940,7 @@ export function AiPage() {
       </ServiceCard>
 
       {/* Email */}
-      <EmailServiceCard assistantId={assistantId} />
+      <EmailServiceCard assistantId={assistantId} assistantHandle={assistantList?.results?.[0]?.handle} />
 
       {/* Image Generation */}
       <ServiceCard

--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -9,31 +9,51 @@ import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
 import {
   assistantsActiveRetrieveOptions,
+  assistantsDomainsListOptions,
   organizationsBillingSubscriptionOnboardingDomainCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen.js";
 import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 
+import { DomainField } from "@/domains/settings/components/domain-field.js";
 import { IconBadge, StepDots } from "./primitives.js";
 import { DOMAIN_EXIT_DELAY_MS, extractOnboardingErrorMessage } from "./utils.js";
 
 export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () => void }) {
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
+  const assistantId = activeAssistant?.id;
+
+  const { data: domainsData } = useQuery({
+    ...assistantsDomainsListOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: !!assistantId,
+  });
+  const existingDomain = domainsData?.results?.[0];
+
   const [subdomain, setSubdomain] = useState("");
   const [emailUsername, setEmailUsername] = useState("hi");
   const [prefilled, setPrefilled] = useState(false);
 
   useEffect(() => {
-    if (prefilled || !activeAssistant?.handle || subdomain) return;
+    if (prefilled) return;
+    if (existingDomain) {
+      setSubdomain(existingDomain.subdomain);
+      setPrefilled(true);
+      return;
+    }
+    if (!activeAssistant?.handle || subdomain) return;
     setSubdomain(activeAssistant.handle);
     setPrefilled(true);
-  }, [activeAssistant?.handle, prefilled, subdomain]);
+  }, [activeAssistant?.handle, existingDomain, prefilled, subdomain]);
+
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
   const domainMutation = useMutation(
     organizationsBillingSubscriptionOnboardingDomainCreateMutation(),
   );
 
+  const isLocked = !!existingDomain || confirmed;
   const busy = domainMutation.isPending || confirmed;
 
   useEffect(() => {
@@ -106,38 +126,42 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
           >
             Email address
           </Typography>
-          <div
-            className="flex h-9 w-full items-center rounded-md border border-[var(--field-border)] bg-[var(--field-bg)] text-body-medium-lighter transition-[border-color] duration-150 focus-within:border-[var(--border-active)]"
-          >
-            <input
-              value={emailUsername}
-              onChange={(e) => setEmailUsername(e.target.value.toLowerCase().trim())}
-              disabled={busy}
-              placeholder="hi"
-              aria-label="Email username"
-              size={Math.max(emailUsername.length, 2)}
-              className="h-full w-0 min-w-[2ch] flex-none bg-transparent pl-3 pr-1.5 text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none disabled:cursor-not-allowed disabled:opacity-60"
-              style={{ width: `${Math.max(emailUsername.length, 2) + 1.5}ch` }}
-            />
-            <span className="shrink-0 font-mono text-[var(--content-secondary)]">@</span>
-            <input
-              value={subdomain}
-              onChange={(e) => setSubdomain(e.target.value.toLowerCase().trim())}
-              disabled={busy}
-              placeholder="my-assistant"
-              aria-label="Subdomain"
-              className="h-full min-w-0 flex-1 bg-transparent pl-1.5 pr-1 text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none disabled:cursor-not-allowed disabled:opacity-60"
-            />
-            <span className="shrink-0 pr-3 font-mono text-[var(--content-secondary)]">.{emailRootDomain}</span>
-          </div>
+          <DomainField
+            subdomain={subdomain}
+            onSubdomainChange={(v) => {
+              setSubdomain(v);
+              if (errorMsg) setErrorMsg(null);
+            }}
+            domainSuffix={emailRootDomain}
+            disabled={busy}
+            error={errorMsg}
+            locked={isLocked}
+            lockedMessage="This domain has been set and cannot be changed."
+            prefix={
+              <>
+                <input
+                  value={emailUsername}
+                  onChange={(e) => setEmailUsername(e.target.value.toLowerCase().trim())}
+                  disabled={busy || isLocked}
+                  readOnly={isLocked}
+                  placeholder="hi"
+                  aria-label="Email username"
+                  size={Math.max(emailUsername.length, 2)}
+                  className="h-full w-0 min-w-[2ch] flex-none bg-transparent pl-3 pr-1.5 text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                  style={{ width: `${Math.max(emailUsername.length, 2) + 1.5}ch` }}
+                />
+                <span className="shrink-0 font-mono text-[var(--content-secondary)]">@</span>
+              </>
+            }
+          />
         </div>
 
-        <Notice tone="info">
-          <span className="font-mono">{subdomain || "<subdomain>"}</span> will also become your assistant&apos;s public handle.
-          You won&apos;t be able to change it once set.
-        </Notice>
-
-        {errorMsg ? <Notice tone="error">{errorMsg}</Notice> : null}
+        {!isLocked && (
+          <Notice tone="info">
+            <span className="font-mono">{subdomain || "<subdomain>"}</span> will also become your assistant&apos;s public handle.
+            You won&apos;t be able to change it once set.
+          </Notice>
+        )}
         {confirmed ? (
           <Notice tone="success">Domain set — redirecting…</Notice>
         ) : null}
@@ -156,22 +180,34 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
           <StepDots current={1} />
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            data-testid="onboarding-domain-skip"
-            disabled={busy}
-            onClick={handleSkip}
-          >
-            Do later
-          </Button>
-          <Button
-            variant="primary"
-            data-testid="onboarding-domain-set"
-            disabled={!subdomain || busy}
-            onClick={handleSet}
-          >
-            Set domain
-          </Button>
+          {isLocked ? (
+            <Button
+              variant="primary"
+              data-testid="onboarding-domain-continue"
+              onClick={onExit}
+            >
+              Continue
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                data-testid="onboarding-domain-skip"
+                disabled={busy}
+                onClick={handleSkip}
+              >
+                Do later
+              </Button>
+              <Button
+                variant="primary"
+                data-testid="onboarding-domain-set"
+                disabled={!subdomain || busy}
+                onClick={handleSet}
+              >
+                Set domain
+              </Button>
+            </>
+          )}
         </div>
       </Modal.Footer>
     </>

--- a/apps/web/src/domains/settings/components/domain-field.tsx
+++ b/apps/web/src/domains/settings/components/domain-field.tsx
@@ -1,0 +1,69 @@
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface DomainFieldProps {
+  subdomain: string;
+  onSubdomainChange: (value: string) => void;
+  domainSuffix: string;
+  subdomainPlaceholder?: string;
+  disabled?: boolean;
+  prefix?: ReactNode;
+  error?: string | null;
+  locked?: boolean;
+  lockedMessage?: string;
+}
+
+export function DomainField({
+  subdomain,
+  onSubdomainChange,
+  domainSuffix,
+  subdomainPlaceholder = "my-assistant",
+  disabled,
+  prefix,
+  error,
+  locked,
+  lockedMessage,
+}: DomainFieldProps) {
+  const borderClass = locked
+    ? "border-[var(--system-positive-strong)]"
+    : error
+      ? "border-[var(--system-negative-strong)]"
+      : "border-[var(--field-border)] focus-within:border-[var(--border-active)]";
+
+  return (
+    <div>
+      <div className={`flex h-9 w-full items-center rounded-md border bg-[var(--field-bg)] text-body-medium-lighter transition-[border-color] duration-150 ${borderClass}`}>
+        {prefix}
+        <input
+          value={subdomain}
+          onChange={(e) => onSubdomainChange(e.target.value.toLowerCase().trim())}
+          disabled={disabled || locked}
+          readOnly={locked}
+          placeholder={subdomainPlaceholder}
+          aria-label="Subdomain"
+          aria-invalid={!!error}
+          className={`h-full min-w-0 flex-1 bg-transparent ${prefix ? "pl-1.5" : "pl-3"} pr-1 text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none disabled:cursor-not-allowed disabled:opacity-60`}
+        />
+        {locked && (
+          <span className="mr-1 flex items-center gap-1 rounded-full bg-[var(--system-positive-weak)] px-2 py-0.5 text-body-small-default text-[var(--system-positive-strong)]">
+            <Check className="h-3 w-3" />
+            Set
+          </span>
+        )}
+        <span className="shrink-0 pr-3 font-mono text-[var(--content-secondary)]">
+          .{domainSuffix}
+        </span>
+      </div>
+      {error && (
+        <p className="mt-1.5 text-body-small-default text-[var(--system-negative-strong)]">
+          {error}
+        </p>
+      )}
+      {locked && lockedMessage && (
+        <p className="mt-1.5 text-body-small-default text-[var(--content-tertiary)]">
+          {lockedMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/environment/environment-store.ts
+++ b/apps/web/src/lib/environment/environment-store.ts
@@ -13,13 +13,21 @@ interface EnvironmentActions {
 
 type EnvironmentStore = EnvironmentConfig & EnvironmentActions;
 
-const DEFAULT_ENVIRONMENT: EnvironmentConfig = {
-  emailRootDomain: "vellum.me",
-  isNonProduction: false,
-};
+function getDefaultEnvironment(): EnvironmentConfig {
+  const env = import.meta.env.VITE_SENTRY_ENVIRONMENT;
+  const isNonProduction = !env || env !== "production";
+
+  let emailRootDomain: string;
+  if (!env || env === "local") emailRootDomain = "local.vellum.me";
+  else if (env === "dev") emailRootDomain = "dev.vellum.me";
+  else if (env === "staging") emailRootDomain = "staging.vellum.me";
+  else emailRootDomain = "vellum.me";
+
+  return { emailRootDomain, isNonProduction };
+}
 
 const useEnvironmentStoreBase = create<EnvironmentStore>()((set) => ({
-  ...DEFAULT_ENVIRONMENT,
+  ...getDefaultEnvironment(),
   setEnvironment: (config) => set(config),
 }));
 


### PR DESCRIPTION
## Summary
- Extracts `DomainField` into a reusable component with `error` and `locked` props for inline server-side error display and read-only locked state
- Both onboarding and settings email card now prefill subdomain from assistant handle, check if a domain is already registered (showing locked state), and display API errors inline
- Environment store now derives `emailRootDomain` and `isNonProduction` from `VITE_SENTRY_ENVIRONMENT` instead of hardcoding defaults, so local/dev/staging builds show the correct domain suffix

## Original prompt
User wanted to show server-side errors (like "This handle is reserved") inline on the DomainField component, then expanded scope to ensure both domain-step (onboarding) and ai-page (settings) correctly prefill from the assistant's handle, show a locked read-only state when the domain is already registered, and use the correct environment-specific domain suffix (local.vellum.me for local builds instead of hardcoded vellum.me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)