### PR TITLE
fix(assistant): match full injected wrapper when stripping for compaction (address Codex review on #31845)

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1103,6 +1103,84 @@ describe("stripInjectionsForCompaction preserves persistent blocks", () => {
 });
 
 // ---------------------------------------------------------------------------
+// stripInjectionsForCompaction — memory/info wrapper shape
+// ---------------------------------------------------------------------------
+
+describe("stripInjectionsForCompaction memory/info wrapper matching", () => {
+  test("injected <info>…</info> static-memory block IS stripped", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<info>\nessentials and threads\n</info>" },
+          { type: "text", text: "Hello" },
+        ],
+      },
+    ];
+
+    const result = stripInjectionsForCompaction(messages);
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
+      "Hello",
+    );
+  });
+
+  test("injected <memory>…</memory> activation block IS stripped", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory>\nactivated slugs\n</memory>" },
+          { type: "text", text: "Hello" },
+        ],
+      },
+    ];
+
+    const result = stripInjectionsForCompaction(messages);
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
+      "Hello",
+    );
+  });
+
+  test("user text merely starting with <info>\\n (no closing tag) is NOT stripped", () => {
+    const userText = "<info>\nHere is what I want to discuss about the markup";
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: userText }],
+      },
+    ];
+
+    const result = stripInjectionsForCompaction(messages);
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
+      userText,
+    );
+  });
+
+  test("user text merely starting with <memory>\\n (no closing tag) is NOT stripped", () => {
+    const userText = "<memory>\nplease remember to buy milk";
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: userText }],
+      },
+    ];
+
+    const result = stripInjectionsForCompaction(messages);
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
+      userText,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // applyRuntimeInjections with nowScratchpad
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -997,23 +997,38 @@ export function buildUnifiedTurnContextBlock(
 // ---------------------------------------------------------------------------
 
 /**
- * Remove text blocks from user messages whose text starts with any of the
- * given prefixes.  If stripping removes all content blocks from a message,
- * the message itself is dropped.
+ * A matcher for an injected text block. A plain string matches by prefix
+ * (`startsWith`). A `{ prefix, suffix }` wrapper requires BOTH the opening
+ * prefix and the closing suffix, so user-authored content that merely begins
+ * with an injection-like opening tag (e.g. a message discussing `<info>`
+ * markup) is not mistaken for an injected block and dropped. This mirrors
+ * `countMemoryPrefixBlocks`, which only treats `<memory>…</memory>` /
+ * `<info>…</info>` blocks as injected when the full wrapper is present.
+ */
+type InjectionMatcher = string | { prefix: string; suffix: string };
+
+/**
+ * Remove text blocks from user messages that match any of the given matchers.
+ * If stripping removes all content blocks from a message, the message itself
+ * is dropped.
  *
  * This is the shared primitive behind the individual strip* functions and
  * the `stripInjectionsForCompaction` pipeline.
  */
 function stripUserTextBlocksByPrefix(
   messages: Message[],
-  prefixes: string[],
+  matchers: InjectionMatcher[],
 ): Message[] {
   return messages
     .map((message) => {
       if (message.role !== "user") return message;
       const nextContent = message.content.filter((block) => {
         if (block.type !== "text") return true;
-        return !prefixes.some((p) => block.text.startsWith(p));
+        return !matchers.some((m) =>
+          typeof m === "string"
+            ? block.text.startsWith(m)
+            : block.text.startsWith(m.prefix) && block.text.endsWith(m.suffix),
+        );
       });
       if (nextContent.length === message.content.length) return message;
       if (nextContent.length === 0) return null;
@@ -1720,8 +1735,8 @@ export function loadSlackActiveThreadFocusBlock(
   return assembleSlackActiveThreadFocusBlock(rows, capabilities);
 }
 
-/** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
-const RUNTIME_INJECTION_PREFIXES = [
+/** Matchers stripped by the pipeline (order doesn't matter — single pass). */
+const RUNTIME_INJECTION_PREFIXES: InjectionMatcher[] = [
   "<channel_capabilities>",
   "<channel_command_context>",
   "<disk_pressure_warning>",
@@ -1742,8 +1757,13 @@ const RUNTIME_INJECTION_PREFIXES = [
   // cadence. The activation pipeline dedupes via `everInjected`, and
   // compaction handles aggregate growth, so accumulation does not cause
   // unbounded context growth. Both wrappers may appear in persisted rows.
-  "<memory>\n",
-  "<info>\n",
+  //
+  // These two use the full `{ prefix, suffix }` wrapper shape (not a bare
+  // prefix) so that user-authored text merely starting with `<memory>\n` or
+  // `<info>\n` is never silently dropped during compaction/`/clean`. This
+  // matches the full-wrapper requirement in `countMemoryPrefixBlocks`.
+  { prefix: "<memory>\n", suffix: "\n</memory>" },
+  { prefix: "<info>\n", suffix: "\n</info>" },
   "<voice_call_control>",
   "<workspace_top_level>", // backward-compat: strip legacy workspace blocks
   // NOTE: <workspace> is intentionally NOT stripped — workspace context


### PR DESCRIPTION
## Summary

Adding `<info>\n` (and the pre-existing `<memory>\n`) to `RUNTIME_INJECTION_PREFIXES` made `stripInjectionsForCompaction` (via `stripUserTextBlocksByPrefix`) delete ANY user text block that merely **starts with** those tags, with no closing-tag check. If the stripped block was the message's only block, the whole user message was dropped — silently deleting legitimate user-authored content during compaction or `/clean`.

This tightens the strip path to match the full injected wrapper shape (`{ prefix, suffix }` requiring both `<info>\n`…`\n</info>` and `<memory>\n`…`\n</memory>`), matching the full-wrapper requirement already enforced by `countMemoryPrefixBlocks`. The actual goal — stripping the injected static-memory and activation blocks on compaction — is preserved.

Intentionally did **not** touch `countMemoryPrefixBlocks` (the other Codex comment): it already requires the complete `<info>...</info>` / `<memory>...</memory>` wrapper, so that comment is a non-issue.

## Changes
- Introduce `InjectionMatcher = string | { prefix, suffix }`; `stripUserTextBlocksByPrefix` now supports wrapper matchers requiring both opening and closing tags.
- Switch the `<memory>\n` and `<info>\n` entries to wrapper matchers.
- Add regression tests: injected wrappers ARE stripped; user text merely starting with `<info>\n`/`<memory>\n` (no closing tag) is NOT stripped.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test conversation-runtime-assembly.test.ts conversation-clean-command.test.ts` (187 pass)

Addresses Codex review on #31845.