### PR TITLE
feat(gateway): add POST /v1/contacts/guardian/channel route for platform auto-verify

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -173,6 +173,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/v1/pair",
   // A2A agent card discovery — read-only, unauthenticated per spec
   "/.well-known/agent-card.json",
+  // Internal-only: reachable only via vembda's trusted gateway-query proxy
+  "/v1/contacts/guardian/channel",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/http/routes/guardian-channel-create.test.ts
+++ b/gateway/src/http/routes/guardian-channel-create.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// --- Mocks ----------------------------------------------------------------
+
+const assistantDbQueryMock = mock((_sql: string, _params?: unknown[]) =>
+  Promise.resolve([]),
+);
+
+const createGuardianBindingMock = mock((_params: unknown) =>
+  Promise.resolve({
+    contactId: "contact-1",
+    channelId: "channel-1",
+    guardianPrincipalId: "principal-1",
+    channel: "email",
+  }),
+);
+
+mock.module("../../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: assistantDbQueryMock,
+  assistantDbRun: mock(() => Promise.resolve()),
+  assistantDbExec: mock(() => Promise.resolve()),
+}));
+
+mock.module("../../auth/guardian-bootstrap.js", () => ({
+  createGuardianBinding: createGuardianBindingMock,
+}));
+
+// Import after mocks are registered
+const { createGuardianChannelHandler } = await import(
+  "./guardian-channel-create.js"
+);
+
+// --- Helpers ---------------------------------------------------------------
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost:7830/v1/contacts/guardian/channel", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe("POST /v1/contacts/guardian/channel", () => {
+  beforeEach(() => {
+    assistantDbQueryMock.mockReset();
+    createGuardianBindingMock.mockReset();
+
+    // Default: guardian exists
+    assistantDbQueryMock.mockResolvedValue([
+      { id: "guardian-1", principal_id: "principal-1" },
+    ]);
+
+    createGuardianBindingMock.mockResolvedValue({
+      contactId: "contact-1",
+      channelId: "channel-1",
+      guardianPrincipalId: "principal-1",
+      channel: "email",
+    });
+  });
+
+  it("creates a guardian channel binding and returns 200", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; verified_via: string };
+    expect(body.ok).toBe(true);
+    expect(body.verified_via).toBe("platform_auto_register");
+
+    // Verify createGuardianBinding was called with correct params
+    expect(createGuardianBindingMock).toHaveBeenCalledTimes(1);
+    const callArgs = createGuardianBindingMock.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.channel).toBe("email");
+    expect(callArgs.externalUserId).toBe("user@example.com");
+    // CRITICAL: deliveryChatId must be externalUserId, not address
+    expect(callArgs.deliveryChatId).toBe("user@example.com");
+    expect(callArgs.guardianPrincipalId).toBe("principal-1");
+    expect(callArgs.displayName).toBe("user@example.com");
+    expect(callArgs.verifiedVia).toBe("platform_auto_register");
+  });
+
+  it("returns 404 when no guardian contact exists", async () => {
+    assistantDbQueryMock.mockResolvedValue([]);
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("No guardian contact exists");
+    expect(createGuardianBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when guardian has no principal_id", async () => {
+    assistantDbQueryMock.mockResolvedValue([
+      { id: "guardian-1", principal_id: null },
+    ]);
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(createGuardianBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing required fields", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        // missing address, externalUserId, status
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; issues: unknown[] };
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeDefined();
+  });
+
+  it("returns 400 when status is not 'active'", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "pending",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; issues: unknown[] };
+    expect(body.error).toBe("Validation failed");
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      new Request("http://localhost:7830/v1/contacts/guardian/channel", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  it("returns 500 when createGuardianBinding throws", async () => {
+    createGuardianBindingMock.mockRejectedValue(
+      new Error("DB write failed"),
+    );
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Failed to create guardian channel");
+  });
+});

--- a/gateway/src/http/routes/guardian-channel-create.test.ts
+++ b/gateway/src/http/routes/guardian-channel-create.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 // --- Mocks ----------------------------------------------------------------
 
-const assistantDbQueryMock = mock((_sql: string, _params?: unknown[]) =>
-  Promise.resolve([]),
+const assistantDbQueryMock = mock(
+  (_sql: string, _params?: unknown[]) =>
+    Promise.resolve([] as Record<string, unknown>[]),
 );
 
 const createGuardianBindingMock = mock((_params: unknown) =>

--- a/gateway/src/http/routes/guardian-channel-create.ts
+++ b/gateway/src/http/routes/guardian-channel-create.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /v1/contacts/guardian/channel — create a guardian channel binding
+ * via platform auto-verify.
+ *
+ * This route is called by the platform's `assistant email register` flow
+ * to auto-verify the owner's email channel. It creates a guardian email
+ * channel binding directly in both the assistant and gateway databases.
+ *
+ * Auth is omitted (defaults to "none") because this route is only
+ * reachable through vembda's trusted `gateway-query` proxy, consistent
+ * with other webhook routes.
+ */
+
+import { z } from "zod";
+
+import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
+import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("guardian-channel-create");
+
+// ---------------------------------------------------------------------------
+// Request schema
+// ---------------------------------------------------------------------------
+
+const GuardianChannelRequestSchema = z.object({
+  type: z.string().trim().toLowerCase(),
+  address: z.string().trim().toLowerCase(),
+  externalUserId: z.string().trim().toLowerCase(),
+  status: z.literal("active"),
+});
+
+// ---------------------------------------------------------------------------
+// Guardian lookup
+// ---------------------------------------------------------------------------
+
+interface GuardianRow {
+  id: string;
+  principal_id: string | null;
+}
+
+/**
+ * Find the existing guardian contact (any channel). Returns null if no
+ * guardian has been verified yet or if the guardian has no principal_id.
+ */
+async function findGuardian(): Promise<(GuardianRow & { principal_id: string }) | null> {
+  const rows = await assistantDbQuery<GuardianRow>(
+    `SELECT id, principal_id FROM contacts WHERE role = 'guardian' LIMIT 1`,
+  );
+
+  const row = rows[0] ?? null;
+  if (!row?.principal_id) return null;
+  return row as GuardianRow & { principal_id: string };
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+export function createGuardianChannelHandler() {
+  return async function handleGuardianChannelCreate(
+    req: Request,
+  ): Promise<Response> {
+    // ── Parse & validate request body ─────────────────────────────
+
+    let rawBody: unknown;
+    try {
+      rawBody = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const parsed = GuardianChannelRequestSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Validation failed", issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const body = parsed.data;
+
+    // ── Find existing guardian ─────────────────────────────────────
+
+    const guardian = await findGuardian();
+    if (!guardian) {
+      log.warn(
+        "No guardian contact exists — cannot create guardian channel",
+      );
+      return Response.json(
+        {
+          error:
+            "No guardian contact exists. The guardian must be verified on at least one channel first.",
+        },
+        { status: 404 },
+      );
+    }
+
+    // ── Create guardian channel binding ────────────────────────────
+    // CRITICAL: deliveryChatId MUST be set to body.externalUserId (not
+    // body.address) — the ACL lookup in findContactChannel
+    // (contact-store.ts:780) queries on external_user_id and
+    // external_chat_id, NOT address. For email, all three values are
+    // typically the same email string, but the param mapping must be
+    // explicit.
+
+    try {
+      await createGuardianBinding({
+        channel: body.type,
+        externalUserId: body.externalUserId,
+        deliveryChatId: body.externalUserId,
+        guardianPrincipalId: guardian.principal_id,
+        displayName: body.address,
+        verifiedVia: "platform_auto_register",
+      });
+    } catch (err) {
+      log.error(
+        { err },
+        "Failed to create guardian channel binding",
+      );
+      return Response.json(
+        { error: "Failed to create guardian channel" },
+        { status: 500 },
+      );
+    }
+
+    log.info(
+      { channel: body.type, address: body.address },
+      "Auto-verified guardian channel via platform auto-register",
+    );
+
+    return Response.json({
+      ok: true,
+      verified_via: "platform_auto_register",
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -58,6 +58,7 @@ import {
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 
 import { createEmailWebhookHandler } from "./http/routes/email-webhook.js";
+import { createGuardianChannelHandler } from "./http/routes/guardian-channel-create.js";
 import { createInboundRegisterHandler } from "./http/routes/inbound-register.js";
 import { createMailgunWebhookHandler } from "./http/routes/mailgun-webhook.js";
 import { createResendWebhookHandler } from "./http/routes/resend-webhook.js";
@@ -417,6 +418,7 @@ async function main() {
     config,
     credentialCache,
   );
+  const handleGuardianChannelCreate = createGuardianChannelHandler();
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const channelVerificationSessionProxy =
     createChannelVerificationSessionProxyHandler(config);
@@ -560,6 +562,13 @@ async function main() {
       auth: "edge-scoped",
       scope: "internal.write",
       handler: (req) => handleInboundRegister(req),
+    },
+
+    // ── Guardian channel creation (platform auto-verify via trusted proxy) ──
+    {
+      path: "/v1/contacts/guardian/channel",
+      method: "POST",
+      handler: (req) => handleGuardianChannelCreate(req),
     },
 
     // ── Audio serving (unauthenticated — Twilio fetches these URLs directly) ──


### PR DESCRIPTION
## Summary
- Add new gateway route POST /v1/contacts/guardian/channel for platform email auto-verification
- Creates guardian channel binding with proper external_user_id and external_chat_id mapping
- Includes test coverage for success, 404, 400, and 500 cases

Part of plan: email-guardian-bootstrap.md (PR 1 of 4)