### PR TITLE
feat(memory-v3): enrich shadow telemetry for after-the-fact analysis

### DIFF
--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -94,6 +94,14 @@ export interface MemoryV2ConceptRowRecord {
     | "not_injected"
     | "page_missing"
     | "corrupt";
+  /**
+   * v3 shadow only: the retrieval lane that surfaced this slug
+   * (`hot` | `sparse` | `dense` | `tree` | `edge`). Lets a shadow run be
+   * analyzed by provenance — which lane each v3 pick came from. Undefined on
+   * `router`/`per-turn`/etc. v2 rows; stored in the JSON concept blob, so older
+   * rows decode with `undefined`.
+   */
+  lane?: string;
 }
 
 export interface MemoryV2ConfigSnapshot {

--- a/assistant/src/memory/v2/harness/trace.ts
+++ b/assistant/src/memory/v2/harness/trace.ts
@@ -41,6 +41,12 @@ export interface GateDecision {
   decision: "ready" | "more";
   /** When "more", the generated follow-up queries seeding the next pass. */
   questions?: string[];
+  /**
+   * The gate's one-line rationale for this verdict, when it supplied one.
+   * Surfaced in the descent trace and the live-shadow telemetry so a run can be
+   * analyzed after the fact ("why did the gate keep this set?").
+   */
+  reasoning?: string;
 }
 
 /** Everything that happened on one pass of the loop. */

--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -547,7 +547,7 @@ describe("runGate — reasoning field", () => {
     expect(schema.required ?? []).not.toContain("reasoning");
   });
 
-  test("accepts model-supplied reasoning without altering the decision", async () => {
+  test("surfaces model-supplied reasoning on the decision without altering the verdict", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
       gateToolResponse({
@@ -566,9 +566,13 @@ describe("runGate — reasoning field", () => {
       provider,
     });
 
-    // Reasoning is ignored by control flow: decision + ordered selection
-    // (model order, omitted sticky appended) are unchanged.
-    expect(result.decision).toEqual({ decision: "ready" });
+    // Reasoning does not alter control flow — the verdict and ordered selection
+    // (model order, omitted sticky appended) are unchanged — but it IS carried
+    // on the decision so a run can be analyzed (trace + shadow telemetry).
+    expect(result.decision).toEqual({
+      decision: "ready",
+      reasoning: "kept the two query-relevant pages, dropped the rest",
+    });
     expect(result.selectedSlugs).toEqual(["b", "a", "c"]);
   });
 });

--- a/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
@@ -268,6 +268,12 @@ describe("memory-v3 shadow middleware", () => {
     expect(logged.conversationId).toBe("conv-shadow");
     expect(logged.turn).toBe(3);
     expect(logged.concepts.map((c) => c.slug)).toEqual(["topic/a", "topic/b"]);
+
+    // Per-slug lane provenance is carried from sourceBySlug; a slug absent from
+    // the map (topic/b) gets no lane rather than a bogus one.
+    const bySlug = new Map(logged.concepts.map((c) => [c.slug, c]));
+    expect(bySlug.get("topic/a")?.lane).toBe("dense");
+    expect(bySlug.get("topic/b")?.lane).toBeUndefined();
   });
 
   test("v3 error → logged/swallowed, turn result unaffected, no log row", async () => {

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -316,19 +316,25 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     sticky,
   );
 
+  const reasoning = parsed.data.reasoning?.trim() || undefined;
+
   if (parsed.data.decision === "more") {
     const questions = (parsed.data.questions ?? []).filter(
       (q) => q.trim().length > 0,
     );
-    const decision: GateDecision =
-      questions.length > 0
-        ? { decision: "more", questions }
-        : { decision: "more" };
+    const decision: GateDecision = {
+      decision: "more",
+      ...(questions.length > 0 ? { questions } : {}),
+      ...(reasoning ? { reasoning } : {}),
+    };
     return { decision, selectedSlugs };
   }
 
   // brief generation lands at cutover (P5) — shadow mode injects v2, so this
   // gate produces only the selection + decision. Do NOT synthesize a voice
   // brief here.
-  return { decision: { decision: "ready" }, selectedSlugs };
+  return {
+    decision: { decision: "ready", ...(reasoning ? { reasoning } : {}) },
+    selectedSlugs,
+  };
 }

--- a/assistant/src/memory/v3/shadow-middleware.ts
+++ b/assistant/src/memory/v3/shadow-middleware.ts
@@ -151,10 +151,13 @@ const SHADOW_CONFIG_SNAPSHOT: MemoryV2ConfigSnapshot = {
  * becomes a zeroed concept row tagged `source: "router"` and
  * `status: "injected"` — the shadow has no activation scores to record, and the
  * `mode='v3_shadow'` row tag (not the concept source) is what distinguishes
- * shadow telemetry from live router selections.
+ * shadow telemetry from live router selections. Each row also carries the
+ * `lane` that surfaced the slug (from `sourceBySlug`) so a shadow run can be
+ * analyzed by provenance.
  */
 function buildShadowConceptRows(
   selectedSlugs: readonly string[],
+  sourceBySlug: ReadonlyMap<string, string>,
 ): MemoryV2ConceptRowRecord[] {
   return selectedSlugs.map((slug) => ({
     slug,
@@ -170,6 +173,7 @@ function buildShadowConceptRows(
     spreadContribution: 0,
     source: "router",
     status: "injected",
+    ...(sourceBySlug.get(slug) ? { lane: sourceBySlug.get(slug) } : {}),
   }));
 }
 
@@ -232,11 +236,37 @@ async function runShadowAndLog(
 
     if (signal.aborted) return;
 
+    // Per-turn summary so a shadow run is analyzable from the logs — the pool
+    // shape, how many passes ran, and the gate's verdict + rationale. The
+    // selection set + per-slug lane land in the activation log below.
+    const passes = output.trace?.passes ?? [];
+    const lastGate = passes[passes.length - 1]?.gate;
+    const laneTally: Record<string, number> = {};
+    for (const lane of output.sourceBySlug.values()) {
+      laneTally[lane] = (laneTally[lane] ?? 0) + 1;
+    }
+    log.info(
+      {
+        conversationId: args.conversationId,
+        turn: args.turnIndex,
+        selected: output.selectedSlugs.length,
+        poolSize: output.sourceBySlug.size,
+        laneTally,
+        passes: passes.length,
+        gateDecision: lastGate?.decision,
+        gateReasoning: lastGate?.reasoning,
+      },
+      "v3 shadow selection",
+    );
+
     recordMemoryV2ActivationLog({
       conversationId: args.conversationId,
       turn: args.turnIndex,
       mode: "v3_shadow",
-      concepts: buildShadowConceptRows(output.selectedSlugs),
+      concepts: buildShadowConceptRows(
+        output.selectedSlugs,
+        output.sourceBySlug,
+      ),
       config: SHADOW_CONFIG_SNAPSHOT,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- The v3 live-shadow middleware logged only the selected slug set (`mode='v3_shadow'`), which isn't enough to analyze a shadow run against the live (`router`) selection. This adds the provenance + rationale a comparison needs.
- **Per-slug lane provenance**: each `v3_shadow` activation-log concept row now carries the `lane` that surfaced the slug (`hot`/`sparse`/`dense`/`tree`/`edge`), stored in the existing JSON concept blob — no migration; older rows decode with `lane: undefined`.
- **Per-turn summary log**: one structured line per shadow turn with pool size, lane tally, pass count, and the gate's decision + reasoning.
- To surface the gate's rationale, `GateDecision` gains an optional `reasoning` — the gate already parsed it from the forced `decide_selection` tool but discarded it; it now flows through the descent trace (so `simulate` shows it too) and the shadow telemetry.

## Original prompt
The live-shadow path records what v3 *would* select but not how it got there, so a shadow period couldn't be compared against the live router by lane/reasoning afterward. This threads the gate's reasoning through (already parsed, was dropped) and tags each shadow selection with its lane + a per-turn summary, so a shadow run is analyzable from the activation log + logs.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] gate.test.ts + shadow-middleware.test.ts pass (26/26 scoped; gate surfaces reasoning on the decision without altering the verdict; shadow rows carry per-slug lane, absent slugs get none)
- [x] loop.test.ts 8/8 (scoped — bun `mock.module` bleeds across files in a combined run)
- [x] prettier + eslint clean