### PR TITLE
feat(memory-v3): always-on scouts (hot/sparse/dense)

### DIFF
--- a/assistant/src/memory/v3/__tests__/scouts.test.ts
+++ b/assistant/src/memory/v3/__tests__/scouts.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for `assistant/src/memory/v3/scouts.ts`.
+ *
+ * The scout lanes read the v2 substrate (page index, injection-event EMA,
+ * Qdrant hybrid query, BM25, dense embed + calibration). Every one of those is
+ * stubbed via `mock.module` so the suite needs no real Qdrant, embedding
+ * backend, or LLM — and the SQLite-backed EMA is replaced by a hand-fed score
+ * map, so the injected `db` is an opaque sentinel the lane never dereferences.
+ *
+ * Coverage:
+ *   - hot lane: ranks the EMA score map desc, marks every hit sticky.
+ *   - sparse lane: reads sparseScore, ranks desc, flags near-exact hits
+ *     sticky + tree-bypass.
+ *   - dense lane: per-subtree quota caps off-domain hits; MMR diversifies.
+ *   - lane toggles: each disabled lane is fully suppressed (no ScoutResult).
+ *   - empty query / empty corpus short-circuits.
+ *   - honors AbortSignal.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PageIndex } from "../../v2/page-index.js";
+import type { ConceptPageQueryResult } from "../../v2/qdrant.js";
+
+// ---------------------------------------------------------------------------
+// Substrate stubs — installed before importing the module under test.
+// ---------------------------------------------------------------------------
+
+// Per-call programmable substrate state. Each test rewires these before
+// calling runScouts; the mock factories below close over the live refs.
+let injectionScores = new Map<string, number>();
+let pageSlugs: string[] = [];
+let hybridHits: ConceptPageQueryResult[] = [];
+let embedCalls = 0;
+
+mock.module("../../v2/injection-events.js", () => ({
+  computeInjectionScores: () => injectionScores,
+}));
+
+mock.module("../../v2/page-index.js", () => ({
+  getPageIndex: async (): Promise<PageIndex> => ({
+    entries: pageSlugs.map((slug, i) => ({
+      id: i + 1,
+      slug,
+      summary: "",
+      edges: [],
+      modifiedAt: 0,
+    })),
+    bySlug: new Map(),
+    byId: new Map(),
+    rendered: "",
+  }),
+}));
+
+mock.module("../../v2/qdrant.js", () => ({
+  hybridQueryConceptPages: async (): Promise<ConceptPageQueryResult[]> =>
+    hybridHits,
+}));
+
+mock.module("../../v2/sparse-bm25.js", () => ({
+  // Non-empty indices so the sparse/dense lanes don't short-circuit on an
+  // "empty query embedding". The values are irrelevant — the stubbed Qdrant
+  // query ignores them and returns `hybridHits` directly.
+  generateBm25QueryEmbedding: (text: string) =>
+    text.trim().length > 0
+      ? { indices: [1], values: [1] }
+      : { indices: [], values: [] },
+}));
+
+mock.module("../../embedding-backend.js", () => ({
+  embedWithBackend: async () => {
+    embedCalls += 1;
+    return { provider: "local", model: "stub", vectors: [[0.1, 0.2, 0.3]] };
+  },
+}));
+
+mock.module("../../anisotropy.js", () => ({
+  applyCorrectionIfCalibrated: async (vec: number[]) => vec,
+}));
+
+const { runScouts } = await import("../scouts.js");
+import type { RetrievalInput } from "../../v2/harness/retriever.js";
+import type { ScoutDeps } from "../scouts.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DB_SENTINEL = { __opaque: true } as unknown as ScoutDeps["db"];
+const DEPS: ScoutDeps = { db: DB_SENTINEL };
+
+type Lanes = { hot: boolean; sparse: boolean; dense: boolean };
+
+function makeInput(opts?: {
+  userMessage?: string;
+  nowText?: string;
+  lanes?: Partial<Lanes>;
+  denseQuota?: { activeDomain: number; offDomain: number };
+  signal?: AbortSignal;
+}): RetrievalInput {
+  const lanes = {
+    hot: true,
+    sparse: true,
+    dense: true,
+    tree: true,
+    edges: true,
+    ...opts?.lanes,
+  };
+  const config = {
+    memory: {
+      v3: {
+        lanes,
+        denseQuota: opts?.denseQuota ?? { activeDomain: 30, offDomain: 8 },
+      },
+    },
+  } as unknown as RetrievalInput["config"];
+  return {
+    workspaceDir: "/tmp/ws",
+    recentTurnPairs: [
+      { assistantMessage: "", userMessage: opts?.userMessage ?? "tell me" },
+    ],
+    nowText: opts?.nowText ?? "now context",
+    priorEverInjected: [],
+    config,
+    signal: opts?.signal,
+  };
+}
+
+function hit(
+  slug: string,
+  scores: Partial<ConceptPageQueryResult>,
+): ConceptPageQueryResult {
+  return { slug, ...scores };
+}
+
+beforeEach(() => {
+  injectionScores = new Map();
+  pageSlugs = [];
+  hybridHits = [];
+  embedCalls = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Hot lane
+// ---------------------------------------------------------------------------
+
+describe("runScouts — hot lane", () => {
+  test("ranks EMA scores desc and marks every hit sticky", async () => {
+    pageSlugs = ["people/alice", "work/proj", "essentials"];
+    injectionScores = new Map([
+      ["work/proj", 0.2],
+      ["people/alice", 0.9],
+    ]);
+
+    const { scouts, sticky } = await runScouts(
+      makeInput({ lanes: { sparse: false, dense: false } }),
+      DEPS,
+    );
+
+    const hot = scouts.find((s) => s.lane === "hot");
+    expect(hot?.slugs).toEqual(["people/alice", "work/proj"]);
+    expect(hot?.scoreBySlug).toEqual({ "people/alice": 0.9, "work/proj": 0.2 });
+    expect([...sticky].sort()).toEqual(["people/alice", "work/proj"]);
+  });
+
+  test("empty corpus yields no hot ScoutResult", async () => {
+    pageSlugs = [];
+    const { scouts } = await runScouts(
+      makeInput({ lanes: { sparse: false, dense: false } }),
+      DEPS,
+    );
+    expect(scouts.find((s) => s.lane === "hot")).toBeUndefined();
+  });
+
+  test("no EMA events yields no hot ScoutResult", async () => {
+    pageSlugs = ["a", "b"];
+    injectionScores = new Map();
+    const { scouts, sticky } = await runScouts(
+      makeInput({ lanes: { sparse: false, dense: false } }),
+      DEPS,
+    );
+    expect(scouts.find((s) => s.lane === "hot")).toBeUndefined();
+    expect(sticky.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sparse lane
+// ---------------------------------------------------------------------------
+
+describe("runScouts — sparse lane", () => {
+  test("reads sparseScore, ranks desc, flags near-exact sticky + bypass", async () => {
+    hybridHits = [
+      hit("docs/readme", { sparseScore: 4.0 }),
+      hit("docs/api", { sparseScore: 3.9 }), // within 90% of top -> near-exact
+      hit("misc/note", { sparseScore: 1.0 }), // below threshold
+      hit("dense/only", { denseScore: 0.8 }), // no sparseScore -> dropped
+    ];
+
+    const { scouts, sticky, bypass } = await runScouts(
+      makeInput({ lanes: { hot: false, dense: false } }),
+      DEPS,
+    );
+
+    const sparse = scouts.find((s) => s.lane === "sparse");
+    expect(sparse?.slugs).toEqual(["docs/readme", "docs/api", "misc/note"]);
+    // Near-exact: readme (top) and api (>= 90% of top). Not misc/note.
+    expect([...sticky].sort()).toEqual(["docs/api", "docs/readme"]);
+    expect([...bypass].sort()).toEqual(["docs/api", "docs/readme"]);
+  });
+
+  test("no sparse hits yields no sparse ScoutResult", async () => {
+    hybridHits = [hit("dense/only", { denseScore: 0.5 })];
+    const { scouts, sticky, bypass } = await runScouts(
+      makeInput({ lanes: { hot: false, dense: false } }),
+      DEPS,
+    );
+    expect(scouts.find((s) => s.lane === "sparse")).toBeUndefined();
+    expect(sticky.size).toBe(0);
+    expect(bypass.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dense lane
+// ---------------------------------------------------------------------------
+
+describe("runScouts — dense lane", () => {
+  test("embeds the query and emits dense hits ranked by denseScore", async () => {
+    hybridHits = [
+      hit("work/a", { denseScore: 0.9 }),
+      hit("work/b", { denseScore: 0.7 }),
+    ];
+    const { scouts } = await runScouts(
+      makeInput({ lanes: { hot: false, sparse: false } }),
+      DEPS,
+    );
+    expect(embedCalls).toBe(1);
+    const dense = scouts.find((s) => s.lane === "dense");
+    expect(dense?.slugs[0]).toBe("work/a");
+    expect(dense?.scoreBySlug).toEqual({ "work/a": 0.9, "work/b": 0.7 });
+  });
+
+  test("per-subtree quota caps off-domain hits", async () => {
+    // Active domain = top hit's domain = "work". Off-domain quota = 1.
+    hybridHits = [
+      hit("work/a", { denseScore: 0.99 }),
+      hit("work/b", { denseScore: 0.98 }),
+      hit("work/c", { denseScore: 0.97 }),
+      hit("people/x", { denseScore: 0.5 }), // off-domain, claims the 1 slot
+      hit("notes/y", { denseScore: 0.4 }), // off-domain, over quota -> dropped
+      hit("misc/z", { denseScore: 0.3 }), // off-domain, over quota -> dropped
+    ];
+    const { scouts } = await runScouts(
+      makeInput({
+        lanes: { hot: false, sparse: false },
+        denseQuota: { activeDomain: 30, offDomain: 1 },
+      }),
+      DEPS,
+    );
+    const dense = scouts.find((s) => s.lane === "dense");
+    const slugs = dense?.slugs ?? [];
+    // All three work/* survive (active quota 30); exactly one off-domain hit.
+    expect(slugs.filter((s) => s.startsWith("work/")).length).toBe(3);
+    const offDomain = slugs.filter((s) => !s.startsWith("work/"));
+    expect(offDomain).toEqual(["people/x"]);
+  });
+
+  test("active-domain quota caps same-subtree hits", async () => {
+    hybridHits = [
+      hit("work/a", { denseScore: 0.99 }),
+      hit("work/b", { denseScore: 0.98 }),
+      hit("work/c", { denseScore: 0.97 }), // over active quota 2 -> dropped
+      hit("people/x", { denseScore: 0.5 }),
+    ];
+    const { scouts } = await runScouts(
+      makeInput({
+        lanes: { hot: false, sparse: false },
+        denseQuota: { activeDomain: 2, offDomain: 8 },
+      }),
+      DEPS,
+    );
+    const slugs = scouts.find((s) => s.lane === "dense")?.slugs ?? [];
+    expect(slugs.filter((s) => s.startsWith("work/")).length).toBe(2);
+    expect(slugs).toContain("people/x");
+  });
+
+  test("MMR interleaves subtrees rather than emitting a same-subtree run", async () => {
+    // Five work/* then one people/* of comparable relevance. Pure score order
+    // would bury people/x last; MMR should pull it forward once work/ is
+    // over-represented.
+    hybridHits = [
+      hit("work/a", { denseScore: 0.95 }),
+      hit("work/b", { denseScore: 0.94 }),
+      hit("work/c", { denseScore: 0.93 }),
+      hit("work/d", { denseScore: 0.92 }),
+      hit("people/x", { denseScore: 0.9 }),
+    ];
+    const { scouts } = await runScouts(
+      makeInput({
+        lanes: { hot: false, sparse: false },
+        denseQuota: { activeDomain: 30, offDomain: 8 },
+      }),
+      DEPS,
+    );
+    const slugs = scouts.find((s) => s.lane === "dense")?.slugs ?? [];
+    // people/x is not stranded at the very end despite the lowest raw score.
+    expect(slugs.indexOf("people/x")).toBeLessThan(slugs.length - 1);
+  });
+
+  test("no dense hits yields no dense ScoutResult", async () => {
+    hybridHits = [hit("sparse/only", { sparseScore: 2.0 })];
+    const { scouts } = await runScouts(
+      makeInput({ lanes: { hot: false, sparse: false } }),
+      DEPS,
+    );
+    expect(scouts.find((s) => s.lane === "dense")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lane toggles
+// ---------------------------------------------------------------------------
+
+describe("runScouts — lane toggles", () => {
+  test("disabling a lane suppresses its ScoutResult", async () => {
+    pageSlugs = ["a"];
+    injectionScores = new Map([["a", 1]]);
+    hybridHits = [hit("docs/a", { sparseScore: 2.0, denseScore: 0.5 })];
+
+    const all = await runScouts(makeInput(), DEPS);
+    expect(all.scouts.map((s) => s.lane).sort()).toEqual([
+      "dense",
+      "hot",
+      "sparse",
+    ]);
+
+    const hotOnly = await runScouts(
+      makeInput({ lanes: { sparse: false, dense: false } }),
+      DEPS,
+    );
+    expect(hotOnly.scouts.map((s) => s.lane)).toEqual(["hot"]);
+    // Dense embed must not run when the dense lane is off.
+    embedCalls = 0;
+    await runScouts(makeInput({ lanes: { dense: false } }), DEPS);
+    expect(embedCalls).toBe(0);
+  });
+
+  test("all lanes off yields empty result", async () => {
+    pageSlugs = ["a"];
+    injectionScores = new Map([["a", 1]]);
+    hybridHits = [hit("docs/a", { sparseScore: 2.0, denseScore: 0.5 })];
+    const { scouts, sticky, bypass } = await runScouts(
+      makeInput({ lanes: { hot: false, sparse: false, dense: false } }),
+      DEPS,
+    );
+    expect(scouts).toEqual([]);
+    expect(sticky.size).toBe(0);
+    expect(bypass.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+describe("runScouts — misc", () => {
+  test("empty query text skips sparse and dense lanes", async () => {
+    pageSlugs = ["a"];
+    injectionScores = new Map([["a", 1]]);
+    hybridHits = [hit("docs/a", { sparseScore: 2.0, denseScore: 0.5 })];
+    const { scouts } = await runScouts(
+      makeInput({ userMessage: "   ", nowText: "  " }),
+      DEPS,
+    );
+    // Hot lane is query-independent and still fires; sparse/dense are gated off.
+    expect(scouts.map((s) => s.lane)).toEqual(["hot"]);
+    expect(embedCalls).toBe(0);
+  });
+
+  test("honors an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    pageSlugs = ["a"];
+    injectionScores = new Map([["a", 1]]);
+    await expect(
+      runScouts(makeInput({ signal: controller.signal }), DEPS),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/memory/v3/scouts.ts
+++ b/assistant/src/memory/v3/scouts.ts
@@ -1,0 +1,392 @@
+// ---------------------------------------------------------------------------
+// Memory v3 — Always-on scout lanes (hot / sparse / dense)
+// ---------------------------------------------------------------------------
+//
+// The v3 retrieval loop opens each pass by fanning out a small set of cheap,
+// always-on "scout" lanes over the v2 read-substrate. Scouts surface candidate
+// concept-page slugs from three complementary signals before any LLM judging
+// (the dense judge lives in a later PR) or tree descent runs:
+//
+//   - hot:    corpus-global access-frequency EMA via `computeInjectionScores`.
+//             Retriever-agnostic — v2 keeps writing `memory_v2_injection_events`,
+//             so a page the user has been touching is "hot" regardless of which
+//             retriever surfaced it. Hits are marked **sticky** so the downstream
+//             gate keeps them in the running.
+//   - sparse: BM25 keyword match. Near-exact (high-score) hits are both
+//             **sticky** and **tree-bypass** — a literal keyword hit is a strong
+//             enough signal that we shouldn't make the slug earn its place by
+//             walking the tree.
+//   - dense:  embedding-similarity match, then an asymmetric per-subtree quota
+//             (generous active-domain slice, thin off-domain slice) plus MMR for
+//             diversity so a single dominant subtree can't crowd out the slate.
+//
+// Each lane is individually toggleable via `config.memory.v3.lanes`. This module
+// performs **no** LLM calls and writes nothing — it is a pure read over the v2
+// substrate. A later PR composes `runScouts` into the full descent loop.
+
+import type { AssistantConfig } from "../../config/types.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { embedWithBackend } from "../embedding-backend.js";
+import type { RetrievalInput } from "../v2/harness/retriever.js";
+import type { ScoutResult } from "../v2/harness/trace.js";
+import { computeInjectionScores } from "../v2/injection-events.js";
+import { getPageIndex } from "../v2/page-index.js";
+import { hybridQueryConceptPages } from "../v2/qdrant.js";
+import { generateBm25QueryEmbedding } from "../v2/sparse-bm25.js";
+
+/** Result of running the always-on scout fanout for one pass. */
+export interface RunScoutsResult {
+  /** Per-lane contributions, one entry per *enabled* lane that produced hits. */
+  scouts: ScoutResult[];
+  /**
+   * Slugs the downstream gate should keep in the running regardless of later
+   * scoring — hot hits and near-exact sparse hits.
+   */
+  sticky: Set<string>;
+  /**
+   * Slugs strong enough (near-exact sparse) to skip the tree-descent gate
+   * entirely. A subset of `sticky`.
+   */
+  bypass: Set<string>;
+}
+
+/** Substrate dependencies injected for testability. */
+export interface ScoutDeps {
+  db: DrizzleDb;
+}
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-lane hit cap before quota/diversity post-processing. The lanes are
+ * always-on and run every pass, so a generous-but-bounded cap keeps the dense
+ * Qdrant round-trip and the per-lane bookkeeping cheap while still giving the
+ * quota/MMR step enough raw candidates to choose from.
+ */
+const LANE_QUERY_LIMIT = 100;
+
+/**
+ * Sparse score at or above which a hit is treated as **near-exact** — sticky
+ * and tree-bypass. BM25 scores are unbounded above and corpus-relative, so the
+ * threshold is taken relative to the top sparse hit in the same pass rather
+ * than as a fixed magnitude: a hit within this fraction of the best sparse
+ * score for the query is "near-exact". A lone strong hit (it is its own max)
+ * always qualifies.
+ */
+const SPARSE_NEAR_EXACT_FRACTION = 0.9;
+
+/**
+ * MMR trade-off: `λ · relevance − (1 − λ) · redundancy`. Closer to 1 favors
+ * raw dense relevance; lower values push harder for subtree diversity. 0.7
+ * keeps relevance in the driver's seat while still breaking up runs of
+ * same-subtree hits.
+ */
+const DENSE_MMR_LAMBDA = 0.7;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the always-on scout lanes for one retrieval pass.
+ *
+ * `queryText` is derived from the last user turn in `input.recentTurnPairs`
+ * joined with `input.nowText` — the same shape the v2 router/activation path
+ * embeds. Disabled lanes (per `config.memory.v3.lanes`) are skipped entirely:
+ * no substrate call, no `ScoutResult` entry.
+ *
+ * Honors `input.signal` — aborts between lanes and around the dense embed.
+ */
+export async function runScouts(
+  input: RetrievalInput,
+  deps: ScoutDeps,
+): Promise<RunScoutsResult> {
+  const { config, signal } = input;
+  const lanes = config.memory.v3.lanes;
+  const queryText = deriveQueryText(input);
+
+  const scouts: ScoutResult[] = [];
+  const sticky = new Set<string>();
+  const bypass = new Set<string>();
+
+  // Hot lane — corpus-global EMA over the full slug universe. Cheap (single
+  // SQL pass) so it runs first and seeds sticky.
+  if (lanes.hot) {
+    signal?.throwIfAborted();
+    const hot = await runHotLane(input, deps);
+    if (hot) {
+      scouts.push(hot);
+      for (const slug of hot.slugs) sticky.add(slug);
+    }
+  }
+
+  // Sparse lane — BM25 keyword match. Near-exact hits seed sticky + bypass.
+  if (lanes.sparse && queryText.length > 0) {
+    signal?.throwIfAborted();
+    const sparse = await runSparseLane(queryText, signal);
+    if (sparse) {
+      scouts.push(sparse.result);
+      for (const slug of sparse.nearExact) {
+        sticky.add(slug);
+        bypass.add(slug);
+      }
+    }
+  }
+
+  // Dense lane — embedding similarity, then per-subtree quota + MMR.
+  if (lanes.dense && queryText.length > 0) {
+    signal?.throwIfAborted();
+    const dense = await runDenseLane(queryText, config, signal);
+    if (dense) scouts.push(dense);
+  }
+
+  return { scouts, sticky, bypass };
+}
+
+// ---------------------------------------------------------------------------
+// Query-text derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the scout query text from the just-arrived user turn plus the NOW
+ * context. Mirrors the v2 activation path (`selectCandidates`): join the
+ * non-empty channels with a newline. The last `recentTurnPairs` entry's
+ * `userMessage` is the turn being routed.
+ */
+function deriveQueryText(input: RetrievalInput): string {
+  const lastPair = input.recentTurnPairs[input.recentTurnPairs.length - 1];
+  const userText = lastPair?.userMessage ?? "";
+  return [userText, input.nowText]
+    .filter((s) => s.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Hot lane
+// ---------------------------------------------------------------------------
+
+async function runHotLane(
+  input: RetrievalInput,
+  deps: ScoutDeps,
+): Promise<ScoutResult | null> {
+  const index = await getPageIndex(input.workspaceDir);
+  const allSlugs = index.entries.map((e) => e.slug);
+  if (allSlugs.length === 0) return null;
+
+  const now = Date.now();
+  const scores = computeInjectionScores(deps.db, allSlugs, now);
+  if (scores.size === 0) return null;
+
+  // Slugs with no events in the read window are omitted by
+  // `computeInjectionScores`, so every entry here has score > 0.
+  const ranked = [...scores.entries()].sort((a, b) => sortByScoreDesc(a, b));
+  const slugs = ranked.map(([slug]) => slug);
+  const scoreBySlug = Object.fromEntries(ranked);
+  return { lane: "hot", slugs, scoreBySlug };
+}
+
+// ---------------------------------------------------------------------------
+// Sparse lane
+// ---------------------------------------------------------------------------
+
+async function runSparseLane(
+  queryText: string,
+  signal: AbortSignal | undefined,
+): Promise<{ result: ScoutResult; nearExact: string[] } | null> {
+  const sparse = generateBm25QueryEmbedding(queryText);
+  if (sparse.indices.length === 0) return null;
+
+  // Dense channel intentionally empty — this lane is BM25-only. `skipSparse:
+  // false` keeps the sparse round-trip on; we read `sparseScore` and ignore
+  // any dense scores the query happens to surface.
+  const hits = await hybridQueryConceptPages(
+    [],
+    sparse,
+    LANE_QUERY_LIMIT,
+    undefined,
+    {
+      skipSparse: false,
+    },
+  );
+  signal?.throwIfAborted();
+
+  const scored = hits
+    .map((hit) => ({ slug: hit.slug, score: hit.sparseScore }))
+    .filter((h): h is { slug: string; score: number } => h.score !== undefined)
+    .sort((a, b) => b.score - a.score);
+  if (scored.length === 0) return null;
+
+  const slugs = scored.map((h) => h.slug);
+  const scoreBySlug = Object.fromEntries(scored.map((h) => [h.slug, h.score]));
+
+  // Near-exact: within SPARSE_NEAR_EXACT_FRACTION of the top sparse score.
+  const topScore = scored[0].score;
+  const threshold = topScore * SPARSE_NEAR_EXACT_FRACTION;
+  const nearExact = scored
+    .filter((h) => topScore > 0 && h.score >= threshold)
+    .map((h) => h.slug);
+
+  return { result: { lane: "sparse", slugs, scoreBySlug }, nearExact };
+}
+
+// ---------------------------------------------------------------------------
+// Dense lane
+// ---------------------------------------------------------------------------
+
+async function runDenseLane(
+  queryText: string,
+  config: AssistantConfig,
+  signal: AbortSignal | undefined,
+): Promise<ScoutResult | null> {
+  // Embed + apply anisotropy correction, mirroring v2 activation's read path.
+  const embedded = await embedWithBackend(config, [queryText], { signal });
+  const dense = await applyCorrectionIfCalibrated(
+    embedded.vectors[0],
+    embedded.provider,
+    embedded.model,
+  );
+  signal?.throwIfAborted();
+
+  const sparse = generateBm25QueryEmbedding(queryText);
+  const hits = await hybridQueryConceptPages(dense, sparse, LANE_QUERY_LIMIT);
+  signal?.throwIfAborted();
+
+  const scored = hits
+    .map((hit) => ({ slug: hit.slug, score: hit.denseScore }))
+    .filter((h): h is { slug: string; score: number } => h.score !== undefined)
+    .sort((a, b) => b.score - a.score);
+  if (scored.length === 0) return null;
+
+  const selected = applyQuotaAndMmr(scored, config.memory.v3);
+  if (selected.length === 0) return null;
+
+  const slugs = selected.map((h) => h.slug);
+  const scoreBySlug = Object.fromEntries(
+    selected.map((h) => [h.slug, h.score]),
+  );
+  return { lane: "dense", slugs, scoreBySlug };
+}
+
+interface ScoredSlug {
+  slug: string;
+  score: number;
+}
+
+/**
+ * Apply the asymmetric per-subtree quota then MMR re-ranking to the dense hits.
+ *
+ * Quota: the conversation's **active domain** is the top-path segment of the
+ * single highest-scoring dense hit. That domain gets a generous slice
+ * (`denseQuota.activeDomain`); every other (off-)domain shares a thin slice
+ * (`denseQuota.offDomain`) so exploratory hits aren't fully starved but can't
+ * dominate either. Quotas are per-domain caps applied in score-descending
+ * order.
+ *
+ * MMR: re-rank the quota-passing pool by `λ · relevance − (1 − λ) · redundancy`
+ * where redundancy is how represented the candidate's subtree already is in the
+ * selected slate. Without per-page embeddings we use subtree co-membership as
+ * the diversity signal — same subtree ⇒ maximally redundant. This breaks up
+ * runs of same-subtree hits without an extra Qdrant round-trip.
+ */
+function applyQuotaAndMmr(
+  scored: readonly ScoredSlug[],
+  v3: AssistantConfig["memory"]["v3"],
+): ScoredSlug[] {
+  if (scored.length === 0) return [];
+
+  const activeDomain = domainOf(scored[0].slug);
+  const { activeDomain: activeQuota, offDomain: offQuota } = v3.denseQuota;
+
+  // Per-subtree quota: active domain gets activeQuota slots; all off-domain
+  // hits compete for a shared offQuota pool. Walk in score-desc order so the
+  // strongest hits claim each quota first.
+  const perDomainCount = new Map<string, number>();
+  let offDomainCount = 0;
+  const quotaPassing: ScoredSlug[] = [];
+  for (const hit of scored) {
+    const domain = domainOf(hit.slug);
+    if (domain === activeDomain) {
+      const used = perDomainCount.get(domain) ?? 0;
+      if (used >= activeQuota) continue;
+      perDomainCount.set(domain, used + 1);
+    } else {
+      if (offDomainCount >= offQuota) continue;
+      offDomainCount += 1;
+    }
+    quotaPassing.push(hit);
+  }
+
+  return mmrReorder(quotaPassing, DENSE_MMR_LAMBDA);
+}
+
+/**
+ * Greedy MMR over a score-ranked pool using subtree co-membership as the
+ * redundancy signal. Each pick maximizes
+ * `λ · normalizedScore − (1 − λ) · subtreeShareInSelected`, so once a subtree
+ * is well-represented its remaining members are deprioritized in favor of
+ * fresh subtrees of comparable relevance. Pure / deterministic.
+ */
+function mmrReorder(pool: readonly ScoredSlug[], lambda: number): ScoredSlug[] {
+  if (pool.length <= 1) return [...pool];
+
+  // Normalize relevance to [0, 1] by the pool max so it shares a scale with the
+  // redundancy term (also [0, 1]). All-zero scores collapse to pure diversity.
+  const maxScore = pool[0].score;
+  const relevance = (hit: ScoredSlug): number =>
+    maxScore > 0 ? hit.score / maxScore : 0;
+
+  const remaining = [...pool];
+  const selected: ScoredSlug[] = [];
+  const selectedDomainCount = new Map<string, number>();
+
+  while (remaining.length > 0) {
+    let bestIdx = 0;
+    let bestMmr = -Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const hit = remaining[i];
+      const domain = domainOf(hit.slug);
+      const share =
+        selected.length === 0
+          ? 0
+          : (selectedDomainCount.get(domain) ?? 0) / selected.length;
+      const mmr = lambda * relevance(hit) - (1 - lambda) * share;
+      if (mmr > bestMmr) {
+        bestMmr = mmr;
+        bestIdx = i;
+      }
+    }
+    const [pick] = remaining.splice(bestIdx, 1);
+    selected.push(pick);
+    const domain = domainOf(pick.slug);
+    selectedDomainCount.set(domain, (selectedDomainCount.get(domain) ?? 0) + 1);
+  }
+
+  return selected;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * The "domain" (subtree) of a page slug — its top path segment. Slugs are
+ * path-relative with `/` separators (e.g. `people/alice` → `people`); a flat
+ * slug (`essentials`) is its own domain.
+ */
+function domainOf(slug: string): string {
+  const slash = slug.indexOf("/");
+  return slash === -1 ? slug : slug.slice(0, slash);
+}
+
+/** Score-desc with a stable slug-ASCII tiebreak. */
+function sortByScoreDesc(
+  a: readonly [string, number],
+  b: readonly [string, number],
+): number {
+  if (b[1] !== a[1]) return b[1] - a[1];
+  return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Add runScouts: hot (EMA via computeInjectionScores), sparse (BM25), dense (embed + per-subtree quota + MMR) lanes over the v2 substrate.
- Returns per-lane ScoutResult[] + sticky/bypass sets; lanes toggleable via config.memory.v3.lanes; no LLM.
- Substrate injected via deps for fully-stubbed tests.

Part of plan: memory-v3-build.md (PR 8 of 19)