### PR TITLE
refactor(memory-v3): per-node page selection in the tree walk

### DIFF
--- a/assistant/src/memory/v3/__tests__/loop.test.ts
+++ b/assistant/src/memory/v3/__tests__/loop.test.ts
@@ -89,7 +89,6 @@ const laneCalls = {
   filter: [] as Array<{ nowText: string; dense: ScoutResult }>,
   walk: [] as Array<{
     nowText: string;
-    seeds: string[];
     scouts: ScoutResult[];
   }>,
   edges: [] as Array<{ seeds: string[] }>,
@@ -132,12 +131,10 @@ mock.module("../filter.js", () => ({
 mock.module("../tree-walk.js", () => ({
   runTreeWalk: async (args: {
     input: RetrievalInput;
-    seeds: string[];
     scouts: ScoutResult[];
   }): Promise<WalkResult> => {
     laneCalls.walk.push({
       nowText: args.input.nowText,
-      seeds: args.seeds,
       scouts: args.scouts,
     });
     return nextOf(lane.walk, walkCallCount++);
@@ -351,9 +348,7 @@ describe("runRetrievalLoop — single pass", () => {
 
     // The filter saw the full dense lane.
     expect(laneCalls.filter[0].dense.slugs).toEqual(["keep", "drop"]);
-    // Only the kept dense slug seeds the tree walk; `drop` never reaches it.
-    expect(laneCalls.walk[0].seeds).toEqual(["keep"]);
-    // Gate's candidate set excludes the dropped dense slug.
+    // The dropped dense slug never reaches the gate's candidate set.
     expect(laneCalls.gate[0].candidates).toEqual(["keep"]);
     expect(out.selectedSlugs).toEqual(["keep"]);
   });

--- a/assistant/src/memory/v3/__tests__/traversal.test.ts
+++ b/assistant/src/memory/v3/__tests__/traversal.test.ts
@@ -52,12 +52,18 @@ function makeTree(
   };
 }
 
-/** Descend into every node child offered (mechanical "descend all" stub). */
+/**
+ * Descend into every node child offered and keep every page child offered
+ * (mechanical "descend all + keep all" stub — the old bulk-collect behavior).
+ */
 function descendAll(
   _nodeId: string,
   children: ReadonlyArray<ChildRef>,
 ): DescendResult {
-  return { descend: children.filter((c) => c.kind === "node") };
+  return {
+    descend: children.filter((c) => c.kind === "node"),
+    keep: children.filter((c) => c.kind === "page"),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -326,8 +332,9 @@ describe("walkTree — descend decision", () => {
       _nodeId: string,
       children: ReadonlyArray<ChildRef>,
     ): DescendResult => ({
-      // Pick only "a".
+      // Pick only "a"; keep every page child encountered.
       descend: children.filter((c) => c.kind === "node" && c.ref === "a"),
+      keep: children.filter((c) => c.kind === "page"),
       reasoning: "a is more relevant",
     });
 
@@ -350,9 +357,13 @@ describe("walkTree — descend decision", () => {
       a: [page("pa")],
     });
 
-    const descend = (): DescendResult => ({
+    const descend = (
+      _nodeId: string,
+      children: ReadonlyArray<ChildRef>,
+    ): DescendResult => ({
       // "ghost" was never offered; "pr" is a page, not a node child.
       descend: [node("ghost"), page("pr")],
+      keep: children.filter((c) => c.kind === "page"),
     });
 
     const { pages, levels } = await walkTree(tree, {
@@ -380,6 +391,7 @@ describe("walkTree — descend decision", () => {
     const descend = (): DescendResult => ({
       // "a" repeated should count once; budget of 2 then still admits "b".
       descend: [node("a"), node("a"), node("b")],
+      keep: [],
     });
 
     const { levels } = await walkTree(tree, {
@@ -391,5 +403,67 @@ describe("walkTree — descend decision", () => {
     const rootLevel = levels.find((l) => l.node === "_root")!;
     expect(rootLevel.descended).toEqual(["a", "b"]);
     expect(rootLevel.skipped).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page keeping
+// ---------------------------------------------------------------------------
+
+describe("walkTree — page keeping", () => {
+  test("collects only the kept page children, dropping the rest", async () => {
+    const tree = makeTree("_root", {
+      _root: [page("pr-keep"), page("pr-drop"), node("a")],
+      a: [page("pa-keep"), page("pa-drop")],
+    });
+
+    // Descend every node; keep only the pages whose slug ends in "-keep".
+    const descend = (
+      _nodeId: string,
+      children: ReadonlyArray<ChildRef>,
+    ): DescendResult => ({
+      descend: children.filter((c) => c.kind === "node"),
+      keep: children.filter(
+        (c) => c.kind === "page" && c.ref.endsWith("-keep"),
+      ),
+    });
+
+    const { pages } = await walkTree(tree, {
+      breadthBudget: 8,
+      maxDepth: 8,
+      descend,
+    });
+
+    // The "-drop" pages were offered but not kept, so they never reach `pages`.
+    expect([...pages].sort()).toEqual(["pa-keep", "pr-keep"]);
+  });
+
+  test("ignores kept refs that were not offered page children of the node", async () => {
+    const tree = makeTree("_root", {
+      _root: [page("real"), node("a")],
+      a: [page("pa")],
+    });
+
+    const descend = (
+      _nodeId: string,
+      children: ReadonlyArray<ChildRef>,
+    ): DescendResult => ({
+      descend: children.filter((c) => c.kind === "node"),
+      // "ghost" was never offered; node("a") is a node, not a page — both are
+      // ignored. Only the genuinely-offered page children survive.
+      keep: [
+        page("ghost"),
+        node("a"),
+        ...children.filter((c) => c.kind === "page"),
+      ],
+    });
+
+    const { pages } = await walkTree(tree, {
+      breadthBudget: 8,
+      maxDepth: 8,
+      descend,
+    });
+
+    expect([...pages].sort()).toEqual(["pa", "real"]);
   });
 });

--- a/assistant/src/memory/v3/__tests__/tree-walk.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-walk.test.ts
@@ -4,22 +4,20 @@
  * The descent provider is always a scripted stub injected via the `provider`
  * arg — no real LLM, no network, no `mock.module`, `~/.vellum/` untouched. The
  * stub keys its scripted decision off the `<node id="...">` marker in the user
- * message so one fixture provider can drive a whole multi-node walk with one
- * call per visited node.
+ * message so one fixture provider can drive a whole multi-node walk.
  *
  * Coverage:
- *   - scripted descent over a fixture tree collects the right leaf pages and
- *     records considered/descended/skipped + reasoning per node.
- *   - one descent call per *visited* node (not per offered child).
- *   - breadthBudget caps descents per node (skip the overflow).
- *   - maxDepth halts the walk.
- *   - scout page hits seed the start node set (deriveSeedNodes) so a subtree the
- *     root never reaches is still walked.
- *   - explicit seeds bias the start set.
- *   - scout hits are rendered into the descend prompt as pressure.
- *   - provider === null → fail-safe: descend nothing, walk still terminates and
- *     collects the pages it reached, reasoning records the failure.
- *   - leaf nodes (no node children) make no provider call.
+ *   - scripted descent collects the kept leaf pages and records
+ *     considered/descended/skipped + reasoning per node.
+ *   - one descent call per *visited node with children* (node or page) — leaf
+ *     buckets are now judged for page selection, not bulk-collected.
+ *   - the descender keeps only the pages the model selects (drops the rest).
+ *   - breadthBudget caps descents per node; maxDepth halts the walk.
+ *   - the walk starts at root only — scout hits steer it as prompt pressure,
+ *     not as mid-tree seeds.
+ *   - provider === null → fail-safe: descend + keep nothing, walk still
+ *     terminates, reasoning records the failure.
+ *   - the forced tool exposes keep_pages (enum = offered page slugs).
  *   - request shape: forced tool_choice on `choose_branches`, abort signal
  *     forwarded.
  */
@@ -39,7 +37,7 @@ import type { PageIndex } from "../../v2/page-index.js";
 import type { LlmCallRecord } from "../llm-capture.js";
 import { DESCENT_SYSTEM_PROMPT } from "../prompts/system-prompts.js";
 import type { ChildRef, TreeIndex } from "../tree-index.js";
-import { createDescender, deriveSeedNodes, runTreeWalk } from "../tree-walk.js";
+import { createDescender, runTreeWalk } from "../tree-walk.js";
 import type { TreeNode } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -78,9 +76,8 @@ function makeNode(id: string, children: ChildRef[]): TreeNode {
 
 /**
  * Build an in-memory `TreeIndex` from a forward-adjacency spec, materializing
- * `nodes`, `childrenByNode`, and the `pageParents` reverse edges (the only maps
- * `tree-walk.ts` reads). `parentsByNode` is left empty — the driver never reads
- * it.
+ * `nodes`, `childrenByNode`, and the `pageParents` reverse edges. `parentsByNode`
+ * is left empty — the driver never reads it.
  */
 function makeTree(
   root: string,
@@ -183,13 +180,26 @@ function nodeIdFromCall(call: ProviderCall): string | null {
   return null;
 }
 
+/** Read the `keep_pages` enum (offered page slugs) out of a built descend tool. */
+function keepPagesEnum(tool: ToolDefinition | undefined): string[] {
+  const schema = tool?.input_schema as
+    | { properties?: { keep_pages?: { items?: { enum?: string[] } } } }
+    | undefined;
+  return schema?.properties?.keep_pages?.items?.enum ?? [];
+}
+
 /**
  * A scripted descent provider. `script` maps a node id to the bare child-node
- * ids to descend (and an optional reasoning string). Records every call and
- * honors an already-aborted signal by throwing.
+ * ids to descend, an optional explicit `keep` (page slugs), and an optional
+ * reasoning. When `keep` is omitted the stub keeps *every* offered page (the old
+ * bulk behavior), so a test only sets `keep` when exercising selective keeping.
+ * Records every call and honors an already-aborted signal by throwing.
  */
 function makeProvider(
-  script: Record<string, { descend: string[]; reasoning?: string }>,
+  script: Record<
+    string,
+    { descend: string[]; keep?: string[]; reasoning?: string }
+  >,
   calls: ProviderCall[],
 ): Provider {
   return {
@@ -204,7 +214,11 @@ function makeProvider(
       const nodeId =
         nodeIdFromCall({ messages, tools, systemPrompt, options }) ?? "";
       const decision = script[nodeId] ?? { descend: [] };
-      const input: Record<string, unknown> = { descend: decision.descend };
+      const keep = decision.keep ?? keepPagesEnum(tools?.[0]);
+      const input: Record<string, unknown> = {
+        descend: decision.descend,
+        keep_pages: keep,
+      };
       if (decision.reasoning !== undefined)
         input.reasoning = decision.reasoning;
       const response: ProviderResponse = {
@@ -226,43 +240,11 @@ function makeProvider(
 }
 
 // ---------------------------------------------------------------------------
-// deriveSeedNodes
-// ---------------------------------------------------------------------------
-
-describe("deriveSeedNodes", () => {
-  test("maps scout page slugs to their parent nodes via pageParents", () => {
-    const tree = makeTree("_root", {
-      _root: [node("a"), node("b")],
-      a: [page("pa")],
-      b: [page("pb")],
-    });
-    const scouts: ScoutResult[] = [{ lane: "sparse", slugs: ["pb"] }];
-    expect(deriveSeedNodes(tree, scouts, [])).toEqual(["b"]);
-  });
-
-  test("unions explicit seeds first, then scout-derived parents, dedup'd", () => {
-    const tree = makeTree("_root", {
-      _root: [node("a")],
-      a: [page("pa")],
-    });
-    const scouts: ScoutResult[] = [{ lane: "hot", slugs: ["pa", "pa"] }];
-    // "a" is both an explicit seed and the parent of pa — appears once, seeds first.
-    expect(deriveSeedNodes(tree, scouts, ["a", "x"])).toEqual(["a", "x"]);
-  });
-
-  test("ignores scout slugs with no parent node", () => {
-    const tree = makeTree("_root", { _root: [page("pr")] });
-    const scouts: ScoutResult[] = [{ lane: "dense", slugs: ["orphan"] }];
-    expect(deriveSeedNodes(tree, scouts, [])).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // runTreeWalk — scripted descent
 // ---------------------------------------------------------------------------
 
 describe("runTreeWalk — scripted descent", () => {
-  test("collects the right leaf pages and records the descend/skip split", async () => {
+  test("collects the kept leaf pages and records the descend/skip split", async () => {
     // _root → {a, b}; a → leaf pa; b → leaf pb. Script descends only "a".
     const tree = makeTree("_root", {
       _root: [node("a"), node("b")],
@@ -281,11 +263,10 @@ describe("runTreeWalk — scripted descent", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
-    // Only the descended branch's page is collected.
+    // Only the descended branch's page is kept; b is skipped entirely.
     expect([...collected]).toEqual(["pa"]);
 
     const rootLevel = levels.find((l) => l.node === "_root")!;
@@ -294,11 +275,38 @@ describe("runTreeWalk — scripted descent", () => {
     expect(rootLevel.skipped).toEqual(["b"]);
     expect(rootLevel.reasoning).toBe("a matches the turn");
 
-    // _root walked (has node children) + a walked (leaf, no call). b skipped.
+    // _root (node children) and a (page child) are both walked; b is skipped.
     expect(levels.map((l) => l.node).sort()).toEqual(["_root", "a"]);
   });
 
-  test("makes exactly one descent call per visited node with node children", async () => {
+  test("keeps only the pages the model selects at a node", async () => {
+    // _root → a, a leaf bucket of two pages. The model keeps only one.
+    const tree = makeTree("_root", {
+      _root: [node("a")],
+      a: [page("pa-keep"), page("pa-drop")],
+    });
+    const pages = makePages(["pa-keep", "pa-drop"]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      {
+        _root: { descend: ["a"] },
+        a: { descend: [], keep: ["pa-keep"] },
+      },
+      calls,
+    );
+
+    const { pages: collected } = await runTreeWalk({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    expect([...collected]).toEqual(["pa-keep"]);
+  });
+
+  test("makes one descent call per visited node with children", async () => {
     const tree = makeTree("_root", {
       _root: [node("a"), node("b")],
       a: [node("c"), page("pa")],
@@ -308,11 +316,7 @@ describe("runTreeWalk — scripted descent", () => {
     const pages = makePages(["pa", "pb", "pc"]);
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      {
-        _root: { descend: ["a", "b"] },
-        a: { descend: ["c"] },
-        // b and c are leaves of the descended set; c has no node children.
-      },
+      { _root: { descend: ["a", "b"] }, a: { descend: ["c"] } },
       calls,
     );
 
@@ -321,14 +325,13 @@ describe("runTreeWalk — scripted descent", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
-    // Calls happen for nodes that HAVE node children: _root, a. b (leaf) and
-    // c (leaf) are visited but short-circuit before the provider call.
+    // Every visited node has children (b and c are page-only leaf buckets that
+    // now get a page-selection call too), so all four are called.
     const calledNodes = calls.map(nodeIdFromCall).sort();
-    expect(calledNodes).toEqual(["_root", "a"]);
+    expect(calledNodes).toEqual(["_root", "a", "b", "c"]);
   });
 
   test("breadthBudget caps descents per node", async () => {
@@ -351,7 +354,6 @@ describe("runTreeWalk — scripted descent", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
@@ -379,7 +381,6 @@ describe("runTreeWalk — scripted descent", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
@@ -390,13 +391,13 @@ describe("runTreeWalk — scripted descent", () => {
 });
 
 // ---------------------------------------------------------------------------
-// runTreeWalk — scout seeding
+// runTreeWalk — root-only walk + scout pressure
 // ---------------------------------------------------------------------------
 
-describe("runTreeWalk — scout seeding", () => {
-  test("scout page hits seed a subtree the root never reaches", async () => {
-    // root only links to a; the "island" subtree is unreachable from root but a
-    // scout surfaced its leaf page, so deriveSeedNodes seeds `island`.
+describe("runTreeWalk — root-only walk", () => {
+  test("starts at root only — a scout hit in an unreachable subtree is not walked", async () => {
+    // root only links to `a`; `island` is unreachable from root. A scout
+    // surfaced its leaf page, but the walk no longer seeds at scout parents.
     const tree = makeTree("_root", {
       _root: [node("a")],
       a: [page("pa")],
@@ -412,35 +413,12 @@ describe("runTreeWalk — scout seeding", () => {
       tree,
       pages,
       scouts,
-      seeds: [],
       provider,
     });
 
-    // Both the root branch (pa) and the scout-seeded island (treasure) reached.
-    expect([...collected].sort()).toEqual(["pa", "treasure"]);
-    expect(levels.map((l) => l.node).sort()).toEqual(["_root", "a", "island"]);
-  });
-
-  test("explicit seeds bias the start set", async () => {
-    const tree = makeTree("_root", {
-      _root: [page("pr")],
-      mid: [page("pm")],
-    });
-    const pages = makePages(["pr", "pm"]);
-    const calls: ProviderCall[] = [];
-    const provider = makeProvider({}, calls);
-
-    const { pages: collected, levels } = await runTreeWalk({
-      input: makeInput(),
-      tree,
-      pages,
-      scouts: [],
-      seeds: ["mid"],
-      provider,
-    });
-
-    expect([...collected].sort()).toEqual(["pm", "pr"]);
-    expect(levels.map((l) => l.node).sort()).toEqual(["_root", "mid"]);
+    // Only the root branch is walked; `island`/treasure is never reached.
+    expect([...collected]).toEqual(["pa"]);
+    expect(levels.map((l) => l.node).sort()).toEqual(["_root", "a"]);
   });
 
   test("renders scout hits into the descend prompt as pressure", async () => {
@@ -458,10 +436,7 @@ describe("runTreeWalk — scout seeding", () => {
       input: makeInput(),
       tree,
       pages,
-      // Pass scouts but no parent-seed match so the start set stays root-only;
-      // we only assert the prompt rendering here.
       scouts,
-      seeds: [],
       provider,
     });
 
@@ -476,11 +451,11 @@ describe("runTreeWalk — scout seeding", () => {
 });
 
 // ---------------------------------------------------------------------------
-// runTreeWalk — fail-safe + request shape
+// runTreeWalk — fail-safe
 // ---------------------------------------------------------------------------
 
 describe("runTreeWalk — fail-safe", () => {
-  test("provider null descends nothing but still terminates and collects reached pages", async () => {
+  test("provider null descends and keeps nothing but still terminates", async () => {
     const tree = makeTree("_root", {
       _root: [node("a"), page("pr")],
       a: [page("pa")],
@@ -492,12 +467,12 @@ describe("runTreeWalk — fail-safe", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider: null,
     });
 
-    // Root's own page is collected; the undescended branch's page is not.
-    expect([...collected]).toEqual(["pr"]);
+    // No provider → the node keeps nothing (the scout lanes carry recall in the
+    // loop), descends nothing, and the walk stops at root.
+    expect([...collected]).toEqual([]);
     expect(levels.map((l) => l.node)).toEqual(["_root"]);
     const rootLevel = levels[0];
     expect(rootLevel.descended).toEqual([]);
@@ -538,7 +513,6 @@ describe("runTreeWalk — fail-safe", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
@@ -547,6 +521,10 @@ describe("runTreeWalk — fail-safe", () => {
     expect(rootLevel.reasoning).toContain("validation");
   });
 });
+
+// ---------------------------------------------------------------------------
+// createDescender — request shape + page selection
+// ---------------------------------------------------------------------------
 
 describe("createDescender — request shape", () => {
   test("forces tool_choice on choose_branches and forwards the abort signal", async () => {
@@ -558,18 +536,13 @@ describe("createDescender — request shape", () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider({ _root: { descend: ["a"] } }, calls);
 
-    const reasoningByNode = new Map<string, string>();
-    const descender = createDescender(
-      {
-        input: makeInput({ signal: AbortSignal.timeout(10_000) }),
-        tree,
-        pages,
-        scouts: [],
-        seeds: [],
-        provider,
-      },
-      reasoningByNode,
-    );
+    const descender = createDescender({
+      input: makeInput({ signal: AbortSignal.timeout(10_000) }),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
 
     await descender("_root", [...tree.childrenByNode.get("_root")!]);
 
@@ -584,24 +557,73 @@ describe("createDescender — request shape", () => {
     expect(call.options?.signal).toBeDefined();
   });
 
-  test("a node with no node children makes no provider call", async () => {
-    const tree = makeTree("leaf", { leaf: [page("p")] });
-    const pages = makePages(["p"]);
+  test("exposes a keep_pages enum of the node's offered page slugs", async () => {
+    const tree = makeTree("bucket", {
+      bucket: [page("p1"), page("p2")],
+    });
+    const pages = makePages(["p1", "p2"]);
     const calls: ProviderCall[] = [];
     const provider = makeProvider({}, calls);
 
-    const reasoningByNode = new Map<string, string>();
-    const descender = createDescender(
-      { input: makeInput(), tree, pages, scouts: [], seeds: [], provider },
-      reasoningByNode,
+    const descender = createDescender({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    await descender("bucket", [...tree.childrenByNode.get("bucket")!]);
+
+    expect(keepPagesEnum(calls[0].tools?.[0]).sort()).toEqual(["p1", "p2"]);
+  });
+
+  test("a node with no children at all makes no provider call", async () => {
+    const tree = makeTree("empty", { empty: [] });
+    const pages = makePages([]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider({}, calls);
+
+    const descender = createDescender({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    const result = await descender("empty", [
+      ...(tree.childrenByNode.get("empty") ?? []),
+    ]);
+    expect(result).toEqual({ descend: [], keep: [], reasoning: "" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a leaf bucket of pages makes a call and keeps the selected pages", async () => {
+    const tree = makeTree("leaf", { leaf: [page("p1"), page("p2")] });
+    const pages = makePages(["p1", "p2"]);
+    const calls: ProviderCall[] = [];
+    // Keep only p1.
+    const provider = makeProvider(
+      { leaf: { descend: [], keep: ["p1"] } },
+      calls,
     );
 
-    const chosen = await descender("leaf", [
+    const descender = createDescender({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    const result = await descender("leaf", [
       ...tree.childrenByNode.get("leaf")!,
     ]);
-    expect(chosen).toEqual([]);
-    expect(calls).toHaveLength(0);
-    expect(reasoningByNode.get("leaf")).toBe("");
+
+    expect(calls).toHaveLength(1);
+    expect(result.descend).toEqual([]);
+    expect(result.keep).toEqual([page("p1")]);
   });
 });
 
@@ -625,7 +647,6 @@ describe("runTreeWalk — descent system prompt", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
@@ -644,7 +665,6 @@ describe("runTreeWalk — descent system prompt", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
     });
 
@@ -656,7 +676,7 @@ describe("runTreeWalk — descent system prompt", () => {
 
 describe("runTreeWalk — capture", () => {
   test("emits one record per descender LLM call, tagged with the node", async () => {
-    // Only _root offers node-children, so exactly one descender call fires.
+    // _root has node children but descends nothing, so exactly one call fires.
     const tree = makeTree("_root", {
       _root: [node("a"), node("b")],
       a: [page("pa")],
@@ -664,7 +684,7 @@ describe("runTreeWalk — capture", () => {
     });
     const pages = makePages(["pa", "pb"]);
     const calls: ProviderCall[] = [];
-    const provider = makeProvider({ _root: { descend: ["a"] } }, calls);
+    const provider = makeProvider({ _root: { descend: [] } }, calls);
     const captured: Omit<LlmCallRecord, "pass">[] = [];
 
     await runTreeWalk({
@@ -672,7 +692,6 @@ describe("runTreeWalk — capture", () => {
       tree,
       pages,
       scouts: [],
-      seeds: [],
       provider,
       capture: (record) => captured.push(record),
     });

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -12,10 +12,10 @@
  *                               sticky/bypass and are never judged; the dense
  *                               near-neighbors are filtered down to meaningful
  *                               associations.
- *   3. {@link runTreeWalk}    — scout-seeded hierarchical descent. Seeded by the
- *                               surviving scout slugs (their tree parents) so
- *                               descent starts near where the lanes landed but
- *                               still fans out from the root.
+ *   3. {@link runTreeWalk}    — root-only hierarchical descent that selects
+ *                               pages per node. Scout hits steer it as descend
+ *                               pressure in the prompt; the descender keeps only
+ *                               the relevant leaf pages it finds.
  *   4. {@link expandEdges}    — provider-free 1–2 hop curated-graph expansion
  *                               over every accumulated confident seed.
  *   5. {@link runGate}        — one capable LLM call over the unioned candidate
@@ -184,10 +184,9 @@ export async function runRetrievalLoop(
       }
     }
 
-    // The surviving scout slugs (kept dense + hot + sparse) seed the tree walk.
-    const survivingSeeds = [...candidates];
-
-    // 3. Tree walk — scout-seeded hierarchical descent. Gated by `lanes.tree`.
+    // 3. Tree walk — root-only hierarchical descent that selects pages per
+    // node. Scout hits steer it as descend pressure in the prompt (the scout
+    // pages themselves already entered `candidates` above). Gated by `lanes.tree`.
     let treeLevels: DescentPass["treeLevels"];
     if (lanes.tree) {
       const [tree, pages] = await Promise.all([
@@ -199,7 +198,6 @@ export async function runRetrievalLoop(
         tree,
         pages,
         scouts: scoutResult.scouts,
-        seeds: survivingSeeds,
         capture: passSink,
       });
       treeLevels = walk.levels;

--- a/assistant/src/memory/v3/traversal.ts
+++ b/assistant/src/memory/v3/traversal.ts
@@ -11,8 +11,10 @@
  * `walkTree` fans out from a `start` node and any `seeds`, level by level:
  *   - At each node it resolves the ordered child refs, hands them to `descend`,
  *     and recurses into the chosen `node:` children (capped by `breadthBudget`).
- *   - Every `page:` child encountered anywhere in the walk is collected into the
- *     returned `pages` set — pages are leaves, never recursed into.
+ *   - The `page:` children the `descend` decision chooses to *keep* are collected
+ *     into the returned `pages` set — pages are leaves, never recursed into. A
+ *     page the decision does not keep is dropped, so the walk emits a curated
+ *     selection rather than every page it passes.
  *   - A `visited` set keyed by canonical id (`node:<id>`) dedups shared
  *     sub-nodes (the DAG case) and terminates cycles (A ↔ B). A node is walked
  *     at most once regardless of how many parents reference it.
@@ -34,15 +36,16 @@ import type { TreeLevel } from "../v2/harness/trace.js";
 import type { ChildRef, TreeIndex } from "./tree-index.js";
 
 /**
- * The descend decision injected into {@link walkTree}. Given a node id and its
- * ordered child refs, return the subset of *node* children to recurse into. The
- * driver PR wires this to the LLM; tests pass a deterministic stub.
+ * The decision injected into {@link walkTree}. Given a node id and its ordered
+ * child refs, return the *node* children to recurse into and the *page* children
+ * to keep for the answer. The driver wires this to the LLM; tests pass a
+ * deterministic stub.
  *
  * Returning a `reasoning` string is optional — when present it is threaded into
  * the emitted {@link TreeLevel}; absent, the level's `reasoning` defaults to
- * `""`. Returned refs that are not `node:` children of `nodeId`, or that repeat,
- * are ignored by the walk (it only recurses into distinct node children it
- * actually offered).
+ * `""`. Returned `descend` refs that are not `node:` children of `nodeId`, and
+ * `keep` refs that are not `page:` children of `nodeId`, are ignored by the walk
+ * (it only acts on the distinct children it actually offered).
  */
 export type DescendDecision = (
   nodeId: string,
@@ -51,11 +54,13 @@ export type DescendDecision = (
 
 /**
  * The result of a {@link DescendDecision}. `descend` lists the `node:` children
- * chosen for recursion; `reasoning` is the optional model rationale recorded on
- * the level.
+ * chosen for recursion; `keep` lists the `page:` children to collect into the
+ * walk's result; `reasoning` is the optional model rationale recorded on the
+ * level.
  */
 export interface DescendResult {
   descend: ChildRef[];
+  keep: ChildRef[];
   reasoning?: string;
 }
 
@@ -75,7 +80,7 @@ export interface WalkOptions {
 
 /** The result of a {@link walkTree} run. */
 export interface WalkResult {
-  /** Every `page:` slug encountered across the walk, dedup'd. */
+  /** Every `page:` slug the descend decision kept across the walk, dedup'd. */
   pages: Set<string>;
   /** One {@link TreeLevel} per walked node, in walk order. */
   levels: TreeLevel[];
@@ -141,9 +146,16 @@ export async function walkTree(
     const nextFrontier: string[] = [];
 
     for (const { nodeId, children, result } of levelResults) {
-      // Collect every page child of this node as a leaf hit.
-      for (const child of children) {
-        if (child.kind === "page") pages.add(child.ref);
+      // Collect only the page children the decision chose to keep, filtered to
+      // the page children this node actually offered — a decision can't keep a
+      // page the node never presented.
+      const offeredPageRefs = new Set(
+        children.filter((c) => c.kind === "page").map((c) => c.ref),
+      );
+      for (const choice of result.keep) {
+        if (choice.kind === "page" && offeredPageRefs.has(choice.ref)) {
+          pages.add(choice.ref);
+        }
       }
 
       // The set of node children this node legitimately offered, in order. The

--- a/assistant/src/memory/v3/tree-walk.ts
+++ b/assistant/src/memory/v3/tree-walk.ts
@@ -9,38 +9,29 @@
  * Per visited node the driver makes one cheap LLM call (`memoryV3Descent`) over
  * the node's *composed* index — `composeNodeIndex` renders one line per child
  * (sub-node summary or leaf page summary) plus the node's routing hints — and
- * asks which child *nodes* to descend into. The prompt also carries the
- * conversation context (the just-arrived turn + NOW) and the surviving scout
- * hits, so descent is **scout-seeded but not scout-bound**: the model sees where
- * the cheap lanes already landed, yet still feels pressure to descend branches
- * the scouts missed. A driver that only ratified the scouts would re-introduce
- * the recall cliff the tree walk exists to avoid.
+ * asks two things: which child *nodes* to descend into, and which leaf *pages*
+ * offered at this node to keep for the answer. Selecting pages at every level is
+ * what makes the walk a curated retrieval rather than a bulk dump: only pages
+ * the model keeps reach the candidate set.
  *
- * Scout seeding works at two layers:
- *   1. **Start set** — `runTreeWalk` derives seed *node* ids from scout-surfaced
- *      *page* slugs via the tree's `pageParents` reverse edges (a scout hit on
- *      `page:foo` seeds every node that lists `page:foo` as a child), unioned
- *      with any explicit `seeds`. `walkTree` fans out from `tree.root` + seeds.
- *   2. **Descend pressure** — the surviving scout slugs are rendered into every
- *      descend prompt so the model can prefer (but is not forced onto) branches
- *      that contain them.
+ * The walk descends from `tree.root` only — it is not seeded mid-tree. Scout
+ * hits steer it solely as **descend pressure**: the surviving scout slugs are
+ * rendered into every descend prompt so the model prefers (but is not forced
+ * onto) branches that contain them. The scout-surfaced pages themselves already
+ * reach the gate directly via the loop, so the walk's job is to find the
+ * relevant pages the scouts missed and to keep only what bears on the turn.
  *
- * Reasoning capture. The `createDescender` signature returns plain `ChildRef[]`
- * (the chosen node children) to match the driver contract; the model's stated
- * rationale is written into a side map keyed by node id. `runTreeWalk` adapts
- * the descender into `walkTree`'s `DescendResult`-returning hook by pairing each
- * node's chosen children with its recorded reasoning, so every emitted
- * `TreeLevel` carries the model's reason for its descend/skip split — making a
- * wrong high-level skip observable rather than silent.
+ * The decision returned per node — `{ descend, keep, reasoning }` — is handed
+ * straight to `walkTree`, so every emitted `TreeLevel` carries the model's
+ * reason for its descend/skip split, making a wrong high-level skip observable
+ * rather than silent.
  *
  * Fail-safe. When no provider is configured (or a per-node call errors / returns
- * an unusable response) the descender descends *nothing* for that node and
- * records the reason. The walk still terminates and still collects every leaf
- * page it reached before the failure; it just stops exploring deeper from the
- * affected node. Failing closed (descend nothing) rather than open (descend all)
- * keeps a broken provider from blowing the breadth budget across the whole tree.
- *
- * This module is currently unwired — a later PR composes it into the loop.
+ * an unusable response) the descender descends *nothing* and keeps *nothing* for
+ * that node, recording the reason. The walk still terminates; it just stops
+ * exploring and collecting from the affected node. Failing closed keeps a broken
+ * provider from blowing the breadth budget, and the scout hits already in the
+ * candidate set keep the turn from going memory-blind.
  */
 
 import { z } from "zod";
@@ -65,7 +56,11 @@ import {
   DESCENT_SYSTEM_PROMPT,
   resolveV3SystemPrompt,
 } from "./prompts/system-prompts.js";
-import type { WalkResult } from "./traversal.js";
+import type {
+  DescendDecision,
+  DescendResult,
+  WalkResult,
+} from "./traversal.js";
 import { walkTree } from "./traversal.js";
 import type { ChildRef, TreeIndex } from "./tree-index.js";
 
@@ -74,18 +69,6 @@ const log = getLogger("memory-v3-tree-walk");
 /** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
 const DESCEND_TOOL_NAME = "choose_branches";
 
-/**
- * The descend decision the driver hands to `walkTree`. Returns the subset of
- * `children` (node refs only) to recurse into. Matches the PR contract: a plain
- * `ChildRef[]` promise. The model's reasoning is threaded out-of-band via the
- * side map populated by {@link createDescender}, not the return value, so this
- * signature stays small.
- */
-export type Descender = (
-  nodeId: string,
-  children: ChildRef[],
-) => Promise<ChildRef[]>;
-
 /** Arguments to {@link createDescender}. */
 export interface CreateDescenderArgs {
   input: RetrievalInput;
@@ -93,8 +76,6 @@ export interface CreateDescenderArgs {
   pages: PageIndex;
   /** Surviving scout hits — rendered into the prompt as descend pressure. */
   scouts: ScoutResult[];
-  /** Explicit seed node ids (folded into the prompt's seed context). */
-  seeds: string[];
   /** Optional debug sink — emits one record per descender LLM call (per node). */
   capture?: LlmCallSink;
   /**
@@ -111,30 +92,36 @@ export type RunTreeWalkArgs = CreateDescenderArgs;
 
 /**
  * The forced-tool input schema. `descend` lists the bare node ids the model
- * chose to recurse into; `reasoning` is its stated rationale for the
- * descend/skip split. Mirrors v2's `select_pages_to_inject` forced-tool shape.
+ * chose to recurse into; `keep_pages` lists the leaf page slugs it chose to keep
+ * for the answer; `reasoning` is its stated rationale. Mirrors v2's
+ * `select_pages_to_inject` forced-tool shape.
  */
 const DescendToolResultSchema = z.object({
   descend: z.array(z.string()),
+  keep_pages: z.array(z.string()).optional(),
   reasoning: z.string().optional(),
 });
 
 /**
- * Build the forced tool definition for one node. `descend` is constrained to
- * the node ids actually offered as `node:` children so the model can only pick
- * from genuine branches (the walk filters anyway, but constraining the schema
- * keeps the model honest and the trace clean).
+ * Build the forced tool definition for one node. `descend` is constrained to the
+ * offered `node:` child ids and `keep_pages` to the offered `page:` child slugs,
+ * so the model can only pick from genuine children (the walk filters anyway, but
+ * constraining the schema keeps the model honest and the trace clean).
  */
-function buildDescendTool(offeredNodeIds: readonly string[]): ToolDefinition {
+function buildDescendTool(
+  offeredNodeIds: readonly string[],
+  offeredPageSlugs: readonly string[],
+): ToolDefinition {
   return {
     name: DESCEND_TOOL_NAME,
     description:
-      "Choose which child nodes of the current memory-tree node to descend " +
-      "into for the current turn. Prefer branches likely to contain pages " +
-      "that bear on the turn; you may favor branches the scout hits point at, " +
-      "but descend other promising branches too — missing a relevant subtree " +
-      "is worse than descending an extra one. Return an empty list only when " +
-      "no child node plausibly bears on the turn.",
+      "At the current memory-tree node, decide two things for the current " +
+      "turn: which child NODES to descend into to find more relevant pages, " +
+      "and which leaf PAGES offered here to keep for the answer. Prefer " +
+      "branches and pages likely to bear on the turn; lean toward keeping a " +
+      "plausibly-relevant page over dropping it — missing a relevant page or " +
+      "subtree is worse than including an extra one. Return empty lists only " +
+      "when nothing here plausibly bears on the turn.",
     input_schema: {
       type: "object",
       properties: {
@@ -145,14 +132,24 @@ function buildDescendTool(offeredNodeIds: readonly string[]): ToolDefinition {
               ? { type: "string", enum: [...offeredNodeIds] }
               : { type: "string" },
           description:
-            "Bare ids of the child nodes to descend into. Choose only from " +
+            "Bare ids of the child NODES to descend into. Choose only from " +
             "the offered node children.",
+        },
+        keep_pages: {
+          type: "array",
+          items:
+            offeredPageSlugs.length > 0
+              ? { type: "string", enum: [...offeredPageSlugs] }
+              : { type: "string" },
+          description:
+            "Slugs of the leaf PAGES offered at this node to keep for the " +
+            "answer. Choose only from the offered page children.",
         },
         reasoning: {
           type: "string",
           description:
-            "One short sentence: why these branches were descended and the " +
-            "rest skipped.",
+            "One short sentence: why these branches and pages were chosen " +
+            "and the rest skipped.",
         },
       },
       required: ["descend"],
@@ -175,34 +172,42 @@ function renderScoutHits(scouts: readonly ScoutResult[]): string {
   return `<scout_hits>\n${lines.join("\n")}\n</scout_hits>`;
 }
 
-/** Fail-safe descend result: descend nothing, recording why on the side map. */
-function failClosed(
-  nodeId: string,
-  reasoning: string,
-  reasoningByNode: Map<string, string>,
-): ChildRef[] {
-  reasoningByNode.set(nodeId, reasoning);
-  return [];
+/** Fail-safe decision: descend nothing and keep nothing, recording why. */
+function failClosed(reasoning: string): DescendResult {
+  return { descend: [], keep: [], reasoning };
 }
 
 /**
- * Create the per-node descend decision driving {@link walkTree}.
+ * Resolve the bare ids/slugs the model returned back to the `ChildRef`s the node
+ * actually offered, dropping anything not offered. The walk filters again, but
+ * resolving here keeps the returned refs canonical.
+ */
+function resolveOffered(
+  refs: readonly string[],
+  offered: Map<string, ChildRef>,
+): ChildRef[] {
+  const out: ChildRef[] = [];
+  for (const ref of refs) {
+    const child = offered.get(ref);
+    if (child) out.push(child);
+  }
+  return out;
+}
+
+/**
+ * Create the per-node decision driving {@link walkTree}.
  *
- * The returned function makes one forced-tool `memoryV3Descent` call per node
- * over its composed index, returning the chosen `node:` children. The model's
- * reasoning for each node is written into `reasoningByNode` (keyed by node id)
- * rather than the return value, so the small `Descender` signature is preserved
- * and {@link runTreeWalk} can merge the reasoning into each `TreeLevel`.
+ * The returned {@link DescendDecision} makes one forced-tool `memoryV3Descent`
+ * call per node that has any children, over its composed index, and returns the
+ * `node:` children to descend plus the `page:` children to keep — with the
+ * model's reasoning inline. A node with no children at all skips the call.
  *
  * Provider resolution honors the `provider` arg (including explicit `null` for
  * the fail-safe path) and otherwise resolves the configured call site once per
  * call. Any failure — no provider, provider throw, missing/mismatched tool_use
- * — fails closed (descend nothing) with the reason recorded.
+ * — fails closed (descend and keep nothing) with the reason recorded.
  */
-export function createDescender(
-  args: CreateDescenderArgs,
-  reasoningByNode: Map<string, string>,
-): Descender {
+export function createDescender(args: CreateDescenderArgs): DescendDecision {
   const { input, tree, pages, scouts } = args;
   const conversationContext = renderConversationContext(input);
   const scoutHits = renderScoutHits(scouts);
@@ -215,13 +220,15 @@ export function createDescender(
     input.workspaceDir,
   );
 
-  return async (nodeId: string, children: ChildRef[]): Promise<ChildRef[]> => {
+  return async (
+    nodeId: string,
+    children: ReadonlyArray<ChildRef>,
+  ): Promise<DescendResult> => {
     const offeredNodes = children.filter((c) => c.kind === "node");
-    // No node children to descend — nothing to ask the model. Record an empty
-    // reasoning so the level still reflects the (trivial) decision.
-    if (offeredNodes.length === 0) {
-      reasoningByNode.set(nodeId, "");
-      return [];
+    const offeredPages = children.filter((c) => c.kind === "page");
+    // No children at all — nothing to ask the model.
+    if (offeredNodes.length === 0 && offeredPages.length === 0) {
+      return { descend: [], keep: [], reasoning: "" };
     }
 
     const provider =
@@ -231,17 +238,14 @@ export function createDescender(
     if (!provider) {
       log.warn(
         { nodeId },
-        "memoryV3Descent provider unavailable; descending nothing",
+        "memoryV3Descent provider unavailable; descending and keeping nothing",
       );
-      return failClosed(
-        nodeId,
-        "no provider configured — descended nothing",
-        reasoningByNode,
-      );
+      return failClosed("no provider configured — descended and kept nothing");
     }
 
     const indexBlock = composeNodeIndex(nodeId, tree, pages);
     const offeredNodeIds = offeredNodes.map((c) => c.ref);
+    const offeredPageSlugs = offeredPages.map((c) => c.ref);
 
     const userMsg: Message = {
       role: "user",
@@ -256,7 +260,7 @@ export function createDescender(
       ],
     };
 
-    const descendTool = buildDescendTool(offeredNodeIds);
+    const descendTool = buildDescendTool(offeredNodeIds, offeredPageSlugs);
 
     const startedAt = Date.now();
     let response;
@@ -276,13 +280,9 @@ export function createDescender(
     } catch (err) {
       log.warn(
         { err, nodeId },
-        "Descent provider call threw; descending nothing",
+        "Descent provider call threw; descending and keeping nothing",
       );
-      return failClosed(
-        nodeId,
-        "descent call failed — descended nothing",
-        reasoningByNode,
-      );
+      return failClosed("descent call failed — descended and kept nothing");
     }
 
     args.capture?.({
@@ -298,12 +298,10 @@ export function createDescender(
     if (!toolBlock || toolBlock.name !== DESCEND_TOOL_NAME) {
       log.warn(
         { stopReason: response.stopReason, nodeId },
-        "Descent model returned no choose_branches tool_use; descending nothing",
+        "Descent model returned no choose_branches tool_use; descending and keeping nothing",
       );
       return failClosed(
-        nodeId,
-        "model returned no descend decision — descended nothing",
-        reasoningByNode,
+        "model returned no descend decision — descended and kept nothing",
       );
     }
 
@@ -311,95 +309,43 @@ export function createDescender(
     if (!parsed.success) {
       log.warn(
         { error: parsed.error.message, nodeId },
-        "Descent tool input did not match schema; descending nothing",
+        "Descent tool input did not match schema; descending and keeping nothing",
       );
       return failClosed(
-        nodeId,
-        "descend decision failed validation — descended nothing",
-        reasoningByNode,
+        "descend decision failed validation — descended and kept nothing",
       );
     }
 
-    reasoningByNode.set(nodeId, parsed.data.reasoning ?? "");
-
-    // Map the chosen bare ids back to the offered ChildRefs. The walk filters
-    // bogus / unoffered refs anyway, but resolving against the offered set here
-    // keeps the returned ChildRefs canonical.
-    const offeredById = new Map(offeredNodes.map((c) => [c.ref, c]));
-    const chosen: ChildRef[] = [];
-    for (const id of parsed.data.descend) {
-      const ref = offeredById.get(id);
-      if (ref) chosen.push(ref);
-    }
-    return chosen;
+    const descend = resolveOffered(
+      parsed.data.descend,
+      new Map(offeredNodes.map((c) => [c.ref, c])),
+    );
+    const keep = resolveOffered(
+      parsed.data.keep_pages ?? [],
+      new Map(offeredPages.map((c) => [c.ref, c])),
+    );
+    return { descend, keep, reasoning: parsed.data.reasoning ?? "" };
   };
 }
 
 /**
- * Derive the seed *node* ids for the walk from the surviving scout *page* hits.
- *
- * Scouts surface concept-page slugs; the tree's `pageParents` reverse edges map
- * each page slug to the node(s) that list it as a child. Seeding the walk at
- * those parent nodes drops the model in near where the cheap lanes already
- * landed (layer 1 of scout seeding), while the walk still fans out from the
- * root and the descend pressure (layer 2) keeps it from collapsing onto the
- * scouts. Explicit `seeds` are unioned in. Order is deterministic: explicit
- * seeds first (in given order), then scout-derived parents in scout/slug order.
- */
-export function deriveSeedNodes(
-  tree: TreeIndex,
-  scouts: readonly ScoutResult[],
-  seeds: readonly string[],
-): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  const push = (id: string): void => {
-    if (seen.has(id)) return;
-    seen.add(id);
-    out.push(id);
-  };
-  for (const id of seeds) push(id);
-  for (const scout of scouts) {
-    for (const slug of scout.slugs) {
-      const parents = tree.pageParents.get(slug);
-      if (!parents) continue;
-      for (const parent of parents) push(parent);
-    }
-  }
-  return out;
-}
-
-/**
- * Drive a full scout-seeded tree walk for one retrieval pass.
+ * Drive a full tree walk for one retrieval pass.
  *
  * Wires {@link createDescender} into {@link walkTree} with `breadthBudget` /
- * `maxDepth` drawn from `config.memory.v3` (on `input.config`) and the start set
- * seeded by {@link deriveSeedNodes}. Returns the collected leaf pages and the
- * per-node `TreeLevel[]`, each level carrying the model's recorded reasoning.
- *
- * The descender records reasoning into a node-keyed side map; this function
- * adapts it into `walkTree`'s `DescendResult`-returning hook by pairing each
- * node's chosen children with its recorded reason, so the walk threads the
- * reasoning onto every emitted level.
+ * `maxDepth` drawn from `config.memory.v3` (on `input.config`). The walk starts
+ * at `tree.root` only — scout hits steer it as descend pressure in the prompt,
+ * not as mid-tree start points. Returns the kept leaf pages and the per-node
+ * `TreeLevel[]`, each level carrying the model's recorded reasoning.
  */
 export async function runTreeWalk(args: RunTreeWalkArgs): Promise<WalkResult> {
-  const { input, tree, scouts, seeds } = args;
+  const { input, tree } = args;
   const v3 = input.config.memory?.v3;
   const breadthBudget = v3?.breadthBudget ?? 6;
   const maxDepth = v3?.maxDepth ?? 6;
 
-  const reasoningByNode = new Map<string, string>();
-  const descender = createDescender(args, reasoningByNode);
-
-  const seedNodes = deriveSeedNodes(tree, scouts, seeds);
-
   return walkTree(tree, {
-    seeds: seedNodes,
     breadthBudget,
     maxDepth,
-    descend: async (nodeId, children) => {
-      const descend = await descender(nodeId, [...children]);
-      return { descend, reasoning: reasoningByNode.get(nodeId) ?? "" };
-    },
+    descend: createDescender(args),
   });
 }


### PR DESCRIPTION
## Summary
- The v3 tree-walk descender now selects **pages** per node, not just which child nodes to recurse into. The forced `choose_branches` tool gains `keep_pages` (enum = the node's offered page slugs); `walkTree` collects only the kept pages, so every bucket the walk enters is judged at page granularity instead of dumped wholesale.
- The walk **descends from root only** — it no longer seeds at the parent node of every scout hit. Scout hits steer descent purely as prompt pressure; the scout-surfaced pages already reach the gate directly via the loop, so recall is preserved.
- This fixes the regression where roughly half the corpus reached the selection gate as query-blind candidates, making v3 under-recall vs v2 on focused/conceptual queries. The descender also now runs at leaf buckets (page-only nodes), which previously made no call and bulk-collected every page.
- Contract cleanup: `createDescender` returns a `DescendDecision` directly (`{ descend, keep, reasoning }`), removing the `reasoningByNode` side map, the `Descender` type, and the now-unused `deriveSeedNodes`.

## Original prompt
Measuring v3 retrieval against v2 via `assistant memory v3 simulate` showed v3 was *worse* than v2 on focused and broad-conceptual queries: the tree walk seeded itself at the parent bucket of every scout hit and bulk-collected all their pages, flooding the selection gate with ~1000 candidates (the vast majority off-topic). The walk was meant to be a selective needle-finder but had become the haystack it was supposed to fix. This change makes the descender choose concept pages at each level and descend from root only — realizing the intended "scouts as guidance → root → choose branches → select pages → gate" design. v3 is pre-production (simulate/shadow only), so the behavior changes directly without a new flag; real validation is re-running the query comparison after restart.

## Test plan
- [ ] After restart, `assistant memory v3 simulate` on representative queries: the gate's candidate pool should drop from ~1000 toward the low hundreds, and recall on focused queries should approach v2.
- [x] `bunx tsc --noEmit` clean; `traversal`/`tree-walk`/`loop`/`coactivation-store` v3 test files pass scoped; prettier + eslint clean.