### PR TITLE
feat(memory-v3): add memory v3 simulate ad-hoc query command

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11707,6 +11707,51 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v3/simulate:
+    post:
+      operationId: memory_v3_simulate_post
+      summary: Dry-run the v3 retrieval loop against an ad-hoc query (read-only)
+      description:
+        Runs the v3 multi-lane bounded-descent retrieval loop read-only against a single synthetic turn built from
+        the supplied query plus the live (or supplied) NOW context. Returns the selected page slugs, per-lane
+        provenance, the full multi-pass descent trace, and accumulated cost. Optional passCap / lane-allowlist overrides
+        apply on top of live config. Invoked directly (not gated by memory.v3.enabled/shadow) so operators can probe v3
+        retrieval before flipping the flags; writes nothing (co-activation persistence is forced off), though each pass
+        still spends the loop's filter + gate LLM calls.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                  minLength: 1
+                nowText:
+                  type: string
+                passCap:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                lanes:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - hot
+                      - sparse
+                      - dense
+                      - tree
+                      - edges
+              required:
+                - query
+              additionalProperties: false
   /v1/memory/v3/tree:
     post:
       operationId: memory_v3_tree_post

--- a/assistant/src/cli/commands/__tests__/memory-v3-render.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3-render.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
+  MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
 } from "../../../runtime/routes/memory-v3-routes.js";
 import {
+  renderSimulation,
   renderTree,
   renderValidationReport,
   reportHasDefects,
@@ -160,5 +162,105 @@ describe("memory v3 — renderTree", () => {
     const out = renderTree(view);
     expect(out).toContain("Unreachable nodes (1):");
     expect(out).toContain("- node:floating");
+  });
+});
+
+function simResult(): MemoryV3SimulateResult {
+  return {
+    query: "what should we ship next",
+    selectedSlugs: ["page-tree", "page-hot", "page-edge"],
+    sourceBySlug: {
+      "page-hot": "hot",
+      "page-tree": "tree",
+      "page-edge": "edge",
+    },
+    trace: {
+      passes: [
+        {
+          passNumber: 1,
+          scouts: [
+            { lane: "hot", slugs: ["page-hot"] },
+            { lane: "sparse", slugs: [] },
+            { lane: "dense", slugs: ["d1", "d2"] },
+          ],
+          treeLevels: [
+            {
+              node: "",
+              considered: ["people", "frames", "objects"],
+              descended: ["people", "frames"],
+              skipped: ["objects"],
+              reasoning: "query is about planning",
+            },
+          ],
+          edgeExpansions: [{ from: "page-tree", pulled: ["page-edge"] }],
+          gate: { decision: "more", questions: ["narrow to roadmap?"] },
+        },
+        {
+          passNumber: 2,
+          scouts: [{ lane: "hot", slugs: [] }],
+          gate: { decision: "ready" },
+        },
+      ],
+    },
+    cost: { ms: 1234 },
+    failureReason: null,
+    effectiveConfig: {
+      passCap: 3,
+      lanes: { hot: true, sparse: true, dense: true, tree: true, edges: false },
+    },
+  };
+}
+
+describe("memory v3 — renderSimulation", () => {
+  test("renders query, effective config, per-pass trace, and grouped selection", () => {
+    const out = renderSimulation(simResult());
+    expect(out).toContain("Memory v3 Retrieval Simulation");
+    expect(out).toContain('Query: "what should we ship next"');
+    expect(out).toContain("passCap: 3");
+    // A disabled lane is surfaced in an `(off: …)` suffix.
+    expect(out).toContain("lanes: hot, sparse, dense, tree  (off: edges)");
+
+    expect(out).toContain("Passes: 2");
+    expect(out).toContain("Pass 1");
+    expect(out).toContain("scouts: hot=1  sparse=0  dense=2");
+    // The root tree level ("" node) prints as [root] with branch counts.
+    expect(out).toContain("[root]: considered 3, descended 2, skipped 1");
+    expect(out).toContain("→ people, frames");
+    expect(out).toContain("reason: query is about planning");
+    expect(out).toContain("edges: 1 seed(s) expanded, 1 pulled");
+    expect(out).toContain("gate: more");
+    expect(out).toContain("? narrow to roadmap?");
+    expect(out).toContain("gate: ready");
+
+    expect(out).toContain("Selected: 3 page(s)");
+    expect(out).toContain("Cost: 1234 ms");
+  });
+
+  test("groups selected slugs by provenance lane in fanout order", () => {
+    const out = renderSimulation(simResult());
+    const hotAt = out.indexOf("hot (1)");
+    const treeAt = out.indexOf("tree (1)");
+    const edgeAt = out.indexOf("edge (1)");
+    expect(hotAt).toBeGreaterThan(-1);
+    expect(treeAt).toBeGreaterThan(-1);
+    expect(edgeAt).toBeGreaterThan(-1);
+    // hot precedes tree precedes edge in SIMULATE_LANE_ORDER.
+    expect(hotAt).toBeLessThan(treeAt);
+    expect(treeAt).toBeLessThan(edgeAt);
+  });
+
+  test("renders all lanes inline when none are disabled", () => {
+    const result = simResult();
+    result.effectiveConfig.lanes.edges = true;
+    const out = renderSimulation(result);
+    expect(out).toContain("lanes: hot, sparse, dense, tree, edges");
+    expect(out).not.toContain("(off:");
+  });
+
+  test("surfaces a failure reason when the loop degraded", () => {
+    const result = simResult();
+    result.failureReason = "dense filter failed open";
+    const out = renderSimulation(result);
+    expect(out).toContain("Failure: dense filter failed open");
   });
 });

--- a/assistant/src/cli/commands/memory-v3-render.ts
+++ b/assistant/src/cli/commands/memory-v3-render.ts
@@ -9,6 +9,8 @@
  */
 
 import type {
+  DescentPass,
+  MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
 } from "../../runtime/routes/memory-v3-routes.js";
@@ -127,6 +129,123 @@ export function renderTree(view: MemoryV3TreeResult): string {
     for (const id of unreached) {
       lines.push(`  - node:${id}`);
     }
+  }
+
+  return lines.join("\n");
+}
+
+/** Canonical print order for the loop's provenance lanes. */
+const SIMULATE_LANE_ORDER = ["hot", "sparse", "dense", "tree", "edge"] as const;
+
+/** Render the effective lane toggles as a one-line `on` / restricted summary. */
+function renderEffectiveLanes(
+  lanes: MemoryV3SimulateResult["effectiveConfig"]["lanes"],
+): string {
+  const on = Object.entries(lanes)
+    .filter(([, enabled]) => enabled)
+    .map(([name]) => name);
+  const off = Object.entries(lanes)
+    .filter(([, enabled]) => !enabled)
+    .map(([name]) => name);
+  if (off.length === 0) return on.join(", ");
+  return `${on.join(", ")}  (off: ${off.join(", ")})`;
+}
+
+/** Render one pass's scout / tree / edge / gate breakdown into `lines`. */
+function renderPass(pass: DescentPass, lines: string[]): void {
+  lines.push(`Pass ${pass.passNumber}`);
+
+  if (pass.scouts && pass.scouts.length > 0) {
+    const summary = pass.scouts
+      .map((s) => `${s.lane}=${s.slugs.length}`)
+      .join("  ");
+    lines.push(`  scouts: ${summary}`);
+  }
+
+  if (pass.treeLevels && pass.treeLevels.length > 0) {
+    lines.push(`  tree: ${pass.treeLevels.length} level(s)`);
+    for (const level of pass.treeLevels) {
+      const node = level.node === "" ? "[root]" : level.node;
+      lines.push(
+        `    ${node}: considered ${level.considered.length}, descended ${level.descended.length}, skipped ${level.skipped.length}`,
+      );
+      if (level.descended.length > 0) {
+        lines.push(`      → ${level.descended.join(", ")}`);
+      }
+      if (level.reasoning.trim().length > 0) {
+        lines.push(`      reason: ${level.reasoning.trim()}`);
+      }
+    }
+  }
+
+  if (pass.edgeExpansions && pass.edgeExpansions.length > 0) {
+    const pulled = pass.edgeExpansions.reduce((n, e) => n + e.pulled.length, 0);
+    lines.push(
+      `  edges: ${pass.edgeExpansions.length} seed(s) expanded, ${pulled} pulled`,
+    );
+  }
+
+  if (pass.gate) {
+    lines.push(`  gate: ${pass.gate.decision}`);
+    for (const q of pass.gate.questions ?? []) {
+      lines.push(`    ? ${q}`);
+    }
+  }
+}
+
+/**
+ * Render a {@link MemoryV3SimulateResult} into a query echo, effective config,
+ * per-pass descent breakdown, and the final selection grouped by provenance
+ * lane (in fanout order). Mirrors the grouped layout of `memory v2 simulate`.
+ */
+export function renderSimulation(result: MemoryV3SimulateResult): string {
+  const lines: string[] = [
+    "Memory v3 Retrieval Simulation",
+    "==============================",
+    `Query: ${JSON.stringify(result.query)}`,
+    "",
+    "Config (effective):",
+    `  passCap: ${result.effectiveConfig.passCap}`,
+    `  lanes: ${renderEffectiveLanes(result.effectiveConfig.lanes)}`,
+    "",
+  ];
+
+  const passes = result.trace.passes;
+  lines.push(`Passes: ${passes.length || "none"}`);
+  for (const pass of passes) {
+    lines.push("");
+    renderPass(pass, lines);
+  }
+  lines.push("");
+
+  lines.push(`Selected: ${result.selectedSlugs.length} page(s)`);
+  const grouped = new Map<string, string[]>();
+  for (const slug of result.selectedSlugs) {
+    const lane = result.sourceBySlug[slug] ?? "unknown";
+    const bucket = grouped.get(lane) ?? [];
+    bucket.push(slug);
+    grouped.set(lane, bucket);
+  }
+  const laneRank = (lane: string): number => {
+    const i = SIMULATE_LANE_ORDER.indexOf(
+      lane as (typeof SIMULATE_LANE_ORDER)[number],
+    );
+    return i === -1 ? SIMULATE_LANE_ORDER.length : i;
+  };
+  const lanes = [...grouped.keys()].sort((a, b) => laneRank(a) - laneRank(b));
+  for (const lane of lanes) {
+    const slugs = grouped.get(lane)!;
+    lines.push(`  ${lane} (${slugs.length})`);
+    for (const slug of slugs) {
+      lines.push(`    - ${slug}`);
+    }
+  }
+
+  if (result.cost.ms !== undefined) {
+    lines.push("", `Cost: ${result.cost.ms} ms`);
+  }
+  if (result.failureReason) {
+    lines.push(`Failure: ${result.failureReason}`);
   }
 
   return lines.join("\n");

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -11,25 +11,33 @@
  *     any defect is found so it is scriptable as a check.
  *   - `tree` — print the tree as an indented outline rooted at the tree root,
  *     marking shared-DAG re-entries.
+ *   - `simulate` — dry-run the v3 retrieval loop against an ad-hoc query and
+ *     print the per-pass descent trace plus the lane-grouped selection.
  *
- * Both are read-only: they mutate nothing and run no LLM. `--json` emits the
- * raw daemon payload for either subcommand.
+ * All are read-only: they mutate nothing. `validate`/`tree` run no LLM;
+ * `simulate` invokes the loop (filter + gate LLM calls) but persists nothing.
+ * `--json` emits the raw daemon payload for any subcommand.
  */
 
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type {
+  MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
 } from "../../runtime/routes/memory-v3-routes.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import {
+  renderSimulation,
   renderTree,
   renderValidationReport,
   reportHasDefects,
 } from "./memory-v3-render.js";
+
+/** Valid lane names accepted by `--lanes` (matches memory.v3.lanes keys). */
+const V3_LANE_NAMES = ["hot", "sparse", "dense", "tree", "edges"] as const;
 
 export function registerMemoryV3Command(program: Command): void {
   // Reuse an existing `memory` parent if a sibling registrar (e.g. v2)
@@ -59,7 +67,8 @@ mutate nothing and run no LLM.
 Examples:
   $ assistant memory v3 validate
   $ assistant memory v3 tree
-  $ assistant memory v3 tree --json | jq '.nodes | length'`,
+  $ assistant memory v3 tree --json | jq '.nodes | length'
+  $ assistant memory v3 simulate -q "what should we ship next"`,
       );
 
       // ── validate ──────────────────────────────────────────────────────────
@@ -156,6 +165,114 @@ Examples:
 
           log.info(renderTree(view));
         });
+
+      // ── simulate ────────────────────────────────────────────────────────────
+
+      v3.command("simulate")
+        .description(
+          "Dry-run the v3 retrieval loop against an ad-hoc query (read-only)",
+        )
+        .requiredOption(
+          "-q, --query <text>",
+          "User query to run a single synthetic retrieval turn against",
+        )
+        .option(
+          "--pass-cap <n>",
+          "Override memory.v3.passCap for this run (positive integer)",
+        )
+        .option(
+          "--lanes <list>",
+          `Restrict to a comma-separated allowlist of lanes (others off): ${V3_LANE_NAMES.join(", ")}`,
+        )
+        .option("--json", "Emit raw JSON instead of a formatted report")
+        .addHelpText(
+          "after",
+          `
+Runs the v3 multi-lane bounded-descent loop read-only against the live page
+index + tree DAG, building a single synthetic turn from the query plus the live
+NOW context. Prints the per-pass descent trace (scouts / tree levels / edge
+expansions / gate verdict) and the final selection grouped by provenance lane.
+
+The loop is invoked directly — it does NOT require memory.v3.enabled or
+memory.v3.shadow, so you can probe v3 retrieval before the flags flip. Writes
+nothing (co-activation persistence is forced off), but each pass still spends
+the loop's dense-filter + gate LLM calls, so pass-cap is the cost knob.
+
+Examples:
+  $ assistant memory v3 simulate -q "what should we ship next"
+  $ assistant memory v3 simulate -q "..." --lanes tree,edges
+  $ assistant memory v3 simulate -q "..." --pass-cap 1 --json | jq '.selectedSlugs'`,
+        )
+        .action(
+          async (opts: {
+            query: string;
+            passCap?: string;
+            lanes?: string;
+            json?: boolean;
+          }) => {
+            let passCap: number | undefined;
+            if (opts.passCap !== undefined) {
+              const parsed = Number(opts.passCap);
+              if (!Number.isInteger(parsed) || parsed < 1) {
+                log.error(
+                  `--pass-cap must be a positive integer (got "${opts.passCap}")`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              passCap = parsed;
+            }
+
+            let lanes: string[] | undefined;
+            if (opts.lanes !== undefined) {
+              const requested = opts.lanes
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0);
+              const invalid = requested.filter(
+                (l) =>
+                  !V3_LANE_NAMES.includes(l as (typeof V3_LANE_NAMES)[number]),
+              );
+              if (invalid.length > 0) {
+                log.error(
+                  `--lanes contains unknown lane(s): ${invalid.join(", ")}. Valid: ${V3_LANE_NAMES.join(", ")}`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              if (requested.length === 0) {
+                log.error("--lanes must list at least one lane");
+                process.exitCode = 1;
+                return;
+              }
+              lanes = requested;
+            }
+
+            const result = await cliIpcCall<MemoryV3SimulateResult>(
+              "memory_v3_simulate",
+              {
+                body: {
+                  query: opts.query,
+                  ...(passCap !== undefined ? { passCap } : {}),
+                  ...(lanes !== undefined ? { lanes } : {}),
+                },
+              },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to simulate v3 retrieval");
+              process.exitCode = 1;
+              return;
+            }
+
+            const payload = result.result!;
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+            log.info(renderSimulation(payload));
+          },
+        );
     },
   });
 }

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -489,6 +489,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/now-text:GET", scopes: ["settings.read"] },
   { endpoint: "memory/v3/validate:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v3/tree:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v3/simulate:POST", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -19,11 +19,34 @@
 
 import { z } from "zod";
 
+import { loadConfig } from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getDb } from "../../memory/db-connection.js";
+import type {
+  RetrievalCost,
+  RetrievalInput,
+} from "../../memory/v2/harness/retriever.js";
+import type { DescentTrace } from "../../memory/v2/harness/trace.js";
+import { loadNowText } from "../../memory/v2/now-text.js";
+import { runRetrievalLoop } from "../../memory/v3/loop.js";
 import { getTreeIndex } from "../../memory/v3/tree-index.js";
 import type { TreeValidationReport } from "../../memory/v3/validate.js";
 import { validateTree } from "../../memory/v3/validate.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// Re-export the loop trace/cost shapes so the CLI renderer can import them from
+// this route module (type-only) without reaching across the
+// `cli/no-daemon-internals` boundary into `memory/v2/harness/*`.
+export type { RetrievalCost } from "../../memory/v2/harness/retriever.js";
+export type {
+  DescentPass,
+  DescentTrace,
+  EdgeExpansion,
+  GateDecision,
+  ScoutResult,
+  TreeLevel,
+} from "../../memory/v2/harness/trace.js";
 
 // ── Validate ────────────────────────────────────────────────────────────
 
@@ -89,6 +112,157 @@ async function handleTree({
   return { root: tree.root, nodes };
 }
 
+// ── Simulate ──────────────────────────────────────────────────────────────
+
+/** The five v3 retrieval lanes, in fanout order. */
+const V3_LANE_NAMES = ["hot", "sparse", "dense", "tree", "edges"] as const;
+
+const MemoryV3SimulateParams = z
+  .object({
+    /** The ad-hoc user query to route a single synthetic turn against. */
+    query: z.string().min(1, "memory.v3.simulate query must be non-empty"),
+    /**
+     * Optional `<now>` override. When omitted the live workspace NOW.md is
+     * loaded so the run exercises production-like standing context.
+     */
+    nowText: z.string().optional(),
+    /** Override `memory.v3.passCap` for this run only. */
+    passCap: z
+      .number()
+      .int("memory.v3.simulate passCap must be an integer")
+      .positive("memory.v3.simulate passCap must be positive")
+      .optional(),
+    /**
+     * Restrict the run to this allowlist of lanes (others forced off). Omit to
+     * inherit the live `memory.v3.lanes` toggles.
+     */
+    lanes: z.array(z.enum(V3_LANE_NAMES)).optional(),
+  })
+  .strict();
+
+/** The v3 lane toggle block, echoed back so the caller sees what actually ran. */
+export interface MemoryV3SimulateLanes {
+  hot: boolean;
+  sparse: boolean;
+  dense: boolean;
+  tree: boolean;
+  edges: boolean;
+}
+
+/**
+ * Wire shape for `memory_v3_simulate`. The loop's `sourceBySlug` Map is
+ * flattened to a plain object (lane label per slug); `trace`/`cost` are already
+ * JSON-serializable. `effectiveConfig` echoes the passCap + lane toggles the
+ * run actually used after overrides were applied.
+ */
+export interface MemoryV3SimulateResult {
+  query: string;
+  selectedSlugs: string[];
+  /** Per-slug provenance lane: `hot` | `sparse` | `dense` | `tree` | `edge`. */
+  sourceBySlug: Record<string, string>;
+  trace: DescentTrace;
+  cost: RetrievalCost;
+  /** Non-null when the dense filter failed open on any pass. */
+  failureReason: string | null;
+  effectiveConfig: {
+    passCap: number;
+    lanes: MemoryV3SimulateLanes;
+  };
+}
+
+/**
+ * Overlay the simulate overrides on the live config. Only the v3 passCap + lane
+ * toggles are exposed; everything else (providers, prompts, scout quotas) stays
+ * exactly as a live turn would see it. `write.coactivation` is forced off so the
+ * simulate stays strictly read-only — the loop's only persistence path is the
+ * co-activation insert, which this guarantees never fires.
+ */
+function applyV3SimulateOverrides(
+  live: AssistantConfig,
+  overrides: { passCap?: number; lanes?: ReadonlyArray<string> },
+): AssistantConfig {
+  const liveV3 = live.memory.v3;
+  const lanes = overrides.lanes
+    ? {
+        hot: overrides.lanes.includes("hot"),
+        sparse: overrides.lanes.includes("sparse"),
+        dense: overrides.lanes.includes("dense"),
+        tree: overrides.lanes.includes("tree"),
+        edges: overrides.lanes.includes("edges"),
+      }
+    : liveV3.lanes;
+  return {
+    ...live,
+    memory: {
+      ...live.memory,
+      v3: {
+        ...liveV3,
+        ...(overrides.passCap !== undefined
+          ? { passCap: overrides.passCap }
+          : {}),
+        lanes,
+        write: { ...liveV3.write, coactivation: false },
+      },
+    },
+  };
+}
+
+/**
+ * Run the v3 retrieval loop read-only against a single ad-hoc query and return
+ * its selection, per-lane provenance, and full descent trace. Mirrors the
+ * single-turn semantics of `memory_v2_simulate_router` (the query becomes the
+ * just-arrived `userMessage` of one synthetic turn) and the input-build of the
+ * v3 shadow middleware, but persists nothing.
+ *
+ * The loop is invoked directly — it is NOT gated by `memory.v3.enabled` /
+ * `.shadow` (those gates live in the shadow middleware), so operators can probe
+ * v3 retrieval while the flags are still off.
+ */
+async function handleSimulate({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV3SimulateResult> {
+  const {
+    query,
+    nowText: rawNowText,
+    passCap,
+    lanes,
+  } = MemoryV3SimulateParams.parse(body);
+
+  const config = applyV3SimulateOverrides(loadConfig(), { passCap, lanes });
+
+  const workspaceDir = getWorkspaceDir();
+  const nowText =
+    rawNowText !== undefined ? rawNowText : await loadNowText(workspaceDir);
+
+  const input: RetrievalInput = {
+    workspaceDir,
+    recentTurnPairs: [{ assistantMessage: "", userMessage: query }],
+    nowText,
+    priorEverInjected: [],
+    config,
+  };
+
+  const output = await runRetrievalLoop(input, { db: getDb() });
+
+  const sourceBySlug: Record<string, string> = {};
+  for (const [slug, lane] of output.sourceBySlug.entries()) {
+    sourceBySlug[slug] = lane;
+  }
+
+  return {
+    query,
+    selectedSlugs: output.selectedSlugs,
+    sourceBySlug,
+    trace: output.trace ?? { passes: [] },
+    cost: output.cost ?? {},
+    failureReason: output.failureReason ?? null,
+    effectiveConfig: {
+      passCap: config.memory.v3.passCap,
+      lanes: config.memory.v3.lanes,
+    },
+  };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -113,5 +287,17 @@ export const ROUTES: RouteDefinition[] = [
       "Returns the v3 tree root id plus every node and its ordered child refs (page:/node:) as a JSON-serializable projection of the in-memory TreeIndex. Read-only; the CLI uses it to print an indented tree with shared-DAG re-entries marked.",
     tags: ["memory"],
     requestBody: MemoryV3TreeParams,
+  },
+  {
+    operationId: "memory_v3_simulate",
+    method: "POST",
+    endpoint: "memory/v3/simulate",
+    handler: handleSimulate,
+    summary:
+      "Dry-run the v3 retrieval loop against an ad-hoc query (read-only)",
+    description:
+      "Runs the v3 multi-lane bounded-descent retrieval loop read-only against a single synthetic turn built from the supplied query plus the live (or supplied) NOW context. Returns the selected page slugs, per-lane provenance, the full multi-pass descent trace, and accumulated cost. Optional passCap / lane-allowlist overrides apply on top of live config. Invoked directly (not gated by memory.v3.enabled/shadow) so operators can probe v3 retrieval before flipping the flags; writes nothing (co-activation persistence is forced off), though each pass still spends the loop's filter + gate LLM calls.",
+    tags: ["memory"],
+    requestBody: MemoryV3SimulateParams,
   },
 ];


### PR DESCRIPTION
## Summary
- Add `assistant memory v3 simulate -q "<query>"` — a read-only CLI to dry-run the v3 multi-lane retrieval loop against an ad-hoc query, printing the per-pass descent trace (scouts / tree levels / edge expansions / gate verdict) and the final selection grouped by provenance lane.
- New `memory_v3_simulate` route invokes `runRetrievalLoop` directly — NOT gated by `memory.v3.enabled`/`shadow`, so v3 retrieval is probeable before the flags flip — and forces `write.coactivation` off so the run never persists. `--pass-cap` / `--lanes` overrides apply on top of live config.
- Adds the route-policy entry (`settings.read`), a CLI renderer + tests (13 pass), and regenerated `openapi.yaml`.

## Original prompt
While working toward shadow-comparing the v3 retrieval loop against the v2 router, the user asked whether any tooling existed to test retrieval queries manually. v2 already had `memory v2 simulate -q`, but v3 only had structural `validate`/`tree` commands and no way to fire an ad-hoc query at the loop. The user asked to build that ad-hoc query tool for v3 — the same lever for eyeballing whether the tree-walk picks sensible pages before wiring up the batch shadow harness.