### PR TITLE
fix(gateway): include runtime denial status in inbound event logs

### DIFF
--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -171,8 +171,12 @@ export async function handleInbound(
         eventId: response.eventId,
         duplicate: response.duplicate,
         hasReply: !!response.assistantMessage,
+        denied: response.denied ?? false,
+        deniedReason: response.denied ? (response.reason ?? "unknown") : undefined,
       },
-      "Inbound event forwarded to runtime",
+      response.denied
+        ? "Inbound event denied by runtime"
+        : "Inbound event forwarded to runtime",
     );
 
     // ── Contact channel interaction tracking (dual-write) ──

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -227,9 +227,17 @@ export function createEmailWebhookHandler(
       dedupCache.mark(eventId);
 
       if (!result.rejected) {
+        const denied = result.runtimeResponse?.denied ?? false;
+        const deniedReason = denied ? (result.runtimeResponse?.reason ?? "unknown") : undefined;
         tlog.info(
-          { status: "forwarded", eventId },
-          "Email message forwarded to runtime",
+          {
+            status: denied ? "denied" : "forwarded",
+            eventId,
+            ...(denied && { deniedReason }),
+          },
+          denied
+            ? "Email message denied by runtime"
+            : "Email message forwarded to runtime",
         );
       }
 

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -219,6 +219,8 @@ export type RuntimeInboundResponse = {
   };
   /** When true, the runtime denied the inbound message (e.g. ACL rejection). */
   denied?: boolean;
+  /** Machine-readable denial reason returned by the runtime ACL (e.g. "not_a_member"). */
+  reason?: string;
   /**
    * A user-facing rejection message that the runtime could not deliver via
    * the callback URL (e.g. due to auth failure). When present, the gateway


### PR DESCRIPTION
## Summary
- Update inbound event handler to log denial status from runtime ACL
- Update email webhook handler to reflect denial status in logs
- Logs now truthfully distinguish between forwarded and denied events

Part of plan: email-guardian-bootstrap.md (PR 2 of 4)