### PR TITLE
fix(web): allow saving edits on existing oauth_subscription connections

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -449,12 +449,16 @@ export function ProviderEditorContent({
 
         auth = { type: "api_key", credential: effectiveCredential };
       } else if (authType === "oauth_subscription") {
-        // OAuth subscription connections are created by the OAuth flow
-        // (handleChatgptUrlSubmit), not through the normal Save path.
-        // If the user somehow reaches here, prompt them to use the
-        // sign-in button instead.
-        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
-        return;
+        if (effectiveMode !== "create" && connection?.auth.type === "oauth_subscription") {
+          // Editing an existing oauth_subscription connection — preserve
+          // the stored auth so users can update display name / status.
+          auth = connection.auth;
+        } else {
+          // Create mode: OAuth subscription connections are created by
+          // the OAuth flow (handleChatgptUrlSubmit), not through Save.
+          setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
+          return;
+        }
       } else if (authType === "none") {
         auth = { type: "none" };
       } else {


### PR DESCRIPTION
## Summary

- Fix a bug where the Save button was entirely blocked for existing `oauth_subscription` connections (e.g. ChatGPT subscriptions), preventing users from saving display name or status changes
- In edit mode, preserve the stored auth from the connection object instead of returning an error; create mode retains the existing guard that directs users to the OAuth sign-in flow

## Test plan

- [ ] Open an existing ChatGPT subscription connection in edit mode
- [ ] Change the display name and verify the Save button works
- [ ] Toggle the connection status and verify Save works
- [ ] Verify that creating a new oauth_subscription connection still shows the "Sign in with ChatGPT" error if Save is clicked directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)