### PR TITLE
feat(web/chat): add CollapsedGroupIcon component with indicator overlay

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -1,0 +1,105 @@
+import { useState, type ReactNode } from "react";
+
+import type { LucideIcon } from "lucide-react";
+
+import { Popover } from "@vellum/design-library";
+import type { Conversation } from "@/domains/chat/api/conversations.js";
+
+// ---------------------------------------------------------------------------
+// Indicator state
+// ---------------------------------------------------------------------------
+
+export type GroupIndicatorState = "attention" | "processing" | "unread" | null;
+
+/**
+ * Derive the highest-priority indicator state for a group of conversations.
+ *
+ * Priority: attention > processing > unread > null.
+ */
+export function getGroupIndicatorState(
+  conversations: Conversation[],
+  processingConversationIds: Set<string> | undefined,
+  attentionConversationIds: Set<string> | undefined,
+): GroupIndicatorState {
+  let hasProcessing = false;
+  let hasUnread = false;
+
+  for (const c of conversations) {
+    if (attentionConversationIds?.has(c.conversationId)) {
+      return "attention";
+    }
+    if (!hasProcessing && processingConversationIds?.has(c.conversationId)) {
+      hasProcessing = true;
+    }
+    if (!hasUnread && c.hasUnseenLatestAssistantMessage) {
+      hasUnread = true;
+    }
+  }
+
+  if (hasProcessing) return "processing";
+  if (hasUnread) return "unread";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Indicator dot color
+// ---------------------------------------------------------------------------
+
+const INDICATOR_CLASS: Record<Exclude<GroupIndicatorState, null>, string> = {
+  attention: "bg-[var(--system-mid-strong)]",
+  processing: "bg-[var(--primary-base)] animate-pulse",
+  unread: "bg-[var(--system-mid-strong)]",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface CollapsedGroupIconProps {
+  /** The group's Lucide icon (Pin, Clock, etc.). */
+  icon: LucideIcon;
+  /** Accessible label for the button (e.g. "Pinned", "Recents"). */
+  label: string;
+  /** Drives the indicator dot overlay. */
+  indicatorState: GroupIndicatorState;
+  /** Popover content (conversation list). */
+  children: ReactNode;
+}
+
+export function CollapsedGroupIcon({
+  icon: Icon,
+  label,
+  indicatorState,
+  children,
+}: CollapsedGroupIconProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-haspopup="dialog"
+          className="relative flex h-8 w-8 items-center justify-center rounded-[6px] bg-[var(--surface-base)] text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+        >
+          <Icon size={18} />
+          {indicatorState != null ? (
+            <span
+              aria-hidden
+              className={`absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] ${INDICATOR_CLASS[indicatorState]}`}
+            />
+          ) : null}
+        </button>
+      </Popover.Trigger>
+      <Popover.Content
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="max-h-[500px] w-72 overflow-y-auto rounded-lg py-2 px-0"
+      >
+        {children}
+      </Popover.Content>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- Add new `CollapsedGroupIcon` component for rendering per-group icon buttons in collapsed sidebar
- Includes indicator dot overlay for attention/processing/unread states
- Includes `getGroupIndicatorState` helper for computing indicator state from conversations

Part of plan: sidebar-collapsed-group-icons.md (PR 1 of 2)