### PR TITLE
fix(assistant): wire domain status CLI to live verification endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7412,6 +7412,15 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/domain/verification-status:
+    post:
+      operationId: domain_verificationstatus_post
+      summary: Get live DNS verification status for a domain
+      tags:
+        - domain
+      responses:
+        "200":
+          description: Successful response
   /v1/email/attachment-get:
     get:
       operationId: email_attachmentget_get

--- a/assistant/src/cli/commands/domain.ts
+++ b/assistant/src/cli/commands/domain.ts
@@ -40,7 +40,7 @@ Examples:
   $ assistant domain register velly
   $ assistant domain register velly --email-username hello
   $ assistant domain register --json
-  $ assistant domain status`,
+  $ assistant domain status velly`,
       );
 
       domain
@@ -139,25 +139,30 @@ Examples:
         );
 
       domain
-        .command("status")
-        .description("Show this assistant's domain registration and health")
+        .command("status <subdomain>")
+        .description(
+          "Show registration and DNS verification status for a subdomain",
+        )
         .addHelpText(
           "after",
           `
-Shows the domain currently registered for this assistant, including
-live DNS verification status from the email provider.
+Arguments:
+  subdomain   The subdomain to check (e.g. "velly").
+
+Shows the domain's registration details and live DNS verification
+status from the email provider.
 
 Examples:
-  $ assistant domain status
+  $ assistant domain status velly
   Domain:       velly.${baseDomain}
   Verification: verified
                 DNS records have been verified. Your domain is ready to send and receive email.
   Created:      2026-04-15
 
-  $ assistant domain status --json
+  $ assistant domain status velly --json
   {"domain":{"subdomain":"velly","id":"..."},"verification":{"status":"verified","message":"..."}}`,
         )
-        .action(async (_opts: unknown, cmd: Command) => {
+        .action(async (subdomain: string, _opts: unknown, cmd: Command) => {
           const r = await cliIpcCall<{
             results: {
               id: string;
@@ -176,19 +181,22 @@ Examples:
 
           const data = r.result!;
           const domains = data.results ?? [];
+          const d = domains.find(
+            (entry) => entry.subdomain === subdomain,
+          );
 
-          if (domains.length === 0) {
+          if (!d) {
             if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, { domain: null, verification: null });
+              writeOutput(cmd, { error: `Domain "${subdomain}" not found` });
+              process.exitCode = 1;
             } else {
-              log.info(
-                "No domain registered for this assistant. Run: assistant domain register [subdomain]",
+              log.error(
+                `Domain "${subdomain}" is not registered for this assistant.`,
               );
+              process.exitCode = 1;
             }
             return;
           }
-
-          const d = domains[0]!;
 
           // Fetch live verification status
           const v = await cliIpcCall<{

--- a/assistant/src/cli/commands/domain.ts
+++ b/assistant/src/cli/commands/domain.ts
@@ -77,7 +77,7 @@ Examples:
   ✓ Registered my-assistant.${baseDomain}
 
   $ assistant domain register velly --json
-  {"domain":"velly.${baseDomain}","id":"...","status":"active","verified":true}`,
+  {"domain":"velly.${baseDomain}","id":"..."}`,
         )
         .action(
           async (
@@ -97,8 +97,6 @@ Examples:
               id: string;
               subdomain?: string;
               domain?: string;
-              status?: string;
-              verified?: boolean;
               created_at?: string;
               created?: string;
               email_error?: { detail: string; code: string };
@@ -136,11 +134,6 @@ Examples:
                   `⚠ Email registration failed: ${data.email_error.detail}`,
                 );
               }
-              if (data.verified === false) {
-                log.info(
-                  "  ⚠ Domain verification pending — this usually resolves within a few seconds.",
-                );
-              }
             }
           },
         );
@@ -152,17 +145,17 @@ Examples:
           "after",
           `
 Shows the domain currently registered for this assistant, including
-verification status and DNS health.
+live DNS verification status from the email provider.
 
 Examples:
   $ assistant domain status
-  Domain:   velly.${baseDomain}
-  Status:   active
-  Verified: yes
-  Created:  2026-04-15
+  Domain:       velly.${baseDomain}
+  Verification: verified
+                DNS records have been verified. Your domain is ready to send and receive email.
+  Created:      2026-04-15
 
   $ assistant domain status --json
-  {"domain":"velly.${baseDomain}","status":"active","verified":true,...}`,
+  {"domain":{"subdomain":"velly","id":"..."},"verification":{"status":"verified","message":"..."}}`,
         )
         .action(async (_opts: unknown, cmd: Command) => {
           const r = await cliIpcCall<{
@@ -170,8 +163,6 @@ Examples:
               id: string;
               subdomain?: string;
               domain?: string;
-              status?: string;
-              verified?: boolean;
               created_at?: string;
               created?: string;
             }[];
@@ -186,27 +177,47 @@ Examples:
           const data = r.result!;
           const domains = data.results ?? [];
 
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, data);
-          } else if (domains.length === 0) {
-            log.info(
-              "No domain registered for this assistant. Run: assistant domain register [subdomain]",
-            );
-          } else {
-            for (const d of domains) {
-              const displayDomain =
-                d.domain ??
-                (d.subdomain ? `${d.subdomain}.${apexDomain}` : "unknown");
-              const createdRaw = d.created_at ?? d.created;
-              const createdDate = createdRaw
-                ? createdRaw.split("T")[0]
-                : "unknown";
-              log.info(`Domain:   ${displayDomain}`);
-              if (d.status != null) log.info(`Status:   ${d.status}`);
-              if (d.verified != null)
-                log.info(`Verified: ${d.verified ? "yes" : "no"}`);
-              log.info(`Created:  ${createdDate}`);
+          if (domains.length === 0) {
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, { domain: null, verification: null });
+            } else {
+              log.info(
+                "No domain registered for this assistant. Run: assistant domain register [subdomain]",
+              );
             }
+            return;
+          }
+
+          const d = domains[0]!;
+
+          // Fetch live verification status
+          const v = await cliIpcCall<{
+            domain: string;
+            status: string;
+            message: string;
+          }>("domain_verification_status", {
+            body: { domain_id: d.id },
+          });
+
+          const verification = v.ok ? v.result : undefined;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, { domain: d, verification: verification ?? null });
+          } else {
+            const displayDomain =
+              d.domain ??
+              (d.subdomain ? `${d.subdomain}.${apexDomain}` : "unknown");
+            const createdRaw = d.created_at ?? d.created;
+            const createdDate = createdRaw
+              ? createdRaw.split("T")[0]
+              : "unknown";
+            log.info(`Domain:       ${displayDomain}`);
+            const vStatus = verification?.status ?? "unknown";
+            log.info(`Verification: ${vStatus}`);
+            if (verification?.message) {
+              log.info(`              ${verification.message}`);
+            }
+            log.info(`Created:      ${createdDate}`);
           }
         });
     },

--- a/assistant/src/runtime/routes/domain-routes.ts
+++ b/assistant/src/runtime/routes/domain-routes.ts
@@ -83,8 +83,6 @@ async function handleDomainRegister({ body = {} }: RouteHandlerArgs) {
     id: string;
     subdomain?: string;
     domain?: string;
-    status?: string;
-    verified?: boolean;
     created_at?: string;
     created?: string;
     email_error?: { detail: string; code: string };
@@ -130,8 +128,6 @@ async function handleDomainStatus(_args: RouteHandlerArgs) {
       id: string;
       subdomain?: string;
       domain?: string;
-      status?: string;
-      verified?: boolean;
       created_at?: string;
       created?: string;
     }[];
@@ -158,6 +154,39 @@ async function handleDomainStatus(_args: RouteHandlerArgs) {
   return data;
 }
 
+async function handleDomainVerificationStatus({
+  body = {},
+}: RouteHandlerArgs) {
+  const { domain_id } = body as { domain_id?: string };
+  if (!domain_id) {
+    throw new BadRequestError("domain_id is required");
+  }
+  const client = await requireClient();
+
+  const response = await client.fetch(
+    `/v1/assistants/${client.platformAssistantId}/domains/${domain_id}/verification-status/`,
+  );
+
+  if (!response.ok) {
+    const respBody = (await response.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const detail = respBody.detail ?? `HTTP ${response.status}`;
+    throw new RouteError(
+      String(detail),
+      "VERIFICATION_STATUS_FAILED",
+      response.status,
+    );
+  }
+
+  return (await response.json()) as {
+    domain: string;
+    status: string;
+    message: string;
+  };
+}
+
 // ── Route definitions ─────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -175,6 +204,14 @@ export const ROUTES: RouteDefinition[] = [
     method: "GET",
     handler: handleDomainStatus,
     summary: "Show domain registration and health",
+    tags: ["domain"],
+  },
+  {
+    operationId: "domain_verification_status",
+    endpoint: "domain/verification-status",
+    method: "POST",
+    handler: handleDomainVerificationStatus,
+    summary: "Get live DNS verification status for a domain",
     tags: ["domain"],
   },
 ];


### PR DESCRIPTION
## Summary

- Remove phantom `verified` and `status` fields from domain register/list response types — the API never returned them
- Add `domain_verification_status` IPC route that calls `GET /v1/assistants/{id}/domains/{id}/verification-status/` (introduced in platform PR #7712)
- `assistant domain status` now fetches domain list + a single verification-status call, showing live Resend DNS verification state with descriptive message

## Test plan

- [ ] `assistant domain status` shows `Domain`, `Verification` (with message), and `Created`
- [ ] `assistant domain status --json` returns `{ domain, verification }` structure
- [ ] When no domain is registered, shows helpful "Run: assistant domain register" message
- [ ] Verification fetch failure degrades gracefully (shows "unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)