### PR TITLE
Fix email guardian channel bootstrap

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2777,7 +2777,7 @@ describe("outbound voice verification", () => {
     }
   });
 
-  test("start_outbound rejects unsupported channels", async () => {
+  test("start_outbound succeeds for email channel", async () => {
     const { lastResponse } = createResponseReader();
     await handleChannelVerificationSession(
       {
@@ -2790,8 +2790,8 @@ describe("outbound voice verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("unsupported_channel");
+    expect(resp!.success).toBe(true);
+    expect(resp!.channel).toBe("email");
   });
 
   test("create_session without destination falls through to inbound challenge", async () => {

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -280,11 +280,13 @@ describe("startOutbound", () => {
     expect(voiceCallInitCalls.length).toBe(1);
   });
 
-  test("unsupported channel returns unsupported_channel", async () => {
-    // Cast to bypass type checking for test purposes
-    const result = await startOutbound({ channel: "email" as never });
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("unsupported_channel");
+  test("email channel creates outbound session", async () => {
+    const result = await startOutbound({
+      channel: "email",
+      destination: "user@example.com",
+    });
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe("email");
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -342,6 +342,49 @@ export async function enforceIngressAcl(
           }
         }
 
+        // Email: initiate a verification challenge via the guardian notification
+        // pipeline. Unlike Slack, we cannot DM the requester directly — the
+        // verification code is delivered to the guardian, who decides whether
+        // to share it with the email sender out-of-band.
+        if (sourceChannel === "email" && (canonicalSenderId ?? rawSenderId)) {
+          const emailVerifyResult = initiateEmailVerificationChallenge({
+            sourceChannel,
+            senderUserId: (canonicalSenderId ?? rawSenderId)!,
+          });
+
+          if (emailVerifyResult.initiated) {
+            try {
+              notifyGuardianOfAccessRequest({
+                canonicalAssistantId,
+                sourceChannel,
+                conversationExternalId,
+                actorExternalId: canonicalSenderId ?? rawSenderId,
+                actorDisplayName,
+                actorUsername,
+                messagePreview: truncate(
+                  trimmedContent,
+                  MESSAGE_PREVIEW_MAX_LENGTH,
+                ),
+              });
+            } catch (err) {
+              log.error(
+                { err, sourceChannel, conversationExternalId },
+                "Failed to notify guardian of access request (email verification)",
+              );
+            }
+
+            return {
+              resolvedMember: null,
+              earlyResponse: ({
+                accepted: true,
+                denied: true,
+                reason: "verification_challenge_sent",
+                verificationSessionId: emailVerifyResult.sessionId,
+              }),
+            };
+          }
+        }
+
         // Notify the guardian about the access request so they can approve/deny.
         // Uses the shared helper which handles guardian binding lookup,
         // deduplication, canonical request creation, and notification emission.
@@ -1048,10 +1091,10 @@ async function handleInviteCodeIntercept(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Slack verification challenge
+// Channel verification challenges
 // ---------------------------------------------------------------------------
 
-interface SlackVerificationResult {
+interface VerificationChallengeResult {
   initiated: boolean;
   sessionId?: string;
 }
@@ -1066,7 +1109,7 @@ interface SlackVerificationResult {
 function initiateSlackVerificationChallenge(params: {
   sourceChannel: ChannelId;
   senderUserId: string;
-}): SlackVerificationResult {
+}): VerificationChallengeResult {
   const { sourceChannel, senderUserId } = params;
 
   // Skip if there is already a pending challenge or active session for
@@ -1117,6 +1160,56 @@ function initiateSlackVerificationChallenge(params: {
     log.error(
       { err, sourceChannel, senderUserId },
       "Failed to initiate Slack verification challenge",
+    );
+    return { initiated: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Email verification challenge
+// ---------------------------------------------------------------------------
+
+function initiateEmailVerificationChallenge(params: {
+  sourceChannel: ChannelId;
+  senderUserId: string;
+}): VerificationChallengeResult {
+  const { sourceChannel, senderUserId } = params;
+
+  const existingChallenge = getPendingSession(sourceChannel);
+  const existingSession = findActiveSession(sourceChannel);
+  const senderHasPending =
+    (existingChallenge &&
+      existingChallenge.expectedExternalUserId === senderUserId) ||
+    (existingSession &&
+      existingSession.expectedExternalUserId === senderUserId);
+  if (senderHasPending) {
+    log.debug(
+      { sourceChannel, senderUserId },
+      "Email verification: skipping — existing challenge/session for this sender",
+    );
+    return { initiated: false };
+  }
+
+  try {
+    const session = createOutboundSession({
+      channel: sourceChannel,
+      expectedExternalUserId: senderUserId,
+      expectedChatId: senderUserId,
+      identityBindingStatus: "bound",
+      destinationAddress: senderUserId,
+      verificationPurpose: "trusted_contact",
+    });
+
+    log.info(
+      { sourceChannel, senderUserId, sessionId: session.sessionId },
+      "Email verification challenge initiated for unknown contact",
+    );
+
+    return { initiated: true, sessionId: session.sessionId };
+  } catch (err) {
+    log.error(
+      { err, sourceChannel, senderUserId },
+      "Failed to initiate email verification challenge",
     );
     return { initiated: false };
   }

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -234,12 +234,20 @@ export async function startOutbound(
       params.rebind,
       originConversationId,
     );
+  } else if (channel === "email") {
+    return startOutboundEmail(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
   }
 
   return {
     success: false,
     error: "unsupported_channel",
-    message: `Outbound verification is only supported for Telegram, phone, and Slack. Got: ${channel}`,
+    message: `Outbound verification is not supported for ${channel}. Supported channels: Telegram, phone, Slack, email.`,
     channel,
   };
 }
@@ -579,6 +587,70 @@ function startOutboundSlack(
     channel,
     originConversationId,
     _pendingSlackDm: { userId: destination, text: slackBody, assistantId },
+  };
+}
+
+function startOutboundEmail(
+  destination: string | undefined,
+  assistantId: string,
+  channel: ChannelId,
+  rebind?: boolean,
+  originConversationId?: string,
+): OutboundActionResult {
+  if (!destination) {
+    return {
+      success: false,
+      error: "missing_destination",
+      message:
+        "An email address is required for outbound email verification.",
+      channel,
+    };
+  }
+
+  const normalizedEmail = destination.trim().toLowerCase();
+
+  const existingBinding = getGuardianBinding(assistantId, channel);
+  if (existingBinding && !rebind) {
+    return {
+      success: false,
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
+      channel,
+    };
+  }
+
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    normalizedEmail,
+    DESTINATION_RATE_WINDOW_MS,
+  );
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    return {
+      success: false,
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this email address. Please try again later.",
+      channel,
+    };
+  }
+
+  const sessionResult = createOutboundSession({
+    channel,
+    expectedExternalUserId: normalizedEmail,
+    expectedChatId: normalizedEmail,
+    identityBindingStatus: "bound",
+    destinationAddress: normalizedEmail,
+    verificationPurpose: rebind ? "guardian" : "trusted_contact",
+  });
+
+  return {
+    success: true,
+    verificationSessionId: sessionResult.sessionId,
+    secret: sessionResult.secret,
+    expiresAt: sessionResult.expiresAt,
+    channel,
+    originConversationId,
   };
 }
 

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -641,7 +641,7 @@ function startOutboundEmail(
     expectedChatId: normalizedEmail,
     identityBindingStatus: "bound",
     destinationAddress: normalizedEmail,
-    verificationPurpose: rebind ? "guardian" : "trusted_contact",
+    verificationPurpose: "guardian",
   });
 
   return {

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -173,6 +173,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/v1/pair",
   // A2A agent card discovery — read-only, unauthenticated per spec
   "/.well-known/agent-card.json",
+  // Internal-only: reachable only via vembda's trusted gateway-query proxy
+  "/v1/contacts/guardian/channel",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -171,8 +171,12 @@ export async function handleInbound(
         eventId: response.eventId,
         duplicate: response.duplicate,
         hasReply: !!response.assistantMessage,
+        denied: response.denied ?? false,
+        deniedReason: response.denied ? (response.reason ?? "unknown") : undefined,
       },
-      "Inbound event forwarded to runtime",
+      response.denied
+        ? "Inbound event denied by runtime"
+        : "Inbound event forwarded to runtime",
     );
 
     // ── Contact channel interaction tracking (dual-write) ──

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -227,9 +227,17 @@ export function createEmailWebhookHandler(
       dedupCache.mark(eventId);
 
       if (!result.rejected) {
+        const denied = result.runtimeResponse?.denied ?? false;
+        const deniedReason = denied ? (result.runtimeResponse?.reason ?? "unknown") : undefined;
         tlog.info(
-          { status: "forwarded", eventId },
-          "Email message forwarded to runtime",
+          {
+            status: denied ? "denied" : "forwarded",
+            eventId,
+            ...(denied && { deniedReason }),
+          },
+          denied
+            ? "Email message denied by runtime"
+            : "Email message forwarded to runtime",
         );
       }
 

--- a/gateway/src/http/routes/guardian-channel-create.test.ts
+++ b/gateway/src/http/routes/guardian-channel-create.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// --- Mocks ----------------------------------------------------------------
+
+const assistantDbQueryMock = mock(
+  (_sql: string, _params?: unknown[]) =>
+    Promise.resolve([] as Record<string, unknown>[]),
+);
+
+const createGuardianBindingMock = mock((_params: unknown) =>
+  Promise.resolve({
+    contactId: "contact-1",
+    channelId: "channel-1",
+    guardianPrincipalId: "principal-1",
+    channel: "email",
+  }),
+);
+
+mock.module("../../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: assistantDbQueryMock,
+  assistantDbRun: mock(() => Promise.resolve()),
+  assistantDbExec: mock(() => Promise.resolve()),
+}));
+
+mock.module("../../auth/guardian-bootstrap.js", () => ({
+  createGuardianBinding: createGuardianBindingMock,
+}));
+
+// Import after mocks are registered
+const { createGuardianChannelHandler } = await import(
+  "./guardian-channel-create.js"
+);
+
+// --- Helpers ---------------------------------------------------------------
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost:7830/v1/contacts/guardian/channel", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe("POST /v1/contacts/guardian/channel", () => {
+  beforeEach(() => {
+    assistantDbQueryMock.mockReset();
+    createGuardianBindingMock.mockReset();
+
+    // Default: guardian exists
+    assistantDbQueryMock.mockResolvedValue([
+      { id: "guardian-1", principal_id: "principal-1" },
+    ]);
+
+    createGuardianBindingMock.mockResolvedValue({
+      contactId: "contact-1",
+      channelId: "channel-1",
+      guardianPrincipalId: "principal-1",
+      channel: "email",
+    });
+  });
+
+  it("creates a guardian channel binding and returns 200", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; verified_via: string };
+    expect(body.ok).toBe(true);
+    expect(body.verified_via).toBe("platform_auto_register");
+
+    // Verify createGuardianBinding was called with correct params
+    expect(createGuardianBindingMock).toHaveBeenCalledTimes(1);
+    const callArgs = createGuardianBindingMock.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.channel).toBe("email");
+    expect(callArgs.externalUserId).toBe("user@example.com");
+    // CRITICAL: deliveryChatId must be externalUserId, not address
+    expect(callArgs.deliveryChatId).toBe("user@example.com");
+    expect(callArgs.guardianPrincipalId).toBe("principal-1");
+    expect(callArgs.displayName).toBe("user@example.com");
+    expect(callArgs.verifiedVia).toBe("platform_auto_register");
+  });
+
+  it("returns 404 when no guardian contact exists", async () => {
+    assistantDbQueryMock.mockResolvedValue([]);
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("No guardian contact exists");
+    expect(createGuardianBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when guardian has no principal_id", async () => {
+    assistantDbQueryMock.mockResolvedValue([
+      { id: "guardian-1", principal_id: null },
+    ]);
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(createGuardianBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing required fields", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        // missing address, externalUserId, status
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; issues: unknown[] };
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeDefined();
+  });
+
+  it("returns 400 when status is not 'active'", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "pending",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; issues: unknown[] };
+    expect(body.error).toBe("Validation failed");
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      new Request("http://localhost:7830/v1/contacts/guardian/channel", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  it("returns 500 when createGuardianBinding throws", async () => {
+    createGuardianBindingMock.mockRejectedValue(
+      new Error("DB write failed"),
+    );
+
+    const handler = createGuardianChannelHandler();
+    const res = await handler(
+      postRequest({
+        type: "email",
+        address: "user@example.com",
+        externalUserId: "user@example.com",
+        status: "active",
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Failed to create guardian channel");
+  });
+});

--- a/gateway/src/http/routes/guardian-channel-create.ts
+++ b/gateway/src/http/routes/guardian-channel-create.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /v1/contacts/guardian/channel — create a guardian channel binding
+ * via platform auto-verify.
+ *
+ * This route is called by the platform's `assistant email register` flow
+ * to auto-verify the owner's email channel. It creates a guardian email
+ * channel binding directly in both the assistant and gateway databases.
+ *
+ * Auth is omitted (defaults to "none") because this route is only
+ * reachable through vembda's trusted `gateway-query` proxy, consistent
+ * with other webhook routes.
+ */
+
+import { z } from "zod";
+
+import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
+import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("guardian-channel-create");
+
+// ---------------------------------------------------------------------------
+// Request schema
+// ---------------------------------------------------------------------------
+
+const GuardianChannelRequestSchema = z.object({
+  type: z.string().trim().toLowerCase(),
+  address: z.string().trim().toLowerCase(),
+  externalUserId: z.string().trim().toLowerCase(),
+  status: z.literal("active"),
+});
+
+// ---------------------------------------------------------------------------
+// Guardian lookup
+// ---------------------------------------------------------------------------
+
+interface GuardianRow {
+  id: string;
+  principal_id: string | null;
+}
+
+/**
+ * Find the existing guardian contact (any channel). Returns null if no
+ * guardian has been verified yet or if the guardian has no principal_id.
+ */
+async function findGuardian(): Promise<(GuardianRow & { principal_id: string }) | null> {
+  const rows = await assistantDbQuery<GuardianRow>(
+    `SELECT id, principal_id FROM contacts WHERE role = 'guardian' LIMIT 1`,
+  );
+
+  const row = rows[0] ?? null;
+  if (!row?.principal_id) return null;
+  return row as GuardianRow & { principal_id: string };
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+export function createGuardianChannelHandler() {
+  return async function handleGuardianChannelCreate(
+    req: Request,
+  ): Promise<Response> {
+    // ── Parse & validate request body ─────────────────────────────
+
+    let rawBody: unknown;
+    try {
+      rawBody = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const parsed = GuardianChannelRequestSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Validation failed", issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const body = parsed.data;
+
+    // ── Find existing guardian ─────────────────────────────────────
+
+    const guardian = await findGuardian();
+    if (!guardian) {
+      log.warn(
+        "No guardian contact exists — cannot create guardian channel",
+      );
+      return Response.json(
+        {
+          error:
+            "No guardian contact exists. The guardian must be verified on at least one channel first.",
+        },
+        { status: 404 },
+      );
+    }
+
+    // ── Create guardian channel binding ────────────────────────────
+    // CRITICAL: deliveryChatId MUST be set to body.externalUserId (not
+    // body.address) — the ACL lookup in findContactChannel
+    // (contact-store.ts:780) queries on external_user_id and
+    // external_chat_id, NOT address. For email, all three values are
+    // typically the same email string, but the param mapping must be
+    // explicit.
+
+    try {
+      await createGuardianBinding({
+        channel: body.type,
+        externalUserId: body.externalUserId,
+        deliveryChatId: body.externalUserId,
+        guardianPrincipalId: guardian.principal_id,
+        displayName: body.address,
+        verifiedVia: "platform_auto_register",
+      });
+    } catch (err) {
+      log.error(
+        { err },
+        "Failed to create guardian channel binding",
+      );
+      return Response.json(
+        { error: "Failed to create guardian channel" },
+        { status: 500 },
+      );
+    }
+
+    log.info(
+      { channel: body.type, address: body.address },
+      "Auto-verified guardian channel via platform auto-register",
+    );
+
+    return Response.json({
+      ok: true,
+      verified_via: "platform_auto_register",
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -564,10 +564,11 @@ async function main() {
       handler: (req) => handleInboundRegister(req),
     },
 
-    // ── Guardian channel creation (platform auto-verify via trusted proxy) ──
+    // ── Guardian channel creation (platform auto-verify) ──
     {
       path: "/v1/contacts/guardian/channel",
       method: "POST",
+      auth: "edge-guardian",
       handler: (req) => handleGuardianChannelCreate(req),
     },
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -58,6 +58,7 @@ import {
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 
 import { createEmailWebhookHandler } from "./http/routes/email-webhook.js";
+import { createGuardianChannelHandler } from "./http/routes/guardian-channel-create.js";
 import { createInboundRegisterHandler } from "./http/routes/inbound-register.js";
 import { createMailgunWebhookHandler } from "./http/routes/mailgun-webhook.js";
 import { createResendWebhookHandler } from "./http/routes/resend-webhook.js";
@@ -417,6 +418,7 @@ async function main() {
     config,
     credentialCache,
   );
+  const handleGuardianChannelCreate = createGuardianChannelHandler();
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const channelVerificationSessionProxy =
     createChannelVerificationSessionProxyHandler(config);
@@ -560,6 +562,13 @@ async function main() {
       auth: "edge-scoped",
       scope: "internal.write",
       handler: (req) => handleInboundRegister(req),
+    },
+
+    // ── Guardian channel creation (platform auto-verify via trusted proxy) ──
+    {
+      path: "/v1/contacts/guardian/channel",
+      method: "POST",
+      handler: (req) => handleGuardianChannelCreate(req),
     },
 
     // ── Audio serving (unauthenticated — Twilio fetches these URLs directly) ──

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -219,6 +219,8 @@ export type RuntimeInboundResponse = {
   };
   /** When true, the runtime denied the inbound message (e.g. ACL rejection). */
   denied?: boolean;
+  /** Machine-readable denial reason returned by the runtime ACL (e.g. "not_a_member"). */
+  reason?: string;
   /**
    * A user-facing rejection message that the runtime could not deliver via
    * the callback URL (e.g. due to auth failure). When present, the gateway


### PR DESCRIPTION
## Summary
Fix the platform's email registration flow by adding the missing gateway endpoint, improving email verification paths, and fixing observability gaps. The `assistant email register` flow calls `POST /v1/contacts/guardian/channel` on the gateway, but this endpoint didn't exist, so no `contact_channels` row was created for the owner's email and all inbound owner emails were denied.

## Self-review result
GAPS FOUND — 1 gap fixed (auth on guardian channel route, per user + Codex feedback)

## PRs merged into feature branch
- #31998: fix(gateway): include runtime denial status in inbound event logs
- #31999: feat(runtime): add email verification challenge bypass in ACL enforcement
- #32000: feat(gateway): add POST /v1/contacts/guardian/channel route for platform auto-verify
- #32003: feat(runtime): enable outbound verification for email channel

### Fix PRs
- #32005: fix(gateway): add edge-guardian auth to guardian channel creation route

Part of plan: email-guardian-bootstrap.md