### PR TITLE
feat(memory-v3): pass-1->pass-2 co-activation logging

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -129,6 +129,7 @@ import {
   migrateMemoryRetrospectiveState,
   migrateMemoryV2ActivationLogs,
   migrateMemoryV2InjectionEvents,
+  migrateMemoryV3Coactivation,
   migrateMessageBookmarks,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
@@ -456,6 +457,7 @@ export function initializeDb(): void {
     migrateConversationCleanedAt,
     migrateRenameCleanedAt,
     migrateLlmUsageAddRawUsage,
+    migrateMemoryV3Coactivation,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/262-memory-v3-coactivation.ts
+++ b/assistant/src/memory/migrations/262-memory-v3-coactivation.ts
@@ -1,0 +1,57 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_memory_v3_coactivation_v1";
+
+/**
+ * Create the memory_v3_coactivation table — an append-only log of
+ * pass-1 → pass-N co-activation pairs observed during a v3 retrieval loop.
+ *
+ * Each row records that a page (`target_slug`) first surfaced on a later
+ * descent pass was co-selected alongside a page (`source_slug`) that surfaced
+ * on pass 1, with `pass_gap` = passOf(target) − passOf(source). This is the
+ * raw gradient signal that edge-learning later reconciles into curated-graph
+ * edge weights: a source that repeatedly precedes a target across turns is a
+ * candidate association. `used` is the usefulness flag (0 here — the loop
+ * cannot know whether the target was actually load-bearing for the turn; a
+ * later edge-learning pass reconciles it).
+ *
+ * The table just accumulates raw events; the edge-learning formula or the
+ * decay/weighting can change later without losing signal.
+ *
+ * Indexes:
+ * - `(source_slug, target_slug)` for per-pair aggregation (the hot path for
+ *   edge-learning reads).
+ * - `(created_at)` for time-range pruning later.
+ */
+export function migrateMemoryV3Coactivation(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS memory_v3_coactivation (
+        id INTEGER PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        source_slug TEXT NOT NULL,
+        target_slug TEXT NOT NULL,
+        pass_gap INTEGER NOT NULL,
+        used INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v3_coactivation_pair
+        ON memory_v3_coactivation (source_slug, target_slug)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v3_coactivation_time
+        ON memory_v3_coactivation (created_at)
+    `);
+  });
+}
+
+export function downMemoryV3Coactivation(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_v3_coactivation`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -243,6 +243,10 @@ export {
   migrateLlmUsageAddRawUsage,
 } from "./261-llm-usage-add-raw-usage.js";
 export {
+  downMemoryV3Coactivation,
+  migrateMemoryV3Coactivation,
+} from "./262-memory-v3-coactivation.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -55,6 +55,7 @@ import { downMemoryV2InjectionEvents } from "./256-memory-v2-injection-events.js
 import { downConversationCleanedAt } from "./259-conversation-cleaned-at.js";
 import { downRenameCleanedAt } from "./260-rename-cleaned-at.js";
 import { downLlmUsageAddRawUsage } from "./261-llm-usage-add-raw-usage.js";
+import { downMemoryV3Coactivation } from "./262-memory-v3-coactivation.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -469,6 +470,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add raw_usage TEXT column to llm_usage_events for storing the provider's untouched usage block as JSON (Anthropic TTL breakdown, OpenAI prompt/completion token details, etc.) so downstream consumers can extract provider-specific detail without per-field schema changes",
     down: downLlmUsageAddRawUsage,
+  },
+  {
+    key: "migration_memory_v3_coactivation_v1",
+    version: 55,
+    description:
+      "Create memory_v3_coactivation table — append-only log of pass-1 → pass-N co-activation pairs (gradient signal) emitted by the v3 retrieval loop and reconciled later by edge-learning",
+    down: downMemoryV3Coactivation,
   },
 ];
 

--- a/assistant/src/memory/v3/__tests__/coactivation-store.test.ts
+++ b/assistant/src/memory/v3/__tests__/coactivation-store.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Tests for `assistant/src/memory/v3/coactivation-store.ts`, its sibling
+ * migration `262-memory-v3-coactivation.ts`, and the loop's co-activation
+ * emission (`loop.ts`, gated by `config.memory.v3.write.coactivation`).
+ *
+ * Coverage:
+ *   - Migration creates the table + both indexes; safe to re-run.
+ *   - recordCoactivations / readCoactivations round-trip; empty list is a
+ *     no-op; `since` filters by created_at.
+ *   - A scripted 2-pass loop emits the expected pass-1 → pass-2 rows with the
+ *     correct pass_gap when the flag is on, and nothing when it is off.
+ *
+ * Uses an in-memory bun:sqlite database — no real workspace DB. The loop's
+ * lane modules are stubbed via `mock.module`, matching `loop.test.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import type { DrizzleDb } from "../../db-connection.js";
+import { getSqliteFrom } from "../../db-connection.js";
+import {
+  downMemoryV3Coactivation,
+  migrateMemoryV3Coactivation,
+} from "../../migrations/262-memory-v3-coactivation.js";
+import * as schema from "../../schema.js";
+import type {
+  RetrievalInput,
+  RetrievalOutput,
+} from "../../v2/harness/retriever.js";
+import type { GateDecision, ScoutResult } from "../../v2/harness/trace.js";
+import {
+  type CoactivationRow,
+  readCoactivations,
+  recordCoactivations,
+} from "../coactivation-store.js";
+
+// memory_checkpoints is required by withCrashRecovery and is normally created
+// by an early core migration. Stand it up by hand so the v3 migration can run
+// in isolation against a fresh in-memory DB.
+const CHECKPOINTS_DDL = /*sql*/ `
+  CREATE TABLE memory_checkpoints (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  )
+`;
+
+// ---------------------------------------------------------------------------
+// Loop lane stubs — installed before importing the module under test. Mirrors
+// loop.test.ts: each test rewires the `lane` refs before calling the loop.
+// ---------------------------------------------------------------------------
+
+interface RunScoutsResult {
+  scouts: ScoutResult[];
+  sticky: Set<string>;
+  bypass: Set<string>;
+}
+interface FilterResult {
+  kept: string[];
+  trace: { judged: string[]; dropped: string[] };
+  failureReason?: string;
+}
+interface WalkResult {
+  pages: Set<string>;
+  levels: Array<{
+    node: string;
+    considered: string[];
+    descended: string[];
+    skipped: string[];
+    reasoning: string;
+  }>;
+}
+interface ExpandResult {
+  pulled: Set<string>;
+  expansions: Array<{ from: string; pulled: string[] }>;
+}
+interface GateResult {
+  decision: GateDecision;
+  selectedSlugs: string[];
+}
+
+const lane = {
+  scouts: [] as RunScoutsResult[],
+  filter: [] as FilterResult[],
+  walk: [] as WalkResult[],
+  edges: [] as ExpandResult[],
+  gate: [] as GateResult[],
+};
+
+function nextOf<T>(list: T[], index: number): T {
+  return list[Math.min(index, list.length - 1)];
+}
+
+let scoutCallCount = 0;
+let filterCallCount = 0;
+let walkCallCount = 0;
+let edgeCallCount = 0;
+let gateCallCount = 0;
+
+mock.module("../scouts.js", () => ({
+  runScouts: async (): Promise<RunScoutsResult> =>
+    nextOf(lane.scouts, scoutCallCount++),
+}));
+mock.module("../filter.js", () => ({
+  filterDenseHits: async (): Promise<FilterResult> =>
+    nextOf(lane.filter, filterCallCount++),
+}));
+mock.module("../tree-walk.js", () => ({
+  runTreeWalk: async (): Promise<WalkResult> =>
+    nextOf(lane.walk, walkCallCount++),
+}));
+mock.module("../edges.js", () => ({
+  expandEdges: async (): Promise<ExpandResult> =>
+    nextOf(lane.edges, edgeCallCount++),
+}));
+mock.module("../gate.js", () => ({
+  runGate: async (): Promise<GateResult> => nextOf(lane.gate, gateCallCount++),
+}));
+mock.module("../tree-index.js", () => ({
+  getTreeIndex: async () => ({
+    nodes: new Map(),
+    childrenByNode: new Map(),
+    parentsByNode: new Map(),
+    pageParents: new Map(),
+    root: "_root",
+  }),
+}));
+mock.module("../../v2/page-index.js", () => ({
+  getPageIndex: async () => ({
+    entries: [],
+    bySlug: new Map(),
+    byId: new Map(),
+    rendered: "",
+  }),
+}));
+
+const { runRetrievalLoop } = await import("../loop.js");
+
+let sqlite: Database;
+let database: DrizzleDb;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  database = drizzle(sqlite, { schema });
+  getSqliteFrom(database).exec(CHECKPOINTS_DDL);
+  migrateMemoryV3Coactivation(database);
+
+  lane.scouts = [];
+  lane.filter = [];
+  lane.walk = [];
+  lane.edges = [];
+  lane.gate = [];
+  scoutCallCount = 0;
+  filterCallCount = 0;
+  walkCallCount = 0;
+  edgeCallCount = 0;
+  gateCallCount = 0;
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function scout(laneName: ScoutResult["lane"], slugs: string[]): ScoutResult {
+  return { lane: laneName, slugs };
+}
+
+function makeInput(opts?: {
+  passCap?: number;
+  coactivation?: boolean;
+}): RetrievalInput {
+  return {
+    workspaceDir: "/tmp/does-not-matter",
+    recentTurnPairs: [],
+    nowText: "NOW",
+    priorEverInjected: [],
+    config: {
+      memory: {
+        v3: {
+          passCap: opts?.passCap ?? 3,
+          lanes: {
+            hot: true,
+            sparse: true,
+            dense: true,
+            tree: true,
+            edges: true,
+          },
+          write: {
+            enabled: false,
+            consolidateIntervalMs: 3600000,
+            coactivation: opts?.coactivation ?? false,
+          },
+        },
+      },
+    } as unknown as RetrievalInput["config"],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Migration.
+// ---------------------------------------------------------------------------
+
+describe("migrateMemoryV3Coactivation", () => {
+  test("creates table and both indexes; safe to re-run", () => {
+    migrateMemoryV3Coactivation(database);
+    migrateMemoryV3Coactivation(database);
+
+    const raw = getSqliteFrom(database);
+    const table = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v3_coactivation'`,
+      )
+      .get();
+    expect(table).toBeTruthy();
+
+    const indexNames = new Set(
+      (
+        raw
+          .query(
+            `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_v3_coactivation'`,
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name),
+    );
+    expect(indexNames.has("idx_memory_v3_coactivation_pair")).toBe(true);
+    expect(indexNames.has("idx_memory_v3_coactivation_time")).toBe(true);
+  });
+
+  test("downMemoryV3Coactivation drops the table", () => {
+    downMemoryV3Coactivation(database);
+    const table = getSqliteFrom(database)
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v3_coactivation'`,
+      )
+      .get();
+    expect(table).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store.
+// ---------------------------------------------------------------------------
+
+describe("recordCoactivations / readCoactivations", () => {
+  test("round-trips rows oldest-first", () => {
+    const rows: CoactivationRow[] = [
+      {
+        conversationId: "conv-1",
+        turn: 3,
+        sourceSlug: "alice",
+        targetSlug: "bob",
+        passGap: 1,
+        used: 0,
+        createdAt: 1_000,
+      },
+      {
+        conversationId: "conv-1",
+        turn: 3,
+        sourceSlug: "alice",
+        targetSlug: "carol",
+        passGap: 2,
+        used: 0,
+        createdAt: 2_000,
+      },
+    ];
+    recordCoactivations(database, rows);
+
+    const read = readCoactivations(database);
+    expect(read).toHaveLength(2);
+    expect(read[0]).toMatchObject({
+      conversationId: "conv-1",
+      turn: 3,
+      sourceSlug: "alice",
+      targetSlug: "bob",
+      passGap: 1,
+      used: 0,
+      createdAt: 1_000,
+    });
+    expect(read[1].targetSlug).toBe("carol");
+    expect(read[1].passGap).toBe(2);
+  });
+
+  test("empty list is a no-op", () => {
+    recordCoactivations(database, []);
+    expect(readCoactivations(database)).toHaveLength(0);
+  });
+
+  test("since filters by created_at", () => {
+    recordCoactivations(database, [
+      {
+        conversationId: "c",
+        turn: 1,
+        sourceSlug: "a",
+        targetSlug: "b",
+        passGap: 1,
+        used: 0,
+        createdAt: 100,
+      },
+      {
+        conversationId: "c",
+        turn: 1,
+        sourceSlug: "a",
+        targetSlug: "c",
+        passGap: 1,
+        used: 0,
+        createdAt: 500,
+      },
+    ]);
+    const recent = readCoactivations(database, 300);
+    expect(recent).toHaveLength(1);
+    expect(recent[0].targetSlug).toBe("c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loop emission.
+// ---------------------------------------------------------------------------
+
+describe("runRetrievalLoop — co-activation emission", () => {
+  /**
+   * Script a 2-pass loop: pass 1 surfaces `a` (hot) + `b` (sparse); pass 2
+   * surfaces `c` (dense). The gate says "more" on pass 1 (selecting a, b) and
+   * "ready" on pass 2 (selecting a, b, c). So `c` is the only pass-2 target,
+   * paired with pass-1 hits a and b → two rows, both pass_gap=1.
+   */
+  function scriptTwoPass(): void {
+    lane.scouts = [
+      {
+        scouts: [scout("hot", ["a"]), scout("sparse", ["b"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+      {
+        scouts: [scout("dense", ["c"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    // Pass 1 has no dense scout, so the filter is only called on pass 2 (one
+    // filter call per dense pass) — its single entry keeps `c`.
+    lane.filter = [{ kept: ["c"], trace: { judged: ["c"], dropped: [] } }];
+    lane.walk = [
+      { pages: new Set(), levels: [] },
+      { pages: new Set(), levels: [] },
+    ];
+    lane.edges = [
+      { pulled: new Set(), expansions: [] },
+      { pulled: new Set(), expansions: [] },
+    ];
+    lane.gate = [
+      {
+        decision: { decision: "more", questions: ["q"] },
+        selectedSlugs: ["a", "b"],
+      },
+      { decision: { decision: "ready" }, selectedSlugs: ["a", "b", "c"] },
+    ];
+  }
+
+  test("emits pass-1 → pass-2 rows with correct pass_gap when flag is on", async () => {
+    scriptTwoPass();
+    const out: RetrievalOutput = await runRetrievalLoop(
+      makeInput({ passCap: 3, coactivation: true }),
+      { db: database, conversationId: "conv-42", turn: 7 },
+    );
+    expect(out.selectedSlugs).toEqual(["a", "b", "c"]);
+
+    const rows = readCoactivations(database);
+    // c (pass 2) paired with each pass-1 hit a and b → two rows.
+    expect(rows).toHaveLength(2);
+    const pairs = rows.map((r) => `${r.sourceSlug}->${r.targetSlug}`).sort();
+    expect(pairs).toEqual(["a->c", "b->c"]);
+    for (const r of rows) {
+      expect(r.targetSlug).toBe("c");
+      expect(r.passGap).toBe(1);
+      expect(r.used).toBe(0);
+      expect(r.conversationId).toBe("conv-42");
+      expect(r.turn).toBe(7);
+    }
+  });
+
+  test("emits nothing when the flag is off", async () => {
+    scriptTwoPass();
+    await runRetrievalLoop(makeInput({ passCap: 3, coactivation: false }), {
+      db: database,
+      conversationId: "conv-42",
+      turn: 7,
+    });
+    expect(readCoactivations(database)).toHaveLength(0);
+  });
+
+  test("single-pass selection emits nothing (no later-surfaced target)", async () => {
+    lane.scouts = [
+      {
+        scouts: [scout("hot", ["a"]), scout("sparse", ["b"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    lane.filter = [{ kept: [], trace: { judged: [], dropped: [] } }];
+    lane.walk = [{ pages: new Set(), levels: [] }];
+    lane.edges = [{ pulled: new Set(), expansions: [] }];
+    lane.gate = [
+      { decision: { decision: "ready" }, selectedSlugs: ["a", "b"] },
+    ];
+
+    await runRetrievalLoop(makeInput({ passCap: 3, coactivation: true }), {
+      db: database,
+      conversationId: "conv-1",
+      turn: 1,
+    });
+    expect(readCoactivations(database)).toHaveLength(0);
+  });
+});

--- a/assistant/src/memory/v3/coactivation-store.ts
+++ b/assistant/src/memory/v3/coactivation-store.ts
@@ -1,0 +1,124 @@
+/**
+ * Memory v3 — co-activation store.
+ *
+ * Best-effort read/write helpers over `memory_v3_coactivation` (migration
+ * 262). Each row is a pass-1 → pass-N co-activation pair observed during a
+ * single v3 retrieval loop: a `target_slug` first surfaced on a later descent
+ * pass was co-selected alongside a `source_slug` that surfaced on pass 1,
+ * `pass_gap = passOf(target) − passOf(source)`.
+ *
+ * This is the raw gradient signal — edge-learning reconciles it into curated
+ * graph edge weights later. Writes are off the retrieval critical path: a
+ * failed insert here must never abort the turn on top of a successful
+ * retrieval the caller already depends on.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("memory-v3-coactivation");
+
+/** One co-activation pair to persist. */
+export interface CoactivationRow {
+  conversationId: string;
+  turn: number;
+  sourceSlug: string;
+  targetSlug: string;
+  passGap: number;
+  /** Usefulness flag. 0 at emit time; reconciled later by edge-learning. */
+  used: number;
+  createdAt: number;
+}
+
+/** A persisted co-activation row, as read back from the table. */
+export interface PersistedCoactivationRow {
+  id: number;
+  conversationId: string;
+  turn: number;
+  sourceSlug: string;
+  targetSlug: string;
+  passGap: number;
+  used: number;
+  createdAt: number;
+}
+
+/**
+ * Append co-activation rows. Best-effort — a SQLite write must never abort the
+ * agent turn on top of a successful retrieval the rest of the caller depends
+ * on. Mirrors {@link recordInjectionEvents}.
+ */
+export function recordCoactivations(
+  database: DrizzleDb,
+  rows: readonly CoactivationRow[],
+): void {
+  if (rows.length === 0) return;
+  try {
+    const raw = getSqliteFrom(database);
+    const insert = raw.prepare(
+      `INSERT INTO memory_v3_coactivation
+        (conversation_id, turn, source_slug, target_slug, pass_gap, used, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const append = raw.transaction((items: readonly CoactivationRow[]) => {
+      for (const r of items) {
+        insert.run(
+          r.conversationId,
+          r.turn,
+          r.sourceSlug,
+          r.targetSlug,
+          r.passGap,
+          r.used,
+          r.createdAt,
+        );
+      }
+    });
+    append(rows);
+  } catch (err) {
+    log.warn(
+      { err, rowCount: rows.length },
+      "failed to record co-activations; continuing",
+    );
+  }
+}
+
+/**
+ * Read co-activation rows, oldest first. When `since` is provided, only rows
+ * with `created_at >= since` are returned.
+ */
+export function readCoactivations(
+  database: DrizzleDb,
+  since?: number,
+): PersistedCoactivationRow[] {
+  const raw = getSqliteFrom(database);
+  const where = since !== undefined ? `WHERE created_at >= ?` : ``;
+  const params = since !== undefined ? [since] : [];
+  const rows = raw
+    .query(
+      `SELECT id, conversation_id, turn, source_slug, target_slug,
+              pass_gap, used, created_at
+        FROM memory_v3_coactivation
+        ${where}
+        ORDER BY created_at ASC, id ASC`,
+    )
+    .all(...params) as Array<{
+    id: number;
+    conversation_id: string;
+    turn: number;
+    source_slug: string;
+    target_slug: string;
+    pass_gap: number;
+    used: number;
+    created_at: number;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    conversationId: r.conversation_id,
+    turn: r.turn,
+    sourceSlug: r.source_slug,
+    targetSlug: r.target_slug,
+    passGap: r.pass_gap,
+    used: r.used,
+    createdAt: r.created_at,
+  }));
+}

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -44,6 +44,7 @@
  * this composition layer) accumulates across every pass.
  */
 
+import { getLogger } from "../../util/logger.js";
 import type { DrizzleDb } from "../db-connection.js";
 import type {
   RetrievalCost,
@@ -56,6 +57,10 @@ import type {
   GateDecision,
 } from "../v2/harness/trace.js";
 import { getPageIndex } from "../v2/page-index.js";
+import {
+  type CoactivationRow,
+  recordCoactivations,
+} from "./coactivation-store.js";
 import { expandEdges } from "./edges.js";
 import { filterDenseHits } from "./filter.js";
 import { runGate } from "./gate.js";
@@ -66,9 +71,19 @@ import { runTreeWalk } from "./tree-walk.js";
 /** Lane label used to tag each selected slug's provenance in `sourceBySlug`. */
 type LaneSource = "hot" | "sparse" | "dense" | "tree" | "edge";
 
+const log = getLogger("memory-v3-loop");
+
 /** Injected dependencies — the SQLite handle the scout hot lane reads. */
 export interface RetrievalLoopDeps {
   db: DrizzleDb;
+  /**
+   * Conversation this retrieval is running for. Stamped on co-activation rows
+   * when `config.memory.v3.write.coactivation` is on. Empty string when the
+   * loop runs in the offline harness (no live conversation).
+   */
+  conversationId?: string;
+  /** Turn number within the conversation, for co-activation provenance. */
+  turn?: number;
 }
 
 /**
@@ -91,6 +106,9 @@ export async function runRetrievalLoop(
 
   // Cross-pass accumulators.
   const sourceBySlug = new Map<string, LaneSource>();
+  // The first pass each slug entered the candidate set. Drives co-activation
+  // emission below — pass-1 hits (gap source) vs. later-surfaced pages (target).
+  const firstPassBySlug = new Map<string, number>();
   const sticky = new Set<string>();
   const passes: DescentPass[] = [];
   // `ms` is the one cost dimension observable at this composition layer — the
@@ -190,6 +208,13 @@ export async function runRetrievalLoop(
       }
     }
 
+    // Record the first pass each candidate surfaced on. The candidate set is
+    // the union of every lane's contribution this pass; a slug keeps the
+    // earliest pass it appeared on (first write wins).
+    for (const slug of candidates) {
+      if (!firstPassBySlug.has(slug)) firstPassBySlug.set(slug, passNumber);
+    }
+
     // 5. Gate — one capable LLM call over the unioned candidate set.
     const gateResult = await runGate({
       input: passInput,
@@ -219,6 +244,21 @@ export async function runRetrievalLoop(
     passNowText = nextPassNowText(input.nowText, gateResult.decision);
   }
 
+  // Co-activation logging — off the critical path. Gated by
+  // `write.coactivation` (default off). Emits one pass-1 → pass-N pair per
+  // (pass-1 hit, later-surfaced page) in the final selection. Best-effort:
+  // wrapped so neither the computation nor the insert can delay or break the
+  // RetrievalOutput the caller depends on.
+  if (v3.write?.coactivation) {
+    emitCoactivations({
+      db: deps.db,
+      conversationId: deps.conversationId ?? "",
+      turn: deps.turn ?? 0,
+      selectedSlugs,
+      firstPassBySlug,
+    });
+  }
+
   const trace: DescentTrace = { passes };
   return {
     selectedSlugs,
@@ -227,6 +267,56 @@ export async function runRetrievalLoop(
     cost,
     failureReason,
   };
+}
+
+/**
+ * Emit pass-1 → pass-N co-activation rows for the final selection.
+ *
+ * For each selected page B first surfaced on pass ≥2, pair it with each
+ * selected page A first surfaced on pass 1 (`pass_gap = passOf(B) − 1`). Pages
+ * only surfaced on pass 1 (or never recorded) emit nothing — the gradient is
+ * the gap between an early hit and a later-surfaced association. `used` is 0:
+ * the loop cannot know whether B was load-bearing for the turn; edge-learning
+ * reconciles usefulness later.
+ *
+ * Best-effort and off the retrieval critical path — any failure is swallowed.
+ */
+function emitCoactivations(args: {
+  db: DrizzleDb;
+  conversationId: string;
+  turn: number;
+  selectedSlugs: readonly string[];
+  firstPassBySlug: ReadonlyMap<string, number>;
+}): void {
+  try {
+    const { db, conversationId, turn, selectedSlugs, firstPassBySlug } = args;
+    const pass1Hits = selectedSlugs.filter(
+      (slug) => firstPassBySlug.get(slug) === 1,
+    );
+    if (pass1Hits.length === 0) return;
+
+    const createdAt = Date.now();
+    const rows: CoactivationRow[] = [];
+    for (const target of selectedSlugs) {
+      const targetPass = firstPassBySlug.get(target);
+      if (targetPass === undefined || targetPass < 2) continue;
+      for (const source of pass1Hits) {
+        rows.push({
+          conversationId,
+          turn,
+          sourceSlug: source,
+          targetSlug: target,
+          passGap: targetPass - 1,
+          used: 0,
+          createdAt,
+        });
+      }
+    }
+
+    recordCoactivations(db, rows);
+  } catch (err) {
+    log.warn({ err }, "failed to emit co-activations; continuing");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add memory_v3_coactivation table (idempotent migration 262) + coactivation-store (best-effort record/read).
- loop.ts emits pass-1->pass-N co-activation rows when config.memory.v3.write.coactivation is on (off by default), off the retrieval critical path.

Part of plan: memory-v3-build.md (PR 17 of 19)