### PR TITLE
feat(web): lock assistant handle when subdomain matches + auto-scroll

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1354,6 +1354,14 @@ export function AiPage() {
   const [overridesOpen, setOverridesOpen] = useState(false);
   const [manageProvidersOpen, setManageProvidersOpen] = useState(false);
 
+  useEffect(() => {
+    const hash = window.location.hash.slice(1);
+    if (!hash) return;
+    requestAnimationFrame(() => {
+      document.getElementById(hash)?.scrollIntoView({ block: "start" });
+    });
+  }, []);
+
   // -- Backend provisioning (matches desktop SettingsStore) --
   const queryClient = useQueryClient();
   const { data: assistantList } = useQuery(assistantsListOptions());

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -438,6 +438,7 @@ function ModeToggle({ mode, onChange }: ModeToggleProps) {
 }
 
 interface ServiceCardProps {
+  id?: string;
   title: string;
   subtitle: string;
   mode: ServiceMode;
@@ -445,9 +446,10 @@ interface ServiceCardProps {
   children: ReactNode;
 }
 
-function ServiceCard({ title, subtitle, mode, onModeChange, children }: ServiceCardProps) {
+function ServiceCard({ id, title, subtitle, mode, onModeChange, children }: ServiceCardProps) {
   return (
     <SettingsCard
+      id={id}
       title={title}
       subtitle={subtitle}
       accessory={<ModeToggle mode={mode} onChange={onModeChange} />}
@@ -1083,6 +1085,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
 
   return (
     <ServiceCard
+      id="email"
       title="Email"
       subtitle="Configure how your assistant sends and receives email"
       mode={mode}

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -6,7 +6,7 @@ import {
   Info,
   Loader2,
 } from "lucide-react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import {
   type ReactNode,
   useCallback,
@@ -864,6 +864,7 @@ interface EmailServiceCardProps {
 function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const [mode, setMode] = useState<ServiceMode>(
     () => getLocalSetting(LS_EMAIL_MODE, "managed") as ServiceMode,
@@ -936,6 +937,16 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
     enabled: !!assistantId && !!address?.id && mode === "managed",
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    if (searchParams.get("release") !== "1" || !domain || address) return;
+    setReleaseConfirmOpen(true);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("release");
+      return next;
+    }, { replace: true });
+  }, [address, domain, searchParams, setSearchParams]);
 
   // -- Mutations -------------------------------------------------------------
   const registerDomain = useMutation(assistantsDomainsCreateMutation());

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -184,7 +184,7 @@ function HandleEditor<T>({
   })();
 
   const helperOrIdle: string | null = (() => {
-    if (errorText) return null;
+    if (errorText) return helperText;
     if (isUnchanged) return idleHelperText ?? null;
     if (isChecking) return "Checking availability…";
     if (availability?.available) return "Available.";
@@ -285,21 +285,6 @@ function HandleEditor<T>({
   })();
 
   // ----------------------------------------------------------------
-  // Live preview — the moment of meaning. Shows what your handle
-  // renders as everywhere else (roadmap comments, mentions, etc.).
-  // When there's no current handle and nothing typed yet, fall back
-  // to a neutral placeholder so the preview line still anchors the
-  // empty state.
-  // ----------------------------------------------------------------
-  const previewHandle =
-    normalized.length > 0
-      ? normalized
-      : initialHandle.length > 0
-        ? initialHandle
-        : "—";
-  const previewIsDirty = !isUnchanged && normalized.length > 0;
-
-  // ----------------------------------------------------------------
   // Button label — empty save button is a dead pixel, so let it
   // narrate its own state instead.
   // ----------------------------------------------------------------
@@ -351,36 +336,11 @@ function HandleEditor<T>({
         }
         rightIcon={rightIcon}
         errorText={errorText ?? undefined}
-        helperText={helperOrIdle ?? helperText}
+        helperText={helperOrIdle ?? undefined}
         aria-invalid={Boolean(errorText)}
         fullWidth
         data-testid={`${fieldId}-input`}
       />
-
-      {/* Live preview — quiet supporting line, not a callout box. */}
-      <div
-        className="flex items-baseline gap-2 text-label-small-default text-[var(--content-tertiary)]"
-        aria-live="polite"
-      >
-        <span>Appears as</span>
-        <AnimatePresence mode="popLayout" initial={false}>
-          <motion.span
-            key={previewHandle}
-            initial={prefersReducedMotion ? false : { opacity: 0, y: 1 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={prefersReducedMotion ? undefined : { opacity: 0, y: -1 }}
-            transition={{ duration: 0.14, ease: "easeOut" }}
-            className={
-              "font-mono " +
-              (previewIsDirty
-                ? "text-[var(--content-primary)]"
-                : "text-[var(--content-secondary)]")
-            }
-          >
-            @{previewHandle}
-          </motion.span>
-        </AnimatePresence>
-      </div>
 
       <div className="flex justify-end">
         <Button
@@ -452,7 +412,7 @@ function UserHandleSection({ initial, onSaved }: UserHandleSectionProps) {
   return (
     <HandleEditor<UserMe>
       initialHandle={initial.username}
-      inputLabel="Handle"
+      inputLabel="User handle"
       helperText="Lowercase letters, digits, hyphens, and underscores. 3–30 characters."
       idleHelperText={idleHelperText}
       checkAvailable={checkAvailable}

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -1,6 +1,9 @@
 import { AlertCircle, Check, Loader2 } from "lucide-react";
+import { Link } from "react-router";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@vellum/design-library/components/button";
 import { Input } from "@vellum/design-library/components/input";
@@ -23,7 +26,9 @@ import {
   updateAssistantHandle,
   type UpdateAssistantHandleResult,
 } from "@/domains/account/handle.js";
+import { assistantsDomainsListOptions } from "@/generated/api/@tanstack/react-query.gen.js";
 import type { Assistant } from "@/generated/api/types.gen.js";
+import { routes } from "@/utils/routes.js";
 
 // Debounce window before firing the availability check. Tight enough that
 // feedback feels live as the user types; loose enough that fast typers
@@ -472,10 +477,16 @@ function AssistantHandleSection({
   assistant,
   onSaved,
 }: AssistantHandleSectionProps) {
-  // Assistants may not have a handle yet (the column is nullable; auto-derivation
-  // only kicks in on rename when the assistant has a non-default name). Treat
-  // ``null`` as an empty string for the editor so the "pick one" flow works.
   const currentHandle = assistant.handle ?? "";
+
+  const domainsQuery = useQuery({
+    ...assistantsDomainsListOptions({
+      path: { assistant_id: assistant.id },
+    }),
+  });
+  const domain = domainsQuery.data?.results?.[0];
+  const lockedBySubdomain =
+    !!domain && domain.subdomain.toLowerCase() === currentHandle.toLowerCase();
 
   const idleHelperText =
     currentHandle.length === 0
@@ -499,6 +510,38 @@ function AssistantHandleSection({
     },
     [assistant.id],
   );
+
+  if (lockedBySubdomain) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Input
+          label="Assistant handle"
+          value={currentHandle}
+          readOnly
+          disabled
+          leftIcon={
+            <span
+              className="select-none font-mono text-[var(--content-tertiary)]"
+              aria-hidden
+            >
+              @
+            </span>
+          }
+          fullWidth
+          data-testid="assistant-handle-input"
+        />
+        <p className="text-body-small-default text-[var(--content-tertiary)]">
+          Cannot change handle while a registered subdomain matches it.{" "}
+          <Link
+            to={`${routes.settings.ai}#email`}
+            className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+          >
+            View subdomain settings
+          </Link>
+        </p>
+      </div>
+    );
+  }
 
   return (
     <HandleEditor<Assistant>

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -531,13 +531,15 @@ function AssistantHandleSection({
           data-testid="assistant-handle-input"
         />
         <p className="text-body-small-default text-[var(--content-tertiary)]">
-          Cannot change handle while a registered subdomain matches it.{" "}
+          Your handle is locked because it's used as your email subdomain.
+          To change it,{" "}
           <Link
-            to={`${routes.settings.ai}#email`}
+            to={`${routes.settings.ai}?release=1#email`}
             className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
           >
-            View subdomain settings
-          </Link>
+            release the subdomain
+          </Link>{" "}
+          first.
         </p>
       </div>
     );

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -338,18 +338,20 @@ function HandleEditor<T>({
         fullWidth
         data-testid={`${fieldId}-input`}
       />
-      <div className="flex justify-end">
-        <Button
-          variant="primary"
-          size="compact"
-          onClick={handleSave}
-          disabled={!isSaveable}
-          aria-live="polite"
-          data-testid={`${fieldId}-save`}
-        >
-          {saveLabel}
-        </Button>
-      </div>
+      {(!isUnchanged || saveStatus !== "idle") && (
+        <div className="flex justify-end">
+          <Button
+            variant="primary"
+            size="compact"
+            onClick={handleSave}
+            disabled={!isSaveable}
+            aria-live="polite"
+            data-testid={`${fieldId}-save`}
+          >
+            {saveLabel}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -531,7 +531,7 @@ function AssistantHandleSection({
           data-testid="assistant-handle-input"
         />
         <p className="text-body-small-default text-[var(--content-tertiary)]">
-          Your handle is locked because it's used as your email subdomain.
+          Your assistant's handle is locked because it's used as its email subdomain.
           To change it,{" "}
           <Link
             to={`${routes.settings.ai}?release=1#email`}

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -310,14 +310,11 @@ function HandleEditor<T>({
   })();
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex items-start gap-2">
       <Input
         label={inputLabel}
         value={value}
         onChange={(e) => {
-          // Strip whitespace as the user types — pasted values often
-          // bring leading/trailing whitespace, and the server lowercases
-          // anyway, so do it here for clean preview.
           setValue(e.target.value.replace(/\s+/g, ""));
           setAvailability(null);
           setServerError(null);
@@ -341,8 +338,7 @@ function HandleEditor<T>({
         fullWidth
         data-testid={`${fieldId}-input`}
       />
-
-      <div className="flex justify-end">
+      <div className="mt-[26px]">
         <Button
           variant="primary"
           size="compact"
@@ -615,7 +611,7 @@ export function ProfileCard({
   }, []);
 
   return (
-    <SettingsCard title="Profile" subtitle="Your public handle on Vellum.">
+    <SettingsCard title="Profile" subtitle="Manage your user and assistant handles.">
       {error ? (
         <p className="text-body-small-default text-[var(--system-negative-strong)]">
           {error}

--- a/apps/web/src/domains/settings/components/profile-card.tsx
+++ b/apps/web/src/domains/settings/components/profile-card.tsx
@@ -310,7 +310,7 @@ function HandleEditor<T>({
   })();
 
   return (
-    <div className="flex items-start gap-2">
+    <div className="flex flex-col gap-4">
       <Input
         label={inputLabel}
         value={value}
@@ -338,7 +338,7 @@ function HandleEditor<T>({
         fullWidth
         data-testid={`${fieldId}-input`}
       />
-      <div className="mt-[26px]">
+      <div className="flex justify-end">
         <Button
           variant="primary"
           size="compact"
@@ -611,7 +611,7 @@ export function ProfileCard({
   }, []);
 
   return (
-    <SettingsCard title="Profile" subtitle="Manage your user and assistant handles.">
+    <SettingsCard title="Profile" subtitle="Manage your user and assistant public handles.">
       {error ? (
         <p className="text-body-small-default text-[var(--system-negative-strong)]">
           {error}


### PR DESCRIPTION
## Summary

- Lock the assistant handle field on the General settings page when a registered subdomain matches the handle — shows a read-only input with help text: *"Cannot change handle while a registered subdomain matches it. [View subdomain settings](/assistant/settings/ai#email)"*
- Add `#email` anchor ID to the Email ServiceCard on Models & Services
- Auto-scroll to hash anchor on the AI settings page so the link lands directly on the Email card

## Test plan

- [ ] With a registered subdomain matching the handle, navigate to `/assistant/settings/general` → handle field is disabled/read-only with help text
- [ ] Click "View subdomain settings" → navigates to `/assistant/settings/ai#email` and scrolls to the Email card
- [ ] Without a matching subdomain, the handle field is fully editable as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)