### PR TITLE
fix(design-library): add top padding to Modal.Footer

### DIFF
--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -196,7 +196,7 @@ function Footer({
   return (
     <div
       data-slot="modal-footer"
-      className={cn("flex justify-end gap-2 px-4 pb-4", className)}
+      className={cn("flex justify-end gap-2 px-4 py-4", className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- Modal.Footer was missing top padding (pb-4 changed to py-4), causing footer content to sit flush against the body above it. This is a design-system level fix affecting all modals.

## Original prompt
The Adjust Plan modal footer text was hugging the body content above it with no vertical separation. Traced to Modal.Footer in the design library having only bottom padding.