### PR TITLE
fix(gemini): gate thinkingConfig on model supportsThinking capability (address Codex review on #31800)

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -285,6 +285,32 @@ describe("GeminiProvider", () => {
     });
   });
 
+  test("omits thinkingConfig for models that do not support thinking", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    // gemini-2.5-flash-lite has supportsThinking: false in the catalog; the
+    // provider must not forward thinking params even when a thinking config is
+    // supplied (gemini is in THINKING_AWARE_PROVIDERS, so retry.ts no longer
+    // strips them).
+    const liteProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-2.5-flash-lite",
+    );
+    await liteProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      {
+        config: {
+          thinking: { type: "adaptive", level: "high", streamThinking: false },
+        },
+      },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toBeUndefined();
+  });
+
   test("omits thinkingConfig when wire shape is adaptive with no extras", async () => {
     fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
 

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -4,6 +4,7 @@ import { ApiError, GoogleGenAI, ThinkingLevel } from "@google/genai";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
   ContentBlock,
@@ -72,6 +73,24 @@ function buildThinkingConfig(
     result.includeThoughts = thinking.streamThinking;
   }
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Whether the active Gemini model accepts a `thinkingConfig`. Non-thinking
+ * models (e.g. `gemini-2.5-flash-lite`) reject thinking params, and gemini is
+ * in `THINKING_AWARE_PROVIDERS` so `providers/retry.ts` no longer strips them —
+ * so we gate on the catalog's `supportsThinking` capability here. Unknown or
+ * uncatalogued models default to allowing thinking config (preserving prior
+ * behavior); only an explicit `supportsThinking: false` suppresses it.
+ */
+function geminiModelSupportsThinking(model: string): boolean {
+  const normalized = model.startsWith("models/")
+    ? model.slice("models/".length)
+    : model;
+  const catalogModel = PROVIDER_CATALOG.find(
+    (provider) => provider.id === "gemini",
+  )?.models.find((m) => m.id === normalized);
+  return catalogModel?.supportsThinking !== false;
 }
 
 function stripGeminiHttpOptions(
@@ -215,10 +234,12 @@ export class GeminiProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
-    const thinkingConfig = buildThinkingConfig(
-      configObj?.thinking as Record<string, unknown> | undefined,
-    );
     const activeModel = modelOverride ?? this.model;
+    const thinkingConfig = geminiModelSupportsThinking(activeModel)
+      ? buildThinkingConfig(
+          configObj?.thinking as Record<string, unknown> | undefined,
+        )
+      : undefined;
 
     try {
       const geminiContents = this.toGeminiContents(messages, activeModel);


### PR DESCRIPTION
## Summary

`buildThinkingConfig` in `assistant/src/providers/gemini/client.ts` forwarded `thinkingConfig` whenever `config.thinking` was present, with **no** check of the model's `supportsThinking` capability. PR #31800 added gemini to `THINKING_AWARE_PROVIDERS`, so `providers/retry.ts` no longer strips thinking params — meaning non-thinking Gemini models (e.g. `gemini-2.5-flash-lite`, which has `supportsThinking: false` in the catalog) now received thinking params and risked provider validation errors.

## Fix

- Added `geminiModelSupportsThinking()` which looks up the active model in `PROVIDER_CATALOG` (normalizing the optional `models/` prefix) and returns `false` only when the catalog explicitly sets `supportsThinking: false`. Unknown/uncatalogued models default to allowing thinking config (preserves prior behavior).
- Gated the `buildThinkingConfig` call in `sendMessage` on this check.
- Added a regression test asserting `thinkingConfig` is omitted for `gemini-2.5-flash-lite`.

The lookup mirrors the existing catalog-access pattern in `config/llm-context-resolution.ts`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/gemini-provider.test.ts` — 41 pass

Addresses Codex review on #31800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)