### PR TITLE
fix(memory-v3): bound edge-expansion seeds and fan-out

### DIFF
--- a/assistant/src/memory/v3/__tests__/edges.test.ts
+++ b/assistant/src/memory/v3/__tests__/edges.test.ts
@@ -340,3 +340,156 @@ describe("expandEdges — cycle safety", () => {
     expect([...pulled].sort()).toEqual(["bob"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Expansion bounds
+// ---------------------------------------------------------------------------
+//
+// These constants mirror the (intentionally module-private) caps in `edges.ts`.
+// The seed set handed to this lane is the union of every upstream lane's
+// candidates, so on a mature corpus it can run to thousands of slugs; expanding
+// all of them to their full neighborhood balloons the downstream gate's pool.
+// The lane caps the seeds expanded, the per-seed fan-out, and the total union.
+const MAX_SEEDS_EXPANDED = 150;
+const MAX_PULLS_PER_SEED = 32;
+const MAX_TOTAL_PULLS = 400;
+
+/** Zero-padded slug so lexical sort matches numeric order (`topics/000`..). */
+function topicSlug(domain: string, i: number): string {
+  return `${domain}/${String(i).padStart(4, "0")}`;
+}
+
+describe("expandEdges — bounds", () => {
+  test("expands at most MAX_SEEDS_EXPANDED seeds, dropping the tail", async () => {
+    // More seeds than the cap, each a 1-hop edge to its own private target.
+    const seedCount = MAX_SEEDS_EXPANDED + 50;
+    const graph: Record<string, string[]> = {};
+    const seeds: string[] = [];
+    for (let i = 0; i < seedCount; i++) {
+      const seed = topicSlug("people", i);
+      const target = topicSlug("targets", i);
+      graph[seed] = [target];
+      graph[target] = [];
+      seeds.push(seed);
+    }
+    await writeGraph(graph);
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds,
+      hops: 1,
+    });
+
+    // Only the first MAX_SEEDS_EXPANDED seeds yield an expansion entry; the
+    // 200-seed input is truncated to the cap.
+    expect(expansions).toHaveLength(MAX_SEEDS_EXPANDED);
+    expect(expansions.map((e) => e.from)).toEqual(
+      seeds.slice(0, MAX_SEEDS_EXPANDED),
+    );
+    // Each surviving seed contributes exactly its one target, so the union is
+    // one slug per expanded seed and stays under the total ceiling.
+    expect(pulled.size).toBe(MAX_SEEDS_EXPANDED);
+    expect(pulled.size).toBeLessThanOrEqual(MAX_TOTAL_PULLS);
+  });
+
+  test("caps a single hub seed's fan-out at MAX_PULLS_PER_SEED", async () => {
+    // One hub seed pointing at far more 1-hop neighbors than the per-seed cap.
+    const fanOut = MAX_PULLS_PER_SEED + 40;
+    const graph: Record<string, string[]> = {};
+    const targets: string[] = [];
+    for (let i = 0; i < fanOut; i++) {
+      const target = topicSlug("topics", i);
+      targets.push(target);
+      graph[target] = [];
+    }
+    graph["hub"] = targets;
+    await writeGraph(graph);
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["hub"],
+      hops: 1,
+    });
+
+    // The hub's neighborhood is truncated to the per-seed cap, deterministically
+    // keeping the lexicographically-first targets.
+    expect(expansions).toHaveLength(1);
+    expect(expansions[0]!.from).toBe("hub");
+    expect(expansions[0]!.pulled).toHaveLength(MAX_PULLS_PER_SEED);
+    expect(expansions[0]!.pulled).toEqual(
+      [...targets].sort().slice(0, MAX_PULLS_PER_SEED),
+    );
+    expect(pulled.size).toBe(MAX_PULLS_PER_SEED);
+  });
+
+  test("bounds the total pulled union at MAX_TOTAL_PULLS across many seeds", async () => {
+    // Enough seeds, each with a per-seed-cap-sized private fan-out, that the
+    // unbounded union would be seedCount * MAX_PULLS_PER_SEED slugs — far past
+    // the total ceiling (ceil(400/32) = 13 seeds fills it). Each seed's targets
+    // are disjoint, so nothing collapses via de-dup and the only thing holding
+    // the union down is the cap.
+    const seedCount = 20;
+    const graph: Record<string, string[]> = {};
+    const seeds: string[] = [];
+    for (let s = 0; s < seedCount; s++) {
+      const seed = topicSlug("people", s);
+      const targets: string[] = [];
+      for (let t = 0; t < MAX_PULLS_PER_SEED; t++) {
+        // Globally-unique target slug per (seed, target) pair.
+        const target = topicSlug("targets", s * MAX_PULLS_PER_SEED + t);
+        targets.push(target);
+        graph[target] = [];
+      }
+      graph[seed] = targets;
+      seeds.push(seed);
+    }
+    await writeGraph(graph);
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds,
+      hops: 1,
+    });
+
+    // The union is held at the ceiling exactly — never overshot — even though
+    // the seeds collectively reach far more slugs.
+    expect(pulled.size).toBe(MAX_TOTAL_PULLS);
+    // Every emitted expansion entry lists only slugs that made it into the
+    // bounded union, so the trace never claims an un-pulled slug.
+    for (const expansion of expansions) {
+      for (const slug of expansion.pulled) {
+        expect(pulled.has(slug)).toBe(true);
+      }
+    }
+  });
+
+  test("duplicate slugs across seeds don't waste the total budget", async () => {
+    // Two seeds, both pointing at the same shared target plus one private each.
+    // The shared slug is counted once, so the union is 3 — well under the cap,
+    // and both seeds still get a faithful expansion entry.
+    await writeGraph({
+      "people/alice": ["topics/shared", "topics/alice-only"],
+      "people/bob": ["topics/shared", "topics/bob-only"],
+      "topics/shared": [],
+      "topics/alice-only": [],
+      "topics/bob-only": [],
+    });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["people/alice", "people/bob"],
+      hops: 1,
+    });
+
+    expect([...pulled].sort()).toEqual([
+      "topics/alice-only",
+      "topics/bob-only",
+      "topics/shared",
+    ]);
+    expect(pulled.size).toBeLessThanOrEqual(MAX_TOTAL_PULLS);
+    expect(expansions).toEqual([
+      { from: "people/alice", pulled: ["topics/alice-only", "topics/shared"] },
+      { from: "people/bob", pulled: ["topics/bob-only", "topics/shared"] },
+    ]);
+  });
+});

--- a/assistant/src/memory/v3/edges.ts
+++ b/assistant/src/memory/v3/edges.ts
@@ -25,6 +25,49 @@ import type { EdgeExpansion } from "../v2/harness/trace.js";
 /** Default hop budget. The design calls for a 1–2 hop walk; 2 is the ceiling. */
 const DEFAULT_HOPS = 2;
 
+// ---------------------------------------------------------------------------
+// Expansion bounds
+// ---------------------------------------------------------------------------
+//
+// The seed set handed to this lane is the *union* of every upstream lane's
+// candidates (scouts + dense filter + tree-walk descent), so on a mature corpus
+// it can run to one-to-two-thousand slugs. Expanding all of them — each to its
+// full 1–2 hop neighborhood — pulls in tens of thousands of slugs, which inflates
+// the downstream selection gate's candidate pool toward the entire corpus and
+// drowns the high-confidence signal. The expansion is also purely structural
+// (no scoring), so a larger pool buys no precision; it only adds gate cost.
+//
+// These bounds keep the lane's output proportional to a curated neighborhood
+// rather than the corpus. They are module-level constants (mirroring
+// `LANE_QUERY_LIMIT` in `scouts.ts`) rather than config fields so the lane stays
+// self-contained — the caps protect the gate regardless of how callers compose
+// the seed union. Truncation is deterministic (sorted slugs) so a given seed
+// graph always yields the same bounded result.
+
+/**
+ * Cap on the number of distinct seeds expanded. Seeds are processed in
+ * first-seen order; once this many have been expanded the rest are dropped. The
+ * upstream lanes already rank their hits, so the earliest seeds are the most
+ * confident — truncating the long tail costs little recall.
+ */
+const MAX_SEEDS_EXPANDED = 150;
+
+/**
+ * Cap on how many slugs a single seed may contribute. A hub node in a dense
+ * curated graph can reach a large 2-hop neighborhood on its own; without this a
+ * single highly-connected seed could dominate the union. The per-seed
+ * neighborhood is truncated to its lexicographically-first slugs.
+ */
+const MAX_PULLS_PER_SEED = 32;
+
+/**
+ * Hard ceiling on the size of the unioned `pulled` set. This is the load-bearing
+ * bound: it caps the lane's contribution to the gate's pool to a few hundred
+ * slugs no matter how many seeds or how dense the graph. Once reached, no
+ * further seeds are expanded.
+ */
+const MAX_TOTAL_PULLS = 400;
+
 export interface ExpandEdgesArgs {
   workspaceDir: string;
   /** Confident seed slugs to expand from. */
@@ -89,10 +132,18 @@ function reachableMerged(
 /**
  * Expand a set of confident seed slugs to their 1–2 hop curated neighborhood.
  *
- * Each seed produces one `EdgeExpansion { from, pulled }` entry (sorted slugs
- * for deterministic output); the seed itself is never in its own `pulled`. The
- * top-level `pulled` set is the union across all seeds — a slug pulled by more
- * than one seed appears once there but in each contributing seed's expansion.
+ * Each expanded seed produces one `EdgeExpansion { from, pulled }` entry (sorted
+ * slugs for deterministic output); the seed itself is never in its own `pulled`.
+ * The top-level `pulled` set is the union across all expanded seeds — a slug
+ * pulled by more than one seed appears once there but in each contributing
+ * seed's expansion.
+ *
+ * Bounded by {@link MAX_SEEDS_EXPANDED}, {@link MAX_PULLS_PER_SEED}, and
+ * {@link MAX_TOTAL_PULLS} so a large seed union or a dense graph can't balloon
+ * the downstream gate's pool — see the bounds block above. Seeds past the count
+ * cap, or any seed reached after the union ceiling is full, are skipped entirely
+ * and get no expansion entry; every entry that is emitted lists exactly the
+ * slugs that seed contributed to the bounded union, so the trace stays faithful.
  *
  * Provider-free and read-only: the only I/O is `getEdgeIndex`, which reads
  * concept-page frontmatter from disk (and caches module-locally in v2).
@@ -113,12 +164,29 @@ export async function expandEdges(
     if (seenSeeds.has(seed)) continue;
     seenSeeds.add(seed);
 
+    // Bound the number of seeds expanded, and stop once the union is full —
+    // the remaining seeds would only inflate the gate's pool. Checked before
+    // doing any per-seed work so an oversized seed set is cheap to truncate.
+    if (seenSeeds.size > MAX_SEEDS_EXPANDED || pulled.size >= MAX_TOTAL_PULLS) {
+      break;
+    }
+
     const reachable = extraAdjacency
       ? reachableMerged(index.outgoing, extraAdjacency, seed, hops)
       : getReachable(index, seed, hops, "out");
 
-    expansions.push({ from: seed, pulled: [...reachable].sort() });
-    for (const slug of reachable) pulled.add(slug);
+    // Per-seed fan-out cap, then trim to the union's remaining headroom so the
+    // total ceiling is hard (never overshot) and the trace entry lists exactly
+    // the slugs this seed contributed to the bounded union. Sorting first keeps
+    // truncation deterministic — a hub seed always yields the same slice. Slugs
+    // already pulled by an earlier seed don't consume headroom (the union Set
+    // de-dupes), so this is a conservative upper bound on what's admitted.
+    const remaining = MAX_TOTAL_PULLS - pulled.size;
+    const perSeedCap = Math.min(MAX_PULLS_PER_SEED, remaining);
+    const seedPulled = [...reachable].sort().slice(0, perSeedCap);
+
+    expansions.push({ from: seed, pulled: seedPulled });
+    for (const slug of seedPulled) pulled.add(slug);
   }
 
   return { pulled, expansions };


### PR DESCRIPTION
## Summary
- Bound the v3 curated edge-expansion lane (`expandEdges`) with three module-level constants — `MAX_SEEDS_EXPANDED` (150), `MAX_PULLS_PER_SEED` (32), and `MAX_TOTAL_PULLS` (400) — so a large candidate union or a dense graph can't balloon the selection gate's pool.
- Per-seed neighborhoods are truncated deterministically (sorted slugs) and trimmed to the union's remaining headroom, so the total ceiling is hard (never overshot) and each emitted expansion entry lists exactly the slugs that seed contributed to the bounded union.
- Extended `edges.test.ts` with bounds tests covering the seed-count cap, the per-seed fan-out cap, the total-union ceiling, and de-dup not wasting the budget; existing coverage and de-duplication are unchanged.

## Original prompt
The edge-expansion lane did 1-2 hop curated-graph expansion over every accumulated candidate seed with no bounds. Because the seed set is the union of every upstream lane's candidates (scouts + dense filter + tree-walk descent), a mature corpus produced ~1000-1800 seeds and ~45,000-68,000 pulls, inflating the gate's candidate pool toward the entire corpus and drowning the high-confidence signal. The expansion is purely structural (no scoring), so a larger pool buys no precision — only gate cost. This change caps the seeds expanded, the per-seed fan-out, and the total pulled set so the lane's output stays proportional to a curated neighborhood rather than the corpus.