### PR TITLE
fix(memory-v3): skip dense Qdrant query when the vector is empty

### DIFF
--- a/assistant/src/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/qdrant.test.ts
@@ -887,4 +887,40 @@ describe("memory v2 qdrant — hybrid query", () => {
     );
     expect(results).toEqual([]);
   });
+
+  test("an empty dense vector runs a sparse-only query (skips the dense channels)", async () => {
+    state.collectionExistsBeforeCreate = true;
+    // Only the two sparse channels should fire. Queue body + summary sparse hits.
+    state.queryResponses.sparse.push({
+      points: [{ score: 7, payload: { slug: "people/alice" } }],
+    });
+    state.queryResponses.sparse.push({
+      points: [{ score: 5, payload: { slug: "people/alice" } }],
+    });
+
+    const results = await hybridQueryConceptPages(
+      [],
+      { indices: [1, 2], values: [0.5, 0.5] },
+      5,
+    );
+
+    // Regression: a 0-dimension dense vector used to be forwarded verbatim,
+    // drawing a Qdrant "Vector dimension error: expected dim N, got 0" 400.
+    // It must now skip the dense channels entirely — only sparse runs.
+    const usings = state.queryCalls.map((c) => c.using).sort();
+    expect(usings).toEqual(["sparse", "summary_sparse"]);
+    expect(state.queryCalls.some((c) => c.using === "dense")).toBe(false);
+    expect(state.queryCalls.some((c) => c.using === "summary_dense")).toBe(
+      false,
+    );
+
+    // The sparse hits still come back; the dense score stays undefined.
+    const alice = results.find((r) => r.slug === "people/alice");
+    expect(alice).toEqual({
+      slug: "people/alice",
+      sparseScore: 7,
+      summarySparseScore: 5,
+    });
+    expect(alice?.denseScore).toBeUndefined();
+  });
 });

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -703,6 +703,10 @@ export async function dropLegacySkillsCollection(): Promise<void> {
  * candidate set is already known so we don't waste hits on unrelated pages.
  * An empty list short-circuits to no results — the caller is asking for
  * "nothing", not "everything".
+ *
+ * An empty `dense` vector runs a sparse-only query: the dense channels are
+ * skipped rather than sent to Qdrant (a 0-dimension vector would 400). This is
+ * the dense counterpart to the `skipSparse` option.
  */
 export async function hybridQueryConceptPages(
   dense: number[],
@@ -730,6 +734,14 @@ export async function hybridQueryConceptPages(
   // Qdrant 1.13.x sparse-index crash that we've reproduced in the wild.
   const skipSparse = options?.skipSparse ?? false;
 
+  // An empty dense query vector means "sparse-only": skip the dense channels
+  // instead of sending a 0-dimension vector to Qdrant (which rejects it with a
+  // "Vector dimension error: expected dim N, got 0" 400). Symmetric to
+  // skipSparse — the fuser treats a missing dense score as a 0 contribution, so
+  // omitting the dense query is equivalent to weighting it to zero. Callers like
+  // the v3 sparse scout lane rely on this to run a BM25-only query.
+  const skipDense = dense.length === 0;
+
   const queryDense = (using: string) =>
     client.query(MEMORY_V2_COLLECTION, {
       query: dense,
@@ -756,9 +768,9 @@ export async function hybridQueryConceptPages(
   };
   const runQueries = async () =>
     Promise.all([
-      queryDense("dense"),
+      skipDense ? emptyResult : queryDense("dense"),
       skipSparse ? emptyResult : querySparse("sparse"),
-      queryDense("summary_dense"),
+      skipDense ? emptyResult : queryDense("summary_dense"),
       skipSparse ? emptyResult : querySparse("summary_sparse"),
     ]);
 


### PR DESCRIPTION
## Summary
- The v3 sparse scout lane calls `hybridQueryConceptPages([], sparse, …)` — passing an empty dense vector on purpose ("BM25-only") — but the helper had only a `skipSparse` guard and always ran the dense channel, sending a 0-dim vector to Qdrant → `Vector dimension error: expected dim 3072, got 0` (400). Since the sparse lane runs before the dense lane, this broke every v3 retrieval invocation.
- Add a `skipDense` guard symmetric to `skipSparse`: when `dense.length === 0`, skip the dense channels instead of querying with an empty vector. The fuser already treats a missing dense score as a 0 contribution, so this is a pure sparse-only query.
- Safe for the v2 live path — all v2 callers (`activation.ts`, `sim.ts`, `context-search`) pass real vectors; `context-search` already early-returns on an empty vector, confirming empty-dense was always invalid here. Adds a regression test asserting the dense channels are skipped.

## Original prompt
After shipping the new `assistant memory v3 simulate` command, the user ran it and got `Error: Bad Request`. Diagnosis traced it to a latent v3 bug the command surfaced: the v3 retrieval loop had never run end-to-end against live Qdrant (it's flag-gated off), and its sparse scout lane was sending a 0-dimension dense vector that Qdrant rejects. This ships the fix so the simulate command — and v3 retrieval generally — works.