### PR TITLE
feat(memory-v3): capture v3 LLM call input + output in simulate

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v3-render.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3-render.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
+  LlmCallRecord,
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
 } from "../../../runtime/routes/memory-v3-routes.js";
 import {
+  renderLlmCalls,
   renderSimulation,
   renderTree,
   renderValidationReport,
@@ -204,6 +206,7 @@ function simResult(): MemoryV3SimulateResult {
     },
     cost: { ms: 1234 },
     failureReason: null,
+    llmCalls: [],
     effectiveConfig: {
       passCap: 3,
       lanes: { hot: true, sparse: true, dense: true, tree: true, edges: false },
@@ -262,5 +265,76 @@ describe("memory v3 — renderSimulation", () => {
     result.failureReason = "dense filter failed open";
     const out = renderSimulation(result);
     expect(out).toContain("Failure: dense filter failed open");
+  });
+});
+
+function llmCall(over: Partial<LlmCallRecord> = {}): LlmCallRecord {
+  return {
+    pass: 1,
+    lane: "gate",
+    callSite: "memoryV3Gate",
+    request: {
+      systemPrompt: "SYS-PROMPT",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "USER-MSG" }] },
+      ],
+      tools: [
+        {
+          name: "decide_selection",
+          description: "decide",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+    },
+    response: {
+      model: "stub-model",
+      stopReason: "tool_use",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      content: [
+        {
+          type: "tool_use",
+          id: "tu-1",
+          name: "decide_selection",
+          input: { decision: "ready", selected_slugs: ["a"] },
+        },
+      ],
+    },
+    ms: 42,
+    ...over,
+  };
+}
+
+describe("memory v3 — renderLlmCalls", () => {
+  test("compact: one line per call with lane, node, and tool summary", () => {
+    const out = renderLlmCalls(
+      [
+        llmCall(),
+        llmCall({
+          lane: "descent",
+          callSite: "memoryV3Descent",
+          node: "people",
+        }),
+      ],
+      { full: false },
+    );
+    expect(out).toContain("LLM calls (2):");
+    expect(out).toContain("pass1 · gate");
+    expect(out).toContain("pass1 · descent · node=people");
+    expect(out).toContain("decide_selection");
+    expect(out).toContain("42ms");
+    // Compact mode must not dump the full system prompt.
+    expect(out).not.toContain("SYS-PROMPT");
+  });
+
+  test("full: includes system prompt, messages, tools, and tool_use input", () => {
+    const out = renderLlmCalls([llmCall()], { full: true });
+    expect(out).toContain("SYS-PROMPT");
+    expect(out).toContain("USER-MSG");
+    expect(out).toContain("decide_selection");
+    expect(out).toContain('"decision"');
+  });
+
+  test("renders 'none' when there are no calls", () => {
+    expect(renderLlmCalls([], { full: false })).toBe("LLM calls: none");
   });
 });

--- a/assistant/src/cli/commands/memory-v3-render.ts
+++ b/assistant/src/cli/commands/memory-v3-render.ts
@@ -10,6 +10,7 @@
 
 import type {
   DescentPass,
+  LlmCallRecord,
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
@@ -248,5 +249,96 @@ export function renderSimulation(result: MemoryV3SimulateResult): string {
     lines.push(`Failure: ${result.failureReason}`);
   }
 
+  return lines.join("\n");
+}
+
+// ── LLM-call capture ────────────────────────────────────────────────────────
+
+type CapturedMessage = LlmCallRecord["request"]["messages"][number];
+type CapturedBlock = LlmCallRecord["response"]["content"][number];
+
+/** Concatenate the text blocks of a message (non-text blocks are ignored). */
+function messageText(message: CapturedMessage): string {
+  return message.content
+    .filter(
+      (b): b is Extract<CapturedBlock, { type: "text" }> => b.type === "text",
+    )
+    .map((b) => b.text)
+    .join("\n");
+}
+
+/** The forced-tool block from a response, if the model returned one. */
+function toolUseOf(
+  call: LlmCallRecord,
+): Extract<CapturedBlock, { type: "tool_use" }> | undefined {
+  return call.response.content.find(
+    (b): b is Extract<CapturedBlock, { type: "tool_use" }> =>
+      b.type === "tool_use",
+  );
+}
+
+function truncate(s: string, max: number): string {
+  const oneLine = s.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+function indent(s: string, by = "    "): string {
+  return s
+    .split("\n")
+    .map((line) => by + line)
+    .join("\n");
+}
+
+/**
+ * Render the captured v3 LLM calls. Compact (default): one line per call —
+ * pass/lane/node, input size, round-trip ms, and the forced-tool summary. Full
+ * (`--show-llm`): the system prompt, every message, the tool names, and the
+ * tool_use input for each call. Grouped in call order (which is pass order).
+ */
+export function renderLlmCalls(
+  calls: readonly LlmCallRecord[],
+  opts: { full: boolean },
+): string {
+  if (calls.length === 0) return "LLM calls: none";
+
+  const lines: string[] = [`LLM calls (${calls.length}):`];
+  for (const call of calls) {
+    const label =
+      `pass${call.pass} · ${call.lane}` +
+      (call.node ? ` · node=${call.node}` : "");
+    const inputChars =
+      call.request.systemPrompt.length +
+      call.request.messages.reduce((n, m) => n + messageText(m).length, 0);
+    const tool = toolUseOf(call);
+    const toolSummary = tool
+      ? `${tool.name}(${truncate(JSON.stringify(tool.input), 80)})`
+      : `no tool_use (stop=${call.response.stopReason})`;
+
+    if (!opts.full) {
+      lines.push(
+        `  ${label} · in ${inputChars}c · ${call.ms}ms · ${truncate(toolSummary, 100)}`,
+      );
+      continue;
+    }
+
+    lines.push("", `── ${label}  (${call.callSite}, ${call.ms}ms) ──`);
+    lines.push("system:", indent(call.request.systemPrompt));
+    lines.push("messages:");
+    for (const message of call.request.messages) {
+      lines.push(
+        indent(`[${message.role}]`),
+        indent(messageText(message), "      "),
+      );
+    }
+    lines.push(`tools: ${call.request.tools.map((t) => t.name).join(", ")}`);
+    lines.push("output:");
+    lines.push(
+      indent(
+        tool
+          ? `${tool.name} ${JSON.stringify(tool.input, null, 2)}`
+          : `(no tool_use, stop=${call.response.stopReason})`,
+      ),
+    );
+  }
   return lines.join("\n");
 }

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -19,6 +19,9 @@
  * `--json` emits the raw daemon payload for any subcommand.
  */
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
@@ -30,6 +33,7 @@ import type {
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import {
+  renderLlmCalls,
   renderSimulation,
   renderTree,
   renderValidationReport,
@@ -185,6 +189,14 @@ Examples:
           `Restrict to a comma-separated allowlist of lanes (others off): ${V3_LANE_NAMES.join(", ")}`,
         )
         .option("--json", "Emit raw JSON instead of a formatted report")
+        .option(
+          "--show-llm",
+          "Print the full input + output of every v3 LLM call (filter / descender / gate)",
+        )
+        .option(
+          "--dump-llm <dir>",
+          "Write one JSON file per v3 LLM call into <dir> (full request + raw response)",
+        )
         .addHelpText(
           "after",
           `
@@ -201,7 +213,9 @@ the loop's dense-filter + gate LLM calls, so pass-cap is the cost knob.
 Examples:
   $ assistant memory v3 simulate -q "what should we ship next"
   $ assistant memory v3 simulate -q "..." --lanes tree,edges
-  $ assistant memory v3 simulate -q "..." --pass-cap 1 --json | jq '.selectedSlugs'`,
+  $ assistant memory v3 simulate -q "..." --pass-cap 1 --json | jq '.selectedSlugs'
+  $ assistant memory v3 simulate -q "..." --show-llm
+  $ assistant memory v3 simulate -q "..." --dump-llm /tmp/v3-calls`,
         )
         .action(
           async (opts: {
@@ -209,6 +223,8 @@ Examples:
             passCap?: string;
             lanes?: string;
             json?: boolean;
+            showLlm?: boolean;
+            dumpLlm?: string;
           }) => {
             let passCap: number | undefined;
             if (opts.passCap !== undefined) {
@@ -271,6 +287,28 @@ Examples:
               return;
             }
             log.info(renderSimulation(payload));
+
+            log.info("");
+            log.info(
+              renderLlmCalls(payload.llmCalls, { full: opts.showLlm === true }),
+            );
+
+            if (opts.dumpLlm !== undefined) {
+              mkdirSync(opts.dumpLlm, { recursive: true });
+              for (const call of payload.llmCalls) {
+                const nodePart = call.node
+                  ? `-${call.node.replace(/\//g, "_")}`
+                  : "";
+                const file = join(
+                  opts.dumpLlm,
+                  `pass${call.pass}-${call.lane}${nodePart}.json`,
+                );
+                writeFileSync(file, JSON.stringify(call, null, 2));
+              }
+              log.info(
+                `\nWrote ${payload.llmCalls.length} LLM-call file(s) to ${opts.dumpLlm}`,
+              );
+            }
           },
         );
     },

--- a/assistant/src/memory/v3/__tests__/filter.test.ts
+++ b/assistant/src/memory/v3/__tests__/filter.test.ts
@@ -31,6 +31,7 @@ import type {
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import type { ScoutResult } from "../../v2/harness/trace.js";
 import { filterDenseHits } from "../filter.js";
+import type { LlmCallRecord } from "../llm-capture.js";
 import { FILTER_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 
 // ---------------------------------------------------------------------------
@@ -417,5 +418,44 @@ describe("filterDenseHits — fail-open", () => {
 
     expect([...result.kept].sort()).toEqual(["a", "b"]);
     expect(result.failureReason).toBe("schema_mismatch");
+  });
+});
+
+describe("filterDenseHits — capture", () => {
+  test("emits one record with the filter's input + raw response", async () => {
+    const calls: ProviderCall[] = [];
+    const captured: Omit<LlmCallRecord, "pass">[] = [];
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["a", "b"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+      capture: (record) => captured.push(record),
+    });
+
+    expect(captured).toHaveLength(1);
+    const rec = captured[0]!;
+    expect(rec.lane).toBe("filter");
+    expect(rec.callSite).toBe("memoryV3Filter");
+    expect(rec.request.tools[0]!.name).toBe("filter_dense_hits");
+    expect(rec.response.stopReason).toBe("tool_use");
+  });
+
+  test("emits nothing when there is nothing to judge (no LLM call)", async () => {
+    const captured: Omit<LlmCallRecord, "pass">[] = [];
+    await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult([]),
+      sticky: new Set(),
+      bypass: new Set(),
+      capture: (record) => captured.push(record),
+    });
+    expect(captured).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../../providers/types.js";
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import { runGate } from "../gate.js";
+import type { LlmCallRecord } from "../llm-capture.js";
 import { GATE_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 
 // ---------------------------------------------------------------------------
@@ -423,5 +424,48 @@ describe("runGate — fail-safe", () => {
 
     expect(result.decision).toEqual({ decision: "ready" });
     expect([...result.selectedSlugs].sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("runGate — capture", () => {
+  test("emits one record with the gate's input + raw response", async () => {
+    const calls: ProviderCall[] = [];
+    const captured: Omit<LlmCallRecord, "pass">[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      calls,
+    );
+
+    await runGate({
+      input: makeInput(),
+      candidates: new Set(["a", "b"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+      capture: (record) => captured.push(record),
+    });
+
+    expect(captured).toHaveLength(1);
+    const rec = captured[0]!;
+    expect(rec.lane).toBe("gate");
+    expect(rec.callSite).toBe("memoryV3Gate");
+    expect(rec.request.tools[0]!.name).toBe("decide_selection");
+    expect(rec.request.systemPrompt.length).toBeGreaterThan(0);
+    expect(rec.request.messages).toHaveLength(1);
+    expect(rec.response.stopReason).toBe("tool_use");
+    expect(rec.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test("emits nothing when the provider is unavailable (fail-safe path)", async () => {
+    const captured: Omit<LlmCallRecord, "pass">[] = [];
+    await runGate({
+      input: makeInput(),
+      candidates: new Set(["a"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider: null,
+      capture: (record) => captured.push(record),
+    });
+    expect(captured).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/v3/__tests__/tree-walk.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-walk.test.ts
@@ -36,6 +36,7 @@ import type {
 import type { RetrievalInput } from "../../v2/harness/retriever.js";
 import type { ScoutResult } from "../../v2/harness/trace.js";
 import type { PageIndex } from "../../v2/page-index.js";
+import type { LlmCallRecord } from "../llm-capture.js";
 import { DESCENT_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 import type { ChildRef, TreeIndex } from "../tree-index.js";
 import { createDescender, deriveSeedNodes, runTreeWalk } from "../tree-walk.js";
@@ -650,5 +651,38 @@ describe("runTreeWalk — descent system prompt", () => {
     const rootCall = calls.find((c) => nodeIdFromCall(c) === "_root")!;
     expect(rootCall.systemPrompt).toBe(override);
     expect(rootCall.systemPrompt).not.toBe(DESCENT_SYSTEM_PROMPT);
+  });
+});
+
+describe("runTreeWalk — capture", () => {
+  test("emits one record per descender LLM call, tagged with the node", async () => {
+    // Only _root offers node-children, so exactly one descender call fires.
+    const tree = makeTree("_root", {
+      _root: [node("a"), node("b")],
+      a: [page("pa")],
+      b: [page("pb")],
+    });
+    const pages = makePages(["pa", "pb"]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider({ _root: { descend: ["a"] } }, calls);
+    const captured: Omit<LlmCallRecord, "pass">[] = [];
+
+    await runTreeWalk({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      seeds: [],
+      provider,
+      capture: (record) => captured.push(record),
+    });
+
+    expect(captured).toHaveLength(1);
+    const rec = captured[0]!;
+    expect(rec.lane).toBe("descent");
+    expect(rec.callSite).toBe("memoryV3Descent");
+    expect(rec.node).toBe("_root");
+    expect(rec.request.tools[0]!.name).toBe("choose_branches");
+    expect(rec.response.stopReason).toBe("tool_use");
   });
 });

--- a/assistant/src/memory/v3/filter.ts
+++ b/assistant/src/memory/v3/filter.ts
@@ -42,6 +42,7 @@ import type {
 import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { ScoutResult } from "../v2/harness/trace.js";
+import type { LlmCallSink } from "./llm-capture.js";
 import { renderConversationContext } from "./prompt-context.js";
 import {
   FILTER_SYSTEM_PROMPT,
@@ -67,6 +68,8 @@ export interface FilterDenseHitsArgs {
   dense: ScoutResult;
   sticky: Set<string>;
   bypass: Set<string>;
+  /** Optional debug sink — emits one record for the filter's LLM call. */
+  capture?: LlmCallSink;
   /**
    * Provider override seam for tests. Production leaves this unset and the
    * filter resolves `getConfiguredProvider("memoryV3Filter")`. `null` is
@@ -210,6 +213,7 @@ export async function filterDenseHits(
 
   const filterTool = buildFilterTool(judged);
 
+  const startedAt = Date.now();
   let response;
   try {
     response = await provider.sendMessage(
@@ -228,6 +232,14 @@ export async function filterDenseHits(
     log.warn({ err }, "Filter provider call threw; failing open (keep all)");
     return buildResult(bypass, judged, judged, "api_error");
   }
+
+  args.capture?.({
+    lane: "filter",
+    callSite: "memoryV3Filter",
+    request: { systemPrompt, messages: [userMsg], tools: [filterTool] },
+    response,
+    ms: Date.now() - startedAt,
+  });
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock || toolBlock.name !== FILTER_TOOL_NAME) {

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -49,6 +49,7 @@ import type {
 import { getLogger } from "../../util/logger.js";
 import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { GateDecision } from "../v2/harness/trace.js";
+import type { LlmCallSink } from "./llm-capture.js";
 import { renderConversationContext } from "./prompt-context.js";
 import {
   GATE_SYSTEM_PROMPT,
@@ -74,6 +75,8 @@ export interface RunGateArgs {
   candidates: Set<string>;
   sticky: Set<string>;
   passNumber: number;
+  /** Optional debug sink — emits one record for the gate's LLM call. */
+  capture?: LlmCallSink;
   /**
    * Provider override seam for tests. Production leaves this unset and the
    * gate resolves `getConfiguredProvider("memoryV3Gate")`. `null` is distinct
@@ -228,6 +231,7 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
 
   const gateTool = buildGateTool(candidateSlugs);
 
+  const startedAt = Date.now();
   let response;
   try {
     response = await provider.sendMessage([userMsg], [gateTool], systemPrompt, {
@@ -241,6 +245,14 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     log.warn({ err }, "Gate provider call threw; failing open (ready)");
     return failSafe(candidates, sticky);
   }
+
+  args.capture?.({
+    lane: "gate",
+    callSite: "memoryV3Gate",
+    request: { systemPrompt, messages: [userMsg], tools: [gateTool] },
+    response,
+    ms: Date.now() - startedAt,
+  });
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock || toolBlock.name !== GATE_TOOL_NAME) {

--- a/assistant/src/memory/v3/llm-capture.ts
+++ b/assistant/src/memory/v3/llm-capture.ts
@@ -1,0 +1,46 @@
+/**
+ * Memory v3 — LLM-call capture types.
+ *
+ * A debugging seam: when a sink is threaded into the retrieval loop, every v3
+ * LLM call (dense filter, each tree-walk descender call, the gate) emits one
+ * {@link LlmCallRecord} carrying the full input it sent and the raw response it
+ * got back. The `simulate` path collects these so an operator can inspect what
+ * each call actually saw and returned. Nothing here is persisted, and the sink
+ * is `undefined` on every non-simulate path, so production pays zero cost.
+ *
+ * Leaf module: it imports only provider types, so the lanes and the loop can
+ * depend on it without a cycle.
+ */
+
+import type {
+  Message,
+  ProviderResponse,
+  ToolDefinition,
+} from "../../providers/types.js";
+
+/**
+ * One captured v3 LLM call — its full input (system prompt, messages, tool
+ * schema) and raw output (provider response). `pass` is the 1-based retrieval
+ * pass the call ran in; `node` is set only for the tree-walk descender (the
+ * node whose composed index it judged). `ms` is the provider round-trip time.
+ */
+export interface LlmCallRecord {
+  pass: number;
+  lane: "filter" | "descent" | "gate";
+  callSite: string;
+  node?: string;
+  request: {
+    systemPrompt: string;
+    messages: Message[];
+    tools: ToolDefinition[];
+  };
+  response: ProviderResponse;
+  ms: number;
+}
+
+/**
+ * The sink a lane calls to emit a capture record. Lanes don't know their pass
+ * number, so they emit without `pass` and the loop wraps the sink to stamp the
+ * current pass. `undefined` on every non-capturing path (the common case).
+ */
+export type LlmCallSink = (record: Omit<LlmCallRecord, "pass">) => void;

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -64,6 +64,7 @@ import {
 import { expandEdges } from "./edges.js";
 import { filterDenseHits } from "./filter.js";
 import { runGate } from "./gate.js";
+import type { LlmCallRecord, LlmCallSink } from "./llm-capture.js";
 import { runScouts } from "./scouts.js";
 import { getTreeIndex } from "./tree-index.js";
 import { runTreeWalk } from "./tree-walk.js";
@@ -84,6 +85,12 @@ export interface RetrievalLoopDeps {
   conversationId?: string;
   /** Turn number within the conversation, for co-activation provenance. */
   turn?: number;
+  /**
+   * Optional debug sink. When set, every v3 LLM call (filter / each descender /
+   * gate) emits one {@link LlmCallRecord} with its full input + raw response.
+   * Undefined on the live/shadow path, so production captures nothing.
+   */
+  capture?: (record: LlmCallRecord) => void;
 }
 
 /**
@@ -130,6 +137,13 @@ export async function runRetrievalLoop(
     const passStart = Date.now();
     const passInput: RetrievalInput = { ...input, nowText: passNowText };
 
+    // Per-pass capture sink: stamp the current pass onto each lane's emitted
+    // record. Stays undefined (inert) unless a capture sink was injected.
+    const sink = deps.capture;
+    const passSink: LlmCallSink | undefined = sink
+      ? (record) => sink({ ...record, pass: passNumber })
+      : undefined;
+
     // 1. Scouts — always-on hot / sparse / dense fanout.
     const scoutResult = await runScouts(passInput, { db: deps.db });
     for (const slug of scoutResult.sticky) sticky.add(slug);
@@ -159,6 +173,7 @@ export async function runRetrievalLoop(
         dense: denseScout,
         sticky: scoutResult.sticky,
         bypass: scoutResult.bypass,
+        capture: passSink,
       });
       for (const slug of filtered.kept) {
         candidates.add(slug);
@@ -185,6 +200,7 @@ export async function runRetrievalLoop(
         pages,
         scouts: scoutResult.scouts,
         seeds: survivingSeeds,
+        capture: passSink,
       });
       treeLevels = walk.levels;
       for (const slug of walk.pages) {
@@ -225,6 +241,7 @@ export async function runRetrievalLoop(
       candidates,
       sticky,
       passNumber,
+      capture: passSink,
     });
     selectedSlugs = gateResult.selectedSlugs;
 

--- a/assistant/src/memory/v3/tree-walk.ts
+++ b/assistant/src/memory/v3/tree-walk.ts
@@ -59,6 +59,7 @@ import type { RetrievalInput } from "../v2/harness/retriever.js";
 import type { ScoutResult } from "../v2/harness/trace.js";
 import type { PageIndex } from "../v2/page-index.js";
 import { composeNodeIndex } from "./index-composition.js";
+import type { LlmCallSink } from "./llm-capture.js";
 import { renderConversationContext } from "./prompt-context.js";
 import {
   DESCENT_SYSTEM_PROMPT,
@@ -94,6 +95,8 @@ export interface CreateDescenderArgs {
   scouts: ScoutResult[];
   /** Explicit seed node ids (folded into the prompt's seed context). */
   seeds: string[];
+  /** Optional debug sink — emits one record per descender LLM call (per node). */
+  capture?: LlmCallSink;
   /**
    * Provider override seam for tests. Production omits it and the descender
    * resolves `getConfiguredProvider("memoryV3Descent")` per call. Explicit
@@ -255,6 +258,7 @@ export function createDescender(
 
     const descendTool = buildDescendTool(offeredNodeIds);
 
+    const startedAt = Date.now();
     let response;
     try {
       response = await provider.sendMessage(
@@ -280,6 +284,15 @@ export function createDescender(
         reasoningByNode,
       );
     }
+
+    args.capture?.({
+      lane: "descent",
+      callSite: "memoryV3Descent",
+      node: nodeId,
+      request: { systemPrompt, messages: [userMsg], tools: [descendTool] },
+      response,
+      ms: Date.now() - startedAt,
+    });
 
     const toolBlock = extractToolUse(response);
     if (!toolBlock || toolBlock.name !== DESCEND_TOOL_NAME) {

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -28,6 +28,7 @@ import type {
 } from "../../memory/v2/harness/retriever.js";
 import type { DescentTrace } from "../../memory/v2/harness/trace.js";
 import { loadNowText } from "../../memory/v2/now-text.js";
+import type { LlmCallRecord } from "../../memory/v3/llm-capture.js";
 import { runRetrievalLoop } from "../../memory/v3/loop.js";
 import { getTreeIndex } from "../../memory/v3/tree-index.js";
 import type { TreeValidationReport } from "../../memory/v3/validate.js";
@@ -47,6 +48,7 @@ export type {
   ScoutResult,
   TreeLevel,
 } from "../../memory/v2/harness/trace.js";
+export type { LlmCallRecord };
 
 // ── Validate ────────────────────────────────────────────────────────────
 
@@ -164,6 +166,12 @@ export interface MemoryV3SimulateResult {
   cost: RetrievalCost;
   /** Non-null when the dense filter failed open on any pass. */
   failureReason: string | null;
+  /**
+   * Every v3 LLM call made during the run (filter / each descender / gate),
+   * with full input + raw response. Empty unless capture was on (it always is
+   * for simulate). Read-only debug surface — persisted nowhere.
+   */
+  llmCalls: LlmCallRecord[];
   effectiveConfig: {
     passCap: number;
     lanes: MemoryV3SimulateLanes;
@@ -242,7 +250,11 @@ async function handleSimulate({
     config,
   };
 
-  const output = await runRetrievalLoop(input, { db: getDb() });
+  const llmCalls: LlmCallRecord[] = [];
+  const output = await runRetrievalLoop(input, {
+    db: getDb(),
+    capture: (record) => llmCalls.push(record),
+  });
 
   const sourceBySlug: Record<string, string> = {};
   for (const [slug, lane] of output.sourceBySlug.entries()) {
@@ -256,6 +268,7 @@ async function handleSimulate({
     trace: output.trace ?? { passes: [] },
     cost: output.cost ?? {},
     failureReason: output.failureReason ?? null,
+    llmCalls,
     effectiveConfig: {
       passCap: config.memory.v3.passCap,
       lanes: config.memory.v3.lanes,


### PR DESCRIPTION
## Summary
- Add a capture seam to the v3 retrieval loop: an optional sink threaded from `runRetrievalLoop` into the dense filter, each tree-walk descender call, and the gate. Each emits one `LlmCallRecord` (system prompt + messages + tool schema + raw response + round-trip ms). Inert unless a sink is injected, so the live/shadow path captures nothing and pays nothing.
- `assistant memory v3 simulate` collects these into `llmCalls` and renders them: compact by default (one line per call), `--show-llm` for the full input/output inline, `--dump-llm <dir>` to write one JSON file per call. Read-only — persisted nowhere.
- New `memory/v3/llm-capture.ts` (`LlmCallRecord` / `LlmCallSink`), a `renderLlmCalls` renderer, and tests for the per-lane capture + the renderer.

## Original prompt
We've been iterating on v3 retrieval quality via `memory v3 simulate` and wanted to see exactly what each v3 LLM call sends and gets back — the filter, every descender call, and the gate — which nothing currently logs. This is "surface 1" of the debugging spec: in-loop capture surfaced through simulate, restart-free. Persisting v3 calls to `llm_request_logs` for live/shadow turns is the deferred surface 2.