### PR TITLE
fix(web): drop iOS-only redirect-to-native on provider-callback error

### DIFF
--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -55,26 +55,24 @@ function redirectToNativeApp(
 }
 
 /**
- * Best-effort check for an iOS Capacitor auth context. Returns true on
- * iPhone, iPad, and iPadOS (which presents as Macintosh with touch).
+ * True if the current browser is iOS or iPadOS. iPadOS 13+ reports a
+ * Macintosh user agent by default, so we disambiguate via
+ * `maxTouchPoints > 1` on a Mac platform — real Macs report 0 or 1.
+ * `"ontouchend" in document` is NOT a reliable touch-device signal on
+ * desktop Safari (the API exists on desktop too), which is why we don't
+ * use it. Same discriminator as `isIOSBrowser` in
+ * `domains/nudges/ios-app-platform.ts`.
  *
- * Used to keep iOS off the native error bounce: setting
- * `window.location.href = scheme://?error=…` inside the iOS
- * `ASWebAuthenticationSession` Safari sheet has been observed to tear
- * the sheet down before the new WebKit cookie store finishes committing
- * the session cookie set by allauth's social callback, making an
- * otherwise-recoverable post-WorkOS failure permanent. macOS does not
- * exhibit the same behavior and still relies on the bounce so the auth
- * sheet closes cleanly into the native UI.
+ * Ref: https://developer.apple.com/forums/thread/119186
  */
-function isIOSAuthContext(): boolean {
+function isIOSBrowser(): boolean {
   if (typeof navigator === "undefined") return false;
   const ua = navigator.userAgent;
-  if (/iPhone|iPad|iPod/i.test(ua)) return true;
-  // iPadOS 13+ reports a Macintosh user agent by default; disambiguate
-  // via touch capability, which Macs don't expose.
-  return /Macintosh/i.test(ua) && "ontouchend" in document;
+  if (/iPhone|iPad|iPod/.test(ua)) return true;
+  const isMacPlatform = navigator.platform.toLowerCase().includes("mac");
+  return isMacPlatform && navigator.maxTouchPoints > 1;
 }
+
 
 /**
  * OAuth provider callback handler. Probes the allauth session after the
@@ -140,7 +138,14 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            if (nativeParams && !isIOSAuthContext()) {
+            // Skip the native-scheme bounce on iOS only: it tears the
+            // `ASWebAuthenticationSession` Safari sheet down before
+            // WebKit finishes committing the session cookie set by
+            // allauth's social callback, turning a recoverable
+            // post-WorkOS failure into a permanent one. macOS does
+            // not exhibit this and still needs the bounce so its
+            // auth sheet closes cleanly into the native UI.
+            if (nativeParams && !isIOSBrowser()) {
               redirectToNativeApp(nativeParams, outcome.message);
               return;
             }

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
+import * as Sentry from "@sentry/react";
 
 import { AccountHeading } from "@/components/account/account-form.js";
 import { AccountShell } from "@/components/account/account-shell.js";
@@ -152,7 +153,10 @@ export function ProviderCallbackPage() {
             setFallbackError(outcome.message);
             break;
         }
-      } catch {
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { context: "provider_callback" },
+        });
         setFallbackError("Something went wrong. Please try signing in again.");
       }
     })();

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -55,6 +55,28 @@ function redirectToNativeApp(
 }
 
 /**
+ * Best-effort check for an iOS Capacitor auth context. Returns true on
+ * iPhone, iPad, and iPadOS (which presents as Macintosh with touch).
+ *
+ * Used to keep iOS off the native error bounce: setting
+ * `window.location.href = scheme://?error=…` inside the iOS
+ * `ASWebAuthenticationSession` Safari sheet has been observed to tear
+ * the sheet down before the new WebKit cookie store finishes committing
+ * the session cookie set by allauth's social callback, making an
+ * otherwise-recoverable post-WorkOS failure permanent. macOS does not
+ * exhibit the same behavior and still relies on the bounce so the auth
+ * sheet closes cleanly into the native UI.
+ */
+function isIOSAuthContext(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  if (/iPhone|iPad|iPod/i.test(ua)) return true;
+  // iPadOS 13+ reports a Macintosh user agent by default; disambiguate
+  // via touch capability, which Macs don't expose.
+  return /Macintosh/i.test(ua) && "ontouchend" in document;
+}
+
+/**
  * OAuth provider callback handler. Probes the allauth session after the
  * IdP redirect and routes the user to the correct next step:
  * - Authenticated → navigate to returnTo or home
@@ -118,20 +140,8 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            if (nativeParams) {
-              // TEMPORARY DEBUG (revert once iOS sign-in cache-miss is
-              // diagnosed): suppress the redirect-back-to-native so the
-              // Safari sheet stays open and the actual getSession()
-              // failure mode is inspectable. Without this, ASWebAuth
-              // catches the scheme:// redirect, closes the sheet, and
-              // destroys the Web Inspector window before anything can
-              // be read.
-              console.log("[debug native auth] getSession result:", result);
-              console.log("[debug native auth] classification outcome:", outcome);
-              console.log("[debug native auth] nativeParams:", nativeParams);
-              setFallbackError(
-                `[debug] ${outcome.message} :: result=${JSON.stringify(result).slice(0, 800)}`,
-              );
+            if (nativeParams && !isIOSAuthContext()) {
+              redirectToNativeApp(nativeParams, outcome.message);
               return;
             }
             setFallbackError(outcome.message);


### PR DESCRIPTION
## Why

Replaces the temporary debug landing in #31770 with a targeted, minimal fix.

The native error branch in `ProviderCallbackPage` previously did `window.location.href = scheme://?error=…` to close the `ASWebAuthenticationSession` Safari sheet and surface the failure in the host app. On iOS Capacitor, that bounce was the proximate cause of a class of post-WorkOS sign-in failures: the Safari sheet would tear down before the new WebKit cookie store finished committing the session cookie set by allauth's social callback, **and every other in-flight request (including ones that would have come back authenticated) was cancelled with the WebKit teardown**. The user ended up with a "Something went wrong" toast on the iOS login page and a permanent failure for that attempt.

Removing the bounce was tested empirically post-#31770 deploy and confirmed to fix iOS sign-in. macOS, which goes through the same SPA page in its own `ASWebAuthenticationSession` context, never exhibited the symptom and **still relies on the bounce to close its auth sheet into the native UI**.

## What

In the `case "error"` branch, only call `redirectToNativeApp` for non-iOS contexts:

```ts
case "error":
  if (nativeParams && !isIOSAuthContext()) {
    redirectToNativeApp(nativeParams, outcome.message);
    return;
  }
  setFallbackError(outcome.message);
  break;
```

`isIOSAuthContext()` is a UA check — `iPhone|iPad|iPod` plus the iPadOS-13+ "Macintosh + touch" disambiguation. Best-effort but reliable for our purposes; macOS Safari never matches.

Also removes the debug payload that landed in #31770 (the `console.log` calls and the `JSON.stringify(result)` rendered to the user as the error subtitle). Both were instrumentation only — the actual diagnostic was already captured before merge.

## Behavior matrix

| Context | Before this PR | After |
|---|---|---|
| iOS Capacitor, native error | Stuck on debug-rendered "Authentication failed" page in sheet | Stuck on clean "Authentication failed" page in sheet with "Back to sign in" link |
| macOS native, native error | `setFallbackError(debug-text)` — sheet stayed open (regression vs. pre-#31770) | `redirectToNativeApp(...)` — sheet bounces back cleanly to native (restored) |
| Web flow (no `nativeParams`) | Unchanged | Unchanged |
| Native happy path / `provider_signup` | Unchanged | Unchanged |
| URL-level `?error=…` (e.g. `signup_closed`) | Unchanged | Unchanged |

## Checks

- `bun run typecheck` — pre-existing errors in `domains/settings` (stale generated openapi clients) on `main`, unrelated to this change. Touched file has no new errors.
- `bun run lint src/domains/account/pages/provider-callback-page.tsx` — clean.
- No existing tests for this file.

## Why this is minimal

The previous PR (#31789, closed) was a deeper architectural change that removed the SPA-side `getSession()` check entirely for native flows. That would have changed macOS's working behavior, which is why this is the narrower fix: only restore macOS to its original-bounce behavior, only suppress the bounce on iOS where it's known to break, and remove the user-visible debug noise.

---
_Generated by [Claude Code](https://claude.ai/code/session_012B87vGYhbhfDCYnwQHr4Mh)_