### PR TITLE
fix(web/home): adjust feed spacing and enlarge dismiss icon

### DIFF
--- a/apps/web/src/domains/home/home-feed-list.tsx
+++ b/apps/web/src/domains/home/home-feed-list.tsx
@@ -67,7 +67,7 @@ export function HomeFeedList({
     );
 
   return (
-    <div className="flex flex-col gap-[var(--app-spacing-sm)]">
+    <div className="flex flex-col gap-[var(--app-spacing-lg)]">
       <HomeFeedFilterBar
         categories={presentCategories}
         activeFilter={effectiveFilter}
@@ -87,7 +87,7 @@ export function HomeFeedList({
         [...grouped.entries()].map(([group, groupItems]) => (
           <section
             key={group}
-            className="flex flex-col gap-[var(--app-spacing-xs)]"
+            className="flex flex-col gap-[var(--app-spacing-md)]"
           >
             <Typography
               variant="body-small-default"

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -97,7 +97,7 @@ export function HomeRecapRow({
             "text-[var(--content-disabled)]",
           )}
         >
-          <TrailingIcon width={7} height={7} aria-hidden="true" />
+          <TrailingIcon width={14} height={14} aria-hidden="true" />
           <span className="text-body-small-default">{trailingLabel}</span>
         </span>
       ) : null}


### PR DESCRIPTION
## Summary
Three small UI polish fixes for the apps/web homepage feed:
- Increase outer feed container gap from 8px to 16px (filter bar to time-group headings)
- Increase time-group section gap from 4px to 12px (heading to notification rows)  
- Double dismiss X icon from 7px to 14px for better hover target

## Self-review result
PASS — all 4 passes clean (external feedback, plan faithfulness, integration, slop audit)

## PRs merged into feature branch
- #32070: fix(web/home): adjust feed spacing and enlarge dismiss icon

Part of plan: web-homepage-spacing.md