### PR TITLE
feat(types): add bootstrapTemplate, initialMessage, and skills to OnboardingContext

### DIFF
--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -10,4 +10,10 @@ export interface OnboardingContext {
   cohort?: string;
   websiteUrl?: string;
   contentSourceUrl?: string;
+  /** Filename of the bootstrap template to use (e.g. "BOOTSTRAP-CONTENT-AUTOMATION.md"). When set, replaces generic BOOTSTRAP.md if still pristine. */
+  bootstrapTemplate?: string;
+  /** Override the first user message content. When set during a wake-up greeting, this replaces the canned greeting. */
+  initialMessage?: string;
+  /** Skills to eagerly load on first turn (e.g. ["geo-writing", "document-editor"]). Informational — the bootstrap template drives actual loading. */
+  skills?: string[];
 }


### PR DESCRIPTION
## Summary
- Add bootstrapTemplate, initialMessage, and skills optional fields to OnboardingContext
- These fields enable the daemon to act as a generic recipe executor instead of hardcoding cohort-specific behavior
- Type-only change, no runtime behavior changes

Part of plan: onboarding-recipe-arch.md (PR 1 of 7)