### PR TITLE
fix(web): parse inline <ui_show> tags as visual surface cards

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -15,6 +15,7 @@ import { MessageHoverActions } from "@/domains/chat/components/message-hover-act
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router.js";
 import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
+import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces.js";
 import { getSlackLinkUrl, type Surface } from "@/domains/chat/types/types.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 import type { AllowlistOption, ChatMessageToolCall, ConfirmationDecision, DirectoryScopeOption, ScopeOption } from "@/domains/chat/api/event-types.js";
@@ -383,6 +384,37 @@ export function TranscriptMessageBody({
               const text = seg?.content;
               if (!text) {
                 return null;
+              }
+              const inlineSegments = parseInlineSurfaces(text);
+              if (inlineSegments) {
+                return (
+                  <div key={`text-${gi}`} className="w-full">
+                    {inlineSegments.map((seg, si) => {
+                      if (seg.type === "surface") {
+                        return (
+                          <div key={`inline-surface-${si}`} className="w-full my-2">
+                            <SurfaceRouter
+                              surface={seg.surface}
+                              onAction={() => {}}
+                              onOpenApp={onOpenApp}
+                              onOpenDocument={onOpenDocument}
+                              assistantId={assistantId}
+                              isToolCallComplete={true}
+                            />
+                          </div>
+                        );
+                      }
+                      return (
+                        <div
+                          key={`inline-text-${si}`}
+                          className={`text-[15px] break-words ${textBubbleClass}`}
+                        >
+                          <ChatMarkdownMessage content={seg.content} hardLineBreaks={message.role === "user"} />
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
               }
               return (
                 <div

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -299,6 +299,45 @@ export function TranscriptMessageBody({
     (tc.toolName === "ui_show" || tc.toolName === "ui_update" || tc.toolName === "ui_dismiss");
   const messageTimestamp = latestMessageActivityTimestamp(message);
 
+  const renderTextWithInlineSurfaces = (text: string, key: string, hardLineBreaks: boolean) => {
+    const inlineSegments = parseInlineSurfaces(text);
+    if (inlineSegments) {
+      return (
+        <div key={key} className="w-full">
+          {inlineSegments.map((seg, si) => {
+            if (seg.type === "surface") {
+              return (
+                <div key={`inline-surface-${si}`} className="my-2 w-full">
+                  <SurfaceRouter
+                    surface={seg.surface}
+                    onAction={() => {}}
+                    onOpenApp={onOpenApp}
+                    onOpenDocument={onOpenDocument}
+                    assistantId={assistantId}
+                    isToolCallComplete={true}
+                  />
+                </div>
+              );
+            }
+            return (
+              <div
+                key={`inline-text-${si}`}
+                className={`break-words text-[15px] ${textBubbleClass}`}
+              >
+                <ChatMarkdownMessage content={seg.content} hardLineBreaks={hardLineBreaks} />
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+    return (
+      <div key={key} className={`break-words text-[15px] ${textBubbleClass}`}>
+        <ChatMarkdownMessage content={text} hardLineBreaks={hardLineBreaks} />
+      </div>
+    );
+  };
+
   if (hasInterleavedToolCalls && message.contentOrder) {
     // Group consecutive entries: merge adjacent toolCall/tool entries into a
     // single group (mirrors macOS `groupContentBlocks`).
@@ -385,45 +424,7 @@ export function TranscriptMessageBody({
               if (!text) {
                 return null;
               }
-              const inlineSegments = parseInlineSurfaces(text);
-              if (inlineSegments) {
-                return (
-                  <div key={`text-${gi}`} className="w-full">
-                    {inlineSegments.map((seg, si) => {
-                      if (seg.type === "surface") {
-                        return (
-                          <div key={`inline-surface-${si}`} className="w-full my-2">
-                            <SurfaceRouter
-                              surface={seg.surface}
-                              onAction={() => {}}
-                              onOpenApp={onOpenApp}
-                              onOpenDocument={onOpenDocument}
-                              assistantId={assistantId}
-                              isToolCallComplete={true}
-                            />
-                          </div>
-                        );
-                      }
-                      return (
-                        <div
-                          key={`inline-text-${si}`}
-                          className={`text-[15px] break-words ${textBubbleClass}`}
-                        >
-                          <ChatMarkdownMessage content={seg.content} hardLineBreaks={message.role === "user"} />
-                        </div>
-                      );
-                    })}
-                  </div>
-                );
-              }
-              return (
-                <div
-                  key={`text-${gi}`}
-                  className={`text-[15px] break-words ${textBubbleClass}`}
-                >
-                  <ChatMarkdownMessage content={text} hardLineBreaks={message.role === "user"} />
-                </div>
-              );
+              return renderTextWithInlineSurfaces(text, `text-${gi}`, message.role === "user");
             }
             if (group.type === "surface") {
               const surface = resolveSurface(group.id);
@@ -448,13 +449,9 @@ export function TranscriptMessageBody({
           {/* Fallback: if message.content exists but no text groups rendered
               (e.g. tool_use_start before any assistant_text_delta), show the
               content. */}
-          {!groups.some((g) => g.type === "text") && message.content && (
-            <div
-              className={`text-[15px] break-words ${textBubbleClass}`}
-            >
-              <ChatMarkdownMessage content={message.content} hardLineBreaks={message.role === "user"} />
-            </div>
-          )}
+          {!groups.some((g) => g.type === "text") && message.content &&
+            renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user")
+          }
           {message.attachments && message.attachments.length > 0 && (
             <MessageAttachments
               attachments={message.attachments}
@@ -495,7 +492,7 @@ export function TranscriptMessageBody({
             );
         const segText = seg?.content ?? entry.id;
         contentElements.push(
-          <ChatMarkdownMessage key={`text-${entry.id}`} content={segText} hardLineBreaks={message.role === "user"} />,
+          renderTextWithInlineSurfaces(segText, `text-${entry.id}`, message.role === "user"),
         );
       } else if (entry.type === "surface") {
         const surface = resolveSurface(entry.id);
@@ -517,14 +514,14 @@ export function TranscriptMessageBody({
     }
     if (contentElements.length === 0 && message.content) {
       contentElements.push(
-        <ChatMarkdownMessage key="fallback" content={message.content} hardLineBreaks={message.role === "user"} />,
+        renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user"),
       );
     }
   } else {
     contentElements.push(
-      message.content ? (
-        <ChatMarkdownMessage key="content" content={message.content} hardLineBreaks={message.role === "user"} />
-      ) : null,
+      message.content
+        ? renderTextWithInlineSurfaces(message.content, "content", message.role === "user")
+        : null,
     );
   }
 

--- a/apps/web/src/domains/chat/utils/parse-inline-surfaces.test.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-surfaces.test.ts
@@ -95,6 +95,17 @@ describe("parseInlineSurfaces", () => {
     }
   });
 
+  test("handles tag with no attributes", () => {
+    const input = '<ui_show>{"title":"T","steps":[]}</ui_show>';
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(1);
+    if (result![0].type === "surface") {
+      expect(result![0].surface.surfaceType).toBe("card");
+      expect(result![0].surface.title).toBe("T");
+    }
+  });
+
   test("generates unique surfaceIds across calls", () => {
     const input = '<ui_show surface_type="card" template="t"> {"title":"T"} </ui_show>';
     const r1 = parseInlineSurfaces(input);

--- a/apps/web/src/domains/chat/utils/parse-inline-surfaces.test.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-surfaces.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseInlineSurfaces } from "./parse-inline-surfaces.js";
+
+describe("parseInlineSurfaces", () => {
+  test("returns null when no <ui_show> tags are present", () => {
+    expect(parseInlineSurfaces("Hello, this is plain text.")).toBeNull();
+  });
+
+  test("parses a single <ui_show> tag with surrounding text", () => {
+    const input =
+      'Before text<ui_show surface_type="card" template="task_progress"> {"title":"Test","steps":[{"id":"s1","label":"Step 1","status":"in_progress"}]} </ui_show>After text';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(3);
+
+    expect(result![0]).toEqual({ type: "text", content: "Before text" });
+
+    const surfaceSegment = result![1];
+    expect(surfaceSegment.type).toBe("surface");
+    if (surfaceSegment.type === "surface") {
+      expect(surfaceSegment.surface.surfaceType).toBe("card");
+      expect(surfaceSegment.surface.data.template).toBe("task_progress");
+      expect(surfaceSegment.surface.title).toBe("Test");
+      const td = surfaceSegment.surface.data.templateData as Record<string, unknown>;
+      expect(Array.isArray(td.steps)).toBe(true);
+    }
+
+    expect(result![2]).toEqual({ type: "text", content: "After text" });
+  });
+
+  test("handles tag at the start of text", () => {
+    const input =
+      '<ui_show surface_type="card" template="task_progress"> {"title":"T"} </ui_show>trailing';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(result![0].type).toBe("surface");
+    expect(result![1]).toEqual({ type: "text", content: "trailing" });
+  });
+
+  test("handles tag at the end of text", () => {
+    const input =
+      'leading<ui_show surface_type="card" template="task_progress"> {"title":"T"} </ui_show>';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(result![0]).toEqual({ type: "text", content: "leading" });
+    expect(result![1].type).toBe("surface");
+  });
+
+  test("handles malformed JSON by emitting the raw tag as text", () => {
+    const input =
+      'before<ui_show surface_type="card" template="x"> {bad json} </ui_show>after';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(3);
+    expect(result![0]).toEqual({ type: "text", content: "before" });
+    expect(result![1].type).toBe("text");
+    expect(result![2]).toEqual({ type: "text", content: "after" });
+  });
+
+  test("handles multiple tags", () => {
+    const input =
+      'a<ui_show surface_type="card" template="t1"> {"title":"First"} </ui_show>b<ui_show surface_type="list" template="t2"> {"title":"Second"} </ui_show>c';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(5);
+    expect(result![0]).toEqual({ type: "text", content: "a" });
+    expect(result![1].type).toBe("surface");
+    expect(result![2]).toEqual({ type: "text", content: "b" });
+    expect(result![3].type).toBe("surface");
+    expect(result![4]).toEqual({ type: "text", content: "c" });
+
+    if (result![1].type === "surface") {
+      expect(result![1].surface.surfaceType).toBe("card");
+    }
+    if (result![3].type === "surface") {
+      expect(result![3].surface.surfaceType).toBe("list");
+    }
+  });
+
+  test("defaults surfaceType to 'card' when surface_type attr is missing", () => {
+    const input = '<ui_show template="task_progress"> {"title":"T"} </ui_show>';
+
+    const result = parseInlineSurfaces(input);
+    expect(result).not.toBeNull();
+    if (result![0].type === "surface") {
+      expect(result![0].surface.surfaceType).toBe("card");
+    }
+  });
+
+  test("generates unique surfaceIds across calls", () => {
+    const input = '<ui_show surface_type="card" template="t"> {"title":"T"} </ui_show>';
+    const r1 = parseInlineSurfaces(input);
+    const r2 = parseInlineSurfaces(input);
+    if (r1![0].type === "surface" && r2![0].type === "surface") {
+      expect(r1![0].surface.surfaceId).not.toBe(r2![0].surface.surfaceId);
+    }
+  });
+});

--- a/apps/web/src/domains/chat/utils/parse-inline-surfaces.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-surfaces.ts
@@ -4,7 +4,7 @@ export type InlineSegment =
   | { type: "text"; content: string }
   | { type: "surface"; surface: Surface };
 
-const UI_SHOW_RE = /<ui_show\s+([^>]*)>([\s\S]*?)<\/ui_show>/g;
+const UI_SHOW_RE = /<ui_show\s*([^>]*)>([\s\S]*?)<\/ui_show>/g;
 const ATTR_RE = /(\w+)="([^"]*)"/g;
 
 let counter = 0;

--- a/apps/web/src/domains/chat/utils/parse-inline-surfaces.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-surfaces.ts
@@ -1,0 +1,76 @@
+import type { Surface } from "@/domains/chat/types/types.js";
+
+export type InlineSegment =
+  | { type: "text"; content: string }
+  | { type: "surface"; surface: Surface };
+
+const UI_SHOW_RE = /<ui_show\s+([^>]*)>([\s\S]*?)<\/ui_show>/g;
+const ATTR_RE = /(\w+)="([^"]*)"/g;
+
+let counter = 0;
+
+/**
+ * Parses `<ui_show>` tags embedded in assistant text and returns an array of
+ * text and surface segments. Returns `null` when no tags are found so callers
+ * can skip the overhead.
+ */
+export function parseInlineSurfaces(text: string): InlineSegment[] | null {
+  UI_SHOW_RE.lastIndex = 0;
+
+  const segments: InlineSegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = UI_SHOW_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: "text", content: text.slice(lastIndex, match.index) });
+    }
+
+    const attrString = match[1];
+    const jsonBody = match[2].trim();
+
+    const attrs: Record<string, string> = {};
+    let attrMatch: RegExpExecArray | null;
+    ATTR_RE.lastIndex = 0;
+    while ((attrMatch = ATTR_RE.exec(attrString)) !== null) {
+      attrs[attrMatch[1]] = attrMatch[2];
+    }
+
+    let templateData: Record<string, unknown> = {};
+    try {
+      templateData = JSON.parse(jsonBody) as Record<string, unknown>;
+    } catch {
+      // Malformed JSON — skip this tag, emit it as text
+      segments.push({ type: "text", content: match[0] });
+      lastIndex = UI_SHOW_RE.lastIndex;
+      continue;
+    }
+
+    const surfaceType = attrs.surface_type ?? "card";
+    const template = attrs.template;
+    const title = (templateData.title as string | undefined) ?? attrs.title;
+
+    const surface: Surface = {
+      surfaceId: `inline-surface-${++counter}`,
+      surfaceType,
+      title,
+      data: {
+        ...(template ? { template } : {}),
+        templateData,
+      },
+    };
+
+    segments.push({ type: "surface", surface });
+    lastIndex = UI_SHOW_RE.lastIndex;
+  }
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", content: text.slice(lastIndex) });
+  }
+
+  return segments;
+}


### PR DESCRIPTION
## Summary

- Adds `parseInlineSurfaces()` utility that extracts `<ui_show>` tags embedded in assistant text and returns an array of text/surface segments
- Modifies `TranscriptMessageBody` to detect inline `<ui_show>` tags in text segments and render them through `SurfaceRouter` instead of as raw text
- Malformed JSON inside tags gracefully falls back to rendering as plain text

## Context

The model sometimes writes `<ui_show surface_type="card" template="task_progress"> {...json...} </ui_show>` inline in its text response instead of calling the `ui_show` tool properly. Previously these tags rendered as literal text. Now they are parsed and rendered as the correct visual card components (e.g., task progress cards with step indicators).

## Test plan

- [x] Unit tests for `parseInlineSurfaces` covering: no tags, single tag, multiple tags, malformed JSON, tag at start/end, attribute defaults, unique IDs
- [x] TypeScript typecheck passes (`bunx tsc --noEmit`)
- [ ] Manual: send a message that triggers `<ui_show>` inline text and verify it renders as a card

🤖 Generated with [Claude Code](https://claude.com/claude-code)