### PR TITLE
feat(web/home): notification row hover action icons

### DIFF
--- a/apps/web/src/domains/home/home-feed-list.tsx
+++ b/apps/web/src/domains/home/home-feed-list.tsx
@@ -11,7 +11,12 @@ import {
   groupByTime,
   sortFeedItems,
 } from "./utils/feed-utils.js";
-import type { FeedItem, FeedItemCategory, FeedTimeGroup } from "./types.js";
+import type {
+  FeedItem,
+  FeedItemCategory,
+  FeedItemStatus,
+  FeedTimeGroup,
+} from "./types.js";
 
 const TIME_GROUP_LABELS: Record<FeedTimeGroup, string> = {
   today: "Today",
@@ -24,6 +29,8 @@ export interface HomeFeedListProps {
   onSelectItem: (item: FeedItem) => void;
   onDismissItem: (itemId: string) => void;
   onRestoreItem: (itemId: string) => void;
+  onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
+  onGoToThread?: (conversationId: string) => void;
 }
 
 export function HomeFeedList({
@@ -31,6 +38,8 @@ export function HomeFeedList({
   onSelectItem,
   onDismissItem,
   onRestoreItem,
+  onToggleRead,
+  onGoToThread,
 }: HomeFeedListProps) {
   const [activeFilter, setActiveFilter] = useState<FeedItemCategory | null>(
     null,
@@ -104,6 +113,8 @@ export function HomeFeedList({
                   item={item}
                   onSelect={onSelectItem}
                   onDismiss={onDismissItem}
+                  onToggleRead={onToggleRead}
+                  onGoToThread={onGoToThread}
                 />
               ))}
             </div>

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -152,6 +152,8 @@ export function HomePage({
         onSelectItem={handleSelectItem}
         onDismissItem={handleDismissItem}
         onRestoreItem={handleRestoreItem}
+        onToggleRead={handleUpdateStatus}
+        onGoToThread={handleGoToThread}
       />
     </>
   );

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -129,7 +129,12 @@ export function HomeRecapRow({
           {onGoToThread && item.conversationId && (
             <HoverIconButton
               title="Go to thread"
-              onClick={() => onGoToThread(item.conversationId!)}
+              onClick={() => {
+                if (isUnread && onToggleRead) {
+                  onToggleRead(item.id, "seen");
+                }
+                onGoToThread(item.conversationId!);
+              }}
             >
               <MessageSquare width={14} height={14} />
             </HoverIconButton>

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -1,9 +1,47 @@
-import { RotateCcw, X } from "lucide-react";
+import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { cn } from "@vellum/design-library";
 import { CATEGORY_STYLES } from "./home-feed-filter-bar.js";
-import type { FeedItem, FeedItemCategory } from "./types.js";
+import type { FeedItem, FeedItemCategory, FeedItemStatus } from "./types.js";
+
+function HoverIconButton({
+  title,
+  onClick,
+  className,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      title={title}
+      aria-label={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(
+        "cursor-pointer text-[var(--content-disabled)] transition-colors hover:text-[var(--content-secondary)]",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
 
 function resolveStyle(category?: FeedItemCategory) {
   if (category && CATEGORY_STYLES[category]) {
@@ -18,6 +56,8 @@ export interface HomeRecapRowProps {
   item: FeedItem;
   onSelect: (item: FeedItem) => void;
   onDismiss: (itemId: string) => void;
+  onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
+  onGoToThread?: (conversationId: string) => void;
   trailingAction?: HomeRecapRowTrailingAction;
 }
 
@@ -25,6 +65,8 @@ export function HomeRecapRow({
   item,
   onSelect,
   onDismiss,
+  onToggleRead,
+  onGoToThread,
   trailingAction = "dismiss",
 }: HomeRecapRowProps) {
   const [isHovering, setIsHovering] = useState(false);
@@ -32,8 +74,6 @@ export function HomeRecapRow({
   const Icon = style.icon;
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
-  const TrailingIcon = isRestore ? RotateCcw : X;
-  const trailingLabel = isRestore ? "Restore" : "Dismiss";
 
   return (
     <button
@@ -76,30 +116,40 @@ export function HomeRecapRow({
         {item.title ?? item.summary}
       </span>
 
-      {isHovering ? (
-        <span
-          role="button"
-          tabIndex={0}
-          aria-label={trailingLabel}
-          onClick={(e) => {
-            e.stopPropagation();
-            onDismiss(item.id);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.stopPropagation();
-              e.preventDefault();
-              onDismiss(item.id);
-            }
-          }}
-          className={cn(
-            "flex shrink-0 cursor-pointer items-center gap-[var(--app-spacing-xs)]",
-            "text-[var(--content-disabled)]",
+      {isHovering && !isRestore ? (
+        <span className="flex shrink-0 items-center gap-[var(--app-spacing-sm)]">
+          {onToggleRead && (
+            <HoverIconButton
+              title={isUnread ? "Mark as read" : "Mark as unread"}
+              onClick={() => onToggleRead(item.id, isUnread ? "seen" : "new")}
+            >
+              {isUnread ? <MailOpen width={14} height={14} /> : <Mail width={14} height={14} />}
+            </HoverIconButton>
           )}
-        >
-          <TrailingIcon width={14} height={14} aria-hidden="true" />
-          <span className="text-body-small-default">{trailingLabel}</span>
+          {onGoToThread && item.conversationId && (
+            <HoverIconButton
+              title="Go to thread"
+              onClick={() => onGoToThread(item.conversationId!)}
+            >
+              <MessageSquare width={14} height={14} />
+            </HoverIconButton>
+          )}
+          <HoverIconButton
+            title="Dismiss"
+            onClick={() => onDismiss(item.id)}
+          >
+            <Trash2 width={14} height={14} />
+          </HoverIconButton>
         </span>
+      ) : isHovering && isRestore ? (
+        <HoverIconButton
+          title="Restore"
+          onClick={() => onDismiss(item.id)}
+          className="flex shrink-0 items-center gap-[var(--app-spacing-xs)]"
+        >
+          <RotateCcw width={14} height={14} aria-hidden="true" />
+          <span className="text-body-small-default">Restore</span>
+        </HoverIconButton>
       ) : null}
     </button>
   );


### PR DESCRIPTION
## Summary
Replace the single "Dismiss" text button on notification row hover with three icon-only action buttons:
- **Read/unread toggle** (Mail/MailOpen) — toggles between "new" and "seen" status
- **Go to thread** (MessageSquare) — conditional on `conversationId` being present
- **Dismiss** (Trash2) — marks item as dismissed

Each icon shows a native tooltip on hover and has a color transition from `--content-disabled` to `--content-secondary`. Dismissed items in the collapsed section retain the existing Restore button.

## Self-review result
PASS — all 4 passes clean (external feedback, plan faithfulness, integration, slop audit)

## PRs merged into feature branch
- #32094: feat(web/home): replace dismiss button with hover action icons

Part of plan: notif-row-hover-actions.md