### PR TITLE
fix(context): preserve aspect ratio in Gemini 3072px tiling estimate (address Codex review on #31586)

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -367,6 +367,28 @@ describe("token estimator", () => {
     expect(tokens).toBeLessThan(4_200);
   });
 
+  test("Gemini preserves aspect ratio when resizing to the 3072px cap", () => {
+    // Gemini rescales BOTH dimensions by a single factor so the longest side
+    // becomes 3072px. A 10000x1000 image → 3072x307, i.e. ceil(3072/768)=4
+    // tiles wide * ceil(307/768)=1 tile high = 4 tiles (~1,032 tokens).
+    // Clamping each side independently would yield 4*2=8 tiles, over-counting
+    // by 2x and risking spurious compaction.
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(10000, 1000),
+        },
+      },
+      { providerName: "gemini" },
+    );
+    // 4 tiles * 258 = 1,032 image tokens + 16 block overhead + 3 media type.
+    expect(tokens).toBeGreaterThanOrEqual(1_032);
+    expect(tokens).toBeLessThan(1_100);
+  });
+
   test("Gemini images ≤384px on both sides count as a single 258-token tile", () => {
     const tokens = estimateContentBlockTokens(
       {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -154,11 +154,16 @@ function estimateGeminiImageTokens(width: number, height: number): number {
   ) {
     return GEMINI_IMAGE_TOKENS_PER_TILE;
   }
-  // Gemini resizes images so the longest side is ≤3072px before tiling.
-  const clampedWidth = Math.min(width, GEMINI_IMAGE_MAX_DIMENSION);
-  const clampedHeight = Math.min(height, GEMINI_IMAGE_MAX_DIMENSION);
-  const tilesWide = Math.ceil(clampedWidth / GEMINI_IMAGE_TILE_SIZE);
-  const tilesHigh = Math.ceil(clampedHeight / GEMINI_IMAGE_TILE_SIZE);
+  // Gemini rescales both dimensions by a single aspect-preserving factor so
+  // the longest side is ≤3072px before tiling. Clamping each side
+  // independently would over-count tiles for extreme aspect ratios
+  // (e.g. 10000×1000 → 3072×307, not 3072×1000).
+  const scale = Math.min(
+    1,
+    GEMINI_IMAGE_MAX_DIMENSION / Math.max(width, height),
+  );
+  const tilesWide = Math.ceil((width * scale) / GEMINI_IMAGE_TILE_SIZE);
+  const tilesHigh = Math.ceil((height * scale) / GEMINI_IMAGE_TILE_SIZE);
   return tilesWide * tilesHigh * GEMINI_IMAGE_TOKENS_PER_TILE;
 }
 


### PR DESCRIPTION
## Summary
`estimateGeminiImageTokens` clamped width and height independently (`Math.min(width, 3072)`, `Math.min(height, 3072)`), but Gemini's pre-tiling step rescales BOTH dimensions by a single factor so the longest side becomes 3072px (aspect-preserving). The independent clamp over-counted tiles for wide/tall images — e.g. 10000x1000 should resize to ~3072x307 (4x1 = 4 tiles) but the old logic yielded 4x2 = 8 tiles — which can still trigger unnecessary compaction.

This computes a single scale factor `Math.min(1, 3072 / Math.max(width, height))` and applies it to both dimensions before the tile-count math. Images already within bounds are unaffected (scale = 1).

## Test plan
- [x] Added regression test for the 10000x1000 extreme-aspect-ratio case
- [x] Existing square-image tests (3000x3000, 4000x4000) unchanged
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/context-token-estimator.test.ts` — 28 pass

Addresses Codex review on #31586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)