### PR TITLE
feat(memory): offline retrieval comparison harness (P1)

### DIFF
--- a/assistant/src/memory/v2/__tests__/harness-metrics.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-metrics.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { aggregate, evalTurn, recallAtK } from "../harness/metrics.js";
+import type { RetrievalOutput } from "../harness/retriever.js";
+
+function out(
+  selected: string[],
+  sourceBySlug: Record<string, string> = {},
+): RetrievalOutput {
+  return {
+    selectedSlugs: selected,
+    sourceBySlug: new Map(Object.entries(sourceBySlug)),
+  };
+}
+
+describe("harness/metrics recallAtK", () => {
+  test("fraction of ground truth recovered within k", () => {
+    const gt = new Set(["a", "b", "c", "d"]);
+    expect(recallAtK(["a", "b", "x"], gt, 10)).toBeCloseTo(0.5);
+    // only the top-2 selections count toward recall@2
+    expect(recallAtK(["a", "b", "c", "d"], gt, 2)).toBeCloseTo(0.5);
+    expect(recallAtK(["a", "b", "c", "d"], gt, 10)).toBeCloseTo(1);
+  });
+
+  test("empty ground truth is vacuously complete (recall 1)", () => {
+    expect(recallAtK([], new Set<string>(), 5)).toBe(1);
+  });
+});
+
+describe("harness/metrics evalTurn", () => {
+  test("hits / misses / extras and per-lane attribution", () => {
+    const e = evalTurn(
+      out(["a", "b", "z"], { a: "tree", b: "sparse", z: "dense" }),
+      ["a", "b", "c"],
+      [5],
+    );
+    expect(e.hits.sort()).toEqual(["a", "b"]);
+    expect(e.misses).toEqual(["c"]);
+    // selected but not in ground truth — reported as diff, not error
+    expect(e.extras).toEqual(["z"]);
+    expect(e.recallAtK[5]).toBeCloseTo(2 / 3);
+    expect(e.hitsByLane).toEqual({ tree: 1, sparse: 1 });
+  });
+
+  test("failureReason surfaces and recall is 0", () => {
+    const o: RetrievalOutput = {
+      selectedSlugs: [],
+      sourceBySlug: new Map(),
+      failureReason: "no_provider",
+    };
+    const e = evalTurn(o, ["a"], [5]);
+    expect(e.failureReason).toBe("no_provider");
+    expect(e.recallAtK[5]).toBe(0);
+  });
+});
+
+describe("harness/metrics aggregate", () => {
+  test("means recall@k and failure rate across turns", () => {
+    const ks = [5];
+    const t1 = evalTurn(out(["a"]), ["a"], ks); // recall 1
+    const t2 = evalTurn(out([]), ["a"], ks); // recall 0
+    const agg = aggregate([t1, t2], ks);
+    expect(agg.turns).toBe(2);
+    expect(agg.meanRecallAtK[5]).toBeCloseTo(0.5);
+    expect(agg.failureRate).toBe(0);
+  });
+
+  test("empty input is well-defined", () => {
+    const agg = aggregate([], [5]);
+    expect(agg.turns).toBe(0);
+    expect(agg.meanRecallAtK[5]).toBe(0);
+    expect(agg.failureRate).toBe(0);
+  });
+});

--- a/assistant/src/memory/v2/__tests__/harness-oracle.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-oracle.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ memory: { enabled: false } }),
+}));
+
+import { getDb } from "../../db-connection.js";
+import { initializeDb } from "../../db-init.js";
+import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
+import {
+  conversations,
+  memoryV2ActivationLogs,
+  messages,
+} from "../../schema.js";
+import { extractOracleTurns } from "../harness/oracle.js";
+
+initializeDb();
+
+const CONFIG_JSON = JSON.stringify({
+  d: 0,
+  c_user: 0,
+  c_assistant: 0,
+  c_now: 0,
+  k: 0,
+  hops: 0,
+  top_k: 0,
+  epsilon: 0,
+});
+
+let seq = 0;
+
+function ensureConversation(id: string): void {
+  getDb()
+    .insert(conversations)
+    .values({ id, createdAt: 0, updatedAt: 0 })
+    .onConflictDoNothing()
+    .run();
+}
+
+function makeConcept(
+  slug: string,
+  status: MemoryV2ConceptRowRecord["status"],
+): MemoryV2ConceptRowRecord {
+  return {
+    slug,
+    finalActivation: 0,
+    ownActivation: 0,
+    priorActivation: 0,
+    simUser: 0,
+    simAssistant: 0,
+    simNow: 0,
+    simUserRerankBoost: 0,
+    simAssistantRerankBoost: 0,
+    inRerankPool: false,
+    spreadContribution: 0,
+    source: "router",
+    status,
+  };
+}
+
+function insertLog(opts: {
+  conversationId: string;
+  messageId: string | null;
+  turn: number;
+  mode: string;
+  concepts: MemoryV2ConceptRowRecord[];
+  createdAt: number;
+}): void {
+  ensureConversation(opts.conversationId);
+  getDb()
+    .insert(memoryV2ActivationLogs)
+    .values({
+      id: `log-${seq++}`,
+      conversationId: opts.conversationId,
+      messageId: opts.messageId,
+      turn: opts.turn,
+      mode: opts.mode,
+      conceptsJson: JSON.stringify(opts.concepts),
+      skillsJson: "[]",
+      configJson: CONFIG_JSON,
+      createdAt: opts.createdAt,
+    })
+    .run();
+}
+
+function insertMessage(
+  id: string,
+  conversationId: string,
+  createdAt: number,
+): void {
+  ensureConversation(conversationId);
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId,
+      role: "assistant",
+      content: JSON.stringify([{ type: "text", text: "reply" }]),
+      createdAt,
+    })
+    .run();
+}
+
+function reset(): void {
+  const db = getDb();
+  db.delete(memoryV2ActivationLogs).run();
+  db.delete(messages).run();
+}
+
+describe("harness/oracle extractOracleTurns", () => {
+  beforeEach(reset);
+
+  test("returns only mode='router' rows with a resolvable messageId", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      concepts: [makeConcept("a", "injected")],
+      createdAt: 100,
+    });
+    // non-router row — ignored
+    insertMessage("m2", "c1", 200);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m2",
+      turn: 2,
+      mode: "per-turn",
+      concepts: [makeConcept("b", "injected")],
+      createdAt: 200,
+    });
+    // router row, null messageId — skipped (no anchor)
+    insertLog({
+      conversationId: "c1",
+      messageId: null,
+      turn: 3,
+      mode: "router",
+      concepts: [makeConcept("c", "injected")],
+      createdAt: 300,
+    });
+    // router row, messageId does not resolve — skipped
+    insertLog({
+      conversationId: "c1",
+      messageId: "ghost",
+      turn: 4,
+      mode: "router",
+      concepts: [makeConcept("d", "injected")],
+      createdAt: 400,
+    });
+
+    const turns = extractOracleTurns(getDb(), { limit: 50 });
+    expect(turns.length).toBe(1);
+    expect(turns[0]?.turn).toBe(1);
+    expect(turns[0]?.groundTruthSlugs).toEqual(["a"]);
+    expect(turns[0]?.anchorMessageId).toBe("m1");
+    expect(turns[0]?.anchorCreatedAt).toBe(100);
+  });
+
+  test("ground truth keeps injected/in_context, drops the rest", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      createdAt: 100,
+      concepts: [
+        makeConcept("inj", "injected"),
+        makeConcept("ctx", "in_context"),
+        makeConcept("noinj", "not_injected"),
+        makeConcept("miss", "page_missing"),
+        makeConcept("bad", "corrupt"),
+      ],
+    });
+    const turns = extractOracleTurns(getDb());
+    expect(turns[0]?.groundTruthSlugs.sort()).toEqual(["ctx", "inj"]);
+  });
+
+  test("includeNotInjected adds not_injected to ground truth", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      createdAt: 100,
+      concepts: [
+        makeConcept("inj", "injected"),
+        makeConcept("noinj", "not_injected"),
+      ],
+    });
+    const turns = extractOracleTurns(getDb(), { includeNotInjected: true });
+    expect(turns[0]?.groundTruthSlugs.sort()).toEqual(["inj", "noinj"]);
+  });
+
+  test("pageExists predicate drops slugs whose page is gone", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      createdAt: 100,
+      concepts: [
+        makeConcept("present", "injected"),
+        makeConcept("gone", "injected"),
+      ],
+    });
+    const turns = extractOracleTurns(getDb(), {
+      pageExists: (slug) => slug === "present",
+    });
+    expect(turns[0]?.groundTruthSlugs).toEqual(["present"]);
+  });
+
+  test("skips rows whose ground truth is empty after filtering", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      createdAt: 100,
+      concepts: [makeConcept("noinj", "not_injected")],
+    });
+    expect(extractOracleTurns(getDb()).length).toBe(0);
+  });
+
+  test("conversationIds filter restricts the scan", () => {
+    insertMessage("m1", "c1", 100);
+    insertLog({
+      conversationId: "c1",
+      messageId: "m1",
+      turn: 1,
+      mode: "router",
+      concepts: [makeConcept("a", "injected")],
+      createdAt: 100,
+    });
+    insertMessage("m2", "c2", 200);
+    insertLog({
+      conversationId: "c2",
+      messageId: "m2",
+      turn: 1,
+      mode: "router",
+      concepts: [makeConcept("b", "injected")],
+      createdAt: 200,
+    });
+    const turns = extractOracleTurns(getDb(), { conversationIds: ["c2"] });
+    expect(turns.length).toBe(1);
+    expect(turns[0]?.conversationId).toBe("c2");
+  });
+});

--- a/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ memory: { enabled: false } }),
+}));
+
+import type { AssistantConfig } from "../../../config/types.js";
+import { getDb } from "../../db-connection.js";
+import { initializeDb } from "../../db-init.js";
+import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
+import {
+  conversations,
+  memoryV2ActivationLogs,
+  messages,
+} from "../../schema.js";
+import type { OracleTurn } from "../harness/oracle.js";
+import { reconstructInput } from "../harness/replay-input.js";
+
+initializeDb();
+
+// loadNowText reads workspace files; a nonexistent dir yields "".
+const WORKSPACE = "/tmp/harness-replay-nonexistent-workspace";
+
+const ZERO_CONFIG = {
+  d: 0,
+  c_user: 0,
+  c_assistant: 0,
+  c_now: 0,
+  k: 0,
+  hops: 0,
+  top_k: 0,
+  epsilon: 0,
+};
+
+let seq = 0;
+
+function ensureConversation(id: string): void {
+  getDb()
+    .insert(conversations)
+    .values({ id, createdAt: 0, updatedAt: 0 })
+    .onConflictDoNothing()
+    .run();
+}
+
+function config(historicalPairs: number): AssistantConfig {
+  return {
+    memory: { v2: { router: { historical_pairs: historicalPairs } } },
+  } as unknown as AssistantConfig;
+}
+
+function insertMessage(
+  id: string,
+  conversationId: string,
+  role: string,
+  text: string,
+  createdAt: number,
+): void {
+  ensureConversation(conversationId);
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId,
+      role,
+      content: JSON.stringify([{ type: "text", text }]),
+      createdAt,
+    })
+    .run();
+}
+
+function makeConcept(
+  slug: string,
+  status: MemoryV2ConceptRowRecord["status"],
+): MemoryV2ConceptRowRecord {
+  return {
+    slug,
+    finalActivation: 0,
+    ownActivation: 0,
+    priorActivation: 0,
+    simUser: 0,
+    simAssistant: 0,
+    simNow: 0,
+    simUserRerankBoost: 0,
+    simAssistantRerankBoost: 0,
+    inRerankPool: false,
+    spreadContribution: 0,
+    source: "router",
+    status,
+  };
+}
+
+function insertRouterLog(
+  conversationId: string,
+  messageId: string,
+  turn: number,
+  concepts: MemoryV2ConceptRowRecord[],
+  createdAt: number,
+): void {
+  ensureConversation(conversationId);
+  getDb()
+    .insert(memoryV2ActivationLogs)
+    .values({
+      id: `log-${seq++}`,
+      conversationId,
+      messageId,
+      turn,
+      mode: "router",
+      conceptsJson: JSON.stringify(concepts),
+      skillsJson: "[]",
+      configJson: JSON.stringify(ZERO_CONFIG),
+      createdAt,
+    })
+    .run();
+}
+
+function turnFor(
+  conversationId: string,
+  turn: number,
+  anchorMessageId: string,
+  anchorCreatedAt: number,
+): OracleTurn {
+  return {
+    conversationId,
+    turn,
+    anchorMessageId,
+    anchorCreatedAt,
+    groundTruthSlugs: ["x"],
+    loggedConfig: ZERO_CONFIG,
+    createdAt: anchorCreatedAt,
+  };
+}
+
+function reset(): void {
+  const db = getDb();
+  db.delete(memoryV2ActivationLogs).run();
+  db.delete(messages).run();
+}
+
+describe("harness/replay-input reconstructInput", () => {
+  beforeEach(reset);
+
+  test("reconstructs the last (assistant,user) pair before the anchor reply", async () => {
+    insertMessage("u1", "c1", "user", "first user", 10);
+    insertMessage("a1", "c1", "assistant", "first reply", 20);
+    insertMessage("u2", "c1", "user", "second user", 30);
+    insertMessage("a2", "c1", "assistant", "second reply", 40); // anchor
+
+    const r = await reconstructInput(
+      getDb(),
+      turnFor("c1", 2, "a2", 40),
+      config(1),
+      WORKSPACE,
+    );
+    expect(r).not.toBeNull();
+    expect(r?.input.recentTurnPairs).toEqual([
+      { assistantMessage: "first reply", userMessage: "second user" },
+    ]);
+    expect(r?.meta.pairsReconstructed).toBe(1);
+    expect(r?.input.nowText).toBe("");
+  });
+
+  test("historical_pairs=2 returns the last two pairs", async () => {
+    insertMessage("u1", "c1", "user", "u-one", 10);
+    insertMessage("a1", "c1", "assistant", "a-one", 20);
+    insertMessage("u2", "c1", "user", "u-two", 30);
+    insertMessage("a2", "c1", "assistant", "a-two", 40);
+    insertMessage("u3", "c1", "user", "u-three", 50);
+    insertMessage("a3", "c1", "assistant", "a-three", 60); // anchor
+
+    const r = await reconstructInput(
+      getDb(),
+      turnFor("c1", 3, "a3", 60),
+      config(2),
+      WORKSPACE,
+    );
+    expect(r?.input.recentTurnPairs).toEqual([
+      { assistantMessage: "a-one", userMessage: "u-two" },
+      { assistantMessage: "a-two", userMessage: "u-three" },
+    ]);
+  });
+
+  test("returns null when the anchor message is not found", async () => {
+    insertMessage("u1", "c1", "user", "hi", 10);
+    const r = await reconstructInput(
+      getDb(),
+      turnFor("c1", 1, "missing-anchor", 999),
+      config(1),
+      WORKSPACE,
+    );
+    expect(r).toBeNull();
+  });
+
+  test("priorEverInjected unions injected/in_context slugs from earlier router turns", async () => {
+    insertMessage("u1", "c1", "user", "u1", 10);
+    insertMessage("a1", "c1", "assistant", "a1", 20);
+    insertMessage("u2", "c1", "user", "u2", 30);
+    insertMessage("a2", "c1", "assistant", "a2", 40); // anchor for turn 2
+    insertRouterLog(
+      "c1",
+      "a1",
+      1,
+      [
+        makeConcept("p1", "injected"),
+        makeConcept("p2", "in_context"),
+        makeConcept("p3", "not_injected"),
+      ],
+      20,
+    );
+
+    const r = await reconstructInput(
+      getDb(),
+      turnFor("c1", 2, "a2", 40),
+      config(1),
+      WORKSPACE,
+    );
+    const slugs = (r?.input.priorEverInjected ?? []).map((e) => e.slug).sort();
+    expect(slugs).toEqual(["p1", "p2"]);
+    expect(r?.meta.priorEverInjectedCount).toBe(2);
+  });
+});

--- a/assistant/src/memory/v2/__tests__/harness-runner.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-runner.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { OracleTurn } from "../harness/oracle.js";
+import type { ReconstructedInput } from "../harness/replay-input.js";
+import type {
+  RetrievalInput,
+  RetrievalOutput,
+  Retriever,
+} from "../harness/retriever.js";
+import { runComparison } from "../harness/runner.js";
+
+const ZERO_CONFIG = {
+  d: 0,
+  c_user: 0,
+  c_assistant: 0,
+  c_now: 0,
+  k: 0,
+  hops: 0,
+  top_k: 0,
+  epsilon: 0,
+};
+
+function oracleTurn(
+  conversationId: string,
+  turn: number,
+  groundTruthSlugs: string[],
+): OracleTurn {
+  return {
+    conversationId,
+    turn,
+    anchorMessageId: `${conversationId}-m${turn}`,
+    anchorCreatedAt: turn * 100,
+    groundTruthSlugs,
+    loggedConfig: ZERO_CONFIG,
+    createdAt: turn * 100,
+  };
+}
+
+const STUB_INPUT: RetrievalInput = {
+  workspaceDir: "/tmp/ws",
+  recentTurnPairs: [{ assistantMessage: "", userMessage: "hi" }],
+  nowText: "",
+  priorEverInjected: [],
+  config: {} as unknown as AssistantConfig,
+};
+
+const STUB_RECONSTRUCTED: ReconstructedInput = {
+  input: STUB_INPUT,
+  meta: {
+    windowPairs: 1,
+    pairsReconstructed: 1,
+    priorEverInjectedCount: 0,
+    nowReconstructedFromCurrent: true,
+  },
+};
+
+function fixedRetriever(name: string, selected: string[]): Retriever {
+  return {
+    name,
+    retrieve: async (): Promise<RetrievalOutput> => ({
+      selectedSlugs: selected,
+      sourceBySlug: new Map(selected.map((s): [string, string] => [s, name])),
+    }),
+  };
+}
+
+describe("harness/runner runComparison", () => {
+  test("scores each retriever against ground truth across turns", async () => {
+    const report = await runComparison({
+      retrievers: [
+        fixedRetriever("router", ["a", "b"]),
+        fixedRetriever("loop", ["a", "c"]),
+      ],
+      oracleTurns: [
+        oracleTurn("c1", 1, ["a", "b"]),
+        oracleTurn("c1", 2, ["a"]),
+      ],
+      reconstruct: async () => STUB_RECONSTRUCTED,
+      ks: [5],
+    });
+
+    expect(report.turnsConsidered).toBe(2);
+    expect(report.turnsScored).toBe(2);
+    expect(report.turnsSkipped).toBe(0);
+
+    const router = report.retrievers.find((r) => r.name === "router");
+    const loop = report.retrievers.find((r) => r.name === "loop");
+    // router recovers all ground truth on both turns → mean recall 1
+    expect(router?.aggregate.meanRecallAtK[5]).toBeCloseTo(1);
+    // loop: turn 1 = 1/2, turn 2 = 1/1 → mean 0.75
+    expect(loop?.aggregate.meanRecallAtK[5]).toBeCloseTo(0.75);
+  });
+
+  test("skips turns whose reconstruction returns null", async () => {
+    const report = await runComparison({
+      retrievers: [fixedRetriever("router", ["a"])],
+      oracleTurns: [oracleTurn("c1", 1, ["a"]), oracleTurn("c1", 2, ["a"])],
+      reconstruct: async (turn) =>
+        turn.turn === 2 ? null : STUB_RECONSTRUCTED,
+      ks: [5],
+    });
+
+    expect(report.turnsScored).toBe(1);
+    expect(report.turnsSkipped).toBe(1);
+    expect(report.perTurn.length).toBe(1);
+    expect(report.perTurn[0]?.turn).toBe(1);
+  });
+});

--- a/assistant/src/memory/v2/harness/metrics.ts
+++ b/assistant/src/memory/v2/harness/metrics.ts
@@ -1,0 +1,124 @@
+/**
+ * Recall@k and per-lane diff for the comparison harness.
+ *
+ * Ground truth is the current router's logged selections (see `oracle.ts`). A
+ * retriever's "extras" (selected, not in ground truth) are reported as a
+ * *diff*, not an error — a better retriever may legitimately surface pages the
+ * router missed. recall@k is the primary signal.
+ */
+
+import type { RetrievalOutput } from "./retriever.js";
+
+export interface TurnEval {
+  groundTruth: string[];
+  selected: string[];
+  /** Ground-truth slugs the retriever selected (anywhere in its output). */
+  hits: string[];
+  /** Ground-truth slugs the retriever missed entirely. */
+  misses: string[];
+  /** Selected slugs not in ground truth — diff, not error. */
+  extras: string[];
+  /** recall@k for each requested k. */
+  recallAtK: Record<number, number>;
+  /** Counts of hits grouped by the retriever's source/lane labels. */
+  hitsByLane: Record<string, number>;
+  costUsd?: number;
+  failureReason: string | null;
+}
+
+export interface AggregateEval {
+  turns: number;
+  meanRecallAtK: Record<number, number>;
+  failureRate: number;
+  meanCostUsd?: number;
+}
+
+/**
+ * recall@k = |topK(selected) ∩ G| / |G|. An empty ground-truth set is defined
+ * as recall 1 (nothing to recall — vacuously complete).
+ */
+export function recallAtK(
+  selected: readonly string[],
+  groundTruth: ReadonlySet<string>,
+  k: number,
+): number {
+  if (groundTruth.size === 0) return 1;
+  let hit = 0;
+  for (const slug of selected.slice(0, k)) {
+    if (groundTruth.has(slug)) hit++;
+  }
+  return hit / groundTruth.size;
+}
+
+export function evalTurn(
+  output: RetrievalOutput,
+  groundTruth: readonly string[],
+  ks: readonly number[],
+): TurnEval {
+  const gtList = Array.from(new Set(groundTruth));
+  const gtSet = new Set(gtList);
+  const selectedSet = new Set(output.selectedSlugs);
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+  for (const slug of gtList) {
+    (selectedSet.has(slug) ? hits : misses).push(slug);
+  }
+  const extras = output.selectedSlugs.filter((s) => !gtSet.has(s));
+
+  const recall: Record<number, number> = {};
+  for (const k of ks) {
+    recall[k] = recallAtK(output.selectedSlugs, gtSet, k);
+  }
+
+  const hitsByLane: Record<string, number> = {};
+  for (const slug of hits) {
+    const lane = output.sourceBySlug.get(slug) ?? "unknown";
+    hitsByLane[lane] = (hitsByLane[lane] ?? 0) + 1;
+  }
+
+  return {
+    groundTruth: gtList,
+    selected: output.selectedSlugs,
+    hits,
+    misses,
+    extras,
+    recallAtK: recall,
+    hitsByLane,
+    ...(output.cost?.usd !== undefined ? { costUsd: output.cost.usd } : {}),
+    failureReason: output.failureReason ?? null,
+  };
+}
+
+export function aggregate(
+  perTurn: readonly TurnEval[],
+  ks: readonly number[],
+): AggregateEval {
+  const turns = perTurn.length;
+
+  const meanRecallAtK: Record<number, number> = {};
+  for (const k of ks) {
+    if (turns === 0) {
+      meanRecallAtK[k] = 0;
+      continue;
+    }
+    let sum = 0;
+    for (const t of perTurn) sum += t.recallAtK[k] ?? 0;
+    meanRecallAtK[k] = sum / turns;
+  }
+
+  const failures = perTurn.filter((t) => t.failureReason != null).length;
+  const costed = perTurn.filter((t) => t.costUsd !== undefined);
+
+  return {
+    turns,
+    meanRecallAtK,
+    failureRate: turns === 0 ? 0 : failures / turns,
+    ...(costed.length > 0
+      ? {
+          meanCostUsd:
+            costed.reduce((s, t) => s + (t.costUsd ?? 0), 0) / costed.length,
+        }
+      : {}),
+  };
+}

--- a/assistant/src/memory/v2/harness/oracle.ts
+++ b/assistant/src/memory/v2/harness/oracle.ts
@@ -1,0 +1,145 @@
+/**
+ * Oracle extraction — the current router's logged selections as silver-standard
+ * ground truth.
+ *
+ * Source: `memory_v2_activation_logs` rows with `mode = 'router'`. Each row's
+ * `messageId` is backfilled to the turn's assistant message (see
+ * `backfillMemoryV2ActivationMessageId`), so we join `messageId → messages.id`
+ * to anchor the turn — robust, no fragile turn-counting. Rows whose messageId
+ * is null (the in-flight turn) or no longer resolves are skipped.
+ *
+ * Ground truth G(turn) = selected slugs with status ∈ {injected, in_context}
+ * (what actually reached the model), optionally + not_injected, and — when a
+ * `pageExists` predicate is supplied — only slugs whose page still exists
+ * (neither retriever can find a nonexistent page). page_missing / corrupt are
+ * always excluded.
+ */
+
+import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+
+import type { DrizzleDb } from "../../db-connection.js";
+import type {
+  MemoryV2ConceptRowRecord,
+  MemoryV2ConfigSnapshot,
+} from "../../memory-v2-activation-log-store.js";
+import { memoryV2ActivationLogs, messages } from "../../schema.js";
+
+export interface OracleTurn {
+  conversationId: string;
+  turn: number;
+  /** Backfilled assistant-message id for this turn — the reconstruction anchor. */
+  anchorMessageId: string;
+  /** `created_at` of the anchor message; reconstruction cuts strictly before it. */
+  anchorCreatedAt: number;
+  /** Slugs the router's judgment put in front of the model (the recall target). */
+  groundTruthSlugs: string[];
+  loggedConfig: MemoryV2ConfigSnapshot;
+  createdAt: number;
+}
+
+export interface ExtractOracleOptions {
+  /** Max log rows to scan (default 50). Some are skipped, so result ≤ limit. */
+  limit?: number;
+  strategy?: "recent" | "random";
+  conversationIds?: string[];
+  /** Include status "not_injected" (selected but cut by the cap) in G. Default false. */
+  includeNotInjected?: boolean;
+  /**
+   * Page-existence predicate, typically backed by `getPageIndex().bySlug`.
+   * When provided, ground-truth slugs whose page no longer exists are dropped.
+   * Omit in unit tests.
+   */
+  pageExists?: (slug: string) => boolean;
+}
+
+export function extractOracleTurns(
+  db: DrizzleDb,
+  options: ExtractOracleOptions = {},
+): OracleTurn[] {
+  const {
+    limit = 50,
+    strategy = "recent",
+    conversationIds,
+    includeNotInjected = false,
+    pageExists,
+  } = options;
+
+  const allowedStatuses = new Set<string>(["injected", "in_context"]);
+  if (includeNotInjected) allowedStatuses.add("not_injected");
+
+  const filters = [
+    eq(memoryV2ActivationLogs.mode, "router"),
+    isNotNull(memoryV2ActivationLogs.messageId),
+  ];
+  if (conversationIds && conversationIds.length > 0) {
+    filters.push(
+      inArray(memoryV2ActivationLogs.conversationId, conversationIds),
+    );
+  }
+
+  const rows = db
+    .select({
+      conversationId: memoryV2ActivationLogs.conversationId,
+      messageId: memoryV2ActivationLogs.messageId,
+      turn: memoryV2ActivationLogs.turn,
+      conceptsJson: memoryV2ActivationLogs.conceptsJson,
+      configJson: memoryV2ActivationLogs.configJson,
+      createdAt: memoryV2ActivationLogs.createdAt,
+    })
+    .from(memoryV2ActivationLogs)
+    .where(and(...filters))
+    .orderBy(
+      strategy === "random"
+        ? sql`RANDOM()`
+        : desc(memoryV2ActivationLogs.createdAt),
+    )
+    .limit(limit)
+    .all();
+
+  const turns: OracleTurn[] = [];
+  for (const row of rows) {
+    const messageId = row.messageId;
+    if (messageId == null) continue;
+
+    const anchor = db
+      .select({ createdAt: messages.createdAt })
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .limit(1)
+      .all();
+    const anchorRow = anchor[0];
+    if (!anchorRow) continue;
+
+    let concepts: MemoryV2ConceptRowRecord[];
+    let loggedConfig: MemoryV2ConfigSnapshot;
+    try {
+      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
+      loggedConfig = JSON.parse(row.configJson) as MemoryV2ConfigSnapshot;
+    } catch {
+      continue;
+    }
+
+    const seen = new Set<string>();
+    const groundTruthSlugs: string[] = [];
+    for (const concept of concepts) {
+      if (!allowedStatuses.has(concept.status)) continue;
+      if (pageExists && !pageExists(concept.slug)) continue;
+      if (seen.has(concept.slug)) continue;
+      seen.add(concept.slug);
+      groundTruthSlugs.push(concept.slug);
+    }
+    if (groundTruthSlugs.length === 0) continue;
+
+    turns.push({
+      conversationId: row.conversationId,
+      turn: row.turn,
+      anchorMessageId: messageId,
+      anchorCreatedAt: anchorRow.createdAt,
+      groundTruthSlugs,
+      loggedConfig,
+      createdAt: row.createdAt,
+    });
+  }
+
+  return turns;
+}

--- a/assistant/src/memory/v2/harness/replay-input.ts
+++ b/assistant/src/memory/v2/harness/replay-input.ts
@@ -1,0 +1,224 @@
+/**
+ * Input reconstruction — rebuild a retriever's per-turn inputs from telemetry.
+ *
+ * The activation log stores only outputs, so replaying a historical turn means
+ * reconstructing the inputs:
+ *  - `recentTurnPairs`: the (assistant, user) pairs ending at the turn's user
+ *    message, windowed by `historical_pairs` and extracted exactly as
+ *    production does (mirrors `extractRecentTurnPairs` in
+ *    `conversation-graph-memory.ts`).
+ *  - `nowText`: read from current workspace files (`loadNowText`). NOT stored
+ *    in the log, so it may differ from what the live turn saw —
+ *    always-approximate; see `ReconstructionMeta.nowReconstructedFromCurrent`.
+ *  - `priorEverInjected`: the union of injected / in_context slugs from earlier
+ *    `mode='router'` logs in the same conversation (turn < target).
+ *
+ * The anchor is the turn's assistant reply; the messages the router saw are
+ * those strictly before it, so we fetch a bounded recent window up to the
+ * anchor's timestamp and cut at the anchor row.
+ */
+
+import { and, asc, desc, eq, lt, lte } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { ContentBlock } from "../../../providers/types.js";
+import type { DrizzleDb } from "../../db-connection.js";
+import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
+import { memoryV2ActivationLogs, messages } from "../../schema.js";
+import { loadNowText } from "../now-text.js";
+import type { RouterTurnPair } from "../router.js";
+import type { EverInjectedEntry } from "../types.js";
+import type { OracleTurn } from "./oracle.js";
+import type { RetrievalInput } from "./retriever.js";
+
+export interface ReconstructionMeta {
+  /** `historical_pairs` window requested. */
+  windowPairs: number;
+  /** Pairs actually reconstructed (may be < window near conversation start). */
+  pairsReconstructed: number;
+  /** `priorEverInjected` entries reconstructed from earlier router logs. */
+  priorEverInjectedCount: number;
+  /**
+   * NOW text is read from current workspace files — it is not stored in the
+   * log and may differ from what the live turn saw. Always true; a recall gap
+   * is partly attributable to this unmeasured drift.
+   */
+  nowReconstructedFromCurrent: true;
+}
+
+export interface ReconstructedInput {
+  input: RetrievalInput;
+  meta: ReconstructionMeta;
+}
+
+/** Minimal message shape for pair extraction. */
+interface PlainMessage {
+  role: string;
+  content: ContentBlock[];
+}
+
+/**
+ * Mirror of production `extractRecentTurnPairs`: walk messages newest-first,
+ * pair each user message with the preceding assistant reply, keep the last `k`
+ * pairs (oldest first). A leading user message with no prior assistant reply is
+ * emitted with an empty `assistantMessage`.
+ */
+function extractRecentTurnPairs(
+  msgs: readonly PlainMessage[],
+  k: number,
+): RouterTurnPair[] {
+  const messageText = (msg: PlainMessage): string =>
+    msg.content
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" ");
+
+  const pairs: RouterTurnPair[] = [];
+  let pendingUser: string | null = null;
+  for (let i = msgs.length - 1; i >= 0 && pairs.length < k; i--) {
+    const msg = msgs[i]!;
+    if (msg.role === "user" && pendingUser === null) {
+      pendingUser = messageText(msg);
+    } else if (msg.role === "assistant" && pendingUser !== null) {
+      pairs.unshift({
+        assistantMessage: messageText(msg),
+        userMessage: pendingUser,
+      });
+      pendingUser = null;
+    }
+  }
+  if (pendingUser !== null && pairs.length < k) {
+    pairs.unshift({ assistantMessage: "", userMessage: pendingUser });
+  }
+  if (pairs.length === 0) {
+    pairs.push({ assistantMessage: "", userMessage: "" });
+  }
+  return pairs;
+}
+
+function parseContent(raw: string): ContentBlock[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ContentBlock[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function reconstructInput(
+  db: DrizzleDb,
+  turn: OracleTurn,
+  config: AssistantConfig,
+  workspaceDir: string,
+): Promise<ReconstructedInput | null> {
+  const windowPairs = config.memory.v2.router.historical_pairs;
+
+  // Fetch a bounded recent window up to the anchor's timestamp (newest first),
+  // then cut everything at/after the anchor reply. We only need the last
+  // `windowPairs` (assistant,user) pairs, so a small generous bound suffices
+  // even for very long conversations.
+  const fetchWindow = Math.max(20, windowPairs * 12);
+  const recent = db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, turn.conversationId),
+        lte(messages.createdAt, turn.anchorCreatedAt),
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(fetchWindow)
+    .all();
+
+  const anchorPos = recent.findIndex((m) => m.id === turn.anchorMessageId);
+  if (anchorPos < 0) return null;
+  const beforeAnchor = recent.slice(anchorPos + 1);
+  if (beforeAnchor.length === 0) return null;
+
+  const plain: PlainMessage[] = beforeAnchor
+    .slice()
+    .reverse()
+    .map((m) => ({ role: m.role, content: parseContent(m.content) }));
+
+  const recentTurnPairs = extractRecentTurnPairs(plain, windowPairs);
+  const priorEverInjected = reconstructPriorEverInjected(
+    db,
+    turn.conversationId,
+    turn.turn,
+  );
+  const nowText = await loadNowText(workspaceDir);
+
+  return {
+    input: {
+      workspaceDir,
+      recentTurnPairs,
+      nowText,
+      priorEverInjected,
+      config,
+    },
+    meta: {
+      windowPairs,
+      pairsReconstructed: recentTurnPairs.length,
+      priorEverInjectedCount: priorEverInjected.length,
+      nowReconstructedFromCurrent: true,
+    },
+  };
+}
+
+const PRIOR_STATUSES = new Set<string>(["injected", "in_context"]);
+
+/**
+ * Union of slugs injected on earlier `mode='router'` turns in this conversation
+ * (turn < `currentTurn`), each tagged with the earliest turn it appeared on —
+ * the harness analogue of the running `everInjected` list production maintains.
+ */
+function reconstructPriorEverInjected(
+  db: DrizzleDb,
+  conversationId: string,
+  currentTurn: number,
+): EverInjectedEntry[] {
+  const rows = db
+    .select({
+      turn: memoryV2ActivationLogs.turn,
+      conceptsJson: memoryV2ActivationLogs.conceptsJson,
+    })
+    .from(memoryV2ActivationLogs)
+    .where(
+      and(
+        eq(memoryV2ActivationLogs.conversationId, conversationId),
+        eq(memoryV2ActivationLogs.mode, "router"),
+        lt(memoryV2ActivationLogs.turn, currentTurn),
+      ),
+    )
+    .orderBy(asc(memoryV2ActivationLogs.turn))
+    .all();
+
+  const firstTurnBySlug = new Map<string, number>();
+  for (const row of rows) {
+    let concepts: MemoryV2ConceptRowRecord[];
+    try {
+      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
+    } catch {
+      continue;
+    }
+    for (const concept of concepts) {
+      if (!PRIOR_STATUSES.has(concept.status)) continue;
+      if (!firstTurnBySlug.has(concept.slug)) {
+        firstTurnBySlug.set(concept.slug, row.turn);
+      }
+    }
+  }
+
+  const entries: EverInjectedEntry[] = [];
+  firstTurnBySlug.forEach((turn, slug) => {
+    entries.push({ slug, turn });
+  });
+  return entries;
+}

--- a/assistant/src/memory/v2/harness/retriever.ts
+++ b/assistant/src/memory/v2/harness/retriever.ts
@@ -1,0 +1,74 @@
+/**
+ * The retriever seam for the memory comparison harness.
+ *
+ * A `Retriever` maps one turn's reconstructed context to a set of selected
+ * concept-page slugs. Multiple strategies (the production router, an
+ * alternative retrieval loop) implement this single interface, so the harness
+ * can run them over the same turns and diff their selections against the oracle
+ * (see `oracle.ts`). Offline only — nothing here runs in the live injection
+ * path.
+ */
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { RouterTurnPair } from "../router.js";
+import type { EverInjectedEntry } from "../types.js";
+import type { DescentTrace } from "./trace.js";
+
+/**
+ * Per-turn context a retriever needs, mirroring the live router's inputs
+ * (`RunRouterParams`). Reconstructed from historical telemetry by
+ * `reconstructInput` (see `replay-input.ts`).
+ */
+export interface RetrievalInput {
+  workspaceDir: string;
+  /**
+   * Recent (assistant, user) pairs, oldest first. The last entry's
+   * `userMessage` is the just-arrived turn being routed.
+   */
+  recentTurnPairs: readonly RouterTurnPair[];
+  /** NOW context (essentials/threads/recent), verbatim. */
+  nowText: string;
+  /** Slugs already injected on prior turns. */
+  priorEverInjected: readonly EverInjectedEntry[];
+  config: AssistantConfig;
+  signal?: AbortSignal;
+}
+
+/** Optional cost accounting for a single retrieval. */
+export interface RetrievalCost {
+  inputTokens?: number;
+  outputTokens?: number;
+  usd?: number;
+  ms?: number;
+}
+
+/** What a retriever returns for one turn. */
+export interface RetrievalOutput {
+  /** Selected page slugs, in the retriever's own ranked order. */
+  selectedSlugs: string[];
+  /**
+   * Per-slug provenance / lane label, retriever-defined — router tiers
+   * (`tier1`, `tier3:0`, …) for the current router, or loop lanes (`sparse`,
+   * `dense`, `tree`, `edge`) for the future loop. Drives per-lane attribution
+   * in `metrics.ts`.
+   */
+  sourceBySlug: ReadonlyMap<string, string>;
+  /**
+   * Loop-only descent trace. Tier-based retrievers (the current router) have
+   * no tree walk and leave this `undefined`; renderers show "(no descent
+   * trace)".
+   */
+  trace?: DescentTrace;
+  cost?: RetrievalCost;
+  /** Non-null when the retriever could not produce a usable selection. */
+  failureReason?: string | null;
+}
+
+/**
+ * A named retrieval strategy. Implementations must not mutate production state
+ * — the harness runs them offline over historical turns.
+ */
+export interface Retriever {
+  readonly name: string;
+  retrieve(input: RetrievalInput): Promise<RetrievalOutput>;
+}

--- a/assistant/src/memory/v2/harness/router-retriever.ts
+++ b/assistant/src/memory/v2/harness/router-retriever.ts
@@ -1,0 +1,43 @@
+/**
+ * Router retriever — the current production router (`runRouter`) adapted to the
+ * harness `Retriever` interface.
+ *
+ * The union cap is left ON (no `disableUnionCap`) so the selection matches what
+ * production would actually inject — the self-test grades the router against
+ * its own injected ground truth.
+ */
+
+import type { DrizzleDb } from "../../db-connection.js";
+import { runRouter } from "../router.js";
+import type {
+  RetrievalInput,
+  RetrievalOutput,
+  Retriever,
+} from "./retriever.js";
+
+/**
+ * @param database optional handle for tier-2 EMA scoring, forwarded to
+ * `runRouter`. Omit to exercise only the tier-1 / tier-3 paths (as the router's
+ * own tests do).
+ */
+export function createRouterRetriever(database?: DrizzleDb): Retriever {
+  return {
+    name: "router",
+    async retrieve(input: RetrievalInput): Promise<RetrievalOutput> {
+      const result = await runRouter({
+        workspaceDir: input.workspaceDir,
+        recentTurnPairs: input.recentTurnPairs,
+        nowText: input.nowText,
+        priorEverInjected: input.priorEverInjected,
+        config: input.config,
+        ...(input.signal ? { signal: input.signal } : {}),
+        ...(database ? { database } : {}),
+      });
+      return {
+        selectedSlugs: result.selectedSlugs,
+        sourceBySlug: result.sourceBySlug,
+        failureReason: result.failureReason,
+      };
+    },
+  };
+}

--- a/assistant/src/memory/v2/harness/runner.ts
+++ b/assistant/src/memory/v2/harness/runner.ts
@@ -1,0 +1,106 @@
+/**
+ * Comparison runner — execute N retrievers over a set of oracle turns and score
+ * each against ground truth.
+ *
+ * The runner is DB/workspace-agnostic: input reconstruction is injected as a
+ * function, so it can be unit-tested with stubs and the route/CLI can wire in
+ * the real `reconstructInput` (which needs a DB + workspace).
+ */
+
+import {
+  aggregate,
+  type AggregateEval,
+  evalTurn,
+  type TurnEval,
+} from "./metrics.js";
+import type { OracleTurn } from "./oracle.js";
+import type { ReconstructedInput } from "./replay-input.js";
+import type { Retriever } from "./retriever.js";
+
+export interface ComparisonTurnResult {
+  conversationId: string;
+  turn: number;
+  /** Per-retriever evaluation for this turn, keyed by retriever name. */
+  byRetriever: Record<string, TurnEval>;
+}
+
+export interface RetrieverReport {
+  name: string;
+  aggregate: AggregateEval;
+}
+
+export interface ComparisonReport {
+  ks: number[];
+  /** Oracle turns handed to the runner. */
+  turnsConsidered: number;
+  /** Turns actually scored (reconstruction succeeded). */
+  turnsScored: number;
+  /** Turns skipped because input reconstruction returned null. */
+  turnsSkipped: number;
+  perTurn: ComparisonTurnResult[];
+  retrievers: RetrieverReport[];
+}
+
+export interface RunComparisonParams {
+  retrievers: readonly Retriever[];
+  oracleTurns: readonly OracleTurn[];
+  /** Reconstruct a turn's retriever input; return null to skip the turn. */
+  reconstruct: (turn: OracleTurn) => Promise<ReconstructedInput | null>;
+  ks: readonly number[];
+  signal?: AbortSignal;
+}
+
+export async function runComparison(
+  params: RunComparisonParams,
+): Promise<ComparisonReport> {
+  const { retrievers, oracleTurns, reconstruct, ks, signal } = params;
+
+  const perTurn: ComparisonTurnResult[] = [];
+  const perRetrieverEvals = new Map<string, TurnEval[]>();
+  for (const retriever of retrievers) {
+    perRetrieverEvals.set(retriever.name, []);
+  }
+
+  let turnsScored = 0;
+  let turnsSkipped = 0;
+
+  for (const turn of oracleTurns) {
+    if (signal?.aborted) break;
+
+    const reconstructed = await reconstruct(turn);
+    if (!reconstructed) {
+      turnsSkipped++;
+      continue;
+    }
+    turnsScored++;
+
+    const byRetriever: Record<string, TurnEval> = {};
+    for (const retriever of retrievers) {
+      if (signal?.aborted) break;
+      const output = await retriever.retrieve(reconstructed.input);
+      const turnEval = evalTurn(output, turn.groundTruthSlugs, ks);
+      byRetriever[retriever.name] = turnEval;
+      perRetrieverEvals.get(retriever.name)?.push(turnEval);
+    }
+
+    perTurn.push({
+      conversationId: turn.conversationId,
+      turn: turn.turn,
+      byRetriever,
+    });
+  }
+
+  const retrieverReports: RetrieverReport[] = retrievers.map((retriever) => ({
+    name: retriever.name,
+    aggregate: aggregate(perRetrieverEvals.get(retriever.name) ?? [], ks),
+  }));
+
+  return {
+    ks: [...ks],
+    turnsConsidered: oracleTurns.length,
+    turnsScored,
+    turnsSkipped,
+    perTurn,
+    retrievers: retrieverReports,
+  };
+}

--- a/assistant/src/memory/v2/harness/trace.ts
+++ b/assistant/src/memory/v2/harness/trace.ts
@@ -1,0 +1,58 @@
+/**
+ * Descent-trace schema for a tree-walking retriever.
+ *
+ * Defined ahead of its producer: the comparison harness renders this and a
+ * tree-walking retriever emits it; a tier-based retriever (no tree walk) leaves
+ * `RetrievalOutput.trace` undefined. Per level it records which branches were
+ * considered, descended, and skipped plus the model's reasoning, so a wrong
+ * high-level skip is observable rather than silent.
+ */
+
+import type { RetrievalCost } from "./retriever.js";
+
+/** A scout lane's contribution on one pass. */
+export interface ScoutResult {
+  lane: "hot" | "sparse" | "dense";
+  slugs: string[];
+  /** Optional per-slug score (BM25 / cosine / EMA) for inspection. */
+  scoreBySlug?: Record<string, number>;
+}
+
+/** One level of the tree walk: what was considered, descended, and skipped. */
+export interface TreeLevel {
+  /** Node whose index page was read ("" for root, else a branch path). */
+  node: string;
+  considered: string[];
+  descended: string[];
+  skipped: string[];
+  /** The model's stated reason for the descend/skip split at this node. */
+  reasoning: string;
+  cost?: RetrievalCost;
+}
+
+/** A 1–2 hop walk along the curated `edges:` graph from a seed page. */
+export interface EdgeExpansion {
+  from: string;
+  pulled: string[];
+}
+
+/** The gate's decision at the end of a pass. */
+export interface GateDecision {
+  decision: "ready" | "more";
+  /** When "more", the generated follow-up queries seeding the next pass. */
+  questions?: string[];
+}
+
+/** Everything that happened on one pass of the loop. */
+export interface DescentPass {
+  passNumber: number;
+  scouts?: ScoutResult[];
+  treeLevels?: TreeLevel[];
+  edgeExpansions?: EdgeExpansion[];
+  gate?: GateDecision;
+}
+
+/** A full loop execution, pass by pass. */
+export interface DescentTrace {
+  passes: DescentPass[];
+}


### PR DESCRIPTION
## Summary
- New offline `assistant/src/memory/v2/harness/` module — a `Retriever` seam (the production router adapts via `runRouter`; a future retrieval loop implements the same interface), an **oracle** extractor over `memory_v2_activation_logs` (`mode='router'`, joined to `messages` via the backfilled `messageId`), **historical input reconstruction**, **recall@k + per-lane** metrics, a **descent-trace** schema, and a **comparison runner**.
- Ground truth = router selections with status `injected`/`in_context` whose page still exists (`not_injected` available behind a flag; `page_missing`/`corrupt` excluded). A retriever's "extras" (selected, not in ground truth) are reported as a *diff*, not an error.
- Fully **additive** — no production code, injection path, or `runRouter` call sites changed. 18 unit tests over an isolated fixture DB (no live DB, no real LLM).

## Original prompt
Kick off P1 of a new memory-retrieval architecture: build the observability + comparison harness *first*, since it's the yardstick every later phase is measured against. It runs one or more retrievers over real historical turns and scores their selected memory pages against the current router's logged selections (the silver-standard oracle), defining the descent-trace format now so a future retrieval loop is built to emit it. This PR is the measurement core (library + tests); the CLI/route surface is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)