### PR TITLE
fix(memory-v3): key the sparse scout lane off the user turn, not user+NOW

### DIFF
--- a/assistant/src/memory/v3/__tests__/scouts.test.ts
+++ b/assistant/src/memory/v3/__tests__/scouts.test.ts
@@ -33,6 +33,9 @@ let injectionScores = new Map<string, number>();
 let pageSlugs: string[] = [];
 let hybridHits: ConceptPageQueryResult[] = [];
 let embedCalls = 0;
+// Records the text the sparse lane keyed its BM25 query off, so tests can
+// assert it is the user turn only (not the NOW context).
+let lastBm25QueryText: string | null = null;
 
 mock.module("../../v2/injection-events.js", () => ({
   computeInjectionScores: () => injectionScores,
@@ -62,10 +65,12 @@ mock.module("../../v2/sparse-bm25.js", () => ({
   // Non-empty indices so the sparse/dense lanes don't short-circuit on an
   // "empty query embedding". The values are irrelevant — the stubbed Qdrant
   // query ignores them and returns `hybridHits` directly.
-  generateBm25QueryEmbedding: (text: string) =>
-    text.trim().length > 0
+  generateBm25QueryEmbedding: (text: string) => {
+    lastBm25QueryText = text;
+    return text.trim().length > 0
       ? { indices: [1], values: [1] }
-      : { indices: [], values: [] },
+      : { indices: [], values: [] };
+  },
 }));
 
 mock.module("../../embedding-backend.js", () => ({
@@ -235,6 +240,23 @@ describe("runScouts — sparse lane", () => {
     // Near-exact: readme (top) and api (>= 90% of top). Not misc/note.
     expect([...sticky].sort()).toEqual(["docs/api", "docs/readme"]);
     expect([...bypass].sort()).toEqual(["docs/api", "docs/readme"]);
+  });
+
+  test("keys the BM25 query off the user turn only, not the NOW context", async () => {
+    hybridHits = [hit("docs/readme", { sparseScore: 4.0 })];
+
+    await runScouts(
+      makeInput({
+        userMessage: "favorite foods",
+        nowText: "ongoing project alpha and journal beta",
+        lanes: { hot: false, dense: false },
+      }),
+      DEPS,
+    );
+
+    // The sparse lane must search the user's words alone — folding NOW in would
+    // make NOW-referenced pages near-exact (sticky) on every turn.
+    expect(lastBm25QueryText).toBe("favorite foods");
   });
 
   test("no sparse hits yields no sparse ScoutResult", async () => {

--- a/assistant/src/memory/v3/scouts.ts
+++ b/assistant/src/memory/v3/scouts.ts
@@ -95,10 +95,12 @@ const DENSE_MMR_LAMBDA = 0.7;
 /**
  * Run the always-on scout lanes for one retrieval pass.
  *
- * `queryText` is derived from the last user turn in `input.recentTurnPairs`
- * joined with `input.nowText` — the same shape the v2 router/activation path
- * embeds. Disabled lanes (per `config.memory.v3.lanes`) are skipped entirely:
- * no substrate call, no `ScoutResult` entry.
+ * The dense lane embeds `queryText` (the last user turn joined with
+ * `input.nowText`, the same shape the v2 router/activation path embeds). The
+ * sparse lane keys off `userText` (the user turn alone) so NOW context can't
+ * make whatever it mentions a near-exact sticky hit on every turn. Disabled
+ * lanes (per `config.memory.v3.lanes`) are skipped entirely: no substrate call,
+ * no `ScoutResult` entry.
  *
  * Honors `input.signal` — aborts between lanes and around the dense embed.
  */
@@ -109,6 +111,7 @@ export async function runScouts(
   const { config, signal } = input;
   const lanes = config.memory.v3.lanes;
   const queryText = deriveQueryText(input);
+  const userText = deriveUserText(input);
 
   const scouts: ScoutResult[] = [];
   const sticky = new Set<string>();
@@ -126,10 +129,17 @@ export async function runScouts(
     if (hot) scouts.push(hot);
   }
 
-  // Sparse lane — BM25 keyword match. Near-exact hits seed sticky + bypass.
-  if (lanes.sparse && queryText.length > 0) {
+  // Sparse lane — BM25 keyword match on the user's words ONLY (not the NOW
+  // context). NOW is ambient standing text; folding it into a keyword query
+  // makes whatever pages NOW happens to mention score near-exact on every
+  // turn, and near-exact hits become sticky + tree-bypass — so NOW-referenced
+  // pages would be force-injected into every selection regardless of the
+  // query. Keying sparse off the user turn keeps lexical match, sticky, and
+  // bypass tied to what the user actually asked. (Dense still embeds NOW below;
+  // semantic context legitimately helps there.)
+  if (lanes.sparse && userText.length > 0) {
     signal?.throwIfAborted();
-    const sparse = await runSparseLane(queryText, signal);
+    const sparse = await runSparseLane(userText, signal);
     if (sparse) {
       scouts.push(sparse.result);
       for (const slug of sparse.nearExact) {
@@ -154,15 +164,25 @@ export async function runScouts(
 // ---------------------------------------------------------------------------
 
 /**
- * Build the scout query text from the just-arrived user turn plus the NOW
+ * The just-arrived user turn's text — the last `recentTurnPairs` entry's
+ * `userMessage`. This is the keyword target for the sparse lane and the basis
+ * for near-exact sticky/bypass, which must reflect what the user actually
+ * asked rather than the ambient NOW context.
+ */
+function deriveUserText(input: RetrievalInput): string {
+  const lastPair = input.recentTurnPairs[input.recentTurnPairs.length - 1];
+  return (lastPair?.userMessage ?? "").trim();
+}
+
+/**
+ * Build the dense-lane query text from the just-arrived user turn plus the NOW
  * context. Mirrors the v2 activation path (`selectCandidates`): join the
- * non-empty channels with a newline. The last `recentTurnPairs` entry's
- * `userMessage` is the turn being routed.
+ * non-empty channels with a newline. NOW is included here because semantic
+ * embedding benefits from standing context; the sparse lane deliberately omits
+ * it (see {@link deriveUserText}).
  */
 function deriveQueryText(input: RetrievalInput): string {
-  const lastPair = input.recentTurnPairs[input.recentTurnPairs.length - 1];
-  const userText = lastPair?.userMessage ?? "";
-  return [userText, input.nowText]
+  return [deriveUserText(input), input.nowText]
     .filter((s) => s.trim().length > 0)
     .join("\n")
     .trim();


### PR DESCRIPTION
## Summary
- `deriveQueryText` joins the user message with the NOW standing-context. The sparse (BM25) lane used it, so NOW-referenced pages scored near-exact on *every* turn — and near-exact sparse hits are marked **sticky** (force-injected into the final selection) + tree-bypass. Net: the same handful of NOW-referenced pages were injected into 100% of selections regardless of query, dominating focused-query results.
- Fix: the sparse lane (and the near-exact sticky/bypass it seeds) now keys off the **user turn alone**. The dense lane still embeds user+NOW (semantic context legitimately helps there).
- Validated against a 12-query diagnostic eval: the previously-ubiquitous pages dropped from ~12/12 selections to 0–1/12 (now appearing only when genuinely query-relevant), and selections fill with query-relevant pages instead. Recall preserved.

## Original prompt
A broad eval of v3 retrieval across 12 diverse queries found the same ~6 pages appearing in every single selection regardless of topic, crowding out query-relevant results. Root-caused to the NOW standing-context being folded into the sparse/BM25 query, turning NOW-referenced pages into permanent sticky hits. This scopes the sparse lane to the user's actual words.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] scouts.test.ts 16/16 (added: sparse keys off the user turn, not NOW)
- [x] loop.test.ts 8/8
- [x] prettier + eslint clean
- [x] 12-query eval: bleed pages 12/12 → 0–1/12; query-relevant selections preserved