### PR TITLE
Polish Share Feedback dialog UI

### DIFF
--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -520,7 +520,10 @@ export function ShareFeedbackModal({
           maxHeight: "calc(100vh - 2rem)",
         }}
       >
-        <div className="mb-4 flex items-center justify-between">
+        <div
+          className="flex items-center justify-between border-b pb-4"
+          style={{ borderColor: "var(--border-subtle)" }}
+        >
           <h2 id={titleId} className="!m-0 text-title-small text-[var(--content-default)]">
             Share Feedback
           </h2>
@@ -534,7 +537,7 @@ export function ShareFeedbackModal({
           />
         </div>
 
-        <div className={`flex flex-col gap-4 overflow-y-auto ${isSubmitting ? "pointer-events-none opacity-60" : ""}`}>
+        <div className={`flex flex-col gap-3.5 overflow-y-auto pt-4 ${isSubmitting ? "pointer-events-none opacity-60" : ""}`}>
           {shouldShowEmail && (
             <Input
               id={`${titleId}-email`}
@@ -553,9 +556,9 @@ export function ShareFeedbackModal({
             <span className="text-body-small-default text-[var(--content-secondary)]">
               Category
             </span>
-            <div className="flex flex-col gap-1.5">
+            <div className="flex gap-2">
               {REASON_OPTIONS.map((option) => (
-                <ReasonCard
+                <ReasonChip
                   key={option.value}
                   option={option}
                   isSelected={selectedReason === option.value}
@@ -577,20 +580,28 @@ export function ShareFeedbackModal({
           />
 
           {selectedReason !== "feature_request" && (
-            <div className="flex flex-wrap items-center gap-3">
-              <Toggle
-                checked={includeLogs}
-                onChange={handleToggleLogs}
-                aria-label="Include browser diagnostics"
-              />
-              <span className="text-body-medium-lighter text-[var(--content-default)]">
-                Include diagnostics
-              </span>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2.5">
+                <Toggle
+                  checked={includeLogs}
+                  onChange={handleToggleLogs}
+                  aria-label="Include browser diagnostics"
+                />
+                <span className="text-body-medium-lighter text-[var(--content-default)]">
+                  Include diagnostics
+                </span>
+                <span
+                  title="Diagnostics include browser context, assistant logs, and timestamps — never passwords or credentials."
+                  className="inline-flex h-4 w-4 items-center justify-center text-[var(--content-tertiary)]"
+                >
+                  <Info className="h-3.5 w-3.5" />
+                </span>
+              </div>
               {includeLogs && (
                 <select
                   value={logTimeRange}
                   onChange={(e) => setLogTimeRange(e.target.value as TimeRange)}
-                  className="rounded-lg border px-2 py-1 text-body-medium-lighter outline-none"
+                  className="rounded-md border px-2 py-1 text-body-small-default outline-none"
                   style={{
                     borderColor: "var(--border-base)",
                     backgroundColor: "var(--surface-base)",
@@ -604,12 +615,6 @@ export function ShareFeedbackModal({
                   ))}
                 </select>
               )}
-              <span
-                title="Diagnostics include browser context, assistant logs, and timestamps — never passwords or credentials."
-                className="inline-flex h-4 w-4 items-center justify-center text-[var(--content-secondary)]"
-              >
-                <Info className="h-3.5 w-3.5" />
-              </span>
             </div>
           )}
 
@@ -667,7 +672,10 @@ export function ShareFeedbackModal({
           )}
         </div>
 
-        <div className="mt-5 flex items-center justify-end gap-2">
+        <div
+          className="mt-4 flex items-center justify-end gap-2 border-t pt-4"
+          style={{ borderColor: "var(--border-subtle)" }}
+        >
           {isSubmitting ? (
             <span className="inline-flex items-center gap-2 text-body-medium-lighter text-[var(--content-secondary)]">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -675,7 +683,7 @@ export function ShareFeedbackModal({
             </span>
           ) : (
             <>
-              <Button variant="outlined" onClick={onClose}>
+              <Button variant="ghost" onClick={onClose}>
                 Cancel
               </Button>
               <Button
@@ -695,7 +703,7 @@ export function ShareFeedbackModal({
   );
 }
 
-function ReasonCard({
+function ReasonChip({
   option,
   isSelected,
   onSelect,
@@ -710,36 +718,23 @@ function ReasonCard({
       type="button"
       onClick={onSelect}
       aria-pressed={isSelected}
-      className="flex w-full items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors"
+      className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-left transition-colors"
       style={{
         borderColor: isSelected ? "var(--primary-base)" : "var(--border-base)",
-        borderWidth: isSelected ? 1.5 : 1,
         backgroundColor: isSelected
-          ? "color-mix(in oklab, var(--primary-base) 8%, transparent)"
-          : "var(--surface-base)",
+          ? "color-mix(in oklab, var(--primary-base) 10%, transparent)"
+          : "transparent",
       }}
     >
       <Icon
-        className="h-4 w-4 shrink-0"
+        className="h-3.5 w-3.5 shrink-0"
         style={{ color: isSelected ? "var(--primary-base)" : "var(--content-secondary)" }}
       />
-      <span className="flex-1 text-body-medium-lighter text-[var(--content-default)]">
-        {option.label}
-      </span>
       <span
-        aria-hidden
-        className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border"
-        style={{
-          borderColor: isSelected ? "var(--primary-base)" : "var(--border-base)",
-          borderWidth: 1.5,
-        }}
+        className="text-body-small-default"
+        style={{ color: isSelected ? "var(--primary-base)" : "var(--content-default)" }}
       >
-        {isSelected && (
-          <span
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: "var(--primary-base)" }}
-          />
-        )}
+        {option.label}
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary
- Convert category selector from full-width stacked cards with radio indicators to compact horizontal pill chips, freeing significant vertical space
- Add subtle border separators to header and footer for clearer visual structure
- Reorganize diagnostics row: group toggle/label/info together on the left, time range dropdown on the right
- Demote Cancel button from `outlined` to `ghost` variant for better visual hierarchy against the primary Submit button

## Original prompt
Clean up the Share Feedback dialog's visual design. The existing layout used oversized stacked category cards with redundant radio button indicators, lacked visual separation between header/body/footer sections, and had a cluttered diagnostics row where the info icon floated loose. The goal was to tighten spacing, improve hierarchy, and make the dialog feel more polished without changing any behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)