### PR TITLE
fix(web/chat): always show all system group icons in collapsed sidebar

### DIFF
--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -397,33 +397,30 @@ export function AssistantSideMenu({
         {collapsed && variant === "rail" ? (
           <div className="flex flex-col items-center gap-1">
             {headerActions}
-            {sidebar.pinned.length > 0 ? (
-              <CollapsedGroupIcon
-                icon={Pin}
-                label="Pinned"
-                indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent("Pinned", sidebar.pinned, close)}
-              </CollapsedGroupIcon>
-            ) : null}
-            {sidebar.recents.all.length > 0 ? (
-              <CollapsedGroupIcon
-                icon={Clock}
-                label="Recents"
-                indicatorState={getGroupIndicatorState(sidebar.recents.all, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent("Recents", sidebar.recents.all, close)}
-              </CollapsedGroupIcon>
-            ) : null}
-            {sidebar.scheduled.length > 0 ? (
-              <CollapsedGroupIcon
-                icon={Calendar}
-                label="Scheduled"
-                indicatorState={getGroupIndicatorState(sidebar.scheduled, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent("Scheduled", sidebar.scheduled, close)}
-              </CollapsedGroupIcon>
-            ) : null}
+            <CollapsedGroupIcon
+              icon={Pin}
+              label="Pinned"
+              disabled={sidebar.pinned.length === 0}
+              indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
+            >
+              {(close) => renderCollapsedGroupContent("Pinned", sidebar.pinned, close)}
+            </CollapsedGroupIcon>
+            <CollapsedGroupIcon
+              icon={Clock}
+              label="Recents"
+              disabled={sidebar.recents.all.length === 0}
+              indicatorState={getGroupIndicatorState(sidebar.recents.all, processingConversationIds, attentionConversationIds)}
+            >
+              {(close) => renderCollapsedGroupContent("Recents", sidebar.recents.all, close)}
+            </CollapsedGroupIcon>
+            <CollapsedGroupIcon
+              icon={Calendar}
+              label="Scheduled"
+              disabled={sidebar.scheduled.length === 0}
+              indicatorState={getGroupIndicatorState(sidebar.scheduled, processingConversationIds, attentionConversationIds)}
+            >
+              {(close) => renderCollapsedGroupContent("Scheduled", sidebar.scheduled, close)}
+            </CollapsedGroupIcon>
             {sidebar.background.length > 0 ? (
               <CollapsedBackgroundGroup
                 conversations={sidebar.background}
@@ -434,16 +431,22 @@ export function AssistantSideMenu({
                 processingConversationIds={processingConversationIds}
                 attentionConversationIds={attentionConversationIds}
               />
-            ) : null}
-            {sidebar.slack.totalCount > 0 ? (
+            ) : (
               <CollapsedGroupIcon
-                icon={Hash}
-                label="Slack"
-                indicatorState={getGroupIndicatorState(sidebar.slack.all, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent("Slack", sidebar.slack.all, close)}
-              </CollapsedGroupIcon>
-            ) : null}
+                icon={Layers}
+                label="Background"
+                disabled
+                indicatorState={null}
+              />
+            )}
+            <CollapsedGroupIcon
+              icon={Hash}
+              label="Slack"
+              disabled={sidebar.slack.totalCount === 0}
+              indicatorState={getGroupIndicatorState(sidebar.slack.all, processingConversationIds, attentionConversationIds)}
+            >
+              {(close) => renderCollapsedGroupContent("Slack", sidebar.slack.all, close)}
+            </CollapsedGroupIcon>
           </div>
         ) : (
           <SideMenu.Section

--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -62,21 +62,35 @@ export interface CollapsedGroupIconProps {
   label: string;
   /** Drives the indicator dot overlay. */
   indicatorState: GroupIndicatorState;
+  /** When true, the group has no conversations — renders a muted icon with no popover. */
+  disabled?: boolean;
   /**
    * Popover content. Accepts a render function that receives a `close` callback
    * to programmatically dismiss the popover (e.g. after selecting a conversation).
    */
-  children: ReactNode | ((close: () => void) => ReactNode);
+  children?: ReactNode | ((close: () => void) => ReactNode);
 }
 
 export function CollapsedGroupIcon({
   icon: Icon,
   label,
   indicatorState,
+  disabled = false,
   children,
 }: CollapsedGroupIconProps) {
   const [open, setOpen] = useState(false);
   const close = useCallback(() => setOpen(false), []);
+
+  if (disabled) {
+    return (
+      <div
+        aria-label={label}
+        className="relative flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--content-disabled)]"
+      >
+        <Icon size={18} />
+      </div>
+    );
+  }
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
@@ -100,6 +114,7 @@ export function CollapsedGroupIcon({
         side="right"
         align="start"
         sideOffset={8}
+        onOpenAutoFocus={(e) => e.preventDefault()}
         className="max-h-[500px] w-72 overflow-y-auto rounded-lg py-2 px-0"
       >
         {typeof children === "function" ? children(close) : children}


### PR DESCRIPTION
## Summary
- Always render all 5 system group icons (Pin, Clock, Calendar, Layers, Hash) even when empty
- Empty groups show a muted/disabled icon (`--content-disabled`) with no popover
- Add `onOpenAutoFocus` prevention to fix phantom pin icon on first popover row (caused by Radix auto-focusing the first PanelItem, which triggered `group-focus-within` on the ThreadPinToggle)