### PR TITLE
feat(web/billing): add invoices modal to plan card

### DIFF
--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -28,15 +28,22 @@ function statusTone(status: string | null): TagTone {
   }
 }
 
-/** Format a minor-unit amount (e.g. cents) in its currency. */
+/**
+ * Format a minor-unit amount in its currency. Stripe amounts are in the
+ * currency's minor unit, whose exponent varies (USD has 2, JPY/KRW have 0),
+ * so we derive the divisor from the currency rather than assuming cents.
+ */
 function formatAmount(minorUnits: number, currency: string): string {
   const code = currency.toUpperCase();
   try {
-    return new Intl.NumberFormat(undefined, {
+    const formatter = new Intl.NumberFormat(undefined, {
       style: "currency",
       currency: code,
-    }).format(minorUnits / 100);
+    });
+    const exponent = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+    return formatter.format(minorUnits / 10 ** exponent);
   } catch {
+    // Unknown currency code: best-effort, assume a 2-digit minor unit.
     return `${(minorUnits / 100).toFixed(2)} ${code}`;
   }
 }

--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -1,0 +1,216 @@
+import { Download, ExternalLink, FileText, Loader2 } from "lucide-react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@vellum/design-library/components/button";
+import { Modal } from "@vellum/design-library/components/modal";
+import { Notice } from "@vellum/design-library/components/notice";
+import { Tag, type TagTone } from "@vellum/design-library/components/tag";
+import { Typography } from "@vellum/design-library/components/typography";
+import { organizationsBillingInvoicesRetrieve } from "@/generated/api/sdk.gen.js";
+import { organizationsBillingInvoicesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen.js";
+import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen.js";
+
+const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [] };
+
+/** Map a Stripe invoice status to a Tag tone for the status chip. */
+function statusTone(status: string | null): TagTone {
+  switch (status) {
+    case "paid":
+      return "positive";
+    case "open":
+      return "warning";
+    case "uncollectible":
+      return "negative";
+    default:
+      // draft, void, or null
+      return "neutral";
+  }
+}
+
+/** Format a minor-unit amount (e.g. cents) in its currency. */
+function formatAmount(minorUnits: number, currency: string): string {
+  const code = currency.toUpperCase();
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+    }).format(minorUnits / 100);
+  } catch {
+    return `${(minorUnits / 100).toFixed(2)} ${code}`;
+  }
+}
+
+/** Format a Unix-seconds timestamp as a human-readable date. */
+function formatDate(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Trigger a PDF download in a new tab. Stripe's `invoice_pdf` URLs serve the
+ * file with an attachment disposition, so the browser downloads rather than
+ * navigates.
+ */
+function downloadPdf(url: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.target = "_blank";
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+interface InvoicesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
+  const invoicesQuery = useQuery({
+    queryKey: organizationsBillingInvoicesRetrieveQueryKey(),
+    enabled: open,
+    queryFn: async ({ signal }) => {
+      const { data, response } = await organizationsBillingInvoicesRetrieve({
+        throwOnError: false,
+        signal,
+      });
+      // A 404 means there's no billing history (no Stripe customer yet) —
+      // treat it as an empty list and render the empty state, not an error.
+      if (response?.status === 404) {
+        return EMPTY_RESPONSE;
+      }
+      if (!response?.ok || !data) {
+        throw new Error(
+          `Failed to load invoices (${response?.status ?? "network error"})`,
+        );
+      }
+      return data;
+    },
+  });
+
+  const invoices = invoicesQuery.data?.invoices ?? [];
+  const downloadable = invoices.filter(
+    (invoice): invoice is Invoice & { invoice_pdf: string } =>
+      invoice.invoice_pdf != null,
+  );
+
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="lg">
+        <Modal.Header>
+          <Modal.Title icon={FileText}>Invoices</Modal.Title>
+          <Modal.Description>
+            Your billing history. Open an invoice for full details or download
+            it as a PDF.
+          </Modal.Description>
+        </Modal.Header>
+
+        <Modal.Body>
+          {invoicesQuery.isLoading ? (
+            <div className="flex items-center gap-2 py-6 text-[var(--content-tertiary)]">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <Typography as="span" variant="body-small-default">
+                Loading invoices...
+              </Typography>
+            </div>
+          ) : invoicesQuery.isError ? (
+            <Notice tone="error">Failed to load invoices.</Notice>
+          ) : invoices.length === 0 ? (
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="py-6 text-center text-[var(--content-tertiary)]"
+              data-testid="invoices-empty"
+            >
+              No Invoices Found
+            </Typography>
+          ) : (
+            <ul className="flex flex-col divide-y divide-[var(--border-base)]">
+              {invoices.map((invoice) => (
+                <li
+                  key={invoice.id}
+                  className="flex items-center gap-3 py-3"
+                  data-testid="invoice-row"
+                >
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <Typography
+                        variant="body-medium-default"
+                        as="span"
+                        className="text-[var(--content-default)]"
+                      >
+                        {invoice.number ?? "Invoice"}
+                      </Typography>
+                      {invoice.status && (
+                        <Tag tone={statusTone(invoice.status)}>
+                          {invoice.status}
+                        </Tag>
+                      )}
+                    </div>
+                    <Typography
+                      variant="body-small-default"
+                      as="div"
+                      className="text-[var(--content-tertiary)]"
+                    >
+                      {formatDate(invoice.created)} ·{" "}
+                      {formatAmount(invoice.amount_due, invoice.currency)}
+                    </Typography>
+                  </div>
+                  {invoice.hosted_invoice_url && (
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="compact"
+                      leftIcon={<ExternalLink />}
+                    >
+                      <a
+                        href={invoice.hosted_invoice_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        View
+                      </a>
+                    </Button>
+                  )}
+                  {invoice.invoice_pdf && (
+                    <Button
+                      variant="ghost"
+                      size="compact"
+                      iconOnly={<Download />}
+                      aria-label="Download invoice PDF"
+                      onClick={() => downloadPdf(invoice.invoice_pdf!)}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Modal.Body>
+
+        <Modal.Footer>
+          {downloadable.length > 0 && (
+            <Button
+              variant="outlined"
+              leftIcon={<Download />}
+              onClick={() => {
+                for (const invoice of downloadable) {
+                  downloadPdf(invoice.invoice_pdf);
+                }
+              }}
+            >
+              Download all
+            </Button>
+          )}
+          <Modal.Close asChild>
+            <Button variant="primary">Done</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/apps/web/src/domains/settings/components/plan-card.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.tsx
@@ -1,4 +1,6 @@
-import { Crown, Loader2, Palmtree, type LucideIcon } from "lucide-react";
+import { Crown, FileText, Loader2, Palmtree, type LucideIcon } from "lucide-react";
+
+import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
@@ -7,6 +9,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Card } from "@vellum/design-library/components/card";
 import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
+import { InvoicesModal } from "./invoices-modal.js";
 import { PlanFeatureList } from "./plan-feature-list.js";
 import {
   organizationsBillingPlansRetrieveOptions,
@@ -70,6 +73,7 @@ function PlanHeading() {
 }
 
 export function PlanCard({ onManage }: PlanCardProps) {
+  const [invoicesOpen, setInvoicesOpen] = useState(false);
   const subscriptionQuery = useQuery(
     organizationsBillingSubscriptionRetrieveOptions(),
   );
@@ -119,7 +123,17 @@ export function PlanCard({ onManage }: PlanCardProps) {
   return (
     <Card padding="lg">
       <div className="flex flex-col gap-4">
-        <PlanHeading />
+        <div className="flex items-start justify-between gap-3">
+          <PlanHeading />
+          <Button
+            variant="outlined"
+            leftIcon={<FileText />}
+            onClick={() => setInvoicesOpen(true)}
+            data-testid="plan-card-invoices-button"
+          >
+            Invoices
+          </Button>
+        </div>
         <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
           <span
             aria-hidden
@@ -164,6 +178,7 @@ export function PlanCard({ onManage }: PlanCardProps) {
           </Typography>
         )}
       </div>
+      <InvoicesModal open={invoicesOpen} onOpenChange={setInvoicesOpen} />
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- Add an **Invoices** button to the top-right of the billing settings Plan card that opens a modal of the org's Stripe invoices (newest first). Each row shows number, date, amount, and a status chip, with a **View** link to the Stripe-hosted invoice that opens in a new tab and a per-invoice PDF **download** button; a **Download all** action in the footer downloads every available PDF.
- Treat a 404 from the invoices endpoint as an empty list — the modal shows **No Invoices Found** instead of an error state (genuine load failures still show an error).
- Consumes `GET /v1/organizations/billing/invoices/` (platform #7740), whose OpenAPI spec landed on main via #31527.

## Original prompt
The platform team just shipped an endpoint for retrieving Stripe invoice history (`GET /v1/organizations/billing/invoices/`). The ask was to surface it in the web billing settings: a button at the top-right of the Plan card that opens a modal listing invoices line by line with a brief summary, a link to each invoice that opens in a new tab, and a button to download an invoice / all invoices. A 404 response should render a 'No Invoices Found' empty state in the modal rather than an error.
