### PR TITLE
fix(memory-v3): cap the hot scout lane to top-N by EMA

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -222,6 +222,7 @@ describe("MemoryV3ConfigSchema", () => {
       breadthBudget: 6,
       maxDepth: 6,
       denseQuota: { activeDomain: 30, offDomain: 8 },
+      hotLimit: 50,
       lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
       ks: [5, 10, 25, 50],
       write: {

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -452,6 +452,14 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Dense-lane candidate quotas split between the active domain and off-domain exploration.",
       ),
+    hotLimit: z
+      .number({ error: "memory.v3.hotLimit must be a number" })
+      .int("memory.v3.hotLimit must be an integer")
+      .positive("memory.v3.hotLimit must be positive")
+      .default(50)
+      .describe(
+        "Top-N cap on the hot scout lane, ranked by injection-frequency EMA. Hot hits are sticky (kept past the gate), so this bounds how many always-on pages the lane forces into the selection. Without a cap a mature corpus — where nearly every page has been injected at some point — surfaces the entire corpus.",
+      ),
     lanes: z
       .object({
         hot: z
@@ -532,6 +540,7 @@ export const MemoryV3ConfigSchema = z
     breadthBudget: 6,
     maxDepth: 6,
     denseQuota: { activeDomain: 30, offDomain: 8 },
+    hotLimit: 50,
     lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
     ks: [5, 10, 25, 50],
     write: {

--- a/assistant/src/memory/v3/__tests__/scouts.test.ts
+++ b/assistant/src/memory/v3/__tests__/scouts.test.ts
@@ -96,6 +96,7 @@ function makeInput(opts?: {
   nowText?: string;
   lanes?: Partial<Lanes>;
   denseQuota?: { activeDomain: number; offDomain: number };
+  hotLimit?: number;
   signal?: AbortSignal;
 }): RetrievalInput {
   const lanes = {
@@ -111,6 +112,7 @@ function makeInput(opts?: {
       v3: {
         lanes,
         denseQuota: opts?.denseQuota ?? { activeDomain: 30, offDomain: 8 },
+        hotLimit: opts?.hotLimit ?? 50,
       },
     },
   } as unknown as RetrievalInput["config"];
@@ -161,6 +163,28 @@ describe("runScouts — hot lane", () => {
     expect(hot?.slugs).toEqual(["people/alice", "work/proj"]);
     expect(hot?.scoreBySlug).toEqual({ "people/alice": 0.9, "work/proj": 0.2 });
     expect([...sticky].sort()).toEqual(["people/alice", "work/proj"]);
+  });
+
+  test("caps the hot lane to the top hotLimit by EMA", async () => {
+    pageSlugs = ["a", "b", "c", "d"];
+    injectionScores = new Map([
+      ["a", 0.9],
+      ["b", 0.7],
+      ["c", 0.5],
+      ["d", 0.3],
+    ]);
+
+    const { scouts, sticky } = await runScouts(
+      makeInput({ lanes: { sparse: false, dense: false }, hotLimit: 2 }),
+      DEPS,
+    );
+
+    // Only the top-2 by EMA survive the cap; the long tail is dropped so it
+    // can't flood the (sticky) candidate set on a mature corpus.
+    const hot = scouts.find((s) => s.lane === "hot");
+    expect(hot?.slugs).toEqual(["a", "b"]);
+    expect(hot?.scoreBySlug).toEqual({ a: 0.9, b: 0.7 });
+    expect([...sticky].sort()).toEqual(["a", "b"]);
   });
 
   test("empty corpus yields no hot ScoutResult", async () => {

--- a/assistant/src/memory/v3/scouts.ts
+++ b/assistant/src/memory/v3/scouts.ts
@@ -182,8 +182,13 @@ async function runHotLane(
   if (scores.size === 0) return null;
 
   // Slugs with no events in the read window are omitted by
-  // `computeInjectionScores`, so every entry here has score > 0.
-  const ranked = [...scores.entries()].sort((a, b) => sortByScoreDesc(a, b));
+  // `computeInjectionScores`, so every entry here has score > 0. Cap to the
+  // top `hotLimit` by EMA: hot hits are sticky (forced past the gate), so an
+  // uncapped lane on a mature corpus — where nearly every page has been
+  // injected at some point — would force the entire corpus into the selection.
+  const ranked = [...scores.entries()]
+    .sort((a, b) => sortByScoreDesc(a, b))
+    .slice(0, input.config.memory.v3.hotLimit);
   const slugs = ranked.map(([slug]) => slug);
   const scoreBySlug = Object.fromEntries(ranked);
   return { lane: "hot", slugs, scoreBySlug };


### PR DESCRIPTION
## Summary
- The v3 hot scout lane returned every page with any injection event (uncapped) and marked them all sticky, so on a mature corpus — ~1800 pages, nearly all injected at some point — it forced ~the entire corpus past the gate. `memory v3 simulate` selected 1797/~1800 pages and edge-expansion ballooned to ~68k pulls.
- Add a `memory.v3.hotLimit` knob (default 50) and cap the hot lane to the top-N by injection-frequency EMA, mirroring the bounded candidate sets the sparse/dense lanes already use. Hot hits are sticky, so bounding the lane bounds how many always-on pages it can force into the selection.
- Scoped to the hot lane only — edge-expansion is untouched (a separate follow-up). Adds a regression test for the cap + bounded sticky set; updates the schema default test.

## Original prompt
Running the new `assistant memory v3 simulate` against the live corpus surfaced degenerate retrieval — the loop returned ~1797 of ~1800 pages. Diagnosis traced it to the hot scout lane being unbounded and sticky, flooding the candidate set and compounding into edge-expansion. The user asked to cap the hot lane to a top-N by EMA via a configurable `memory.v3` knob, scoped to the hot lane only.