### PR TITLE
feat(memory): memory v2 compare CLI + route (P1 surface)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11426,6 +11426,50 @@ paths:
               required:
                 - op
               additionalProperties: false
+  /v1/memory/v2/compare-retrievers:
+    post:
+      operationId: memory_v2_compareretrievers_post
+      summary: Compare retrievers against the router's logged selections (read-only)
+      description:
+        Runs one or more retrievers over a sample of historical turns (memory_v2_activation_logs, mode='router')
+        and scores their selected pages against the logged selections as ground truth, reconstructing each turn's inputs
+        from the messages table + current NOW. Read-only — writes nothing. Each scored turn re-runs the router (one LLM
+        call), so keep `limit` modest. Today the only retriever is the router itself, so this is the harness self-test.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                strategy:
+                  type: string
+                  enum:
+                    - recent
+                    - random
+                conversationIds:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                ks:
+                  type: array
+                  items:
+                    type: integer
+                    exclusiveMinimum: 0
+                    maximum: 9007199254740991
+                includeNotInjected:
+                  type: boolean
+              additionalProperties: false
   /v1/memory/v2/concept-frequency:
     post:
       operationId: memory_v2_conceptfrequency_post

--- a/assistant/src/cli/commands/__tests__/memory-v2-compare-render.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2-compare-render.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ComparisonReport } from "../../../memory/v2/harness/runner.js";
+import {
+  renderComparisonReport,
+  renderTurnTrace,
+} from "../memory-v2-compare-render.js";
+
+function sampleReport(): ComparisonReport {
+  return {
+    ks: [5, 10],
+    turnsConsidered: 3,
+    turnsScored: 1,
+    turnsSkipped: 2,
+    perTurn: [
+      {
+        conversationId: "c1",
+        turn: 7,
+        byRetriever: {
+          router: {
+            groundTruth: ["a", "b"],
+            selected: ["a", "x"],
+            hits: ["a"],
+            misses: ["b"],
+            extras: ["x"],
+            recallAtK: { 5: 0.5, 10: 0.5 },
+            hitsByLane: { tier1: 1 },
+            failureReason: null,
+          },
+        },
+      },
+    ],
+    retrievers: [
+      {
+        name: "router",
+        aggregate: {
+          turns: 1,
+          meanRecallAtK: { 5: 0.5, 10: 0.5 },
+          failureRate: 0,
+        },
+      },
+    ],
+  };
+}
+
+describe("memory v2 compare — renderComparisonReport", () => {
+  test("renders turn counts, recall@k, and per-lane attribution", () => {
+    const out = renderComparisonReport(sampleReport());
+    expect(out).toContain("considered 3, scored 1, skipped 2");
+    expect(out).toContain("Retriever: router");
+    expect(out).toContain("recall@5: 0.500");
+    expect(out).toContain("recall@10: 0.500");
+    expect(out).toContain("failures: 0.0%");
+    expect(out).toContain("hits by lane: tier1=1");
+  });
+
+  test("renders mean cost when present", () => {
+    const report = sampleReport();
+    report.retrievers[0]!.aggregate.meanCostUsd = 0.0123;
+    expect(renderComparisonReport(report)).toContain("mean cost: $0.0123");
+  });
+
+  test("handles a report with no scored turns", () => {
+    const out = renderComparisonReport({
+      ks: [5],
+      turnsConsidered: 4,
+      turnsScored: 0,
+      turnsSkipped: 4,
+      perTurn: [],
+      retrievers: [
+        {
+          name: "router",
+          aggregate: { turns: 0, meanRecallAtK: { 5: 0 }, failureRate: 0 },
+        },
+      ],
+    });
+    expect(out).toContain("No turns scored");
+  });
+});
+
+describe("memory v2 compare — renderTurnTrace", () => {
+  test("renders the per-retriever breakdown for a scored turn", () => {
+    const out = renderTurnTrace(sampleReport(), "c1", 7);
+    expect(out).toContain("Turn c1:7");
+    expect(out).toContain("Retriever: router");
+    expect(out).toContain("selected (2): a, x");
+    expect(out).toContain("hits (1): a");
+    expect(out).toContain("misses (1): b");
+    expect(out).toContain("extras (1): x");
+    expect(out).toContain("(no descent trace — tier-based retriever)");
+  });
+
+  test("explains when the requested turn was not scored", () => {
+    const out = renderTurnTrace(sampleReport(), "c1", 999);
+    expect(out).toContain("not found");
+    expect(out).toContain("turnsSkipped=2");
+  });
+});

--- a/assistant/src/cli/commands/memory-v2-compare-render.ts
+++ b/assistant/src/cli/commands/memory-v2-compare-render.ts
@@ -1,0 +1,115 @@
+/**
+ * Text rendering for `assistant memory v2 compare` — turns a
+ * `ComparisonReport` (the daemon route's response) into a human-readable
+ * summary and a per-turn breakdown.
+ *
+ * Lives CLI-side because formatting for the terminal is a presentation concern
+ * (mirroring the inline rendering in the `simulate` subcommand). It imports
+ * only the response *type* from the daemon — `cli/no-daemon-internals` permits
+ * type-only imports but forbids pulling in daemon runtime modules.
+ */
+
+import type { ComparisonReport } from "../../memory/v2/harness/runner.js";
+
+function sortedKs(report: ComparisonReport): number[] {
+  return [...report.ks].sort((a, b) => a - b);
+}
+
+/** Sum per-lane hit counts across every scored turn for one retriever. */
+function laneTotals(
+  report: ComparisonReport,
+  retrieverName: string,
+): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const turn of report.perTurn) {
+    const ev = turn.byRetriever[retrieverName];
+    if (!ev) continue;
+    for (const [lane, count] of Object.entries(ev.hitsByLane)) {
+      totals[lane] = (totals[lane] ?? 0) + count;
+    }
+  }
+  return totals;
+}
+
+export function renderComparisonReport(report: ComparisonReport): string {
+  const ks = sortedKs(report);
+  const lines: string[] = [
+    "Memory Retrieval Comparison",
+    "===========================",
+    `Turns: considered ${report.turnsConsidered}, scored ${report.turnsScored}, skipped ${report.turnsSkipped}`,
+    `recall@k cutoffs: ${ks.join(", ")}`,
+    "",
+  ];
+
+  if (report.turnsScored === 0) {
+    lines.push(
+      "No turns scored — nothing to report.",
+      "(Every sampled turn was skipped — e.g. input reconstruction failed, or none matched the filter.)",
+    );
+    return lines.join("\n");
+  }
+
+  for (const retriever of report.retrievers) {
+    lines.push(`Retriever: ${retriever.name}`);
+    for (const k of ks) {
+      const value = retriever.aggregate.meanRecallAtK[k];
+      lines.push(
+        `  recall@${k}: ${value !== undefined ? value.toFixed(3) : "n/a"}`,
+      );
+    }
+    lines.push(
+      `  failures: ${(retriever.aggregate.failureRate * 100).toFixed(1)}%`,
+    );
+    if (retriever.aggregate.meanCostUsd !== undefined) {
+      lines.push(`  mean cost: $${retriever.aggregate.meanCostUsd.toFixed(4)}`);
+    }
+    const lanes = Object.entries(laneTotals(report, retriever.name)).sort(
+      (a, b) => b[1] - a[1],
+    );
+    const laneStr = lanes.map(([lane, count]) => `${lane}=${count}`).join(", ");
+    lines.push(`  hits by lane: ${laneStr.length > 0 ? laneStr : "(none)"}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+export function renderTurnTrace(
+  report: ComparisonReport,
+  conversationId: string,
+  turn: number,
+): string {
+  const entry = report.perTurn.find(
+    (t) => t.conversationId === conversationId && t.turn === turn,
+  );
+  if (!entry) {
+    return (
+      `Turn ${conversationId}:${turn} not found in the report. Only scored ` +
+      `turns appear here — skipped turns (e.g. failed input reconstruction) ` +
+      `are excluded. turnsScored=${report.turnsScored}, ` +
+      `turnsSkipped=${report.turnsSkipped}.`
+    );
+  }
+
+  const ks = sortedKs(report);
+  const header = `Turn ${conversationId}:${turn}`;
+  const lines: string[] = [header, "-".repeat(header.length)];
+
+  for (const [name, ev] of Object.entries(entry.byRetriever)) {
+    const recallStr = ks
+      .map((k) => `${k}:${(ev.recallAtK[k] ?? 0).toFixed(3)}`)
+      .join("  ");
+    lines.push(
+      `Retriever: ${name}`,
+      `  selected (${ev.selected.length}): ${ev.selected.join(", ") || "(none)"}`,
+      `  hits (${ev.hits.length}): ${ev.hits.join(", ") || "(none)"}`,
+      `  misses (${ev.misses.length}): ${ev.misses.join(", ") || "(none)"}`,
+      `  extras (${ev.extras.length}): ${ev.extras.join(", ") || "(none)"}`,
+      `  recall@k: ${recallStr}`,
+      "  (no descent trace — tier-based retriever)",
+      "",
+    );
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -19,6 +19,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { ComparisonReport } from "../../memory/v2/harness/runner.js";
 import type {
   MemoryV2BackfillOp,
   MemoryV2BackfillResult,
@@ -29,6 +30,10 @@ import type {
 } from "../../runtime/routes/memory-v2-routes.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import {
+  renderComparisonReport,
+  renderTurnTrace,
+} from "./memory-v2-compare-render.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -565,6 +570,168 @@ Examples:
                 }
               }
               log.info("");
+            }
+          },
+        );
+
+      // ── compare ─────────────────────────────────────────────────────────
+
+      v2.command("compare")
+        .description(
+          "Compare retrievers against the router's logged picks over a sample of real turns (read-only)",
+        )
+        .option(
+          "--limit <n>",
+          "How many historical turns to sample (default 20). Each re-runs the router = one LLM call.",
+        )
+        .option(
+          "--strategy <recent|random>",
+          "Sampling strategy over historical turns (default recent)",
+        )
+        .option(
+          "--k <list>",
+          "Comma-separated recall@k cutoffs (default 5,10,25,50)",
+        )
+        .option(
+          "--conversation <id>",
+          "Restrict to a conversation id (repeatable)",
+          (val: string, acc: string[]) => {
+            acc.push(val);
+            return acc;
+          },
+          [] as string[],
+        )
+        .option(
+          "--trace <conversationId:turn>",
+          "Print the per-retriever breakdown for one scored turn",
+        )
+        .option(
+          "--include-not-injected",
+          "Also count router picks cut by the injection cap as ground truth",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted report")
+        .addHelpText(
+          "after",
+          `
+Runs the comparison harness read-only: samples historical 'router'-mode turns
+from memory_v2_activation_logs, reconstructs each turn's inputs, re-runs each
+retriever, and scores selections against the logged picks (recall@k). NO writes.
+
+Cost: each scored turn re-runs the router (one LLM call), so --limit is the
+cost knob — start small. Today the only retriever is the router itself, so this
+is the harness self-test (router graded against its own logged picks); the gap
+from 1.0 is input-reconstruction drift (NOW.md / config moved since the turn).
+
+Examples:
+  $ assistant memory v2 compare --limit 20
+  $ assistant memory v2 compare --limit 50 --strategy random --k 5,10,25
+  $ assistant memory v2 compare --limit 20 --trace conv-abc:7
+  $ assistant memory v2 compare --limit 20 --json | jq '.retrievers[0].aggregate'`,
+        )
+        .action(
+          async (opts: {
+            limit?: string;
+            strategy?: string;
+            k?: string;
+            conversation?: string[];
+            trace?: string;
+            includeNotInjected?: boolean;
+            json?: boolean;
+          }) => {
+            let limit: number | undefined;
+            if (opts.limit !== undefined) {
+              const parsed = Number(opts.limit);
+              if (!Number.isInteger(parsed) || parsed < 1) {
+                log.error(
+                  `--limit must be a positive integer (got "${opts.limit}")`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              limit = parsed;
+            }
+
+            if (
+              opts.strategy !== undefined &&
+              opts.strategy !== "recent" &&
+              opts.strategy !== "random"
+            ) {
+              log.error(
+                `--strategy must be "recent" or "random" (got "${opts.strategy}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+
+            let ks: number[] | undefined;
+            if (opts.k !== undefined) {
+              ks = opts.k.split(",").map((s) => Number(s.trim()));
+              if (ks.some((k) => !Number.isInteger(k) || k < 1)) {
+                log.error(
+                  `--k must be a comma-separated list of positive integers (got "${opts.k}")`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+            }
+
+            const conversationIds =
+              opts.conversation && opts.conversation.length > 0
+                ? opts.conversation
+                : undefined;
+
+            const result = await cliIpcCall<ComparisonReport>(
+              "memory_v2_compare_retrievers",
+              {
+                body: {
+                  ...(limit !== undefined ? { limit } : {}),
+                  ...(opts.strategy !== undefined
+                    ? { strategy: opts.strategy }
+                    : {}),
+                  ...(ks !== undefined ? { ks } : {}),
+                  ...(conversationIds !== undefined ? { conversationIds } : {}),
+                  ...(opts.includeNotInjected === true
+                    ? { includeNotInjected: true }
+                    : {}),
+                },
+              },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to compare retrievers");
+              process.exitCode = 1;
+              return;
+            }
+
+            const payload = result.result!;
+
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+
+            log.info(renderComparisonReport(payload));
+
+            if (opts.trace !== undefined) {
+              const sep = opts.trace.lastIndexOf(":");
+              if (sep <= 0 || sep === opts.trace.length - 1) {
+                log.error(
+                  `--trace must be "<conversationId>:<turn>" (got "${opts.trace}")`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              const conversationId = opts.trace.slice(0, sep);
+              const turn = Number(opts.trace.slice(sep + 1));
+              if (!Number.isInteger(turn)) {
+                log.error(
+                  `--trace turn must be an integer (got "${opts.trace.slice(sep + 1)}")`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              log.info("");
+              log.info(renderTurnTrace(payload, conversationId, turn));
             }
           },
         );

--- a/assistant/src/memory/v2/__tests__/harness-compare.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-compare.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ memory: { enabled: false } }),
+}));
+
+import type { AssistantConfig } from "../../../config/types.js";
+import { getDb } from "../../db-connection.js";
+import { initializeDb } from "../../db-init.js";
+import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
+import {
+  conversations,
+  memoryV2ActivationLogs,
+  messages,
+} from "../../schema.js";
+import { runComparisonOverHistory } from "../harness/compare.js";
+import type { RetrievalOutput, Retriever } from "../harness/retriever.js";
+
+initializeDb();
+
+// loadNowText reads workspace files; a nonexistent dir yields "".
+const WORKSPACE = "/tmp/harness-compare-nonexistent-workspace";
+
+const ZERO_CONFIG = {
+  d: 0,
+  c_user: 0,
+  c_assistant: 0,
+  c_now: 0,
+  k: 0,
+  hops: 0,
+  top_k: 0,
+  epsilon: 0,
+};
+
+let seq = 0;
+
+function config(historicalPairs: number): AssistantConfig {
+  return {
+    memory: { v2: { router: { historical_pairs: historicalPairs } } },
+  } as unknown as AssistantConfig;
+}
+
+function ensureConversation(id: string): void {
+  getDb()
+    .insert(conversations)
+    .values({ id, createdAt: 0, updatedAt: 0 })
+    .onConflictDoNothing()
+    .run();
+}
+
+function insertMessage(
+  id: string,
+  conversationId: string,
+  role: string,
+  text: string,
+  createdAt: number,
+): void {
+  ensureConversation(conversationId);
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId,
+      role,
+      content: JSON.stringify([{ type: "text", text }]),
+      createdAt,
+    })
+    .run();
+}
+
+function makeConcept(
+  slug: string,
+  status: MemoryV2ConceptRowRecord["status"],
+): MemoryV2ConceptRowRecord {
+  return {
+    slug,
+    finalActivation: 0,
+    ownActivation: 0,
+    priorActivation: 0,
+    simUser: 0,
+    simAssistant: 0,
+    simNow: 0,
+    simUserRerankBoost: 0,
+    simAssistantRerankBoost: 0,
+    inRerankPool: false,
+    spreadContribution: 0,
+    source: "router",
+    status,
+  };
+}
+
+function insertRouterLog(
+  conversationId: string,
+  messageId: string,
+  turn: number,
+  concepts: MemoryV2ConceptRowRecord[],
+  createdAt: number,
+): void {
+  ensureConversation(conversationId);
+  getDb()
+    .insert(memoryV2ActivationLogs)
+    .values({
+      id: `log-${seq++}`,
+      conversationId,
+      messageId,
+      turn,
+      mode: "router",
+      conceptsJson: JSON.stringify(concepts),
+      skillsJson: "[]",
+      configJson: JSON.stringify(ZERO_CONFIG),
+      createdAt,
+    })
+    .run();
+}
+
+function stubRetriever(name: string, selected: string[]): Retriever {
+  return {
+    name,
+    retrieve: async (): Promise<RetrievalOutput> => ({
+      selectedSlugs: selected,
+      sourceBySlug: new Map(selected.map((s): [string, string] => [s, name])),
+    }),
+  };
+}
+
+function reset(): void {
+  const db = getDb();
+  db.delete(memoryV2ActivationLogs).run();
+  db.delete(messages).run();
+}
+
+/** Seed one router turn: user msg, assistant anchor, and the logged picks. */
+function seedTurn(groundTruth: string[]): void {
+  insertMessage("u1", "c1", "user", "hello", 10);
+  insertMessage("a1", "c1", "assistant", "hi", 20); // anchor for turn 1
+  insertRouterLog(
+    "c1",
+    "a1",
+    1,
+    groundTruth.map((slug) => makeConcept(slug, "injected")),
+    20,
+  );
+}
+
+describe("harness/compare runComparisonOverHistory", () => {
+  beforeEach(reset);
+
+  test("scores a stub retriever against the logged ground truth", async () => {
+    seedTurn(["p1", "p2"]);
+
+    const report = await runComparisonOverHistory({
+      db: getDb(),
+      workspaceDir: WORKSPACE,
+      config: config(1),
+      retrievers: [stubRetriever("stub", ["p1", "z"])],
+      ks: [5],
+    });
+
+    expect(report.turnsConsidered).toBe(1);
+    expect(report.turnsScored).toBe(1);
+    expect(report.turnsSkipped).toBe(0);
+    // hit p1, miss p2 → recall@5 = 1/2
+    expect(report.retrievers[0]?.aggregate.meanRecallAtK[5]).toBeCloseTo(0.5);
+  });
+
+  test("pageExists narrows the ground truth set", async () => {
+    seedTurn(["p1", "p2"]);
+
+    const report = await runComparisonOverHistory({
+      db: getDb(),
+      workspaceDir: WORKSPACE,
+      config: config(1),
+      retrievers: [stubRetriever("stub", ["p1", "z"])],
+      ks: [5],
+      pageExists: (slug) => slug === "p1", // p2 no longer exists
+    });
+
+    // ground truth is just {p1}; stub selected p1 → recall 1.0
+    expect(report.retrievers[0]?.aggregate.meanRecallAtK[5]).toBeCloseTo(1);
+  });
+});

--- a/assistant/src/memory/v2/harness/compare.ts
+++ b/assistant/src/memory/v2/harness/compare.ts
@@ -1,0 +1,57 @@
+/**
+ * Run the comparison harness over a sample of historical turns.
+ *
+ * Ties the harness pieces together: pull oracle turns from telemetry, run each
+ * retriever over each turn's reconstructed inputs, score against the logged
+ * ground truth. Kept separate from the route handler so it can be unit-tested
+ * with a stub retriever and a fixture DB — no live router / LLM.
+ */
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { DrizzleDb } from "../../db-connection.js";
+import { extractOracleTurns } from "./oracle.js";
+import { reconstructInput } from "./replay-input.js";
+import type { Retriever } from "./retriever.js";
+import { type ComparisonReport, runComparison } from "./runner.js";
+
+export interface RunComparisonOverHistoryParams {
+  db: DrizzleDb;
+  workspaceDir: string;
+  config: AssistantConfig;
+  retrievers: readonly Retriever[];
+  ks: number[];
+  limit?: number;
+  strategy?: "recent" | "random";
+  conversationIds?: string[];
+  includeNotInjected?: boolean;
+  pageExists?: (slug: string) => boolean;
+  signal?: AbortSignal;
+}
+
+export async function runComparisonOverHistory(
+  params: RunComparisonOverHistoryParams,
+): Promise<ComparisonReport> {
+  const { db, workspaceDir, config } = params;
+
+  const oracleTurns = extractOracleTurns(db, {
+    ...(params.limit !== undefined ? { limit: params.limit } : {}),
+    ...(params.strategy !== undefined ? { strategy: params.strategy } : {}),
+    ...(params.conversationIds !== undefined
+      ? { conversationIds: params.conversationIds }
+      : {}),
+    ...(params.includeNotInjected !== undefined
+      ? { includeNotInjected: params.includeNotInjected }
+      : {}),
+    ...(params.pageExists !== undefined
+      ? { pageExists: params.pageExists }
+      : {}),
+  });
+
+  return runComparison({
+    retrievers: params.retrievers,
+    oracleTurns,
+    reconstruct: (turn) => reconstructInput(db, turn, config, workspaceDir),
+    ks: params.ks,
+    ...(params.signal !== undefined ? { signal: params.signal } : {}),
+  });
+}

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -23,6 +23,9 @@ import {
   totalEdgeCount,
   validateEdgeTargets,
 } from "../../memory/v2/edge-index.js";
+import { runComparisonOverHistory } from "../../memory/v2/harness/compare.js";
+import { createRouterRetriever } from "../../memory/v2/harness/router-retriever.js";
+import type { ComparisonReport } from "../../memory/v2/harness/runner.js";
 import { computeInjectionScores } from "../../memory/v2/injection-events.js";
 import { loadNowText } from "../../memory/v2/now-text.js";
 import { getPageIndex } from "../../memory/v2/page-index.js";
@@ -602,6 +605,53 @@ async function handleGetNowText(): Promise<MemoryV2NowTextResult> {
   return { nowText };
 }
 
+// ── Compare retrievers over historical turns (read-only) ────────────────
+
+const MemoryV2CompareRetrieversParams = z
+  .object({
+    /**
+     * How many historical `mode='router'` turns to sample. Each scored turn
+     * re-runs the router (one LLM call), so keep this modest. Default 20.
+     */
+    limit: z.number().int().positive().optional(),
+    strategy: z.enum(["recent", "random"]).optional(),
+    conversationIds: z.array(z.string().min(1)).optional(),
+    ks: z.array(z.number().int().positive()).optional(),
+    includeNotInjected: z.boolean().optional(),
+  })
+  .strict();
+
+const DEFAULT_COMPARE_LIMIT = 20;
+const DEFAULT_COMPARE_KS = [5, 10, 25, 50];
+
+export async function handleCompareRetrievers({
+  body = {},
+  abortSignal,
+}: RouteHandlerArgs): Promise<ComparisonReport> {
+  requireMemoryV2Enabled();
+  const { limit, strategy, conversationIds, ks, includeNotInjected } =
+    MemoryV2CompareRetrieversParams.parse(body);
+
+  const config = loadConfig();
+  const workspaceDir = getWorkspaceDir();
+  const pageIndex = await getPageIndex(workspaceDir);
+  const db = getDb();
+
+  return runComparisonOverHistory({
+    db,
+    workspaceDir,
+    config,
+    retrievers: [createRouterRetriever(db)],
+    ks: ks ?? DEFAULT_COMPARE_KS,
+    limit: limit ?? DEFAULT_COMPARE_LIMIT,
+    pageExists: (slug) => pageIndex.bySlug.has(slug),
+    ...(strategy !== undefined ? { strategy } : {}),
+    ...(conversationIds !== undefined ? { conversationIds } : {}),
+    ...(includeNotInjected !== undefined ? { includeNotInjected } : {}),
+    ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+  });
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -692,6 +742,18 @@ export const ROUTES: RouteDefinition[] = [
       "Runs the memory router against the live page index + EMA scores with optional tier_size / batch_size overrides, without recording an injection event or writing an activation log. Returns the slugs that would have been selected, per-slug tier provenance, EMA scores, and the effective router config so operators can validate knob changes before flipping them in workspace config.",
     tags: ["memory"],
     requestBody: MemoryV2SimulateRouterParams,
+  },
+  {
+    operationId: "memory_v2_compare_retrievers",
+    method: "POST",
+    endpoint: "memory/v2/compare-retrievers",
+    handler: handleCompareRetrievers,
+    summary:
+      "Compare retrievers against the router's logged selections (read-only)",
+    description:
+      "Runs one or more retrievers over a sample of historical turns (memory_v2_activation_logs, mode='router') and scores their selected pages against the logged selections as ground truth, reconstructing each turn's inputs from the messages table + current NOW. Read-only — writes nothing. Each scored turn re-runs the router (one LLM call), so keep `limit` modest. Today the only retriever is the router itself, so this is the harness self-test.",
+    tags: ["memory"],
+    requestBody: MemoryV2CompareRetrieversParams,
   },
   {
     operationId: "memory_v2_router_prompt_template",


### PR DESCRIPTION
## Summary
- **Route** `memory_v2_compare_retrievers` (read-only): samples historical `mode='router'` turns from `memory_v2_activation_logs`, reconstructs each turn's inputs, re-runs each retriever, and scores selections against the logged picks as ground truth. Mirrors the `memory_v2_simulate_router` pattern; each scored turn re-runs the router (one LLM call), so `limit` defaults to 20.
- **CLI** `assistant memory v2 compare` — `--limit / --strategy / --k / --conversation / --trace / --include-not-injected / --json`; prints a recall@k table + per-lane attribution, and a per-turn breakdown via `--trace`.
- **Harness assembly** `runComparisonOverHistory` (new, unit-tested with a stub retriever + fixture DB) wires the PR1 oracle / reconstruct / runner together. The renderer is CLI-side — the `cli/no-daemon-internals` rule forbids the IPC CLI from importing daemon modules, so only the response *type* is imported.
- Today's only retriever is the router itself, so this is the **harness self-test** (router vs. its own logged picks); the gap from 1.0 is input-reconstruction drift. Regenerated `openapi.yaml` (one new operation).

## Original prompt
Second PR of P1 (the memory-retrieval comparison harness): expose the now-merged harness library as a route + CLI so a human (and the assistant) can run comparisons and read recall@k + a per-turn breakdown. Read-only and additive; the descent-trace surface is a placeholder until a trace-emitting retriever exists (P5). Part of the larger effort to validate a new memory-retrieval loop against the current router before any cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)