### PR TITLE
feat(runtime): enable outbound verification for email channel

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2777,7 +2777,7 @@ describe("outbound voice verification", () => {
     }
   });
 
-  test("start_outbound rejects unsupported channels", async () => {
+  test("start_outbound succeeds for email channel", async () => {
     const { lastResponse } = createResponseReader();
     await handleChannelVerificationSession(
       {
@@ -2790,8 +2790,8 @@ describe("outbound voice verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("unsupported_channel");
+    expect(resp!.success).toBe(true);
+    expect(resp!.channel).toBe("email");
   });
 
   test("create_session without destination falls through to inbound challenge", async () => {

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -280,11 +280,13 @@ describe("startOutbound", () => {
     expect(voiceCallInitCalls.length).toBe(1);
   });
 
-  test("unsupported channel returns unsupported_channel", async () => {
-    // Cast to bypass type checking for test purposes
-    const result = await startOutbound({ channel: "email" as never });
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("unsupported_channel");
+  test("email channel creates outbound session", async () => {
+    const result = await startOutbound({
+      channel: "email",
+      destination: "user@example.com",
+    });
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe("email");
   });
 });
 

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -234,12 +234,20 @@ export async function startOutbound(
       params.rebind,
       originConversationId,
     );
+  } else if (channel === "email") {
+    return startOutboundEmail(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
   }
 
   return {
     success: false,
     error: "unsupported_channel",
-    message: `Outbound verification is only supported for Telegram, phone, and Slack. Got: ${channel}`,
+    message: `Outbound verification is not supported for ${channel}. Supported channels: Telegram, phone, Slack, email.`,
     channel,
   };
 }
@@ -579,6 +587,70 @@ function startOutboundSlack(
     channel,
     originConversationId,
     _pendingSlackDm: { userId: destination, text: slackBody, assistantId },
+  };
+}
+
+function startOutboundEmail(
+  destination: string | undefined,
+  assistantId: string,
+  channel: ChannelId,
+  rebind?: boolean,
+  originConversationId?: string,
+): OutboundActionResult {
+  if (!destination) {
+    return {
+      success: false,
+      error: "missing_destination",
+      message:
+        "An email address is required for outbound email verification.",
+      channel,
+    };
+  }
+
+  const normalizedEmail = destination.trim().toLowerCase();
+
+  const existingBinding = getGuardianBinding(assistantId, channel);
+  if (existingBinding && !rebind) {
+    return {
+      success: false,
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
+      channel,
+    };
+  }
+
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    normalizedEmail,
+    DESTINATION_RATE_WINDOW_MS,
+  );
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    return {
+      success: false,
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this email address. Please try again later.",
+      channel,
+    };
+  }
+
+  const sessionResult = createOutboundSession({
+    channel,
+    expectedExternalUserId: normalizedEmail,
+    expectedChatId: normalizedEmail,
+    identityBindingStatus: "bound",
+    destinationAddress: normalizedEmail,
+    verificationPurpose: rebind ? "guardian" : "trusted_contact",
+  });
+
+  return {
+    success: true,
+    verificationSessionId: sessionResult.sessionId,
+    secret: sessionResult.secret,
+    expiresAt: sessionResult.expiresAt,
+    channel,
+    originConversationId,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add email channel support to the outbound verification flow
- Create startOutboundEmail function mirroring the Slack outbound pattern
- Update unsupported-channel error message to reflect email support

Part of plan: email-guardian-bootstrap.md (PR 4 of 4)