### PR TITLE
fix(memory-v3): make the hot scout lane a droppable candidate, not sticky

### DIFF
--- a/assistant/src/memory/v3/__tests__/scouts.test.ts
+++ b/assistant/src/memory/v3/__tests__/scouts.test.ts
@@ -8,7 +8,8 @@
  * map, so the injected `db` is an opaque sentinel the lane never dereferences.
  *
  * Coverage:
- *   - hot lane: ranks the EMA score map desc, marks every hit sticky.
+ *   - hot lane: ranks the EMA score map desc; hits are candidates but NOT
+ *     sticky (the query-aware gate may drop them).
  *   - sparse lane: reads sparseScore, ranks desc, flags near-exact hits
  *     sticky + tree-bypass.
  *   - dense lane: per-subtree quota caps off-domain hits; MMR diversifies.
@@ -147,7 +148,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("runScouts — hot lane", () => {
-  test("ranks EMA scores desc and marks every hit sticky", async () => {
+  test("ranks EMA scores desc and seeds candidates without marking them sticky", async () => {
     pageSlugs = ["people/alice", "work/proj", "essentials"];
     injectionScores = new Map([
       ["work/proj", 0.2],
@@ -162,7 +163,9 @@ describe("runScouts — hot lane", () => {
     const hot = scouts.find((s) => s.lane === "hot");
     expect(hot?.slugs).toEqual(["people/alice", "work/proj"]);
     expect(hot?.scoreBySlug).toEqual({ "people/alice": 0.9, "work/proj": 0.2 });
-    expect([...sticky].sort()).toEqual(["people/alice", "work/proj"]);
+    // Hot hits are candidates only — the query-aware gate may still drop them,
+    // so they must NOT be force-kept via sticky.
+    expect(sticky.size).toBe(0);
   });
 
   test("caps the hot lane to the top hotLimit by EMA", async () => {
@@ -180,11 +183,12 @@ describe("runScouts — hot lane", () => {
     );
 
     // Only the top-2 by EMA survive the cap; the long tail is dropped so it
-    // can't flood the (sticky) candidate set on a mature corpus.
+    // can't flood the candidate set on a mature corpus.
     const hot = scouts.find((s) => s.lane === "hot");
     expect(hot?.slugs).toEqual(["a", "b"]);
     expect(hot?.scoreBySlug).toEqual({ a: 0.9, b: 0.7 });
-    expect([...sticky].sort()).toEqual(["a", "b"]);
+    // Even the capped hot hits are not sticky.
+    expect(sticky.size).toBe(0);
   });
 
   test("empty corpus yields no hot ScoutResult", async () => {

--- a/assistant/src/memory/v3/scouts.ts
+++ b/assistant/src/memory/v3/scouts.ts
@@ -10,8 +10,9 @@
 //   - hot:    corpus-global access-frequency EMA via `computeInjectionScores`.
 //             Retriever-agnostic — v2 keeps writing `memory_v2_injection_events`,
 //             so a page the user has been touching is "hot" regardless of which
-//             retriever surfaced it. Hits are marked **sticky** so the downstream
-//             gate keeps them in the running.
+//             retriever surfaced it. Hits are seeded as ordinary **candidates**
+//             (not sticky) so the query-aware downstream gate can still drop a
+//             recency page that doesn't bear on the turn.
 //   - sparse: BM25 keyword match. Near-exact (high-score) hits are both
 //             **sticky** and **tree-bypass** — a literal keyword hit is a strong
 //             enough signal that we shouldn't make the slug earn its place by
@@ -41,7 +42,8 @@ export interface RunScoutsResult {
   scouts: ScoutResult[];
   /**
    * Slugs the downstream gate should keep in the running regardless of later
-   * scoring — hot hits and near-exact sparse hits.
+   * scoring — near-exact sparse hits. Hot-lane hits are deliberately excluded:
+   * they contribute candidates but must earn their place through the gate.
    */
   sticky: Set<string>;
   /**
@@ -113,14 +115,15 @@ export async function runScouts(
   const bypass = new Set<string>();
 
   // Hot lane — corpus-global EMA over the full slug universe. Cheap (single
-  // SQL pass) so it runs first and seeds sticky.
+  // SQL pass) so it runs first. Hot hits are seeded as ordinary candidates but
+  // NOT sticky: the EMA ranks recency/frequency, not query relevance, so
+  // force-keeping the top-N recency pages would dominate every turn with
+  // operationally-frequent pages instead of the pages that bear on the query.
+  // Letting them pass through the query-aware gate lets irrelevant ones drop.
   if (lanes.hot) {
     signal?.throwIfAborted();
     const hot = await runHotLane(input, deps);
-    if (hot) {
-      scouts.push(hot);
-      for (const slug of hot.slugs) sticky.add(slug);
-    }
+    if (hot) scouts.push(hot);
   }
 
   // Sparse lane — BM25 keyword match. Near-exact hits seed sticky + bypass.
@@ -183,9 +186,9 @@ async function runHotLane(
 
   // Slugs with no events in the read window are omitted by
   // `computeInjectionScores`, so every entry here has score > 0. Cap to the
-  // top `hotLimit` by EMA: hot hits are sticky (forced past the gate), so an
-  // uncapped lane on a mature corpus — where nearly every page has been
-  // injected at some point — would force the entire corpus into the selection.
+  // top `hotLimit` by EMA: on a mature corpus — where nearly every page has
+  // been injected at some point — an uncapped lane would flood the candidate
+  // set with the entire corpus, so keep only the strongest recency signals.
   const ranked = [...scores.entries()]
     .sort((a, b) => sortByScoreDesc(a, b))
     .slice(0, input.config.memory.v3.hotLimit);


### PR DESCRIPTION
## Summary
- The hot scout lane (`runScouts` in `assistant/src/memory/v3/scouts.ts`) no longer adds its hits to the `sticky` set; hot slugs are still pushed as a `ScoutResult` so they stay in the candidate set, but the query-aware selection gate can now drop hot pages that don't bear on the turn.
- Sparse near-exact sticky/bypass behavior is left unchanged — only the hot lane stops being sticky.
- Updated `assistant/src/memory/v3/__tests__/scouts.test.ts` so the hot-lane tests assert hot hits appear as the hot `ScoutResult`'s slugs but are NOT added to `sticky`; all other tests stay green.

## Original prompt
The hot lane surfaces the top-N pages by injection-frequency EMA (recently/frequently injected pages), and `runScouts` marked every hot hit sticky. Because the downstream selection gate force-keeps sticky slugs, the top-N recency pages were injected into every turn regardless of query relevance, crowding out the pages that actually bear on the turn. The task: make the hot lane contribute candidates but not sticky, so the now-query-aware gate can drop irrelevant recency pages, while keeping the hot `ScoutResult` so hot slugs remain candidates. Scope was strictly limited to `scouts.ts` and its test file.

## Follow-up (out of scope here)
True conversation continuity — not dropping pages that were injected on the prior turn — should be driven by `priorEverInjected`, not by the hot lane's EMA approximation. A later change should wire that signal in; this PR intentionally does not.