### PR TITLE
fix(auth): replace native auth debug block with fallback navigation

### DIFF
--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -118,20 +118,16 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            if (nativeParams) {
-              // TEMPORARY DEBUG (revert once iOS sign-in cache-miss is
-              // diagnosed): suppress the redirect-back-to-native so the
-              // Safari sheet stays open and the actual getSession()
-              // failure mode is inspectable. Without this, ASWebAuth
-              // catches the scheme:// redirect, closes the sheet, and
-              // destroys the Web Inspector window before anything can
-              // be read.
-              console.log("[debug native auth] getSession result:", result);
-              console.log("[debug native auth] classification outcome:", outcome);
-              console.log("[debug native auth] nativeParams:", nativeParams);
-              setFallbackError(
-                `[debug] ${outcome.message} :: result=${JSON.stringify(result).slice(0, 800)}`,
-              );
+            if (nativeParams && returnTo) {
+              // getSession() could not confirm authentication, but the
+              // session cookie may still be present (e.g. the allauth
+              // callback set it on a redirect that the browser processed
+              // correctly, but a timing or infrastructure issue caused
+              // the fetch to miss it). Navigate directly to the Django
+              // native callback — @login_required will verify the
+              // session server-side and either issue the authorization
+              // code or redirect to the login page.
+              window.location.href = returnTo;
               return;
             }
             setFallbackError(outcome.message);


### PR DESCRIPTION
## Prompt / plan

macOS app login for platform-hosted assistants is broken — the Safari sheet opened by `ASWebAuthenticationSession` never closes, and the app stays stuck at "Logging in..." indefinitely. Root cause: a temporary debug block in `ProviderCallbackPage` suppresses the redirect-back-to-native-app when `getSession()` returns an error, keeping the Safari sheet open for Web Inspector debugging.

### Why this is needed

The debug block (commit `33c6abf`, May 22) was added to diagnose why `getSession()` fails in the native auth flow ("iOS sign-in cache-miss"). It was marked `TEMPORARY (revert once iOS sign-in cache-miss is diagnosed)` but was never reverted.

Simply reverting to the pre-debug behavior (`redirectToNativeApp(nativeParams, error)`) was explicitly ruled out because that error redirect was breaking iOS login — the native app received an error callback, closed the Safari sheet, and showed an error toast, preventing login entirely.

### The fix

Replace the debug block with a **fallback navigation** to the Django native callback URL (`returnTo`). When `getSession()` fails:

1. Navigate to `returnTo` (e.g. `/accounts/native/callback?scheme=vellum-assistant&state=...`)
2. Django's `@login_required` verifies the session server-side
3. If authenticated → authorization code issued → custom scheme redirect → native app completes login
4. If not authenticated → user sees login page (graceful degradation, better than infinite hang)

This avoids both failure modes:
- **Before debug code**: error redirect → native app shows error → user stuck
- **With debug code**: no redirect → Safari sheet stays open → app shows "Logging in..." forever
- **This fix**: fallback navigation → server-side session check → login succeeds if cookie is present

### Benefits

- Unblocks macOS login for platform-hosted assistants
- Unblocks iOS login (same code path)
- Preserves the SPA's role in handling pending signup flows and allauth-level errors
- Degrades gracefully (login page) instead of failing silently (infinite spinner or error toast)

### Safety

- **Narrowly scoped**: only changes the `case "error"` branch when `nativeParams && returnTo` are present
- **No changes to success path**: authenticated users still follow the normal `resolvePostLoginDestination` → navigation flow
- **No changes to allauth error path**: URL-level errors (`?error=signup_closed`) are still caught at line 78 before `getSession()` is called
- **No client-side changes needed**: macOS/iOS clients are unaware of SPA internals

### Alternatives not taken

1. **Revert to `redirectToNativeApp(nativeParams, error)`**: user explicitly said this was breaking iOS login
2. **Remove SPA from native flow entirely**: the SPA handles pending signup and error rendering for edge cases; bypassing it loses those flows
3. **Add retry logic for `getSession()`**: masks the underlying issue without fixing it; adds latency

### Root cause analysis

**How the code got into this state**: A developer added the debug block to keep the Safari sheet open for Web Inspector inspection during iOS cache-miss diagnosis. It was marked temporary with a clear revert trigger, but the trigger condition (diagnosis complete) happened without the revert being applied.

**Warning signs missed**: The debug block made the native auth flow unconditionally fail for all users (not just debug builds). A feature flag or environment check would have limited the blast radius.

**Prevention**: Debug-only code that breaks production flows should be gated behind a development-only condition (e.g. `__DEV__` flag, query param opt-in) rather than deployed unconditionally.

### References

- [Apple `ASWebAuthenticationSession` docs](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession): custom URL scheme callback behavior
- Companion server-side fix in `vellum-ai/vellum-assistant-platform` (uses relative URL for `next_url` to prevent cross-domain cookie loss)

## Test plan

- Deploy both this PR and the companion platform PR
- Verify macOS native login: Safari sheet opens → WorkOS auth → sheet closes → app receives session → "Logging in..." resolves
- Verify iOS native login: same flow via Capacitor NativeAuth plugin
- Verify web login is unaffected (does not go through native callback path)
- Verify `signup_closed` error still renders correctly in the Safari sheet (line 146 handler)

Link to Devin session: https://app.devin.ai/sessions/67886aaf1d26446b8bd5535792de95ce
Requested by: @ashleeradka