### PR TITLE
fix(memory): thread abort signal into compare retriever inputs (address Codex review on #31969)

### DIFF
--- a/assistant/src/memory/v2/__tests__/harness-runner.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-runner.test.ts
@@ -92,6 +92,32 @@ describe("harness/runner runComparison", () => {
     expect(loop?.aggregate.meanRecallAtK[5]).toBeCloseTo(0.75);
   });
 
+  test("threads the abort signal into each retriever's input", async () => {
+    const controller = new AbortController();
+    const seenSignals: (AbortSignal | undefined)[] = [];
+    const capturingRetriever: Retriever = {
+      name: "router",
+      retrieve: async (input): Promise<RetrievalOutput> => {
+        seenSignals.push(input.signal);
+        return { selectedSlugs: [], sourceBySlug: new Map() };
+      },
+    };
+
+    // Fresh reconstructed input per turn so we exercise the per-turn assignment.
+    await runComparison({
+      retrievers: [capturingRetriever],
+      oracleTurns: [oracleTurn("c1", 1, ["a"])],
+      reconstruct: async () => ({
+        ...STUB_RECONSTRUCTED,
+        input: { ...STUB_INPUT },
+      }),
+      ks: [5],
+      signal: controller.signal,
+    });
+
+    expect(seenSignals).toEqual([controller.signal]);
+  });
+
   test("skips turns whose reconstruction returns null", async () => {
     const report = await runComparison({
       retrievers: [fixedRetriever("router", ["a"])],

--- a/assistant/src/memory/v2/harness/runner.ts
+++ b/assistant/src/memory/v2/harness/runner.ts
@@ -74,6 +74,12 @@ export async function runComparison(
     }
     turnsScored++;
 
+    // Thread the abort signal into the reconstructed input so retrievers that
+    // wrap LLM calls (e.g. the router retriever forwarding to `runRouter`) abort
+    // the in-flight per-turn call on caller disconnect — the loop gating below
+    // only stops scheduling new work, it can't cancel the current retrieval.
+    if (signal) reconstructed.input.signal = signal;
+
     const byRetriever: Record<string, TurnEval> = {};
     for (const retriever of retrievers) {
       if (signal?.aborted) break;


### PR DESCRIPTION
## Summary

Addresses Codex review on #31969.

`runComparison` gated only its turn `for` loop on `signal?.aborted`, but the reconstructed `RetrievalInput` never had its `signal` field set. Since `createRouterRetriever` forwards only `input.signal` to `runRouter`, an aborted HTTP/CLI compare request could still run the full in-flight per-turn router LLM call to completion — wasting cost and keeping workers busy after the caller disconnected.

Fix: assign `params.signal` onto `reconstructed.input.signal` in the runner loop before invoking retrievers, so `runRouter` receives the signal and can abort the in-flight LLM call.

## Changes
- `assistant/src/memory/v2/harness/runner.ts`: thread the abort signal into each reconstructed input before retrieval.
- `assistant/src/memory/v2/__tests__/harness-runner.test.ts`: add a test asserting the signal reaches each retriever's input.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/memory/v2/__tests__/harness-runner.test.ts` (3 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)