### PR TITLE
fix(gateway): add edge-guardian auth to guardian channel creation route

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -564,10 +564,11 @@ async function main() {
       handler: (req) => handleInboundRegister(req),
     },
 
-    // ── Guardian channel creation (platform auto-verify via trusted proxy) ──
+    // ── Guardian channel creation (platform auto-verify) ──
     {
       path: "/v1/contacts/guardian/channel",
       method: "POST",
+      auth: "edge-guardian",
       handler: (req) => handleGuardianChannelCreate(req),
     },
 


### PR DESCRIPTION
## Summary
- Add `auth: "edge-guardian"` to the `POST /v1/contacts/guardian/channel` route
- Addresses Codex review feedback on PR #32000: route was unauthenticated, allowing any caller to create guardian channel bindings

Part of plan: email-guardian-bootstrap.md (fix)