### PR TITLE
fix(web): move ChatGPT Subscription behind Auth Type dropdown

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -44,12 +44,13 @@ const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "openai-compatible",
 ];
 
-type AuthType = "api_key" | "platform" | "none";
+type AuthType = "api_key" | "platform" | "none" | "oauth_subscription";
 
 const AUTH_TYPE_DISPLAY_NAMES: Record<AuthType, string> = {
   api_key: "API Key",
   platform: "Platform (managed proxy)",
   none: "None (local / no auth)",
+  oauth_subscription: "ChatGPT Subscription",
 };
 
 // NOTE: The set of providers that support `platform` auth is sourced from
@@ -177,9 +178,6 @@ export function ProviderEditorContent({
     null,
   );
   const chatgptStateRef = useRef<string>("");
-
-  const chatgptFlagEnabled =
-    chatgptSubscriptionEnabled && provider === "openai" && effectiveMode === "create";
 
   async function handleChatgptSignIn() {
     setChatgptOAuthState("starting");
@@ -450,6 +448,13 @@ export function ProviderEditorContent({
         }
 
         auth = { type: "api_key", credential: effectiveCredential };
+      } else if (authType === "oauth_subscription") {
+        // OAuth subscription connections are created by the OAuth flow
+        // (handleChatgptUrlSubmit), not through the normal Save path.
+        // If the user somehow reaches here, prompt them to use the
+        // sign-in button instead.
+        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
+        return;
       } else if (authType === "none") {
         auth = { type: "none" };
       } else {
@@ -621,6 +626,12 @@ export function ProviderEditorContent({
                       return "api_key";
                     }
                     if (
+                      prev === "oauth_subscription" &&
+                      newProvider !== "openai"
+                    ) {
+                      return "api_key";
+                    }
+                    if (
                       prev === "platform" &&
                       !providerSupportsPlatformAuth(newProvider)
                     ) {
@@ -699,6 +710,15 @@ export function ProviderEditorContent({
                 types = ["api_key", "platform"];
               } else {
                 types = ["api_key"];
+              }
+              // Add oauth_subscription when ChatGPT flag is enabled for
+              // OpenAI in create mode.
+              if (
+                chatgptSubscriptionEnabled &&
+                provider === "openai" &&
+                effectiveMode === "create"
+              ) {
+                types.push("oauth_subscription");
               }
               // Preserve the current auth type in edit mode so existing
               // connections display their saved value even if the type is
@@ -872,23 +892,9 @@ export function ProviderEditorContent({
           </>
         )}
 
-        {/* Status — always editable, including for managed connections. */}
-        <Toggle
-          checked={status === "active"}
-          onChange={(v) => setStatus(v ? "active" : "disabled")}
-          label="Active"
-        />
-
-        {/* ChatGPT Subscription OAuth — manual copy-paste flow */}
-        {chatgptFlagEnabled ? (
+        {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
+        {authType === "oauth_subscription" && (
           <div className="space-y-3 rounded-lg border border-[var(--border-default)] p-4">
-            <Typography
-              variant="body-medium-default"
-              as="p"
-              className="text-[var(--content-default)]"
-            >
-              ChatGPT Subscription
-            </Typography>
             <Typography
               variant="body-small-default"
               as="p"
@@ -1013,7 +1019,14 @@ export function ProviderEditorContent({
               </Button>
             ) : null}
           </div>
-        ) : null}
+        )}
+
+        {/* Status — always editable, including for managed connections. */}
+        <Toggle
+          checked={status === "active"}
+          onChange={(v) => setStatus(v ? "active" : "disabled")}
+          label="Active"
+        />
 
         {error && (
           <Typography


### PR DESCRIPTION
## Summary

- Moves the ChatGPT Subscription sign-in flow from a standalone always-visible section to an `oauth_subscription` option in the Auth Type dropdown
- When creating an OpenAI connection with the ChatGPT flag enabled, users now select "ChatGPT Subscription" from Auth Type instead of seeing both API Key and ChatGPT sections simultaneously
- Existing `oauth_subscription` connections display correctly in edit mode via the preserved-auth-type fallback

## Test plan

- [ ] With `chatgptSubscriptionEnabled` flag on, create a new OpenAI connection -- Auth Type dropdown should include "ChatGPT Subscription"
- [ ] Selecting "ChatGPT Subscription" hides the API Key field and shows the OAuth sign-in flow
- [ ] Selecting "API Key" hides the OAuth sign-in flow and shows the API Key field
- [ ] Switching provider away from OpenAI while "ChatGPT Subscription" is selected resets to "API Key"
- [ ] Edit mode for existing `oauth_subscription` connections shows the correct auth type
- [ ] The "ChatGPT Subscription" option does NOT appear for non-OpenAI providers or in edit mode
- [ ] `bunx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)