### PR TITLE
fix(memory-v3): rank edge-expansion seeds by lane trust

### DIFF
--- a/assistant/src/memory/v3/__tests__/edges.test.ts
+++ b/assistant/src/memory/v3/__tests__/edges.test.ts
@@ -493,3 +493,71 @@ describe("expandEdges — bounds", () => {
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Seed ranking by lane trust
+// ---------------------------------------------------------------------------
+
+describe("expandEdges — seed ranking", () => {
+  test("ranks tree/dense/sparse seeds ahead of hot before the seed cap", async () => {
+    // 200 seeds (> the 150 cap), each with a private 1-hop edge. In candidate
+    // order the first 150 are hot (recency) and the last 50 are tree (LLM-
+    // chosen). Without ranking the cap would expand all 150 hot and drop every
+    // tree seed; with laneBySlug the tree seeds must be expanded first.
+    const hotCount = 150;
+    const treeCount = 50;
+    const graph: Record<string, string[]> = {};
+    const seeds: string[] = [];
+    const laneBySlug = new Map<string, string>();
+    for (let i = 0; i < hotCount; i++) {
+      const seed = topicSlug("hot", i);
+      graph[seed] = [topicSlug("hot-targets", i)];
+      graph[topicSlug("hot-targets", i)] = [];
+      seeds.push(seed);
+      laneBySlug.set(seed, "hot");
+    }
+    for (let i = 0; i < treeCount; i++) {
+      const seed = topicSlug("tree", i);
+      graph[seed] = [topicSlug("tree-targets", i)];
+      graph[topicSlug("tree-targets", i)] = [];
+      seeds.push(seed);
+      laneBySlug.set(seed, "tree");
+    }
+    await writeGraph(graph);
+
+    const { expansions } = await expandEdges({
+      workspaceDir,
+      seeds,
+      hops: 1,
+      laneBySlug,
+    });
+
+    const expandedFrom = expansions.map((e) => e.from);
+    // The seed cap still holds.
+    expect(expandedFrom).toHaveLength(MAX_SEEDS_EXPANDED);
+    // Every tree seed survives the cap (ranked ahead of hot) and leads the
+    // order, keeping candidate order within the tier (stable sort).
+    const treeSeeds = seeds.slice(hotCount);
+    expect(expandedFrom.slice(0, treeCount)).toEqual(treeSeeds);
+    // The dropped seeds are the tail-end hot seeds, not any tree seed.
+    const droppedHot = seeds.slice(hotCount - treeCount, hotCount);
+    for (const h of droppedHot) expect(expandedFrom).not.toContain(h);
+  });
+
+  test("without laneBySlug, seeds keep candidate order", async () => {
+    const graph: Record<string, string[]> = {};
+    const seeds: string[] = [];
+    for (let i = 0; i < MAX_SEEDS_EXPANDED + 10; i++) {
+      const seed = topicSlug("people", i);
+      graph[seed] = [topicSlug("targets", i)];
+      graph[topicSlug("targets", i)] = [];
+      seeds.push(seed);
+    }
+    await writeGraph(graph);
+
+    const { expansions } = await expandEdges({ workspaceDir, seeds, hops: 1 });
+    expect(expansions.map((e) => e.from)).toEqual(
+      seeds.slice(0, MAX_SEEDS_EXPANDED),
+    );
+  });
+});

--- a/assistant/src/memory/v3/edges.ts
+++ b/assistant/src/memory/v3/edges.ts
@@ -68,10 +68,48 @@ const MAX_PULLS_PER_SEED = 32;
  */
 const MAX_TOTAL_PULLS = 400;
 
+// ---------------------------------------------------------------------------
+// Seed ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Lane-trust order used to rank seeds *before* the {@link MAX_SEEDS_EXPANDED}
+ * cap (lower = expanded first). The seed union arrives in lane order (hot
+ * first), so without reordering the seed budget is spent on the hot recency
+ * lane and the LLM-vetted tree/dense seeds — the most query-relevant — are the
+ * ones truncated. Ranking tree > dense > sparse > hot spends the budget on
+ * relevance first. A seed whose lane is unknown/absent (or edge-pulled) ranks
+ * last. Requires `laneBySlug`; without it the incoming order is kept.
+ */
+const SEED_LANE_RANK: Readonly<Record<string, number>> = {
+  tree: 0,
+  dense: 1,
+  sparse: 2,
+  hot: 3,
+};
+const SEED_LANE_RANK_LAST = 4;
+
+function seedRank(
+  slug: string,
+  laneBySlug: ReadonlyMap<string, string>,
+): number {
+  const lane = laneBySlug.get(slug);
+  return lane !== undefined
+    ? (SEED_LANE_RANK[lane] ?? SEED_LANE_RANK_LAST)
+    : SEED_LANE_RANK_LAST;
+}
+
 export interface ExpandEdgesArgs {
   workspaceDir: string;
   /** Confident seed slugs to expand from. */
   seeds: Iterable<string>;
+  /**
+   * Per-seed lane provenance (slug → first lane that surfaced it). When present,
+   * seeds are ranked by lane trust ({@link SEED_LANE_RANK}) before the seed cap,
+   * so the budget is spent on query-relevant seeds rather than recency. Typed as
+   * a plain string map to avoid importing the loop's `LaneSource` (circular).
+   */
+  laneBySlug?: ReadonlyMap<string, string>;
   /** Hop budget for the outgoing walk. Defaults to {@link DEFAULT_HOPS}. */
   hops?: number;
   /**
@@ -151,16 +189,34 @@ function reachableMerged(
 export async function expandEdges(
   args: ExpandEdgesArgs,
 ): Promise<ExpandEdgesResult> {
-  const { workspaceDir, seeds, hops = DEFAULT_HOPS, extraAdjacency } = args;
+  const {
+    workspaceDir,
+    seeds,
+    hops = DEFAULT_HOPS,
+    extraAdjacency,
+    laneBySlug,
+  } = args;
 
   const index = await getEdgeIndex(workspaceDir);
   const pulled = new Set<string>();
   const expansions: EdgeExpansion[] = [];
 
-  // De-dupe seeds while preserving first-seen order for a stable trace.
+  // Rank seeds by lane trust before the seed cap so the budget goes to the most
+  // query-relevant seeds (tree/dense/sparse) rather than recency (hot), which
+  // leads the incoming candidate order. `Array.prototype.sort` is stable, so
+  // seeds within a tier keep their candidate order. Without `laneBySlug` the
+  // incoming order is preserved.
+  const orderedSeeds = [...seeds];
+  if (laneBySlug) {
+    orderedSeeds.sort(
+      (a, b) => seedRank(a, laneBySlug) - seedRank(b, laneBySlug),
+    );
+  }
+
+  // De-dupe seeds while preserving (ranked) order for a stable trace.
   const seenSeeds = new Set<string>();
 
-  for (const seed of seeds) {
+  for (const seed of orderedSeeds) {
     if (seenSeeds.has(seed)) continue;
     seenSeeds.add(seed);
 

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -200,6 +200,10 @@ export async function runRetrievalLoop(
       const expansion = await expandEdges({
         workspaceDir: passInput.workspaceDir,
         seeds: [...candidates],
+        // Rank seeds by the lane that surfaced them (tree/dense/sparse before
+        // hot) so the seed cap spends its budget on query-relevant seeds, not
+        // recency. `sourceBySlug` holds each candidate's first-seen lane.
+        laneBySlug: sourceBySlug,
       });
       edgeExpansions = expansion.expansions;
       for (const slug of expansion.pulled) {


### PR DESCRIPTION
## Summary
- Edge-expansion capped seeds in candidate order — which is lane order (hot → sparse → dense → tree) — so the 150-seed budget was spent on hot (recency) seeds and the LLM-vetted tree/dense seeds (most query-relevant) were the ones truncated. Backwards.
- Rank seeds by lane trust (tree > dense > sparse > hot) before the seed cap, stable within a tier so candidate order breaks ties. `loop.ts` passes the existing `sourceBySlug` (first-lane provenance) as `laneBySlug`; `edges.ts` sorts seeds before applying the unchanged 150 / 32 / 400 caps. With no lane info the incoming order is preserved.
- Adds two ranking tests (tree seeds lead and survive the cap; absent lane map preserves candidate order).

## Original prompt
After bounding edge-expansion, the seed cap was still spending its budget on the lowest-confidence seeds: the candidate union arrives in lane order (hot first), so the 150-seed cap expanded recency pages and dropped the tree/dense seeds that actually bear on the query. This reorders seeds by lane trust before the cap — the cheap version of confidence ranking (no multi-lane agreement tracking) — so the budget goes to the seeds we're most sure about.