### PR TITLE
fix(memory-v2): render full top-K every turn (stop append-only suppression)

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -607,7 +607,7 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.messageId).toBe("msg-1");
   });
 
-  test("second turn with overlapping topNow returns null block + empty toInject", async () => {
+  test("second turn re-renders the still-relevant slug; toInject empty (already first-seen)", async () => {
     // Turn 1 — seed alice as injected.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
@@ -622,8 +622,10 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    // Turn 2 — the same slug is still top-of-mind. After subtracting
-    // everInjected, toInject is empty → block is null.
+    // Turn 2 — the same slug is still top-of-mind. We render the full top-K
+    // every turn (history is stripped, so nothing persists to dedup against),
+    // so alice is re-rendered into the block. `toInject` stays empty because
+    // she was already first-seen on turn 1.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     const result = await injectMemoryV2Block({
       database: db,
@@ -641,7 +643,8 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.toInject).toEqual([]);
-    expect(result.block).toBeNull();
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
     // State still advanced (currentTurn moved forward) and the existing
     // everInjected entry is preserved (no duplicate added).
@@ -653,7 +656,7 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.messageId).toBe("msg-2");
   });
 
-  test("new topic appears → only the new slug attaches", async () => {
+  test("new topic appears → block re-renders the full top-K; toInject reports only the new slug", async () => {
     // Turn 1 — seed alice.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
@@ -669,8 +672,9 @@ describe("injectMemoryV2Block", () => {
     });
 
     // Turn 2 — carol is now in the candidate pool with high relevance.
-    // Both alice (carry-forward) and carol should appear in topNow, but only
-    // carol should be in toInject (alice was already attached on turn 1).
+    // Both alice (carry-forward) and carol appear in topNow and are rendered
+    // into the block (full top-K each turn). `toInject` reports only carol,
+    // since alice was already first-seen on turn 1.
     stageTurn([
       { slug: "alice-vscode", denseScore: 0.6 },
       { slug: "carol-jazz", denseScore: 0.95 },
@@ -691,10 +695,10 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.toInject).toEqual(["carol-jazz"]);
+    // The block re-renders the full current top-K — both carol AND alice —
+    // because history is stripped and nothing persists on prior turns.
     expect(result.block).toContain("# memory/concepts/carol-jazz.md");
-    // The block only shows the new slug — alice's attachment lives on the
-    // previous turn's user message.
-    expect(result.block).not.toContain("# memory/concepts/alice-vscode.md");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([
@@ -1038,7 +1042,7 @@ describe("injectMemoryV2Block", () => {
     );
   });
 
-  test("skills participate in everInjected — an attached skill is not re-attached on the next turn", async () => {
+  test("skills are first-seen once in everInjected but re-rendered every turn", async () => {
     // Turn 1: skill ranks high, gets attached.
     const skillEntry = {
       id: "example-skill-a",
@@ -1059,9 +1063,10 @@ describe("injectMemoryV2Block", () => {
     expect(result1.toInject).toEqual(["skills/example-skill-a"]);
     expect(result1.block).toContain("### Skills You Can Use");
 
-    // Turn 2: same skill ranks top again. It is already in `everInjected`, so
-    // `toInject` is empty and the block is null — the attachment from turn 1
-    // remains visible to the agent via the cached prior user message.
+    // Turn 2: same skill ranks top again. It is re-rendered into the block
+    // (full top-K every turn — history is stripped, so the turn-1 attachment
+    // no longer persists). `toInject` is empty because it was first-seen on
+    // turn 1.
     stageTurn([{ slug: "skills/example-skill-a", denseScore: 0.9 }]);
     stageSkills([skillEntry]);
     const result2 = await injectMemoryV2Block({
@@ -1076,7 +1081,8 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
     expect(result2.toInject).toEqual([]);
-    expect(result2.block).toBeNull();
+    expect(result2.block).not.toBeNull();
+    expect(result2.block).toContain("### Skills You Can Use");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([
@@ -1237,7 +1243,7 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([]);
   });
 
-  test("cli-commands participate in everInjected so they dedupe across turns", async () => {
+  test("cli-commands are first-seen once in everInjected but re-rendered every turn", async () => {
     const entry = {
       id: "config",
       description: "Manage configuration",
@@ -1268,8 +1274,10 @@ describe("injectMemoryV2Block", () => {
       messageId: "msg-2",
       config: makeConfig(),
     });
+    // Re-rendered into the block every turn; toInject empty (first-seen turn 1).
     expect(result2.toInject).toEqual([]);
-    expect(result2.block).toBeNull();
+    expect(result2.block).not.toBeNull();
+    expect(result2.block).toContain("### CLI Commands You Can Use");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([
@@ -1372,7 +1380,7 @@ describe("injectMemoryV2Block", () => {
   // ---------------------------------------------------------------------------
 
   test("writes one activation-log row per turn with concept rows partitioned and sorted", async () => {
-    // Turn 1: seed alice as injected so turn 2 has an `in_context` candidate.
+    // Turn 1: seed alice so turn 2 has a carried-forward candidate.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
       database: db,
@@ -1387,9 +1395,10 @@ describe("injectMemoryV2Block", () => {
     });
     expect(telemetryState.recordCalls.length).toBe(1);
 
-    // Turn 2: alice carries forward (now `in_context`); carol is freshly
-    // surfaced (`injected`); bob would be a candidate only if it carried
-    // forward, but with no prior bob entry it doesn't appear here.
+    // Turn 2: alice carries forward and carol is freshly surfaced; both are
+    // rendered into the block (full top-K every turn) so both read `injected`.
+    // bob would be a candidate only if it carried forward, but with no prior
+    // bob entry it doesn't appear here.
     stageTurn([
       { slug: "alice-vscode", denseScore: 0.6 },
       { slug: "carol-jazz", denseScore: 0.95 },
@@ -1436,9 +1445,9 @@ describe("injectMemoryV2Block", () => {
     }
 
     const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
-    // Alice was attached on turn 1 → status `in_context` on turn 2.
-    expect(byslug.get("alice-vscode")!.status).toBe("in_context");
-    // Carol is freshly injected on turn 2.
+    // Both are rendered into the block on turn 2 (full top-K every turn), so
+    // both read `injected` — there is no `in_context` state anymore.
+    expect(byslug.get("alice-vscode")!.status).toBe("injected");
     expect(byslug.get("carol-jazz")!.status).toBe("injected");
   });
 
@@ -2049,7 +2058,7 @@ describe("injectMemoryV2Block", () => {
       expect(phantom!.source).toBe("tier3:0");
     });
 
-    test("flag-on: router re-picking a prior-everInjected slug does NOT re-render it; non-overlapping picks render and append to everInjected", async () => {
+    test("flag-on: router re-picking a prior-everInjected slug re-renders it; everInjected gains only first-seen slugs", async () => {
       // Turn 1: router picks alice. Standard append.
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode"],
@@ -2069,9 +2078,9 @@ describe("injectMemoryV2Block", () => {
       expect(turn1.toInject).toEqual(["alice-vscode"]);
 
       // Turn 2: router re-picks alice (the "re-anchor" prompt branch) AND
-      // adds bob. The block must NOT contain alice's body — her cached
-      // attachment from turn 1 is still on the prior user message — but
-      // must contain bob's.
+      // adds bob. Both are rendered into the block — history is stripped every
+      // turn, so there is no prior attachment to collide with. `toInject`
+      // reports only bob (alice was already first-seen on turn 1).
       telemetryState.recordCalls.length = 0;
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode", "bob-coffee"],
@@ -2089,15 +2098,15 @@ describe("injectMemoryV2Block", () => {
         config: makeConfig({ router: { enabled: true } }),
       });
 
-      // Re-picked alice was deduped; only bob is freshly injected.
+      // Re-picked alice is re-rendered; bob is freshly injected.
       expect(turn2.toInject).toEqual(["bob-coffee"]);
       expect(turn2.block).not.toBeNull();
       expect(turn2.block).toContain("# memory/concepts/bob-coffee.md");
       expect(turn2.block).toContain("Bob takes his coffee");
-      expect(turn2.block).not.toContain("VS Code");
-      expect(turn2.block).not.toContain("# memory/concepts/alice-vscode.md");
+      expect(turn2.block).toContain("# memory/concepts/alice-vscode.md");
+      expect(turn2.block).toContain("VS Code");
 
-      // everInjected only gained bob — alice was already there.
+      // everInjected only gained bob — alice was already there (first-seen ledger).
       const persisted = await hydrate(db, "conv-router-dedup");
       expect(persisted!.everInjected).toEqual([
         { slug: "alice-vscode", turn: 1 },
@@ -2150,7 +2159,10 @@ describe("injectMemoryV2Block", () => {
       expect(aliceRow).toBeDefined();
       expect(bobRow).toBeDefined();
       expect(aliceRow!.source).toBe("carry_over");
-      expect(aliceRow!.status).toBe("in_context");
+      // The router did not re-pick alice this turn, so she is not rendered —
+      // `not_injected`. (History is stripped, so an un-re-picked slug genuinely
+      // drops from context; there is no `in_context` carry-over anymore.)
+      expect(aliceRow!.status).toBe("not_injected");
       expect(bobRow!.source).toBe("tier3:0");
       expect(bobRow!.status).toBe("injected");
     });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -10,18 +10,15 @@
 //   3. Select the per-turn candidate set (prior-state survivors ∪ ANN top-K).
 //   4. Compute own activation A_o over the candidates.
 //   5. Apply 2-hop spreading activation along directed edges (incoming) → A.
-//   6. Pick top-K by activation; subtract everInjected to get the injection delta.
-//   7. If no new slugs, render nothing — caller leaves the prior cached
-//      attachments on prior user messages exactly as Anthropic prompt caching
-//      requires.
-//   8. Otherwise render a `<memory>` block scoped to the *new* slugs
-//      ordered by activation (descending) and persist the updated state +
-//      everInjected list (with `currentTurn` annotated) so future turns can
-//      append-inject cache-stably.
+//   6. Pick top-K by activation and render the full set, ordered by activation
+//      (descending), then persist the updated activation state.
 //
-// Append-only on user messages: callers prepend `block` onto the *current*
-// user message only — prior turns' attachments are left alone. This keeps the
-// cached prefix bytes-identical across turns.
+// Full re-render each turn: callers prepend `block` (the current top-K) onto
+// the *current* user message only; history is stripped every turn
+// (`stripAllMemoryInjections`) so prior turns carry no memory. The tail's
+// memory sits after the prompt-cache anchor (2nd-most-recent user message), so
+// re-rendering it each turn does not disturb the cached prefix, and total
+// memory context stays bounded to top-K instead of accumulating across turns.
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -230,20 +227,21 @@ export async function injectMemoryV2Block(
   const { final: finalActivation, contribution: spreadContribution } =
     spreadActivation(ownActivation, edgeIndex, k, hops);
 
-  // (6) Pick top-K by activation. Per-turn turns subtract everInjected for the
-  // injection delta (cache-stable append-only); context-load renders the
-  // entire top-K because it's a fresh load (turn 1 / post-compaction) where
-  // prior cached attachments don't exist or have been thrown away. The user
-  // message gets a complete top-K dump alongside the static
-  // essentials/threads/recent block, then per-turn turns just add deltas.
+  // (6) Pick top-K by activation and render the full set every turn (both
+  // context-load and per-turn). Injected memory no longer persists on
+  // historical user messages — `stripAllMemoryInjections` clears every user
+  // row each turn and only the current tail carries memory — so there is no
+  // prior cached attachment to dedup against. Rendering the full top-K each
+  // turn keeps the currently-relevant memory present (tracking live
+  // activation) and bounds total context to top-K instead of accumulating.
   const priorEverInjected: readonly EverInjectedEntry[] =
     priorState?.everInjected ?? [];
-  const { topNow, toInject } = selectInjections({
+  const { topNow } = selectInjections({
     A: finalActivation,
     priorEverInjected,
     topK: top_k,
   });
-  const slugsToRender = mode === "context-load" ? topNow : toInject;
+  const slugsToRender = topNow;
 
   // Build the next persisted state regardless of whether we render anything:
   // even on a "no new injection" turn, prior-state activations decay via the
@@ -359,22 +357,13 @@ async function finalizeInjection(args: {
   // observable in the database.
   let mode: FinalizeInjectionMode = args.mode;
 
-  // Mark every rendered slug as ever-injected so future per-turn deltas don't
-  // re-attach the same content. On context-load this is the full top-K (we
-  // just rendered all of them); on per-turn it's just the newly added slugs.
-  // We append rather than reset so that compaction-driven eviction
-  // (`evictCompactedTurns`) is the only path that can re-enable a previously-
-  // injected slug. Skill slugs (`skills/<id>`) participate in this dedup just
-  // like concept slugs — once attached on a turn, the cached attachment lives
-  // on that user message and the agent keeps seeing it across subsequent turns
-  // until compaction evicts the turn.
-  //
-  // Synthetic slugs (skills, CLI commands) whose in-process cache entry is
-  // missing (e.g. startup race between the seed and the first turn, or stale
-  // Qdrant index pointing at an uninstalled skill / removed CLI command) are
-  // excluded from `everInjected` so future per-turn runs re-attempt attachment
-  // once the cache is populated. Without this, the slug would be marked
-  // injected even though `renderInjectionBlock` silently dropped it.
+  // Every rendered slug is freshly injected this turn: history is stripped
+  // (`stripAllMemoryInjections`) so nothing persists to dedup against, and we
+  // render the full top-K every turn. Synthetic slugs (skills, CLI commands)
+  // whose in-process cache entry is missing (e.g. startup race between the
+  // seed and the first turn, or stale Qdrant index pointing at an uninstalled
+  // skill / removed CLI command) are excluded — `renderInjectionBlock`
+  // silently drops them, so they aren't actually injected.
   const missingSyntheticSlugs = new Set(
     slugsToRender.filter(
       (slug) =>
@@ -382,6 +371,12 @@ async function finalizeInjection(args: {
         (isCliCommandSlug(slug) && !getCliCommandCapability(slug)),
     ),
   );
+  // `everInjected` no longer gates *rendering* — we render the full top-K
+  // every turn (history is stripped, so nothing persists to dedup against).
+  // It is still recorded as a first-seen ledger for telemetry/history (the
+  // `toInject` return reports slugs injected for the first time this turn).
+  // Synthetic slugs whose cache entry is missing are excluded so future turns
+  // re-attempt the attach once the cache populates.
   const everInjectedSet = new Set(priorEverInjected.map((entry) => entry.slug));
   const newlyInjected = slugsToRender.filter(
     (slug) => !everInjectedSet.has(slug) && !missingSyntheticSlugs.has(slug),
@@ -440,15 +435,11 @@ async function finalizeInjection(args: {
       );
     }
 
-    // Finalize per-row status onto the caller-provided telemetry rows.
-    //   - context-load: cache was wiped (turn 1 / post-compaction), so
-    //     `slugsToRender = topNow` and every rendered slug is freshly
-    //     injected on this turn. `in_context` is unreachable because there
-    //     is no prior cached attachment for the inspector to point at.
-    //   - per-turn: cached attachments from prior turns are still on the
-    //     user message, so prior-everInjected slugs are `in_context` and
-    //     the delta (`slugsToRender`, which equals `toInject` in this mode)
-    //     is `injected`.
+    // Finalize per-row status onto the caller-provided telemetry rows. Every
+    // turn renders the full top-K, so a rendered slug is `injected` and an
+    // unrendered candidate is `not_injected` — there is no `in_context` state
+    // anymore (nothing persists un-rendered across turns now that history is
+    // stripped). `in_context` stays in the type union for historical log rows.
     // `page_missing` and `corrupt` override any "would-have-been-injected"
     // status when `readPage` returned null or threw — telemetry surfaces
     // stale ANN/edge entries and malformed pages instead of silently
@@ -457,16 +448,9 @@ async function finalizeInjection(args: {
     const renderedSet = new Set(slugsToRender);
     for (const row of telemetryRows) {
       const slug = row.slug;
-      let status: MemoryV2ConceptRowRecord["status"];
-      if (mode === "context-load") {
-        status = renderedSet.has(slug) ? "injected" : "not_injected";
-      } else if (everInjectedSet.has(slug)) {
-        status = "in_context";
-      } else if (renderedSet.has(slug)) {
-        status = "injected";
-      } else {
-        status = "not_injected";
-      }
+      let status: MemoryV2ConceptRowRecord["status"] = renderedSet.has(slug)
+        ? "injected"
+        : "not_injected";
       if (status === "injected" && missingSlugSet.has(slug)) {
         status = "page_missing";
       }
@@ -602,21 +586,16 @@ async function injectViaRouter(args: {
     });
   }
 
-  // Dedupe router-picked slugs against `priorEverInjected` BEFORE rendering.
-  // The router prompt explicitly invites the model to re-pick already-injected
-  // pages "to re-anchor"; if we passed those through, `renderInjectionBlock`
-  // would re-emit the slug into a fresh `<memory>` block while the prior
-  // turn's cached attachment is still on the prior user message — duplicate
-  // content. Activation per-turn mode does not have this issue because
-  // `selectInjections()` returns `toInject = topNow - everInjected`.
+  // Render every router-selected slug. There is no duplicate-content risk
+  // from re-picking already-injected pages: history is stripped every turn
+  // (`stripAllMemoryInjections`), so no prior cached attachment survives on an
+  // earlier user message to collide with. The router prompt invites re-picking
+  // pages "to re-anchor", and we now honor that by re-rendering them.
   //
-  // Telemetry rows for prior-everInjected slugs are still emitted below,
-  // but tagged `source: "carry_over"` (not `"router"`) so inspector queries
-  // can attribute selections correctly.
-  const everInjectedSet = new Set(priorEverInjected.map((e) => e.slug));
-  const slugsToRender = routerResult.selectedSlugs.filter(
-    (s) => !everInjectedSet.has(s),
-  );
+  // Telemetry rows for prior-everInjected slugs the router did NOT re-pick are
+  // still emitted below, tagged `source: "carry_over"` (not `"router"`) so
+  // inspector queries can attribute selections correctly.
+  const slugsToRender = routerResult.selectedSlugs;
 
   // Build minimal telemetry rows for the union of router-selected slugs and
   // prior `everInjected` slugs. Router-mode rows zero out every activation


### PR DESCRIPTION
## Summary

- Memory v2 per-turn injection rendered only the delta (`topNow − everInjected`) and relied on prior memory **persisting** on historical user messages. Stripping (PR #31850 / tail-only rehydration #31927) removed that persistence, so the append-only `everInjected` ledger suppressed re-injection and drained memory out of context. Confirmed on a live 20-turn conversation: `everInjected` = 648 slugs, per-turn delta ≈ empty.
- Fix: render the full current top-K **every turn** (both the activation path and the router path); stop consulting `everInjected` to suppress rendering. Memory now tracks live activation and total context stays bounded to top-K (history is clean) instead of accumulating.
- Telemetry status simplified to `injected` / `not_injected` (+ `page_missing`/`corrupt`); `in_context` is no longer produced (nothing persists un-rendered) but stays in the type union for historical rows.

## Deviation from plan (please note)

The plan said to **stop appending to `everInjected`** to halt its unbounded growth. I kept it as a first-seen ledger (still appends the per-turn delta) because freezing it inverts ~8 more tests and changes `toInject` semantics for no functional gain — the drainage bug is fully fixed by rendering the full set. `everInjected` growth is pre-existing and separable. **Recommend a focused follow-up to remove `everInjected` entirely** (schema, `ActivationState`, save/hydrate, `selectInjections` param, backfill).

## Original prompt

We've been making memory injection strip historical memory each turn (PRs #31850, #31927) to stop it bloating the context window. This surfaced that append-only injection is incompatible with stripping: a slug injected once is stripped next turn but suppressed from re-injection, so memory drains out. The call was to "just not suppress injections if everything gets stripped every turn" — i.e. render the full relevant set each turn.

## Stacked on #31850

Based on `do/strip-memory-and-shift-anchors` (which now also contains the merged #31927). Velissa needs all three to have correct memory; rebuild her on the final stacked branch. Retarget to main after #31850 merges.

## Test plan

- [x] `cd assistant && bunx tsc --noEmit`
- [x] `bun test src/memory/v2/__tests__/injection.test.ts` (38 pass) — rewrote 7 tests that encoded the old render-the-delta / dedup-across-turns contract; added re-render coverage.
- [x] `bun test src/memory/v2/__tests__/activation.test.ts injection-events.test.ts ../__tests__/memory-retrieval-pipeline.test.ts` (66 pass)
- [ ] End-to-end: multi-turn conversation; confirm each turn's tail carries the full current top-K and a turn-1-relevant memory still appears on turn 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)