### PR TITLE
fix(macos): show ChatGPT sign-in only when oauth_subscription auth type is selected

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -1293,6 +1293,16 @@ struct ProvidersSheet: View {
             return
         }
 
+        // OAuth subscription connections are created by the OAuth sign-in
+        // flow (handleChatgptUrlSubmit), not the Create/Save button. Block
+        // commitEditor so a user who selects "ChatGPT Subscription" and
+        // clicks Create without completing the OAuth flow doesn't end up
+        // with a broken connection missing OAuth tokens.
+        if draft.authType == "oauth_subscription" {
+            actionError = "Use the \"Sign in with ChatGPT\" button to connect your subscription."
+            return
+        }
+
         var credentialRef = draft.credential.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if draft.authType == "api_key" {

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -399,13 +399,13 @@ struct ProvidersSheet: View {
                             editorNoneNote
                         } else if editorDraft.authType == "oauth_subscription" {
                             editorOAuthSubscriptionNote
+                            if isChatgptSubscriptionVisible {
+                                chatgptSubscriptionSection
+                            }
                         }
                     }
                     .disabled(isAuthLocked)
                     editorStatusToggle
-                    if isChatgptSubscriptionVisible {
-                        chatgptSubscriptionSection
-                    }
                     if let actionError {
                         Text(actionError)
                             .font(VFont.bodySmallDefault)
@@ -584,6 +584,15 @@ struct ProvidersSheet: View {
         ]
         if store.isPlatformCapable(provider) {
             options.append((label: "Platform (managed by Vellum)", value: "platform"))
+        }
+        // Offer ChatGPT Subscription when the feature flag is on and
+        // the provider is OpenAI. In create mode this lets the user
+        // pick the OAuth flow; in edit mode the fallback below handles
+        // connections that already carry this auth type.
+        if provider == "openai",
+           let flagStore = assistantFeatureFlagStore,
+           flagStore.isEnabled("chatgpt-subscription-auth") {
+            options.append((label: "ChatGPT Subscription", value: "oauth_subscription"))
         }
         // Preserve the current auth type in edit mode so existing connections
         // display their saved value even if the type is no longer offered for


### PR DESCRIPTION
## Summary

- Move the ChatGPT Subscription sign-in section inside the `oauth_subscription` auth-type conditional block so it only renders when the user selects "ChatGPT Subscription" from the Auth Type dropdown — previously it appeared unconditionally at the bottom of the form alongside the API Key field
- Add `oauth_subscription` as a proactive dropdown option in the Auth Type picker when the `chatgpt-subscription-auth` feature flag is enabled and the provider is OpenAI, so users can discover and select the flow without it being hidden

## Test plan

- [ ] Open Settings > Provider Connections > New Connection, pick OpenAI as provider
- [ ] Confirm the Auth Type dropdown includes "ChatGPT Subscription" (requires `chatgpt-subscription-auth` flag enabled)
- [ ] With "API Key" selected, confirm only the API Key field is shown (no ChatGPT sign-in section at the bottom)
- [ ] Switch Auth Type to "ChatGPT Subscription" and confirm the sign-in section appears
- [ ] Switch back to "API Key" and confirm the sign-in section disappears
- [ ] In edit mode for an existing `oauth_subscription` connection, confirm the note text shows but the sign-in flow does not (create-mode only gate still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)