### PR TITLE
perf(anthropic): cache the per-turn memory block across the tool loop

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -242,9 +242,11 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
-  test("applies the standard 4-breakpoint cache layout in a tool-use loop", async () => {
-    // system(1) + tools(1) + turn-anchor on Turn 1 (1) + tail on tool_result
-    // (1) = 4, the Anthropic per-request cap. All four breakpoints present.
+  test("applies a 4-breakpoint cache layout in a tool-use loop (system present)", async () => {
+    // With a system prompt present, the tool breakpoint is dropped (the system
+    // breakpoint already caches [tools + system]). The 4 breakpoints are:
+    // system(1) + turn-anchor on Turn 1 (1) + memory-anchor on Turn 2 (1) +
+    // tail on tool_result (1) = 4, the Anthropic per-request cap.
     const prompt = "You are a helpful assistant.";
     const messages: Message[] = [
       userMsg("Turn 1"),
@@ -263,15 +265,14 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(system).toHaveLength(1);
     expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
+    // Tool breakpoint dropped — the system breakpoint covers [tools + system].
     const tools = lastStreamParams!.tools as Array<{
       cache_control?: { type: string; ttl?: string };
     }>;
-    expect(tools[tools.length - 1].cache_control).toEqual({
-      type: "ephemeral",
-      ttl: "1h",
-    });
+    expect(tools[tools.length - 1].cache_control).toBeUndefined();
 
-    // Turn-anchor (Turn 1 — 2nd-most-recent stable user msg) + tail still present
+    // Turn-anchor (Turn 1 — 2nd-most-recent stable user msg) + memory anchor
+    // (Turn 2) + tail (tool_result) present.
     const sent = lastStreamParams!.messages as Array<{
       role: string;
       content: Array<{
@@ -283,6 +284,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(
       turnAnchor.content[turnAnchor.content.length - 1].cache_control,
     ).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Memory anchor (Turn 2 — current memory-bearing msg) gets a stable 5m
+    // breakpoint so the loop reads the memory instead of re-creating it.
+    const memoryAnchor = sent[2];
+    expect(
+      memoryAnchor.content[memoryAnchor.content.length - 1].cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "5m" });
     const lastMsg = sent[sent.length - 1];
     expect(lastMsg.content[lastMsg.content.length - 1].cache_control).toEqual({
       type: "ephemeral",
@@ -327,6 +334,29 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(lastStreamParams!.tools).toBeUndefined();
   });
 
+  test("tools have no cache_control when a system prompt is present", async () => {
+    // The system breakpoint already caches the [tools + system] prefix
+    // (Anthropic order: tools → system → messages), so the redundant tool
+    // breakpoint is dropped — freeing a slot for the per-turn memory anchor.
+    await provider.sendMessage(
+      [userMsg("Hi")],
+      sampleTools,
+      "You are helpful.",
+    );
+
+    const system = lastStreamParams!.system as Array<{
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    const tools = lastStreamParams!.tools as Array<{
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    for (const tool of tools) {
+      expect(tool.cache_control).toBeUndefined();
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Advancing tail — 5m cache on last block after turn-starting message
   // -----------------------------------------------------------------------
@@ -365,19 +395,19 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       ttl: "1h",
     });
 
-    // Memory-bearing user message (Turn 2) has no cache_control
+    // Memory-bearing user message (Turn 2) gets a stable 5m memory anchor on
+    // its last block, so the loop reads it instead of re-creating it.
     const memoryBearing = sent[2];
-    for (const block of memoryBearing.content) {
-      expect(block.cache_control).toBeUndefined();
-    }
+    const memoryLast = memoryBearing.content[memoryBearing.content.length - 1];
+    expect(memoryLast.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
 
-    // Last message (tool_result) gets 5m advancing tail
+    // Last message (tool_result) gets the 5m advancing tail
     const lastMessage = sent[sent.length - 1];
     const lastBlock = lastMessage.content[lastMessage.content.length - 1];
     expect(lastBlock.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
   });
 
-  test("stable user messages get 1h cache anchors; memory-bearing most-recent is skipped", async () => {
+  test("stable user messages get 1h cache anchors; memory-bearing most-recent gets a 5m anchor", async () => {
     const messages: Message[] = [
       userMsg("Turn 1"),
       assistantMsg("Response 1"),
@@ -413,13 +443,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       type: "ephemeral",
       ttl: "1h",
     });
-    // Memory-bearing user message (Turn 3 — most recent) has no cache_control.
-    // Its content is unstable across turns because memory gets stripped from
-    // history on subsequent turns.
+    // Memory-bearing user message (Turn 3 — most recent) gets a stable 5m
+    // memory anchor on its last block (intra-turn only — its content is
+    // unstable across turns because memory gets stripped from history).
     const memoryBearing = userMessages[userMessages.length - 1];
-    for (const block of memoryBearing.content) {
-      expect(block.cache_control).toBeUndefined();
-    }
+    const memoryLast = memoryBearing.content[memoryBearing.content.length - 1];
+    expect(memoryLast.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
   });
 
   test("disableTurnStartCache suppresses the 1h breakpoint on the turn-anchor user message", async () => {
@@ -451,6 +480,13 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const turnAnchor = sent[0];
     const turnAnchorLast = turnAnchor.content[turnAnchor.content.length - 1];
     expect(turnAnchorLast.cache_control).toBeUndefined();
+    // The 5m memory anchor is gated on the same flag, so the most-recent
+    // (volatile) message must NOT be cached either — this is what protects
+    // one-shot callers like the memory router whose trailing block changes
+    // every call.
+    const mostRecent = sent[sent.length - 1];
+    const mostRecentLast = mostRecent.content[mostRecent.content.length - 1];
+    expect(mostRecentLast.cache_control).toBeUndefined();
   });
 
   test("backstop anchor is NOT applied during a tool-use loop", async () => {
@@ -486,6 +522,60 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const turn2 = sent[2];
     const turn2Last = turn2.content[turn2.content.length - 1];
     expect(turn2Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("breakpoint budget stays within 4 in a tool-use loop with system + tools", async () => {
+    // Count every cache_control across system + tools + messages — must stay
+    // at Anthropic's per-request cap of 4: system + turn-anchor + memory-anchor
+    // + tail (tool breakpoint dropped, backstop off mid-loop).
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2"),
+      toolUseMsg("tu_1", "bash"),
+      toolResultMsg("tu_1", "output"),
+    ];
+    await provider.sendMessage(messages, sampleTools, "You are helpful.");
+
+    let count = 0;
+    const system = (lastStreamParams!.system ?? []) as Array<{
+      cache_control?: unknown;
+    }>;
+    for (const b of system) if (b.cache_control) count++;
+    const tools = (lastStreamParams!.tools ?? []) as Array<{
+      cache_control?: unknown;
+    }>;
+    for (const t of tools) if (t.cache_control) count++;
+    const sent = (lastStreamParams!.messages ?? []) as Array<{
+      content: Array<{ cache_control?: unknown }>;
+    }>;
+    for (const m of sent)
+      for (const b of m.content) if (b.cache_control) count++;
+
+    expect(count).toBe(4);
+  });
+
+  test("Haiku: memory anchor has cache_control without a ttl field", async () => {
+    // Haiku doesn't support the extended-cache-ttl beta, so all ephemeral
+    // breakpoints (including the 5m memory anchor) omit `ttl`.
+    const haiku = new AnthropicProvider("sk-ant-test", "claude-haiku-4-5");
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2"),
+      toolUseMsg("tu_1", "bash"),
+      toolResultMsg("tu_1", "output"),
+    ];
+    await haiku.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      content: Array<{ cache_control?: { type: string; ttl?: string } }>;
+    }>;
+    // Turn 2 carries the memory anchor — ephemeral, no ttl.
+    const memoryAnchor = sent[2];
+    expect(
+      memoryAnchor.content[memoryAnchor.content.length - 1].cache_control,
+    ).toEqual({ type: "ephemeral" });
   });
 
   // -----------------------------------------------------------------------
@@ -1829,7 +1919,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[4].content[0].text).toBe("Follow-up question");
   });
 
-  test("multi-turn with workspace injection: prev-turn + last user message get 1h cache", async () => {
+  test("multi-turn with workspace injection: stable anchors get 1h, memory-bearing gets 5m", async () => {
     const messages: Message[] = [
       {
         role: "user",
@@ -1893,11 +1983,13 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       ttl: "1h",
     });
 
-    // Memory-bearing user message (turn 3, most-recent): no cache_control.
+    // Memory-bearing user message (turn 3, most-recent): the workspace block
+    // stays uncached but the last block gets the stable 5m memory anchor.
     const memoryBearing = userMsgs[userMsgs.length - 1];
-    for (const block of memoryBearing.content) {
-      expect(block.cache_control).toBeUndefined();
-    }
+    expect(memoryBearing.content[0].cache_control).toBeUndefined();
+    expect(
+      memoryBearing.content[memoryBearing.content.length - 1].cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "5m" });
 
     // No top-level cache_control — breakpoints are set directly on blocks
     expect(
@@ -1933,12 +2025,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       ttl: "1h",
     });
 
-    // Memory-bearing user msg ("Read the config file") — no cache_control
+    // Memory-bearing user msg ("Read the config file") — stable 5m memory anchor
     const memoryBearing = sent[2];
     expect(memoryBearing.role).toBe("user");
-    for (const block of memoryBearing.content) {
-      expect(block.cache_control).toBeUndefined();
-    }
+    expect(
+      memoryBearing.content[memoryBearing.content.length - 1].cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "5m" });
 
     // Non-last tool result messages do NOT get cache_control
     const toolResultMsgs = sent.filter(
@@ -2186,14 +2278,11 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
     }>;
     expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
-    // Last tool cache control
+    // Tool breakpoint dropped — the system breakpoint covers [tools + system].
     const tools = lastStreamParams!.tools as Array<{
       cache_control?: { type: string; ttl?: string };
     }>;
-    expect(tools[tools.length - 1].cache_control).toEqual({
-      type: "ephemeral",
-      ttl: "1h",
-    });
+    expect(tools[tools.length - 1].cache_control).toBeUndefined();
   });
 });
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1084,6 +1084,13 @@ export class AnthropicProvider implements Provider {
         ];
       }
 
+      // Tools come first in Anthropic's cache prefix (tools → system →
+      // messages), so when a system prompt is present its breakpoint already
+      // caches the whole [tools + system] prefix and a separate tool
+      // breakpoint is redundant. Only anchor the tools directly when there is
+      // no system prompt to cover them — dropping the redundant breakpoint
+      // frees a slot for the per-turn memory anchor below.
+      const includeToolBreakpoint = !systemPrompt;
       if (tools && tools.length > 0) {
         if (
           this.useNativeWebSearch &&
@@ -1094,7 +1101,7 @@ export class AnthropicProvider implements Provider {
             name: t.name,
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
-            ...(i === otherTools.length - 1
+            ...(includeToolBreakpoint && i === otherTools.length - 1
               ? { cache_control: cacheControl }
               : {}),
           }));
@@ -1109,7 +1116,9 @@ export class AnthropicProvider implements Provider {
             name: t.name,
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
-            ...(i === tools.length - 1 ? { cache_control: cacheControl } : {}),
+            ...(includeToolBreakpoint && i === tools.length - 1
+              ? { cache_control: cacheControl }
+              : {}),
           }));
         }
       }
@@ -1118,10 +1127,11 @@ export class AnthropicProvider implements Provider {
       // message carries a dynamic memory injection that is stripped from
       // history on subsequent turns (see stripAllMemoryInjections in
       // conversation-graph-memory.ts), so its content is NOT byte-stable
-      // across turns and we cannot anchor a cache there. Anchor instead on
-      // the 2nd-most-recent user message — historical user messages have
-      // memory stripped, so their content is stable and the cached prefix
-      // through that point survives across turns.
+      // across turns. The 1h cross-turn anchors below therefore avoid it and
+      // sit on the 2nd-/3rd-most-recent (already-stripped, stable) user
+      // messages. A separate 5m memory anchor caches the current message
+      // within the turn so the memory block is written once and read by every
+      // subsequent tool-loop call instead of re-created each iteration.
       const msgs = sentMessages;
       const findUserTextMsgIdx = (startIdx: number): number => {
         for (let i = startIdx; i >= 0; i--) {
@@ -1137,13 +1147,15 @@ export class AnthropicProvider implements Provider {
         }
         return -1;
       };
-      const applyCacheControlToLastBlock = (msgIdx: number): void => {
+      const applyCacheControlToLastBlock = (
+        msgIdx: number,
+        cc: typeof cacheControl | typeof tailCacheControl = cacheControl,
+      ): void => {
         const content = msgs[msgIdx].content;
         if (!Array.isArray(content) || content.length === 0) return;
         const lastBlock = content[content.length - 1];
         if (typeof lastBlock !== "string") {
-          (lastBlock as unknown as Record<string, unknown>).cache_control =
-            cacheControl;
+          (lastBlock as unknown as Record<string, unknown>).cache_control = cc;
         }
       };
 
@@ -1182,6 +1194,19 @@ export class AnthropicProvider implements Provider {
           applyCacheControlToLastBlock(prevTurnAnchorIdx);
       }
 
+      // Per-turn memory anchor: a short-lived 5m breakpoint on the current
+      // turn's memory-bearing user message, applied on EVERY call of the turn.
+      // The memory block is byte-stable within a turn, so this writes it once
+      // (first call) and lets every later tool-loop call READ it — Anthropic
+      // only reads cache at breakpoints present in the current request, so a
+      // stable anchor here (rather than the advancing tail, which moves to the
+      // newest message) is what keeps the memory cached across the loop.
+      // Skipped when `disableTurnStartCache` is set (e.g. the memory router,
+      // whose trailing block changes every call and must not be cached).
+      if (mostRecentUserMsgIdx >= 0 && !disableTurnStartCache) {
+        applyCacheControlToLastBlock(mostRecentUserMsgIdx, tailCacheControl);
+      }
+
       // Advancing tail: place a short-lived 5m cache breakpoint on the last
       // block of the last message during tool-use loops (when the
       // memory-bearing user message is NOT the very last message — meaning
@@ -1217,11 +1242,14 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Cache-breakpoint accounting: system(1) + tools(1) + turn-anchor(1) +
-      // (tail OR backstop)(1) = 4 — exactly Anthropic's per-request cap.
-      // Tail and backstop are mutually exclusive (backstop only fires when
-      // the memory-bearing user msg is the very last message, which
-      // suppresses the tail), so the total can't drift past 4.
+      // Cache-breakpoint accounting (max 4). With a system prompt present the
+      // tool breakpoint is dropped (the system breakpoint already caches the
+      // [tools + system] prefix), leaving system(1) + turn-anchor(1) +
+      // memory-anchor(1) + (backstop OR advancing-tail)(1). Backstop and tail
+      // stay mutually exclusive (backstop only on the turn's first request,
+      // which is exactly when the tail is suppressed because the memory-bearing
+      // msg is last), so the total never exceeds 4. Without a system prompt the
+      // tool breakpoint takes the system slot and the same count holds.
 
       // Strip orphaned UTF-16 surrogates so the Anthropic JSON parser never
       // sees invalid strings produced by upstream surrogate-splitting `.slice()` calls.


### PR DESCRIPTION
## Summary

Diagnosed from inspector traces showing a large uncached `input_tokens` on the first call of a turn and a large `cache_creation` on every subsequent tool-loop call. **Cache breakpoints were working** (the prefix is reused) — the cost was the full top-K `<memory>` block (~16k tokens) prepended to the current turn's user message:

- On the turn's **first call** it sits past all 4 cache anchors → processed **uncached**.
- During the **tool loop** Anthropic only reads cache at breakpoints present in the current request (this is why the backstop exists), and the only stable anchor near the memory is the 1h turn anchor on the *previous* turn's user message — which is *before* the memory. So the memory is **re-created on every loop iteration**.

This is the dominant per-turn cost and it grew sharply when memory moved to rendering the full top-K every turn (#31929/#31939).

**Fix:** Anthropic caches in prefix order `tools → system → messages`, so the system-prompt breakpoint already caches the `[tools + system]` prefix. Our system prompt is session-stable (no per-turn `<now>`/timestamp/memory — that all lives in `<turn_context>` on *user* messages), so the separate last-tool breakpoint is redundant whenever a system prompt is present. **Drop it** in that case and spend the reclaimed slot on a **stable 5m anchor on the memory-bearing user message, applied on every call of the turn** — so the memory is written once (first call) and *read* by every later loop call instead of re-created.

- Tool breakpoint is **kept** when there's no system prompt (nothing else covers the tool defs then).
- Memory anchor is gated on `!disableTurnStartCache` so it never caches the memory router's volatile `<last_turn>` block.
- Breakpoint budget stays at Anthropic's **4-per-request cap** in every branch (the tool→memory swap is what frees the slot).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `anthropic-provider.test.ts` (86), `router.test.ts` (43), `native-web-search` (10), `llm-context-normalization` (26), `openrouter-provider-only` (14) all pass
- [x] lint clean
- [ ] **Empirical (decisive):** rebuild Velissa on this branch, run a multi-tool-call turn, check the inspector:
  - Call 1: the ~16k memory shows as **cache_creation**, not uncached `input tokens`.
  - Call 2+: the memory shows as **cache_read**, not re-created; per-call `cache_creation` drops to ~the tool_use+tool_result delta.
  - Regression signal: if the `[tools + system]` prefix is re-created every turn (large creation on the system prefix), the tools→system ordering assumption is wrong → revert.

Stacked on `do/strip-memory-and-shift-anchors` (#31850); builds on its turn-anchor/backstop/advancing-tail logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)