### PR TITLE
fix(web): redesign billing modals with read-only resource cards, inline downgrade, auto-focus domain

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -131,6 +131,7 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
           </Typography>
           <DomainField
             subdomain={subdomain}
+            autoFocus
             onSubdomainChange={(v) => {
               setSubdomain(v);
               if (errorMsg) setErrorMsg(null);

--- a/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -1,26 +1,84 @@
-import { ArrowLeft, Cpu } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight, Cpu, HardDrive, Server } from "lucide-react";
+import { useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@vellum/design-library/components/button";
-import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Notice } from "@vellum/design-library/components/notice";
-import { Tag } from "@vellum/design-library/components/tag";
 import { Typography } from "@vellum/design-library/components/typography";
 import type { MachineSizeEnum, MachineTierEnum } from "@/generated/api/types.gen.js";
 import {
   assistantsActiveRetrieveOptions,
   assistantsResizeMutation,
 } from "@/generated/api/@tanstack/react-query.gen.js";
-import { buildMachineSizeOptions } from "@/lib/billing/machine-sizes.js";
+import {
+  SIZE_DESCRIPTION,
+  SIZE_LABEL,
+} from "@/lib/billing/machine-sizes.js";
 
 import { IconBadge, StepDots } from "./primitives.js";
 import {
   allowedMachineSizesForTier,
   extractOnboardingErrorMessage,
 } from "./utils.js";
+
+function ResourceCard({
+  icon: Icon,
+  label,
+  from,
+  fromDetail,
+  to,
+  toDetail,
+}: {
+  icon: typeof Server;
+  label: string;
+  from: string;
+  fromDetail?: string;
+  to: string;
+  toDetail?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
+      <span
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{
+          backgroundColor: "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
+        }}
+      >
+        <Icon className="h-4 w-4 text-[var(--system-positive-strong)]" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-label-small-default text-[var(--content-tertiary)]">
+          {label}
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-tertiary)] line-through">
+              {from}
+            </span>
+            {fromDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)] line-through">
+                {fromDetail}
+              </span>
+            )}
+          </div>
+          <ArrowRight className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]" />
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-default)]">
+              {to}
+            </span>
+            {toDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)]">
+                {toDetail}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function SetupStep({
   storageGib,
@@ -34,21 +92,18 @@ export function SetupStep({
   onAdvance: () => void;
 }) {
   const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
-  const currentSize = activeAssistant?.machine_size as MachineSizeEnum | null | undefined;
-  const machineSizeOptions = useMemo(
-    () =>
-      buildMachineSizeOptions(
-        allowedMachineSizesForTier(maxTier),
-        currentSize,
-        <Tag tone="positive">Current</Tag>,
-      ),
-    [maxTier, currentSize],
-  );
-  const [selectedSize, setSelectedSize] = useState<MachineSizeEnum>(
-    machineSizeOptions[0]?.value ?? "small",
-  );
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const currentSize = (activeAssistant?.machine_size as MachineSizeEnum) || "small";
+  const currentGib = activeAssistant?.provisioned_storage_gib ?? null;
 
+  const allowedSizes = allowedMachineSizesForTier(maxTier);
+  const targetSize: MachineSizeEnum =
+    allowedSizes.length > 0 ? allowedSizes[allowedSizes.length - 1] : currentSize;
+
+  const machineChanged = targetSize !== currentSize;
+  const canGrowStorage =
+    storageGib != null && (currentGib == null || currentGib < storageGib);
+
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const resizeMutation = useMutation(assistantsResizeMutation());
 
   const handleContinue = () => {
@@ -57,7 +112,7 @@ export function SetupStep({
       {
         path: { id: activeAssistant.id },
         body: {
-          machine_size: selectedSize,
+          machine_size: targetSize,
           ...(storageGib != null ? { storage_gib: storageGib } : {}),
         },
       },
@@ -78,10 +133,6 @@ export function SetupStep({
     );
   };
 
-  const description = storageGib != null
-    ? `Pick a machine size and we'll apply your ${storageGib} GiB of included storage.`
-    : "Pick a machine size for your assistant.";
-
   return (
     <>
       <Modal.Body
@@ -92,36 +143,43 @@ export function SetupStep({
           <IconBadge icon={Cpu} />
           <div className="space-y-2">
             <Typography variant="title-small" as="h1">
-              Choose your compute
+              Your assistant's new resources
             </Typography>
             <Typography
               variant="body-medium-lighter"
               as="p"
               className="text-[var(--content-secondary)]"
             >
-              {description}
+              Your assistant will go offline briefly while it resizes.
             </Typography>
           </div>
         </div>
 
-        <div className="space-y-1">
-          <Typography
-            variant="label-small-default"
-            as="label"
-            className="text-[var(--content-secondary)]"
-          >
-            Machine size
-          </Typography>
-          <Dropdown
-            options={machineSizeOptions}
-            value={selectedSize}
-            onChange={setSelectedSize}
-            aria-label="Machine size"
-            data-testid="onboarding-machine-size"
-          />
+        <div className="flex flex-col gap-2">
+          {machineChanged && (
+            <ResourceCard
+              icon={Cpu}
+              label="Machine"
+              from={SIZE_LABEL[currentSize]}
+              fromDetail={SIZE_DESCRIPTION[currentSize]}
+              to={SIZE_LABEL[targetSize]}
+              toDetail={SIZE_DESCRIPTION[targetSize]}
+            />
+          )}
+          {canGrowStorage && (
+            <ResourceCard
+              icon={HardDrive}
+              label="Storage"
+              from={currentGib != null ? `${currentGib} GiB` : "—"}
+              to={`${storageGib} GiB`}
+            />
+          )}
+          {!machineChanged && !canGrowStorage && (
+            <Notice tone="neutral">
+              Your assistant is already running at the maximum size for your plan.
+            </Notice>
+          )}
         </div>
-
-        <Notice tone="info">Your assistant will go offline briefly while it resizes.</Notice>
 
         {errorMsg ? <Notice tone="error">{errorMsg}</Notice> : null}
       </Modal.Body>
@@ -153,7 +211,7 @@ export function SetupStep({
             disabled={resizeMutation.isPending || !activeAssistant?.id}
             onClick={handleContinue}
           >
-            Continue
+            Apply & Restart
           </Button>
         </div>
       </Modal.Footer>

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -1,4 +1,4 @@
-import { Crown, Loader2, Palmtree } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Crown, Loader2, Palmtree } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -136,7 +136,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
   const portalMutation = useBillingPortalSession(portalSnapshot);
-  const [downgradeOpen, setDowngradeOpen] = useState(false);
+  const [view, setView] = useState<"plans" | "downgrade-confirm">("plans");
   const [tierDowngradeOpen, setTierDowngradeOpen] = useState(false);
   const [selectedMachineTier, setSelectedMachineTier] =
     useState<MachineTierEnum | null>(null);
@@ -325,7 +325,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
 
   const handleConfirmDowngrade = () => {
     if (portalMutation.isPending) return;
-    setDowngradeOpen(false);
+    setView("plans");
     portalMutation.mutate({});
   };
 
@@ -457,10 +457,57 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
       <Modal.Root
         open={open}
         onOpenChange={(next) => {
-          if (!next) onClose();
+          if (!next) {
+            setView("plans");
+            onClose();
+          }
         }}
       >
-        <Modal.Content size="lg">
+        <Modal.Content size={view === "plans" ? "lg" : "md"}>
+          {view === "downgrade-confirm" ? (
+            <>
+              <Modal.Header>
+                <Modal.Title icon={AlertTriangle}>Downgrade to Base?</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <Typography
+                  as="p"
+                  variant="body-medium-default"
+                  className="text-(--content-secondary)"
+                >
+                  Downgrading removes the following Pro features:
+                </Typography>
+                <ul className="mt-4 list-disc space-y-2 pl-5">
+                  {lostFeatures.map((feature) => (
+                    <li key={feature}>
+                      <Typography as="span" variant="body-medium-default">
+                        {feature}
+                      </Typography>
+                    </li>
+                  ))}
+                </ul>
+              </Modal.Body>
+              <Modal.Footer>
+                <Button
+                  variant="ghost"
+                  onClick={() => setView("plans")}
+                  disabled={portalMutation.isPending}
+                  leftIcon={<ArrowLeft className="h-4 w-4" />}
+                >
+                  Back
+                </Button>
+                <Button
+                  variant="danger"
+                  onClick={handleConfirmDowngrade}
+                  disabled={portalMutation.isPending}
+                  data-testid="confirm-downgrade-button"
+                >
+                  Confirm Downgrade
+                </Button>
+              </Modal.Footer>
+            </>
+          ) : (
+            <>
           <Modal.Header>
             <Modal.Title className="sr-only">Upgrade Plan</Modal.Title>
           </Modal.Header>
@@ -690,7 +737,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 <Button
                                   variant="outlined"
                                   className="w-full"
-                                  onClick={() => setDowngradeOpen(true)}
+                                  onClick={() => setView("downgrade-confirm")}
                                   disabled={portalMutation.isPending}
                                   data-testid="modal-downgrade-to-base-button"
                                 >
@@ -740,15 +787,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
               </Button>
             </div>
           </Modal.Footer>
+            </>
+          )}
         </Modal.Content>
       </Modal.Root>
-      <DowngradeReconfirmModal
-        open={downgradeOpen}
-        onCancel={() => setDowngradeOpen(false)}
-        onConfirm={handleConfirmDowngrade}
-        confirming={portalMutation.isPending}
-        lostFeatures={lostFeatures}
-      />
       <DowngradeReconfirmModal
         open={tierDowngradeOpen}
         onCancel={() => setTierDowngradeOpen(false)}

--- a/apps/web/src/domains/settings/components/domain-field.tsx
+++ b/apps/web/src/domains/settings/components/domain-field.tsx
@@ -6,6 +6,7 @@ interface DomainFieldProps {
   domainSuffix: string;
   subdomainPlaceholder?: string;
   disabled?: boolean;
+  autoFocus?: boolean;
   prefix?: ReactNode;
   error?: string | null;
   locked?: boolean;
@@ -18,6 +19,7 @@ export function DomainField({
   domainSuffix,
   subdomainPlaceholder = "my-assistant",
   disabled,
+  autoFocus,
   prefix,
   error,
   locked,
@@ -36,6 +38,7 @@ export function DomainField({
           onChange={(e) => onSubdomainChange(e.target.value.toLowerCase().trim())}
           disabled={disabled || locked}
           readOnly={locked}
+          autoFocus={autoFocus}
           placeholder={subdomainPlaceholder}
           aria-label="Subdomain"
           aria-invalid={!!error}

--- a/apps/web/src/domains/settings/components/tier-upgrade-resize-modal.tsx
+++ b/apps/web/src/domains/settings/components/tier-upgrade-resize-modal.tsx
@@ -1,13 +1,11 @@
-import { Loader2, Server } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowRight, Cpu, HardDrive, Loader2, Server } from "lucide-react";
+import { useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@vellum/design-library/components/button";
-import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Notice } from "@vellum/design-library/components/notice";
-import { Tag } from "@vellum/design-library/components/tag";
 import { toast } from "@vellum/design-library/components/toast";
 import { extractResizeError } from "@/domains/settings/components/resize-errors.js";
 import {
@@ -18,12 +16,70 @@ import {
 import type { MachineSizeEnum } from "@/generated/api/types.gen.js";
 import {
   allowedMachineSizesForTier,
-  buildMachineSizeOptions,
+  SIZE_DESCRIPTION,
+  SIZE_LABEL,
 } from "@/lib/billing/machine-sizes.js";
 
 export interface TierUpgradeResizeModalProps {
   open: boolean;
   onClose: () => void;
+}
+
+function ResourceCard({
+  icon: Icon,
+  label,
+  from,
+  fromDetail,
+  to,
+  toDetail,
+}: {
+  icon: typeof Server;
+  label: string;
+  from: string;
+  fromDetail?: string;
+  to: string;
+  toDetail?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
+      <span
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{
+          backgroundColor: "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
+        }}
+      >
+        <Icon className="h-4 w-4 text-[var(--system-positive-strong)]" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-label-small-default text-[var(--content-tertiary)]">
+          {label}
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-tertiary)] line-through">
+              {from}
+            </span>
+            {fromDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)] line-through">
+                {fromDetail}
+              </span>
+            )}
+          </div>
+          <ArrowRight className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]" />
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-default)]">
+              {to}
+            </span>
+            {toDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)]">
+                {toDetail}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function TierUpgradeResizeModal({
@@ -47,28 +103,15 @@ export function TierUpgradeResizeModal({
   const availableGib = onboardingQuery.data?.selected_storage_gib ?? null;
   const allowedSizes = allowedMachineSizesForTier(maxTier);
 
-  const largestSize = allowedSizes.length > 0 ? allowedSizes[allowedSizes.length - 1] : null;
-  const [selectedSize, setSelectedSize] = useState<MachineSizeEnum | null>(null);
-  const displaySize = selectedSize ?? largestSize ?? currentSize;
-  const [resizeError, setResizeError] = useState<string | null>(null);
+  const targetSize: MachineSizeEnum =
+    allowedSizes.length > 0 ? allowedSizes[allowedSizes.length - 1] : currentSize;
 
-  const machineSizeOptions = useMemo(
-    () =>
-      buildMachineSizeOptions(
-        allowedSizes,
-        currentSize,
-        <Tag tone="positive">Current</Tag>,
-      ),
-    [allowedSizes, currentSize],
-  );
-
-  const effectiveSelectedSize =
-    allowedSizes.includes(displaySize) && displaySize !== currentSize
-      ? displaySize
-      : null;
-
+  const machineChanged = targetSize !== currentSize;
   const canGrowStorage =
     availableGib != null && (currentGib == null || currentGib < availableGib);
+  const hasChanges = machineChanged || canGrowStorage;
+
+  const [resizeError, setResizeError] = useState<string | null>(null);
 
   const resizeMutation = useMutation({
     ...assistantsResizeMutation(),
@@ -77,7 +120,6 @@ export function TierUpgradeResizeModal({
         id: "assistant-resize",
       });
       setResizeError(null);
-      setSelectedSize(null);
       onClose();
     },
     onError: (error) => {
@@ -98,7 +140,6 @@ export function TierUpgradeResizeModal({
       open={open}
       onOpenChange={(o) => {
         if (!o) {
-          setSelectedSize(null);
           setResizeError(null);
           onClose();
         }
@@ -108,7 +149,7 @@ export function TierUpgradeResizeModal({
         <Modal.Header>
           <Modal.Title icon={Server}>Plan Updated</Modal.Title>
           <Modal.Description>
-            Your plan has been updated with new resources. Apply them now to resize your assistant — it will briefly restart.
+            Your new resources are ready. Apply them now to resize your assistant — it will briefly restart.
           </Modal.Description>
         </Modal.Header>
         <Modal.Body>
@@ -116,44 +157,35 @@ export function TierUpgradeResizeModal({
             <div className="flex items-center justify-center py-6">
               <Loader2 className="h-5 w-5 animate-spin text-[var(--content-tertiary)]" />
             </div>
+          ) : !hasChanges ? (
+            <Notice tone="neutral">
+              Your assistant is already running at the maximum size for your plan.
+            </Notice>
           ) : (
-            <div className="flex flex-col gap-3">
-              {allowedSizes.length === 0 ? (
-                <Notice tone="warning">
-                  No machine tier configured. Contact support.
-                </Notice>
-              ) : (
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-label-medium-default text-[var(--content-secondary)]">
-                    Machine Size
-                  </span>
-                  <Dropdown
-                    options={machineSizeOptions}
-                    value={displaySize}
-                    onChange={setSelectedSize}
-                    aria-label="Compute machine size"
-                    data-testid="portal-resize-machine-size"
-                  />
-                </div>
+            <div className="flex flex-col gap-2">
+              {machineChanged && (
+                <ResourceCard
+                  icon={Cpu}
+                  label="Machine"
+                  from={SIZE_LABEL[currentSize]}
+                  fromDetail={SIZE_DESCRIPTION[currentSize]}
+                  to={SIZE_LABEL[targetSize]}
+                  toDetail={SIZE_DESCRIPTION[targetSize]}
+                />
               )}
-              {canGrowStorage ? (
-                <Notice tone="info">
-                  {currentGib != null
-                    ? `Storage will be expanded from ${currentGib} GiB to ${availableGib} GiB.`
-                    : `Storage will be expanded to ${availableGib} GiB.`}
-                </Notice>
-              ) : currentGib != null ? (
-                <Notice tone="neutral">
-                  Storage is already at its provisioned size ({currentGib} GiB) and will not change.
-                </Notice>
-              ) : (
-                <Notice tone="neutral">
-                  Storage will not change.
-                </Notice>
+              {canGrowStorage && (
+                <ResourceCard
+                  icon={HardDrive}
+                  label="Storage"
+                  from={currentGib != null ? `${currentGib} GiB` : "—"}
+                  to={`${availableGib} GiB`}
+                />
               )}
-              {resizeError && (
-                <Notice tone="error">{resizeError}</Notice>
-              )}
+            </div>
+          )}
+          {resizeError && (
+            <div className="mt-3">
+              <Notice tone="error">{resizeError}</Notice>
             </div>
           )}
         </Modal.Body>
@@ -161,7 +193,6 @@ export function TierUpgradeResizeModal({
           <Button
             variant="ghost"
             onClick={() => {
-              setSelectedSize(null);
               setResizeError(null);
               onClose();
             }}
@@ -169,12 +200,7 @@ export function TierUpgradeResizeModal({
             Do Later
           </Button>
           <Button
-            disabled={
-              dataLoading ||
-              (effectiveSelectedSize == null && !canGrowStorage) ||
-              isLoading ||
-              !assistant?.id
-            }
+            disabled={dataLoading || !hasChanges || isLoading || !assistant?.id}
             leftIcon={
               isLoading ? <Loader2 className="animate-spin" /> : undefined
             }
@@ -182,8 +208,8 @@ export function TierUpgradeResizeModal({
               if (!assistant?.id) return;
               setResizeError(null);
               const body: { machine_size?: MachineSizeEnum; storage_gib?: number } = {};
-              if (effectiveSelectedSize != null) {
-                body.machine_size = effectiveSelectedSize;
+              if (machineChanged) {
+                body.machine_size = targetSize;
               }
               if (canGrowStorage && availableGib != null) {
                 body.storage_gib = availableGib;
@@ -194,7 +220,7 @@ export function TierUpgradeResizeModal({
               });
             }}
           >
-            {resizeError ? "Retry" : "Apply"}
+            {resizeError ? "Retry" : "Apply & Restart"}
           </Button>
         </Modal.Footer>
       </Modal.Content>


### PR DESCRIPTION
## Summary
- Redesigns the tier upgrade resize modal and onboarding setup step as read-only confirmation steps. Removes the machine size dropdown, auto-selects the largest allowed size, and shows before/after resource cards for machine (with CPU/memory specs) and storage.
- Converts the Downgrade to Base flow in the Adjust Plan modal from a stacked modal-over-modal to an inline master/detail view with a back button.
- Adds autoFocus prop to DomainField and uses it on the onboarding domain step so the subdomain input is focused on entry.

## Original prompt
After shipping the tier upgrade resize modal, the user iterated on the design: removed the dropdown in favor of read-only resource cards showing the new machine specs (size name plus CPU/memory as a detail line) and storage. Applied the same treatment to the Base-to-Pro onboarding setup step. Converted the downgrade confirmation from a modal-over-modal to an inline view. Added auto-focus to the domain input in the onboarding flow.