### PR TITLE
fix: add diagnostic logging for Codex subscription API errors

### DIFF
--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai";
 
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { createStreamTimeout } from "../stream-timeout.js";
@@ -15,6 +16,8 @@ import type {
 } from "../types.js";
 import { ContextOverflowError } from "../types.js";
 import { detectOpenAICompatibleContextOverflow } from "./chat-completions-provider.js";
+
+const log = getLogger("openai-responses");
 
 export interface OpenAIResponsesProviderOptions {
   baseURL?: string;
@@ -412,6 +415,21 @@ export class OpenAIResponsesProvider implements Provider {
           ? signal.reason
           : undefined;
       if (error instanceof OpenAI.APIError) {
+        // Temporary diagnostic: log the raw error shape for Codex 400 debugging
+        if (this.codexSubscription) {
+          log.warn(
+            {
+              status: error.status,
+              message: error.message,
+              code: error.code,
+              type: error.type,
+              param: error.param,
+              errorBody: error.error,
+              headers: Object.fromEntries(error.headers?.entries?.() ?? []),
+            },
+            "Codex subscription API error — raw details",
+          );
+        }
         const overflow = detectOpenAICompatibleContextOverflow(error);
         if (overflow) {
           throw new ContextOverflowError(
@@ -433,8 +451,12 @@ export class OpenAIResponsesProvider implements Provider {
         if (retryAfterMs !== undefined)
           errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
+        const extras = [error.code, error.type, error.param]
+          .filter(Boolean)
+          .join(", ");
+        const extraSuffix = extras ? ` [${extras}]` : "";
         throw new ProviderError(
-          `${this.providerLabel} API error (${error.status}): ${error.message}`,
+          `${this.providerLabel} API error (${error.status}): ${error.message}${extraSuffix}`,
           this.name,
           error.status,
           Object.keys(errorOptions).length > 0 ? errorOptions : undefined,

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -109,6 +109,7 @@ export class OpenAIResponsesProvider implements Provider {
   private streamTimeoutMs: number;
   private useNativeWebSearch: boolean;
   private codexSubscription: boolean;
+  private lastCodexErrorBody: string | undefined;
 
   constructor(
     apiKey: string,
@@ -128,6 +129,27 @@ export class OpenAIResponsesProvider implements Provider {
         ? "https://chatgpt.com/backend-api/codex"
         : options.baseURL,
       timeout: sdkTimeoutMs,
+      ...(this.codexSubscription
+        ? {
+            fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+              const res = await globalThis.fetch(url, init);
+              if (!res.ok) {
+                const body = await res.text();
+                this.lastCodexErrorBody = body;
+                log.warn(
+                  { status: res.status, body, url: String(url) },
+                  "Codex endpoint raw error response",
+                );
+                return new Response(body, {
+                  status: res.status,
+                  statusText: res.statusText,
+                  headers: res.headers,
+                });
+              }
+              return res;
+            },
+          }
+        : {}),
     });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
@@ -451,12 +473,22 @@ export class OpenAIResponsesProvider implements Provider {
         if (retryAfterMs !== undefined)
           errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
+        let errorDetail = error.message;
+        if (this.lastCodexErrorBody) {
+          try {
+            const parsed = JSON.parse(this.lastCodexErrorBody);
+            if (parsed.detail) errorDetail = parsed.detail;
+          } catch {
+            errorDetail = this.lastCodexErrorBody.slice(0, 200);
+          }
+          this.lastCodexErrorBody = undefined;
+        }
         const extras = [error.code, error.type, error.param]
           .filter(Boolean)
           .join(", ");
         const extraSuffix = extras ? ` [${extras}]` : "";
         throw new ProviderError(
-          `${this.providerLabel} API error (${error.status}): ${error.message}${extraSuffix}`,
+          `${this.providerLabel} API error (${error.status}): ${errorDetail}${extraSuffix}`,
           this.name,
           error.status,
           Object.keys(errorOptions).length > 0 ? errorOptions : undefined,


### PR DESCRIPTION
## Summary

- Adds temporary diagnostic `log.warn` when a Codex subscription API call hits an `OpenAI.APIError`, capturing `status`, `message`, `code`, `type`, `param`, `error` body, and response headers — the SDK may drop the body if the JSON lacks an `error` key, so "400 (no body)" could be misleading.
- Enriches the thrown `ProviderError` message with `error.code`, `error.type`, and `error.param` (if present) so they surface in logs and error handlers without needing the warn line.

## Test plan

- [ ] Deploy to an environment with Codex subscription enabled and trigger a 400 error; confirm the warn log contains all raw error fields.
- [ ] Verify non-Codex API errors are unaffected (no extra log line, message format unchanged when code/type/param are absent).
- [ ] TypeScript typecheck passes (`bunx tsc --noEmit` in `assistant/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)