### PR TITLE
feat(gateway): add vellum provider to /inbound/register for platform-managed email

### DIFF
--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -1,12 +1,13 @@
 /**
  * POST /inbound/register — auto-verify the guardian's email channel when
- * a BYO email provider (Resend or Mailgun) webhook is registered.
+ * an email provider is registered.
  *
- * The platform provides `guardian_email` in the request body. For
+ * The platform provides `guardian_email` in the request body. For BYO
  * providers with an identity API (Mailgun), the gateway cross-verifies
- * the email against the API response. For providers without one
+ * the email against the API response. For BYO providers without one
  * (Resend), it validates that the stored API key is functional (proving
- * account ownership) and trusts the provided email.
+ * account ownership) and trusts the provided email. For platform-managed
+ * email (type "vellum"), the route's edge-scoped auth is sufficient.
  *
  * On success, creates a guardian email channel binding directly in both
  * the assistant and gateway databases (dual-write).
@@ -22,6 +23,7 @@ import { credentialKey } from "../../credential-key.js";
 import { getLogger } from "../../logger.js";
 import { validateMailgunEmail } from "./mailgun-identity.js";
 import { validateResendEmail } from "./resend-identity.js";
+import { validateVellumEmail } from "./vellum-identity.js";
 
 const log = getLogger("inbound-register");
 
@@ -53,7 +55,10 @@ type EmailValidator = (
 const providerValidators: Record<string, EmailValidator> = {
   resend: validateResendEmail,
   mailgun: validateMailgunEmail,
+  vellum: validateVellumEmail,
 };
+
+const selfAuthenticatedProviders = new Set(["vellum"]);
 
 // ---------------------------------------------------------------------------
 // Guardian lookup
@@ -120,18 +125,25 @@ export function createInboundRegisterHandler(
 
     // ── Resolve API key from credential cache ───────────────────
 
-    const apiKeyCredKey = credentialKey(providerType, "api_key");
-    const apiKey = await credentialCache.get(apiKeyCredKey, { force: true });
+    let apiKey = "";
 
-    if (!apiKey) {
-      log.warn(
-        { providerType },
-        "No API key configured for provider — cannot auto-verify guardian",
-      );
-      return Response.json(
-        { error: `No API key configured for ${providerType}` },
-        { status: 409 },
-      );
+    if (!selfAuthenticatedProviders.has(providerType)) {
+      const apiKeyCredKey = credentialKey(providerType, "api_key");
+      const resolvedKey = await credentialCache.get(apiKeyCredKey, {
+        force: true,
+      });
+
+      if (!resolvedKey) {
+        log.warn(
+          { providerType },
+          "No API key configured for provider — cannot auto-verify guardian",
+        );
+        return Response.json(
+          { error: `No API key configured for ${providerType}` },
+          { status: 409 },
+        );
+      }
+      apiKey = resolvedKey;
     }
 
     // ── Validate email with provider ────────────────────────────

--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -115,12 +115,8 @@ export function createInboundRegisterHandler(
 
     // ── Resolve provider validator ──────────────────────────────
 
-    const isPlatform =
-      process.env.IS_PLATFORM?.trim().toLowerCase() === "true" ||
-      process.env.IS_PLATFORM?.trim() === "1";
-
     const validator = providerValidators[providerType];
-    if (!validator || (selfAuthenticatedProviders.has(providerType) && !isPlatform)) {
+    if (!validator) {
       return Response.json(
         { error: `Unsupported provider type: ${providerType}` },
         { status: 400 },

--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -115,8 +115,12 @@ export function createInboundRegisterHandler(
 
     // ── Resolve provider validator ──────────────────────────────
 
+    const isPlatform =
+      process.env.IS_PLATFORM?.trim().toLowerCase() === "true" ||
+      process.env.IS_PLATFORM?.trim() === "1";
+
     const validator = providerValidators[providerType];
-    if (!validator) {
+    if (!validator || (selfAuthenticatedProviders.has(providerType) && !isPlatform)) {
       return Response.json(
         { error: `Unsupported provider type: ${providerType}` },
         { status: 400 },

--- a/gateway/src/http/routes/vellum-identity.ts
+++ b/gateway/src/http/routes/vellum-identity.ts
@@ -1,0 +1,24 @@
+/**
+ * Vellum identity validation — platform-managed email.
+ *
+ * The route's edge-scoped auth already authenticates the platform,
+ * so no external API key validation is needed.
+ */
+
+import { getLogger } from "../../logger.js";
+import type { EmailValidationResult } from "./inbound-register.js";
+
+const log = getLogger("vellum-identity");
+
+export async function validateVellumEmail(
+  _apiKey: string,
+  guardianEmail: string,
+): Promise<EmailValidationResult | null> {
+  log.info("Platform-managed email — trusting provided guardian email");
+  return {
+    channel: "email",
+    externalUserId: guardianEmail,
+    deliveryChatId: guardianEmail,
+    displayName: guardianEmail,
+  };
+}

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -4007,9 +4007,9 @@ export function buildSchema(): Record<string, unknown> {
       },
       "/inbound/register": {
         post: {
-          summary: "Auto-verify guardian email (BYO provider)",
+          summary: "Auto-verify guardian email",
           description:
-            "Called by the platform after registering a BYO email provider webhook. Validates the provider API key, cross-checks the guardian email (when provider supports it), and creates a guardian email channel binding.",
+            "Called by the platform to auto-verify the guardian's email channel. For BYO providers (resend, mailgun), validates the provider API key. For platform-managed email (vellum), the route's auth is sufficient. Creates a guardian email channel binding.",
           operationId: "inboundRegister",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -4022,7 +4022,7 @@ export function buildSchema(): Record<string, unknown> {
                   properties: {
                     type: {
                       type: "string",
-                      description: "Email provider type (e.g. resend, mailgun)",
+                      description: "Email provider type (e.g. resend, mailgun, vellum)",
                     },
                     guardian_email: {
                       type: "string",


### PR DESCRIPTION
## Summary
- Add "vellum" as a provider type to the `/inbound/register` endpoint so platform-managed email can auto-verify the guardian's email channel binding
- Self-authenticated providers skip the API key lookup since the route's edge-scoped auth already authenticates the platform
- New `vellum-identity.ts` validator trusts the guardian email without external API calls

## Original prompt
When a guardian uses platform-managed email (not BYO Resend/Mailgun), their email is known through WorkOS auth but no code path creates the guardian's email channel binding. The `/inbound/register` endpoint only supported BYO providers, so guardians emailing their assistant got denied with "I don't recognize your address." This adds a "vellum" provider type that trusts the platform-provided guardian email since the route's auth already authenticates the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)