### PR TITLE
feat(memory-v3): expose reasoning on gate + filter forced tools

### DIFF
--- a/assistant/src/memory/v3/__tests__/filter.test.ts
+++ b/assistant/src/memory/v3/__tests__/filter.test.ts
@@ -459,3 +459,54 @@ describe("filterDenseHits — capture", () => {
     expect(captured).toHaveLength(0);
   });
 });
+
+describe("filterDenseHits — reasoning field", () => {
+  test("exposes an optional reasoning property in the forced tool schema", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["a", "b"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+    });
+
+    const schema = calls[0].tools![0].input_schema as {
+      properties: Record<string, { type?: string }>;
+      required?: string[];
+    };
+    expect(schema.properties.reasoning?.type).toBe("string");
+    // Reasoning is purely additive — the model may omit it.
+    expect(schema.required ?? []).not.toContain("reasoning");
+  });
+
+  test("accepts model-supplied reasoning without altering the kept set", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      filterToolResponse({
+        keep_slugs: ["c", "a"],
+        reasoning:
+          "kept the cross-domain associations, dropped the near-duplicate",
+      }),
+      calls,
+    );
+
+    const result = await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["a", "b", "c"]),
+      sticky: new Set(),
+      bypass: new Set(),
+      provider,
+    });
+
+    // Reasoning is ignored by control flow: kept/dropped unchanged.
+    expect(result.kept).toEqual(["c", "a"]);
+    expect(result.trace.dropped).toEqual(["b"]);
+    expect(result.failureReason).toBeUndefined();
+  });
+});

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -469,3 +469,54 @@ describe("runGate — capture", () => {
     expect(captured).toHaveLength(0);
   });
 });
+
+describe("runGate — reasoning field", () => {
+  test("exposes an optional reasoning property in the forced tool schema", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      calls,
+    );
+
+    await runGate({
+      input: makeInput(),
+      candidates: new Set(["a", "b"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+    });
+
+    const schema = calls[0].tools![0].input_schema as {
+      properties: Record<string, { type?: string }>;
+      required?: string[];
+    };
+    expect(schema.properties.reasoning?.type).toBe("string");
+    // Reasoning is purely additive — the model may omit it.
+    expect(schema.required ?? []).not.toContain("reasoning");
+  });
+
+  test("accepts model-supplied reasoning without altering the decision", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({
+        decision: "ready",
+        selected_slugs: ["b", "a"],
+        reasoning: "kept the two query-relevant pages, dropped the rest",
+      }),
+      calls,
+    );
+
+    const result = await runGate({
+      input: makeInput(),
+      candidates: new Set(["a", "b", "c"]),
+      sticky: new Set(["c"]),
+      passNumber: 1,
+      provider,
+    });
+
+    // Reasoning is ignored by control flow: decision + ordered selection
+    // (model order, omitted sticky appended) are unchanged.
+    expect(result.decision).toEqual({ decision: "ready" });
+    expect(result.selectedSlugs).toEqual(["b", "a", "c"]);
+  });
+});

--- a/assistant/src/memory/v3/filter.ts
+++ b/assistant/src/memory/v3/filter.ts
@@ -116,6 +116,11 @@ function buildFilterTool(judgedSlugs: readonly string[]): ToolDefinition {
           description:
             "The subset of candidate page slugs to keep. Choose only from the candidate set.",
         },
+        reasoning: {
+          type: "string",
+          description:
+            "One short sentence: why these hits were kept and the rest dropped.",
+        },
       },
       required: ["keep_slugs"],
     },
@@ -124,6 +129,7 @@ function buildFilterTool(judgedSlugs: readonly string[]): ToolDefinition {
 
 const FilterToolResultSchema = z.object({
   keep_slugs: z.array(z.string()),
+  reasoning: z.string().optional(),
 });
 
 /**

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -126,6 +126,12 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
           description:
             "When decision='more', the generated follow-up questions seeding the next pass.",
         },
+        reasoning: {
+          type: "string",
+          description:
+            "One short sentence: why this ready/more verdict, and which " +
+            "candidates were kept or dropped.",
+        },
       },
       required: ["decision"],
     },
@@ -136,6 +142,7 @@ const GateToolResultSchema = z.object({
   decision: z.enum(["ready", "more"]),
   selected_slugs: z.array(z.string()).optional(),
   questions: z.array(z.string()).optional(),
+  reasoning: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add an optional `reasoning` string to the `decide_selection` (gate) and `filter_dense_hits` (dense filter) forced-tool schemas, mirroring the descender's `choose_branches`. The two most consequential v3 retrieval calls can now explain *why* they kept/dropped/escalated.
- Surfaces automatically through `assistant memory v3 simulate --show-llm` / `--dump-llm`: the capture records the raw `tool_use` input and the full renderer prints it, so no capture or renderer changes were needed.
- Purely additive — tool control flow, fail-open/fail-safe behavior, and the resulting selected/kept sets are unchanged. Added gate + filter tests asserting the schema exposes an optional `reasoning` and that a model-supplied reasoning does not alter the decision.

## Original prompt
While exercising the new v3 LLM-call capture tooling against the live retrieval loop, the gate and filter calls came back with no rationale — their forced-tool schemas had no `reasoning` field at all (only the tree-walk descender did), making the selection gate a black box in the very surface built to inspect it. The ask was to add an optional `reasoning` field to both `decide_selection` and `filter_dense_hits`, mirroring `choose_branches`, so `simulate --show-llm`/`--dump-llm` shows why each call decided what it did. Hard constraint: the gate and filter must keep failing open with their selection logic unchanged — reasoning is purely additive.