### PR TITLE
fix: include provider error detail in rejection message

### DIFF
--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -437,9 +437,15 @@ function classifyCore(
           errorCategory: "image_dimensions_too_large",
         };
       }
+      // Extract the provider detail after "API error (NNN): " prefix
+      const detailMatch = message.match(/API error \(\d+\):\s*(.+)/i);
+      const detail = detailMatch?.[1];
+      const suffix = detail
+        ? `: ${detail.length > 200 ? detail.slice(0, 200) + "…" : detail}`
+        : "";
       return {
         code: "PROVIDER_API",
-        userMessage: `The AI provider rejected the request (HTTP ${error.statusCode}).`,
+        userMessage: `The AI provider rejected the request (HTTP ${error.statusCode})${suffix}`,
         retryable: true,
         errorCategory: "provider_api_error",
       };


### PR DESCRIPTION
## Summary
- Follow-up to #31926 — also includes the provider's error detail text (truncated to 200 chars) in the user-facing error message
- e.g. `"The AI provider rejected the request (HTTP 400): Invalid parameter: ..."`
- Temporary diagnostic aid for debugging ChatGPT subscription 400 errors on dev — will revert the extra verbosity once root cause is found

## Test plan
- [x] Typecheck passes
- [x] All 121 conversation-error tests pass
- [ ] Deploy to dev and reproduce ChatGPT subscription error to see the actual OpenAI rejection reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)