### PR TITLE
fix(web): invalidate assistant list cache after domain mutations

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -42,6 +42,7 @@ import {
   assistantsEmailAddressesStatusRetrieveOptions,
   assistantsEmailAddressesStatusRetrieveQueryKey,
   assistantsListOptions,
+  assistantsListQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen.js";
 import { reportError } from "@/lib/errors/report.js";
@@ -957,6 +958,11 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
         }),
       });
     }
+    // Domain registration can change the assistant's handle; invalidate the
+    // assistant list so the cached handle stays fresh.
+    void queryClient.invalidateQueries({
+      queryKey: assistantsListQueryKey(),
+    });
   }, [address?.id, assistantId, queryClient]);
 
   // -- Handlers --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Domain registration (`register_assistant_domain`) can change the assistant's handle when the chosen subdomain differs from the current handle.
- The `invalidateEmailQueries` helper on the AI settings page previously only refreshed domain and email queries, leaving the assistant list (which includes the `handle` field) stale.
- Added `assistantsListQueryKey()` to the invalidation set so the cached handle is refreshed after domain create/delete.

## Original prompt
Ensure the APIs for creating/deleting subdomains also invalidate the cache of whatever APIs expose the assistant's handle. Domain registration syncs the handle when the chosen subdomain differs, but the client-side TanStack Query cache for the assistant list (which exposes `handle`) was not being invalidated after domain mutations — only the domain and email-specific queries were refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)