### PR TITLE
fix(memory-v2): stop router suppressing re-selection of injected pages

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -698,10 +698,6 @@ describe("forkConversation", () => {
           "concepts/q3-launch-plan": 0.71,
           "concepts/marketing-ops": 0.34,
         }),
-        everInjectedJson: JSON.stringify([
-          { slug: "concepts/q3-launch-plan", turn: 1 },
-          { slug: "concepts/marketing-ops", turn: 1 },
-        ]),
         currentTurn: 2,
         updatedAt: 1_700_000_000_000,
       })
@@ -716,10 +712,6 @@ describe("forkConversation", () => {
         "concepts/q3-launch-plan": 0.71,
         "concepts/marketing-ops": 0.34,
       },
-      everInjected: [
-        { slug: "concepts/q3-launch-plan", turn: 1 },
-        { slug: "concepts/marketing-ops", turn: 1 },
-      ],
       currentTurn: 2,
       updatedAt: 1_700_000_000_000,
     });
@@ -799,7 +791,6 @@ describe("forkConversation", () => {
         conversationId: source.id,
         messageId: lastMessage.id,
         stateJson: JSON.stringify({ "concepts/foo": 0.5 }),
-        everInjectedJson: JSON.stringify([{ slug: "concepts/foo", turn: 2 }]),
         currentTurn: 2,
         updatedAt: 1_700_000_000_000,
       })
@@ -892,7 +883,6 @@ describe("forkConversation", () => {
         conversationId: source.id,
         messageId: lastMessage.id,
         stateJson: JSON.stringify({ "concepts/foo": 0.9 }),
-        everInjectedJson: JSON.stringify([{ slug: "concepts/foo", turn: 1 }]),
         currentTurn: 1,
         updatedAt: 1_700_000_000_000,
       })

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -403,8 +403,6 @@ and no activation state is mutated. Use this to preview the effect of a
 config knob change before flipping it in workspace config.json.
 
 Limitations:
-  - priorEverInjected is empty (single-turn simulation; live router dedups
-    against pages already in context).
   - NOW.md is read at simulate-time, not historical-turn time.
   - assistantMessage is empty.
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1739,9 +1739,9 @@ const RUNTIME_INJECTION_PREFIXES = [
   // `<memory __injected>…`) are both stripped so each compaction
   // re-injects the freshest essentials/threads/recent/buffer view and
   // re-runs the activation pipeline, matching the `<knowledge_base>`
-  // cadence. The activation pipeline dedupes via `everInjected`, and
-  // compaction handles aggregate growth, so accumulation does not cause
-  // unbounded context growth. Both wrappers may appear in persisted rows.
+  // cadence. The pipeline re-renders the full top-K each turn and history is
+  // stripped, so memory context stays bounded to top-K and does not
+  // accumulate. Both wrappers may appear in persisted rows.
   "<memory>\n",
   "<info>\n",
   "<voice_call_control>",

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -177,8 +177,6 @@ const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
 const schema = await import("../../schema.js");
 const { _resetMemoryV2QdrantForTests } = await import("../../v2/qdrant.js");
-const { hydrate: hydrateActivationState, save: saveActivationState } =
-  await import("../../v2/activation-store.js");
 
 // The wiring layer calls `getDb()` to fetch the SQLite handle. We mock
 // only that one export and spread the real module so unrelated callers
@@ -567,11 +565,8 @@ describe("ConversationGraphMemory.prepareMemory — memory.enabled gate", () => 
   });
 });
 
-describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () => {
-  test("clears everInjected so a previously-injected slug can re-attach", async () => {
-    // Without this wiring, `selectInjections` keeps subtracting the slug from
-    // every per-turn delta even though compaction discarded the cached
-    // `<memory>` attachment that previously made it visible.
+describe("ConversationGraphMemory.onCompacted — v2 re-injection", () => {
+  test("re-attaches a previously-injected slug after compaction", async () => {
     const conversationId = "conv-test-evict";
     const memory = new ConversationGraphMemory(conversationId);
     const config = makeConfig(true);
@@ -588,17 +583,10 @@ describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () =>
       "# memory/concepts/alice-vscode.md",
     );
 
-    const before = await hydrateActivationState(testDbHandle!, conversationId);
-    expect(before?.everInjected.map((e) => e.slug)).toContain("alice-vscode");
-
     await memory.onCompacted(1);
 
-    const after = await hydrateActivationState(testDbHandle!, conversationId);
-    expect(after?.everInjected).toEqual([]);
-
-    // Turn 2 — same Qdrant relevance. With everInjected cleared the slug
-    // should appear again in the injection block (re-attached on the new
-    // user message after compaction).
+    // Turn 2 — same Qdrant relevance. The slug should appear again in the
+    // injection block (re-attached on the new user message after compaction).
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     const next = await memory.prepareMemory(
       makeMessages("And what about Alice's editor again?"),
@@ -609,37 +597,5 @@ describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () =>
     expect(next.injectedBlockText).toContain(
       "# memory/concepts/alice-vscode.md",
     );
-  });
-
-  test("clears everInjected entries whose turn exceeds the tracker's currentTurn (zombie drift)", async () => {
-    // Regression: under the prior turn-bounded eviction, entries with `turn >
-    // tracker.currentTurn` survived `onCompacted` forever. This can happen
-    // after a non-graceful shutdown: `everInjected` is persisted every turn
-    // while the tracker snapshot is only persisted on graceful dispose, so a
-    // SIGKILL'd session followed by a reload restores the tracker from an
-    // older snapshot with a lower currentTurn while keeping the high-turn
-    // entries on disk.
-    const conversationId = "conv-test-zombie-drift";
-    const memory = new ConversationGraphMemory(conversationId);
-
-    // Seed the simulated post-crash state directly: tracker stays at
-    // currentTurn=0 (default for a fresh ConversationGraphMemory), while the
-    // persisted row carries everInjected entries from turns 10 and 20 (left
-    // over from a prior session that never disposed cleanly).
-    await saveActivationState(testDbHandle!, conversationId, {
-      messageId: "msg-zombie",
-      state: {},
-      everInjected: [
-        { slug: "alice-vscode", turn: 10 },
-        { slug: "bob-pkg-mgr", turn: 20 },
-      ],
-      currentTurn: 0,
-      updatedAt: 1,
-    });
-
-    await memory.onCompacted(0);
-
-    const after = await hydrateActivationState(testDbHandle!, conversationId);
-    expect(after?.everInjected).toEqual([]);
   });
 });

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -26,11 +26,6 @@ import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
 import {
-  clearEverInjected as clearV2EverInjected,
-  hydrate as hydrateV2State,
-  save as saveV2State,
-} from "../v2/activation-store.js";
-import {
   injectMemoryV2Block,
   type InjectMemoryV2Mode,
 } from "../v2/injection.js";
@@ -220,28 +215,6 @@ export class ConversationGraphMemory {
     // so we conservatively clear everything and reload.
     const upToTurn = this.tracker.getTurn();
     this.tracker.evictCompactedTurns(upToTurn);
-
-    // Mirror the eviction on the v2 activation row: the cached `<memory>`
-    // attachments those slugs lived on are gone, but `everInjected` would
-    // otherwise keep them deduped from per-turn deltas forever.
-    //
-    // Cleared unconditionally rather than filtered by `upToTurn`: the
-    // tracker's `currentTurn` is only persisted on graceful dispose while
-    // `everInjected` is persisted every turn, so a SIGKILL'd session can
-    // leave entries with `turn > tracker.currentTurn` that a turn-bounded
-    // filter would skip.
-    try {
-      const db = getDb();
-      const state = await hydrateV2State(db, this.conversationId);
-      if (state) {
-        await saveV2State(db, this.conversationId, clearV2EverInjected(state));
-      }
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Failed to evict v2 activation state on compaction (non-fatal)",
-      );
-    }
 
     this.needsReload = true;
     log.info(

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -56,11 +56,11 @@ export interface MemoryV2ConceptRowRecord {
    *     A single-batch (no-tier carve-out) workspace produces `tier3:0`.
    *     The bucket index lets inspector queries attribute selections to
    *     specific hash-bucketed parallel calls.
-   *   - `carry_over`  — router-mode row representing a slug carried over
-   *     from `priorEverInjected` that the router did NOT re-pick on this
-   *     turn. The cached attachment from a prior turn is still present
-   *     on a prior user message; emitting one of the tier tags for these
-   *     rows would overcount router selections in inspector queries.
+   *   - `carry_over`  — legacy router-mode row for a slug carried over from
+   *     the prior-injected ledger that the router did NOT re-pick. No longer
+   *     emitted (the router renders its full selection each turn, and memory
+   *     no longer persists across turns); retained so the inspector can render
+   *     old activation log rows.
    *
    * All router-mode rows (`tier*`, `router`, `carry_over`) zero out the
    * activation values (`finalActivation`, `ownActivation`, etc.) because

--- a/assistant/src/memory/schema/memory-graph.ts
+++ b/assistant/src/memory/schema/memory-graph.ts
@@ -159,9 +159,11 @@ export const memoryGraphNodeEdits = sqliteTable("memory_graph_node_edits", {
  * conversation; created lazily on first injection.
  *
  * - `stateJson`: sparse `{slug: activation}` map (only slugs > epsilon).
- * - `everInjectedJson`: append-only `[{slug, turn}]` list used to keep
- *   per-turn injections strictly delta-only. Pruned when compaction evicts
- *   the turns whose attached slugs lived on.
+ *
+ * The physical table also carries a legacy `ever_injected_json` column
+ * (created by migrations 232/241, `NOT NULL DEFAULT '[]'`). It is intentionally
+ * unmapped here — nothing reads it, and omitting it from inserts lets SQLite
+ * supply the default. Left in place to avoid a table-rewrite migration.
  *
  * No FK to conversations.id — fork() may copy state for a child
  * conversation that hasn't been persisted yet, and stale rows are cheap.
@@ -170,7 +172,6 @@ export const activationState = sqliteTable("activation_state", {
   conversationId: text("conversation_id").primaryKey(),
   messageId: text("message_id").notNull(),
   stateJson: text("state_json").notNull(),
-  everInjectedJson: text("ever_injected_json").notNull().default("[]"),
   currentTurn: integer("current_turn").notNull().default(0),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
+++ b/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renderRouterPrompt — determinism & snapshot stability snapshot of fixed inputs 1`] = `
 "You are a background helper for Aria. Your job is to route memory pages for the next assistant turn between Aria and Alice.
 
-You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
+You will be shown the recent conversation, a \`<now>\` marker for the current time, and a \`# Concept Page Index\` listing every routable page on this workspace.
 
 Pick the concept pages whose contents would help Aria respond well on this turn. Lean toward inclusion when in doubt — missing a relevant page is a worse error than surfacing a few unused ones, because the assistant can ignore extras but can't summon context that wasn't loaded. Abstain (return an empty list) only when nothing in the index plausibly bears on the turn.
 
@@ -12,8 +12,6 @@ Index format. Each line of the index has the shape:
     [id] slug — summary (edges: a, b, c)
 
 \`id\` is a small integer used to refer to this page. \`edges\` are numeric IDs into the same list, pointing at related pages; you may follow them when one page strongly implies another.
-
-Already-injected pages. Pages whose IDs appear in \`<already_injected_ids>\` were picked on the previous turn. Do not pick them again unless Aria should re-anchor on that material — e.g., the topic genuinely returns after drifting away. Routine continuity does not require re-picking; the prior turn's pages are already in the assistant's working context.
 
 Time. Bias toward pages that match the current state implied by \`<now>\` and the active conversational threads (what is happening today, what was just decided, who is being discussed). Stale pages with no bearing on the live conversation should be skipped even if their summaries look superficially relevant.
 

--- a/assistant/src/memory/v2/__tests__/activation-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation-store.test.ts
@@ -6,12 +6,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { type DrizzleDb, getSqliteFrom } from "../../db-connection.js";
 import { migrateActivationState } from "../../migrations/232-activation-state.js";
 import * as schema from "../../schema.js";
-import {
-  clearEverInjected,
-  forkActivationState,
-  hydrate,
-  save,
-} from "../activation-store.js";
+import { forkActivationState, hydrate, save } from "../activation-store.js";
 import type { ActivationState } from "../types.js";
 
 function createTestDb(): DrizzleDb {
@@ -36,10 +31,6 @@ function buildState(overrides: Partial<ActivationState> = {}): ActivationState {
   return {
     messageId: "msg-1",
     state: { "alice-prefers-vscode": 0.42, "bob-coffee-order": 0.18 },
-    everInjected: [
-      { slug: "alice-prefers-vscode", turn: 1 },
-      { slug: "bob-coffee-order", turn: 2 },
-    ],
     currentTurn: 3,
     updatedAt: 1_700_000_000_000,
     ...overrides,
@@ -88,7 +79,6 @@ describe("activation-store", () => {
         buildState({
           messageId: "msg-2",
           state: { "carla-likes-vim": 0.9 },
-          everInjected: [{ slug: "carla-likes-vim", turn: 5 }],
           currentTurn: 5,
           updatedAt: 1_700_000_001_000,
         }),
@@ -98,14 +88,13 @@ describe("activation-store", () => {
       expect(loaded).toEqual({
         messageId: "msg-2",
         state: { "carla-likes-vim": 0.9 },
-        everInjected: [{ slug: "carla-likes-vim", turn: 5 }],
         currentTurn: 5,
         updatedAt: 1_700_000_001_000,
       });
     });
 
-    test("persists empty state map and ever-injected list", async () => {
-      const state = buildState({ state: {}, everInjected: [] });
+    test("persists empty state map", async () => {
+      const state = buildState({ state: {} });
       await save(db, "conv-empty", state);
 
       const loaded = await hydrate(db, "conv-empty");
@@ -143,62 +132,6 @@ describe("activation-store", () => {
 
       const child = await hydrate(db, "conv-child");
       expect(child?.currentTurn).toBe(7);
-    });
-  });
-
-  describe("clearEverInjected", () => {
-    test("empties the everInjected list", () => {
-      const state = buildState({
-        everInjected: [
-          { slug: "slug-a", turn: 1 },
-          { slug: "slug-b", turn: 2 },
-          { slug: "slug-c", turn: 3 },
-        ],
-      });
-
-      const result = clearEverInjected(state);
-
-      expect(result.everInjected).toEqual([]);
-    });
-
-    test("clears entries even when their turn exceeds currentTurn — the SIGKILL drift case", () => {
-      // Regression: under turn-bounded eviction, entries with turn >
-      // currentTurn survived forever. A non-graceful shutdown can persist
-      // everInjected entries with high turn values, then a restart restores
-      // the tracker from an older snapshot with a lower currentTurn.
-      const state = buildState({
-        currentTurn: 5,
-        everInjected: [
-          { slug: "slug-a", turn: 10 },
-          { slug: "slug-b", turn: 20 },
-        ],
-      });
-
-      const result = clearEverInjected(state);
-
-      expect(result.everInjected).toEqual([]);
-    });
-
-    test("returns a new object — does not mutate the input", () => {
-      const state = buildState({
-        everInjected: [{ slug: "slug-a", turn: 1 }],
-      });
-
-      const result = clearEverInjected(state);
-
-      expect(result.everInjected).toEqual([]);
-      expect(state.everInjected).toEqual([{ slug: "slug-a", turn: 1 }]);
-      expect(result).not.toBe(state);
-    });
-
-    test("preserves every other field on the state", () => {
-      const state = buildState();
-      const result = clearEverInjected(state);
-
-      expect(result.messageId).toBe(state.messageId);
-      expect(result.state).toEqual(state.state);
-      expect(result.currentTurn).toBe(state.currentTurn);
-      expect(result.updatedAt).toBe(state.updatedAt);
     });
   });
 });

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -10,8 +10,7 @@
  *   - `spreadActivation`: orphan yields A == A_o; spread walks incoming edges
  *      only (A→B boosts B but not A); hops=2 reaches second-degree predecessors
  *      but not third; bounded in [0,1].
- *   - `selectInjections`: top-K rank, deterministic tie-break, delta against
- *      `everInjected`.
+ *   - `selectInjections`: top-K rank, deterministic tie-break.
  *
  * Hermetic by design: the embedding backend, qdrant client, and `getConfig`
  * are mocked at the module level so the suite never starts a real backend.
@@ -293,7 +292,6 @@ describe("selectCandidates", () => {
         "bob-coffee": 0.005, // below epsilon
         "carol-jazz": 0.2,
       },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -313,7 +311,6 @@ describe("selectCandidates", () => {
     const priorState: ActivationState = {
       messageId: "msg-1",
       state: { "alice-vscode": 0.5 },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -341,7 +338,6 @@ describe("selectCandidates", () => {
         "alice-vscode": 0.5, // in prior AND in ANN
         "carol-jazz": 0.3, // prior only
       },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -445,7 +441,6 @@ describe("computeOwnActivation", () => {
     const priorState: ActivationState = {
       messageId: "msg-1",
       state: { alice: 0.6 },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -476,7 +471,6 @@ describe("computeOwnActivation", () => {
     const priorState: ActivationState = {
       messageId: "msg-1",
       state: { alice: 1.0 },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -546,7 +540,6 @@ describe("computeOwnActivation", () => {
     const priorState: ActivationState = {
       messageId: "msg-1",
       state: { alice: 0.6 },
-      everInjected: [],
       currentTurn: 1,
       updatedAt: 1,
     };
@@ -1113,10 +1106,9 @@ describe("selectInjections", () => {
   test("returns empty when activation is empty", () => {
     const out = selectInjections({
       A: new Map(),
-      priorEverInjected: [],
       topK: 5,
     });
-    expect(out).toEqual({ topNow: [], toInject: [] });
+    expect(out).toEqual({ topNow: [] });
   });
 
   test("returns empty when topK is 0", () => {
@@ -1125,10 +1117,9 @@ describe("selectInjections", () => {
         ["alice", 0.5],
         ["bob", 0.4],
       ]),
-      priorEverInjected: [],
       topK: 0,
     });
-    expect(out).toEqual({ topNow: [], toInject: [] });
+    expect(out).toEqual({ topNow: [] });
   });
 
   test("ranks by activation descending and trims to topK", () => {
@@ -1139,35 +1130,9 @@ describe("selectInjections", () => {
         ["carol", 0.5],
         ["delta", 0.3],
       ]),
-      priorEverInjected: [],
       topK: 2,
     });
     expect(out.topNow).toEqual(["bob", "carol"]);
-    expect(out.toInject).toEqual(["bob", "carol"]);
-  });
-
-  test("subtracts everInjected slugs from toInject", () => {
-    const out = selectInjections({
-      A: new Map([
-        ["alice", 0.9],
-        ["bob", 0.7],
-        ["carol", 0.5],
-      ]),
-      priorEverInjected: [{ slug: "alice", turn: 0 }],
-      topK: 5,
-    });
-    expect(out.topNow).toEqual(["alice", "bob", "carol"]);
-    expect(out.toInject).toEqual(["bob", "carol"]);
-  });
-
-  test("returns empty toInject when every topNow slug has been injected", () => {
-    const out = selectInjections({
-      A: new Map([["alice", 0.9]]),
-      priorEverInjected: [{ slug: "alice", turn: 1 }],
-      topK: 5,
-    });
-    expect(out.topNow).toEqual(["alice"]);
-    expect(out.toInject).toEqual([]);
   });
 
   test("breaks ties by slug ascending for deterministic output", () => {
@@ -1177,7 +1142,6 @@ describe("selectInjections", () => {
         ["alice", 0.5],
         ["mike", 0.5],
       ]),
-      priorEverInjected: [],
       topK: 5,
     });
     expect(out.topNow).toEqual(["alice", "mike", "zeta"]);

--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -445,7 +445,6 @@ describe("memoryV2ActivationRecomputeJob", () => {
     await saveActivation(getDb(), "conv-with-state", {
       messageId: "msg-prior",
       state: { "alice-prefers-vscode": 0.9 },
-      everInjected: [{ slug: "alice-prefers-vscode", turn: 1 }],
       currentTurn: 2,
       updatedAt: 1,
     });
@@ -459,9 +458,6 @@ describe("memoryV2ActivationRecomputeJob", () => {
     const next = await hydrateActivation(getDb(), "conv-with-state");
     expect(next).not.toBeNull();
     expect(next?.messageId).toBe("msg-prior");
-    expect(next?.everInjected).toEqual([
-      { slug: "alice-prefers-vscode", turn: 1 },
-    ]);
     // updatedAt was bumped.
     expect(next?.updatedAt).toBeGreaterThan(1);
   });
@@ -483,7 +479,6 @@ describe("memoryV2ActivationRecomputeJob", () => {
     await saveActivation(getDb(), "conv-empty-msgs", {
       messageId: "msg-x",
       state: {},
-      everInjected: [],
       currentTurn: 0,
       updatedAt: 1,
     });

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1946,10 +1946,10 @@ describe("injectMemoryV2Block", () => {
       });
       expect(turn1.toInject).toEqual(["alice-vscode"]);
 
-      // Turn 2: router re-picks alice (the "re-anchor" prompt branch) AND
-      // adds bob. Both are rendered into the block — history is stripped every
-      // turn, so there is no prior attachment to collide with — and both are
-      // reported in `toInject`.
+      // Turn 2: router re-picks alice (still relevant) AND adds bob. Both are
+      // rendered into the block — history is stripped every turn, so there is
+      // no prior attachment to collide with — and both are reported in
+      // `toInject`.
       telemetryState.recordCalls.length = 0;
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode", "bob-coffee"],

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -3,16 +3,15 @@
  *
  * Coverage matrix:
  *   - Empty state seeds the first injection (initial conversation turn).
- *   - Second turn whose `topNow` overlaps prior `everInjected` returns
- *     `toInject = []` and `block = null` (cache-stable empty path).
- *   - A new topic appearing on a later turn injects only the new slug.
- *   - `evictCompactedTurns` re-enables a previously-injected slug —
- *     after eviction the same slug appears again in `toInject`.
+ *   - A later turn re-renders the full current top-K every turn (history is
+ *     stripped, so nothing persists to dedup against) and reports it in
+ *     `toInject`.
+ *   - A new topic appearing on a later turn is rendered alongside the
+ *     still-relevant carried-forward slugs.
  *   - Unified-pool skills: a `skills/<id>` slug ranked into the top-K is
  *     rendered under `### Skills You Can Use`, mixed concept-page+skill
  *     blocks render concept sections first then the skills suffix, both
- *     empty → null block, skills participate in `everInjected` so they
- *     deduplicate across turns just like concepts.
+ *     empty → null block.
  *
  * Hermetic by design: the embedding backend, qdrant client, and `getConfig`
  * are mocked at the module level so the suite never reaches a real backend.
@@ -401,8 +400,7 @@ const { migrateActivationState } =
 const { migrateMemoryV2InjectionEvents } =
   await import("../../migrations/256-memory-v2-injection-events.js");
 const schema = await import("../../schema.js");
-const { clearEverInjected, hydrate, save } =
-  await import("../activation-store.js");
+const { hydrate } = await import("../activation-store.js");
 const { injectMemoryV2Block } = await import("../injection.js");
 const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
 
@@ -595,19 +593,15 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).toContain("# memory/concepts/alice-vscode.md");
     expect(result.block).toContain("VS Code");
 
-    // State persisted: alice's activation is above epsilon and recorded;
-    // everInjected captured the new slug + currentTurn.
+    // State persisted: alice's activation is above epsilon and recorded.
     const persisted = await hydrate(db, "conv-1");
     expect(persisted).not.toBeNull();
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 1 },
-    ]);
     expect(persisted!.state["alice-vscode"]).toBeGreaterThan(0.01);
     expect(persisted!.currentTurn).toBe(1);
     expect(persisted!.messageId).toBe("msg-1");
   });
 
-  test("second turn re-renders the still-relevant slug; toInject empty (already first-seen)", async () => {
+  test("second turn re-renders the still-relevant slug into the block", async () => {
     // Turn 1 — seed alice as injected.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
@@ -624,8 +618,7 @@ describe("injectMemoryV2Block", () => {
 
     // Turn 2 — the same slug is still top-of-mind. We render the full top-K
     // every turn (history is stripped, so nothing persists to dedup against),
-    // so alice is re-rendered into the block. `toInject` stays empty because
-    // she was already first-seen on turn 1.
+    // so alice is re-rendered into the block and reported in `toInject`.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     const result = await injectMemoryV2Block({
       database: db,
@@ -642,21 +635,17 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    expect(result.toInject).toEqual([]);
+    expect(result.toInject).toEqual(["alice-vscode"]);
     expect(result.block).not.toBeNull();
     expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
-    // State still advanced (currentTurn moved forward) and the existing
-    // everInjected entry is preserved (no duplicate added).
+    // State still advanced (currentTurn moved forward).
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.currentTurn).toBe(2);
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 1 },
-    ]);
     expect(persisted!.messageId).toBe("msg-2");
   });
 
-  test("new topic appears → block re-renders the full top-K; toInject reports only the new slug", async () => {
+  test("new topic appears → block and toInject both carry the full top-K", async () => {
     // Turn 1 — seed alice.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
@@ -673,8 +662,8 @@ describe("injectMemoryV2Block", () => {
 
     // Turn 2 — carol is now in the candidate pool with high relevance.
     // Both alice (carry-forward) and carol appear in topNow and are rendered
-    // into the block (full top-K each turn). `toInject` reports only carol,
-    // since alice was already first-seen on turn 1.
+    // into the block (full top-K each turn), and both are reported in
+    // `toInject` — there is no first-seen dedup anymore.
     stageTurn([
       { slug: "alice-vscode", denseScore: 0.6 },
       { slug: "carol-jazz", denseScore: 0.95 },
@@ -694,63 +683,13 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    expect(result.toInject).toEqual(["carol-jazz"]);
+    expect(new Set(result.toInject)).toEqual(
+      new Set(["carol-jazz", "alice-vscode"]),
+    );
     // The block re-renders the full current top-K — both carol AND alice —
     // because history is stripped and nothing persists on prior turns.
     expect(result.block).toContain("# memory/concepts/carol-jazz.md");
     expect(result.block).toContain("# memory/concepts/alice-vscode.md");
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 1 },
-      { slug: "carol-jazz", turn: 2 },
-    ]);
-  });
-
-  test("compaction eviction makes a previously-injected slug eligible again", async () => {
-    // Turn 1 — seed alice.
-    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
-    await injectMemoryV2Block({
-      database: db,
-      conversationId: "conv-1",
-      currentTurn: 1,
-      recentTurnPairs: [
-        { assistantMessage: "", userMessage: "Alice's editor" },
-      ],
-      nowText: "Now",
-      messageId: "msg-1",
-      config: makeConfig(),
-    });
-
-    // Simulate compaction: clear the entire everInjected list.
-    const beforeEvict = await hydrate(db, "conv-1");
-    expect(beforeEvict).not.toBeNull();
-    const afterEvict = clearEverInjected(beforeEvict!);
-    expect(afterEvict.everInjected).toEqual([]);
-    await save(db, "conv-1", afterEvict);
-
-    // Turn 2 — alice should now be re-injectable since eviction cleared the
-    // everInjected entry. Same simulated relevance as before.
-    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
-    const result = await injectMemoryV2Block({
-      database: db,
-      conversationId: "conv-1",
-      currentTurn: 2,
-      recentTurnPairs: [
-        { assistantMessage: "", userMessage: "Alice's editor again" },
-      ],
-      nowText: "Now",
-      messageId: "msg-2",
-      config: makeConfig(),
-    });
-
-    expect(result.toInject).toEqual(["alice-vscode"]);
-    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 2 },
-    ]);
   });
 
   test("page with summary renders as path + summary, no body, with the CRITICAL header", async () => {
@@ -933,13 +872,6 @@ describe("injectMemoryV2Block", () => {
     expect(result.toInject).toEqual(["phantom-slug"]);
     expect(result.block).toBeNull();
 
-    // everInjected still records the slug so future turns subtract it and
-    // we don't infinite-loop on a missing page.
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "phantom-slug", turn: 1 },
-    ]);
-
     // Activation log marks the slug `page_missing` (not `injected`) so a
     // stale Qdrant / edge-index entry pointing at a vanished page is
     // visible in telemetry instead of masquerading as a successful inject.
@@ -1042,7 +974,7 @@ describe("injectMemoryV2Block", () => {
     );
   });
 
-  test("skills are first-seen once in everInjected but re-rendered every turn", async () => {
+  test("skills are re-rendered every turn", async () => {
     // Turn 1: skill ranks high, gets attached.
     const skillEntry = {
       id: "example-skill-a",
@@ -1065,8 +997,7 @@ describe("injectMemoryV2Block", () => {
 
     // Turn 2: same skill ranks top again. It is re-rendered into the block
     // (full top-K every turn — history is stripped, so the turn-1 attachment
-    // no longer persists). `toInject` is empty because it was first-seen on
-    // turn 1.
+    // no longer persists) and reported again in `toInject`.
     stageTurn([{ slug: "skills/example-skill-a", denseScore: 0.9 }]);
     stageSkills([skillEntry]);
     const result2 = await injectMemoryV2Block({
@@ -1080,14 +1011,9 @@ describe("injectMemoryV2Block", () => {
       messageId: "msg-2",
       config: makeConfig(),
     });
-    expect(result2.toInject).toEqual([]);
+    expect(result2.toInject).toEqual(["skills/example-skill-a"]);
     expect(result2.block).not.toBeNull();
     expect(result2.block).toContain("### Skills You Can Use");
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "skills/example-skill-a", turn: 1 },
-    ]);
   });
 
   test("skill slugs whose entry is missing from the cache are dropped silently", async () => {
@@ -1110,16 +1036,11 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    // The skill is excluded from `toInject` (and `everInjected`) so future
-    // per-turn runs re-attempt the attach once the cache is populated.
-    // `block` collapses to null because the only candidate was a cache miss.
+    // The skill is excluded from `toInject` so the slug isn't reported as
+    // injected. `block` collapses to null because the only candidate was a
+    // cache miss.
     expect(result.toInject).toEqual([]);
     expect(result.block).toBeNull();
-
-    // Persisted `everInjected` must not record the missing skill — that
-    // would block retry on a later turn until compaction-driven eviction.
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([]);
   });
 
   test("returns null when both concept pages and skills are empty", async () => {
@@ -1238,12 +1159,9 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.toInject).toEqual([]);
     expect(result.block).toBeNull();
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([]);
   });
 
-  test("cli-commands are first-seen once in everInjected but re-rendered every turn", async () => {
+  test("cli-commands are re-rendered every turn", async () => {
     const entry = {
       id: "config",
       description: "Manage configuration",
@@ -1274,18 +1192,13 @@ describe("injectMemoryV2Block", () => {
       messageId: "msg-2",
       config: makeConfig(),
     });
-    // Re-rendered into the block every turn; toInject empty (first-seen turn 1).
-    expect(result2.toInject).toEqual([]);
+    // Re-rendered into the block every turn and reported in toInject.
+    expect(result2.toInject).toEqual(["cli-commands/config"]);
     expect(result2.block).not.toBeNull();
     expect(result2.block).toContain("### CLI Commands You Can Use");
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "cli-commands/config", turn: 1 },
-    ]);
   });
 
-  test("context-load mode renders topNow even when every slug was previously injected", async () => {
+  test("context-load mode re-renders the full top-K across turns", async () => {
     // Turn 1 (per-turn): seed alice as injected.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
@@ -1301,9 +1214,9 @@ describe("injectMemoryV2Block", () => {
     });
 
     // Subsequent context-load (post-compaction or fresh load): alice is
-    // back in the candidate pool. Per-turn would dedup against everInjected
-    // and produce a null block; context-load must re-render the full top-K
-    // because cached attachments don't exist on a fresh load.
+    // back in the candidate pool and is re-rendered. We render the full
+    // top-K every turn regardless of mode, so context-load behaves like
+    // per-turn here.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     const result = await injectMemoryV2Block({
       database: db,
@@ -1320,22 +1233,12 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.block).not.toBeNull();
     expect(result.block).toContain("# memory/concepts/alice-vscode.md");
-    // No newly-injected slug — alice was already in everInjected.
-    expect(result.toInject).toEqual([]);
-
-    // everInjected stays a single entry (alice was already there) — context-
-    // load doesn't double-stamp.
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 1 },
-    ]);
+    expect(result.toInject).toEqual(["alice-vscode"]);
   });
 
   test("context-load mode renders the full top-K on a fresh first turn", async () => {
-    // Turn 1 with no prior state and three candidates. Per-turn and context-
-    // load behave identically when everInjected is empty (toInject == topNow),
-    // but this asserts the contract: a fresh first user message gets the
-    // entire top-K rendered, not just a delta.
+    // Turn 1 with no prior state and three candidates. This asserts the
+    // contract: a fresh first user message gets the entire top-K rendered.
     stageTurn([
       { slug: "alice-vscode", denseScore: 0.9 },
       { slug: "bob-coffee", denseScore: 0.8 },
@@ -1365,14 +1268,6 @@ describe("injectMemoryV2Block", () => {
       new Set(["alice-vscode", "bob-coffee", "carol-jazz"]),
     );
     expect(result.toInject).toHaveLength(3);
-
-    // All three slugs persisted to everInjected so the next per-turn doesn't
-    // re-attach the same content.
-    const persisted = await hydrate(db, "conv-1");
-    expect(new Set(persisted!.everInjected.map((e) => e.slug))).toEqual(
-      new Set(["alice-vscode", "bob-coffee", "carol-jazz"]),
-    );
-    expect(persisted!.everInjected).toHaveLength(3);
   });
 
   // ---------------------------------------------------------------------------
@@ -1488,9 +1383,9 @@ describe("injectMemoryV2Block", () => {
   });
 
   test("context-load mode marks every rendered slug as `injected`, never `in_context`", async () => {
-    // Turn 1 (per-turn): seed alice as injected so the next turn's prior
-    // `everInjected` includes her — the same setup the per-turn telemetry
-    // test uses, so the difference between modes is unambiguous.
+    // Turn 1 (per-turn): seed alice so she carries forward into the next
+    // turn's candidate pool — the same setup the per-turn telemetry test
+    // uses, so the difference between modes is unambiguous.
     stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
     await injectMemoryV2Block({
       database: db,
@@ -1510,8 +1405,7 @@ describe("injectMemoryV2Block", () => {
     // Both end up in `topNow` (and therefore in `slugsToRender` since
     // context-load renders the full top-K). The status field must reflect
     // that they were physically rendered into the new user message on this
-    // turn — `injected` for both — rather than reading `in_context` for
-    // alice based on stale prior `everInjected` state.
+    // turn — `injected` for both — never the legacy `in_context` status.
     stageTurn([
       { slug: "alice-vscode", denseScore: 0.6 },
       { slug: "carol-jazz", denseScore: 0.95 },
@@ -1537,9 +1431,9 @@ describe("injectMemoryV2Block", () => {
     expect(row.mode).toBe("context-load");
 
     const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
-    // Both rendered slugs read as `injected` — alice especially, even though
-    // she's in prior `everInjected`, because context-load actually rendered
-    // her into the fresh user message on this turn.
+    // Both rendered slugs read as `injected` — alice especially, since
+    // context-load actually rendered her into the fresh user message on this
+    // turn rather than assuming she persists from a prior turn.
     expect(byslug.get("alice-vscode")!.status).toBe("injected");
     expect(byslug.get("carol-jazz")!.status).toBe("injected");
 
@@ -1623,16 +1517,11 @@ describe("injectMemoryV2Block", () => {
     });
 
     // No row captured (the throw aborted the push), but the caller still
-    // produced a regular block + toInject result and persisted state.
+    // produced a regular block + toInject result.
     expect(telemetryState.recordCalls.length).toBe(0);
     expect(result.toInject).toEqual(["alice-vscode"]);
     expect(result.block).not.toBeNull();
     expect(result.block).toContain("# memory/concepts/alice-vscode.md");
-
-    const persisted = await hydrate(db, "conv-1");
-    expect(persisted!.everInjected).toEqual([
-      { slug: "alice-vscode", turn: 1 },
-    ]);
   });
 
   // ---------------------------------------------------------------------------
@@ -1685,16 +1574,10 @@ describe("injectMemoryV2Block", () => {
     expect(byslug.get("alice-vscode")!.status).toBe("corrupt");
     expect(byslug.get("carol-jazz")!.status).toBe("injected");
 
-    // (c) Both slugs land in `toInject` and `everInjected` — same handling
-    // as `page_missing` (see the phantom-slug test): the slug was attempted
-    // this turn, telemetry records the outcome, and we don't keep re-trying
-    // a stale Qdrant / edge-index entry on every subsequent turn.
+    // (c) Both slugs land in `toInject` — same handling as `page_missing`
+    // (see the phantom-slug test): the slug was attempted this turn and
+    // telemetry records the outcome.
     expect(new Set(result.toInject)).toEqual(
-      new Set(["alice-vscode", "carol-jazz"]),
-    );
-    const persisted = await hydrate(db, "conv-1");
-    const everInjectedSlugs = persisted!.everInjected.map((e) => e.slug);
-    expect(new Set(everInjectedSlugs)).toEqual(
       new Set(["alice-vscode", "carol-jazz"]),
     );
   });
@@ -1823,7 +1706,7 @@ describe("injectMemoryV2Block", () => {
   // ---------------------------------------------------------------------------
 
   describe("router mode", () => {
-    test("flag-on: router-selected slugs render and append to everInjected", async () => {
+    test("flag-on: router-selected slugs render and report in toInject", async () => {
       // Router picks alice. The activation pipeline never runs — we don't
       // stage any qdrant responses here, and that's intentional. The
       // candidate set comes straight from the router's `selectedSlugs`.
@@ -1850,9 +1733,6 @@ describe("injectMemoryV2Block", () => {
       expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
       const persisted = await hydrate(db, "conv-router-1");
-      expect(persisted!.everInjected).toEqual([
-        { slug: "alice-vscode", turn: 1 },
-      ]);
       // Router mode persists an empty sparse activation map — the router
       // does not compute spreading-activation scores.
       expect(persisted!.state).toEqual({});
@@ -1906,7 +1786,6 @@ describe("injectMemoryV2Block", () => {
       expect(persisted!.currentTurn).toBe(3);
       expect(persisted!.messageId).toBe("msg-fail");
       expect(persisted!.state).toEqual({});
-      expect(persisted!.everInjected).toEqual([]);
 
       // Single telemetry row with `mode: "errored"` (not `"router"`).
       expect(telemetryState.recordCalls.length).toBe(1);
@@ -1992,10 +1871,9 @@ describe("injectMemoryV2Block", () => {
       expect(result.block).toBeNull();
       expect(result.toInject).toEqual([]);
 
-      // No prior everInjected to dedup against, so toInject is empty and
-      // nothing renders. State still advanced.
+      // Router abstained, so toInject is empty and nothing renders. State
+      // still advanced.
       const persisted = await hydrate(db, "conv-router-abstain");
-      expect(persisted!.everInjected).toEqual([]);
       expect(persisted!.currentTurn).toBe(1);
 
       // Telemetry: `mode: "router"` row with zero injected pages.
@@ -2011,7 +1889,7 @@ describe("injectMemoryV2Block", () => {
       expect(injectedCount).toBe(0);
     });
 
-    test("flag-on: router-selected slug whose page is missing on disk records `page_missing` and is NOT added to everInjected", async () => {
+    test("flag-on: router-selected slug whose page is missing on disk records `page_missing`", async () => {
       routerState.nextResult = {
         selectedSlugs: ["phantom-router-slug"],
         failureReason: null,
@@ -2029,19 +1907,10 @@ describe("injectMemoryV2Block", () => {
 
       // No backing page → block collapses to null.
       expect(result.block).toBeNull();
-      // toInject mirrors `newlyInjected` from `finalizeInjection` — the
-      // missing slug still flowed through `slugsToRender` so it's recorded
-      // here (matching the activation-mode phantom-slug contract).
+      // The missing slug still flowed through `slugsToRender`, so it's
+      // reported in `toInject` (matching the activation-mode phantom-slug
+      // contract); the render simply drops it.
       expect(result.toInject).toEqual(["phantom-router-slug"]);
-
-      // Activation-mode parity: the phantom slug DOES land in everInjected
-      // so we don't infinite-retry it. (This matches the behavior the
-      // existing `returns null block when toInject slugs all reference
-      // missing pages` test asserts for activation mode.)
-      const persisted = await hydrate(db, "conv-router-missing");
-      expect(persisted!.everInjected).toEqual([
-        { slug: "phantom-router-slug", turn: 1 },
-      ]);
 
       // Telemetry: `status: "page_missing"` for the phantom slug.
       expect(telemetryState.recordCalls.length).toBe(1);
@@ -2058,7 +1927,7 @@ describe("injectMemoryV2Block", () => {
       expect(phantom!.source).toBe("tier3:0");
     });
 
-    test("flag-on: router re-picking a prior-everInjected slug re-renders it; everInjected gains only first-seen slugs", async () => {
+    test("flag-on: router re-picking an already-rendered slug re-renders it", async () => {
       // Turn 1: router picks alice. Standard append.
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode"],
@@ -2079,8 +1948,8 @@ describe("injectMemoryV2Block", () => {
 
       // Turn 2: router re-picks alice (the "re-anchor" prompt branch) AND
       // adds bob. Both are rendered into the block — history is stripped every
-      // turn, so there is no prior attachment to collide with. `toInject`
-      // reports only bob (alice was already first-seen on turn 1).
+      // turn, so there is no prior attachment to collide with — and both are
+      // reported in `toInject`.
       telemetryState.recordCalls.length = 0;
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode", "bob-coffee"],
@@ -2098,73 +1967,13 @@ describe("injectMemoryV2Block", () => {
         config: makeConfig({ router: { enabled: true } }),
       });
 
-      // Re-picked alice is re-rendered; bob is freshly injected.
-      expect(turn2.toInject).toEqual(["bob-coffee"]);
+      // Both re-picked alice and freshly-picked bob are rendered and reported.
+      expect(turn2.toInject).toEqual(["alice-vscode", "bob-coffee"]);
       expect(turn2.block).not.toBeNull();
       expect(turn2.block).toContain("# memory/concepts/bob-coffee.md");
       expect(turn2.block).toContain("Bob takes his coffee");
       expect(turn2.block).toContain("# memory/concepts/alice-vscode.md");
       expect(turn2.block).toContain("VS Code");
-
-      // everInjected only gained bob — alice was already there (first-seen ledger).
-      const persisted = await hydrate(db, "conv-router-dedup");
-      expect(persisted!.everInjected).toEqual([
-        { slug: "alice-vscode", turn: 1 },
-        { slug: "bob-coffee", turn: 2 },
-      ]);
-    });
-
-    test("flag-on: telemetry distinguishes `source: router` (router picks) from `source: carry_over` (prior-everInjected slugs the router did not re-pick)", async () => {
-      // Turn 1: seed everInjected with alice.
-      routerState.nextResult = {
-        selectedSlugs: ["alice-vscode"],
-        failureReason: null,
-      };
-      await injectMemoryV2Block({
-        database: db,
-        conversationId: "conv-router-source",
-        currentTurn: 1,
-        recentTurnPairs: [{ assistantMessage: "", userMessage: "Alice" }],
-        nowText: "Now",
-        messageId: "msg-1",
-        config: makeConfig({ router: { enabled: true } }),
-      });
-      telemetryState.recordCalls.length = 0;
-
-      // Turn 2: router picks bob only. alice is still in everInjected but
-      // not re-picked — her telemetry row must read `source: carry_over`,
-      // not `source: router`.
-      routerState.nextResult = {
-        selectedSlugs: ["bob-coffee"],
-        failureReason: null,
-      };
-      await injectMemoryV2Block({
-        database: db,
-        conversationId: "conv-router-source",
-        currentTurn: 2,
-        recentTurnPairs: [{ assistantMessage: "", userMessage: "Bob" }],
-        nowText: "Now",
-        messageId: "msg-2",
-        config: makeConfig({ router: { enabled: true } }),
-      });
-
-      expect(telemetryState.recordCalls.length).toBe(1);
-      const row = telemetryState.recordCalls[0] as {
-        mode: string;
-        concepts: Array<{ slug: string; source: string; status: string }>;
-      };
-      expect(row.mode).toBe("router");
-      const aliceRow = row.concepts.find((c) => c.slug === "alice-vscode");
-      const bobRow = row.concepts.find((c) => c.slug === "bob-coffee");
-      expect(aliceRow).toBeDefined();
-      expect(bobRow).toBeDefined();
-      expect(aliceRow!.source).toBe("carry_over");
-      // The router did not re-pick alice this turn, so she is not rendered —
-      // `not_injected`. (History is stripped, so an un-re-picked slug genuinely
-      // drops from context; there is no `in_context` carry-over anymore.)
-      expect(aliceRow!.status).toBe("not_injected");
-      expect(bobRow!.source).toBe("tier3:0");
-      expect(bobRow!.status).toBe("injected");
     });
 
     test("flag-off (default): activation pipeline still runs unchanged", async () => {
@@ -2201,14 +2010,12 @@ describe("injectMemoryV2Block", () => {
       expect(row.mode).toBe("per-turn");
     });
 
-    test("flag-on + mode='context-load': router runs (everInjected was cleared by onCompacted so dedupe is a no-op; abstention is accepted as the trade-off)", async () => {
+    test("flag-on + mode='context-load': router runs and renders its picks", async () => {
       // Context-load is the full top-K bootstrap fired after compaction or
-      // a fresh conversation reload. The earlier worry about the router's
-      // `everInjected` dedupe filtering out post-compaction restorations
-      // doesn't apply: `ConversationGraphMemory.onCompacted` calls
-      // `evictCompactedTurnsV2` which empties the list before this code
-      // runs. Router abstention here means no v2 pages this turn — that's
-      // preferable to letting the activation graph pick something arbitrary.
+      // a fresh conversation reload. The router runs the same way as on a
+      // per-turn injection — it picks the relevant pages and they are
+      // rendered. Router abstention here means no v2 pages this turn, which
+      // is preferable to letting the activation graph pick something arbitrary.
       routerState.nextResult = {
         selectedSlugs: ["alice-vscode"],
         failureReason: null,

--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -188,15 +188,18 @@ describe("renderRouterPrompt — content expectations", () => {
     expect(out).toContain("select_pages_to_inject");
   });
 
-  test("describes the already_injected_ids and now markers", () => {
+  test("describes the now marker and does not reference prior-turn picks", () => {
     const out = renderRouterPrompt({
       assistantName: "Aria",
       userName: "Alice",
       pageIndexBlock: SAMPLE_INDEX,
     });
 
-    expect(out).toContain("<already_injected_ids>");
     expect(out).toContain("<now>");
+    // The router is stateless about prior picks — it must not be told what it
+    // injected before (that signal drove memory drainage once history started
+    // being stripped every turn).
+    expect(out).not.toContain("<already_injected_ids>");
   });
 
   test("biases toward inclusion when in doubt", () => {

--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -248,7 +248,6 @@ const COMMON_PARAMS = {
     },
   ],
   nowText: "2026-05-10 14:00 PT",
-  priorEverInjected: [] as { slug: string; turn: number }[],
 };
 
 // ---------------------------------------------------------------------------
@@ -384,13 +383,12 @@ describe("runRouter — successful tool_use", () => {
     }
   });
 
-  test("user message has two text blocks: <now> and <last_turn>+already_injected", async () => {
+  test("user message has two text blocks: <now> and <last_turn>", async () => {
     providerStub = makeProvider(toolUseResponse([1]));
 
     await runRouter({
       workspaceDir,
       ...COMMON_PARAMS,
-      priorEverInjected: [{ slug: "alpha", turn: 1 }],
       config: makeConfig(),
     });
 
@@ -415,10 +413,8 @@ describe("runRouter — successful tool_use", () => {
     expect(blockA.text).toContain("</now>");
     expect(blockA.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
-    // Block B — already-injected IDs + last turn, NO cache_control.
+    // Block B — last turn, NO cache_control.
     expect(blockB.type).toBe("text");
-    expect(blockB.text).toContain("<already_injected_ids>");
-    expect(blockB.text).toContain("1"); // alpha → id 1
     expect(blockB.text).toContain("<last_turn>");
     expect(blockB.text).toContain("[user]: What's on my plate today?");
     expect(blockB.text).toContain("[assistant]: Let me check your plan.");
@@ -441,7 +437,6 @@ describe("runRouter — successful tool_use", () => {
         { assistantMessage: recentAssistant, userMessage: justArrived },
       ],
       nowText: "now",
-      priorEverInjected: [],
       // Budget: just enough room for the most-recent pair plus the old user
       // line in full, leaving a small slice for the very oldest assistant
       // (which should be front-truncated with the `…` marker).
@@ -486,7 +481,6 @@ describe("runRouter — successful tool_use", () => {
         { assistantMessage: huge, userMessage: "just arrived" },
       ],
       nowText: "now",
-      priorEverInjected: [],
       config: makeConfig(), // historical_pairs_max_chars: null
     });
 
@@ -713,39 +707,6 @@ describe("runRouter — batched (batch_size set)", () => {
     expect(new Set(result.selectedSlugs).size).toBe(
       result.selectedSlugs.length,
     );
-  });
-
-  test("priorEverInjected is filtered to the batch's own slugs as local IDs", async () => {
-    providerStub = makeProvider(toolUseResponse([1]));
-    await runRouter({
-      workspaceDir,
-      ...COMMON_PARAMS,
-      priorEverInjected: [
-        { slug: "alpha", turn: 1 },
-        { slug: "echo", turn: 1 },
-      ],
-      config: makeConfig({ batchSize: 2 }),
-    });
-
-    // Exactly the batches containing alpha or echo should mention any
-    // already_injected_id; other batches should have an empty list.
-    for (const call of providerCalls) {
-      const text =
-        (call.messages[0].content as Array<{ text?: string }>)[1]?.text ?? "";
-      const hasAlpha = call.systemPrompt?.includes("alpha");
-      const hasEcho = call.systemPrompt?.includes("echo");
-      const expectsId = hasAlpha || hasEcho;
-      // Block contents: "<already_injected_ids>\n{ids}\n</already_injected_ids>"
-      const match = text.match(
-        /<already_injected_ids>\n([^\n]*)\n<\/already_injected_ids>/,
-      );
-      const idsStr = match?.[1] ?? "";
-      if (expectsId) {
-        expect(idsStr.trim().length).toBeGreaterThan(0);
-      } else {
-        expect(idsStr.trim()).toBe("");
-      }
-    }
   });
 
   test("partial failure: one batch fails, others succeed → union returned with success", async () => {

--- a/assistant/src/memory/v2/activation-store.ts
+++ b/assistant/src/memory/v2/activation-store.ts
@@ -5,7 +5,7 @@
 // One row per conversation. The row is hydrated on resume, mutated in-memory
 // across the turn, and written back at the end of the turn. Forking a
 // conversation copies the parent row so the child starts with the same
-// activation/everInjected snapshot.
+// activation snapshot.
 
 import { eq } from "drizzle-orm";
 
@@ -31,7 +31,6 @@ export async function hydrate(
   return ActivationStateSchema.parse({
     messageId: row.messageId,
     state: JSON.parse(row.stateJson),
-    everInjected: JSON.parse(row.everInjectedJson),
     currentTurn: row.currentTurn,
     updatedAt: row.updatedAt,
   });
@@ -47,14 +46,12 @@ export async function save(
   state: ActivationState,
 ): Promise<void> {
   const stateJson = JSON.stringify(state.state);
-  const everInjectedJson = JSON.stringify(state.everInjected);
   database
     .insert(activationState)
     .values({
       conversationId,
       messageId: state.messageId,
       stateJson,
-      everInjectedJson,
       currentTurn: state.currentTurn,
       updatedAt: state.updatedAt,
     })
@@ -63,7 +60,6 @@ export async function save(
       set: {
         messageId: state.messageId,
         stateJson,
-        everInjectedJson,
         currentTurn: state.currentTurn,
         updatedAt: state.updatedAt,
       },
@@ -74,10 +70,8 @@ export async function save(
 /**
  * Copy the parent conversation's activation row to a new conversation id.
  * No-op if the parent has no state (e.g. fork happened before any injection).
- *
- * The child row inherits everInjected as-is so previously-attached slugs are
- * not re-injected on the child's first turn — matching the v1 semantics where
- * a fork carries over all in-context memories.
+ * The child inherits the parent's activation map so its first turn starts from
+ * the same retrieval state.
  *
  * Synchronous so it can run inside the bun:sqlite transaction that wraps
  * `forkConversation()` — keeping the state copy atomic with the message and
@@ -101,7 +95,6 @@ export function forkActivationState(
       conversationId: newConversationId,
       messageId: row.messageId,
       stateJson: row.stateJson,
-      everInjectedJson: row.everInjectedJson,
       currentTurn: row.currentTurn,
       updatedAt: row.updatedAt,
     })
@@ -110,27 +103,9 @@ export function forkActivationState(
       set: {
         messageId: row.messageId,
         stateJson: row.stateJson,
-        everInjectedJson: row.everInjectedJson,
         currentTurn: row.currentTurn,
         updatedAt: row.updatedAt,
       },
     })
     .run();
-}
-
-/**
- * Clear all `everInjected` entries. Used after compaction: the cached
- * `<memory>` attachments those slugs lived on are gone, so future turns
- * should be free to re-inject them.
- *
- * Unconditionally empties the list rather than filtering by turn number.
- * `everInjected` is persisted on every turn while the in-memory tracker's
- * `currentTurn` is only snapshotted on graceful conversation dispose, so a
- * non-graceful shutdown (SIGKILL, crash) followed by a reload can leave
- * `everInjected` entries with `turn` values above the restored tracker's
- * `currentTurn`. A turn-bounded filter misses those stale entries and they
- * dedupe forever; a full clear is robust to that drift.
- */
-export function clearEverInjected(state: ActivationState): ActivationState {
-  return { ...state, everInjected: [] };
 }

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -43,7 +43,7 @@ import { hybridQueryConceptPages } from "./qdrant.js";
 import { rerankCandidates } from "./reranker.js";
 import { simBatch } from "./sim.js";
 import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
-import type { ActivationState, EverInjectedEntry } from "./types.js";
+import type { ActivationState } from "./types.js";
 
 /**
  * Sentinel passed to Qdrant when `config.memory.v2.ann_candidate_limit` is
@@ -506,33 +506,27 @@ function bfsPredecessorDistances(
 interface SelectInjectionsParams {
   /** Final activation map after spread. */
   A: ReadonlyMap<string, number>;
-  /** Slugs already attached to a prior user message (with their turn). */
-  priorEverInjected: readonly EverInjectedEntry[];
   /** Cap on the per-turn injection slate, e.g. `config.memory.v2.top_k`. */
   topK: number;
 }
 
 interface SelectInjectionsResult {
-  /** Top-K slugs by activation (descending), used for the cached top-now view. */
+  /** Top-K slugs by activation (descending) — the set to render this turn. */
   topNow: string[];
-  /**
-   * Slugs in `topNow` that have not yet been attached to any prior user
-   * message — the new injections to render on the current user message.
-   */
-  toInject: string[];
 }
 
 /**
  * Pick the top-K slugs by activation (descending; stable on ties via slug
- * lexicographic order) and subtract slugs already in `priorEverInjected` to
- * yield the per-turn injection delta. Empty activation map → empty results.
+ * lexicographic order). This is the full set rendered each turn — history is
+ * stripped every turn, so there is no prior attachment to subtract against.
+ * Empty activation map → empty result.
  */
 export function selectInjections(
   params: SelectInjectionsParams,
 ): SelectInjectionsResult {
-  const { A, priorEverInjected, topK } = params;
+  const { A, topK } = params;
   if (A.size === 0 || topK <= 0) {
-    return { topNow: [], toInject: [] };
+    return { topNow: [] };
   }
 
   const ranked = [...A.entries()].sort(([slugA, valA], [slugB, valB]) => {
@@ -541,8 +535,5 @@ export function selectInjections(
   });
 
   const topNow = ranked.slice(0, topK).map(([slug]) => slug);
-  const everSet = new Set(priorEverInjected.map((entry) => entry.slug));
-  const toInject = topNow.filter((slug) => !everSet.has(slug));
-
-  return { topNow, toInject };
+  return { topNow };
 }

--- a/assistant/src/memory/v2/backfill-jobs.ts
+++ b/assistant/src/memory/v2/backfill-jobs.ts
@@ -252,7 +252,6 @@ async function recomputeForConversation(
   return {
     messageId: priorState.messageId,
     state: sparseState,
-    everInjected: priorState.everInjected,
     currentTurn: priorState.currentTurn,
     updatedAt: Date.now(),
   };

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -44,7 +44,7 @@ import { recordInjectionEvents } from "./injection-events.js";
 import { readPage, renderPageContent } from "./page-store.js";
 import { type RouterTurnPair, runRouter } from "./router.js";
 import { getSkillCapability, isSkillSlug } from "./skill-store.js";
-import type { ActivationState, EverInjectedEntry } from "./types.js";
+import type { ActivationState } from "./types.js";
 
 const log = getLogger("memory-v2-injection");
 
@@ -76,7 +76,7 @@ export interface InjectMemoryV2BlockParams {
   database: DrizzleDb;
   /** Conversation key for hydrate/save. */
   conversationId: string;
-  /** Caller-tracked turn number, persisted with each new everInjected entry. */
+  /** Caller-tracked turn number, persisted on the activation_state row. */
   currentTurn: number;
   /**
    * Recent assistant/user turn pairs, oldest first. Must contain at least
@@ -110,12 +110,12 @@ export interface InjectMemoryV2BlockResult {
    */
   block: string | null;
   /**
-   * Slugs we attempted to attach this turn (top-K minus everInjected).
-   * Always populated even when `block` is `null` — phantom slugs whose
-   * backing page is missing on disk land here and are recorded in
-   * `everInjected` so we don't infinite-retry next turn. Callers using
-   * this for "we injected N slugs" telemetry should cross-reference
-   * `block !== null` (or the activation log's `page_missing` status).
+   * Slugs we attempted to render this turn — the full top-K, minus synthetic
+   * slugs (skills, CLI commands) whose backing capability cache entry is
+   * missing. Always populated even when `block` is `null` (e.g. phantom slugs
+   * whose backing page is missing on disk still land here). Callers using this
+   * for "we injected N slugs" telemetry should cross-reference `block !== null`
+   * (or the activation log's `page_missing` status).
    */
   toInject: string[];
 }
@@ -169,10 +169,7 @@ export async function injectMemoryV2Block(
   // remains the default (flag-off) behavior — every code path past this
   // branch only runs when the router is disabled.
   //
-  // Runs on both `per-turn` and `context-load`. The `everInjected` dedupe
-  // concern from earlier doesn't apply post-compaction because
-  // `evictCompactedTurnsV2` in `ConversationGraphMemory.onCompacted`
-  // empties the list before this code runs. Router abstention on
+  // Runs on both `per-turn` and `context-load`. Router abstention on
   // context-load means no v2 pages restored that turn, which is preferable
   // to letting the activation graph pick something arbitrary.
   if (config.memory.v2.router.enabled) {
@@ -185,7 +182,6 @@ export async function injectMemoryV2Block(
       nowText,
       messageId,
       config,
-      priorState,
       signal,
     });
   }
@@ -234,11 +230,8 @@ export async function injectMemoryV2Block(
   // prior cached attachment to dedup against. Rendering the full top-K each
   // turn keeps the currently-relevant memory present (tracking live
   // activation) and bounds total context to top-K instead of accumulating.
-  const priorEverInjected: readonly EverInjectedEntry[] =
-    priorState?.everInjected ?? [];
   const { topNow } = selectInjections({
     A: finalActivation,
-    priorEverInjected,
     topK: top_k,
   });
   const slugsToRender = topNow;
@@ -285,7 +278,6 @@ export async function injectMemoryV2Block(
     mode,
     currentTurn,
     messageId,
-    priorEverInjected,
     slugsToRender,
     telemetryRows,
     config,
@@ -298,18 +290,16 @@ export async function injectMemoryV2Block(
  * router branch (PR 10) can reuse the same persistence + render +
  * telemetry-finalization pipeline. Performs:
  *
- *   1. Build `nextEverInjected` from `slugsToRender`, filtering out skill
- *      slugs whose capability cache entry is missing so future turns
- *      re-attempt attachment once the cache is populated.
+ *   1. Compute the rendered-slug set (`toInject`) from `slugsToRender`,
+ *      filtering out synthetic slugs whose capability cache entry is missing.
  *   2. Persist the next activation_state row.
  *   3. Render the injection block.
- *   4. Finalize per-row `status` (`injected | in_context | not_injected |
- *      page_missing | corrupt`) on the caller-provided telemetry rows
- *      using the render result.
+ *   4. Finalize per-row `status` (`injected | not_injected | page_missing |
+ *      corrupt`) on the caller-provided telemetry rows using the render result.
  *   5. Sort rows by `finalActivation` descending and flush the activation
  *      log — even when an error is thrown partway through, so silent
  *      failures remain observable.
- *   6. Return the rendered block plus `toInject = newlyInjected`.
+ *   6. Return the rendered block plus `toInject` (the rendered-slug set).
  *
  * The caller pre-builds `telemetryRows` with all per-candidate breakdown
  * fields filled in (router-mode callers can pass zeros where the
@@ -324,7 +314,6 @@ async function finalizeInjection(args: {
   mode: FinalizeInjectionMode;
   currentTurn: number;
   messageId: string;
-  priorEverInjected: readonly EverInjectedEntry[];
   slugsToRender: string[];
   telemetryRows: MemoryV2ConceptRowRecord[];
   config: AssistantConfig;
@@ -344,7 +333,6 @@ async function finalizeInjection(args: {
     conversationId,
     currentTurn,
     messageId,
-    priorEverInjected,
     slugsToRender,
     telemetryRows,
     config,
@@ -357,13 +345,13 @@ async function finalizeInjection(args: {
   // observable in the database.
   let mode: FinalizeInjectionMode = args.mode;
 
-  // Every rendered slug is freshly injected this turn: history is stripped
-  // (`stripAllMemoryInjections`) so nothing persists to dedup against, and we
-  // render the full top-K every turn. Synthetic slugs (skills, CLI commands)
-  // whose in-process cache entry is missing (e.g. startup race between the
-  // seed and the first turn, or stale Qdrant index pointing at an uninstalled
-  // skill / removed CLI command) are excluded — `renderInjectionBlock`
-  // silently drops them, so they aren't actually injected.
+  // We render the full top-K every turn; history is stripped
+  // (`stripAllMemoryInjections`) so nothing persists to dedup against.
+  // Synthetic slugs (skills, CLI commands) whose in-process cache entry is
+  // missing (e.g. startup race between the seed and the first turn, or a stale
+  // Qdrant index pointing at an uninstalled skill / removed CLI command) are
+  // excluded — `renderInjectionBlock` silently drops them, so they aren't
+  // actually injected.
   const missingSyntheticSlugs = new Set(
     slugsToRender.filter(
       (slug) =>
@@ -371,25 +359,15 @@ async function finalizeInjection(args: {
         (isCliCommandSlug(slug) && !getCliCommandCapability(slug)),
     ),
   );
-  // `everInjected` no longer gates *rendering* — we render the full top-K
-  // every turn (history is stripped, so nothing persists to dedup against).
-  // It is still recorded as a first-seen ledger for telemetry/history (the
-  // `toInject` return reports slugs injected for the first time this turn).
-  // Synthetic slugs whose cache entry is missing are excluded so future turns
-  // re-attempt the attach once the cache populates.
-  const everInjectedSet = new Set(priorEverInjected.map((entry) => entry.slug));
-  const newlyInjected = slugsToRender.filter(
-    (slug) => !everInjectedSet.has(slug) && !missingSyntheticSlugs.has(slug),
+  // `toInject` reports the slugs we actually attempted to render this turn —
+  // the full top-K minus the missing synthetic slugs above.
+  const toInject = slugsToRender.filter(
+    (slug) => !missingSyntheticSlugs.has(slug),
   );
-  const nextEverInjected: EverInjectedEntry[] = [
-    ...priorEverInjected,
-    ...newlyInjected.map((slug) => ({ slug, turn: currentTurn })),
-  ];
 
   const nextActivationState: ActivationState = {
     messageId,
     state: nextStateMap,
-    everInjected: nextEverInjected,
     currentTurn,
     updatedAt: Date.now(),
   };
@@ -492,7 +470,7 @@ async function finalizeInjection(args: {
   }
 
   if (caughtErr !== undefined && !args.bestEffort) throw caughtErr;
-  return { block, toInject: newlyInjected };
+  return { block, toInject };
 }
 
 /**
@@ -518,7 +496,6 @@ async function injectViaRouter(args: {
   nowText: string;
   messageId: string;
   config: AssistantConfig;
-  priorState: ActivationState | null;
   signal?: AbortSignal;
 }): Promise<InjectMemoryV2BlockResult> {
   const {
@@ -530,18 +507,13 @@ async function injectViaRouter(args: {
     nowText,
     messageId,
     config,
-    priorState,
     signal,
   } = args;
-
-  const priorEverInjected: readonly EverInjectedEntry[] =
-    priorState?.everInjected ?? [];
 
   const routerResult = await runRouter({
     workspaceDir,
     recentTurnPairs,
     nowText,
-    priorEverInjected,
     config,
     database,
     ...(signal ? { signal } : {}),
@@ -562,14 +534,13 @@ async function injectViaRouter(args: {
       "memory v2 router failure; skipping injection",
     );
     // Delegate the failure path to `finalizeInjection` with empty inputs
-    // and `mode: "errored"`. The helper persists a stub activation_state
-    // (preserving `priorEverInjected` so future turns still subtract
-    // previously-attached slugs) and writes the telemetry row through the
-    // same code path as the success branch — no inline duplication of
-    // `save` + `recordMemoryV2ActivationLog`. `bestEffort: true` matches
-    // the pre-refactor inline behavior of logging and continuing if the
-    // stub-state `save()` throws — we don't want a transient SQLite write
-    // to abort the turn on top of the router failure that already happened.
+    // and `mode: "errored"`. The helper persists a stub activation_state and
+    // writes the telemetry row through the same code path as the success
+    // branch — no inline duplication of `save` + `recordMemoryV2ActivationLog`.
+    // `bestEffort: true` matches the pre-refactor inline behavior of logging
+    // and continuing if the stub-state `save()` throws — we don't want a
+    // transient SQLite write to abort the turn on top of the router failure
+    // that already happened.
     return finalizeInjection({
       workspaceDir,
       database,
@@ -577,7 +548,6 @@ async function injectViaRouter(args: {
       mode: "errored",
       currentTurn,
       messageId,
-      priorEverInjected,
       slugsToRender: [],
       telemetryRows: [],
       config,
@@ -586,27 +556,18 @@ async function injectViaRouter(args: {
     });
   }
 
-  // Render every router-selected slug. There is no duplicate-content risk
-  // from re-picking already-injected pages: history is stripped every turn
-  // (`stripAllMemoryInjections`), so no prior cached attachment survives on an
-  // earlier user message to collide with. The router prompt invites re-picking
-  // pages "to re-anchor", and we now honor that by re-rendering them.
-  //
-  // Telemetry rows for prior-everInjected slugs the router did NOT re-pick are
-  // still emitted below, tagged `source: "carry_over"` (not `"router"`) so
-  // inspector queries can attribute selections correctly.
+  // Render every router-selected slug onto the current user message. History
+  // is stripped every turn (`stripAllMemoryInjections`), so the full selected
+  // set is rendered fresh each turn and total memory context stays bounded to
+  // the router's per-turn `max_page_ids` cap.
   const slugsToRender = routerResult.selectedSlugs;
 
-  // Build minimal telemetry rows for the union of router-selected slugs and
-  // prior `everInjected` slugs. Router-mode rows zero out every activation
-  // value (no spreading activation runs). Slugs the router picked carry
-  // their batch's tier tag from `routerResult.sourceBySlug` (e.g. `tier1`,
-  // `tier3:2`); prior-everInjected slugs the router did NOT re-pick get
-  // `source: "carry_over"`. The `status` placeholder is overwritten by
+  // Build minimal telemetry rows for the router-selected slugs. Router-mode
+  // rows zero out every activation value (no spreading activation runs); each
+  // slug carries its batch's tier tag from `routerResult.sourceBySlug` (e.g.
+  // `tier1`, `tier3:2`). The `status` placeholder is overwritten by
   // `finalizeInjection`.
-  const telemetrySlugs = new Set<string>(routerResult.selectedSlugs);
-  for (const entry of priorEverInjected) telemetrySlugs.add(entry.slug);
-  const telemetryRows: MemoryV2ConceptRowRecord[] = [...telemetrySlugs].map(
+  const telemetryRows: MemoryV2ConceptRowRecord[] = slugsToRender.map(
     (slug) => ({
       slug,
       finalActivation: 0,
@@ -619,7 +580,7 @@ async function injectViaRouter(args: {
       simAssistantRerankBoost: 0,
       inRerankPool: false,
       spreadContribution: 0,
-      source: routerResult.sourceBySlug.get(slug) ?? "carry_over",
+      source: routerResult.sourceBySlug.get(slug) ?? "router",
       status: "not_injected",
     }),
   );
@@ -631,7 +592,6 @@ async function injectViaRouter(args: {
     mode: "router",
     currentTurn,
     messageId,
-    priorEverInjected,
     slugsToRender,
     telemetryRows,
     config,

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -53,16 +53,15 @@ const PAGE_INDEX_PLACEHOLDER = "{{PAGE_INDEX}}";
  * with a `page_ids` array; the runtime parses the response via the tool
  * definition declared in the router job module.
  *
- * Recent message context and `<now>` / `<already_injected_ids>` blocks are
- * appended at the call site so we don't inadvertently expand `{{` inside
- * dynamic content.
+ * Recent message context and the `<now>` block are appended at the call site
+ * so we don't inadvertently expand `{{` inside dynamic content.
  *
  * Exported so the simulator route can return the bundled template verbatim
  * for the playground's "Load default" affordance.
  */
 export const ROUTER_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOLDER}. Your job is to route memory pages for the next assistant turn between ${ASSISTANT_NAME_PLACEHOLDER} and ${USER_NAME_PLACEHOLDER}.
 
-You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
+You will be shown the recent conversation, a \`<now>\` marker for the current time, and a \`# Concept Page Index\` listing every routable page on this workspace.
 
 Pick the concept pages whose contents would help ${ASSISTANT_NAME_PLACEHOLDER} respond well on this turn. Lean toward inclusion when in doubt — missing a relevant page is a worse error than surfacing a few unused ones, because the assistant can ignore extras but can't summon context that wasn't loaded. Abstain (return an empty list) only when nothing in the index plausibly bears on the turn.
 
@@ -72,7 +71,7 @@ Index format. Each line of the index has the shape:
 
 \`id\` is a small integer used to refer to this page. \`edges\` are numeric IDs into the same list, pointing at related pages; you may follow them when one page strongly implies another.
 
-Already-injected pages. Pages whose IDs appear in \`<already_injected_ids>\` were picked on the previous turn. Do not pick them again unless ${ASSISTANT_NAME_PLACEHOLDER} should re-anchor on that material — e.g., the topic genuinely returns after drifting away. Routine continuity does not require re-picking; the prior turn's pages are already in the assistant's working context.
+Re-picking. Pick every page that bears on this turn, including ones you picked on previous turns — each turn's selection is rendered fresh, so a page you leave out is no longer available to ${ASSISTANT_NAME_PLACEHOLDER}. Sustained-relevance pages must be re-picked every turn they stay relevant, not just when they first come up.
 
 Time. Bias toward pages that match the current state implied by \`<now>\` and the active conversational threads (what is happening today, what was just decided, who is being discussed). Stale pages with no bearing on the live conversation should be skipped even if their summaries look superficially relevant.
 

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -71,8 +71,6 @@ Index format. Each line of the index has the shape:
 
 \`id\` is a small integer used to refer to this page. \`edges\` are numeric IDs into the same list, pointing at related pages; you may follow them when one page strongly implies another.
 
-Re-picking. Pick every page that bears on this turn, including ones you picked on previous turns — each turn's selection is rendered fresh, so a page you leave out is no longer available to ${ASSISTANT_NAME_PLACEHOLDER}. Sustained-relevance pages must be re-picked every turn they stay relevant, not just when they first come up.
-
 Time. Bias toward pages that match the current state implied by \`<now>\` and the active conversational threads (what is happening today, what was just decided, who is being discussed). Stale pages with no bearing on the live conversation should be skipped even if their summaries look superficially relevant.
 
 Emit your selection by calling \`select_pages_to_inject\` with the chosen \`page_ids\`. Return an empty array to abstain.

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -59,7 +59,6 @@ import {
   splitTier2,
 } from "./page-index.js";
 import { resolveRouterPrompt } from "./prompts/router.js";
-import type { EverInjectedEntry } from "./types.js";
 
 const log = getLogger("memory-v2-router");
 
@@ -184,8 +183,6 @@ interface RunRouterParams {
   recentTurnPairs: readonly RouterTurnPair[];
   /** Verbatim contents to inject into `<now>...</now>` on this turn. */
   nowText: string;
-  /** Slugs already injected on prior turns (used to seed `<already_injected_ids>`). */
-  priorEverInjected: readonly EverInjectedEntry[];
   config: AssistantConfig;
   signal?: AbortSignal;
   /**
@@ -245,7 +242,7 @@ interface RunRouterParams {
 export async function runRouter(
   params: RunRouterParams,
 ): Promise<RouterResult> {
-  const { workspaceDir, priorEverInjected, config } = params;
+  const { workspaceDir, config } = params;
 
   const pageIndex = await getPageIndex(workspaceDir);
   if (pageIndex.entries.length === 0) {
@@ -306,7 +303,6 @@ export async function runRouter(
       runRouterBatch({
         ...params,
         batchIndex: index,
-        priorEverInjected,
         provider,
       }),
     ),
@@ -373,10 +369,10 @@ interface RunRouterBatchParams extends RunRouterParams {
 }
 
 /**
- * Route one batch of the page index. Uses batch-local IDs everywhere
- * (including `<already_injected_ids>`, which is filtered to slugs present
- * in this batch). Provider is passed in by the orchestrator so we don't
- * re-resolve it N times for an N-batch turn.
+ * Route one batch of the page index. Uses batch-local IDs throughout — the
+ * model in batch B can only reference page IDs present in its own prompt.
+ * Provider is passed in by the orchestrator so we don't re-resolve it N times
+ * for an N-batch turn.
  */
 async function runRouterBatch(
   params: RunRouterBatchParams,
@@ -385,7 +381,6 @@ async function runRouterBatch(
     workspaceDir,
     recentTurnPairs,
     nowText,
-    priorEverInjected,
     config,
     signal,
     batchIndex,
@@ -402,15 +397,6 @@ async function runRouterBatch(
     },
     params.routerPromptOverride ?? null,
   );
-
-  // Filter prior-injected to slugs present in THIS batch and map to
-  // batch-local IDs. The model in batch B can't reference global IDs that
-  // aren't in its prompt, so listing them would just be noise.
-  const priorIds: number[] = [];
-  for (const entry of priorEverInjected) {
-    const local = batchIndex.bySlug.get(entry.slug);
-    if (local) priorIds.push(local.id);
-  }
 
   // Trim the pairs down to the configured `<last_turn>` content budget,
   // newest-message-first so the just-arrived user turn keeps full claim
@@ -441,9 +427,7 @@ async function runRouterBatch(
       cachedTextBlock(`<now>\n${nowText}\n</now>`),
       {
         type: "text",
-        text:
-          `<already_injected_ids>\n${priorIds.join(", ")}\n</already_injected_ids>\n\n` +
-          lastTurnBlock,
+        text: lastTurnBlock,
       },
     ],
   };

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -66,29 +66,14 @@ export type ConceptPage = z.infer<typeof ConceptPageSchema>;
 // ---------------------------------------------------------------------------
 
 /**
- * One entry in the per-conversation `everInjected` list. Tracks which
- * concept-page slug was injected on which turn so compaction can selectively
- * evict slugs whose attachments lived on compacted turns.
- */
-export const EverInjectedEntrySchema = z.object({
-  slug: z.string(),
-  turn: z.number().int().nonnegative(),
-});
-
-export type EverInjectedEntry = z.infer<typeof EverInjectedEntrySchema>;
-
-/**
  * Snapshot of memory v2 retrieval state for a single conversation.
  *
  * `state` is a sparse map of slug → activation in [0, 1]; only slugs above
- * `epsilon` are persisted. `everInjected` is the running list of slugs the
- * assistant has already attached to a user message, used to make injection
- * append-only and cache-stable.
+ * `epsilon` are persisted.
  */
 export const ActivationStateSchema = z.object({
   messageId: z.string(),
   state: z.record(z.string(), z.number()),
-  everInjected: z.array(EverInjectedEntrySchema),
   currentTurn: z.number().int().nonnegative(),
   updatedAt: z.number().int().nonnegative(),
 });

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -516,7 +516,6 @@ export async function handleSimulateRouter({
     workspaceDir,
     recentTurnPairs,
     nowText,
-    priorEverInjected: [],
     config: mergedConfig,
     database: getDb(),
     ...(profileOverride !== undefined


### PR DESCRIPTION
## Summary

The strip + tail-only-rehydrate + no-suppress stack (#31850 / #31927 / #31929) fixed memory drainage on the **non-router** activation path. But the LLM router is **enabled by default**, and the drainage is still live there — driven by the router *prompt*, which #31929 left untouched.

The router prompt told the model that already-injected pages were *"already in the assistant's working context"* and not to re-pick them, seeded from the full append-only `everInjected` ledger via an `<already_injected_ids>` block. Since memory is now stripped from history every turn, that premise is **false**: an un-re-picked page is gone. So the router abstains from re-picking sustained-relevance pages and they drain out of context — the exact bug #31929 fixed for the other path.

This PR:
- Removes the `<already_injected_ids>` block and the false-premise instruction from the router prompt; replaces it with a positive *"re-pick sustained-relevance pages every turn"* instruction. The router now re-selects the full relevant set each turn, mirroring the non-router behavior.
- Removes the now-vestigial `everInjected` ledger end-to-end: `ActivationState` field + schema, store `hydrate`/`save`/`fork`, `clearEverInjected`, `selectInjections` param, backfill carry-forward, and the `onCompacted` clear. `injectMemoryV2Block`'s `toInject` now reports the full rendered set each turn.
- Leaves the physical `ever_injected_json` column in place (unmapped in Drizzle, `NOT NULL DEFAULT '[]'`) to avoid a table-rewrite migration.

## Evidence (Velissa, conv `130c7200…`, read-only)
- 21/21 turns ran in `router` mode (router is default-on; no override).
- Turn 21: **648 suppressed vs 10 actually injected**; injected-count decaying turn over turn (51 → 35 → 21 → 16 → **10**).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `injection` / `activation` / `activation-store` / `router` / `backfill-jobs` / `conversation-graph-memory-v2-routing` / `conversation-fork-crud` / `db-activation-state` / `injection-events` / `memory-retrieval-pipeline` tests pass (run individually; combined runs hit a pre-existing worktree mock-ordering artifact)
- [x] lint clean
- [ ] **Rebuild Velissa on this branch and confirm injected-count holds steady across turns** (the end-to-end behavioral check; can't be done statically)

Stacked on `do/strip-memory-and-shift-anchors` (#31850), same base as #31927/#31929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)