### PR TITLE
fix(assistant): make compaction history-stripped marker write non-fatal (address Codex review on #31712)

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -3968,5 +3968,81 @@ describe("session-agent-loop", () => {
       );
       expect(stripCalls.length).toBeGreaterThanOrEqual(1);
     });
+
+    test("strip-site marker write is non-fatal when the helper throws", async () => {
+      setConversationHistoryStrippedAtMock.mockImplementation(() => {
+        throw new Error("db write failed");
+      });
+
+      mockReducerStepFn = (msgs: Message[]) => ({
+        messages: msgs,
+        tier: "forced_compaction",
+        state: {
+          appliedTiers: ["forced_compaction"],
+          injectionMode: "full",
+          exhausted: false,
+        },
+        estimatedTokens: 5000,
+      });
+
+      let callCount = 0;
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        if (callCount === 1) {
+          onEvent({
+            type: "error",
+            error: new Error("context_length_exceeded"),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 50,
+          });
+          return [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [{ type: "text", text: "partial" }] as ContentBlock[],
+            },
+          ];
+        }
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50,
+          outputTokens: 25,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      // Must not throw — the strip-site marker write is wrapped in try/catch.
+      await expect(
+        runAgentLoopImpl(ctx, "hello", "msg-1", () => {}),
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -226,6 +226,30 @@ import type { TrustContext } from "./trust-context.js";
 import { stripHistoricalWebSearchResults } from "./web-search-history.js";
 
 const log = getLogger("conversation-agent-loop");
+
+/**
+ * Best-effort persistence of the history-stripped marker after an
+ * injection-strip event (compaction / overflow recovery). The marker is a
+ * durability hint, not turn-critical state — a transient SQLite write failure
+ * (SQLITE_BUSY, disk-full, read-only FS) must not abort the turn. Logs a
+ * warning and continues on failure, preserving the long-standing non-fatal
+ * contract for this metadata write.
+ */
+function markHistoryStrippedBestEffort(
+  conversationId: string,
+  strippedAt: number,
+  logger: ReturnType<typeof getLogger>,
+): void {
+  try {
+    setConversationHistoryStrippedAt(conversationId, strippedAt);
+  } catch (err) {
+    logger.warn(
+      { err },
+      "Failed to persist history-stripped marker after compaction strip (non-fatal)",
+    );
+  }
+}
+
 const DISK_PRESSURE_ERROR_CODE = "DISK_SPACE_CRITICAL" as const;
 const DISK_PRESSURE_ERROR_CATEGORY = "disk_pressure";
 
@@ -2312,7 +2336,7 @@ export async function runAgentLoopImpl(
       // so we compact the "raw" persistent messages.
       const rawHistory = stripInjectionsForCompaction(updatedHistory);
       ctx.messages = rawHistory;
-      setConversationHistoryStrippedAt(ctx.conversationId, Date.now());
+      markHistoryStrippedBestEffort(ctx.conversationId, Date.now(), rlog);
 
       ctx.emitActivityState(
         "thinking",
@@ -2596,7 +2620,7 @@ export async function runAgentLoopImpl(
 
       if (updatedHistory.length > preRunHistoryLength) {
         ctx.messages = stripInjectionsForCompaction(updatedHistory);
-        setConversationHistoryStrippedAt(ctx.conversationId, Date.now());
+        markHistoryStrippedBestEffort(ctx.conversationId, Date.now(), rlog);
         convergenceStripped = true;
         preRepairMessages = updatedHistory;
         preRunHistoryLength = updatedHistory.length;
@@ -2841,7 +2865,7 @@ export async function runAgentLoopImpl(
           // pre-rerun messages.
           if (updatedHistory.length > preRunHistoryLength) {
             ctx.messages = stripInjectionsForCompaction(updatedHistory);
-            setConversationHistoryStrippedAt(ctx.conversationId, Date.now());
+            markHistoryStrippedBestEffort(ctx.conversationId, Date.now(), rlog);
             convergenceStripped = true;
             preRepairMessages = updatedHistory;
             preRunHistoryLength = updatedHistory.length;
@@ -3694,7 +3718,7 @@ export async function applyCompactionResult(
     result.summaryText,
     ctx.contextCompactedMessageCount,
   );
-  setConversationHistoryStrippedAt(ctx.conversationId, compactedAt);
+  markHistoryStrippedBestEffort(ctx.conversationId, compactedAt, log);
   if (options.slackContextCompactionWatermarkTs) {
     updateConversationSlackContextWatermark(
       ctx.conversationId,


### PR DESCRIPTION
## Summary

Addresses Codex review on #31712.

PR #31712 replaced three guarded `clearStrippedInjectionMetadataForConversation` calls (previously wrapped in `try/catch` + warn, explicitly non-fatal) with **unguarded** `setConversationHistoryStrippedAt(...)` calls in the compaction/overflow strip path of `conversation-agent-loop.ts`, and added a fourth unguarded call in `applyCompactionResult`. A transient SQLite write error (SQLITE_BUSY, disk-full, read-only FS) would throw and **abort the turn**. The PR also deleted the test asserting non-fatal behavior.

This restores the non-fatal contract: all four strip-site marker writes now route through a `markHistoryStrippedBestEffort` helper that catches, logs a warning, and continues. The marker is a best-effort durability hint, not turn-critical state.

- Consolidates the guarding into one helper rather than re-introducing three duplicated `try/catch` blocks.
- Re-adds the regression test (mirroring the one #31712 deleted) asserting the strip-site marker write is non-fatal when the helper throws.

Intentionally skipped Codex's migration-260 comment — it is nonsensical: migration 259 adds `cleaned_at` (the old column name), not `history_stripped_at`, so there is no schema drift.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/conversation-agent-loop.test.ts` — 60 pass, 0 fail (incl. re-added non-fatal test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)