### PR TITLE
fix(oauth): route credential-health BYO ping through withValidToken

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -12,6 +12,7 @@ let mockProviders: Array<{
   pingMethod: string | null;
   pingHeaders: string | null;
   pingBody: string | null;
+  managedServiceConfigKey?: string;
 }> = [];
 
 let mockConnections: Map<
@@ -32,6 +33,24 @@ let mockFetchResponse: { ok: boolean; status: number } = {
   status: 200,
 };
 let mockFetchThrows = false;
+
+// Per-test refresh outcome — drives the withValidToken mock.
+//   "ok"          → refresh succeeds (or wasn't needed); callback runs with token
+//   "refresh_failed" → refresh throws TokenExpiredError (revoked refresh token)
+type RefreshOutcome = "ok" | "refresh_failed";
+let mockRefreshOutcome: RefreshOutcome = "ok";
+
+// Managed-path mock state.
+const managedProviders = new Set<string>();
+let managedListResponse: {
+  ok: boolean;
+  status: number;
+  body?: unknown;
+} = { ok: true, status: 200, body: { results: [] } };
+let managedPingOutcome:
+  | { kind: "status"; status: number }
+  | { kind: "credential_required" }
+  | { kind: "throw"; message: string } = { kind: "status", status: 200 };
 
 // ── Module mocks ─────────────────────────────────────────────────────
 
@@ -81,6 +100,88 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
+class MockTokenExpiredError extends Error {
+  constructor(service: string, message?: string) {
+    super(message ?? `Token expired for "${service}"`);
+    this.name = "TokenExpiredError";
+  }
+}
+
+mock.module("../security/token-manager.js", () => ({
+  TokenExpiredError: MockTokenExpiredError,
+  withValidToken: async (
+    service: string,
+    callback: (token: string) => Promise<unknown>,
+    opts: { connectionId: string },
+  ) => {
+    if (mockRefreshOutcome === "refresh_failed") {
+      throw new MockTokenExpiredError(service);
+    }
+    const token =
+      secureKeyValues.get(
+        `oauth_connection/${opts.connectionId}/access_token`,
+      ) ?? "refreshed-token";
+    return callback(token);
+  },
+}));
+
+// Managed-path mocks: services schema, config loader, platform client,
+// PlatformOAuthConnection. The managed code path uses dynamic imports for
+// these so they only matter when a managed test scenario is exercised.
+mock.module("../config/schemas/services.js", () => ({
+  ServicesSchema: {
+    shape: {
+      "google-oauth": {},
+      "notion-oauth": {},
+    },
+  },
+  getServiceMode: (_services: unknown, key: string) =>
+    managedProviders.has(key) ? "managed" : "your-own",
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+}));
+
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => ({
+      platformAssistantId: "test-assistant",
+      fetch: async (_path: string) => ({
+        ok: managedListResponse.ok,
+        status: managedListResponse.status,
+        json: async () => managedListResponse.body ?? { results: [] },
+      }),
+    }),
+  },
+}));
+
+class MockCredentialRequiredError extends Error {
+  constructor() {
+    super("credential required");
+    this.name = "CredentialRequiredError";
+  }
+}
+
+mock.module("../oauth/platform-connection.js", () => ({
+  PlatformOAuthConnection: class {
+    constructor(_opts: unknown) {}
+    async request(_req: unknown) {
+      if (managedPingOutcome.kind === "credential_required") {
+        throw new MockCredentialRequiredError();
+      }
+      if (managedPingOutcome.kind === "throw") {
+        throw new Error(managedPingOutcome.message);
+      }
+      return {
+        status: managedPingOutcome.status,
+        headers: {},
+        body: {},
+      };
+    }
+  },
+}));
+
 // ── Import under test ────────────────────────────────────────────────
 
 const { checkAllCredentials, checkCredentialForProvider, _setFetchFn } =
@@ -106,6 +207,7 @@ function addProvider(
     defaultScopes?: string[];
     pingUrl?: string | null;
     pingMethod?: string | null;
+    managedServiceConfigKey?: string;
   },
 ) {
   mockProviders.push({
@@ -115,6 +217,10 @@ function addProvider(
     pingMethod: opts?.pingMethod ?? null,
     pingHeaders: null,
     pingBody: null,
+    // checkManagedProvider reads this field via OAuthProviderRow; the
+    // health-check code branches to the managed path only when set AND
+    // when managedProviders includes the corresponding config key.
+    managedServiceConfigKey: opts?.managedServiceConfigKey,
   });
 }
 
@@ -159,6 +265,10 @@ describe("credential-health-service", () => {
     mockConnections = new Map();
     mockFetchResponse = { ok: true, status: 200 };
     mockFetchThrows = false;
+    mockRefreshOutcome = "ok";
+    managedProviders.clear();
+    managedListResponse = { ok: true, status: 200, body: { results: [] } };
+    managedPingOutcome = { kind: "status", status: 200 };
   });
 
   test("returns empty report when no providers exist", async () => {
@@ -238,8 +348,12 @@ describe("credential-health-service", () => {
     expect(report.results[0]!.canAutoRecover).toBe(false);
   });
 
-  test("returns expiring when token is past expiresAt with refresh token", async () => {
-    addProvider("google");
+  test("returns healthy when expired token has a refresh token, no ping URL, and refresh succeeds via the ping path", async () => {
+    // Without a pingUrl there's no opportunity to exercise the refresh —
+    // the connection is reported as healthy on the trust that the next
+    // real API call will refresh transparently. This matches the contract
+    // for connections that have a refresh token but no liveness endpoint.
+    addProvider("google"); // no pingUrl
     addConnection("google", "conn-1", {
       expiresAt: Date.now() - 60_000, // 1 minute ago
       hasRefreshToken: true,
@@ -247,8 +361,59 @@ describe("credential-health-service", () => {
     setToken("conn-1");
 
     const report = await checkAllCredentials();
-    expect(report.results[0]!.status).toBe("expiring");
+    expect(report.results[0]!.status).toBe("healthy");
     expect(report.results[0]!.canAutoRecover).toBe(true);
+  });
+
+  test("expired BYO token + successful refresh + 200 ping → healthy", async () => {
+    // The withValidToken mock returns "refreshed" by default; pingProvider
+    // sees a fresh token and the upstream returns 200.
+    mockFetchResponse = { ok: true, status: 200 };
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() - 60_000,
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("healthy");
+  });
+
+  test("expired BYO token + refresh fails (revoked refresh token) → revoked", async () => {
+    mockRefreshOutcome = "refresh_failed";
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() - 60_000,
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("revoked");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("BYO ping that still returns 401 after a refresh attempt → revoked", async () => {
+    // Refresh succeeds (mockRefreshOutcome stays "ok") but the upstream
+    // still returns 401 — the token was genuinely revoked by the provider.
+    mockFetchResponse = { ok: false, status: 401 };
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("revoked");
+    expect(report.results[0]!.details).toContain("after a refresh attempt");
   });
 
   test("returns expiring when token expires within 7 days without refresh token", async () => {
@@ -456,6 +621,90 @@ describe("credential-health-service", () => {
       expect(report.results).toHaveLength(1);
       expect(report.results[0]!.status).toBe("unreachable");
       expect(report.results[0]!.canAutoRecover).toBe(true);
+    });
+  });
+
+  describe("managed-provider path", () => {
+    // Distinguishing managed-path failure modes: a 424 from the platform
+    // proxy (CredentialRequiredError) means the platform tried and gave up
+    // on refresh — actionable, fire reconnect alert. A bare 401/403 from
+    // the upstream provider could be a transient platform-side miss (proxy
+    // didn't refresh-before-forward) and should NOT fire reconnect alerts
+    // without further evidence — demote to ping_failed.
+
+    function setupManagedGoogle(opts?: { hasActiveConnection?: boolean }) {
+      addProvider("google", {
+        pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+        managedServiceConfigKey: "google-oauth",
+      });
+      managedProviders.add("google-oauth");
+      if (opts?.hasActiveConnection !== false) {
+        managedListResponse = {
+          ok: true,
+          status: 200,
+          body: {
+            results: [
+              {
+                id: "platform-conn-1",
+                account_label: "user@example.com",
+                status: "ACTIVE",
+              },
+            ],
+          },
+        };
+      }
+    }
+
+    test("managed 2xx ping → healthy", async () => {
+      setupManagedGoogle();
+      managedPingOutcome = { kind: "status", status: 200 };
+
+      const report = await checkAllCredentials();
+      const google = report.results.find((r) => r.provider === "google");
+      expect(google!.status).toBe("healthy");
+    });
+
+    test("managed 424 (CredentialRequiredError) → revoked", async () => {
+      setupManagedGoogle();
+      managedPingOutcome = { kind: "credential_required" };
+
+      const report = await checkAllCredentials();
+      const google = report.results.find((r) => r.provider === "google");
+      expect(google!.status).toBe("revoked");
+      expect(google!.canAutoRecover).toBe(false);
+      expect(google!.details).toContain("cannot be refreshed");
+    });
+
+    test("managed 401 from upstream → ping_failed, not revoked", async () => {
+      // This is the key change: previously this would fire a user-facing
+      // reconnect alert (because "revoked" is in hardFailureStatuses). Now
+      // we treat upstream 401 as potentially transient — only a 424 from
+      // the platform proxy is trusted enough to trigger the alert.
+      setupManagedGoogle();
+      managedPingOutcome = { kind: "status", status: 401 };
+
+      const report = await checkAllCredentials();
+      const google = report.results.find((r) => r.provider === "google");
+      expect(google!.status).toBe("ping_failed");
+      expect(google!.status).not.toBe("revoked");
+    });
+
+    test("managed 403 from upstream → ping_failed, not revoked", async () => {
+      setupManagedGoogle();
+      managedPingOutcome = { kind: "status", status: 403 };
+
+      const report = await checkAllCredentials();
+      const google = report.results.find((r) => r.provider === "google");
+      expect(google!.status).toBe("ping_failed");
+    });
+
+    test("managed 500 from upstream → ping_failed", async () => {
+      setupManagedGoogle();
+      managedPingOutcome = { kind: "status", status: 500 };
+
+      const report = await checkAllCredentials();
+      const google = report.results.find((r) => r.provider === "google");
+      expect(google!.status).toBe("ping_failed");
     });
   });
 

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -7,8 +7,10 @@
  * - Scope coverage (grantedScopes vs provider defaultScopes)
  * - Liveness ping (for providers with a pingUrl)
  *
- * Designed to run during the heartbeat cycle. All checks are diagnostic —
- * no token refresh or recovery is attempted.
+ * Designed to run during the heartbeat cycle. The BYO liveness ping is
+ * routed through `withValidToken`, so a stale-but-refreshable access token
+ * is refreshed transparently before the ping fires — this prevents the
+ * heartbeat from misreporting a refreshable connection as `"revoked"`.
  */
 
 import { isTokenExpired } from "@vellumai/credential-storage";
@@ -22,6 +24,10 @@ import {
   type OAuthConnectionRow,
   type OAuthProviderRow,
 } from "../oauth/oauth-store.js";
+import {
+  TokenExpiredError,
+  withValidToken,
+} from "../security/token-manager.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("credential-health");
@@ -125,6 +131,45 @@ async function pingProvider(
   }
 }
 
+/**
+ * Map a pingProvider result onto a CredentialHealthResult, or null when the
+ * ping succeeded. `authErrorContext` distinguishes whether a 401/403 came
+ * after a refresh attempt (refreshable connection) or directly from the
+ * stored token (manual-token / no-refresh connection) — the latter is the
+ * historical message wording.
+ */
+type PingFailureContext = "after_refresh" | "no_refresh";
+
+function pingResultToHealthFailure(
+  base: Omit<CredentialHealthResult, "status" | "details" | "canAutoRecover">,
+  provider: string,
+  connectionId: string,
+  pingResult: { ok: boolean; authError: boolean },
+  authErrorContext: PingFailureContext,
+): CredentialHealthResult | null {
+  if (pingResult.ok) return null;
+  if (pingResult.authError) {
+    const suffix =
+      authErrorContext === "after_refresh" ? " after a refresh attempt" : "";
+    return {
+      ...base,
+      status: "revoked",
+      details: `${provider} token was rejected (401/403)${suffix}. The token may have been revoked. Re-authorization required.`,
+      canAutoRecover: false,
+    };
+  }
+  log.debug(
+    { provider, connectionId },
+    "Credential ping failed with non-auth error",
+  );
+  return {
+    ...base,
+    status: "ping_failed",
+    details: `${provider} liveness check failed (non-auth error). This may be transient.`,
+    canAutoRecover: false,
+  };
+}
+
 // ── Core check ────────────────────────────────────────────────────────
 
 interface CheckConnectionOpts {
@@ -192,14 +237,18 @@ async function checkConnection(
   const token = tokenResult.value;
 
   // 2. Check token expiry
-  if (isTokenExpired(expiresAt)) {
+  //
+  // When the token is expired AND there is no refresh token, we have no path
+  // to recovery — short-circuit to "expired". When there IS a refresh token,
+  // we fall through so the ping (via withValidToken) can attempt a refresh
+  // and confirm whether the refresh token still works. Without that, we'd
+  // return "expiring" speculatively even when the refresh token was revoked.
+  if (isTokenExpired(expiresAt) && !hasRefreshToken) {
     return {
       ...base,
-      status: hasRefreshToken ? "expiring" : "expired",
-      details: hasRefreshToken
-        ? `Token for ${provider} is expired but has a refresh token — auto-recovery may work.`
-        : `Token for ${provider} is expired with no refresh token. Re-authorization required.`,
-      canAutoRecover: hasRefreshToken,
+      status: "expired",
+      details: `Token for ${provider} is expired with no refresh token. Re-authorization required.`,
+      canAutoRecover: false,
     };
   }
 
@@ -234,36 +283,51 @@ async function checkConnection(
   }
 
   // 4. Liveness ping
+  //
+  // For refreshable connections we route through withValidToken so an
+  // expired-but-refreshable token gets refreshed before the ping fires.
+  // Without this wrapping, the ping would hit 401 on a stale token and the
+  // connection would be misreported as "revoked" — even though the next real
+  // API call (which goes through BYOOAuthConnection.request → withValidToken)
+  // would have refreshed and succeeded.
   if (pingUrl) {
-    const pingResult = await pingProvider(
-      token,
-      pingUrl,
-      pingMethod,
-      pingHeaders,
-      pingBody,
-    );
-    if (!pingResult.ok) {
-      if (pingResult.authError) {
-        return {
-          ...base,
-          status: "revoked",
-          details: `${provider} token was rejected (401/403). The token may have been revoked. Re-authorization required.`,
-          canAutoRecover: false,
-        };
+    const runPing = (t: string) =>
+      pingProvider(t, pingUrl, pingMethod, pingHeaders, pingBody);
+
+    let pingResult: { ok: boolean; authError: boolean };
+    let authContext: PingFailureContext;
+
+    if (hasRefreshToken) {
+      try {
+        pingResult = await withValidToken(provider, runPing, { connectionId });
+      } catch (err) {
+        if (err instanceof TokenExpiredError) {
+          // Refresh itself failed (revoked refresh token, invalid_grant, etc.)
+          return {
+            ...base,
+            status: "revoked",
+            details: `${provider} token refresh failed. The refresh token may have been revoked. Re-authorization required.`,
+            canAutoRecover: false,
+          };
+        }
+        throw err;
       }
-      // Non-auth ping failure — log but don't mark as critical.
-      // Could be a transient API issue.
-      log.debug(
-        { provider, connectionId },
-        "Credential ping failed with non-auth error",
-      );
-      return {
-        ...base,
-        status: "ping_failed",
-        details: `${provider} liveness check failed (non-auth error). This may be transient.`,
-        canAutoRecover: false,
-      };
+      authContext = "after_refresh";
+    } else {
+      // Manual-token provider or an OAuth provider whose initial flow
+      // didn't return a refresh_token — nothing to refresh, ping directly.
+      pingResult = await runPing(token);
+      authContext = "no_refresh";
     }
+
+    const failure = pingResultToHealthFailure(
+      base,
+      provider,
+      connectionId,
+      pingResult,
+      authContext,
+    );
+    if (failure) return failure;
   }
 
   return {
@@ -434,10 +498,28 @@ async function checkManagedProvider(
             canAutoRecover: true,
           });
         } else if (pingResp.status === 401 || pingResp.status === 403) {
+          // 401/403 from the upstream provider after the platform proxy
+          // forwarded the request. From the daemon side we can't tell
+          // whether the proxy attempted (and failed) a refresh-before-
+          // forward or skipped refresh entirely and forwarded a stale token.
+          // Either way it's not definitively unrecoverable — the next ping
+          // cycle may succeed if the platform re-refreshes. Demote to
+          // ping_failed so we don't fire a user-facing reconnect alert on
+          // what may be a transient platform-side miss. Only platform-
+          // attested 424 (CredentialRequiredError below) signals genuine
+          // unrecoverable failure.
+          log.debug(
+            {
+              provider: providerRow.provider,
+              connectionId: conn.id,
+              status: pingResp.status,
+            },
+            "Managed credential ping returned 401/403 — treating as potentially transient",
+          );
           results.push({
             ...base,
-            status: "revoked",
-            details: `${providerRow.provider} managed token was rejected (${pingResp.status}). Reconnect on the Vellum platform.`,
+            status: "ping_failed",
+            details: `${providerRow.provider} managed liveness check returned ${pingResp.status} from the upstream provider. The Vellum platform may not have refreshed the token before forwarding; will retry next cycle.`,
             canAutoRecover: false,
           });
         } else {
@@ -450,8 +532,11 @@ async function checkManagedProvider(
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        // CredentialRequiredError means the platform can't materialize
-        // the token — treat as revoked.
+        // CredentialRequiredError corresponds to a 424 from the platform
+        // proxy — the platform attempted (and gave up on) refresh and is
+        // telling us the credential is genuinely unrecoverable. This is
+        // the only managed-path signal we trust enough to fire a user-
+        // facing reconnect alert.
         if (
           err &&
           typeof err === "object" &&
@@ -461,7 +546,7 @@ async function checkManagedProvider(
           results.push({
             ...base,
             status: "revoked",
-            details: `${providerRow.provider} managed connection is no longer valid. Reconnect on the Vellum platform.`,
+            details: `${providerRow.provider} managed connection cannot be refreshed by the Vellum platform. Reconnect on the Vellum platform.`,
             canAutoRecover: false,
           });
         } else {

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -199,6 +199,9 @@ export const PROVIDER_SEED_DATA: Record<
       },
     ],
     appType: "Public integration",
+    setupNotes: [
+      "Enable Token Rotation on your Notion integration (developer dashboard → your integration → Configuration → Token rotation). Without it, Notion does not issue a refresh token and the connection cannot auto-recover if Notion revokes the access token server-side — you will silently lose access and need to reconnect manually.",
+    ],
     identityUrl: "https://api.notion.com/v1/users/me",
     identityHeaders: { "Notion-Version": "2022-06-28" },
     identityResponsePaths: ["name", "person.email"],


### PR DESCRIPTION
## Summary

- BYO credential-health ping now routes through `withValidToken`, so an expired-but-refreshable token is refreshed transparently before the ping fires — stops the heartbeat from misreporting refreshable connections as `"revoked"` and firing spurious user-facing reconnect alerts.
- Managed-path upstream 401/403 is demoted from `"revoked"` to `"ping_failed"` (not in `hardFailureStatuses`). Only platform-attested 424 (`CredentialRequiredError`) — where the platform itself has tried and given up on refresh — is trusted enough to fire the reconnect alert.
- Notion provider seed gains `setupNotes` instructing BYO users to enable Token Rotation in their Notion integration dashboard; without it Notion doesn't issue a refresh token and the connection cannot auto-recover from server-side revocation.

## Original prompt

Users were reporting Gmail and Notion OAuth integrations getting "disconnected daily." Investigation in the daemon traced the symptom to the credential-health heartbeat: the BYO liveness ping read the raw access token from secure storage and never went through the refresh-aware `withValidToken` wrapper that real API calls use, so any Gmail token that had merely expired at the 1-hour mark would return 401 on the ping and the heartbeat would flag the connection as revoked even though the next real call would have refreshed and succeeded. The managed path was lumping platform-attested 424 ("platform gave up on refresh") together with upstream 401 ("could be transient platform-side miss") as the same `"revoked"` status, also leading to false alarms.

This PR addresses the daemon-side share of the work tracked in JARVIS-959. The platform-side refresh-before-forward investigation is in a separate ticket (JARVIS-960).

## Notes for reviewer

- The change to `checkConnection` removes the speculative `"expiring"` short-circuit when an expired token has a refresh token. Previously the code returned `"expiring"` without ever attempting refresh, on the trust that auto-recovery "may work." Now the ping actually verifies refresh works and returns `"healthy"` on success, `"revoked"` if refresh fails. The one carved-out case — expired + refresh + no `pingUrl` — still returns `"healthy"` since there's no way to verify, matching the contract for connections without a liveness endpoint.
- Added module mocks for `token-manager.js`, `platform/client.js`, `platform-connection.js`, `config/loader.js`, and `config/schemas/services.js` to enable the new BYO refresh and managed-path tests. The mocks are gated by `mockRefreshOutcome` / `managedProviders` / `managedPingOutcome` flags that reset in `beforeEach` so existing tests aren't affected.

## Test plan

- [x] `bun test src/__tests__/credential-health-service.test.ts` — 31/31 pass (added 3 BYO refresh tests and 5 managed-path tests)
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual smoke: trigger heartbeat with a deliberately-expired Gmail token and confirm the connection is reported as `"healthy"` after refresh rather than `"revoked"`