### PR TITLE
fix(web): fix unused variable lint error in DomainVerificationChip

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -863,7 +863,7 @@ const EMAIL_BYO_PROVIDERS: readonly EmailByoProvider[] = [
 
 function DomainVerificationChip({
   status,
-  message,
+  message: _message,
   isLoading,
 }: {
   status: string | undefined;


### PR DESCRIPTION
## Summary
- Prefix the unused `message` destructured param with `_` in `DomainVerificationChip` to fix the `@typescript-eslint/no-unused-vars` lint error that broke CI.

## Original prompt
CI was failing on main due to a lint error: the `message` parameter in the `DomainVerificationChip` component was defined but never used. The fix prefixes it with `_` via destructuring rename to satisfy the `no-unused-vars` rule.