### PR TITLE
fix(memory): bound recall@k and align replay prior-injected with production (address Codex review on #31968)

### DIFF
--- a/assistant/src/memory/v2/__tests__/harness-metrics.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-metrics.test.ts
@@ -25,6 +25,15 @@ describe("harness/metrics recallAtK", () => {
   test("empty ground truth is vacuously complete (recall 1)", () => {
     expect(recallAtK([], new Set<string>(), 5)).toBe(1);
   });
+
+  test("duplicate selections cannot push recall above 1.0", () => {
+    // A retriever emitting the same slug twice must not double-count it.
+    expect(recallAtK(["a", "a"], new Set(["a"]), 10)).toBe(1);
+    // Duplicates inside the top-k window still count once.
+    const gt = new Set(["a", "b"]);
+    expect(recallAtK(["a", "a", "b"], gt, 10)).toBeCloseTo(1);
+    expect(recallAtK(["a", "a", "b"], gt, 2)).toBeCloseTo(0.5);
+  });
 });
 
 describe("harness/metrics evalTurn", () => {

--- a/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
@@ -195,7 +195,7 @@ describe("harness/replay-input reconstructInput", () => {
     expect(r).toBeNull();
   });
 
-  test("priorEverInjected unions injected/in_context slugs from earlier router turns", async () => {
+  test("priorEverInjected mirrors production everInjected retention from earlier router turns", async () => {
     insertMessage("u1", "c1", "user", "u1", 10);
     insertMessage("a1", "c1", "assistant", "a1", 20);
     insertMessage("u2", "c1", "user", "u2", 30);
@@ -207,7 +207,12 @@ describe("harness/replay-input reconstructInput", () => {
       [
         makeConcept("p1", "injected"),
         makeConcept("p2", "in_context"),
-        makeConcept("p3", "not_injected"),
+        // page_missing / corrupt concept pages are retained in production's
+        // everInjected (so they aren't re-attempted every turn), so the replay
+        // must include them too.
+        makeConcept("p3", "page_missing"),
+        makeConcept("p4", "corrupt"),
+        makeConcept("p5", "not_injected"),
       ],
       20,
     );
@@ -219,7 +224,7 @@ describe("harness/replay-input reconstructInput", () => {
       WORKSPACE,
     );
     const slugs = (r?.input.priorEverInjected ?? []).map((e) => e.slug).sort();
-    expect(slugs).toEqual(["p1", "p2"]);
-    expect(r?.meta.priorEverInjectedCount).toBe(2);
+    expect(slugs).toEqual(["p1", "p2", "p3", "p4"]);
+    expect(r?.meta.priorEverInjectedCount).toBe(4);
   });
 });

--- a/assistant/src/memory/v2/harness/metrics.ts
+++ b/assistant/src/memory/v2/harness/metrics.ts
@@ -36,6 +36,10 @@ export interface AggregateEval {
 /**
  * recall@k = |topK(selected) ∩ G| / |G|. An empty ground-truth set is defined
  * as recall 1 (nothing to recall — vacuously complete).
+ *
+ * The top-k window is deduped before intersecting with the ground-truth set so
+ * a retriever that emits the same slug twice (e.g. `['a','a']`) cannot count it
+ * twice and push recall above 1.0. Recall is therefore bounded in [0, 1].
  */
 export function recallAtK(
   selected: readonly string[],
@@ -44,7 +48,7 @@ export function recallAtK(
 ): number {
   if (groundTruth.size === 0) return 1;
   let hit = 0;
-  for (const slug of selected.slice(0, k)) {
+  for (const slug of new Set(selected.slice(0, k))) {
     if (groundTruth.has(slug)) hit++;
   }
   return hit / groundTruth.size;

--- a/assistant/src/memory/v2/harness/replay-input.ts
+++ b/assistant/src/memory/v2/harness/replay-input.ts
@@ -10,8 +10,10 @@
  *  - `nowText`: read from current workspace files (`loadNowText`). NOT stored
  *    in the log, so it may differ from what the live turn saw —
  *    always-approximate; see `ReconstructionMeta.nowReconstructedFromCurrent`.
- *  - `priorEverInjected`: the union of injected / in_context slugs from earlier
- *    `mode='router'` logs in the same conversation (turn < target).
+ *  - `priorEverInjected`: the union of retained slugs from earlier
+ *    `mode='router'` logs in the same conversation (turn < target). Retained
+ *    statuses mirror production's `everInjected` (injected / in_context, plus
+ *    page_missing / corrupt — see `PRIOR_STATUSES`).
  *
  * The anchor is the turn's assistant reply; the messages the router saw are
  * those strictly before it, so we fetch a bounded recent window up to the
@@ -172,7 +174,21 @@ export async function reconstructInput(
   };
 }
 
-const PRIOR_STATUSES = new Set<string>(["injected", "in_context"]);
+// Production's `everInjected` retains a slug once it is rendered, EXCEPT for
+// missing synthetic slugs (skills/CLI commands whose capability cache is empty
+// — see `missingSyntheticSlugs` in `injection.ts`). Concept pages that turn out
+// `page_missing` or `corrupt` at render time are still retained so they aren't
+// re-attempted every turn (see the `page_missing ... DOES land in everInjected`
+// case in `injection.test.ts`). The replay must mirror that retention or it
+// builds a narrower prior-state than live routing, skewing comparisons. Missing
+// synthetic slugs never enter the missing/corrupt buckets — they log as
+// `injected` — so widening here introduces no new synthetic-slug discrepancy.
+const PRIOR_STATUSES = new Set<string>([
+  "injected",
+  "in_context",
+  "page_missing",
+  "corrupt",
+]);
 
 /**
  * Union of slugs injected on earlier `mode='router'` turns in this conversation


### PR DESCRIPTION
Addresses Codex review on #31968 (offline retrieval comparison harness).

## (a) recall@k bounded to [0, 1]
`recallAtK` in `harness/metrics.ts` counted every matching entry in `selected.slice(0, k)`, so a retriever emitting a duplicate slug (e.g. `['a','a']` vs `{'a'}`) scored 2/1 = 2.0. Now the top-k window is deduped (`new Set(selected.slice(0, k))`) before intersecting with ground truth, so distinct ground-truth slugs are counted at most once and recall is bounded in [0, 1].

## (b) replay prior-injected aligned with production retention — APPLIED
`reconstructPriorEverInjected` in `harness/replay-input.ts` only accepted `injected` / `in_context` statuses. Verified production retention in `injection.ts` (`finalizeInjection`): a rendered slug is retained in `everInjected` EXCEPT for missing synthetic slugs (skills/CLI commands whose capability cache is empty — `missingSyntheticSlugs`). Concept pages that render as `page_missing` or `corrupt` ARE retained so they aren't re-attempted every turn — confirmed by the `injection.test.ts` case "router-selected slug whose page is missing on disk ... the phantom slug DOES land in everInjected". Missing synthetic slugs never enter the missing/corrupt buckets (`renderInjectionBlock` `continue`s without recording them) and log as `injected`, so widening introduces no new synthetic-slug discrepancy. `PRIOR_STATUSES` now includes `page_missing` and `corrupt`, matching production.

## Tests
- Added recall@k dedup regression test (duplicates can't exceed 1.0).
- Extended the replay retention test to assert `page_missing` / `corrupt` are now reconstructed.
- `bunx tsc --noEmit` clean; both harness test files pass (11 tests).