### PR TITLE
feat(memory-v3): make the filter/descent/gate system prompts configurable

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -230,6 +230,11 @@ describe("MemoryV3ConfigSchema", () => {
         consolidateIntervalMs: 3600000,
         coactivation: false,
       },
+      prompts: {
+        filter: { override: null, path: null },
+        descent: { override: null, path: null },
+        gate: { override: null, path: null },
+      },
     });
   });
 
@@ -334,6 +339,50 @@ describe("MemoryV3ConfigSchema", () => {
       write: { consolidateIntervalMs: 1800000 },
     });
     expect(parsed.write.consolidateIntervalMs).toBe(1800000);
+  });
+
+  test("parses the prompts subtree to null overrides when omitted", () => {
+    const parsed = MemoryV3ConfigSchema.parse({});
+    expect(parsed.prompts).toEqual({
+      filter: { override: null, path: null },
+      descent: { override: null, path: null },
+      gate: { override: null, path: null },
+    });
+  });
+
+  test("accepts a partial prompts override and defaults the rest", () => {
+    const parsed = MemoryV3ConfigSchema.parse({
+      prompts: { filter: { override: "custom filter prompt" } },
+    });
+    expect(parsed.prompts.filter).toEqual({
+      override: "custom filter prompt",
+      path: null,
+    });
+    // Lanes not mentioned keep their null defaults.
+    expect(parsed.prompts.descent).toEqual({ override: null, path: null });
+    expect(parsed.prompts.gate).toEqual({ override: null, path: null });
+  });
+
+  test("accepts a file path override for a prompt lane", () => {
+    const parsed = MemoryV3ConfigSchema.parse({
+      prompts: { gate: { path: "~/prompts/v3-gate.md" } },
+    });
+    expect(parsed.prompts.gate).toEqual({
+      override: null,
+      path: "~/prompts/v3-gate.md",
+    });
+  });
+
+  test("rejects a non-string prompts override", () => {
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ prompts: { filter: { override: 42 } } }),
+    ).toThrow();
+  });
+
+  test("rejects a non-string prompts path", () => {
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ prompts: { descent: { path: 7 } } }),
+    ).toThrow();
   });
 });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -390,6 +390,33 @@ export const MemoryV2ConfigSchema = z
 export type MemoryV2Config = z.infer<typeof MemoryV2ConfigSchema>;
 
 /**
+ * Per-lane system-prompt override for a v3 LLM call site. `override` is an
+ * inline prompt string (highest precedence); `path` points at a file whose
+ * contents replace the bundled prompt. Both default to `null` (use the bundled
+ * prompt). Shared by the filter, descent, and gate entries under
+ * `memory.v3.prompts`. The whole object is `.default(...)`-wrapped so an
+ * omitted lane parses to `{ override: null, path: null }`.
+ */
+const V3PromptOverrideSchema = z
+  .object({
+    override: z
+      .string({ error: "memory.v3.prompts.*.override must be a string" })
+      .nullable()
+      .default(null)
+      .describe(
+        "Optional inline system-prompt string that replaces the bundled prompt for this lane. Takes precedence over `path`. An empty or whitespace-only string is ignored (falls back to `path` / bundled).",
+      ),
+    path: z
+      .string({ error: "memory.v3.prompts.*.path must be a string" })
+      .nullable()
+      .default(null)
+      .describe(
+        "Optional path to a file whose contents replace the bundled prompt for this lane. Absolute paths are used as-is, a leading `~/` expands to the home directory, otherwise the path resolves under the workspace root. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+      ),
+  })
+  .default({ override: null, path: null });
+
+/**
  * Memory v3 (multi-lane, bounded-descent retrieval) configuration.
  *
  * Additive scaffolding only — defaults to `enabled: false` so existing
@@ -532,6 +559,26 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Memory v3 write-path configuration. All default-off scaffolding — controls whether v3 consolidation owns the shared-buffer drain + tree build. Consumed by later PRs.",
       ),
+    prompts: z
+      .object({
+        filter: V3PromptOverrideSchema.describe(
+          "Override for the dense-hit filter lane's system prompt.",
+        ),
+        descent: V3PromptOverrideSchema.describe(
+          "Override for the tree-walk descent driver's system prompt.",
+        ),
+        gate: V3PromptOverrideSchema.describe(
+          "Override for the selection gate's system prompt.",
+        ),
+      })
+      .default({
+        filter: { override: null, path: null },
+        descent: { override: null, path: null },
+        gate: { override: null, path: null },
+      })
+      .describe(
+        "Per-lane system-prompt overrides for the three v3 LLM call sites (filter, descent, gate). Each entry takes an inline `override` string (highest precedence) and/or a file `path` whose contents replace the bundled prompt; absolute paths are used as-is, a leading `~/` expands to the home directory, otherwise the path resolves under the workspace root. An empty/whitespace inline override or a missing/unreadable/empty file falls back to the bundled prompt. Lets the prompts be iterated at runtime without a rebuild/restart — mirroring `memory.v2.router.router_prompt_path`.",
+      ),
   })
   .default({
     enabled: false,
@@ -547,6 +594,11 @@ export const MemoryV3ConfigSchema = z
       enabled: false,
       consolidateIntervalMs: 3600000,
       coactivation: false,
+    },
+    prompts: {
+      filter: { override: null, path: null },
+      descent: { override: null, path: null },
+      gate: { override: null, path: null },
     },
   })
   .describe(

--- a/assistant/src/memory/v3/__tests__/filter.test.ts
+++ b/assistant/src/memory/v3/__tests__/filter.test.ts
@@ -31,6 +31,7 @@ import type {
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import type { ScoutResult } from "../../v2/harness/trace.js";
 import { filterDenseHits } from "../filter.js";
+import { FILTER_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 
 // ---------------------------------------------------------------------------
 // Helpers.
@@ -121,6 +122,17 @@ function makeInput(overrides?: Partial<RetrievalInput>): RetrievalInput {
 
 function denseResult(slugs: string[]): ScoutResult {
   return { lane: "dense", slugs };
+}
+
+/**
+ * Build a `RetrievalInput["config"]` carrying a `memory.v3.prompts.filter`
+ * inline override. The cast mirrors `makeInput`'s — the filter only reads the
+ * prompts path on config.
+ */
+function configWithFilterOverride(override: string): RetrievalInput["config"] {
+  return {
+    memory: { v3: { prompts: { filter: { override, path: null } } } },
+  } as unknown as RetrievalInput["config"];
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +304,46 @@ describe("filterDenseHits — no LLM call", () => {
 
     expect([...result.kept].sort()).toEqual(["x", "y"]);
     expect(result.trace).toEqual({ judged: [], dropped: [] });
+  });
+});
+
+describe("filterDenseHits — system prompt", () => {
+  test("uses the bundled default when no override is configured", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["a", "b"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+    });
+
+    expect(calls[0].systemPrompt).toBe(FILTER_SYSTEM_PROMPT);
+  });
+
+  test("uses the configured inline override as the system prompt", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    const override = "CUSTOM FILTER PROMPT — keep only the obvious matches.";
+    await filterDenseHits({
+      input: makeInput({ config: configWithFilterOverride(override) }),
+      dense: denseResult(["a", "b"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+    });
+
+    expect(calls[0].systemPrompt).toBe(override);
+    expect(calls[0].systemPrompt).not.toBe(FILTER_SYSTEM_PROMPT);
   });
 });
 

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../../providers/types.js";
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import { runGate } from "../gate.js";
+import { GATE_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 
 // ---------------------------------------------------------------------------
 // Helpers.
@@ -107,6 +108,17 @@ function makeInput(overrides?: Partial<RetrievalInput>): RetrievalInput {
     config: {} as unknown as RetrievalInput["config"],
     ...overrides,
   };
+}
+
+/**
+ * Build a `RetrievalInput["config"]` carrying a `memory.v3.prompts.gate`
+ * inline override. The cast mirrors `makeInput`'s — the gate only reads the
+ * prompts path on config.
+ */
+function configWithGateOverride(override: string): RetrievalInput["config"] {
+  return {
+    memory: { v3: { prompts: { gate: { override, path: null } } } },
+  } as unknown as RetrievalInput["config"];
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +322,46 @@ describe("runGate — more decision", () => {
     });
 
     expect(result.selectedSlugs).toContain("sticky-page");
+  });
+});
+
+describe("runGate — system prompt", () => {
+  test("uses the bundled default when no override is configured", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      calls,
+    );
+
+    await runGate({
+      input: makeInput(),
+      candidates: new Set(["a", "b"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+    });
+
+    expect(calls[0].systemPrompt).toBe(GATE_SYSTEM_PROMPT);
+  });
+
+  test("uses the configured inline override as the system prompt", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      calls,
+    );
+
+    const override = "CUSTOM GATE PROMPT — finalize aggressively.";
+    await runGate({
+      input: makeInput({ config: configWithGateOverride(override) }),
+      candidates: new Set(["a", "b"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+    });
+
+    expect(calls[0].systemPrompt).toBe(override);
+    expect(calls[0].systemPrompt).not.toBe(GATE_SYSTEM_PROMPT);
   });
 });
 

--- a/assistant/src/memory/v3/__tests__/system-prompts.test.ts
+++ b/assistant/src/memory/v3/__tests__/system-prompts.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for `assistant/src/memory/v3/prompts/system-prompts.ts`.
+ *
+ * Covers the override-resolution precedence and fail-open fallback shared by
+ * the three v3 lanes (filter / descent / gate):
+ *   - no config / both seams null → bundled prompt.
+ *   - inline `override` wins over `path` and bundled.
+ *   - empty / whitespace-only inline override → falls through to path/bundled.
+ *   - file `path` (absolute, `~/`, and workspace-relative) → file contents.
+ *   - missing / empty / non-regular file → bundled.
+ *
+ * Uses a real temp dir for the file-path branch; no `~/.vellum/` access, no
+ * network, no `mock.module`.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveV3SystemPrompt } from "../prompts/system-prompts.js";
+
+const BUNDLED = "BUNDLED DEFAULT PROMPT";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "v3-prompts-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("resolveV3SystemPrompt — no override", () => {
+  test("undefined config → bundled", () => {
+    expect(resolveV3SystemPrompt(BUNDLED, undefined, workspaceDir)).toBe(
+      BUNDLED,
+    );
+  });
+
+  test("both seams null → bundled", () => {
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: null },
+        workspaceDir,
+      ),
+    ).toBe(BUNDLED);
+  });
+});
+
+describe("resolveV3SystemPrompt — inline override", () => {
+  test("inline override is returned verbatim", () => {
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: "INLINE PROMPT", path: null },
+        workspaceDir,
+      ),
+    ).toBe("INLINE PROMPT");
+  });
+
+  test("inline override wins over a configured path", () => {
+    const file = join(workspaceDir, "from-file.md");
+    writeFileSync(file, "FROM FILE");
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: "INLINE WINS", path: file },
+        workspaceDir,
+      ),
+    ).toBe("INLINE WINS");
+  });
+
+  test("empty / whitespace inline override falls through to bundled", () => {
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: "   \n  ", path: null },
+        workspaceDir,
+      ),
+    ).toBe(BUNDLED);
+  });
+
+  test("empty inline override falls through to the configured path", () => {
+    const file = join(workspaceDir, "from-file.md");
+    writeFileSync(file, "FROM FILE");
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: "", path: file },
+        workspaceDir,
+      ),
+    ).toBe("FROM FILE");
+  });
+});
+
+describe("resolveV3SystemPrompt — file path", () => {
+  test("absolute path → file contents", () => {
+    const file = join(workspaceDir, "prompt.md");
+    writeFileSync(file, "ABSOLUTE FILE PROMPT");
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: file },
+        workspaceDir,
+      ),
+    ).toBe("ABSOLUTE FILE PROMPT");
+  });
+
+  test("workspace-relative path resolves under workspaceDir", () => {
+    writeFileSync(join(workspaceDir, "rel.md"), "RELATIVE FILE PROMPT");
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: "rel.md" },
+        workspaceDir,
+      ),
+    ).toBe("RELATIVE FILE PROMPT");
+  });
+
+  test("missing file → bundled (fail-open)", () => {
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: join(workspaceDir, "does-not-exist.md") },
+        workspaceDir,
+      ),
+    ).toBe(BUNDLED);
+  });
+
+  test("empty file → bundled (fail-open)", () => {
+    const file = join(workspaceDir, "empty.md");
+    writeFileSync(file, "   \n");
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: file },
+        workspaceDir,
+      ),
+    ).toBe(BUNDLED);
+  });
+
+  test("a directory path (not a regular file) → bundled (fail-open)", () => {
+    expect(
+      resolveV3SystemPrompt(
+        BUNDLED,
+        { override: null, path: workspaceDir },
+        workspaceDir,
+      ),
+    ).toBe(BUNDLED);
+  });
+});

--- a/assistant/src/memory/v3/__tests__/tree-walk.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-walk.test.ts
@@ -36,6 +36,7 @@ import type {
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import type { ScoutResult } from "../../v2/harness/trace.js";
 import type { PageIndex } from "../../v2/page-index.js";
+import { DESCENT_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 import type { ChildRef, TreeIndex } from "../tree-index.js";
 import { createDescender, deriveSeedNodes, runTreeWalk } from "../tree-walk.js";
 import type { TreeNode } from "../types.js";
@@ -134,14 +135,33 @@ function makeInput(
   overrides?: Partial<RetrievalInput> & {
     breadthBudget?: number;
     maxDepth?: number;
+    /** Inline override for `memory.v3.prompts.descent`. */
+    descentOverride?: string;
   },
 ): RetrievalInput {
   const breadthBudget = overrides?.breadthBudget ?? 8;
   const maxDepth = overrides?.maxDepth ?? 8;
   const config = {
-    memory: { v3: { breadthBudget, maxDepth } },
+    memory: {
+      v3: {
+        breadthBudget,
+        maxDepth,
+        ...(overrides?.descentOverride !== undefined
+          ? {
+              prompts: {
+                descent: { override: overrides.descentOverride, path: null },
+              },
+            }
+          : {}),
+      },
+    },
   } as unknown as RetrievalInput["config"];
-  const { breadthBudget: _b, maxDepth: _m, ...rest } = overrides ?? {};
+  const {
+    breadthBudget: _b,
+    maxDepth: _m,
+    descentOverride: _d,
+    ...rest
+  } = overrides ?? {};
   return {
     workspaceDir: "/tmp/does-not-matter",
     recentTurnPairs: [{ assistantMessage: "", userMessage: "tell me about a" }],
@@ -581,5 +601,54 @@ describe("createDescender — request shape", () => {
     expect(chosen).toEqual([]);
     expect(calls).toHaveLength(0);
     expect(reasoningByNode.get("leaf")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runTreeWalk — descent system prompt
+// ---------------------------------------------------------------------------
+
+describe("runTreeWalk — descent system prompt", () => {
+  const tree = makeTree("_root", {
+    _root: [node("a")],
+    a: [page("pa")],
+  });
+
+  test("uses the bundled default when no override is configured", async () => {
+    const pages = makePages(["pa"]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider({ _root: { descend: ["a"] } }, calls);
+
+    await runTreeWalk({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      seeds: [],
+      provider,
+    });
+
+    const rootCall = calls.find((c) => nodeIdFromCall(c) === "_root")!;
+    expect(rootCall.systemPrompt).toBe(DESCENT_SYSTEM_PROMPT);
+  });
+
+  test("uses the configured inline override as the descent system prompt", async () => {
+    const pages = makePages(["pa"]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider({ _root: { descend: ["a"] } }, calls);
+
+    const override = "CUSTOM DESCENT PROMPT — descend everything plausible.";
+    await runTreeWalk({
+      input: makeInput({ descentOverride: override }),
+      tree,
+      pages,
+      scouts: [],
+      seeds: [],
+      provider,
+    });
+
+    const rootCall = calls.find((c) => nodeIdFromCall(c) === "_root")!;
+    expect(rootCall.systemPrompt).toBe(override);
+    expect(rootCall.systemPrompt).not.toBe(DESCENT_SYSTEM_PROMPT);
   });
 });

--- a/assistant/src/memory/v3/filter.ts
+++ b/assistant/src/memory/v3/filter.ts
@@ -43,6 +43,10 @@ import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { ScoutResult } from "../v2/harness/trace.js";
 import { renderConversationContext } from "./prompt-context.js";
+import {
+  FILTER_SYSTEM_PROMPT,
+  resolveV3SystemPrompt,
+} from "./prompts/system-prompts.js";
 
 const log = getLogger("memory-v3-filter");
 
@@ -184,11 +188,11 @@ export async function filterDenseHits(
     return buildResult(bypass, judged, judged, "no_provider");
   }
 
-  const systemPrompt =
-    "You are a fast relevance filter for a memory-retrieval loop. You are given " +
-    "candidate concept pages surfaced by embedding similarity for the current " +
-    "turn. Keep the pages that are meaningful associations and drop the " +
-    "spurious near-neighbors. When in doubt, keep.";
+  const systemPrompt = resolveV3SystemPrompt(
+    FILTER_SYSTEM_PROMPT,
+    input.config.memory?.v3?.prompts?.filter,
+    input.workspaceDir,
+  );
 
   const userMsg: Message = {
     role: "user",

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -50,6 +50,10 @@ import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { GateDecision } from "../v2/harness/trace.js";
 import { renderConversationContext } from "./prompt-context.js";
+import {
+  GATE_SYSTEM_PROMPT,
+  resolveV3SystemPrompt,
+} from "./prompts/system-prompts.js";
 
 const log = getLogger("memory-v3-gate");
 
@@ -198,15 +202,11 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     return failSafe(candidates, sticky);
   }
 
-  const systemPrompt =
-    "You are the final selection gate for a memory-retrieval loop. You are " +
-    "given the candidate concept pages gathered so far for the current turn. " +
-    "Decide whether they are sufficient to answer the next reply. Lean toward " +
-    "recall: keep a candidate whenever it plausibly bears on the turn rather " +
-    "than dropping it. When the turn asks for a list, for 'all of' something, " +
-    "or for a broad answer, select every candidate that plausibly belongs — " +
-    "do not trim to only the most prominent ones. Drop a candidate only when it " +
-    "is clearly irrelevant to the turn.";
+  const systemPrompt = resolveV3SystemPrompt(
+    GATE_SYSTEM_PROMPT,
+    input.config.memory?.v3?.prompts?.gate,
+    input.workspaceDir,
+  );
 
   const stickySlugs = [...sticky];
   const userMsg: Message = {

--- a/assistant/src/memory/v3/prompts/system-prompts.ts
+++ b/assistant/src/memory/v3/prompts/system-prompts.ts
@@ -1,0 +1,196 @@
+/**
+ * Memory v3 — bundled lane system prompts + override resolution.
+ *
+ * The three v3 retrieval-loop lanes that make an LLM judgment call each carry a
+ * system prompt:
+ *
+ *   - the dense-hit filter (`filter.ts`),
+ *   - the tree-walk descent driver (`tree-walk.ts`),
+ *   - the selection gate (`gate.ts`).
+ *
+ * The bundled bodies live here (under `prompts/`) so they are reviewable on
+ * their own, mirroring the convention established by the v2 router prompt
+ * (`../../v2/prompts/router.ts`). Operators may override any of the three at
+ * runtime via `memory.v3.prompts.<lane>` so the prompts can be iterated without
+ * a rebuild/restart — the same fast-iteration affordance the v2 router prompt
+ * already has.
+ *
+ * Each lane's config entry carries two seams, resolved highest-precedence
+ * first by {@link resolveV3SystemPrompt}:
+ *   1. `override` — an inline prompt string (takes precedence over the path).
+ *   2. `path` — a file whose contents replace the bundled body. Absolute paths
+ *      are used as-is, a leading `~/` expands to the home directory, otherwise
+ *      the path resolves under the workspace root.
+ *
+ * Failure handling is intentionally permissive: a missing file, read error,
+ * oversized file, or empty/whitespace-only body all log a warning and fall back
+ * to the bundled prompt. Retrieval must never break because of a bad override.
+ */
+
+import { lstatSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import { getLogger } from "../../../util/logger.js";
+
+const log = getLogger("memory-v3-prompts");
+
+/**
+ * Hard upper bound on an override (inline or file). The bundled prompts are
+ * well under 4 KiB; 1 MiB is generous for any reasonable hand-edit while still
+ * preventing pathological inputs from being slurped into memory on every lane
+ * call. Matches the v2 router prompt's guard.
+ */
+const MAX_PROMPT_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Bundled system prompt for the fast dense-hit filter (`filter.ts`). Keeps the
+ * meaningful embedding-similarity associations and drops spurious
+ * near-neighbors before the more expensive selection gate runs.
+ */
+export const FILTER_SYSTEM_PROMPT =
+  "You are a fast relevance filter for a memory-retrieval loop. You are given " +
+  "candidate concept pages surfaced by embedding similarity for the current " +
+  "turn. Keep the pages that are meaningful associations and drop the " +
+  "spurious near-neighbors. When in doubt, keep.";
+
+/**
+ * Bundled system prompt for the tree-walk descent driver (`tree-walk.ts`).
+ * Decides which child nodes of the current memory-tree node to descend into.
+ */
+export const DESCENT_SYSTEM_PROMPT =
+  "You are the descent driver for a hierarchical memory-retrieval walk. At each " +
+  "node you see its child index (one line per child sub-node or leaf page) and " +
+  "the current conversation turn. Choose which child *nodes* to descend into to " +
+  "find the pages that bear on the next reply. Leaf pages are collected " +
+  "automatically — you only decide which branches to explore deeper.";
+
+/**
+ * Bundled system prompt for the selection gate (`gate.ts`). Decides whether the
+ * accumulated candidate pages are sufficient to answer the next reply.
+ */
+export const GATE_SYSTEM_PROMPT =
+  "You are the final selection gate for a memory-retrieval loop. You are " +
+  "given the candidate concept pages gathered so far for the current turn. " +
+  "Decide whether they are sufficient to answer the next reply. Lean toward " +
+  "recall: keep a candidate whenever it plausibly bears on the turn rather " +
+  "than dropping it. When the turn asks for a list, for 'all of' something, " +
+  "or for a broad answer, select every candidate that plausibly belongs — " +
+  "do not trim to only the most prominent ones. Drop a candidate only when it " +
+  "is clearly irrelevant to the turn.";
+
+/**
+ * One lane's prompt-override config: an optional inline `override` string and
+ * an optional file `path`. Both default to `null`. Mirrors the v2 router
+ * prompt's `router_prompt_path` (file) plus inline-override seam, generalized
+ * to the three v3 lanes.
+ */
+export interface V3PromptOverrideConfig {
+  override: string | null;
+  path: string | null;
+}
+
+/**
+ * Resolve a v3 lane's system prompt, applying the configured override (inline
+ * first, then file path) and falling back to `bundled` when neither produces a
+ * usable body. Unlike the v2 router prompt these bodies carry no placeholders,
+ * so the resolved contents are returned verbatim.
+ *
+ * @param bundled  The lane's bundled default body (the fallback).
+ * @param config   The lane's `memory.v3.prompts.<lane>` config, if present.
+ * @param workspaceDir  Workspace root used to resolve a relative file `path`.
+ */
+export function resolveV3SystemPrompt(
+  bundled: string,
+  config: V3PromptOverrideConfig | undefined,
+  workspaceDir: string,
+): string {
+  // Inline override wins over the file path and the bundled body. An
+  // empty/whitespace-only string is treated as "no override" so a cleared
+  // config value falls through to the path/bundled resolution.
+  const inline = config?.override ?? null;
+  if (inline !== null) {
+    if (inline.length > MAX_PROMPT_BYTES) {
+      log.warn(
+        {
+          size: inline.length,
+          limit: MAX_PROMPT_BYTES,
+          reason: "oversized_inline_override",
+          fallback: "path_or_bundled",
+        },
+        "v3 system-prompt inline override exceeds size limit; falling back",
+      );
+    } else if (inline.trim().length > 0) {
+      return inline;
+    }
+  }
+
+  const path = config?.path ?? null;
+  if (path === null) return bundled;
+
+  const resolvedPath = resolveOverridePath(path, workspaceDir);
+  let contents: string;
+  try {
+    const stat = lstatSync(resolvedPath);
+    if (!stat.isFile()) {
+      log.warn(
+        {
+          configuredPath: path,
+          resolvedPath,
+          reason: "not_regular_file",
+          fallback: "bundled",
+        },
+        "v3 system-prompt override is not a regular file; using bundled prompt",
+      );
+      return bundled;
+    }
+    if (stat.size > MAX_PROMPT_BYTES) {
+      log.warn(
+        {
+          configuredPath: path,
+          resolvedPath,
+          size: stat.size,
+          limit: MAX_PROMPT_BYTES,
+          reason: "oversized_override",
+          fallback: "bundled",
+        },
+        "v3 system-prompt override exceeds size limit; using bundled prompt",
+      );
+      return bundled;
+    }
+    contents = readFileSync(resolvedPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    log.warn(
+      { configuredPath: path, resolvedPath, code, fallback: "bundled" },
+      "v3 system-prompt override unreadable; using bundled prompt",
+    );
+    return bundled;
+  }
+
+  if (contents.trim().length === 0) {
+    log.warn(
+      {
+        configuredPath: path,
+        resolvedPath,
+        reason: "empty_override",
+        fallback: "bundled",
+      },
+      "v3 system-prompt override is empty; using bundled prompt",
+    );
+    return bundled;
+  }
+
+  return contents;
+}
+
+function resolveOverridePath(
+  overridePath: string,
+  workspaceDir: string,
+): string {
+  if (overridePath.startsWith("~/")) {
+    return join(homedir(), overridePath.slice(2));
+  }
+  if (isAbsolute(overridePath)) return overridePath;
+  return join(workspaceDir, overridePath);
+}

--- a/assistant/src/memory/v3/tree-walk.ts
+++ b/assistant/src/memory/v3/tree-walk.ts
@@ -60,6 +60,10 @@ import type { ScoutResult } from "../v2/harness/trace.js";
 import type { PageIndex } from "../v2/page-index.js";
 import { composeNodeIndex } from "./index-composition.js";
 import { renderConversationContext } from "./prompt-context.js";
+import {
+  DESCENT_SYSTEM_PROMPT,
+  resolveV3SystemPrompt,
+} from "./prompts/system-prompts.js";
 import type { WalkResult } from "./traversal.js";
 import { walkTree } from "./traversal.js";
 import type { ChildRef, TreeIndex } from "./tree-index.js";
@@ -168,13 +172,6 @@ function renderScoutHits(scouts: readonly ScoutResult[]): string {
   return `<scout_hits>\n${lines.join("\n")}\n</scout_hits>`;
 }
 
-const DESCENT_SYSTEM_PROMPT =
-  "You are the descent driver for a hierarchical memory-retrieval walk. At each " +
-  "node you see its child index (one line per child sub-node or leaf page) and " +
-  "the current conversation turn. Choose which child *nodes* to descend into to " +
-  "find the pages that bear on the next reply. Leaf pages are collected " +
-  "automatically — you only decide which branches to explore deeper.";
-
 /** Fail-safe descend result: descend nothing, recording why on the side map. */
 function failClosed(
   nodeId: string,
@@ -206,6 +203,14 @@ export function createDescender(
   const { input, tree, pages, scouts } = args;
   const conversationContext = renderConversationContext(input);
   const scoutHits = renderScoutHits(scouts);
+  // Resolve the descent system prompt once for the whole walk — config is
+  // stable across the per-node calls, so there is no reason to re-resolve
+  // (and re-read any override file) per node.
+  const systemPrompt = resolveV3SystemPrompt(
+    DESCENT_SYSTEM_PROMPT,
+    input.config.memory?.v3?.prompts?.descent,
+    input.workspaceDir,
+  );
 
   return async (nodeId: string, children: ChildRef[]): Promise<ChildRef[]> => {
     const offeredNodes = children.filter((c) => c.kind === "node");
@@ -255,7 +260,7 @@ export function createDescender(
       response = await provider.sendMessage(
         [userMsg],
         [descendTool],
-        DESCENT_SYSTEM_PROMPT,
+        systemPrompt,
         {
           config: {
             callSite: "memoryV3Descent" as const,


### PR DESCRIPTION
## Summary
- Add a `memory.v3.prompts` config block to `MemoryV3ConfigSchema` with per-lane entries (`filter`, `descent`, `gate`), each carrying an optional inline `override` string and an optional file `path` (both default `null`).
- Resolve the configured override in `filter.ts`, `tree-walk.ts`, and `gate.ts` via a new shared `resolveV3SystemPrompt` helper (in `memory/v3/prompts/system-prompts.ts`) that applies inline-override → file-path → bundled-default precedence and fails open to the bundled prompt on any miss (empty/whitespace, missing/unreadable/oversized file). The bundled constants are kept as the defaults.
- Add tests: schema defaults/overrides, the resolver's precedence + fail-open fallback, and per-lane assertions that a configured override is the system prompt passed to the provider while an unset override uses the bundled default.

## Original prompt
The v3 retrieval loop makes three LLM calls (dense filter, tree-walk descent, selection gate), each with an inline system-prompt constant — so iterating on the wording required a rebuild/restart. This change makes those three prompts overridable via `config.json`, mirroring how the v2 router prompt (`memory.v2.router.router_prompt_path`) is already configurable, so they can be tuned at runtime. Scope is system prompts only — the forced-tool input schemas and tool descriptions remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)