### PR TITLE
feat(memory-v3): curated edge-expansion lane

### DIFF
--- a/assistant/src/memory/v3/__tests__/edges.test.ts
+++ b/assistant/src/memory/v3/__tests__/edges.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for `assistant/src/memory/v3/edges.ts` — the curated edge-expansion
+ * lane.
+ *
+ * Coverage matrix:
+ *   - 1-hop and 2-hop outgoing expansion from a single seed.
+ *   - Default hops (2) when omitted.
+ *   - Seed excluded from its own `pulled`.
+ *   - Multiple seeds: top-level `pulled` is the union; per-seed expansions
+ *     attribute correctly; duplicate seeds collapse.
+ *   - `extraAdjacency` merges with the curated graph during traversal.
+ *   - `extraAdjacency` bridges across hops (curated → extra → curated).
+ *   - Cycles in the curated graph (and via extraAdjacency) terminate, bounded
+ *     by hops + the visited set.
+ *   - Empty seeds / orphan seed → empty result.
+ *   - Provider-free: the only I/O is reading fixture concept pages.
+ *
+ * Tests live in temp workspaces (mkdtemp) and never touch `~/.vellum/`.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { invalidateEdgeIndex } from "../../v2/edge-index.js";
+import { writePage } from "../../v2/page-store.js";
+import type { ConceptPage } from "../../v2/types.js";
+import { expandEdges } from "../edges.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-memory-v3-edges-"));
+});
+
+afterEach(() => {
+  // The v2 edge index caches module-locally; clear it so the next test's fresh
+  // workspace doesn't read a stale snapshot.
+  invalidateEdgeIndex();
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function makePage(slug: string, edges: string[] = []): ConceptPage {
+  return {
+    slug,
+    frontmatter: { edges, ref_files: [], ref_urls: [] },
+    body: "",
+  };
+}
+
+/** Write a small chain/graph of pages by `{ slug: edges }` map. */
+async function writeGraph(graph: Record<string, string[]>): Promise<void> {
+  for (const [slug, edges] of Object.entries(graph)) {
+    await writePage(workspaceDir, makePage(slug, edges));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-seed expansion
+// ---------------------------------------------------------------------------
+
+describe("expandEdges — single seed", () => {
+  test("1-hop expansion pulls only direct out-neighbors", async () => {
+    // alice -> bob -> carol
+    await writeGraph({ alice: ["bob"], bob: ["carol"], carol: [] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 1,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob"]);
+    expect(expansions).toEqual([{ from: "alice", pulled: ["bob"] }]);
+  });
+
+  test("2-hop expansion pulls the 2-hop frontier", async () => {
+    // alice -> bob -> carol
+    await writeGraph({ alice: ["bob"], bob: ["carol"], carol: [] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob", "carol"]);
+    expect(expansions).toEqual([{ from: "alice", pulled: ["bob", "carol"] }]);
+  });
+
+  test("defaults to 2 hops when hops is omitted", async () => {
+    await writeGraph({ alice: ["bob"], bob: ["carol"], carol: ["dave"] });
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+    });
+
+    // 2-hop reach from alice: bob (1) + carol (2); dave (3) is out of budget.
+    expect([...pulled].sort()).toEqual(["bob", "carol"]);
+  });
+
+  test("excludes the seed itself from pulled", async () => {
+    // Self-referential-ish: a -> b -> a would put `a` back in reach, but the
+    // seed must never appear in its own pulled set.
+    await writeGraph({ alice: ["bob"], bob: ["alice"] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+    });
+
+    expect(pulled.has("alice")).toBe(false);
+    expect([...pulled].sort()).toEqual(["bob"]);
+    expect(expansions[0]!.pulled).not.toContain("alice");
+  });
+
+  test("orphan seed (no outgoing edges) yields an empty expansion", async () => {
+    await writeGraph({ alice: [] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+    });
+
+    expect(pulled.size).toBe(0);
+    expect(expansions).toEqual([{ from: "alice", pulled: [] }]);
+  });
+
+  test("edges are directed — incoming neighbors are never pulled", async () => {
+    // bob -> alice. Seeding alice must NOT pull bob (that's an in-edge).
+    await writeGraph({ bob: ["alice"], alice: [] });
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+    });
+
+    expect(pulled.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple seeds
+// ---------------------------------------------------------------------------
+
+describe("expandEdges — multiple seeds", () => {
+  test("top-level pulled is the union across seeds", async () => {
+    await writeGraph({
+      alice: ["bob"],
+      bob: [],
+      carol: ["dave"],
+      dave: [],
+    });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "carol"],
+      hops: 1,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob", "dave"]);
+    expect(expansions).toEqual([
+      { from: "alice", pulled: ["bob"] },
+      { from: "carol", pulled: ["dave"] },
+    ]);
+  });
+
+  test("a slug pulled by two seeds appears once in pulled, once per expansion", async () => {
+    // alice -> shared, carol -> shared
+    await writeGraph({ alice: ["shared"], carol: ["shared"], shared: [] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "carol"],
+      hops: 1,
+    });
+
+    expect([...pulled]).toEqual(["shared"]);
+    expect(expansions).toEqual([
+      { from: "alice", pulled: ["shared"] },
+      { from: "carol", pulled: ["shared"] },
+    ]);
+  });
+
+  test("duplicate seeds collapse to a single expansion entry", async () => {
+    await writeGraph({ alice: ["bob"], bob: [] });
+
+    const { expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "alice"],
+      hops: 1,
+    });
+
+    expect(expansions).toEqual([{ from: "alice", pulled: ["bob"] }]);
+  });
+
+  test("empty seed set yields an empty result", async () => {
+    await writeGraph({ alice: ["bob"], bob: [] });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: [],
+    });
+
+    expect(pulled.size).toBe(0);
+    expect(expansions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extraAdjacency injection seam
+// ---------------------------------------------------------------------------
+
+describe("expandEdges — extraAdjacency", () => {
+  test("merges injected out-edges with the curated graph", async () => {
+    // Curated: alice -> bob. Injected: alice -> extra.
+    await writeGraph({ alice: ["bob"], bob: [], extra: [] });
+
+    const extraAdjacency = new Map<string, Set<string>>([
+      ["alice", new Set(["extra"])],
+    ]);
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 1,
+      extraAdjacency,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob", "extra"]);
+    expect(expansions).toEqual([{ from: "alice", pulled: ["bob", "extra"] }]);
+  });
+
+  test("injected edges bridge across hops (curated -> extra -> curated)", async () => {
+    // Curated: alice -> bob, learned -> dave. Injected: bob -> learned.
+    // 2-hop reach: bob (curated, hop 1) -> learned (extra, hop 2)...
+    // and learned -> dave is hop 3, out of a 2-hop budget.
+    await writeGraph({
+      alice: ["bob"],
+      bob: [],
+      learned: ["dave"],
+      dave: [],
+    });
+
+    const extraAdjacency = new Map<string, Set<string>>([
+      ["bob", new Set(["learned"])],
+    ]);
+
+    const twoHop = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+      extraAdjacency,
+    });
+    expect([...twoHop.pulled].sort()).toEqual(["bob", "learned"]);
+
+    const threeHop = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 3,
+      extraAdjacency,
+    });
+    expect([...threeHop.pulled].sort()).toEqual(["bob", "dave", "learned"]);
+  });
+
+  test("absent extraAdjacency leaves the curated walk unchanged", async () => {
+    await writeGraph({ alice: ["bob"], bob: ["carol"], carol: [] });
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob", "carol"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle safety
+// ---------------------------------------------------------------------------
+
+describe("expandEdges — cycle safety", () => {
+  test("a cycle in the curated graph terminates and does not loop", async () => {
+    // alice -> bob -> carol -> alice (3-cycle).
+    await writeGraph({
+      alice: ["bob"],
+      bob: ["carol"],
+      carol: ["alice"],
+    });
+
+    // A generous hop budget would loop forever without a visited set.
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 100,
+    });
+
+    // Reaches bob and carol; alice (the seed) is excluded even though the
+    // cycle points back at it.
+    expect([...pulled].sort()).toEqual(["bob", "carol"]);
+    expect(expansions[0]!.pulled).not.toContain("alice");
+  });
+
+  test("a cycle introduced via extraAdjacency also terminates", async () => {
+    // Curated: alice -> bob. Injected cycle: bob -> alice.
+    await writeGraph({ alice: ["bob"], bob: [] });
+
+    const extraAdjacency = new Map<string, Set<string>>([
+      ["bob", new Set(["alice"])],
+    ]);
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 100,
+      extraAdjacency,
+    });
+
+    expect([...pulled].sort()).toEqual(["bob"]);
+  });
+
+  test("a self-loop edge does not loop or pull the seed", async () => {
+    // alice -> alice (self-loop is dropped by the index, but guard anyway).
+    await writeGraph({ alice: ["alice", "bob"], bob: [] });
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice"],
+      hops: 2,
+    });
+
+    expect(pulled.has("alice")).toBe(false);
+    expect([...pulled].sort()).toEqual(["bob"]);
+  });
+});

--- a/assistant/src/memory/v3/edges.ts
+++ b/assistant/src/memory/v3/edges.ts
@@ -1,0 +1,125 @@
+/**
+ * Memory v3 — Curated edge-expansion lane.
+ *
+ * Given a set of confident seed slugs, pull their 1–2 hop *outgoing*
+ * neighborhood from the curated `edges:` graph (each concept page's
+ * frontmatter `edges:` list, surfaced by v2's `getEdgeIndex`). This is a
+ * provider-free, read-only structural expansion — no LLM, no scoring. It
+ * answers "given that we're confident about A, what does A's curated graph
+ * say we should also pull in?".
+ *
+ * The optional `extraAdjacency` parameter is the seam a later PR uses to inject
+ * above-threshold *weighted auto-edges* (edges the system learned, not ones a
+ * human curated) WITHOUT modifying this module. When supplied, it is treated as
+ * additional out-edges merged with the curated graph during traversal: the
+ * effective out-neighborhood of a node is `curated[node] ∪ extraAdjacency[node]`.
+ *
+ * The result is the union of every seed's reachable neighborhood (`pulled`,
+ * with seeds themselves excluded) plus a per-seed `EdgeExpansion[]` trace so a
+ * harness can attribute each pulled slug to the seed it came from.
+ */
+
+import { getEdgeIndex, getReachable } from "../v2/edge-index.js";
+import type { EdgeExpansion } from "../v2/harness/trace.js";
+
+/** Default hop budget. The design calls for a 1–2 hop walk; 2 is the ceiling. */
+const DEFAULT_HOPS = 2;
+
+export interface ExpandEdgesArgs {
+  workspaceDir: string;
+  /** Confident seed slugs to expand from. */
+  seeds: Iterable<string>;
+  /** Hop budget for the outgoing walk. Defaults to {@link DEFAULT_HOPS}. */
+  hops?: number;
+  /**
+   * Extra *outgoing* adjacency (`from → Set<to>`) merged with the curated graph
+   * during traversal. The injection seam for learned weighted auto-edges; this
+   * module never reads or thresholds weights itself — the caller pre-filters to
+   * above-threshold edges before passing them in.
+   */
+  extraAdjacency?: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+export interface ExpandEdgesResult {
+  /** Union of every seed's reachable neighborhood, seeds excluded. */
+  pulled: Set<string>;
+  /** Per-seed attribution: which slugs each seed pulled in. */
+  expansions: EdgeExpansion[];
+}
+
+/**
+ * BFS the outgoing neighborhood of `seed` within `hops`, walking the union of
+ * the curated `outgoing` adjacency and any `extraAdjacency`. Mirrors v2's
+ * `getReachable` semantics — start excluded, bounded by `hops` and a visited
+ * set so cycles can't loop — but over a merged adjacency view.
+ */
+function reachableMerged(
+  curated: ReadonlyMap<string, ReadonlySet<string>>,
+  extra: ReadonlyMap<string, ReadonlySet<string>>,
+  seed: string,
+  hops: number,
+): Set<string> {
+  const result = new Set<string>();
+  if (hops <= 0) return result;
+
+  const visited = new Set<string>([seed]);
+  let frontier: string[] = [seed];
+
+  for (let depth = 0; depth < hops && frontier.length > 0; depth++) {
+    const next: string[] = [];
+    for (const node of frontier) {
+      const curatedNeighbors = curated.get(node);
+      const extraNeighbors = extra.get(node);
+      for (const neighbors of [curatedNeighbors, extraNeighbors]) {
+        if (!neighbors) continue;
+        for (const neighbor of neighbors) {
+          if (visited.has(neighbor)) continue;
+          visited.add(neighbor);
+          result.add(neighbor);
+          next.push(neighbor);
+        }
+      }
+    }
+    frontier = next;
+  }
+
+  return result;
+}
+
+/**
+ * Expand a set of confident seed slugs to their 1–2 hop curated neighborhood.
+ *
+ * Each seed produces one `EdgeExpansion { from, pulled }` entry (sorted slugs
+ * for deterministic output); the seed itself is never in its own `pulled`. The
+ * top-level `pulled` set is the union across all seeds — a slug pulled by more
+ * than one seed appears once there but in each contributing seed's expansion.
+ *
+ * Provider-free and read-only: the only I/O is `getEdgeIndex`, which reads
+ * concept-page frontmatter from disk (and caches module-locally in v2).
+ */
+export async function expandEdges(
+  args: ExpandEdgesArgs,
+): Promise<ExpandEdgesResult> {
+  const { workspaceDir, seeds, hops = DEFAULT_HOPS, extraAdjacency } = args;
+
+  const index = await getEdgeIndex(workspaceDir);
+  const pulled = new Set<string>();
+  const expansions: EdgeExpansion[] = [];
+
+  // De-dupe seeds while preserving first-seen order for a stable trace.
+  const seenSeeds = new Set<string>();
+
+  for (const seed of seeds) {
+    if (seenSeeds.has(seed)) continue;
+    seenSeeds.add(seed);
+
+    const reachable = extraAdjacency
+      ? reachableMerged(index.outgoing, extraAdjacency, seed, hops)
+      : getReachable(index, seed, hops, "out");
+
+    expansions.push({ from: seed, pulled: [...reachable].sort() });
+    for (const slug of reachable) pulled.add(slug);
+  }
+
+  return { pulled, expansions };
+}


### PR DESCRIPTION
## Summary
- Add expandEdges: 1-2 hop neighborhood pull over the curated edges: graph (reuses v2 edge-index), no LLM.
- extraAdjacency seam lets a later PR inject above-threshold weighted auto-edges without changing this module.

Part of plan: memory-v3-build.md (PR 11 of 19)