### PR TITLE
fix: include HTTP status code in provider rejection error message

### DIFF
--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -439,7 +439,7 @@ function classifyCore(
       }
       return {
         code: "PROVIDER_API",
-        userMessage: "The AI provider rejected the request.",
+        userMessage: `The AI provider rejected the request (HTTP ${error.statusCode}).`,
         retryable: true,
         errorCategory: "provider_api_error",
       };


### PR DESCRIPTION
## Summary
- Includes the HTTP status code in the generic "AI provider rejected the request" error message
- Changes `"The AI provider rejected the request."` → `"The AI provider rejected the request (HTTP {statusCode})."`
- Helps diagnose provider rejections (e.g. distinguishing 403 vs 409 vs 400) without exposing raw provider error text to users

## Motivation
ChatGPT subscription auth fails on dev-assistant.vellum.ai with the generic "AI provider rejected the request" message, and we can't tell what OpenAI's Codex endpoint actually returned without daemon logs. Adding the status code gives us a signal without needing log access.

## Test plan
- [x] Typecheck passes
- [x] All 121 conversation-error tests pass
- [ ] Deploy to dev and reproduce the ChatGPT subscription error to see the actual status code

🤖 Generated with [Claude Code](https://claude.com/claude-code)