### PR TITLE
feat(web): add confirmation modal when registering a subdomain

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1165,7 +1165,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
                 open={registerConfirmOpen}
                 title="Set Subdomain"
                 message={<><code className="rounded bg-[var(--surface-active)] px-1 py-0.5 font-mono text-[0.9em]">{subdomainDraft.trim().toLowerCase() || "subdomain"}</code> will also become your assistant's public handle. You won't be able to change it once set.</>}
-                confirmLabel="Set Subdomain"
+                confirmLabel="Confirm"
                 onConfirm={handleRegisterDomain}
                 onCancel={() => setRegisterConfirmOpen(false)}
               />

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -879,6 +879,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
   const [usernameDraft, setUsernameDraft] = useState("");
   const [usernameError, setUsernameError] = useState<string | null>(null);
   const [savingMode, setSavingMode] = useState(false);
+  const [registerConfirmOpen, setRegisterConfirmOpen] = useState(false);
   const [releaseConfirmOpen, setReleaseConfirmOpen] = useState(false);
   const [removeAddressConfirmOpen, setRemoveAddressConfirmOpen] = useState(false);
 
@@ -966,6 +967,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
       setSubdomainError("Enter a subdomain.");
       return;
     }
+    setRegisterConfirmOpen(false);
     try {
       await registerDomain.mutateAsync({
         path: { assistant_id: assistantId },
@@ -1154,11 +1156,19 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
                 numbers, and hyphens only.
               </p>
               <Button
-                onClick={handleRegisterDomain}
+                onClick={() => setRegisterConfirmOpen(true)}
                 disabled={registerDomain.isPending || !subdomainDraft.trim()}
               >
                 {registerDomain.isPending ? "Registering…" : "Register"}
               </Button>
+              <ConfirmDialog
+                open={registerConfirmOpen}
+                title="Set Subdomain"
+                message={<><code className="rounded bg-[var(--surface-active)] px-1 py-0.5 font-mono text-[0.9em]">{subdomainDraft.trim().toLowerCase() || "subdomain"}</code> will also become your assistant's public handle. You won't be able to change it once set.</>}
+                confirmLabel="Set Subdomain"
+                onConfirm={handleRegisterDomain}
+                onCancel={() => setRegisterConfirmOpen(false)}
+              />
             </div>
           ) : !address ? (
             <div className="space-y-4">


### PR DESCRIPTION
## Summary

- Adds a confirmation modal before subdomain registration, warning that the subdomain will also become the assistant's public handle and cannot be changed once set
- Copy mirrors the pro plan onboarding flow: `"<subdomain> will also become your assistant's public handle. You won't be able to change it once set."`
- Subdomain is displayed in monospace within the modal message

## Test plan

- [ ] Enter a subdomain and click Register → confirmation modal appears
- [ ] Modal shows the entered subdomain in monospace with the handle warning
- [ ] Confirm → subdomain registers as before
- [ ] Cancel → returns to form without registering

🤖 Generated with [Claude Code](https://claude.com/claude-code)