### PR TITLE
fix(web): allow selecting smaller machine sizes in resize dropdown

### DIFF
--- a/apps/web/src/lib/billing/machine-sizes.ts
+++ b/apps/web/src/lib/billing/machine-sizes.ts
@@ -69,11 +69,9 @@ export function buildMachineSizeOptions(
   currentSize: MachineSizeEnum | null | undefined,
   currentSuffix: ReactNode,
 ): DropdownOption<MachineSizeEnum>[] {
-  const currentRank = currentSize ? machineSizeRank(currentSize) : -1;
   return sizes.map((size) => ({
     value: size,
     label: `${SIZE_LABEL[size]} — ${SIZE_DESCRIPTION[size]}`,
     suffix: size === currentSize ? currentSuffix : undefined,
-    disabled: machineSizeRank(size) < currentRank,
   }));
 }


### PR DESCRIPTION
## Summary
- Remove per-option disabling of machine sizes smaller than the current size in the resize dropdown, allowing users to downsize

## Original prompt
User decided that smaller machine sizes should not be disabled in the resize assistant modal dropdown — users should be free to select any allowed size, including downsizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)