### PR TITLE
fix(image-studio): prevent autonomous service config changes on error

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -321,6 +321,9 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Mock Gemini error: API failure");
+    expect(result.content).toContain(
+      "Do not change service configuration (mode, provider, or model) to try to fix it",
+    );
   });
 
   test("openai generation error uses OpenAI-specific mapping", async () => {
@@ -331,6 +334,34 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Mock OpenAI error: openai failure");
+    expect(result.content).toContain(
+      "Do not change service configuration (mode, provider, or model) to try to fix it",
+    );
+  });
+
+  test("missing credentials error includes guidance not to change service config", async () => {
+    mockGeminiKey = undefined;
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No Gemini API key");
+    expect(result.content).toContain(
+      "Do not change service configuration (mode, provider, or model) to try to fix it",
+    );
+  });
+
+  test("managed mode credential error includes guidance not to change service config", async () => {
+    mockImageGenMode = "managed";
+    mockManagedBaseUrl = undefined;
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Managed proxy is not available");
+    expect(result.content).toContain(
+      "Do not change service configuration (mode, provider, or model) to try to fix it",
+    );
   });
 
   test("reads source images from file paths on disk", async () => {

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -37,3 +37,7 @@ You are an image generation assistant. When the user asks you to create or edit 
 - When editing images, clearly describe what changes you want made to the source image.
 - Use the `variants` parameter (1-4) to generate multiple options and pick the best one.
 - If no API key is configured for the selected model's provider (Gemini or OpenAI), the tool will return an error - ask the user to set one up.
+
+## Error handling
+
+When image generation fails, report the error to the user as-is. **Do not** attempt to fix the error by changing service configuration (e.g. switching between "managed" and "your-own" mode, or changing the provider/model). Service configuration changes should only be made at the user's explicit request via Settings.

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -30,7 +30,7 @@ export async function run(
   });
   if (!credentials) {
     return {
-      content: errorHint ?? "Image generation is not configured.",
+      content: `${errorHint ?? "Image generation is not configured."}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
       isError: true,
     };
   }
@@ -131,7 +131,7 @@ export async function run(
     };
   } catch (error) {
     return {
-      content: mapImageGenError(provider, error),
+      content: `${mapImageGenError(provider, error)}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
       isError: true,
     };
   }


### PR DESCRIPTION
## Summary

- When image generation failed in production, the assistant autonomously ran `assistant config set services.image-generation.mode your-own` via bash, breaking the user's setup (they were on managed mode with no API keys configured).
- Added explicit "Do not change service configuration" guidance in error responses from the `media_generate_image` tool (both credential-missing and generation-failure paths).
- Added an "Error handling" section to the image-studio SKILL.md reinforcing this constraint at the prompt level.
- Added test coverage verifying the guidance text appears in all error paths.

## Test plan

- [x] `bun test src/__tests__/media-generate-image.test.ts` — all 28 tests pass
- [x] Typecheck clean (pre-existing unrelated error in `ces-client` package)
- [ ] Verify on dev that image generation errors no longer trigger config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)