### PR TITLE
feat(memory-v3): live shadow via memoryRetrieval middleware (inject v2, log v3)

### DIFF
--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -115,11 +115,15 @@ export interface RecordMemoryV2ActivationLogParams {
    * `per-turn` for normal append injections, `errored` when `injectMemoryV2Block`
    * threw before completing — telemetry is still written so silent failures
    * are observable in the database, with whatever `concepts` rows had been
-   * built so far (possibly empty). `router` indicates the Sonnet
-   * router selected the per-turn page set; router-mode rows carry zeroed
-   * activation values and `source: "router"` on every concept row.
+   * built so far (possibly empty). `router` indicates the LLM router selected
+   * the per-turn page set; router-mode rows carry zeroed activation values and
+   * `source: "router"` on every concept row. `v3_shadow` is written by the
+   * live-shadow v3 retrieval middleware: it records v3's selection set for
+   * comparison without affecting injected context. The harness oracle filters
+   * `mode='router'`, so `v3_shadow` rows never pollute it; the inspector can
+   * still surface them.
    */
-  mode: "context-load" | "per-turn" | "errored" | "router";
+  mode: "context-load" | "per-turn" | "errored" | "router" | "v3_shadow";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -167,7 +171,7 @@ export function backfillMemoryV2ActivationMessageId(
 export interface MemoryV2ActivationLog {
   conversationId: string;
   turn: number;
-  mode: "context-load" | "per-turn" | "errored" | "router";
+  mode: "context-load" | "per-turn" | "errored" | "router" | "v3_shadow";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -188,7 +192,12 @@ export function getMemoryV2ActivationLogByMessageIds(
   return {
     conversationId: row.conversationId,
     turn: row.turn,
-    mode: row.mode as "context-load" | "per-turn" | "errored" | "router",
+    mode: row.mode as
+      | "context-load"
+      | "per-turn"
+      | "errored"
+      | "router"
+      | "v3_shadow",
     concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
     config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
   };

--- a/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for the live-shadow `memoryRetrieval` middleware
+ * (`assistant/src/memory/v3/shadow-middleware.ts`).
+ *
+ * The critical invariant this PR guarantees: with `memory.v3.shadow` off
+ * (the default), the middleware is a byte-for-byte pass-through — it returns
+ * the downstream `MemoryResult` unchanged, never calls the v3 loop, and never
+ * writes a log row. With the flag on, it runs the v3 loop alongside the
+ * default path, logs v3's selection as `mode='v3_shadow'`, and STILL returns
+ * the unchanged downstream result (v2 injected, never v3). A v3 failure is
+ * swallowed and the turn result is unaffected.
+ *
+ * Everything the middleware reaches (config, the v3 loop, the activation-log
+ * store, message/now/everInjected reads) is stubbed via `mock.module` — no
+ * real LLM, no real workspace DB.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+import type { AssistantConfig } from "../../../config/schema.js";
+import type { TrustContext } from "../../../daemon/trust-context.js";
+import type {
+  MemoryArgs,
+  MemoryResult,
+  TurnContext,
+} from "../../../plugins/types.js";
+import type { RecordMemoryV2ActivationLogParams } from "../../memory-v2-activation-log-store.js";
+import type {
+  RetrievalInput,
+  RetrievalOutput,
+} from "../../v2/harness/retriever.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// ── Mutable test doubles, rewired per test ───────────────────────────────
+
+/** Drives `config.memory.v3.{enabled,shadow}` and `historical_pairs`. */
+let v3Enabled = false;
+let v3Shadow = false;
+
+function makeConfig(): AssistantConfig {
+  return {
+    memory: {
+      v2: { router: { historical_pairs: 1 } },
+      v3: { enabled: v3Enabled, shadow: v3Shadow },
+    },
+  } as unknown as AssistantConfig;
+}
+
+/** Captured `runRetrievalLoop` invocations. */
+const loopCalls: Array<{ input: RetrievalInput }> = [];
+/** Behavior of the stubbed loop — overridden per test. */
+let loopImpl: (
+  input: RetrievalInput,
+) => Promise<RetrievalOutput> = async () => ({
+  selectedSlugs: [],
+  sourceBySlug: new Map(),
+  trace: { passes: [] },
+  cost: { ms: 0 },
+  failureReason: null,
+});
+
+/** Captured `recordMemoryV2ActivationLog` calls. */
+const logCalls: RecordMemoryV2ActivationLogParams[] = [];
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => makeConfig(),
+}));
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => "/tmp/shadow-test-workspace",
+}));
+// Chainable drizzle-query stub: every builder method returns the same object
+// and `.all()` yields the seeded rows. The shadow middleware reads recent
+// messages via `db.select(...).from(...).where(...).orderBy(...).limit(...).all()`.
+const messageRows: Array<{ role: string; content: string }> = [
+  {
+    role: "user",
+    content: JSON.stringify([{ type: "text", text: "hello memory" }]),
+  },
+];
+function makeFakeDb(): never {
+  const builder: Record<string, unknown> = {};
+  for (const m of ["select", "from", "where", "orderBy", "limit"]) {
+    builder[m] = () => builder;
+  }
+  builder.all = () => messageRows.slice();
+  return builder as never;
+}
+mock.module("../../db-connection.js", () => ({
+  getDb: () => makeFakeDb(),
+}));
+mock.module("../../v2/now-text.js", () => ({
+  loadNowText: async () => "NOW context",
+}));
+mock.module("../../v2/activation-store.js", () => ({
+  hydrate: async () => ({ everInjected: [{ slug: "old/page", turn: 0 }] }),
+}));
+mock.module("../loop.js", () => ({
+  runRetrievalLoop: async (input: RetrievalInput): Promise<RetrievalOutput> => {
+    loopCalls.push({ input });
+    return loopImpl(input);
+  },
+}));
+mock.module("../../memory-v2-activation-log-store.js", () => ({
+  recordMemoryV2ActivationLog: (params: RecordMemoryV2ActivationLogParams) => {
+    logCalls.push(params);
+  },
+}));
+
+const { memoryV3ShadowMiddleware } = await import("../shadow-middleware.js");
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(): TurnContext {
+  return {
+    requestId: "req-shadow-test",
+    conversationId: "conv-shadow",
+    turnIndex: 3,
+    trust,
+  };
+}
+
+function makeArgs(signal?: AbortSignal): MemoryArgs {
+  return {
+    conversationId: "conv-shadow",
+    trustContext: trust,
+    turnIndex: 3,
+    signal: signal ?? new AbortController().signal,
+  };
+}
+
+/** The unchanged downstream (v2/default) result the terminal returns. */
+const DOWNSTREAM_RESULT: MemoryResult = {
+  pkbContent: "pkb",
+  nowContent: "now",
+  memoryGraphBlocks: [{ kind: "default.graph" }],
+};
+
+/** Flush the detached shadow chain (microtasks + a macrotask hop). */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  v3Enabled = false;
+  v3Shadow = false;
+  loopCalls.length = 0;
+  logCalls.length = 0;
+  loopImpl = async () => ({
+    selectedSlugs: [],
+    sourceBySlug: new Map(),
+    trace: { passes: [] },
+    cost: { ms: 0 },
+    failureReason: null,
+  });
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("memory-v3 shadow middleware", () => {
+  test("flag off → byte-for-byte pass-through, no v3 call, no log write", async () => {
+    v3Enabled = false;
+    v3Shadow = false;
+    let nextCalls = 0;
+    const args = makeArgs();
+    const result = await memoryV3ShadowMiddleware(
+      args,
+      async (a) => {
+        nextCalls++;
+        // identity is preserved — pass-through hands the same args down.
+        expect(a).toBe(args);
+        return DOWNSTREAM_RESULT;
+      },
+      makeCtx(),
+    );
+
+    // Returns the exact downstream object reference, unchanged.
+    expect(result).toBe(DOWNSTREAM_RESULT);
+    expect(nextCalls).toBe(1);
+
+    await flush();
+    expect(loopCalls.length).toBe(0);
+    expect(logCalls.length).toBe(0);
+  });
+
+  test("enabled but shadow off → still a pure pass-through", async () => {
+    v3Enabled = true;
+    v3Shadow = false;
+    const args = makeArgs();
+    const result = await memoryV3ShadowMiddleware(
+      args,
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+    expect(result).toBe(DOWNSTREAM_RESULT);
+    await flush();
+    expect(loopCalls.length).toBe(0);
+    expect(logCalls.length).toBe(0);
+  });
+
+  test("flag on → v3 runs, v3_shadow row logged, downstream result unchanged", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+    loopImpl = async () => ({
+      selectedSlugs: ["topic/a", "topic/b"],
+      sourceBySlug: new Map([["topic/a", "dense"]]),
+      trace: { passes: [] },
+      cost: { ms: 12 },
+      failureReason: null,
+    });
+
+    const args = makeArgs();
+    const result = await memoryV3ShadowMiddleware(
+      args,
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+
+    // The injected result is the v2/default result, NOT v3.
+    expect(result).toBe(DOWNSTREAM_RESULT);
+
+    await flush();
+
+    // v3 ran exactly once, with a faithfully-built RetrievalInput.
+    expect(loopCalls.length).toBe(1);
+    const input = loopCalls[0]!.input;
+    expect(input.nowText).toBe("NOW context");
+    expect(input.workspaceDir).toBe("/tmp/shadow-test-workspace");
+    expect(input.priorEverInjected).toEqual([{ slug: "old/page", turn: 0 }]);
+    expect(input.recentTurnPairs.length).toBeGreaterThan(0);
+    expect(input.recentTurnPairs.at(-1)?.userMessage).toBe("hello memory");
+
+    // Exactly one v3_shadow row, carrying v3's selection.
+    expect(logCalls.length).toBe(1);
+    const logged = logCalls[0]!;
+    expect(logged.mode).toBe("v3_shadow");
+    expect(logged.conversationId).toBe("conv-shadow");
+    expect(logged.turn).toBe(3);
+    expect(logged.concepts.map((c) => c.slug)).toEqual(["topic/a", "topic/b"]);
+  });
+
+  test("v3 error → logged/swallowed, turn result unaffected, no log row", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+    loopImpl = async () => {
+      throw new Error("v3 boom");
+    };
+
+    const args = makeArgs();
+    // The middleware must not reject even though the detached shadow throws.
+    const result = await memoryV3ShadowMiddleware(
+      args,
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+    expect(result).toBe(DOWNSTREAM_RESULT);
+
+    await flush();
+    // Loop was attempted; the failure short-circuited before logging.
+    expect(loopCalls.length).toBe(1);
+    expect(logCalls.length).toBe(0);
+  });
+
+  test("aborted signal → shadow does no v3 work", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await memoryV3ShadowMiddleware(
+      makeArgs(controller.signal),
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+    expect(result).toBe(DOWNSTREAM_RESULT);
+
+    await flush();
+    expect(loopCalls.length).toBe(0);
+    expect(logCalls.length).toBe(0);
+  });
+});

--- a/assistant/src/memory/v3/shadow-middleware.ts
+++ b/assistant/src/memory/v3/shadow-middleware.ts
@@ -1,0 +1,305 @@
+/**
+ * Memory v3 — live-shadow `memoryRetrieval` middleware.
+ *
+ * Registered unconditionally into the `memoryRetrieval` pipeline, but inert
+ * unless BOTH `config.memory.v3.enabled` and `config.memory.v3.shadow` are on.
+ * When inert it is a byte-for-byte pass-through: it returns `next(args)`
+ * verbatim and performs zero extra work (no v3 call, no DB read, no log write).
+ *
+ * When active, it:
+ *   1. Returns the real (v2/default) `MemoryResult` from `next(args)` promptly —
+ *      the injected context is ALWAYS the v2 result, never v3.
+ *   2. Kicks off the v3 retrieval loop DETACHED (not awaited on the path that
+ *      returns the result), so the shadow run can never block or slow the turn.
+ *   3. Logs v3's selection set to `memory_v2_activation_logs` with
+ *      `mode = "v3_shadow"`. The harness oracle filters `mode='router'`, so
+ *      shadow rows never pollute it; the inspector can still surface them.
+ *
+ * The shadow build mirrors the inputs the v2 router receives (recent turn
+ * pairs, NOW context, prior-ever-injected slugs, config) so its recall is
+ * measured against the same situational context the live path saw. Failures
+ * are swallowed with a warn — the shadow is observational only and must never
+ * affect the live turn.
+ */
+
+import { desc, eq } from "drizzle-orm";
+
+import { getConfig } from "../../config/loader.js";
+import { registerPlugin } from "../../plugins/registry.js";
+import {
+  type MemoryArgs,
+  type MemoryResult,
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+} from "../../plugins/types.js";
+import type { ContentBlock } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getDb } from "../db-connection.js";
+import {
+  type MemoryV2ConceptRowRecord,
+  type MemoryV2ConfigSnapshot,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
+import { messages } from "../schema.js";
+import { hydrate } from "../v2/activation-store.js";
+import type { RetrievalInput } from "../v2/harness/retriever.js";
+import { loadNowText } from "../v2/now-text.js";
+import type { RouterTurnPair } from "../v2/router.js";
+import type { EverInjectedEntry } from "../v2/types.js";
+import { runRetrievalLoop } from "./loop.js";
+
+const log = getLogger("memory-v3-shadow");
+
+/**
+ * Extract the recent (assistant, user) turn pairs from a conversation's
+ * message list, newest-pair-last, capped at `k`. Mirrors production
+ * `extractRecentTurnPairs` in `conversation-graph-memory.ts` (and its harness
+ * twin in `replay-input.ts`) so the shadow's `recentTurnPairs` matches what the
+ * live router was fed.
+ */
+function extractRecentTurnPairs(
+  msgs: ReadonlyArray<{ role: string; content: ContentBlock[] }>,
+  k: number,
+): RouterTurnPair[] {
+  const messageText = (content: ContentBlock[]): string =>
+    content
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" ");
+
+  const pairs: RouterTurnPair[] = [];
+  let pendingUser: string | null = null;
+  for (let i = msgs.length - 1; i >= 0 && pairs.length < k; i--) {
+    const msg = msgs[i]!;
+    if (msg.role === "user" && pendingUser === null) {
+      pendingUser = messageText(msg.content);
+    } else if (msg.role === "assistant" && pendingUser !== null) {
+      pairs.unshift({
+        assistantMessage: messageText(msg.content),
+        userMessage: pendingUser,
+      });
+      pendingUser = null;
+    }
+  }
+  if (pendingUser !== null && pairs.length < k) {
+    pairs.unshift({ assistantMessage: "", userMessage: pendingUser });
+  }
+  if (pairs.length === 0) {
+    pairs.push({ assistantMessage: "", userMessage: "" });
+  }
+  return pairs;
+}
+
+/** Parse a persisted JSON content-block string; tolerate malformed rows. */
+function parseContent(raw: string): ContentBlock[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ContentBlock[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Load the most recent messages for a conversation, oldest-first, bounded to a
+ * small generous multiple of `historicalPairs`. Pair extraction only needs the
+ * tail, so a bounded `LIMIT` query avoids loading an entire (potentially
+ * multi-GB) conversation on every shadow turn — mirrors the harness's bounded
+ * fetch in `replay-input.ts`.
+ */
+function loadRecentMessages(
+  db: DrizzleDb,
+  conversationId: string,
+  historicalPairs: number,
+): Array<{ role: string; content: ContentBlock[] }> {
+  const fetchWindow = Math.max(20, historicalPairs * 12);
+  const rows = db
+    .select({ role: messages.role, content: messages.content })
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(fetchWindow)
+    .all();
+  return rows
+    .reverse()
+    .map((r) => ({ role: r.role, content: parseContent(r.content) }));
+}
+
+/**
+ * Empty config snapshot for shadow log rows. The activation-state values are
+ * meaningless for a v3 selection (it computes no spreading-activation scores),
+ * so they are zeroed — exactly as the v2 router-mode rows do.
+ */
+const SHADOW_CONFIG_SNAPSHOT: MemoryV2ConfigSnapshot = {
+  d: 0,
+  c_user: 0,
+  c_assistant: 0,
+  c_now: 0,
+  k: 0,
+  hops: 0,
+  top_k: 0,
+  epsilon: 0,
+};
+
+/**
+ * Build the concept rows logged for a v3 shadow selection. Each selected slug
+ * becomes a zeroed concept row tagged `source: "router"` and
+ * `status: "injected"` — the shadow has no activation scores to record, and the
+ * `mode='v3_shadow'` row tag (not the concept source) is what distinguishes
+ * shadow telemetry from live router selections.
+ */
+function buildShadowConceptRows(
+  selectedSlugs: readonly string[],
+): MemoryV2ConceptRowRecord[] {
+  return selectedSlugs.map((slug) => ({
+    slug,
+    finalActivation: 0,
+    ownActivation: 0,
+    priorActivation: 0,
+    simUser: 0,
+    simAssistant: 0,
+    simNow: 0,
+    simUserRerankBoost: 0,
+    simAssistantRerankBoost: 0,
+    inRerankPool: false,
+    spreadContribution: 0,
+    source: "router",
+    status: "injected",
+  }));
+}
+
+/**
+ * Run the v3 retrieval loop for the shadow and log its selection. Best-effort:
+ * any failure is logged and swallowed. Honors `signal` so a cancelled turn
+ * stops the shadow's lane work.
+ */
+async function runShadowAndLog(
+  args: MemoryArgs,
+  signal: AbortSignal,
+): Promise<void> {
+  try {
+    if (signal.aborted) return;
+
+    const config = getConfig();
+    const workspaceDir = getWorkspaceDir();
+    const db = getDb();
+
+    const historicalPairs = config.memory.v2.router.historical_pairs;
+    const recentMessages = loadRecentMessages(
+      db,
+      args.conversationId,
+      historicalPairs,
+    );
+    const recentTurnPairs = extractRecentTurnPairs(
+      recentMessages,
+      historicalPairs,
+    );
+
+    const nowText = await loadNowText(workspaceDir);
+
+    let priorEverInjected: readonly EverInjectedEntry[] = [];
+    try {
+      const state = await hydrate(db, args.conversationId);
+      priorEverInjected = state?.everInjected ?? [];
+    } catch (err) {
+      log.warn(
+        { err, conversationId: args.conversationId },
+        "v3 shadow: failed to hydrate prior-ever-injected; continuing with empty set",
+      );
+    }
+
+    if (signal.aborted) return;
+
+    const input: RetrievalInput = {
+      workspaceDir,
+      recentTurnPairs,
+      nowText,
+      priorEverInjected,
+      config,
+      signal,
+    };
+
+    const output = await runRetrievalLoop(input, {
+      db,
+      conversationId: args.conversationId,
+      turn: args.turnIndex,
+    });
+
+    if (signal.aborted) return;
+
+    recordMemoryV2ActivationLog({
+      conversationId: args.conversationId,
+      turn: args.turnIndex,
+      mode: "v3_shadow",
+      concepts: buildShadowConceptRows(output.selectedSlugs),
+      config: SHADOW_CONFIG_SNAPSHOT,
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId: args.conversationId, turn: args.turnIndex },
+      "v3 shadow retrieval failed; live turn unaffected",
+    );
+  }
+}
+
+/**
+ * Live-shadow `memoryRetrieval` middleware.
+ *
+ * Flag-gated INSIDE the middleware (per-turn, live-toggle): when v3 shadow is
+ * off it is a pure pass-through. When on, it fires the v3 loop detached and
+ * returns the unchanged downstream (v2) result immediately.
+ */
+export const memoryV3ShadowMiddleware: Middleware<MemoryArgs, MemoryResult> =
+  async function memoryV3Shadow(args, next) {
+    const v3 = getConfig().memory.v3;
+    if (!v3.enabled || !v3.shadow) {
+      // Inert: byte-for-byte pass-through, zero extra work.
+      return next(args);
+    }
+
+    // Detached — never awaited on the path that returns the result, so the
+    // shadow can neither block nor slow the live turn. Errors are swallowed
+    // inside `runShadowAndLog`.
+    void runShadowAndLog(args, args.signal);
+
+    return next(args);
+  };
+
+/**
+ * First-party plugin contributing the live-shadow `memoryRetrieval`
+ * middleware. Registered unconditionally by the plugin bootstrap (it is inert
+ * unless both v3 flags are on), so the registration is always present but does
+ * zero work in the default (flags-off) configuration.
+ */
+export const memoryV3ShadowPlugin: Plugin = {
+  manifest: {
+    name: "memory-v3-shadow",
+    version: "0.0.1",
+  },
+  middleware: {
+    memoryRetrieval: memoryV3ShadowMiddleware,
+  },
+};
+
+// Module-load side effect: register the shadow plugin at import time so the
+// registry is populated even in tests that skip `bootstrapPlugins()`, matching
+// the first-party `default-*` plugins. Idempotent via the swallowed
+// duplicate-name check (the defaults aggregator also lists this plugin).
+try {
+  registerPlugin(memoryV3ShadowPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both the defaults aggregator and the
+    // direct module import run in the same process.
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -24,6 +24,7 @@
  * chain) does not trip a TDZ.
  */
 
+import { memoryV3ShadowPlugin } from "../../memory/v3/shadow-middleware.js";
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
 import { type Plugin, PluginExecutionError } from "../types.js";
 import { defaultCircuitBreakerPlugin } from "./circuit-breaker.js";
@@ -60,6 +61,11 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultEmptyResponsePlugin,
     defaultToolErrorPlugin,
     defaultMemoryRetrievalPlugin,
+    // Live-shadow v3 retrieval. Always registered; inert unless both
+    // `memory.v3.enabled` and `memory.v3.shadow` are on (gated inside the
+    // middleware). Ordered after the default so the default terminal still
+    // produces the injected (v2) `MemoryResult`.
+    memoryV3ShadowPlugin,
     defaultInjectorsPlugin,
     defaultTokenEstimatePlugin,
     defaultOverflowReducePlugin,


### PR DESCRIPTION
## Summary
- Register a memoryRetrieval middleware that, only when config.memory.v3.enabled && shadow, runs the v3 loop alongside v2, logs v3 selections as mode='v3_shadow', and returns the v2 result unchanged (inject v2 only), off the critical path.
- Flag-off (default) is a byte-for-byte pass-through; no DB migration (reuses the activation-log table with a new mode value).

Note: post-compaction reinjection (reinjectCachedMemory in conversation-graph-memory.ts, called directly from the overflow-reducer reinjectForMode callback in conversation-agent-loop.ts ~L2058) bypasses the memoryRetrieval pipeline, so the shadow does not cover it. Per the plan this is left as-is (no scope expansion); the shadow covers per-turn and context-load retrieval, which both flow through the pipeline.

Part of plan: memory-v3-build.md (PR 15 of 19)