### PR TITLE
fix(assistant): remove temporary Codex subscription diagnostic logging

### DIFF
--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -438,21 +438,6 @@ export class OpenAIResponsesProvider implements Provider {
           ? signal.reason
           : undefined;
       if (error instanceof OpenAI.APIError) {
-        // Temporary diagnostic: log the raw error shape for Codex 400 debugging
-        if (this.codexSubscription) {
-          log.warn(
-            {
-              status: error.status,
-              message: error.message,
-              code: error.code,
-              type: error.type,
-              param: error.param,
-              errorBody: error.error,
-              headers: Object.fromEntries(error.headers?.entries?.() ?? []),
-            },
-            "Codex subscription API error — raw details",
-          );
-        }
         const overflow = detectOpenAICompatibleContextOverflow(error);
         if (overflow) {
           throw new ContextOverflowError(


### PR DESCRIPTION
## Summary

- Remove the temporary diagnostic log block in the Codex subscription error handler that was added in #31952 to debug a 400 error
- The root cause was found and fixed in #31957 (`store: false`), so this diagnostic logging is no longer needed
- The permanent `lastCodexErrorBody` mechanism and the custom fetch handler's raw error log are retained

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Verified the permanent log at line ~139 ("Codex endpoint raw error response") is untouched
- [x] Verified the `lastCodexErrorBody` mechanism is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)