### PR TITLE
refactor(memory-v3): move the memory tree from memory/v3/tree to memory/tree

### DIFF
--- a/assistant/src/__tests__/workspace-migration-089-move-memory-tree-out-of-v3.test.ts
+++ b/assistant/src/__tests__/workspace-migration-089-move-memory-tree-out-of-v3.test.ts
@@ -1,0 +1,86 @@
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { moveMemoryTreeOutOfV3Migration } from "../workspace/migrations/089-move-memory-tree-out-of-v3.js";
+
+describe("workspace migration 089 — move memory tree out of v3", () => {
+  let ws: string;
+
+  beforeEach(() => {
+    ws = fs.mkdtempSync(join(tmpdir(), "ws-mig-089-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  function writeOldTree(): void {
+    const oldTree = join(ws, "memory", "v3", "tree");
+    fs.mkdirSync(join(oldTree, "people"), { recursive: true });
+    fs.writeFileSync(join(oldTree, "_root.md"), "root");
+    fs.writeFileSync(join(oldTree, "people", "alice.md"), "alice");
+  }
+
+  test("moves memory/v3/tree -> memory/tree (incl. nested) and drops the empty v3 wrapper", () => {
+    writeOldTree();
+    moveMemoryTreeOutOfV3Migration.run(ws);
+
+    expect(fs.existsSync(join(ws, "memory", "v3"))).toBe(false);
+    expect(
+      fs.readFileSync(join(ws, "memory", "tree", "_root.md"), "utf-8"),
+    ).toBe("root");
+    expect(
+      fs.readFileSync(
+        join(ws, "memory", "tree", "people", "alice.md"),
+        "utf-8",
+      ),
+    ).toBe("alice");
+  });
+
+  test("is idempotent — re-running after the move changes nothing", () => {
+    writeOldTree();
+    moveMemoryTreeOutOfV3Migration.run(ws);
+    moveMemoryTreeOutOfV3Migration.run(ws);
+
+    expect(
+      fs.readFileSync(join(ws, "memory", "tree", "_root.md"), "utf-8"),
+    ).toBe("root");
+  });
+
+  test("no-op on a fresh workspace with no old tree", () => {
+    moveMemoryTreeOutOfV3Migration.run(ws);
+    expect(fs.existsSync(join(ws, "memory", "tree"))).toBe(false);
+  });
+
+  test("never clobbers an existing memory/tree", () => {
+    writeOldTree();
+    const newTree = join(ws, "memory", "tree");
+    fs.mkdirSync(newTree, { recursive: true });
+    fs.writeFileSync(join(newTree, "_root.md"), "existing");
+
+    moveMemoryTreeOutOfV3Migration.run(ws);
+
+    // Destination preserved; source left in place for manual resolution.
+    expect(fs.readFileSync(join(newTree, "_root.md"), "utf-8")).toBe(
+      "existing",
+    );
+    expect(fs.existsSync(join(ws, "memory", "v3", "tree", "_root.md"))).toBe(
+      true,
+    );
+  });
+
+  test("down() restores memory/tree back to memory/v3/tree", () => {
+    const newTree = join(ws, "memory", "tree");
+    fs.mkdirSync(newTree, { recursive: true });
+    fs.writeFileSync(join(newTree, "_root.md"), "root");
+
+    moveMemoryTreeOutOfV3Migration.down(ws);
+
+    expect(fs.existsSync(join(ws, "memory", "tree"))).toBe(false);
+    expect(
+      fs.readFileSync(join(ws, "memory", "v3", "tree", "_root.md"), "utf-8"),
+    ).toBe("root");
+  });
+});

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -50,7 +50,7 @@ export function registerMemoryV3Command(program: Command): void {
         "after",
         `
 The v3 memory subsystem layers a hand-authored DAG of tree nodes over the
-flat v2 concept pages. Each node lives under /workspace/memory/v3/tree/ and
+flat v2 concept pages. Each node lives under /workspace/memory/tree/ and
 its frontmatter 'children' list references sub-nodes (node:<id>) and leaf
 concept pages (page:<slug>). The structure is authored by the v2 → v3
 data-migration, so these subcommands are read-only inspection only — they

--- a/assistant/src/memory/v3/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v3/__tests__/consolidation-job.test.ts
@@ -244,7 +244,7 @@ describe("memoryV3ConsolidateJob — non-empty shared buffer", () => {
     expect(prompt).not.toContain(CUTOFF_PLACEHOLDER);
     expect(prompt).toMatch(/\b[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} (AM|PM)\b/);
     // v3-distinctive: the prompt routes into the v3 tree, not just flat pages.
-    expect(prompt).toContain("memory/v3/tree/");
+    expect(prompt).toContain("memory/tree/");
     // Standing-context files preserved exactly as v2 (shared).
     expect(prompt).toContain("memory/buffer.md");
     expect(prompt).toContain("memory/recent.md");
@@ -310,7 +310,7 @@ describe("CONSOLIDATION_PROMPT (v3)", () => {
   });
 
   test("adds the v3 tree-authoring routing the shared concept pages get indexed into", () => {
-    expect(CONSOLIDATION_PROMPT).toContain("memory/v3/tree/");
+    expect(CONSOLIDATION_PROMPT).toContain("memory/tree/");
     expect(CONSOLIDATION_PROMPT).toContain("children");
     // The DAG cycle / reachability discipline must be in the prompt.
     expect(CONSOLIDATION_PROMPT.toLowerCase()).toContain("cycle");

--- a/assistant/src/memory/v3/__tests__/tree-store.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-store.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `assistant/src/memory/v3/tree-store.ts`.
+ * Tests for `assistant/src/memory/tree-store.ts`.
  *
  * Coverage matrix:
  *   - slugify: lowercase / kebab-case / ascii / 80-char cap / empty fallback.
@@ -14,7 +14,7 @@
  *     hidden dirs / non-.md / temp files, missing dir → [].
  *   - deleteNode: nested-id round-trip, idempotent on missing.
  *   - renderNodeContent: frontmatter + body shape.
- *   - No change to memory/concepts/ (v3 lives under memory/v3/tree/).
+ *   - No change to memory/concepts/ (v3 lives under memory/tree/).
  *
  * Tests use temp workspaces under `os.tmpdir()`; they never touch `~/.vellum/`.
  */

--- a/assistant/src/memory/v3/prompts/consolidation.ts
+++ b/assistant/src/memory/v3/prompts/consolidation.ts
@@ -13,7 +13,7 @@
  * shared concept pages canonical (the agent still writes
  * `memory/concepts/<class>/<slug>.md` so the v2 router keeps working off them)
  * but ALSO threads each touched page into the v3 **tree**: an authored DAG of
- * `memory/v3/tree/<id>.md` nodes whose markdown body is the node's
+ * `memory/tree/<id>.md` nodes whose markdown body is the node's
  * self-description and whose `children` list points at pages (`page:<slug>`) and
  * sub-nodes (`node:<id>`). The tree is the navigable index over the flat page
  * store — consolidation is where it's authored and refreshed.
@@ -71,7 +71,7 @@ Cutoff timestamp for this run: \`${CUTOFF_PLACEHOLDER}\`. Anything in \`memory/b
 
 - Your identity files (already loaded into context)
 - All existing pages in \`memory/concepts/\` (your prior state — use \`list_files\` and \`read_file\` as needed)
-- All existing tree nodes in \`memory/v3/tree/\` (the index over those pages)
+- All existing tree nodes in \`memory/tree/\` (the index over those pages)
 - \`memory/buffer.md\` entries with timestamp < \`${CUTOFF_PLACEHOLDER}\`
 - \`memory/recent.md\` current contents (if it exists)
 - Existing pages' \`edges:\` frontmatter (the flat see-also graph — read each page to see what it points at)
@@ -79,7 +79,7 @@ Cutoff timestamp for this run: \`${CUTOFF_PLACEHOLDER}\`. Anything in \`memory/b
 # Outputs
 
 - New or updated \`memory/concepts/<class>/<slug>.md\` articles (the canonical, shared content)
-- New or updated \`memory/v3/tree/<id>.md\` nodes that index those articles (see "The tree")
+- New or updated \`memory/tree/<id>.md\` nodes that index those articles (see "The tree")
 - Updated \`memory/recent.md\` (≤2000 chars, latest first, prose)
 - Updated \`memory/essentials.md\` (≤10000 chars)
 - Updated \`memory/threads.md\` (≤10000 chars)
@@ -195,7 +195,7 @@ The pages MOST likely to bloat are the ones with the highest emotional charge �
 
 # The tree — the navigable index over your pages
 
-The v3 tree lives at \`memory/v3/tree/<id>.md\`. It is a **DAG overlay** over the flat \`memory/concepts/\` pages: pages stay canonical and untouched as content, and the tree is the browsable hierarchy that routes to them. Think of it as the wiki's category tree + table of contents, authored by hand.
+The v3 tree lives at \`memory/tree/<id>.md\`. It is a **DAG overlay** over the flat \`memory/concepts/\` pages: pages stay canonical and untouched as content, and the tree is the browsable hierarchy that routes to them. Think of it as the wiki's category tree + table of contents, authored by hand.
 
 ## Node shape
 
@@ -216,7 +216,7 @@ summary: one-line self-description of what this node organizes.
 A few sentences — the node's full self-description. What region of memory does this node organize? What lives under it? Write it so next-you, descending the tree, can decide in one read whether to go deeper here.
 \`\`\`
 
-- The node id is the relative path under \`memory/v3/tree/\` minus \`.md\` — e.g. \`people\`, \`people/colleagues\`, \`work/active-projects\`. The root node is \`_root\`.
+- The node id is the relative path under \`memory/tree/\` minus \`.md\` — e.g. \`people\`, \`people/colleagues\`, \`work/active-projects\`. The root node is \`_root\`.
 - \`children\` is the **ordered, canonical** list of outgoing references. Each entry is either \`page:<slug>\` (a leaf concept page) or \`node:<id>\` (a sub-node). This list IS the DAG edge — it's the portable replacement for filesystem symlinks. A page or node may be referenced by more than one parent (hence DAG, not tree).
 - \`summary\` (one line) + the body are how the parent's index is composed at read time — keep both crisp.
 - \`routing_hints\` (optional, one line) disambiguates between sibling branches.

--- a/assistant/src/memory/v3/tree-store.ts
+++ b/assistant/src/memory/v3/tree-store.ts
@@ -1,9 +1,9 @@
 /**
  * Memory v3 — Tree node store.
  *
- * Owns the on-disk read/write contract for `memory/v3/tree/<id>.md`. Nodes may
- * live directly under `memory/v3/tree/` or nested in subdirectories (e.g.
- * `memory/v3/tree/people/colleagues.md`); the id encodes the relative path from
+ * Owns the on-disk read/write contract for `memory/tree/<id>.md`. Nodes may
+ * live directly under `memory/tree/` or nested in subdirectories (e.g.
+ * `memory/tree/people/colleagues.md`); the id encodes the relative path from
  * `tree/` minus the `.md` extension, using forward slashes as separators (so
  * `people/colleagues` is a valid id).
  *
@@ -102,7 +102,7 @@ export function slugify(input: string): string {
  * Validate a node id — possibly path-shaped — that is about to cross the
  * storage boundary. Throws on any malformed or unsafe value.
  *
- * The on-disk tree treats ids as relative paths under `memory/v3/tree/`. A
+ * The on-disk tree treats ids as relative paths under `memory/tree/`. A
  * malformed id (e.g. `..`, leading `/`, embedded null byte) could escape that
  * root via `path.join` if it slipped through, so we enforce shape here at every
  * read/write/delete entry point rather than relying on callers.
@@ -169,12 +169,12 @@ export function validateNodeId(id: string): void {
 // ---------------------------------------------------------------------------
 
 export function getTreeDir(workspaceDir: string): string {
-  return join(workspaceDir, "memory", "v3", "tree");
+  return join(workspaceDir, "memory", "tree");
 }
 
 /**
  * Resolve the absolute path for a node id. Ids may contain `/` to indicate
- * folder hierarchy under `memory/v3/tree/`; `path.join` handles those correctly
+ * folder hierarchy under `memory/tree/`; `path.join` handles those correctly
  * on POSIX, and `validateNodeId` (called at every public entry point) rejects
  * shapes that could escape the tree root.
  */

--- a/assistant/src/memory/v3/types.ts
+++ b/assistant/src/memory/v3/types.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 // ---------------------------------------------------------------------------
 
 /**
- * YAML frontmatter at the top of a v3 tree node (`memory/v3/tree/<id>.md`).
+ * YAML frontmatter at the top of a v3 tree node (`memory/tree/<id>.md`).
  *
  * The v3 tree is a DAG *overlay* over the existing flat `memory/concepts/`
  * pages. A node organizes a region of the graph: its markdown body is the
@@ -53,7 +53,7 @@ export type TreeNodeFrontmatter = z.infer<typeof TreeNodeFrontmatterSchema>;
 
 /**
  * A single tree node on disk. The id is the relative path from
- * `memory/v3/tree/` minus `.md`, using forward slashes — so `people` and
+ * `memory/tree/` minus `.md`, using forward slashes — so `people` and
  * `people/colleagues` are both valid ids. The id is the stable identity used
  * in `children` references (`node:<id>`) and is the portable node handle a
  * future data-migration authors by hand.

--- a/assistant/src/workspace/migrations/089-move-memory-tree-out-of-v3.ts
+++ b/assistant/src/workspace/migrations/089-move-memory-tree-out-of-v3.ts
@@ -1,0 +1,86 @@
+import * as fs from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-089-move-memory-tree-out-of-v3");
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === "ENOENT"
+  );
+}
+
+/**
+ * Move `<workspace>/memory/<fromRel>` to `<workspace>/memory/<toRel>` when the
+ * source exists and the destination does not. Idempotent: a missing source is a
+ * no-op (already migrated, or never created), and an existing destination is
+ * left untouched (we never clobber). Both directions go through here so `run`
+ * and `down` share the same safety checks.
+ */
+function moveMemorySubdir(
+  workspaceDir: string,
+  fromRel: string,
+  toRel: string,
+): void {
+  const memoryDir = join(workspaceDir, "memory");
+  const src = join(memoryDir, fromRel);
+  const dest = join(memoryDir, toRel);
+  try {
+    if (!fs.existsSync(src)) return;
+    if (fs.existsSync(dest)) {
+      log.warn(
+        { src, dest },
+        "Both source and destination tree dirs exist; leaving in place for manual resolution",
+      );
+      return;
+    }
+    fs.mkdirSync(dirname(dest), { recursive: true });
+    fs.renameSync(src, dest);
+    log.info({ src, dest }, "Moved memory tree directory");
+  } catch (err) {
+    if (isNotFoundError(err)) return;
+    log.warn({ err, src, dest }, "Failed to move memory tree directory");
+    throw err;
+  }
+}
+
+/** Remove `<workspace>/memory/v3` if it is now an empty wrapper (the tree was
+ *  its only child). Best-effort — a non-empty or missing dir is left alone. */
+function removeEmptyV3Wrapper(workspaceDir: string): void {
+  const v3Dir = join(workspaceDir, "memory", "v3");
+  try {
+    if (fs.existsSync(v3Dir) && fs.readdirSync(v3Dir).length === 0) {
+      fs.rmdirSync(v3Dir);
+    }
+  } catch {
+    // Non-fatal: leaving an empty memory/v3 wrapper is harmless.
+  }
+}
+
+/**
+ * Relocate the v3 memory tree from `memory/v3/tree` to `memory/tree`.
+ *
+ * The tree is a DAG overlay over the flat `memory/concepts/` pages and is now a
+ * top-level sibling of `concepts/` (matching the storage design), no longer
+ * nested under a `v3/` wrapper. `getTreeDir` reads `memory/tree` after this
+ * change, so any pre-existing hand-authored tree must move with it.
+ */
+export const moveMemoryTreeOutOfV3Migration: WorkspaceMigration = {
+  id: "089-move-memory-tree-out-of-v3",
+  description: "Relocate the v3 memory tree from memory/v3/tree to memory/tree",
+  retryFailedCheckpoint: true,
+
+  run(workspaceDir: string): void {
+    moveMemorySubdir(workspaceDir, join("v3", "tree"), "tree");
+    removeEmptyV3Wrapper(workspaceDir);
+  },
+
+  down(workspaceDir: string): void {
+    moveMemorySubdir(workspaceDir, "tree", join("v3", "tree"));
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -86,6 +86,7 @@ import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "./085-memory-v2-bm
 import { revertStaleGeminiMisRewritesMigration } from "./086-revert-stale-gemini-mis-rewrites.js";
 import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanced-profile.js";
 import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecate-background-conversation-override.js";
+import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -183,4 +184,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   revertStaleGeminiMisRewritesMigration,
   memoryRouterBalancedProfileMigration,
   deprecateBackgroundConversationOverrideMigration,
+  moveMemoryTreeOutOfV3Migration,
 ];


### PR DESCRIPTION
## Summary
- Relocate the v3 DAG tree overlay from `memory/v3/tree/` to `memory/tree/` — a top-level sibling of `memory/concepts/`, matching the storage-design diagram. `getTreeDir` now returns `memory/tree`.
- Update every on-disk-path reference: node store + types doc, the consolidation prompt (which tells the assistant where to author nodes), CLI help text, and tests.
- Add **workspace migration 089** to move any existing `memory/v3/tree` → `memory/tree` on startup (idempotent, never clobbers an existing `memory/tree`, drops the now-empty `memory/v3` wrapper; `down()` reverses it). This relocates a partially-authored tree automatically.

Unchanged on purpose: the route/CLI surface (`memory v3 tree`, `memory/v3/tree:POST`) and the `src/memory/v3/` source namespace — those track the feature version, not the disk path. The `.v3-state` consolidation-lock dir is also left as-is.

## Test plan
- [x] `bun test` migration 089 (move/idempotent/no-op/no-clobber/down) + tree-store + consolidation-job (83 pass)
- [x] `bunx tsc --noEmit`, `bun run lint` clean