### PR TITLE
feat(cli): add `vellum flags` command

### DIFF
--- a/cli/src/commands/flags.ts
+++ b/cli/src/commands/flags.ts
@@ -54,28 +54,53 @@ function printFlagTable(flags: FeatureFlagEntry[]): void {
 function printHelp(): void {
   console.log("Usage: vellum flags [subcommand] [options]");
   console.log("");
+  console.log("Show and toggle feature flags for the active assistant.");
+  console.log("Reads from the gateway's merged flag state (persisted overrides > remote > defaults).");
+  console.log("");
   console.log("Subcommands:");
-  console.log("  (none)              List all feature flags");
+  console.log("  (none)              List all feature flags in a table");
   console.log("  get <key>           Show details for a single flag");
-  console.log("  set <key> <bool>    Set a flag to true or false");
+  console.log("  set <key> <bool>    Set a flag override to true or false");
   console.log("");
   console.log("Options:");
   console.log("  --help, -h          Show this help");
+  console.log("");
+  console.log("Examples:");
+  console.log("  $ vellum flags                                 # list all flags");
+  console.log("  $ vellum flags get query-complexity-routing     # inspect one flag");
+  console.log("  $ vellum flags set voice-mode true              # enable a flag");
 }
 
-async function createClient(): Promise<AssistantClient> {
+function createClient(): AssistantClient {
   try {
     return new AssistantClient();
   } catch {
     throw new Error(
-      "No running assistant found. Start one with 'vellum wake' first.",
+      "No assistant found. Hatch one with 'vellum hatch' first.",
     );
   }
 }
 
+function rethrowFetchError(err: unknown): never {
+  if (
+    err instanceof TypeError &&
+    (err.message.includes("fetch") || err.message.includes("connect"))
+  ) {
+    throw new Error(
+      "Could not reach the assistant gateway. Is it running? Try 'vellum wake'.",
+    );
+  }
+  throw err;
+}
+
 async function listFlags(): Promise<void> {
-  const client = await createClient();
-  const res = await client.get("/feature-flags");
+  const client = createClient();
+  let res: Response;
+  try {
+    res = await client.get("/feature-flags");
+  } catch (err) {
+    rethrowFetchError(err);
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to fetch flags: HTTP ${res.status} ${body}`.trim());
@@ -89,8 +114,13 @@ async function listFlags(): Promise<void> {
 }
 
 async function getFlag(key: string): Promise<void> {
-  const client = await createClient();
-  const res = await client.get("/feature-flags");
+  const client = createClient();
+  let res: Response;
+  try {
+    res = await client.get("/feature-flags");
+  } catch (err) {
+    rethrowFetchError(err);
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to fetch flags: HTTP ${res.status} ${body}`.trim());
@@ -107,8 +137,13 @@ async function getFlag(key: string): Promise<void> {
 }
 
 async function setFlag(key: string, value: boolean): Promise<void> {
-  const client = await createClient();
-  const res = await client.patch(`/feature-flags/${key}`, { enabled: value });
+  const client = createClient();
+  let res: Response;
+  try {
+    res = await client.patch(`/feature-flags/${key}`, { enabled: value });
+  } catch (err) {
+    rethrowFetchError(err);
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to set flag: HTTP ${res.status} ${body}`.trim());

--- a/cli/src/commands/flags.ts
+++ b/cli/src/commands/flags.ts
@@ -1,0 +1,162 @@
+import { AssistantClient } from "../lib/assistant-client.js";
+
+type FeatureFlagEntry = {
+  key: string;
+  label: string;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  description: string;
+};
+
+type FlagsResponse = {
+  flags: FeatureFlagEntry[];
+};
+
+function pad(s: string, w: number): string {
+  return s + " ".repeat(Math.max(0, w - s.length));
+}
+
+function printFlagTable(flags: FeatureFlagEntry[]): void {
+  const headers = { key: "KEY", enabled: "ENABLED", default: "DEFAULT", label: "LABEL" };
+
+  const rows = flags
+    .slice()
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .map((f) => ({
+      key: f.enabled !== f.defaultEnabled ? `* ${f.key}` : `  ${f.key}`,
+      enabled: String(f.enabled),
+      default: String(f.defaultEnabled),
+      label: f.label,
+    }));
+
+  const all = [headers, ...rows];
+  const colWidths = {
+    key: Math.max(...all.map((r) => r.key.length)),
+    enabled: Math.max(...all.map((r) => r.enabled.length)),
+    default: Math.max(...all.map((r) => r.default.length)),
+    label: Math.max(...all.map((r) => r.label.length)),
+  };
+
+  const formatRow = (r: typeof headers) =>
+    `${pad(r.key, colWidths.key)}  ${pad(r.enabled, colWidths.enabled)}  ${pad(r.default, colWidths.default)}  ${r.label}`;
+
+  console.log(formatRow(headers));
+  console.log(
+    `${"-".repeat(colWidths.key)}  ${"-".repeat(colWidths.enabled)}  ${"-".repeat(colWidths.default)}  ${"-".repeat(colWidths.label)}`,
+  );
+  for (const row of rows) {
+    console.log(formatRow(row));
+  }
+  console.log("");
+  console.log("* = overridden (differs from default)");
+}
+
+function printHelp(): void {
+  console.log("Usage: vellum flags [subcommand] [options]");
+  console.log("");
+  console.log("Subcommands:");
+  console.log("  (none)              List all feature flags");
+  console.log("  get <key>           Show details for a single flag");
+  console.log("  set <key> <bool>    Set a flag to true or false");
+  console.log("");
+  console.log("Options:");
+  console.log("  --help, -h          Show this help");
+}
+
+async function createClient(): Promise<AssistantClient> {
+  try {
+    return new AssistantClient();
+  } catch {
+    throw new Error(
+      "No running assistant found. Start one with 'vellum wake' first.",
+    );
+  }
+}
+
+async function listFlags(): Promise<void> {
+  const client = await createClient();
+  const res = await client.get("/feature-flags");
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to fetch flags: HTTP ${res.status} ${body}`.trim());
+  }
+  const data = (await res.json()) as FlagsResponse;
+  if (data.flags.length === 0) {
+    console.log("No feature flags found.");
+    return;
+  }
+  printFlagTable(data.flags);
+}
+
+async function getFlag(key: string): Promise<void> {
+  const client = await createClient();
+  const res = await client.get("/feature-flags");
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to fetch flags: HTTP ${res.status} ${body}`.trim());
+  }
+  const data = (await res.json()) as FlagsResponse;
+  const flag = data.flags.find((f) => f.key === key);
+  if (!flag) {
+    throw new Error(`Flag "${key}" not found.`);
+  }
+  console.log(`Key:            ${flag.key}`);
+  console.log(`Enabled:        ${flag.enabled}`);
+  console.log(`Default:        ${flag.defaultEnabled}`);
+  console.log(`Description:    ${flag.description || "(none)"}`);
+}
+
+async function setFlag(key: string, value: boolean): Promise<void> {
+  const client = await createClient();
+  const res = await client.patch(`/feature-flags/${key}`, { enabled: value });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to set flag: HTTP ${res.status} ${body}`.trim());
+  }
+  console.log(`Flag "${key}" set to ${value}`);
+}
+
+export async function flags(): Promise<void> {
+  const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    return;
+  }
+
+  const subcommand = args[0];
+
+  if (!subcommand) {
+    await listFlags();
+    return;
+  }
+
+  if (subcommand === "get") {
+    const key = args[1];
+    if (!key) {
+      console.error("Usage: vellum flags get <key>");
+      process.exit(1);
+    }
+    await getFlag(key);
+    return;
+  }
+
+  if (subcommand === "set") {
+    const key = args[1];
+    const rawValue = args[2];
+    if (!key || rawValue === undefined) {
+      console.error("Usage: vellum flags set <key> <true|false>");
+      process.exit(1);
+    }
+    if (rawValue !== "true" && rawValue !== "false") {
+      console.error(`Invalid value "${rawValue}". Must be "true" or "false".`);
+      process.exit(1);
+    }
+    await setFlag(key, rawValue === "true");
+    return;
+  }
+
+  console.error(`Unknown subcommand: ${subcommand}`);
+  printHelp();
+  process.exit(1);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import { client } from "./commands/client";
 import { env } from "./commands/env";
 import { events } from "./commands/events";
 import { exec } from "./commands/exec";
+import { flags } from "./commands/flags";
 import { hatch } from "./commands/hatch";
 import { login, logout, whoami } from "./commands/login";
 import { logs } from "./commands/logs";
@@ -37,6 +38,7 @@ const commands = {
   env,
   events,
   exec,
+  flags,
   hatch,
   login,
   logout,
@@ -72,6 +74,7 @@ function printHelp(): void {
   console.log("  env      Manage the default CLI environment");
   console.log("  events   Stream events from a running assistant");
   console.log("  exec     Execute a command inside an assistant's container");
+  console.log("  flags    Show and toggle feature flags");
   console.log("  hatch    Create a new assistant instance");
   console.log("  logs     View logs from an assistant instance");
   console.log("  login    Log in to the Vellum platform");


### PR DESCRIPTION
## Summary

- Adds `vellum flags` CLI command to inspect and toggle feature flags for the active assistant
- `vellum flags` — lists all flags in a table with override markers
- `vellum flags get <key>` — shows a single flag's details
- `vellum flags set <key> <true|false>` — toggles a flag via the gateway PATCH endpoint
- Uses `AssistantClient` HTTP requests, so it works for both local and cloud/managed assistants

## Motivation

Feature flag state was previously only visible through the Developer panel in the web UI. This command lets you check and toggle flags from the terminal without switching to a browser, which is especially useful during debugging sessions where you need to quickly verify whether a flag is enabled.

## Test plan

- [ ] `vellum flags` lists all flags with correct enabled/default values
- [ ] `vellum flags get query-complexity-routing` shows flag details
- [ ] `vellum flags set query-complexity-routing true` toggles the flag
- [ ] `vellum flags --help` shows usage
- [ ] Error when no assistant is running shows helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)