### PR TITLE
feat(cli): extend roadmap command with CRUD, search, and upvote

### DIFF
--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -7,14 +7,28 @@ function printUsage(): void {
   console.log("");
   console.log("Subcommands:");
   console.log(
-    "  create --title <title> [--description <desc>] [--tag <slug>...]",
+    "  list     [--query <q>] [--status <s>] [--tag <slug>] [--sort upvotes|created] [--limit <n>]",
   );
+  console.log("  get      <slug>");
+  console.log(
+    "  create   --title <title> [--description <desc>] [--tag <slug>...]",
+  );
+  console.log(
+    "  update   <slug> [--title <title>] [--description <desc>] [--status <s>] [--tag <slug>...]",
+  );
+  console.log("  delete   <slug>");
+  console.log("  upvote   <slug>");
+  console.log("  unvote   <slug>");
   console.log("");
   console.log("Examples:");
+  console.log('  $ vellum roadmap list --query "dark mode"');
+  console.log("  $ vellum roadmap list --status planned --sort upvotes");
+  console.log("  $ vellum roadmap get my-feature-slug");
   console.log('  $ vellum roadmap create --title "Add dark mode"');
   console.log(
-    '  $ vellum roadmap create --title "OAuth support" --description "Support for Google and GitHub" --tag integrations',
+    '  $ vellum roadmap update my-feature --status planned --tag integrations',
   );
+  console.log("  $ vellum roadmap upvote my-feature-slug");
 }
 
 function consumeValue(args: string[], i: number, flag: string): string {
@@ -26,11 +40,198 @@ function consumeValue(args: string[], i: number, flag: string): string {
   return next;
 }
 
-function parseCreateArgs(args: string[]): {
-  title: string | undefined;
-  description: string | undefined;
-  tags: string[];
-} {
+function requireAuth(): string {
+  const token = readPlatformToken();
+  if (!token) {
+    console.error("Not logged in. Run `vellum login` first.");
+    process.exit(1);
+  }
+  return token;
+}
+
+function requireSlug(args: string[], command: string): string {
+  const slug = args[0];
+  if (!slug || slug.startsWith("--")) {
+    console.error(`Usage: vellum roadmap ${command} <slug>`);
+    process.exit(1);
+  }
+  return slug;
+}
+
+function makeLink(url: string): string {
+  return `\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`;
+}
+
+async function apiFetch(
+  path: string,
+  options: {
+    method?: string;
+    token?: string;
+    body?: Record<string, unknown>;
+    params?: Record<string, string>;
+  } = {},
+): Promise<Response> {
+  const webUrl = getWebUrl();
+  let url = `${webUrl}/api/marketing${path}`;
+  if (options.params) {
+    const qs = new URLSearchParams(options.params).toString();
+    if (qs) url += `?${qs}`;
+  }
+
+  const headers: Record<string, string> = {};
+  if (options.token) headers["X-Session-Token"] = options.token;
+  if (options.body) headers["Content-Type"] = "application/json";
+
+  return fetch(url, {
+    method: options.method ?? "GET",
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+}
+
+async function handleError(
+  response: Response,
+  action: string,
+): Promise<never> {
+  const text = await response.text().catch(() => "");
+  console.error(`Failed to ${action} (${response.status}): ${text}`);
+  process.exit(1);
+}
+
+// ── list ──
+
+interface ListItem {
+  slug: string;
+  title: string;
+  status: string;
+  upvote_count: number;
+  comment_count: number;
+  tags: { slug: string; name: string }[];
+  viewer_upvoted: boolean | null;
+}
+
+async function roadmapList(args: string[]): Promise<void> {
+  const params: Record<string, string> = {};
+  const token = readPlatformToken() ?? undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--query":
+      case "-q":
+        params.q = consumeValue(args, i, "--query");
+        i++;
+        break;
+      case "--status":
+        params.status = consumeValue(args, i, "--status");
+        i++;
+        break;
+      case "--tag":
+        params.tag = consumeValue(args, i, "--tag");
+        i++;
+        break;
+      case "--sort":
+        params.sort = consumeValue(args, i, "--sort");
+        i++;
+        break;
+      case "--limit":
+        params.limit = consumeValue(args, i, "--limit");
+        i++;
+        break;
+      case "--offset":
+        params.offset = consumeValue(args, i, "--offset");
+        i++;
+        break;
+    }
+  }
+
+  const response = await apiFetch("/v1/roadmap", { params, token });
+  if (!response.ok) return handleError(response, "list roadmap items");
+
+  const data = (await response.json()) as {
+    items: ListItem[];
+    total: number;
+  };
+
+  if (data.items.length === 0) {
+    console.log("No roadmap items found.");
+    return;
+  }
+
+  const webUrl = getWebUrl();
+  console.log(`Showing ${data.items.length} of ${data.total} items:\n`);
+
+  for (const item of data.items) {
+    const upvoted = item.viewer_upvoted ? " (upvoted)" : "";
+    const tags = item.tags.length > 0
+      ? ` [${item.tags.map((t) => t.slug).join(", ")}]`
+      : "";
+    console.log(
+      `  ${item.title}  ▲${item.upvote_count}${upvoted}  💬${item.comment_count}  ${item.status}${tags}`,
+    );
+    console.log(`    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
+  }
+}
+
+// ── get ──
+
+async function roadmapGet(args: string[]): Promise<void> {
+  const slug = requireSlug(args, "get");
+  const token = readPlatformToken() ?? undefined;
+  const response = await apiFetch(`/v1/roadmap/${slug}`, { token });
+  if (!response.ok) return handleError(response, "get roadmap item");
+
+  const item = (await response.json()) as {
+    slug: string;
+    title: string;
+    description: string;
+    status: string;
+    upvote_count: number;
+    comment_count: number;
+    tags: { slug: string; name: string }[];
+    viewer_upvoted: boolean | null;
+    creator_username: string;
+    created: string;
+    comments: {
+      id: string;
+      author_username: string;
+      author_is_staff: boolean;
+      body: string;
+      created: string;
+    }[];
+  };
+
+  const webUrl = getWebUrl();
+  const upvoted = item.viewer_upvoted ? " (upvoted)" : "";
+  const tags =
+    item.tags.length > 0
+      ? item.tags.map((t) => t.slug).join(", ")
+      : "none";
+
+  console.log(item.title);
+  console.log(`  slug:     ${item.slug}`);
+  console.log(`  status:   ${item.status}`);
+  console.log(`  upvotes:  ${item.upvote_count}${upvoted}`);
+  console.log(`  tags:     ${tags}`);
+  console.log(`  by:       ${item.creator_username}`);
+  console.log(`  created:  ${item.created}`);
+  console.log(`  url:      ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
+  if (item.description) {
+    console.log(`\n${item.description}`);
+  }
+
+  if (item.comments.length > 0) {
+    console.log(`\nComments (${item.comments.length}):`);
+    for (const c of item.comments) {
+      const staff = c.author_is_staff ? " [staff]" : "";
+      console.log(`  ${c.author_username}${staff} (${c.created}):`);
+      console.log(`    ${c.body}`);
+    }
+  }
+}
+
+// ── create ──
+
+async function roadmapCreate(args: string[]): Promise<void> {
   let title: string | undefined;
   let description: string | undefined;
   const tags: string[] = [];
@@ -52,12 +253,6 @@ function parseCreateArgs(args: string[]): {
     }
   }
 
-  return { title, description, tags };
-}
-
-async function roadmapCreate(args: string[]): Promise<void> {
-  const { title, description, tags } = parseCreateArgs(args);
-
   if (!title) {
     console.error("Error: --title is required.");
     console.error('Usage: vellum roadmap create --title "My feature request"');
@@ -65,35 +260,17 @@ async function roadmapCreate(args: string[]): Promise<void> {
     return;
   }
 
-  const token = readPlatformToken();
-  if (!token) {
-    console.error("Not logged in. Run `vellum login` first.");
-    process.exitCode = 1;
-    return;
-  }
-
-  const webUrl = getWebUrl();
-  const url = `${webUrl}/api/marketing/v1/roadmap`;
-
+  const token = requireAuth();
   const body: Record<string, unknown> = { title };
   if (description) body.description = description;
   if (tags.length > 0) body.tags = tags;
 
-  const response = await fetch(url, {
+  const response = await apiFetch("/v1/roadmap", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Session-Token": token,
-    },
-    body: JSON.stringify(body),
+    token,
+    body,
   });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    console.error(`Failed to create roadmap item (${response.status}): ${text}`);
-    process.exitCode = 1;
-    return;
-  }
+  if (!response.ok) return handleError(response, "create roadmap item");
 
   const item = (await response.json()) as {
     slug: string;
@@ -101,11 +278,128 @@ async function roadmapCreate(args: string[]): Promise<void> {
     status: string;
   };
 
+  const webUrl = getWebUrl();
   console.log(`Created roadmap item: ${item.title}`);
   console.log(`  slug:   ${item.slug}`);
   console.log(`  status: ${item.status}`);
-  console.log(`  url:    ${webUrl}/roadmap/${item.slug}`);
+  console.log(`  url:    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
 }
+
+// ── update ──
+
+async function roadmapUpdate(args: string[]): Promise<void> {
+  const slug = requireSlug(args, "update");
+
+  let title: string | undefined;
+  let description: string | undefined;
+  let status: string | undefined;
+  const tags: string[] = [];
+
+  for (let i = 1; i < args.length; i++) {
+    switch (args[i]) {
+      case "--title":
+        title = consumeValue(args, i, "--title");
+        i++;
+        break;
+      case "--description":
+        description = consumeValue(args, i, "--description");
+        i++;
+        break;
+      case "--status":
+        status = consumeValue(args, i, "--status");
+        i++;
+        break;
+      case "--tag":
+        tags.push(consumeValue(args, i, "--tag"));
+        i++;
+        break;
+    }
+  }
+
+  const body: Record<string, unknown> = {};
+  if (title !== undefined) body.title = title;
+  if (description !== undefined) body.description = description;
+  if (status !== undefined) body.status = status;
+  if (tags.length > 0) body.tags = tags;
+
+  if (Object.keys(body).length === 0) {
+    console.error("Error: at least one field to update is required.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const token = requireAuth();
+  const response = await apiFetch(`/v1/roadmap/${slug}`, {
+    method: "PATCH",
+    token,
+    body,
+  });
+  if (!response.ok) return handleError(response, "update roadmap item");
+
+  const item = (await response.json()) as {
+    slug: string;
+    title: string;
+    status: string;
+  };
+
+  const webUrl = getWebUrl();
+  console.log(`Updated roadmap item: ${item.title}`);
+  console.log(`  slug:   ${item.slug}`);
+  console.log(`  status: ${item.status}`);
+  console.log(`  url:    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
+}
+
+// ── delete ──
+
+async function roadmapDelete(args: string[]): Promise<void> {
+  const slug = requireSlug(args, "delete");
+  const token = requireAuth();
+  const response = await apiFetch(`/v1/roadmap/${slug}`, {
+    method: "DELETE",
+    token,
+  });
+  if (!response.ok) return handleError(response, "delete roadmap item");
+
+  console.log(`Deleted roadmap item: ${slug}`);
+}
+
+// ── upvote / unvote ──
+
+async function roadmapUpvote(args: string[]): Promise<void> {
+  const slug = requireSlug(args, "upvote");
+  const token = requireAuth();
+  const response = await apiFetch(`/v1/roadmap/${slug}/upvote`, {
+    method: "POST",
+    token,
+  });
+  if (!response.ok) return handleError(response, "upvote roadmap item");
+
+  const data = (await response.json()) as {
+    slug: string;
+    upvote_count: number;
+  };
+
+  console.log(`Upvoted: ${data.slug} (${data.upvote_count} total)`);
+}
+
+async function roadmapUnvote(args: string[]): Promise<void> {
+  const slug = requireSlug(args, "unvote");
+  const token = requireAuth();
+  const response = await apiFetch(`/v1/roadmap/${slug}/upvote`, {
+    method: "DELETE",
+    token,
+  });
+  if (!response.ok) return handleError(response, "remove upvote");
+
+  const data = (await response.json()) as {
+    slug: string;
+    upvote_count: number;
+  };
+
+  console.log(`Removed upvote: ${data.slug} (${data.upvote_count} total)`);
+}
+
+// ── main ──
 
 export async function roadmap(): Promise<void> {
   const args = process.argv.slice(3);
@@ -117,8 +411,29 @@ export async function roadmap(): Promise<void> {
   }
 
   switch (sub) {
+    case "list":
+    case "ls":
+      await roadmapList(args.slice(1));
+      break;
+    case "get":
+    case "show":
+      await roadmapGet(args.slice(1));
+      break;
     case "create":
       await roadmapCreate(args.slice(1));
+      break;
+    case "update":
+      await roadmapUpdate(args.slice(1));
+      break;
+    case "delete":
+    case "rm":
+      await roadmapDelete(args.slice(1));
+      break;
+    case "upvote":
+      await roadmapUpvote(args.slice(1));
+      break;
+    case "unvote":
+      await roadmapUnvote(args.slice(1));
       break;
     default:
       console.error(`Unknown subcommand: ${sub}`);

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -59,7 +59,7 @@ function requireSlug(args: string[], command: string): string {
 }
 
 // eslint-disable-next-line no-control-regex
-const ANSI_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]|\x1b(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1b\\))/g;
+const ANSI_RE = /[\x00-\x08\x0b-\x1f\x7f]|\x1b(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1b\\))/g;
 function sanitize(text: string): string {
   return text.replace(ANSI_RE, "");
 }

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -58,6 +58,12 @@ function requireSlug(args: string[], command: string): string {
   return slug;
 }
 
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]|\x1b(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1b\\))/g;
+function sanitize(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
 function makeLink(url: string): string {
   return `\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`;
 }
@@ -163,10 +169,10 @@ async function roadmapList(args: string[]): Promise<void> {
   for (const item of data.items) {
     const upvoted = item.viewer_upvoted ? " (upvoted)" : "";
     const tags = item.tags.length > 0
-      ? ` [${item.tags.map((t) => t.slug).join(", ")}]`
+      ? ` [${item.tags.map((t) => sanitize(t.slug)).join(", ")}]`
       : "";
     console.log(
-      `  ${item.title}  ▲${item.upvote_count}${upvoted}  💬${item.comment_count}  ${item.status}${tags}`,
+      `  ${sanitize(item.title)}  ▲${item.upvote_count}${upvoted}  💬${item.comment_count}  ${item.status}${tags}`,
     );
     console.log(`    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
   }
@@ -204,27 +210,27 @@ async function roadmapGet(args: string[]): Promise<void> {
   const upvoted = item.viewer_upvoted ? " (upvoted)" : "";
   const tags =
     item.tags.length > 0
-      ? item.tags.map((t) => t.slug).join(", ")
+      ? item.tags.map((t) => sanitize(t.slug)).join(", ")
       : "none";
 
-  console.log(item.title);
+  console.log(sanitize(item.title));
   console.log(`  slug:     ${item.slug}`);
   console.log(`  status:   ${item.status}`);
   console.log(`  upvotes:  ${item.upvote_count}${upvoted}`);
   console.log(`  tags:     ${tags}`);
-  console.log(`  by:       ${item.creator_username}`);
+  console.log(`  by:       ${sanitize(item.creator_username)}`);
   console.log(`  created:  ${item.created}`);
   console.log(`  url:      ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
   if (item.description) {
-    console.log(`\n${item.description}`);
+    console.log(`\n${sanitize(item.description)}`);
   }
 
   if (item.comments.length > 0) {
     console.log(`\nComments (${item.comments.length}):`);
     for (const c of item.comments) {
       const staff = c.author_is_staff ? " [staff]" : "";
-      console.log(`  ${c.author_username}${staff} (${c.created}):`);
-      console.log(`    ${c.body}`);
+      console.log(`  ${sanitize(c.author_username)}${staff} (${c.created}):`);
+      console.log(`    ${sanitize(c.body)}`);
     }
   }
 }
@@ -279,7 +285,7 @@ async function roadmapCreate(args: string[]): Promise<void> {
   };
 
   const webUrl = getWebUrl();
-  console.log(`Created roadmap item: ${item.title}`);
+  console.log(`Created roadmap item: ${sanitize(item.title)}`);
   console.log(`  slug:   ${item.slug}`);
   console.log(`  status: ${item.status}`);
   console.log(`  url:    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);
@@ -343,7 +349,7 @@ async function roadmapUpdate(args: string[]): Promise<void> {
   };
 
   const webUrl = getWebUrl();
-  console.log(`Updated roadmap item: ${item.title}`);
+  console.log(`Updated roadmap item: ${sanitize(item.title)}`);
   console.log(`  slug:   ${item.slug}`);
   console.log(`  status: ${item.status}`);
   console.log(`  url:    ${makeLink(`${webUrl}/roadmap/${item.slug}`)}`);


### PR DESCRIPTION
## Summary
- Extends `vellum roadmap` CLI with full CRUD operations: `list`, `get`, `create`, `update`, `delete`
- Adds `upvote` and `unvote` subcommands for voting on roadmap items
- Adds search/filter support via `list --query`, `--status`, `--tag`, `--sort`, `--limit` flags
- Refactors internals with shared helpers (`apiFetch`, `requireAuth`, `requireSlug`, `makeLink`) and clickable OSC 8 hyperlinks in output

## Original prompt
The user wanted to extend the existing `vellum roadmap create` CLI command to support all CRUD operations (list, get, create, update, delete) plus search and upvote, matching the full marketing API surface. The API endpoints were discovered from the sibling `vellum-assistant-platform` repo's Flask marketing app at `/v1/roadmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)