### PR TITLE
fix(assistant): add symmetric downward routing to switch_inference_profile

### DIFF
--- a/assistant/src/daemon/switch-inference-profile-tool.ts
+++ b/assistant/src/daemon/switch-inference-profile-tool.ts
@@ -36,7 +36,7 @@ export function buildSwitchInferenceProfileToolDef(
 
   return {
     name: SWITCH_INFERENCE_PROFILE_TOOL_NAME,
-    description: `Switch to a different inference profile BEFORE answering. You MUST call this tool when the user's query requires capabilities beyond what your current profile ("${currentLabel}") provides. Examples of when to switch to a more capable profile: multi-step reasoning or analysis, math proofs or derivations, complex coding tasks, detailed creative writing, or any task requiring deep thought. Examples of when to switch to a faster profile: simple greetings, one-word answers, factual lookups. When in doubt about whether you can handle the query well, switch to a more capable profile.\n\nAvailable profiles:\n${profileDescriptions}`,
+    description: `Switch to a different inference profile BEFORE answering. You MUST call this tool when the user's query requires capabilities beyond what your current profile ("${currentLabel}") provides — AND you MUST also call it when the query is trivially simple and a faster, cheaper profile would handle it equally well.\n\nSwitch UP (to a more capable profile) for: multi-step reasoning or analysis, math proofs or derivations, complex coding tasks, detailed creative writing, or any task requiring deep thought.\n\nSwitch DOWN (to a faster profile) for: simple greetings or chitchat, one-word or single-sentence answers, factual lookups, acknowledgments, or any query that does not benefit from advanced reasoning.\n\nWhen in doubt about whether you can handle the query well, switch UP. When in doubt about whether the query is too simple for your current profile, switch DOWN.\n\nAvailable profiles:\n${profileDescriptions}`,
     input_schema: {
       type: "object" as const,
       properties: {


### PR DESCRIPTION
## Summary
- Adds symmetric MUST language for **downward routing** in the `switch_inference_profile` tool description
- Previously the tool was biased toward upward routing only — Quality/Opus never routed down to Speed for simple queries like "hi"
- Restructures the description with explicit "Switch UP" / "Switch DOWN" sections so the model treats both directions equally

Follows up on #31958 which fixed the initial tool description for upward routing.

## Test plan
- [x] Typecheck passes
- [x] Existing inference profile tests pass (5/5)
- [x] Tested locally: Quality profile + "hi" → model calls `switch_inference_profile` to route down to Speed
- [ ] Test on dev after deploy: verify downward routing from Quality for simple queries
- [ ] Verify upward routing still works: Speed profile + complex query → routes to Quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)