### PR TITLE
fix(web): show inline error in adjust plan modal when tier change fails

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -659,6 +659,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
                                 />
+                                {(changeMachineTierMutation.isError || changeStorageTierMutation.isError) && (
+                                  <Notice tone="error">
+                                    {extractMutationError(
+                                      changeMachineTierMutation.error ?? changeStorageTierMutation.error,
+                                      "Failed to update plan. Please try again.",
+                                    )}
+                                  </Notice>
+                                )}
                                 <Button
                                   variant="primary"
                                   className="w-full"


### PR DESCRIPTION
## Summary
- When the `change-machine-tier` or `change-storage-tier` API call fails, show an inline error notice above the "Update Plan" button instead of only relying on a toast (which is easy to miss inside an open modal).

## Test plan
- [ ] Open Manage → pick a tier → click Update Plan with a condition that causes failure → verify red error banner appears above the button
- [ ] Verify the error message uses the server response when available, falls back to generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)