### PR TITLE
feat(web/chat): redesign disk pressure banners

### DIFF
--- a/apps/web/src/assistant/api.ts
+++ b/apps/web/src/assistant/api.ts
@@ -67,7 +67,7 @@ export type GetHealthzResult =
   | { ok: true; status: number; data: AssistantHealthz }
   | { ok: false; status: number; error: Record<string, unknown> };
 
-export type DiskPressureState = "disabled" | "ok" | "critical" | "unknown";
+export type DiskPressureState = "disabled" | "ok" | "warning" | "critical" | "unknown";
 
 export type DiskPressureBlockedCapability =
   | "agent-turns"

--- a/apps/web/src/assistant/disk-pressure.ts
+++ b/apps/web/src/assistant/disk-pressure.ts
@@ -2,6 +2,7 @@ import type { DiskPressureStatus } from "@/assistant/api.js";
 
 export type DiskPressureMonitorMode =
   | "inactive"
+  | "warning"
   | "acknowledgement-required"
   | "cleanup";
 

--- a/apps/web/src/assistant/disk-pressure.ts
+++ b/apps/web/src/assistant/disk-pressure.ts
@@ -35,10 +35,17 @@ export function requiresDiskPressureAcknowledgement(
   );
 }
 
+function isDiskPressureWarning(
+  status: DiskPressureStatus | null | undefined,
+): boolean {
+  return Boolean(status?.enabled && status.state === "warning");
+}
+
 export function shouldShowDiskPressureBanner(
   status: DiskPressureStatus | null | undefined,
 ): boolean {
   return (
+    isDiskPressureWarning(status) ||
     requiresDiskPressureAcknowledgement(status) ||
     isDiskPressureCleanupActive(status)
   );
@@ -53,6 +60,10 @@ export function getDiskPressureMonitorMode(
 
   if (isDiskPressureCleanupActive(status)) {
     return "cleanup";
+  }
+
+  if (isDiskPressureWarning(status)) {
+    return "warning";
   }
 
   return "inactive";

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -19,7 +19,7 @@
  */
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
+import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ChatBody } from "@/domains/chat/components/chat-body.js";
 import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
@@ -984,10 +984,33 @@ export function ChatRouteContent({
   // Disk pressure banner
   // -------------------------------------------------------------------------
 
+  const [warningDismissed, setWarningDismissed] = useState(() => {
+    if (!assistantId) return false;
+    return localStorage.getItem(`disk-pressure-warning-dismissed-${assistantId}`) === "true";
+  });
+
+  const dismissWarning = useCallback(() => {
+    if (!assistantId) return;
+    localStorage.setItem(`disk-pressure-warning-dismissed-${assistantId}`, "true");
+    setWarningDismissed(true);
+  }, [assistantId]);
+
+  // Reset dismiss when state escalates to critical or drops below warning
+  useEffect(() => {
+    const st = diskPressure.status?.state;
+    if (st && st !== "warning" && warningDismissed) {
+      if (assistantId) {
+        localStorage.removeItem(`disk-pressure-warning-dismissed-${assistantId}`);
+      }
+      setWarningDismissed(false);
+    }
+  }, [diskPressure.status?.state, warningDismissed, assistantId]);
+
   const renderDiskPressureBanner = useCallback((): ReactNode => {
     if (!diskPressure.status) return null;
     const mode = diskPressure.mode === "inactive" ? null : (diskPressure.mode as DiskPressureBannerMode | null);
     if (!mode) return null;
+    if (mode === "warning" && warningDismissed) return null;
     return (
       <DiskPressureBanner
         status={diskPressure.status}
@@ -995,14 +1018,14 @@ export function ChatRouteContent({
         isAcknowledging={diskPressure.isAcknowledgingDiskPressure}
         acknowledgeError={diskPressure.diskPressureAcknowledgeError?.message ?? null}
         onAcknowledge={() => void diskPressure.acknowledgeDiskPressure()}
-        onDismissWarning={() => {/* TODO: localStorage dismiss */}}
+        onDismissWarning={dismissWarning}
         onReviewWorkspaceData={() => void navigate(routes.workspace)}
         // Only platform-hosted assistants (kind === "active") have a billing plan to upgrade.
         // No dedicated hosting-topology store exists yet, so we read from the assistantState prop.
         onUpgradeStorage={assistantState.kind === "active" ? () => void navigate(`${routes.settings.billing}?adjust_plan=1`) : null}
       />
     );
-  }, [diskPressure, navigate, assistantState.kind]);
+  }, [diskPressure, navigate, assistantState.kind, warningDismissed, dismissWarning]);
 
   // -------------------------------------------------------------------------
   // Billing composer banner

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -995,7 +995,6 @@ export function ChatRouteContent({
         isAcknowledging={diskPressure.isAcknowledgingDiskPressure}
         acknowledgeError={diskPressure.diskPressureAcknowledgeError?.message ?? null}
         onAcknowledge={() => void diskPressure.acknowledgeDiskPressure()}
-        onReviewDiskUsage={handleReviewDiskUsage}
         onDismissWarning={() => {/* TODO: localStorage dismiss */}}
         onReviewWorkspaceData={() => void navigate(routes.workspace)}
         // Only platform-hosted assistants (kind === "active") have a billing plan to upgrade.
@@ -1003,7 +1002,7 @@ export function ChatRouteContent({
         onUpgradeStorage={assistantState.kind === "active" ? () => void navigate(`${routes.settings.billing}?adjust_plan=1`) : null}
       />
     );
-  }, [diskPressure, handleReviewDiskUsage, navigate]);
+  }, [diskPressure, navigate, assistantState.kind]);
 
   // -------------------------------------------------------------------------
   // Billing composer banner

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -422,7 +422,7 @@ export function ChatRouteContent({
   setTranscriptPagination: _setTranscriptPagination,
   setShowAddCreditsModal,
   diskPressure,
-  handleReviewDiskUsage,
+  handleReviewDiskUsage: _handleReviewDiskUsage,
   nudges,
   attachments,
   voice,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -996,9 +996,14 @@ export function ChatRouteContent({
         acknowledgeError={diskPressure.diskPressureAcknowledgeError?.message ?? null}
         onAcknowledge={() => void diskPressure.acknowledgeDiskPressure()}
         onReviewDiskUsage={handleReviewDiskUsage}
+        onDismissWarning={() => {/* TODO: localStorage dismiss */}}
+        onReviewWorkspaceData={() => void navigate(routes.workspace)}
+        // Only platform-hosted assistants (kind === "active") have a billing plan to upgrade.
+        // No dedicated hosting-topology store exists yet, so we read from the assistantState prop.
+        onUpgradeStorage={assistantState.kind === "active" ? () => void navigate(`${routes.settings.billing}?adjust_plan=1`) : null}
       />
     );
-  }, [diskPressure, handleReviewDiskUsage]);
+  }, [diskPressure, handleReviewDiskUsage, navigate]);
 
   // -------------------------------------------------------------------------
   // Billing composer banner

--- a/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
+++ b/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
@@ -15,7 +15,6 @@ export interface DiskPressureBannerProps {
   isAcknowledging?: boolean;
   acknowledgeError?: string | null;
   onAcknowledge: () => void;
-  onReviewDiskUsage: () => void;
   onDismissWarning?: () => void;
   onReviewWorkspaceData?: () => void;
   onUpgradeStorage?: (() => void) | null;
@@ -28,15 +27,12 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
     isAcknowledging = false,
     acknowledgeError,
     onAcknowledge,
-    onReviewDiskUsage,
     onDismissWarning,
     onReviewWorkspaceData,
     onUpgradeStorage,
   } = props;
   const [showAcknowledgeModal, setShowAcknowledgeModal] = useState(false);
   const formattedUsage = formatDiskPressureUsage(status);
-  const usagePrefix =
-    formattedUsage === "Unknown" ? null : `Current usage: ${formattedUsage}. `;
 
   if (mode === "warning") {
     const usagePercent = status.usagePercent ?? 0;

--- a/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
+++ b/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
@@ -1,12 +1,13 @@
 
-import { HardDrive } from "lucide-react";
+import { useState } from "react";
+import { AlertTriangle, HardDrive } from "lucide-react";
 
-import { Button } from "@vellum/design-library";
+import { Button, Modal } from "@vellum/design-library";
 import { Notice } from "@vellum/design-library";
 import type { DiskPressureStatus } from "@/assistant/api.js";
 import { formatDiskPressureUsage } from "@/assistant/disk-pressure.js";
 
-export type DiskPressureBannerMode = "acknowledgement-required" | "cleanup";
+export type DiskPressureBannerMode = "warning" | "acknowledgement-required" | "cleanup";
 
 export interface DiskPressureBannerProps {
   status: DiskPressureStatus;
@@ -15,6 +16,9 @@ export interface DiskPressureBannerProps {
   acknowledgeError?: string | null;
   onAcknowledge: () => void;
   onReviewDiskUsage: () => void;
+  onDismissWarning?: () => void;
+  onReviewWorkspaceData?: () => void;
+  onUpgradeStorage?: (() => void) | null;
 }
 
 export function DiskPressureBanner(props: DiskPressureBannerProps) {
@@ -25,76 +29,217 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
     acknowledgeError,
     onAcknowledge,
     onReviewDiskUsage,
+    onDismissWarning,
+    onReviewWorkspaceData,
+    onUpgradeStorage,
   } = props;
+  const [showAcknowledgeModal, setShowAcknowledgeModal] = useState(false);
   const formattedUsage = formatDiskPressureUsage(status);
   const usagePrefix =
     formattedUsage === "Unknown" ? null : `Current usage: ${formattedUsage}. `;
 
+  if (mode === "warning") {
+    const usagePercent = status.usagePercent ?? 0;
+
+    return (
+      <Notice
+        tone="warning"
+        title="Storage is running low"
+        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        onDismiss={onDismissWarning}
+        className="p-4"
+        data-testid="disk-pressure-banner"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--surface-active)]">
+              <div
+                className="h-full rounded-full transition-[width] duration-300"
+                style={{
+                  width: `${usagePercent}%`,
+                  backgroundColor: "var(--system-mid-strong)",
+                }}
+              />
+            </div>
+            <span className="text-body-medium-default shrink-0 tabular-nums text-[color:var(--system-mid-strong)]">
+              {formattedUsage}
+            </span>
+          </div>
+          <p className="m-0">
+            Your assistant will enter a locked state if it runs out of storage.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {onReviewWorkspaceData && (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={onReviewWorkspaceData}
+              >
+                Review Workspace Data
+              </Button>
+            )}
+            {onUpgradeStorage && (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={onUpgradeStorage}
+              >
+                Upgrade Storage
+              </Button>
+            )}
+          </div>
+        </div>
+      </Notice>
+    );
+  }
+
   if (mode === "cleanup") {
+    const cleanupPercent = status.usagePercent ?? 0;
+
     return (
       <Notice
         tone="warning"
         title="Cleanup mode is active"
         icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
-        actions={
-          <Button
-            variant="outlined"
-            size="regular"
-            onClick={onReviewDiskUsage}
-          >
-            Review storage
-          </Button>
-        }
         className="p-4"
         data-testid="disk-pressure-banner"
       >
-        {usagePrefix}
-        Background processes and trusted-contact messages remain blocked until
-        storage is freed.
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--surface-active)]">
+              <div
+                className="h-full rounded-full transition-[width] duration-300"
+                style={{
+                  width: `${cleanupPercent}%`,
+                  backgroundColor: "var(--system-mid-strong)",
+                }}
+              />
+            </div>
+            <span className="text-body-medium-default shrink-0 tabular-nums text-[color:var(--system-mid-strong)]">
+              {formattedUsage}
+            </span>
+          </div>
+          <p className="m-0">
+            Prompt your assistant to free up space before it runs out and enters a locked state.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {onReviewWorkspaceData && (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={onReviewWorkspaceData}
+              >
+                Review Workspace Data
+              </Button>
+            )}
+            {onUpgradeStorage && (
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={onUpgradeStorage}
+              >
+                Upgrade Storage
+              </Button>
+            )}
+          </div>
+        </div>
       </Notice>
     );
   }
 
+  const criticalPercent = status.usagePercent ?? 0;
+
   return (
-    <Notice
-      tone="error"
-      title="Storage is critically low"
-      icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
-      actions={
-        <>
-          <Button
-            variant="primary"
-            size="regular"
-            disabled={isAcknowledging}
-            onClick={onAcknowledge}
-          >
-            {isAcknowledging ? "Acknowledging..." : "Acknowledge and clean up"}
-          </Button>
-          <Button
-            variant="outlined"
-            size="regular"
-            onClick={onReviewDiskUsage}
-          >
-            Review storage
-          </Button>
-        </>
-      }
-      className="p-4"
-      data-testid="disk-pressure-banner"
-    >
-      <span>
-        {usagePrefix}
-        Background processes and trusted-contact messages are blocked until
-        storage is freed. Acknowledge to continue with cleanup tools.
-      </span>
-      {acknowledgeError ? (
-        <span
-          className="mt-2 block text-[var(--system-negative-strong)]"
-          role="alert"
-        >
-          {acknowledgeError}
-        </span>
-      ) : null}
-    </Notice>
+    <>
+      <Notice
+        tone="error"
+        title="Storage is critically low"
+        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        className="p-4"
+        data-testid="disk-pressure-banner"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--surface-active)]">
+              <div
+                className="h-full rounded-full transition-[width] duration-300"
+                style={{
+                  width: `${criticalPercent}%`,
+                  backgroundColor: "var(--system-negative-strong)",
+                }}
+              />
+            </div>
+            <span className="text-body-medium-default shrink-0 tabular-nums text-[color:var(--system-negative-strong)]">
+              {formattedUsage}
+            </span>
+          </div>
+          <p className="m-0">
+            Your assistant will enter a locked state if it runs out of storage.
+          </p>
+          {acknowledgeError ? (
+            <span
+              className="text-[var(--system-negative-strong)]"
+              role="alert"
+            >
+              {acknowledgeError}
+            </span>
+          ) : null}
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => setShowAcknowledgeModal(true)}
+            >
+              Review
+            </Button>
+          </div>
+        </div>
+      </Notice>
+
+      <Modal.Root
+        open={showAcknowledgeModal}
+        onOpenChange={(open) => {
+          if (!open) setShowAcknowledgeModal(false);
+        }}
+      >
+        <Modal.Content size="sm">
+          <Modal.Header>
+            <Modal.Title icon={AlertTriangle}>
+              Storage is critically low
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Modal.Description>
+              Your assistant will enter a locked state if it runs out of
+              storage. You should either prompt your assistant to free up space
+              or increase your storage.
+            </Modal.Description>
+          </Modal.Body>
+          <Modal.Footer>
+            {onUpgradeStorage && (
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  setShowAcknowledgeModal(false);
+                  onUpgradeStorage();
+                }}
+              >
+                Upgrade Storage
+              </Button>
+            )}
+            <Button
+              variant="primary"
+              disabled={isAcknowledging}
+              onClick={() => {
+                onAcknowledge();
+                setShowAcknowledgeModal(false);
+              }}
+            >
+              {isAcknowledging ? "Acknowledging..." : "Acknowledge"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </>
   );
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6744,6 +6744,7 @@ paths:
                         enum:
                           - disabled
                           - ok
+                          - warning
                           - critical
                           - unknown
                       locked:
@@ -6829,6 +6830,7 @@ paths:
                         enum:
                           - disabled
                           - ok
+                          - warning
                           - critical
                           - unknown
                       locked:
@@ -6930,6 +6932,7 @@ paths:
                         enum:
                           - disabled
                           - ok
+                          - warning
                           - critical
                           - unknown
                       locked:

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -6,6 +6,7 @@ import { cancelBackgroundTools } from "../tools/background-tool-registry.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 
+export const DISK_PRESSURE_WARNING_THRESHOLD_PERCENT = 80;
 export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
 export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
 export const DISK_PRESSURE_OVERRIDE_CONFIRMATION = "I understand the risks";
@@ -15,7 +16,7 @@ export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
   "remote-ingress",
 ] as const;
 
-export type DiskPressureState = "disabled" | "ok" | "critical" | "unknown";
+export type DiskPressureState = "disabled" | "ok" | "warning" | "critical" | "unknown";
 
 export type DiskPressureBlockedCapability =
   (typeof DISK_PRESSURE_BLOCKED_CAPABILITIES)[number];
@@ -229,11 +230,22 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
     (usageInfo.usedMb / usageInfo.totalMb) * 100,
   );
   const isCritical = usagePercent >= DISK_PRESSURE_THRESHOLD_PERCENT;
+  const isWarning = !isCritical && usagePercent >= DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
   const lastCheckedAt = new Date().toISOString();
 
-  if (!isCritical) {
+  if (!isCritical && !isWarning) {
     return replaceStatus({
       ...OPEN_STATUS,
+      usagePercent,
+      path: usageInfo.path,
+      lastCheckedAt,
+    });
+  }
+
+  if (isWarning) {
+    return replaceStatus({
+      ...OPEN_STATUS,
+      state: "warning",
       usagePercent,
       path: usageInfo.path,
       lastCheckedAt,

--- a/assistant/src/runtime/routes/disk-pressure-routes.ts
+++ b/assistant/src/runtime/routes/disk-pressure-routes.ts
@@ -11,7 +11,7 @@ import type { RouteDefinition } from "./types.js";
 
 const DiskPressureStatusSchema = z.object({
   enabled: z.boolean(),
-  state: z.enum(["disabled", "ok", "critical", "unknown"]),
+  state: z.enum(["disabled", "ok", "warning", "critical", "unknown"]),
   locked: z.boolean(),
   acknowledged: z.boolean(),
   overrideActive: z.boolean(),


### PR DESCRIPTION
## Summary

- **New warning state (80% threshold):** Amber dismissible banner with progress bar, "Review Workspace Data" and "Upgrade Storage" CTAs
- **Redesigned critical state (90% threshold):** Red banner with progress bar and "Review" CTA that opens a confirmation modal with "Acknowledge" and "Upgrade Storage" actions
- **Redesigned cleanup state (post-acknowledge):** Amber banner with progress bar, updated copy ("Prompt your assistant to free up space..."), and same workspace/upgrade CTAs
- **Platform-only upgrade CTA:** "Upgrade Storage" button only renders for platform-hosted assistants (`assistantState.kind === "active"`)

## Test plan

- [ ] Verify warning banner appears at 80%+ disk usage with dismiss X, progress bar, and both CTAs
- [ ] Verify critical banner appears at 90%+ with "Review" opening confirmation modal
- [ ] Verify modal "Acknowledge" calls the acknowledge API and transitions to cleanup mode
- [ ] Verify modal "Upgrade Storage" navigates to `/settings/billing?adjust_plan=1`
- [ ] Verify cleanup banner shows updated copy and CTAs after acknowledgement
- [ ] Verify "Upgrade Storage" CTA is hidden for self-hosted assistants
- [ ] Verify "Review Workspace Data" navigates to `/assistant/workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)