### PR TITLE
Make roadmap CLI URL a clickable hyperlink

### DIFF
--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -104,7 +104,8 @@ async function roadmapCreate(args: string[]): Promise<void> {
   console.log(`Created roadmap item: ${item.title}`);
   console.log(`  slug:   ${item.slug}`);
   console.log(`  status: ${item.status}`);
-  console.log(`  url:    ${webUrl}/roadmap/${item.slug}`);
+  const url = `${webUrl}/roadmap/${item.slug}`;
+  console.log(`  url:    \x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`);
 }
 
 export async function roadmap(): Promise<void> {

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -73,13 +73,13 @@ async function roadmapCreate(args: string[]): Promise<void> {
   }
 
   const webUrl = getWebUrl();
-  const url = `${webUrl}/api/marketing/v1/roadmap`;
+  const apiUrl = `${webUrl}/api/marketing/v1/roadmap`;
 
   const body: Record<string, unknown> = { title };
   if (description) body.description = description;
   if (tags.length > 0) body.tags = tags;
 
-  const response = await fetch(url, {
+  const response = await fetch(apiUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Uses the OSC 8 terminal hyperlink escape sequence so the URL printed by `vellum roadmap create` is clickable in supported terminals (iTerm2, Terminal.app, Wezterm, Windows Terminal, etc.)

**Stacks on:** #31902

## Test plan
- [ ] Run `vellum roadmap create --title "test"` and confirm the URL is clickable in iTerm2/Terminal.app
- [ ] Confirm output still looks reasonable in terminals without hyperlink support (displays as plain text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)