### PR TITLE
fix(memory-v3): nudge the selection gate toward recall

### DIFF
--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -108,7 +108,10 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
           type: "array",
           items: { type: "string", enum: [...candidateSlugs] },
           description:
-            "Final ordered page slugs to inject. Choose only from the candidate set.",
+            "Final ordered page slugs to inject. Choose only from the candidate " +
+            "set. Prefer keeping a plausibly-relevant page over dropping it; for a " +
+            "list / 'all of X' / breadth request, include every candidate that " +
+            "plausibly applies rather than trimming to the most prominent few.",
         },
         questions: {
           type: "array",
@@ -198,7 +201,12 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
   const systemPrompt =
     "You are the final selection gate for a memory-retrieval loop. You are " +
     "given the candidate concept pages gathered so far for the current turn. " +
-    "Decide whether they are sufficient to answer the next reply.";
+    "Decide whether they are sufficient to answer the next reply. Lean toward " +
+    "recall: keep a candidate whenever it plausibly bears on the turn rather " +
+    "than dropping it. When the turn asks for a list, for 'all of' something, " +
+    "or for a broad answer, select every candidate that plausibly belongs — " +
+    "do not trim to only the most prominent ones. Drop a candidate only when it " +
+    "is clearly irrelevant to the turn.";
 
   const stickySlugs = [...sticky];
   const userMsg: Message = {


### PR DESCRIPTION
## Summary
- The v3 selection gate had no inclusivity guidance, so it returned only a salient subset and under-recalled — "tell me about all the people you know" selected ~15 of 45 candidate people, dropping the long tail even though all 45 were candidates.
- Add a recall-leaning nudge to the gate's system prompt and the `selected_slugs` tool description, mirroring the filter ("when in doubt, keep") and the descender ("missing a relevant subtree is worse"): keep a candidate when it plausibly bears on the turn, and for list / "all of X" / breadth requests select every plausible candidate rather than trimming to the prominent few. Still drops clearly-irrelevant candidates on focused queries.
- Prose-only — no change to the gate's control flow, schema, or sticky handling, and the filter/descender are untouched.

## Original prompt
Iterating on v3 retrieval quality via `memory v3 simulate`: after making the gate query-aware, "tell me about all the people you know" still returned only ~15 of 45 candidate people. The candidate set was complete (the tree walk collected all of them) — the gate was deliberately selective because its prompt, unlike the loop's other LLM lanes, carried no inclusivity guidance. This adds that nudge so the gate leans toward recall, especially for enumerative/breadth requests.