### PR TITLE
fix(memory-v3): pin selection lanes to temperature 0

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -47,10 +47,13 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   memoryV2Migration: { profile: "cost-optimized" },
   memoryV2Sweep: { profile: "cost-optimized" },
   memoryV2Consolidation: { profile: "balanced" },
-  // memory v3: cheap filter + descent, capable gate.
-  memoryV3Filter: { profile: "cost-optimized" },
-  memoryV3Descent: { profile: "cost-optimized" },
-  memoryV3Gate: { profile: "balanced" },
+  // memory v3: cheap filter + descent, capable gate. All three are
+  // selection/classification calls, not generation — pin temperature to 0 so
+  // the same candidate set yields the same keep/descend/select decision instead
+  // of sampling-driven variance.
+  memoryV3Filter: { profile: "cost-optimized", temperature: 0 },
+  memoryV3Descent: { profile: "cost-optimized", temperature: 0 },
+  memoryV3Gate: { profile: "balanced", temperature: 0 },
   conversationSummarization: { profile: "cost-optimized" },
   conversationTitle: { profile: "cost-optimized" },
   approvalCopy: { profile: "cost-optimized" },


### PR DESCRIPTION
## Summary
- The v3 retrieval loop's three LLM lanes — dense filter, tree-walk descender, and selection gate — are selection/classification tasks, but inherited an unset `temperature` from their profiles and ran at the provider default (~1.0).
- This produced sampling-driven variance: the same candidate set could yield materially different keep/descend/select decisions across runs (e.g. a thematic query's relevant-page selection swung run-to-run).
- Pin `temperature: 0` on `memoryV3Filter`, `memoryV3Descent`, and `memoryV3Gate` in `call-site-defaults.ts`, mirroring the existing `recall` call-site default.

## Original prompt
While profiling v3 retrieval quality, the selection lanes showed run-to-run variance traceable to running at the provider's default sampling temperature rather than 0. Since these are classification/selection calls (keep/descend/select), not generation, they should be deterministic. This pins them to temperature 0.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `llm-callsite-catalog.test.ts` + `llm-resolver.test.ts` pass (47/47)
- [x] prettier + eslint clean
- [ ] Post-restart: v3 simulate on a thematic query shows reduced selection variance (Gemini is not bit-deterministic at temp 0, so some residual remains)