### PR TITLE
feat(web): show relative pricing in billing modal for Pro subscribers

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -354,10 +354,13 @@ export function AdjustPlanModal({ open, onClose }: AdjustPlanModalProps) {
 
   const priceForMachine = (tier: MachineTierEnum | null): number | null =>
     machineTiersForPicker.find((t) => t.tier === tier)?.price_cents ?? null;
+  const priceForStorage = (tier: StorageTierEnum | null): number | null =>
+    storageTiersForPicker.find((t) => t.tier === tier)?.price_cents ?? null;
   // A machine downgrade (cheaper than current) routes through the reconfirm
   // modal first; an upgrade fires immediately.
   const nextMachinePrice = priceForMachine(selectedMachineTier);
   const currentMachinePrice = priceForMachine(currentMachineTier);
+  const currentStoragePrice = priceForStorage(currentStorageTier);
   const isMachineDowngrade =
     machineChanged &&
     nextMachinePrice != null &&
@@ -545,6 +548,27 @@ export function AdjustPlanModal({ open, onClose }: AdjustPlanModalProps) {
                                   Forever
                                 </Typography>
                               </>
+                            ) : proTierChangeMode &&
+                              currentMachinePrice != null &&
+                              currentStoragePrice != null ? (
+                              <>
+                                <Typography as="p" variant="title-medium">
+                                  Currently $
+                                  {Math.round(
+                                    (plan.base_price_cents +
+                                      currentMachinePrice +
+                                      currentStoragePrice) /
+                                      100,
+                                  )}
+                                </Typography>
+                                <Typography
+                                  as="p"
+                                  variant="body-small-default"
+                                  className="text-[var(--content-tertiary)]"
+                                >
+                                  Billed monthly
+                                </Typography>
+                              </>
                             ) : (
                               <>
                                 <Typography as="p" variant="title-medium">
@@ -621,6 +645,8 @@ export function AdjustPlanModal({ open, onClose }: AdjustPlanModalProps) {
                                   selectedStorageTier={selectedStorageTier}
                                   onMachineTierChange={setSelectedMachineTier}
                                   onStorageTierChange={setSelectedStorageTier}
+                                  currentMachinePriceCents={currentMachinePrice}
+                                  currentStoragePriceCents={currentStoragePrice}
                                 />
                                 <Button
                                   variant="primary"

--- a/apps/web/src/domains/settings/components/downgrade-reconfirm-modal.tsx
+++ b/apps/web/src/domains/settings/components/downgrade-reconfirm-modal.tsx
@@ -38,7 +38,7 @@ export function DowngradeReconfirmModal({
             variant="body-medium-default"
             className="text-(--content-secondary)"
           >
-            Downgrading removes the following Pro features.
+            Downgrading removes the following Pro features:
           </Typography>
           <ul className="mt-4 list-disc space-y-2 pl-5">
             {lostFeatures.map((feature) => (

--- a/apps/web/src/domains/settings/components/resize-card.tsx
+++ b/apps/web/src/domains/settings/components/resize-card.tsx
@@ -80,6 +80,7 @@ export function ResizeCard({
   );
   const displaySize = selectedSize ?? largestSize ?? currentSize;
   const [upgradeModalOpen, setUpgradeModalOpen] = useState<"storage" | "machine" | null>(null);
+  const [resizeError, setResizeError] = useState<string | null>(null);
 
   const resizeMutation = useMutation({
     ...assistantsResizeMutation(),
@@ -87,17 +88,17 @@ export function ResizeCard({
       toast.success("Resize started. Changes will apply shortly.", {
         id: "assistant-resize",
       });
+      setResizeError(null);
       setSelectedSize(null);
       setResizeModalOpen(false);
       void refetch();
     },
     onError: (error) => {
-      toast.error(
+      setResizeError(
         extractResizeError(
           error,
           "Failed to resize assistant. Please try again.",
         ),
-        { id: "assistant-resize-error" },
       );
     },
   });
@@ -355,6 +356,7 @@ export function ResizeCard({
           if (!o) {
             setResizeModalOpen(false);
             setSelectedSize(null);
+            setResizeError(null);
           }
         }}
       >
@@ -400,6 +402,9 @@ export function ResizeCard({
                   Storage will not change.
                 </Notice>
               )}
+              {resizeError && (
+                <Notice tone="error">{resizeError}</Notice>
+              )}
             </div>
           </Modal.Body>
           <Modal.Footer className="items-center justify-between">
@@ -419,6 +424,7 @@ export function ResizeCard({
                 onClick={() => {
                   setResizeModalOpen(false);
                   setSelectedSize(null);
+                  setResizeError(null);
                 }}
               >
                 Cancel
@@ -429,6 +435,7 @@ export function ResizeCard({
                   isLoading ? <Loader2 className="animate-spin" /> : undefined
                 }
                 onClick={() => {
+                  setResizeError(null);
                   const body: { machine_size?: MachineSizeEnum; storage_gib?: number } = {};
                   if (effectiveSelectedSize != null) {
                     body.machine_size = effectiveSelectedSize;
@@ -442,7 +449,7 @@ export function ResizeCard({
                   });
                 }}
               >
-                Apply
+                {resizeError ? "Retry" : "Apply"}
               </Button>
             </div>
           </Modal.Footer>

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -1,4 +1,5 @@
 import { Info } from "lucide-react";
+import { useMemo } from "react";
 
 import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Typography } from "@vellum/design-library/components/typography";
@@ -40,6 +41,15 @@ function formatMonthly(totalCents: number): string {
     : `$${dollars.toFixed(2)}/mo`;
 }
 
+function formatDelta(deltaCents: number): string {
+  const prefix = deltaCents > 0 ? "+" : "−";
+  const absDollars = Math.abs(deltaCents) / 100;
+  const formatted = Number.isInteger(absDollars)
+    ? `$${absDollars}`
+    : `$${absDollars.toFixed(2)}`;
+  return `${prefix}${formatted}/mo`;
+}
+
 export interface TierPickerProps {
   machineTiers: MachineTier[];
   storageTiers: StorageTier[];
@@ -48,6 +58,8 @@ export interface TierPickerProps {
   selectedStorageTier: StorageTierEnum | null;
   onMachineTierChange: (tier: MachineTierEnum) => void;
   onStorageTierChange: (tier: StorageTierEnum) => void;
+  currentMachinePriceCents?: number | null;
+  currentStoragePriceCents?: number | null;
 }
 
 export function TierPicker({
@@ -58,6 +70,8 @@ export function TierPicker({
   selectedStorageTier,
   onMachineTierChange,
   onStorageTierChange,
+  currentMachinePriceCents,
+  currentStoragePriceCents,
 }: TierPickerProps) {
   const selectedMachine = machineTiers.find(
     (t) => t.tier === selectedMachineTier,
@@ -71,6 +85,51 @@ export function TierPicker({
         selectedMachine.price_cents +
         selectedStorage.price_cents
       : null;
+  const currentTotalCents =
+    currentMachinePriceCents != null && currentStoragePriceCents != null
+      ? basePriceCents + currentMachinePriceCents + currentStoragePriceCents
+      : null;
+  const totalDelta =
+    totalCents != null && currentTotalCents != null
+      ? totalCents - currentTotalCents
+      : null;
+
+  const machineOptions = useMemo(
+    () =>
+      machineTiers.map((t) => {
+        const label = MACHINE_TIER_LABEL[t.tier] ?? t.label;
+        const priceLabel =
+          currentMachinePriceCents != null
+            ? t.price_cents === currentMachinePriceCents
+              ? `(${formatMonthly(t.price_cents)}, current)`
+              : formatDelta(t.price_cents - currentMachinePriceCents)
+            : `+${formatMonthly(t.price_cents)}`;
+        return {
+          value: t.tier as MachineTierEnum,
+          label: `${label} ${priceLabel}`,
+          disabled: isTierDisabled(t),
+        };
+      }),
+    [machineTiers, currentMachinePriceCents],
+  );
+
+  const storageOptions = useMemo(
+    () =>
+      storageTiers.map((t) => {
+        const priceLabel =
+          currentStoragePriceCents != null
+            ? t.price_cents === currentStoragePriceCents
+              ? `(${formatMonthly(t.price_cents)}, current)`
+              : formatDelta(t.price_cents - currentStoragePriceCents)
+            : `+${formatMonthly(t.price_cents)}`;
+        return {
+          value: t.tier as StorageTierEnum,
+          label: `${t.storage_gib} GiB ${priceLabel}`,
+          disabled: isTierDisabled(t),
+        };
+      }),
+    [storageTiers, currentStoragePriceCents],
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -92,13 +151,7 @@ export function TierPicker({
           placeholder="Select a machine tier"
           value={selectedMachineTier ?? ("" as MachineTierEnum)}
           onChange={onMachineTierChange}
-          options={machineTiers.map((t) => ({
-            value: t.tier as MachineTierEnum,
-            label: `${MACHINE_TIER_LABEL[t.tier] ?? t.label} +${formatMonthly(
-              t.price_cents,
-            )}`,
-            disabled: isTierDisabled(t),
-          }))}
+          options={machineOptions}
         />
       </div>
       <div className="flex flex-col gap-1.5">
@@ -119,11 +172,7 @@ export function TierPicker({
           placeholder="Select a storage tier"
           value={selectedStorageTier ?? ("" as StorageTierEnum)}
           onChange={onStorageTierChange}
-          options={storageTiers.map((t) => ({
-            value: t.tier as StorageTierEnum,
-            label: `${t.storage_gib} GiB +${formatMonthly(t.price_cents)}`,
-            disabled: isTierDisabled(t),
-          }))}
+          options={storageOptions}
         />
       </div>
       {totalCents !== null && (
@@ -135,8 +184,19 @@ export function TierPicker({
             className="text-[var(--content-default)]"
           >
             Total: {formatMonthly(totalCents)}
+            {totalDelta != null && totalDelta !== 0 && (
+              <span className="ml-1 text-[var(--content-tertiary)]">
+                ({formatDelta(totalDelta)})
+              </span>
+            )}
           </Typography>
-          <span title="Includes a $10/mo platform fee">
+          <span
+            title={
+              totalDelta != null && totalDelta !== 0
+                ? `Your Pro Plan subscription will change from ${formatMonthly(currentTotalCents!)} to ${formatMonthly(totalCents!)}. Includes a $10/month flat fee for Pro Features.`
+                : "Includes a $10/month flat fee for Pro Features."
+            }
+          >
             <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
           </span>
         </div>


### PR DESCRIPTION
## Summary
- Pro subscribers now see relative pricing when adjusting their plan: dropdown options show the cost delta from their current tier (e.g. `+$25/mo`, `−$25/mo`) and the header shows "Currently $X" instead of "From $X"
- Total line includes a delta indicator and the tooltip explains the plan cost change when tiers are modified
- Resize modal now shows inline error notices instead of toasts, with "Retry" button text on failure

## Original prompt
The user wanted to improve the Pro plan adjustment flow in the billing modal. Currently, existing Pro subscribers see absolute add-on prices ("+$60/mo") which don't convey the cost impact of changing tiers. The request was to show relative pricing based on the user's current selection, change "From $50" to "Currently $X", and update the tooltip to explain the cost change. Additionally, the resize modal needed inline error handling instead of toasts, and minor copy fixes.