### PR TITLE
fix(memory): gate v2 buffer-size consolidation trigger on checkpoint (address Codex review on #31578)

### DIFF
--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -279,8 +279,31 @@ describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
     maybeEnqueueGraphMaintenanceJobs(config, now);
 
     expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
-    // Checkpoint refreshed so the next tick doesn't immediately re-fire.
+    // Checkpoint refreshed so the time-based branch doesn't re-fire.
     expect(getMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY)).toBe(String(now));
+  });
+
+  test("does not re-fire on every tick while buffer stays over threshold", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+
+    const now = Date.now();
+    // Recent checkpoint so the time-based branch never fires across ticks —
+    // the only thing that could re-enqueue is the size branch.
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    writeBuffer(10);
+
+    // Simulate several worker ticks with the buffer still over threshold and
+    // the first-tick job still pending (nothing has drained it yet).
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    maybeEnqueueGraphMaintenanceJobs(config, now + 1_000);
+    maybeEnqueueGraphMaintenanceJobs(config, now + 2_000);
+
+    // A pending consolidate job dedupes the later ticks — only one enqueue.
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
   });
 
   test("does not enqueue when buffer is under the threshold", () => {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -65,6 +65,7 @@ import {
   enqueuePruneOldTraceEventsJob,
   failMemoryJob,
   failStalledJobs,
+  hasActiveJobOfType,
   type MemoryJob,
   type MemoryJobType,
   resetRunningJobsToPending,
@@ -791,8 +792,18 @@ export function maybeEnqueueGraphMaintenanceJobs(
   // Size-based trigger: when the shared buffer crosses the configured line
   // count, drain it now rather than waiting out the interval. Retargets to the
   // same consolidator the interval branch above selected.
+  //
+  // The size branch is checkpoint-blind by design (it must fire before the
+  // interval elapses), so it dedupes against an already-active consolidate job
+  // instead — otherwise it would re-enqueue on every worker tick while the
+  // buffer stays over threshold, flooding the queue with redundant LLM work.
   const maxLines = config.memory.v2.consolidation_max_buffer_lines;
-  if (v2Active && !enqueuedConsolidate && maxLines !== null) {
+  if (
+    v2Active &&
+    !enqueuedConsolidate &&
+    maxLines !== null &&
+    !hasActiveJobOfType(consolidateEntry.jobType)
+  ) {
     const bufferPath = join(getWorkspaceDir(), "memory", "buffer.md");
     if (countBufferLines(bufferPath) >= maxLines) {
       enqueueMemoryJob(consolidateEntry.jobType, {});


### PR DESCRIPTION
## Summary
The buffer-size trigger added in #31578 (`maybeEnqueueGraphMaintenanceJobs` in `assistant/src/memory/jobs-worker.ts`) only *wrote* the `memory_v2_consolidate_last_run` checkpoint after enqueueing — it never read it. The interval branch reads the checkpoint before re-firing, but the size branch is checkpoint-blind, so while the buffer stayed over threshold it re-enqueued `memory_v2_consolidate` on **every worker tick**, flooding the queue with redundant LLM consolidation work until the buffer finally drained.

## Fix
Gate the size branch on the existing `hasActiveJobOfType(consolidateEntry.jobType)` helper (whose docstring is literally "Used to prevent duplicate enqueues for long-running maintenance jobs"). This dedupes against an already pending/running consolidate job while preserving the trigger's intent — it can still fire *before* the interval elapses when the buffer is large, it just won't re-fire every tick. The dedup check is ordered after the cheap boolean guards and before the buffer file read, so it adds no file I/O when a job is already active.

## Tests
- Added a regression test (`does not re-fire on every tick while buffer stays over threshold`) that runs three consecutive ticks with the buffer over threshold and a recent checkpoint, asserting only one job is enqueued.
- Fixed a misleading comment in an existing test that claimed the checkpoint alone prevented re-firing.
- All 15 tests in `jobs-worker-v2-schedule.test.ts` pass; `bunx tsc --noEmit` is clean.

Addresses Codex review on #31578.

## Test plan
- [x] `cd assistant && bunx tsc --noEmit`
- [x] `cd assistant && bun test src/memory/__tests__/jobs-worker-v2-schedule.test.ts`