### PR TITLE
feat(memory-v3): tree index with DAG adjacency + cache

### DIFF
--- a/assistant/src/memory/v3/__tests__/tree-index.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-index.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for `assistant/src/memory/v3/tree-index.ts`.
+ *
+ * Coverage matrix:
+ *   - getTreeIndex builds correct DAG adjacency on a fixture tree
+ *     (root → 2 sub-nodes → page leaves; one node referenced by two parents).
+ *   - childrenByNode preserves children order and parses page:/node: refs.
+ *   - parentsByNode / pageParents reverse adjacency, incl. a 2-parent node.
+ *   - root detection: reserved `_root` wins; single-parentless fallback;
+ *     ambiguous fallback warns + picks deterministically.
+ *   - dangling refs retained (structural-only build).
+ *   - malformed child refs dropped.
+ *   - cache hit returns the same object; invalidateTreeIndex forces a rebuild.
+ *   - writeNode / deleteNode invalidate the cache.
+ *
+ * Tests use temp workspaces under `os.tmpdir()`; they never touch `~/.vellum/`.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getTreeIndex, invalidateTreeIndex } from "../tree-index.js";
+import {
+  deleteNode,
+  getTreeDir,
+  ROOT_NODE_ID,
+  writeNode,
+} from "../tree-store.js";
+import type { TreeNode } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-tree-index-test-"));
+});
+
+afterEach(() => {
+  invalidateTreeIndex();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function node(id: string, children: string[], body = `body ${id}`): TreeNode {
+  return { id, frontmatter: { children }, body };
+}
+
+/**
+ * Seed a fixture DAG:
+ *   _root → node:people, node:projects
+ *   people → page:alice, node:shared
+ *   projects → page:apollo, node:shared   ← shared has two parents (DAG)
+ *   shared → page:shared-page
+ *
+ * writeNode invalidates the cache as a side effect, so we invalidate once more
+ * at the end to leave a clean slate for the test body's first getTreeIndex.
+ */
+async function seedFixture(): Promise<void> {
+  await writeNode(
+    workspaceDir,
+    node(ROOT_NODE_ID, ["node:people", "node:projects"]),
+  );
+  await writeNode(workspaceDir, node("people", ["page:alice", "node:shared"]));
+  await writeNode(
+    workspaceDir,
+    node("projects", ["page:apollo", "node:shared"]),
+  );
+  await writeNode(workspaceDir, node("shared", ["page:shared-page"]));
+  invalidateTreeIndex();
+}
+
+// ---------------------------------------------------------------------------
+// DAG adjacency
+// ---------------------------------------------------------------------------
+
+describe("getTreeIndex — DAG adjacency", () => {
+  test("builds forward adjacency preserving children order and ref kinds", async () => {
+    await seedFixture();
+    const index = await getTreeIndex(workspaceDir);
+
+    expect(index.childrenByNode.get(ROOT_NODE_ID)).toEqual([
+      { kind: "node", ref: "people" },
+      { kind: "node", ref: "projects" },
+    ]);
+    expect(index.childrenByNode.get("people")).toEqual([
+      { kind: "page", ref: "alice" },
+      { kind: "node", ref: "shared" },
+    ]);
+    expect(index.childrenByNode.get("shared")).toEqual([
+      { kind: "page", ref: "shared-page" },
+    ]);
+  });
+
+  test("builds node reverse adjacency incl. a node with two parents", async () => {
+    await seedFixture();
+    const index = await getTreeIndex(workspaceDir);
+
+    expect(index.parentsByNode.get("people")).toEqual(new Set([ROOT_NODE_ID]));
+    expect(index.parentsByNode.get("projects")).toEqual(
+      new Set([ROOT_NODE_ID]),
+    );
+    // `shared` is referenced by both `people` and `projects` → DAG.
+    expect(index.parentsByNode.get("shared")).toEqual(
+      new Set(["people", "projects"]),
+    );
+  });
+
+  test("builds page reverse adjacency keyed by page slug", async () => {
+    await seedFixture();
+    const index = await getTreeIndex(workspaceDir);
+
+    expect(index.pageParents.get("alice")).toEqual(new Set(["people"]));
+    expect(index.pageParents.get("apollo")).toEqual(new Set(["projects"]));
+    expect(index.pageParents.get("shared-page")).toEqual(new Set(["shared"]));
+  });
+
+  test("populates nodes map with every readable node", async () => {
+    await seedFixture();
+    const index = await getTreeIndex(workspaceDir);
+
+    expect([...index.nodes.keys()].sort()).toEqual([
+      ROOT_NODE_ID,
+      "people",
+      "projects",
+      "shared",
+    ]);
+    expect(index.nodes.get("shared")?.body).toBe("body shared");
+  });
+
+  test("retains dangling refs (structural-only build, no existence check)", async () => {
+    await writeNode(
+      workspaceDir,
+      node(ROOT_NODE_ID, ["node:missing-node", "page:missing-page"]),
+    );
+    invalidateTreeIndex();
+    const index = await getTreeIndex(workspaceDir);
+
+    // Forward edge retained even though no such node/page file exists.
+    expect(index.childrenByNode.get(ROOT_NODE_ID)).toEqual([
+      { kind: "node", ref: "missing-node" },
+      { kind: "page", ref: "missing-page" },
+    ]);
+    // Reverse adjacency retained too — validation (a later PR) reports these.
+    expect(index.parentsByNode.get("missing-node")).toEqual(
+      new Set([ROOT_NODE_ID]),
+    );
+    expect(index.pageParents.get("missing-page")).toEqual(
+      new Set([ROOT_NODE_ID]),
+    );
+  });
+
+  test("drops malformed child refs (no page:/node: prefix)", async () => {
+    await writeNode(
+      workspaceDir,
+      node(ROOT_NODE_ID, ["page:ok", "bogus-no-prefix", "node:", "page:"]),
+    );
+    invalidateTreeIndex();
+    const index = await getTreeIndex(workspaceDir);
+
+    expect(index.childrenByNode.get(ROOT_NODE_ID)).toEqual([
+      { kind: "page", ref: "ok" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Root detection
+// ---------------------------------------------------------------------------
+
+describe("getTreeIndex — root detection", () => {
+  test("prefers the reserved _root node when present", async () => {
+    await seedFixture();
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.root).toBe(ROOT_NODE_ID);
+  });
+
+  test("falls back to the single parentless node when no _root", async () => {
+    await writeNode(workspaceDir, node("top", ["node:child"]));
+    await writeNode(workspaceDir, node("child", []));
+    invalidateTreeIndex();
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.root).toBe("top");
+  });
+
+  test("ambiguous root warns and picks ASCII-smallest deterministically", async () => {
+    // Two parentless nodes, no _root → ambiguous.
+    await writeNode(workspaceDir, node("zeta", []));
+    await writeNode(workspaceDir, node("alpha", []));
+    invalidateTreeIndex();
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.root).toBe("alpha");
+  });
+
+  test("empty workspace yields _root", async () => {
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.root).toBe(ROOT_NODE_ID);
+    expect(index.nodes.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache behavior
+// ---------------------------------------------------------------------------
+
+describe("getTreeIndex — cache", () => {
+  test("cache hit returns the same object reference", async () => {
+    await seedFixture();
+    const first = await getTreeIndex(workspaceDir);
+    const second = await getTreeIndex(workspaceDir);
+    expect(second).toBe(first);
+  });
+
+  test("invalidateTreeIndex forces a rebuild", async () => {
+    await seedFixture();
+    const first = await getTreeIndex(workspaceDir);
+    invalidateTreeIndex(workspaceDir);
+    const second = await getTreeIndex(workspaceDir);
+    expect(second).not.toBe(first);
+    // Same structural content though.
+    expect([...second.nodes.keys()].sort()).toEqual(
+      [...first.nodes.keys()].sort(),
+    );
+  });
+
+  test("scoped invalidation only clears the matching workspace", async () => {
+    await seedFixture();
+    const first = await getTreeIndex(workspaceDir);
+    invalidateTreeIndex("/some/other/workspace");
+    const second = await getTreeIndex(workspaceDir);
+    expect(second).toBe(first);
+  });
+
+  test("writeNode invalidates the cache", async () => {
+    await seedFixture();
+    const first = await getTreeIndex(workspaceDir);
+    await writeNode(workspaceDir, node("newcomer", []));
+    const second = await getTreeIndex(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(second.nodes.has("newcomer")).toBe(true);
+  });
+
+  test("deleteNode invalidates the cache", async () => {
+    await seedFixture();
+    const first = await getTreeIndex(workspaceDir);
+    expect(first.nodes.has("shared")).toBe(true);
+    await deleteNode(workspaceDir, "shared");
+    const second = await getTreeIndex(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(second.nodes.has("shared")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read failures
+// ---------------------------------------------------------------------------
+
+describe("getTreeIndex — robustness", () => {
+  test("ignores a missing tree dir (fresh workspace) → empty index", async () => {
+    // No nodes written; getTreeDir not even created.
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.nodes.size).toBe(0);
+    expect(index.childrenByNode.size).toBe(0);
+    expect(index.parentsByNode.size).toBe(0);
+    expect(index.pageParents.size).toBe(0);
+  });
+
+  test("tree dir present but empty → empty index", async () => {
+    // Materialize the dir without any node files.
+    rmSync(getTreeDir(workspaceDir), { recursive: true, force: true });
+    await writeNode(workspaceDir, node("only", []));
+    await deleteNode(workspaceDir, "only");
+    invalidateTreeIndex();
+    const index = await getTreeIndex(workspaceDir);
+    expect(index.nodes.size).toBe(0);
+  });
+});

--- a/assistant/src/memory/v3/tree-index.ts
+++ b/assistant/src/memory/v3/tree-index.ts
@@ -1,0 +1,237 @@
+/**
+ * Memory v3 — Tree index (DAG build + cache).
+ *
+ * The v3 tree is a DAG *overlay* over the flat `memory/concepts/` pages: every
+ * node carries an ordered `children` list whose entries are either
+ * `"page:<slug>"` (a leaf concept page, canonical content untouched by v3) or
+ * `"node:<id>"` (a sub-node in the tree). A page or node may be referenced by
+ * more than one parent — hence DAG, not tree.
+ *
+ * This module scans every node on disk and materializes that edge list into
+ * forward and reverse adjacency maps so downstream routing/validation can walk
+ * the graph without re-reading the filesystem:
+ *   - `childrenByNode` — node id → ordered child refs (forward edges).
+ *   - `parentsByNode` — node id → set of parent node ids (reverse edges for
+ *     `node:` children).
+ *   - `pageParents` — page slug → set of parent node ids (reverse edges for
+ *     `page:` children).
+ *
+ * The build is **structural only**: it never verifies that a referenced page
+ * or node actually exists. Dangling refs are retained in the adjacency maps so
+ * a later validation pass can report them. Root detection prefers the reserved
+ * `_root` id; absent that it picks the single node with no parents (warning and
+ * picking deterministically if the choice is ambiguous).
+ *
+ * The build is cached module-locally per `workspaceDir`, mirroring
+ * `../v2/page-index.ts`. Callers must invalidate via `invalidateTreeIndex` when
+ * tree nodes change — `tree-store.ts`'s `writeNode` / `deleteNode` already do.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { listNodes, readNode, ROOT_NODE_ID } from "./tree-store.js";
+import type { TreeNode } from "./types.js";
+
+const log = getLogger("memory-v3-tree-index");
+
+/** Prefix marking a child ref that targets a leaf concept page. */
+const PAGE_REF_PREFIX = "page:";
+
+/** Prefix marking a child ref that targets a sub-node in the tree. */
+const NODE_REF_PREFIX = "node:";
+
+/**
+ * A single parsed `children` entry. `kind` distinguishes a leaf concept page
+ * (`"page"`) from a sub-node (`"node"`); `ref` is the bare slug or node id with
+ * the `page:` / `node:` prefix stripped.
+ */
+export interface ChildRef {
+  kind: "page" | "node";
+  ref: string;
+}
+
+/**
+ * Snapshot of the v3 tree DAG for one workspace.
+ *
+ * `nodes` is every readable node keyed by id. The three adjacency maps are
+ * derived from each node's `children`:
+ *   - `childrenByNode` — forward edges, preserving `children` order.
+ *   - `parentsByNode` — reverse edges restricted to `node:` children.
+ *   - `pageParents` — reverse edges restricted to `page:` children, keyed by
+ *     page slug.
+ *
+ * `root` is the entry-point node id (`_root` when present). Dangling refs (a
+ * `node:`/`page:` target with no on-disk file) are retained throughout —
+ * validation, not the index build, is responsible for surfacing them.
+ */
+export interface TreeIndex {
+  nodes: Map<string, TreeNode>;
+  childrenByNode: Map<string, ReadonlyArray<ChildRef>>;
+  parentsByNode: Map<string, Set<string>>;
+  pageParents: Map<string, Set<string>>;
+  root: string;
+}
+
+interface CachedIndex {
+  workspaceDir: string;
+  index: TreeIndex;
+}
+
+let cache: CachedIndex | null = null;
+
+/**
+ * Parse a raw `children` entry into a {@link ChildRef}. Returns `null` for any
+ * entry that does not carry a recognized `page:` / `node:` prefix or whose ref
+ * body is empty — those are malformed and dropped (with a warn) rather than
+ * faithfully threaded through adjacency.
+ */
+function parseChildRef(raw: string): ChildRef | null {
+  if (raw.startsWith(PAGE_REF_PREFIX)) {
+    const ref = raw.slice(PAGE_REF_PREFIX.length);
+    return ref.length > 0 ? { kind: "page", ref } : null;
+  }
+  if (raw.startsWith(NODE_REF_PREFIX)) {
+    const ref = raw.slice(NODE_REF_PREFIX.length);
+    return ref.length > 0 ? { kind: "node", ref } : null;
+  }
+  return null;
+}
+
+/** Append `parent` to the parent-set for `key`, creating the set on demand. */
+function addParent(
+  map: Map<string, Set<string>>,
+  key: string,
+  parent: string,
+): void {
+  let parents = map.get(key);
+  if (!parents) {
+    parents = new Set();
+    map.set(key, parents);
+  }
+  parents.add(parent);
+}
+
+/**
+ * Pick the root node id from the materialized adjacency. Prefers the reserved
+ * {@link ROOT_NODE_ID} when a node with that id exists. Otherwise the root is
+ * the single node with no parents; if several nodes are parentless the choice
+ * is ambiguous, so warn and pick the ASCII-smallest id for determinism. With no
+ * nodes at all the root is `_root` (the well-known handle a migration authors
+ * first), matching the empty-workspace contract.
+ */
+function pickRoot(
+  nodes: Map<string, TreeNode>,
+  parentsByNode: Map<string, Set<string>>,
+): string {
+  if (nodes.has(ROOT_NODE_ID)) {
+    return ROOT_NODE_ID;
+  }
+
+  const parentless = [...nodes.keys()].filter(
+    (id) => !parentsByNode.has(id) || parentsByNode.get(id)!.size === 0,
+  );
+  parentless.sort();
+
+  if (parentless.length === 1) {
+    return parentless[0];
+  }
+  if (parentless.length === 0) {
+    return ROOT_NODE_ID;
+  }
+  log.warn(
+    { parentless },
+    "Ambiguous tree root — no '_root' node and multiple parentless nodes; picking ASCII-smallest deterministically",
+  );
+  return parentless[0];
+}
+
+/**
+ * Return a `TreeIndex` for `workspaceDir`. Cached module-locally; the cache is
+ * invalidated by `invalidateTreeIndex` (called by `tree-store.ts` hooks when
+ * nodes change).
+ *
+ * Cold builds list every node and read them in parallel, dropping any whose
+ * read rejects with a warn so one broken node never blocks the rest of the
+ * index. Each readable node's `children` is parsed into {@link ChildRef}s and
+ * threaded into forward (`childrenByNode`) and reverse (`parentsByNode` /
+ * `pageParents`) adjacency. The build is structural only — referenced
+ * pages/nodes are never verified to exist; dangling refs are retained for a
+ * later validation pass.
+ */
+export async function getTreeIndex(workspaceDir: string): Promise<TreeIndex> {
+  if (cache && cache.workspaceDir === workspaceDir) {
+    return cache.index;
+  }
+
+  const ids = await listNodes(workspaceDir);
+
+  // Read every node in parallel; nodes whose read rejects are dropped with a
+  // warn so a single broken node never blocks the rest of the index.
+  const settled = await Promise.allSettled(
+    ids.map((id) => readNode(workspaceDir, id)),
+  );
+
+  const nodes = new Map<string, TreeNode>();
+  const childrenByNode = new Map<string, ReadonlyArray<ChildRef>>();
+  const parentsByNode = new Map<string, Set<string>>();
+  const pageParents = new Map<string, Set<string>>();
+
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    const id = ids[i];
+    if (result.status === "rejected") {
+      log.warn(
+        { id, err: result.reason },
+        "Dropping tree node from index — read failed",
+      );
+      continue;
+    }
+    const node = result.value;
+    // `readNode` returns null only on ENOENT; a node listed by `listNodes`
+    // that vanishes between list and read is a benign race — drop it silently.
+    if (!node) continue;
+    nodes.set(id, node);
+  }
+
+  // Build adjacency in a second pass so every node is registered first — that
+  // keeps a deterministic, list-order iteration independent of read timing.
+  for (const node of nodes.values()) {
+    const childRefs: ChildRef[] = [];
+    for (const raw of node.frontmatter.children) {
+      const parsed = parseChildRef(raw);
+      if (!parsed) {
+        log.warn(
+          { id: node.id, raw },
+          "Dropping malformed child ref — expected 'page:<slug>' or 'node:<id>'",
+        );
+        continue;
+      }
+      childRefs.push(parsed);
+      const reverse = parsed.kind === "node" ? parentsByNode : pageParents;
+      addParent(reverse, parsed.ref, node.id);
+    }
+    childrenByNode.set(node.id, childRefs);
+  }
+
+  const root = pickRoot(nodes, parentsByNode);
+
+  const index: TreeIndex = {
+    nodes,
+    childrenByNode,
+    parentsByNode,
+    pageParents,
+    root,
+  };
+  cache = { workspaceDir, index };
+  return index;
+}
+
+/**
+ * Clear the cached index. Pass `workspaceDir` to scope invalidation to a
+ * specific cache entry; omit it to clear unconditionally.
+ */
+export function invalidateTreeIndex(workspaceDir?: string): void {
+  if (!cache) return;
+  if (workspaceDir === undefined || cache.workspaceDir === workspaceDir) {
+    cache = null;
+  }
+}

--- a/assistant/src/memory/v3/tree-store.ts
+++ b/assistant/src/memory/v3/tree-store.ts
@@ -40,6 +40,7 @@ import { dirname, join, relative, sep } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import { FRONTMATTER_REGEX } from "../../skills/frontmatter.js";
+import { invalidateTreeIndex } from "./tree-index.js";
 import { type TreeNode, TreeNodeFrontmatterSchema } from "./types.js";
 
 /** Filename suffix for tree nodes. */
@@ -296,6 +297,7 @@ export async function writeNode(
     await rm(tmpPath, { force: true }).catch(() => {});
     throw err;
   }
+  invalidateTreeIndex(workspaceDir);
 }
 
 /**
@@ -367,4 +369,5 @@ export async function deleteNode(
     }
     throw err;
   }
+  invalidateTreeIndex(workspaceDir);
 }


### PR DESCRIPTION
## Summary
- Add getTreeIndex: scans v3 nodes, builds DAG adjacency (childrenByNode/parentsByNode/pageParents) + root detection, cached per workspace.
- Wire invalidateTreeIndex into writeNode/deleteNode.
- Structural build only (dangling refs retained for later validation).

Part of plan: memory-v3-build.md (PR 2 of 19)