### PR TITLE
fix(memory-v3): make the gate and dense filter query-aware

### DIFF
--- a/assistant/src/memory/v3/__tests__/filter.test.ts
+++ b/assistant/src/memory/v3/__tests__/filter.test.ts
@@ -188,6 +188,37 @@ describe("filterDenseHits — judged keep/drop", () => {
     expect(userText).toContain("b");
   });
 
+  test("includes the just-arrived turn so the filter judges query-aware", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    await filterDenseHits({
+      input: makeInput({
+        recentTurnPairs: [
+          {
+            assistantMessage: "an earlier reply",
+            userMessage: "tell me about the people you know",
+          },
+        ],
+      }),
+      dense: denseResult(["a", "b"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+    });
+
+    const userText = calls[0].messages[0].content
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    // The filter must judge against the user's actual question, not just NOW.
+    expect(userText).toContain("<last_turn>");
+    expect(userText).toContain("tell me about the people you know");
+    expect(userText).toContain("an earlier reply");
+  });
+
   test("drops a model-kept slug outside the judged set", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -167,6 +167,37 @@ describe("runGate — ready decision", () => {
     expect(userText).toContain("b");
   });
 
+  test("includes the just-arrived turn so the selection is query-aware", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      calls,
+    );
+
+    await runGate({
+      input: makeInput({
+        recentTurnPairs: [
+          {
+            assistantMessage: "an earlier reply",
+            userMessage: "tell me about the people you know",
+          },
+        ],
+      }),
+      candidates: new Set(["a", "b"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+    });
+
+    const userText = calls[0].messages[0].content
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    // The gate must see the user's actual question, not just NOW + slugs.
+    expect(userText).toContain("<last_turn>");
+    expect(userText).toContain("tell me about the people you know");
+    expect(userText).toContain("an earlier reply");
+  });
+
   test("drops a model-selected slug outside the candidate set", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(

--- a/assistant/src/memory/v3/filter.ts
+++ b/assistant/src/memory/v3/filter.ts
@@ -42,6 +42,7 @@ import type {
 import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { ScoutResult } from "../v2/harness/trace.js";
+import { renderConversationContext } from "./prompt-context.js";
 
 const log = getLogger("memory-v3-filter");
 
@@ -194,7 +195,7 @@ export async function filterDenseHits(
     content: [
       {
         type: "text",
-        text: `<now>\n${input.nowText}\n</now>`,
+        text: renderConversationContext(input),
       },
       {
         type: "text",

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -49,6 +49,7 @@ import type {
 import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { GateDecision } from "../v2/harness/trace.js";
+import { renderConversationContext } from "./prompt-context.js";
 
 const log = getLogger("memory-v3-gate");
 
@@ -205,7 +206,7 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     content: [
       {
         type: "text",
-        text: `<now>\n${input.nowText}\n</now>`,
+        text: renderConversationContext(input),
       },
       {
         type: "text",

--- a/assistant/src/memory/v3/prompt-context.ts
+++ b/assistant/src/memory/v3/prompt-context.ts
@@ -1,0 +1,33 @@
+/**
+ * Memory v3 — shared LLM-prompt context block.
+ *
+ * Every v3 lane that makes a judgment call (the dense filter, the tree-walk
+ * descent driver, the selection gate) must see the same situational context:
+ * the standing NOW block plus the just-arrived turn being retrieved for. This
+ * is the single source of that block so the lanes can't drift apart — a lane
+ * that omits the turn judges relevance blind to what the user actually asked.
+ */
+
+import type { RetrievalInput } from "../v2/harness/retriever.js";
+
+/**
+ * Render the standing NOW context plus the just-arrived turn for a v3 lane's
+ * LLM prompt. The just-arrived user turn is the last `recentTurnPairs` entry's
+ * `userMessage`; the prior assistant reply (when present) precedes it. NOW is
+ * passed verbatim. With no turn pairs the `<last_turn>` block is empty but
+ * still emitted, so the prompt shape is stable.
+ */
+export function renderConversationContext(input: RetrievalInput): string {
+  const lines: string[] = [];
+  const lastPair = input.recentTurnPairs[input.recentTurnPairs.length - 1];
+  if (lastPair) {
+    if (lastPair.assistantMessage.trim().length > 0) {
+      lines.push(`[assistant]: ${lastPair.assistantMessage}`);
+    }
+    lines.push(`[user]: ${lastPair.userMessage}`);
+  }
+  return (
+    `<now>\n${input.nowText}\n</now>\n\n` +
+    `<last_turn>\n${lines.join("\n")}\n</last_turn>`
+  );
+}

--- a/assistant/src/memory/v3/tree-walk.ts
+++ b/assistant/src/memory/v3/tree-walk.ts
@@ -59,6 +59,7 @@ import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { ScoutResult } from "../v2/harness/trace.js";
 import type { PageIndex } from "../v2/page-index.js";
 import { composeNodeIndex } from "./index-composition.js";
+import { renderConversationContext } from "./prompt-context.js";
 import type { WalkResult } from "./traversal.js";
 import { walkTree } from "./traversal.js";
 import type { ChildRef, TreeIndex } from "./tree-index.js";
@@ -150,26 +151,6 @@ function buildDescendTool(offeredNodeIds: readonly string[]): ToolDefinition {
       required: ["descend"],
     },
   };
-}
-
-/**
- * Render the recent-turn + NOW context the descend prompt needs. The just-
- * arrived user turn is the last pair's `userMessage`; the prior assistant reply
- * (when present) precedes it. NOW is passed verbatim.
- */
-function renderConversationContext(input: RetrievalInput): string {
-  const lines: string[] = [];
-  const lastPair = input.recentTurnPairs[input.recentTurnPairs.length - 1];
-  if (lastPair) {
-    if (lastPair.assistantMessage.trim().length > 0) {
-      lines.push(`[assistant]: ${lastPair.assistantMessage}`);
-    }
-    lines.push(`[user]: ${lastPair.userMessage}`);
-  }
-  return (
-    `<now>\n${input.nowText}\n</now>\n\n` +
-    `<last_turn>\n${lines.join("\n")}\n</last_turn>`
-  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- The v3 selection gate and dense filter built their LLM prompt from only `<now>` + candidate slugs, omitting the just-arrived user turn — so the *final selection* and the dense filter judged relevance blind to what the user actually asked.
- Surfaced by `memory v3 simulate`: "tell me about all the people you know" selected 0 people pages even though the tree walk correctly descended into the `people` / `sidd-person` nodes — the query-blind gate then discarded them.
- Extract the existing `renderConversationContext` (NOW + `<last_turn>`) out of tree-walk.ts into a shared `prompt-context.ts`, and use it in the gate and filter prompts too, so all three judgment lanes see the same query context. Scouts and tree-walk already included the turn. Adds tests asserting the turn appears in both prompts.

## Original prompt
End-to-end runs of the new `memory v3 simulate` showed the loop discarding good retrieval — the tree walk found the right region for a "people" query but the final gate selected none of it. Diagnosis: the gate and dense filter build their prompts from NOW + candidate slugs only, never the just-arrived user turn, so they judge relevance blind to the question. This threads the turn into both, reusing the context shape the scouts and tree-walk already rely on.