### PR TITLE
Improve credits exhausted banner copy and add auto top-ups link

### DIFF
--- a/apps/web/src/components/add-credits-modal.tsx
+++ b/apps/web/src/components/add-credits-modal.tsx
@@ -1,6 +1,6 @@
 
 import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
-import { useLocation, useSearchParams } from "react-router";
+import { Link, useLocation, useSearchParams } from "react-router";
 import { useEffect, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -156,6 +156,14 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
                 {extractCheckoutError(checkoutMutation.error)}
               </div>
             )}
+
+            <Link
+              to="/assistant/settings/billing"
+              className="text-body-small-default text-[var(--content-tertiary)] underline hover:text-[var(--content-secondary)]"
+              onClick={() => onOpenChange(false)}
+            >
+              Configure Automatic Top-Ups →
+            </Link>
           </div>
         </Modal.Body>
 

--- a/apps/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/apps/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -10,10 +10,10 @@ export function CreditsExhaustedBanner({
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your balance has run out"
+      ariaLabel="Your credit balance has run out"
       icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
-      title="Your balance has run out"
-      subtitle="Add funds to pick up where you left off."
+      title="Your credit balance has run out"
+      subtitle="Purchase additional credits to pick up where you left off."
       ctaLabel="Add Funds"
       onAction={onAddFunds}
     />


### PR DESCRIPTION
## Summary
- Updated credits exhausted banner copy: "Your credit balance has run out" / "Purchase additional credits to pick up where you left off."
- Added a "Configure Automatic Top-Ups →" link in the Add Credits modal that navigates to `/assistant/settings/billing`

## Test plan
- [ ] Trigger credits exhausted state and verify updated banner copy
- [ ] Open Add Credits modal and verify the auto top-ups link appears below the amount dropdown
- [ ] Click the link and verify it navigates to billing settings and closes the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)