### PR TITLE
fix(prompts): strip comments before IDENTITY template detection (address Codex review on #31642)

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -171,6 +171,42 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("# Soul\n\nBe thoughtful.");
   });
 
+  test("gates off the unmodified bundled IDENTITY.md template when no BOOTSTRAP.md is present", () => {
+    // Regression: the seeded IDENTITY.md ships with `_`-comment lines, so
+    // the raw workspace body never equals the comment-stripped bundled
+    // template. `isTemplateContent` must comment-strip BOTH sides — otherwise
+    // detection fails and the `08-identity` transform leaks the blank
+    // template scaffolding into every fresh post-onboarding prompt.
+    const bundledIdentity = readFileSync(
+      join(import.meta.dirname, "..", "prompts", "templates", "IDENTITY.md"),
+      "utf-8",
+    );
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), bundledIdentity);
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "# Soul\n\nBe thoughtful.");
+    const result = buildSystemPrompt();
+    // SOUL still renders; the template scaffolding must not.
+    expect(result).toContain("# Soul\n\nBe thoughtful.");
+    expect(result).not.toContain("This file is yours.");
+    expect(result).not.toContain("(not yet chosen)");
+  });
+
+  test("includes the unmodified bundled IDENTITY.md template during bootstrap", () => {
+    // The mirror case: when BOOTSTRAP.md is active the template is included
+    // verbatim so the model can see the field structure and produce a valid
+    // file_write on the first turn.
+    const bundledIdentity = readFileSync(
+      join(import.meta.dirname, "..", "prompts", "templates", "IDENTITY.md"),
+      "utf-8",
+    );
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), bundledIdentity);
+    writeFileSync(
+      join(TEST_DIR, "BOOTSTRAP.md"),
+      "# First run\n\nGet started.",
+    );
+    const result = buildSystemPrompt();
+    expect(result).toContain("This file is yours.");
+  });
+
   test("trims whitespace from file content", () => {
     writeFileSync(join(TEST_DIR, "SOUL.md"), "\n  Be kind  \n\n");
     const result = buildSystemPrompt();

--- a/assistant/src/prompts/template-detection.ts
+++ b/assistant/src/prompts/template-detection.ts
@@ -6,9 +6,15 @@ import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 /**
  * Returns true when the prompt file content is still the unmodified template
- * shipped with the daemon.  Compares the stripped workspace content against
- * the stripped bundled template source so the check stays accurate even if
- * templates are edited in future releases.
+ * shipped with the daemon.  Comment-strips BOTH the workspace content and the
+ * bundled template source before comparing, so the check stays accurate even
+ * if templates are edited in future releases — and regardless of whether the
+ * caller passes raw or already-stripped content.  Most callers pre-strip via
+ * `readPromptFile`/`stripCommentLines`, but the `08-identity` section
+ * transform receives the raw workspace body (comment-stripping happens after
+ * the transform in `renderSection`); stripping here keeps detection correct
+ * for both.  `stripCommentLines` is idempotent, so pre-stripped callers are
+ * unaffected.
  *
  * Kept in a leaf module so the bundled section registry can depend on it
  * without forming a cycle through `system-prompt.ts → sections.ts →
@@ -30,7 +36,7 @@ export function isTemplateContent(
     const templateContent = stripCommentLines(
       readFileSync(templatePath, "utf-8"),
     );
-    return content === templateContent;
+    return stripCommentLines(content) === templateContent;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- `isTemplateContent` compared the RAW workspace body against the comment-stripped bundled template. Since the seeded IDENTITY.md starts with `_` comment lines, detection always returned false and the `08-identity` transform leaked the blank template scaffolding into every fresh user's system prompt post-onboarding (no BOOTSTRAP.md).
- Fix: comment-strip BOTH sides in `isTemplateContent`, matching its own docstring. `stripCommentLines` is idempotent, so the existing pre-stripping callers (`readPromptFile`, heartbeat) are unaffected.
- Added regression tests: the unmodified bundled IDENTITY.md is gated off when no BOOTSTRAP.md is present, and included verbatim during bootstrap.

Addresses Codex review on #31642.