### PR TITLE
feat(memory-v3): weighted, decaying auto-edge learning job

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -129,6 +129,7 @@ import {
   migrateMemoryRetrospectiveState,
   migrateMemoryV2ActivationLogs,
   migrateMemoryV2InjectionEvents,
+  migrateMemoryV3AutoEdges,
   migrateMemoryV3Coactivation,
   migrateMessageBookmarks,
   migrateMessagesConversationCreatedAtIndex,
@@ -458,6 +459,7 @@ export function initializeDb(): void {
     migrateRenameCleanedAt,
     migrateLlmUsageAddRawUsage,
     migrateMemoryV3Coactivation,
+    migrateMemoryV3AutoEdges,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -84,6 +84,7 @@ import {
 } from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
 import { memoryV3ConsolidateJob } from "./v3/consolidation-job.js";
+import { memoryV3EdgeLearningJob } from "./v3/edge-learning-job.js";
 import { memoryV3IndexMaintenanceJob } from "./v3/maintenance.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -610,6 +611,10 @@ async function processJob(
       return;
     case "memory_v3_index_maintenance":
       await memoryV3IndexMaintenanceJob(job);
+      return;
+    case "memory_v3_edge_learning":
+      // Fast lane: bounded DB work (decay + reinforce + read), no LLM.
+      memoryV3EdgeLearningJob(job);
       return;
     case "memory_v2_migrate":
       await memoryV2MigrateJob(job, config);

--- a/assistant/src/memory/migrations/263-memory-v3-auto-edges.ts
+++ b/assistant/src/memory/migrations/263-memory-v3-auto-edges.ts
@@ -1,0 +1,50 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_memory_v3_auto_edges_v1";
+
+/**
+ * Create the memory_v3_auto_edges table — the **learned** edge graph, a
+ * distinct class from the curated `edges:` frontmatter graph.
+ *
+ * Each row is a weighted directed association `source_slug → target_slug` that
+ * the edge-learning job (`memory_v3_edge_learning`) accrues from *used*
+ * co-activations (migration 262's `memory_v3_coactivation` rows) and decays
+ * over time. `weight` is a multiplicatively-decaying real; `last_reinforced_at`
+ * is the wall-clock ms of the most recent reinforcement, used by the decay
+ * pass to compute elapsed time per pair.
+ *
+ * Auto-edges are advisory: the read path consumes only above-threshold pairs
+ * via edge-expansion's `extraAdjacency` seam, and high-weight pairs surface as
+ * promotion *candidates* for the assistant to ratify into curated `edges:`
+ * during consolidation. This table never auto-writes page frontmatter.
+ *
+ * `PRIMARY KEY(source_slug, target_slug)` makes each ordered pair unique, so
+ * reinforce is a single UPSERT. The index on `(weight)` keeps the
+ * above-threshold scan and top-N promotion-candidate read cheap as the learned
+ * graph grows.
+ */
+export function migrateMemoryV3AutoEdges(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS memory_v3_auto_edges (
+        source_slug TEXT NOT NULL,
+        target_slug TEXT NOT NULL,
+        weight REAL NOT NULL,
+        last_reinforced_at INTEGER NOT NULL,
+        PRIMARY KEY (source_slug, target_slug)
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v3_auto_edges_weight
+        ON memory_v3_auto_edges (weight)
+    `);
+  });
+}
+
+export function downMemoryV3AutoEdges(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_v3_auto_edges`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -247,6 +247,10 @@ export {
   migrateMemoryV3Coactivation,
 } from "./262-memory-v3-coactivation.js";
 export {
+  downMemoryV3AutoEdges,
+  migrateMemoryV3AutoEdges,
+} from "./263-memory-v3-auto-edges.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -56,6 +56,7 @@ import { downConversationCleanedAt } from "./259-conversation-cleaned-at.js";
 import { downRenameCleanedAt } from "./260-rename-cleaned-at.js";
 import { downLlmUsageAddRawUsage } from "./261-llm-usage-add-raw-usage.js";
 import { downMemoryV3Coactivation } from "./262-memory-v3-coactivation.js";
+import { downMemoryV3AutoEdges } from "./263-memory-v3-auto-edges.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -477,6 +478,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create memory_v3_coactivation table — append-only log of pass-1 → pass-N co-activation pairs (gradient signal) emitted by the v3 retrieval loop and reconciled later by edge-learning",
     down: downMemoryV3Coactivation,
+  },
+  {
+    key: "migration_memory_v3_auto_edges_v1",
+    version: 56,
+    description:
+      "Create memory_v3_auto_edges table — weighted, decaying learned association graph (distinct from curated edges:) accrued by the edge-learning job from used co-activations and consumed above-threshold by edge expansion",
+    down: downMemoryV3AutoEdges,
   },
 ];
 

--- a/assistant/src/memory/v3/__tests__/edge-learning-job.test.ts
+++ b/assistant/src/memory/v3/__tests__/edge-learning-job.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for `assistant/src/memory/v3/auto-edges.ts`, `edge-learning-job.ts`,
+ * and their sibling migration `263-memory-v3-auto-edges.ts`.
+ *
+ * Coverage:
+ *   - Migration creates the table + weight index; safe to re-run; down drops it.
+ *   - reinforce upserts and accrues weight on the (source, target) PK.
+ *   - decay multiplicatively reduces unused weights and prunes near-zero edges.
+ *   - aboveThreshold returns exactly the edge-expansion `extraAdjacency` shape.
+ *   - A job run over fixture co-activations reinforces *used* rows only, skips
+ *     unused ones, and emits weight-floored, diversity-capped promotion
+ *     candidates. No real LLM, no real workspace DB.
+ *
+ * Uses an in-memory bun:sqlite database. The checkpoints module is stubbed with
+ * an in-memory Map so the watermark works without a real getDb() backing store;
+ * runEdgeLearning takes the in-memory DB explicitly for all auto-edge and
+ * co-activation reads.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+const checkpointStore = new Map<string, string>();
+mock.module("../../checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) =>
+    checkpointStore.set(key, value),
+}));
+
+import type { DrizzleDb } from "../../db-connection.js";
+import { getSqliteFrom } from "../../db-connection.js";
+import { migrateMemoryV3Coactivation } from "../../migrations/262-memory-v3-coactivation.js";
+import {
+  downMemoryV3AutoEdges,
+  migrateMemoryV3AutoEdges,
+} from "../../migrations/263-memory-v3-auto-edges.js";
+import * as schema from "../../schema.js";
+import {
+  aboveThreshold,
+  decay,
+  reinforce,
+  topByWeight,
+} from "../auto-edges.js";
+import {
+  type CoactivationRow,
+  recordCoactivations,
+} from "../coactivation-store.js";
+import {
+  EDGE_DECAY_HALF_LIFE_MS,
+  MAX_CANDIDATES_PER_SOURCE,
+  MAX_PROMOTION_CANDIDATES,
+  runEdgeLearning,
+} from "../edge-learning-job.js";
+
+// memory_checkpoints is required by withCrashRecovery and normally created by an
+// early core migration. Stand it up by hand so the v3 migrations can run in
+// isolation against a fresh in-memory DB.
+const CHECKPOINTS_DDL = /*sql*/ `
+  CREATE TABLE memory_checkpoints (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  )
+`;
+
+let sqlite: Database;
+let database: DrizzleDb;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  database = drizzle(sqlite, { schema });
+  getSqliteFrom(database).exec(CHECKPOINTS_DDL);
+  migrateMemoryV3Coactivation(database);
+  migrateMemoryV3AutoEdges(database);
+  checkpointStore.clear();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function readWeight(source: string, target: string): number | undefined {
+  const row = getSqliteFrom(database)
+    .query(
+      `SELECT weight FROM memory_v3_auto_edges
+        WHERE source_slug = ? AND target_slug = ?`,
+    )
+    .get(source, target) as { weight: number } | undefined;
+  return row?.weight;
+}
+
+// ---------------------------------------------------------------------------
+// Migration.
+// ---------------------------------------------------------------------------
+
+describe("migrateMemoryV3AutoEdges", () => {
+  test("creates table and weight index; safe to re-run", () => {
+    migrateMemoryV3AutoEdges(database);
+    migrateMemoryV3AutoEdges(database);
+
+    const raw = getSqliteFrom(database);
+    const table = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v3_auto_edges'`,
+      )
+      .get();
+    expect(table).toBeTruthy();
+
+    const indexNames = new Set(
+      (
+        raw
+          .query(
+            `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_v3_auto_edges'`,
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name),
+    );
+    expect(indexNames.has("idx_memory_v3_auto_edges_weight")).toBe(true);
+  });
+
+  test("downMemoryV3AutoEdges drops the table", () => {
+    downMemoryV3AutoEdges(database);
+    const table = getSqliteFrom(database)
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v3_auto_edges'`,
+      )
+      .get();
+    expect(table).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auto-edges store.
+// ---------------------------------------------------------------------------
+
+describe("reinforce", () => {
+  test("inserts a new pair at the increment, then accrues on the PK", () => {
+    reinforce(database, "a", "b", 1_000);
+    expect(readWeight("a", "b")).toBe(1);
+    reinforce(database, "a", "b", 2_000);
+    expect(readWeight("a", "b")).toBe(2);
+  });
+
+  test("directed pairs are independent", () => {
+    reinforce(database, "a", "b", 1_000);
+    reinforce(database, "b", "a", 1_000);
+    expect(readWeight("a", "b")).toBe(1);
+    expect(readWeight("b", "a")).toBe(1);
+  });
+});
+
+describe("decay", () => {
+  test("halves a weight after one half-life and advances last_reinforced_at", () => {
+    reinforce(database, "a", "b", 0);
+    // Push it above the half-life so the decayed weight stays above the floor.
+    reinforce(database, "a", "b", 0); // weight = 2
+    const pruned = decay(
+      database,
+      EDGE_DECAY_HALF_LIFE_MS,
+      EDGE_DECAY_HALF_LIFE_MS,
+    );
+    expect(pruned).toBe(0);
+    const w = readWeight("a", "b")!;
+    expect(w).toBeCloseTo(1, 5);
+
+    const stamped = getSqliteFrom(database)
+      .query(
+        `SELECT last_reinforced_at FROM memory_v3_auto_edges
+          WHERE source_slug='a' AND target_slug='b'`,
+      )
+      .get() as { last_reinforced_at: number };
+    expect(stamped.last_reinforced_at).toBe(EDGE_DECAY_HALF_LIFE_MS);
+  });
+
+  test("prunes edges that decay below the floor", () => {
+    reinforce(database, "a", "b", 0);
+    // Ten half-lives ⇒ weight × 2^-10 ≈ 0.001 < floor.
+    const pruned = decay(
+      database,
+      10 * EDGE_DECAY_HALF_LIFE_MS,
+      EDGE_DECAY_HALF_LIFE_MS,
+    );
+    expect(pruned).toBe(1);
+    expect(readWeight("a", "b")).toBeUndefined();
+  });
+
+  test("clamps future timestamps so decay never amplifies weight", () => {
+    reinforce(database, "a", "b", 10_000);
+    // now < last_reinforced_at ⇒ elapsed clamps to 0 ⇒ weight unchanged.
+    decay(database, 0, EDGE_DECAY_HALF_LIFE_MS);
+    expect(readWeight("a", "b")).toBe(1);
+  });
+});
+
+describe("aboveThreshold", () => {
+  test("returns the source → Set<target> adjacency for above-threshold pairs", () => {
+    reinforce(database, "a", "b", 0); // weight 1
+    reinforce(database, "a", "c", 0);
+    reinforce(database, "a", "c", 0); // weight 2
+    reinforce(database, "x", "y", 0); // weight 1
+
+    const adjacency = aboveThreshold(database, 2);
+    // Only a→c clears the threshold of 2.
+    expect([...adjacency.keys()]).toEqual(["a"]);
+    expect([...adjacency.get("a")!]).toEqual(["c"]);
+
+    const inclusive = aboveThreshold(database, 1);
+    expect([...inclusive.get("a")!].sort()).toEqual(["b", "c"]);
+    expect([...inclusive.get("x")!]).toEqual(["y"]);
+  });
+
+  test("empty when nothing clears the threshold", () => {
+    reinforce(database, "a", "b", 0);
+    expect(aboveThreshold(database, 5).size).toBe(0);
+  });
+});
+
+describe("topByWeight", () => {
+  test("returns heaviest edges first, capped at limit", () => {
+    reinforce(database, "a", "b", 0);
+    reinforce(database, "a", "b", 0); // weight 2
+    reinforce(database, "c", "d", 0); // weight 1
+    const top = topByWeight(database, 1);
+    expect(top).toHaveLength(1);
+    expect(top[0]).toMatchObject({
+      sourceSlug: "a",
+      targetSlug: "b",
+      weight: 2,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// edge-learning job.
+// ---------------------------------------------------------------------------
+
+function coact(
+  source: string,
+  target: string,
+  used: number,
+  createdAt: number,
+): CoactivationRow {
+  return {
+    conversationId: "conv-1",
+    turn: 1,
+    sourceSlug: source,
+    targetSlug: target,
+    passGap: 1,
+    used,
+    createdAt,
+  };
+}
+
+describe("runEdgeLearning", () => {
+  test("reinforces used co-activations only and skips unused ones", () => {
+    recordCoactivations(database, [
+      coact("a", "b", 1, 100),
+      coact("a", "b", 1, 200),
+      coact("c", "d", 0, 300),
+    ]);
+
+    const result = runEdgeLearning(database, 1_000);
+    expect(result.reinforced).toBe(2);
+    expect(result.skippedUnused).toBe(1);
+    expect(readWeight("a", "b")).toBe(2);
+    expect(readWeight("c", "d")).toBeUndefined();
+  });
+
+  test("advances the watermark so the same co-activation isn't re-counted", () => {
+    recordCoactivations(database, [coact("a", "b", 1, 100)]);
+    runEdgeLearning(database, 1_000);
+    expect(readWeight("a", "b")).toBe(1);
+
+    // Second run with no new co-activations: only decay, no fresh reinforcement.
+    const second = runEdgeLearning(database, 1_000);
+    expect(second.reinforced).toBe(0);
+    expect(readWeight("a", "b")).toBe(1);
+
+    // A newer co-activation past the watermark is picked up.
+    recordCoactivations(database, [coact("a", "b", 1, 500)]);
+    const third = runEdgeLearning(database, 1_000);
+    expect(third.reinforced).toBe(1);
+    expect(readWeight("a", "b")).toBe(2);
+  });
+
+  test("emits promotion candidates above the weight floor", () => {
+    // Two used co-activations ⇒ weight 2 ≥ floor (1.5); single ⇒ weight 1 < floor.
+    recordCoactivations(database, [
+      coact("a", "b", 1, 100),
+      coact("a", "b", 1, 200),
+      coact("c", "d", 1, 300),
+    ]);
+    const result = runEdgeLearning(database, 1_000);
+    const pairs = result.candidates.map(
+      (c) => `${c.sourceSlug}->${c.targetSlug}`,
+    );
+    expect(pairs).toEqual(["a->b"]);
+  });
+
+  test("caps candidates per source so one hub can't monopolize the slate", () => {
+    const rows: CoactivationRow[] = [];
+    let t = 100;
+    // Hub "a" → many targets, each reinforced twice (weight 2 ≥ floor).
+    for (let i = 0; i < MAX_CANDIDATES_PER_SOURCE + 3; i++) {
+      rows.push(coact("a", `t${i}`, 1, t++));
+      rows.push(coact("a", `t${i}`, 1, t++));
+    }
+    recordCoactivations(database, rows);
+    const result = runEdgeLearning(database, 1_000);
+    const fromA = result.candidates.filter((c) => c.sourceSlug === "a");
+    expect(fromA.length).toBe(MAX_CANDIDATES_PER_SOURCE);
+    expect(result.candidates.length).toBeLessThanOrEqual(
+      MAX_PROMOTION_CANDIDATES,
+    );
+  });
+});

--- a/assistant/src/memory/v3/auto-edges.ts
+++ b/assistant/src/memory/v3/auto-edges.ts
@@ -1,0 +1,223 @@
+/**
+ * Memory v3 — learned weighted auto-edge store.
+ *
+ * Read/write helpers over `memory_v3_auto_edges` (migration 263) — the
+ * **learned** association graph, a distinct class from the curated `edges:`
+ * frontmatter graph. Each row is a weighted directed pair `source → target`
+ * that the edge-learning job accrues from *used* co-activations and decays over
+ * wall-clock time.
+ *
+ * Three primitives:
+ *   - {@link reinforce} — bump a pair's weight, but only for a *used*
+ *     co-activation (we reinforce usefulness, not mere retrieval).
+ *   - {@link decay} — multiplicatively decay all weights toward zero on a
+ *     half-life schedule, so a pair that stops being reinforced fades. This is
+ *     the rich-get-richer counterweight: weight is a leaky integrator, not a
+ *     monotone counter.
+ *   - {@link aboveThreshold} — project the learned graph to the
+ *     `ReadonlyMap<source, ReadonlySet<target>>` adjacency that edge
+ *     expansion's `extraAdjacency` seam consumes (only pairs at/above a weight
+ *     threshold traverse).
+ *
+ * The decay model mirrors v2's injection-events EMA: `λ = ln 2 / halfLife`, and
+ * a pair decays by `exp(-λ × elapsed)` since its `last_reinforced_at`.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("memory-v3-auto-edges");
+
+/** Weight added to a pair per *used* co-activation reinforcement. */
+export const REINFORCE_INCREMENT = 1;
+
+/** Weights below this after decay are pruned rather than kept as dead rows. */
+export const PRUNE_FLOOR = 0.01;
+
+/** A learned auto-edge, as read back from the table. */
+export interface AutoEdgeRow {
+  sourceSlug: string;
+  targetSlug: string;
+  weight: number;
+  lastReinforcedAt: number;
+}
+
+/**
+ * Reinforce the directed pair `source → target`: bump its weight by
+ * {@link REINFORCE_INCREMENT} and stamp `last_reinforced_at = now`. **Only call
+ * this for a *used* co-activation** — the edge graph encodes which associations
+ * actually proved load-bearing for a turn, not which pages merely surfaced
+ * together. (The caller decides usedness from the co-activation's `used` flag;
+ * this primitive is unconditional so it stays composable.)
+ *
+ * UPSERT on the `(source, target)` primary key: a new pair starts at the
+ * increment; an existing pair accrues on top of its current weight (after the
+ * latest decay pass, since decay rewrites weight in place).
+ *
+ * Best-effort: a failed write must never abort the edge-learning job.
+ */
+export function reinforce(
+  database: DrizzleDb,
+  source: string,
+  target: string,
+  now: number,
+): void {
+  try {
+    const raw = getSqliteFrom(database);
+    raw
+      .prepare(
+        `INSERT INTO memory_v3_auto_edges
+           (source_slug, target_slug, weight, last_reinforced_at)
+           VALUES (?, ?, ?, ?)
+         ON CONFLICT(source_slug, target_slug) DO UPDATE SET
+           weight = weight + ?,
+           last_reinforced_at = ?`,
+      )
+      .run(source, target, REINFORCE_INCREMENT, now, REINFORCE_INCREMENT, now);
+  } catch (err) {
+    log.warn(
+      { err, source, target },
+      "failed to reinforce auto-edge; continuing",
+    );
+  }
+}
+
+/**
+ * Multiplicatively decay every auto-edge weight toward zero on a half-life
+ * schedule: `weight ← weight × exp(-λ × (now − last_reinforced_at))`, with
+ * `λ = ln 2 / halfLifeMs`. A pair last reinforced one half-life ago halves; two
+ * half-lives ago quarters; and so on. `last_reinforced_at` advances to `now`
+ * so successive decay passes don't double-count the same elapsed interval.
+ *
+ * Pairs whose decayed weight falls below {@link PRUNE_FLOOR} are deleted so the
+ * learned graph doesn't accumulate a long tail of effectively-dead edges.
+ *
+ * Returns the number of rows pruned, for the job's structured log.
+ */
+export function decay(
+  database: DrizzleDb,
+  now: number,
+  halfLifeMs: number,
+): number {
+  if (halfLifeMs <= 0) return 0;
+  const lambda = Math.LN2 / halfLifeMs;
+  try {
+    const raw = getSqliteFrom(database);
+    const rows = raw
+      .query(
+        `SELECT source_slug, target_slug, weight, last_reinforced_at
+           FROM memory_v3_auto_edges`,
+      )
+      .all() as Array<{
+      source_slug: string;
+      target_slug: string;
+      weight: number;
+      last_reinforced_at: number;
+    }>;
+    if (rows.length === 0) return 0;
+
+    const update = raw.prepare(
+      `UPDATE memory_v3_auto_edges
+         SET weight = ?, last_reinforced_at = ?
+         WHERE source_slug = ? AND target_slug = ?`,
+    );
+    const prune = raw.prepare(
+      `DELETE FROM memory_v3_auto_edges
+         WHERE source_slug = ? AND target_slug = ?`,
+    );
+
+    let pruned = 0;
+    const apply = raw.transaction(() => {
+      for (const row of rows) {
+        // Future timestamps (clock skew) would amplify rather than decay — clamp
+        // elapsed at 0 so decay only ever shrinks weight.
+        const elapsed = Math.max(0, now - row.last_reinforced_at);
+        const decayed = row.weight * Math.exp(-lambda * elapsed);
+        if (decayed < PRUNE_FLOOR) {
+          prune.run(row.source_slug, row.target_slug);
+          pruned += 1;
+        } else {
+          update.run(decayed, now, row.source_slug, row.target_slug);
+        }
+      }
+    });
+    apply();
+    return pruned;
+  } catch (err) {
+    log.warn({ err }, "failed to decay auto-edges; continuing");
+    return 0;
+  }
+}
+
+/**
+ * Project the learned graph to the `extraAdjacency` shape edge expansion
+ * consumes: `source → Set<target>` for every pair whose weight is at or above
+ * `threshold`. Edge expansion thresholds nothing itself — it merges whatever
+ * adjacency it's handed — so this read is where the weight cutoff is applied.
+ *
+ * Returns an empty map on any read failure so the caller (a best-effort read
+ * lane) degrades to "no learned edges" rather than aborting retrieval.
+ */
+export function aboveThreshold(
+  database: DrizzleDb,
+  threshold: number,
+): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  try {
+    const raw = getSqliteFrom(database);
+    const rows = raw
+      .query(
+        `SELECT source_slug, target_slug
+           FROM memory_v3_auto_edges
+           WHERE weight >= ?
+           ORDER BY source_slug ASC, target_slug ASC`,
+      )
+      .all(threshold) as Array<{ source_slug: string; target_slug: string }>;
+    for (const row of rows) {
+      let targets = adjacency.get(row.source_slug);
+      if (!targets) {
+        targets = new Set<string>();
+        adjacency.set(row.source_slug, targets);
+      }
+      targets.add(row.target_slug);
+    }
+  } catch (err) {
+    log.warn({ err, threshold }, "failed to read auto-edges; continuing");
+  }
+  return adjacency;
+}
+
+/**
+ * Read the top-weight auto-edges, heaviest first, capped at `limit`. The
+ * edge-learning job surfaces these as advisory promotion candidates for the
+ * assistant to ratify into curated `edges:` during consolidation.
+ */
+export function topByWeight(database: DrizzleDb, limit: number): AutoEdgeRow[] {
+  if (limit <= 0) return [];
+  try {
+    const raw = getSqliteFrom(database);
+    const rows = raw
+      .query(
+        `SELECT source_slug, target_slug, weight, last_reinforced_at
+           FROM memory_v3_auto_edges
+           ORDER BY weight DESC, source_slug ASC, target_slug ASC
+           LIMIT ?`,
+      )
+      .all(limit) as Array<{
+      source_slug: string;
+      target_slug: string;
+      weight: number;
+      last_reinforced_at: number;
+    }>;
+    return rows.map((r) => ({
+      sourceSlug: r.source_slug,
+      targetSlug: r.target_slug,
+      weight: r.weight,
+      lastReinforcedAt: r.last_reinforced_at,
+    }));
+  } catch (err) {
+    log.warn({ err, limit }, "failed to read top auto-edges; continuing");
+    return [];
+  }
+}

--- a/assistant/src/memory/v3/edge-learning-job.ts
+++ b/assistant/src/memory/v3/edge-learning-job.ts
@@ -1,0 +1,160 @@
+/**
+ * Memory v3 — `memory_v3_edge_learning` job (fast lane, no LLM).
+ *
+ * Reconciles the raw co-activation log (`memory_v3_coactivation`, migration
+ * 262) into the weighted learned-edge graph (`memory_v3_auto_edges`, migration
+ * 263). One pass does three things:
+ *
+ *   1. **Decay** — multiplicatively age all existing auto-edge weights toward
+ *      zero on a half-life schedule (the rich-get-richer counterweight: an edge
+ *      that stops being reinforced fades, so a once-hot pair can't dominate the
+ *      adjacency forever).
+ *   2. **Reinforce** — for each recent co-activation whose `used` flag is set,
+ *      bump the `source → target` weight. *Used-only*: we learn associations
+ *      that proved load-bearing for a turn, not pairs that merely surfaced
+ *      together. The watermark checkpoint advances so each co-activation is
+ *      counted once.
+ *   3. **Propose** — surface the top-weight auto-edges as advisory promotion
+ *      *candidates* for the assistant to ratify into curated `edges:` during
+ *      consolidation. This job PROPOSES; it never auto-writes page frontmatter.
+ *      Diversity counterweight: candidates are capped and a single source's
+ *      out-edges are bounded so one hub can't monopolize the slate.
+ *
+ * Decay runs before reinforce so a fresh reinforcement isn't immediately aged
+ * by the same pass. The job is idempotent in effect: re-running with no new
+ * co-activations only decays (which is itself elapsed-time-bounded).
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { getMemoryCheckpoint, setMemoryCheckpoint } from "../checkpoints.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getDb } from "../db-connection.js";
+import type { MemoryJob } from "../jobs-store.js";
+import {
+  type AutoEdgeRow,
+  decay,
+  reinforce,
+  topByWeight,
+} from "./auto-edges.js";
+import { readCoactivations } from "./coactivation-store.js";
+
+const log = getLogger("memory-v3-edge-learning");
+
+/**
+ * Half-life of auto-edge weight decay. Matches the v2 injection-score cadence
+ * (3 days) — a pair reinforced 3 days ago and never since contributes half its
+ * weight, 6 days ago a quarter.
+ */
+export const EDGE_DECAY_HALF_LIFE_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Max promotion candidates surfaced per run (the diversity cap). */
+export const MAX_PROMOTION_CANDIDATES = 20;
+
+/** Max candidates contributed by any single source slug (anti-hub diversity). */
+export const MAX_CANDIDATES_PER_SOURCE = 3;
+
+/**
+ * Minimum weight for an auto-edge to be eligible for promotion. A pair must
+ * accrue more than a single reinforcement (which decays away) before it's worth
+ * proposing as a curated edge.
+ */
+export const PROMOTION_WEIGHT_FLOOR = 1.5;
+
+/** Checkpoint key for the high-water mark of reconciled co-activations. */
+const WATERMARK_KEY = "memory_v3_edge_learning:coactivation_watermark";
+
+/** Summary of one edge-learning pass, returned for the dispatcher log + tests. */
+export interface EdgeLearningResult {
+  /** Used co-activations reinforced this pass. */
+  reinforced: number;
+  /** Co-activations skipped because `used` was falsy. */
+  skippedUnused: number;
+  /** Auto-edges pruned by decay (fell below the floor). */
+  pruned: number;
+  /** Advisory promotion candidates, heaviest first, after the diversity cap. */
+  candidates: AutoEdgeRow[];
+}
+
+/**
+ * Run one edge-learning pass against `database`. Pure of LLM and workspace I/O —
+ * the whole pass is bounded DB work, hence the fast lane.
+ */
+export function runEdgeLearning(
+  database: DrizzleDb,
+  now = Date.now(),
+): EdgeLearningResult {
+  // 1. Decay first so this pass's reinforcements aren't immediately aged.
+  const pruned = decay(database, now, EDGE_DECAY_HALF_LIFE_MS);
+
+  // 2. Reinforce from co-activations newer than the watermark. The watermark is
+  //    a created_at boundary; `since` is inclusive so we nudge it forward by 1ms
+  //    to avoid re-counting the boundary row.
+  const watermark = parseInt(getMemoryCheckpoint(WATERMARK_KEY) ?? "0", 10);
+  const since = watermark > 0 ? watermark + 1 : undefined;
+  const coactivations = readCoactivations(database, since);
+
+  let reinforced = 0;
+  let skippedUnused = 0;
+  let maxCreatedAt = watermark;
+  for (const row of coactivations) {
+    if (row.createdAt > maxCreatedAt) maxCreatedAt = row.createdAt;
+    // Reinforce usefulness, not mere retrieval: skip co-activations the loop
+    // (or a later usefulness reconciliation) did not mark as used.
+    if (!row.used) {
+      skippedUnused += 1;
+      continue;
+    }
+    reinforce(database, row.sourceSlug, row.targetSlug, now);
+    reinforced += 1;
+  }
+  if (maxCreatedAt > watermark) {
+    setMemoryCheckpoint(WATERMARK_KEY, String(maxCreatedAt));
+  }
+
+  // 3. Propose promotion candidates: heaviest auto-edges above the floor, capped
+  //    overall and per-source so a single hub can't monopolize the slate.
+  const candidates = selectPromotionCandidates(
+    topByWeight(database, MAX_PROMOTION_CANDIDATES * MAX_CANDIDATES_PER_SOURCE),
+  );
+
+  log.info(
+    {
+      reinforced,
+      skippedUnused,
+      pruned,
+      candidateCount: candidates.length,
+    },
+    "v3 edge learning complete",
+  );
+
+  return { reinforced, skippedUnused, pruned, candidates };
+}
+
+/**
+ * Apply the weight floor and the overall / per-source diversity caps to a
+ * weight-sorted list of auto-edges. Input must already be sorted heaviest-first
+ * (as {@link topByWeight} returns).
+ */
+function selectPromotionCandidates(sorted: AutoEdgeRow[]): AutoEdgeRow[] {
+  const out: AutoEdgeRow[] = [];
+  const perSource = new Map<string, number>();
+  for (const edge of sorted) {
+    if (out.length >= MAX_PROMOTION_CANDIDATES) break;
+    if (edge.weight < PROMOTION_WEIGHT_FLOOR) continue;
+    const count = perSource.get(edge.sourceSlug) ?? 0;
+    if (count >= MAX_CANDIDATES_PER_SOURCE) continue;
+    perSource.set(edge.sourceSlug, count + 1);
+    out.push(edge);
+  }
+  return out;
+}
+
+/**
+ * Job handler for `memory_v3_edge_learning`. Thin wrapper over
+ * {@link runEdgeLearning} so the heavy lifting (and its tests) live in one
+ * place. The job carries no payload — it always reconciles the whole recent
+ * co-activation log.
+ */
+export function memoryV3EdgeLearningJob(_job: MemoryJob): EdgeLearningResult {
+  return runEdgeLearning(getDb());
+}


### PR DESCRIPTION
## Summary
- Add memory_v3_auto_edges table (idempotent migration 263) + auto-edges store (reinforce on used-only, decay, aboveThreshold adjacency for edge-expansion's extraAdjacency seam).
- Add memory_v3_edge_learning job: reinforces/decays from co-activations, proposes high-weight edges as advisory promotion candidates (assistant ratifies during consolidation).

Part of plan: memory-v3-build.md (PR 18 of 19)