### PR TITLE
fix(memory): policy + test entry for v2 compare-retrievers

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -143,6 +143,7 @@ describe("subcommand registration", () => {
     const subcommandNames = v2!.commands.map((c) => c.name()).sort();
     expect(subcommandNames).toEqual([
       "activation",
+      "compare",
       "ema",
       "reembed",
       "reembed-skills",

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -479,6 +479,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/ema-scores:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/simulate-router:POST", scopes: ["settings.read"] },
   {
+    endpoint: "memory/v2/compare-retrievers:POST",
+    scopes: ["settings.read"],
+  },
+  {
     endpoint: "memory/v2/router-prompt-template:GET",
     scopes: ["settings.read"],
   },


### PR DESCRIPTION
## Summary
- Add a `settings.read` route-policy entry for the read-only `memory/v2/compare-retrievers` endpoint, fixing the `guard-tests.test.ts` "every protected endpoint must have a policy entry" failure.
- Add `"compare"` to the expected v2 subcommand list in `memory-v2.test.ts`, fixing the subcommand-registration assertion.

## Original prompt
Fix the specific failing Test job in CI run 26383315343 on `main`. That job went red right after #31969 ("memory v2 compare CLI + route") merged — the new `compare` CLI subcommand and `memory/v2/compare-retrievers` route landed without updating the subcommand-registration test or adding a route-policy entry, so two guard/registration tests failed. Scope was limited to fixing only those two failures.