### PR TITLE
feat(memory-v3): optional candidate summaries for the selection gate

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -235,6 +235,7 @@ describe("MemoryV3ConfigSchema", () => {
         descent: { override: null, path: null },
         gate: { override: null, path: null },
       },
+      gateCandidateSummaries: false,
     });
   });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -579,6 +579,14 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Per-lane system-prompt overrides for the three v3 LLM call sites (filter, descent, gate). Each entry takes an inline `override` string (highest precedence) and/or a file `path` whose contents replace the bundled prompt; absolute paths are used as-is, a leading `~/` expands to the home directory, otherwise the path resolves under the workspace root. An empty/whitespace inline override or a missing/unreadable/empty file falls back to the bundled prompt. Lets the prompts be iterated at runtime without a rebuild/restart — mirroring `memory.v2.router.router_prompt_path`.",
       ),
+    gateCandidateSummaries: z
+      .boolean({
+        error: "memory.v3.gateCandidateSummaries must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "When true, the selection gate sees each candidate as `slug — summary` instead of the bare slug, so it can judge relevance on page content. Off by default: with the bundled (precision-leaning) gate prompt this makes the gate more selective. It pays off paired with a recall-leaning gate prompt override, where the summaries let the gate recognize non-obvious associative/emotional matches it would otherwise pass over. Adds the candidate summaries to the gate prompt (larger input).",
+      ),
   })
   .default({
     enabled: false,
@@ -600,6 +608,7 @@ export const MemoryV3ConfigSchema = z
       descent: { override: null, path: null },
       gate: { override: null, path: null },
     },
+    gateCandidateSummaries: false,
   })
   .describe(
     "Memory v3 — multi-lane bounded-descent retrieval. Additive scaffolding, disabled by default.",

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -253,6 +253,58 @@ describe("runGate — ready decision", () => {
   });
 });
 
+describe("runGate — candidate summaries", () => {
+  test("renders candidates as `slug — summary` when summaryBySlug is provided", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: ["a/one"] }),
+      calls,
+    );
+
+    const result = await runGate({
+      input: makeInput(),
+      candidates: new Set(["a/one", "b/two"]),
+      sticky: new Set(),
+      passNumber: 1,
+      summaryBySlug: new Map([
+        ["a/one", "first summary"],
+        ["b/two", "second summary"],
+      ]),
+      provider,
+    });
+
+    // The model still answers in bare slugs (the enum is slug-only).
+    expect(result.selectedSlugs).toEqual(["a/one"]);
+    const userText = calls[0].messages[0].content
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(userText).toContain("a/one — first summary");
+    expect(userText).toContain("b/two — second summary");
+  });
+
+  test("falls back to the bare slug when no summary is available", async () => {
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: [] }),
+      calls,
+    );
+
+    await runGate({
+      input: makeInput(),
+      candidates: new Set(["a/one"]),
+      sticky: new Set(),
+      passNumber: 1,
+      provider,
+    });
+
+    const userText = calls[0].messages[0].content
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(userText).toContain("a/one");
+    expect(userText).not.toContain("a/one —");
+  });
+});
+
 describe("runGate — more decision", () => {
   test("surfaces generated follow-up questions", async () => {
     const calls: ProviderCall[] = [];

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -75,6 +75,15 @@ export interface RunGateArgs {
   candidates: Set<string>;
   sticky: Set<string>;
   passNumber: number;
+  /**
+   * Per-candidate one-line summaries, keyed by slug. When present, candidates
+   * are rendered to the model as `slug — summary` so the gate can judge
+   * relevance on page content rather than the slug alone. Missing entries fall
+   * back to the bare slug; the forced tool's `selected_slugs` enum stays
+   * slug-only. The loop passes this only when `memory.v3.gateCandidateSummaries`
+   * is set.
+   */
+  summaryBySlug?: ReadonlyMap<string, string>;
   /** Optional debug sink — emits one record for the gate's LLM call. */
   capture?: LlmCallSink;
   /**
@@ -115,10 +124,12 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
           type: "array",
           items: { type: "string", enum: [...candidateSlugs] },
           description:
-            "Final ordered page slugs to inject. Choose only from the candidate " +
-            "set. Prefer keeping a plausibly-relevant page over dropping it; for a " +
-            "list / 'all of X' / breadth request, include every candidate that " +
-            "plausibly applies rather than trimming to the most prominent few.",
+            "Final ordered page slugs to inject. Each candidate is listed as " +
+            "`slug — summary` when summaries are available; return only the slug " +
+            "(left of the em-dash), and only from the candidate set. Prefer keeping " +
+            "a plausibly-relevant page over dropping it; for a list / 'all of X' / " +
+            "breadth request, include every candidate that plausibly applies rather " +
+            "than trimming to the most prominent few.",
         },
         questions: {
           type: "array",
@@ -144,6 +155,24 @@ const GateToolResultSchema = z.object({
   questions: z.array(z.string()).optional(),
   reasoning: z.string().optional(),
 });
+
+/**
+ * Render the candidate list for the prompt. With summaries available each line
+ * is `slug — summary` so the model can judge relevance on content; without them
+ * it falls back to the bare slug. The slug (left of the em-dash) is what the
+ * `selected_slugs` enum constrains, so the model always answers in slugs.
+ */
+function renderCandidateLines(
+  slugs: readonly string[],
+  summaryBySlug: ReadonlyMap<string, string> | undefined,
+): string {
+  return slugs
+    .map((slug) => {
+      const summary = summaryBySlug?.get(slug);
+      return summary ? `${slug} — ${summary}` : slug;
+    })
+    .join("\n");
+}
 
 /**
  * Order a slug selection: keep the model's returned order, restricted to the
@@ -231,7 +260,9 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
         text:
           `<pass_number>${passNumber}</pass_number>\n\n` +
           `<sticky_slugs>\n${stickySlugs.join("\n")}\n</sticky_slugs>\n\n` +
-          `<candidate_slugs>\n${candidateSlugs.join("\n")}\n</candidate_slugs>`,
+          `<candidates>\n` +
+          `${renderCandidateLines(candidateSlugs, args.summaryBySlug)}\n` +
+          `</candidates>`,
       },
     ],
   };

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -233,12 +233,27 @@ export async function runRetrievalLoop(
       if (!firstPassBySlug.has(slug)) firstPassBySlug.set(slug, passNumber);
     }
 
+    // When gateCandidateSummaries is enabled (opt-in), render candidates to the
+    // gate as `slug — summary` so it can judge relevance on page content rather
+    // than the slug alone. getPageIndex is cached, so this reuses the index the
+    // scouts/tree lanes already built this pass.
+    let summaryBySlug: Map<string, string> | undefined;
+    if (passInput.config.memory.v3.gateCandidateSummaries) {
+      const pageIndex = await getPageIndex(passInput.workspaceDir);
+      summaryBySlug = new Map<string, string>();
+      for (const slug of candidates) {
+        const summary = pageIndex.bySlug.get(slug)?.summary;
+        if (summary) summaryBySlug.set(slug, summary);
+      }
+    }
+
     // 5. Gate — one capable LLM call over the unioned candidate set.
     const gateResult = await runGate({
       input: passInput,
       candidates,
       sticky,
       passNumber,
+      summaryBySlug,
       capture: passSink,
     });
     selectedSlugs = gateResult.selectedSlugs;


### PR DESCRIPTION
## Summary
- Adds an opt-in `memory.v3.gateCandidateSummaries` config flag (default **false** — no behavior change for existing configs).
- When enabled, the retrieval loop builds a slug→summary map from the cached page index and the gate renders each candidate as `slug — summary` instead of the bare slug, so it can judge relevance on page content. The forced `decide_selection` tool's `selected_slugs` enum stays slug-only — the model still answers in slugs.
- Off by default because, with the bundled precision-leaning gate prompt, summaries make the gate *more* selective. It is intended to pair with a recall-leaning gate prompt override (`memory.v3.prompts.gate`), where the summaries let the gate recognize non-obvious associative matches it would otherwise pass over.

## Original prompt
While tuning the v3 retrieval loop for a recall-leaning configuration, the gate's slug-only candidate view limited its ability to weigh candidates whose relevance isn't legible from the slug. This adds an opt-in flag to give the gate one-line candidate summaries (the same data the descender already sees), gated off so default behavior is unchanged.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] gate.test.ts + memory-v2.test.ts pass (68/68; added: gate renders `slug — summary` when summaries provided, bare slug otherwise; schema default includes the new flag)
- [x] prettier + eslint clean