### PR TITLE
web/settings: improve managed email upsell copy and auto-open upgrade modal

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1219,19 +1219,20 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
             <Notice
               tone="info"
               icon={<Crown className="h-4 w-4" aria-hidden />}
-              title="Managed email is a Pro plan feature"
+              title="Get a dedicated email address for your assistant"
               actions={
                 <Button
                   size="compact"
-                  onClick={() => navigate(routes.settings.billing)}
+                  onClick={() => navigate(`${routes.settings.billing}?adjust_plan`)}
                 >
                   Upgrade to Pro
                 </Button>
               }
             >
-              Upgrade to register a {`<your-subdomain>.${emailRootDomain}`}{" "}
-              address managed by Vellum, or switch to <strong>Your Own</strong>{" "}
-              to bring your own provider.
+              Pro plans include a managed{" "}
+              {`<your-subdomain>.${emailRootDomain}`} inbox — no provider
+              setup required. Or switch to <strong>Your Own</strong> to bring
+              an existing provider.
             </Notice>
           ) : !assistantId ? (
             <p className="text-body-medium-lighter text-[var(--content-tertiary)]">


### PR DESCRIPTION
## Summary
- Reframe the email upsell notice title from "Managed email is a Pro plan feature" to "Get a dedicated email address for your assistant" — leads with value instead of restriction
- Update body copy to emphasize what Pro includes rather than what's missing
- Navigate to billing with `?adjust_plan` query param so the upgrade modal opens automatically on redirect

## Original prompt
User wanted to improve the copy on the managed email upsell card in the AI settings page. We chose an approach that leads with the benefit ("Get a dedicated email address for your assistant") rather than the gate ("Pro plan feature"), and updated the CTA to auto-open the upgrade modal via the existing `?adjust_plan` query param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)