### PR TITLE
fix(web/chat): add tooltip to disabled collapsed sidebar group icons

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -85,6 +85,7 @@ export function CollapsedGroupIcon({
     return (
       <div
         aria-label={label}
+        title="No conversations"
         className="relative flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--content-disabled)]"
       >
         <Icon size={18} />


### PR DESCRIPTION
Add native title="No conversations" tooltip on hover for disabled (empty) group icons.