### PR TITLE
fix(web/chat): remove background color from collapsed sidebar group icons

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -85,7 +85,7 @@ export function CollapsedGroupIcon({
           type="button"
           aria-label={label}
           aria-haspopup="dialog"
-          className="relative flex h-8 w-8 items-center justify-center rounded-[6px] bg-[var(--surface-base)] text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+          className="relative flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
         >
           <Icon size={18} />
           {indicatorState != null ? (


### PR DESCRIPTION
## Summary
Remove `bg-[var(--surface-base)]` from the CollapsedGroupIcon button so icons render without a gray background box. The background is only applied when the popover is expanded (`aria-[expanded=true]:bg-[var(--surface-active)]`).