### PR TITLE
fix(memory-v3): address Codex review on #31990 (slow-lane consolidate + positive interval)

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -316,6 +316,24 @@ describe("MemoryV3ConfigSchema", () => {
       MemoryV3ConfigSchema.parse({ write: { consolidateIntervalMs: 1.5 } }),
     ).toThrow();
   });
+
+  test("rejects a non-positive write.consolidateIntervalMs", () => {
+    // 0 or negative would make the scheduler's `now - lastRun >= interval`
+    // check always true, flooding the queue with consolidation jobs.
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ write: { consolidateIntervalMs: 0 } }),
+    ).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ write: { consolidateIntervalMs: -1000 } }),
+    ).toThrow();
+  });
+
+  test("accepts a positive write.consolidateIntervalMs override", () => {
+    const parsed = MemoryV3ConfigSchema.parse({
+      write: { consolidateIntervalMs: 1800000 },
+    });
+    expect(parsed.write.consolidateIntervalMs).toBe(1800000);
+  });
 });
 
 describe("MemoryConfigSchema integration with v3 block", () => {

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -504,6 +504,7 @@ export const MemoryV3ConfigSchema = z
             error: "memory.v3.write.consolidateIntervalMs must be a number",
           })
           .int("memory.v3.write.consolidateIntervalMs must be an integer")
+          .positive("memory.v3.write.consolidateIntervalMs must be positive")
           .default(3600000)
           .describe(
             "Interval, in milliseconds, between scheduled v3 consolidation runs once the v3 write path owns the drain. Default 1 hour.",

--- a/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
@@ -39,4 +39,13 @@ describe("memory job classes", () => {
     const set = new Set(SLOW_LLM_JOB_TYPES);
     expect(set.size).toBe(SLOW_LLM_JOB_TYPES.length);
   });
+
+  test("memory_v3_consolidate is a slow LLM job (lane isolation)", () => {
+    // It hands off to a background agent for up to 15 min, like
+    // memory_v2_consolidate; it must not sit in the fast lane and starve
+    // short jobs. The mechanical v3 jobs intentionally stay fast.
+    expect(SLOW_LLM_JOB_TYPES).toContain("memory_v3_consolidate");
+    expect(SLOW_LLM_JOB_TYPES).not.toContain("memory_v3_index_maintenance");
+    expect(SLOW_LLM_JOB_TYPES).not.toContain("memory_v3_edge_learning");
+  });
 });

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -70,6 +70,7 @@ export const SLOW_LLM_JOB_TYPES: MemoryJobType[] = [
   "generate_conversation_starters",
   "memory_v2_sweep",
   "memory_v2_consolidate",
+  "memory_v3_consolidate",
   "memory_v2_migrate",
   "memory_retrospective",
   "backfill",


### PR DESCRIPTION
## Summary
Addresses the two actionable Codex comments on #31990 (merged):

- **P1 — lane isolation:** add `memory_v3_consolidate` to `SLOW_LLM_JOB_TYPES`. It hands off to a background agent for up to 15 min (like `memory_v2_consolidate`); in the fast lane it could starve short jobs once `memory.v3.write.enabled` is on. The mechanical v3 jobs (`memory_v3_index_maintenance`, `memory_v3_edge_learning`) intentionally stay fast.
- **P2 — queue flood guard:** constrain `memory.v3.write.consolidateIntervalMs` to `.positive()`. `0`/negative made `maybeEnqueueGraphMaintenanceJobs`' `now - lastRun >= interval` always true, enqueuing a consolidation every worker pass.

Both paths are still flag-gated (`memory.v3.write.enabled` defaults off), so this only matters once the v3 write path is switched on — but the guards belong in now.

## Test plan
- [x] `bun test` jobs-store-job-classes + memory-v2 schema (48 pass)
- [x] `bunx tsc --noEmit`, `bun run lint`, prettier clean

Follow-up to #31990.