### PR TITLE
fix(web/chat): add hover background to collapsed sidebar group icons

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -99,7 +99,7 @@ export function CollapsedGroupIcon({
           type="button"
           aria-label={label}
           aria-haspopup="dialog"
-          className="relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+          className="relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
         >
           <Icon size={18} />
           {indicatorState != null ? (


### PR DESCRIPTION
Add hover:bg-[var(--surface-hover)] to group icon buttons for visual feedback on hover.