### PR TITLE
fix(macos): allow editing ChatGPT subscription connections

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -61,15 +61,23 @@ struct ProvidersSheet: View {
     @State private var chatgptOAuthStoredState = ""
 
     /// True when the ChatGPT subscription OAuth section should be visible:
-    /// feature flag enabled, provider is "openai", and we're in create mode.
+    /// feature flag enabled, provider is "openai", and either we're in create
+    /// mode (new connection) or editing an existing oauth_subscription
+    /// connection (so the user can re-authenticate if needed).
     private var isChatgptSubscriptionVisible: Bool {
         guard let flagStore = assistantFeatureFlagStore,
               flagStore.isEnabled("chatgpt-subscription-auth"),
-              editorDraft.provider == "openai",
-              case .create = editorState else {
+              editorDraft.provider == "openai" else {
             return false
         }
-        return true
+        switch editorState {
+        case .create:
+            return true
+        case .edit, .managedEdit:
+            return editorDraft.authType == "oauth_subscription"
+        case .none:
+            return false
+        }
     }
 
     // MARK: - Nested Types
@@ -1295,10 +1303,12 @@ struct ProvidersSheet: View {
 
         // OAuth subscription connections are created by the OAuth sign-in
         // flow (handleChatgptUrlSubmit), not the Create/Save button. Block
-        // commitEditor so a user who selects "ChatGPT Subscription" and
-        // clicks Create without completing the OAuth flow doesn't end up
-        // with a broken connection missing OAuth tokens.
-        if draft.authType == "oauth_subscription" {
+        // commitEditor in create mode so a user who selects "ChatGPT
+        // Subscription" and clicks Create without completing the OAuth flow
+        // doesn't end up with a broken connection missing OAuth tokens.
+        // In edit mode the OAuth tokens are already set up, so allow saves
+        // for display name / status changes.
+        if draft.authType == "oauth_subscription" && editorState == .create {
             actionError = "Use the \"Sign in with ChatGPT\" button to connect your subscription."
             return
         }


### PR DESCRIPTION
## Summary
- **Bug 1**: `commitEditor()` blocked all saves for `oauth_subscription` auth type, preventing edits to display name or status on existing connections. Fixed by only blocking in create mode — in edit mode, OAuth tokens are already set up.
- **Bug 2**: `isChatgptSubscriptionVisible` required create mode, hiding the "Sign in with ChatGPT" button when editing an existing `oauth_subscription` connection. Fixed by also showing the OAuth section in edit/managedEdit mode when the connection's auth type is `oauth_subscription`.

## Test plan
- [ ] Create a new ChatGPT subscription connection via OAuth flow — verify the "Sign in with ChatGPT" button appears and the Create button still blocks without completing OAuth
- [ ] Open an existing `oauth_subscription` connection for editing — verify the "Sign in with ChatGPT" button is visible and the Save button works for display name/status changes
- [ ] Edit a non-oauth_subscription OpenAI connection — verify the ChatGPT OAuth section is NOT shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)