### PR TITLE
fix(macos/settings): stop Assistant Version section from reflowing on Check for updates

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/apps/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -285,6 +285,7 @@ export function AssistantUpgrades({
 
       <Button
         variant={isRollback ? "outlined" : "primary"}
+        className="min-w-[160px]"
         leftIcon={
           upgradeCreate.isPending ||
           rollbackCreate.isPending ||
@@ -311,7 +312,7 @@ export function AssistantUpgrades({
           : isRollback
             ? "Rollback"
             : isPreviewReleaseChannel
-              ? "Update Preview"
+              ? "Update preview"
               : "Update"}
       </Button>
       {isPreviewReleaseChannel && (
@@ -338,23 +339,23 @@ export function AssistantUpgrades({
         open={showConfirmation}
         title={
           isRollback
-            ? "Rollback Assistant"
+            ? "Rollback assistant"
             : isPreviewReleaseChannel
-              ? "Update Preview Release"
-              : "Update Assistant"
+              ? "Update preview release"
+              : "Update assistant"
         }
         message={
           isRollback
             ? `Rollback to version ${effectiveSelectedVersion ?? "unknown"}? The assistant will be briefly unavailable.`
             : isPreviewReleaseChannel
-              ? `Update to Preview version ${effectiveSelectedVersion ?? "latest"}? The assistant will be briefly unavailable during the update.`
+              ? `Update to preview version ${effectiveSelectedVersion ?? "latest"}? The assistant will be briefly unavailable during the update.`
             : `Update to version ${effectiveSelectedVersion ?? "latest"}? The assistant will be briefly unavailable during the update.`
         }
         confirmLabel={
           isRollback
             ? "Rollback"
             : isPreviewReleaseChannel
-              ? "Update Preview"
+              ? "Update preview"
               : "Update"
         }
         onConfirm={handleUpgrade}

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -332,6 +332,7 @@ struct AssistantUpgradeSection: View {
                             isCheckingLocal = false
                         }
                     }
+                    .frame(minWidth: 160)
                 } else if topology != .remote {
                     VButton(
                         label: isLoadingReleases ? "Checking..." : "Check for Updates",
@@ -350,6 +351,7 @@ struct AssistantUpgradeSection: View {
                             }
                         }
                     }
+                    .frame(minWidth: 160)
                     .disabled(isLoadingReleases || isUpgrading)
 
                     VButton(
@@ -361,16 +363,16 @@ struct AssistantUpgradeSection: View {
                         showingUpgradeConfirmation = true
                     }
                     .disabled(!upgradeAvailable || isUpgrading || pickerReleases.isEmpty)
-                }
-            }
 
-            if isLoadingReleases || isUpgrading {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(isUpgrading ? (isRollback ? "Rolling back assistant..." : "Upgrading assistant...") : "Checking for updates...")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
+                    if isUpgrading {
+                        HStack(spacing: VSpacing.sm) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text(isRollback ? "Rolling back assistant..." : "Upgrading assistant...")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -317,7 +317,7 @@ struct AssistantUpgradeSection: View {
             HStack(spacing: VSpacing.md) {
                 if topology == .local {
                     VButton(
-                        label: isCheckingLocal ? "Checking..." : "Check for Updates",
+                        label: isCheckingLocal ? "Checking..." : "Check for updates",
                         style: .outlined,
                         isDisabled: isCheckingLocal
                     ) {
@@ -335,7 +335,7 @@ struct AssistantUpgradeSection: View {
                     .frame(minWidth: 160)
                 } else if topology != .remote {
                     VButton(
-                        label: isLoadingReleases ? "Checking..." : "Check for Updates",
+                        label: isLoadingReleases ? "Checking..." : "Check for updates",
                         style: .outlined
                     ) {
                         Task {


### PR DESCRIPTION
## Summary
- Pin the Check for updates button to `minWidth: 160` so the label swap to "Checking…" no longer reflows the row.
- Drop the spinner row that appeared below the buttons (which pushed Storage & Resources down on every click when no update was available).
- For upgrade/rollback, show the progress spinner + status inline to the right of the buttons instead of below.
- Lowercase the button copy to "Check for updates".

## Test plan
- [ ] Settings → Assistant Version: click Check for updates while on the latest version; the button label swaps to "Checking…" in place and the Storage & Resources section below does not move.
- [ ] Trigger an upgrade and confirm the "Upgrading assistant…" spinner appears to the right of the buttons (not below).
- [ ] Trigger a rollback and confirm the "Rolling back assistant…" spinner appears in the same inline position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)