### PR TITLE
fix(web/settings): keep "Assistant" title-cased in dialog titles

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/apps/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -339,10 +339,10 @@ export function AssistantUpgrades({
         open={showConfirmation}
         title={
           isRollback
-            ? "Rollback assistant"
+            ? "Rollback Assistant"
             : isPreviewReleaseChannel
               ? "Update preview release"
-              : "Update assistant"
+              : "Update Assistant"
         }
         message={
           isRollback


### PR DESCRIPTION
## Summary
Follow-up to #32069. "Assistant" is a proper noun in this product domain, so restore the title-cased forms in the upgrade and rollback confirmation dialog titles.

- `Rollback assistant` → `Rollback Assistant`
- `Update assistant` → `Update Assistant`

`Update preview release` stays lowercase since "preview" is just a release-channel descriptor.

## Test plan
- [ ] Open the Update Assistant confirmation dialog on the platform settings page — title shows "Update Assistant".
- [ ] Open the Rollback Assistant confirmation dialog — title shows "Rollback Assistant".

🤖 Generated with [Claude Code](https://claude.com/claude-code)