### PR TITLE
fix(memory): align fork cutoff with (createdAt,id) cursor ordering (address Codex review on #31588)

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -214,6 +214,40 @@ describe("forkConversation", () => {
     ]);
   });
 
+  test("pinned fork through a (createdAt, id) cutoff matches the cursor slice for same-timestamp rows", () => {
+    // Regression for the memory-retrospective cutoff/fork divergence: the job
+    // picks its cutoff from `getMessagesAfter`, which orders by `(createdAt,
+    // id)`. `forkConversation` must slice on the same order so same-millisecond
+    // siblings aren't skipped forever or reprocessed. Insert rows whose
+    // insertion order is the reverse of their `(createdAt, id)` order to expose
+    // the divergence: a `createdAt`-only slice would pick the wrong prefix.
+    const source = createConversation("Same-timestamp cutoff thread");
+    const db = getDb();
+    const createdAt = Date.now();
+    // Insert d, c, b, a so SQLite's createdAt-only tie order (≈ rowid /
+    // insertion order) is the opposite of the (createdAt, id) cursor order
+    // (a, b, c, d). All are plain user rows so no display-turn extension fires.
+    for (const id of ["msg-d", "msg-c", "msg-b", "msg-a"]) {
+      db.run(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('${id}', '${source.id}', 'user', '${id}', ${createdAt})`,
+      );
+    }
+
+    // Cutoff = "msg-c": the cursor treats {msg-a, msg-b, msg-c} as processed
+    // and {msg-d} as still-after-the-cutoff. The fork must contain exactly the
+    // first three in `(createdAt, id)` order.
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: "msg-c",
+    });
+
+    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
+      "msg-a",
+      "msg-b",
+      "msg-c",
+    ]);
+  });
+
   test("advances fork boundary through consecutive assistant rows after the requested message", async () => {
     // When the read-path merges consecutive assistant DB rows into a single
     // display row, the client only addresses the anchor id. Forking through
@@ -273,9 +307,15 @@ describe("forkConversation", () => {
     // between — otherwise the fork loses tool_use ↔ tool_result pairing
     // and produces an invalid LLM history.
     const source = createConversation("Tool-result gap thread");
-    await addMessage(source.id, "user", "Find the latest sales numbers", undefined, {
-      skipIndexing: true,
-    });
+    await addMessage(
+      source.id,
+      "user",
+      "Find the latest sales numbers",
+      undefined,
+      {
+        skipIndexing: true,
+      },
+    );
     const anchor = await addMessage(
       source.id,
       "assistant",
@@ -527,13 +567,34 @@ describe("forkConversation", () => {
       },
       { skipIndexing: true },
     );
-    await addMessage(source.id, "assistant", "Reply 1", undefined, {
+    const reply1 = await addMessage(
+      source.id,
+      "assistant",
+      "Reply 1",
+      undefined,
+      {
+        skipIndexing: true,
+      },
+    );
+    const tail = await addMessage(source.id, "user", "Tail turn", undefined, {
       skipIndexing: true,
     });
-    await addMessage(source.id, "user", "Tail turn", undefined, {
-      skipIndexing: true,
-    });
-    const compactedAt = Date.now();
+    // Pin strictly-increasing timestamps so the pinned fork boundary is
+    // unambiguous. `addMessage` stamps `Date.now()`, and these three rows can
+    // land in the same millisecond; under the `(createdAt, id)` tie-break the
+    // pinned fork uses, that would let `m1`'s slice reorder relative to its
+    // siblings. Distinct timestamps keep this test focused on its intent —
+    // pre-compaction metadata + compaction-state inheritance.
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${reply1.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 2} WHERE id = '${tail.id}'`,
+    );
+    const compactedAt = base + 3;
     getDb()
       .update(conversations)
       .set({

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -576,6 +576,20 @@ export function forkConversation(params: {
     throw new UserError(`Conversation ${conversationId} not found`);
   }
   const sourceMessages = getMessages(conversationId);
+  if (throughMessageId != null) {
+    // `getMessages` orders by `createdAt` only; when rows share an identical
+    // millisecond timestamp the tie order is unspecified. Callers that pin the
+    // fork to a cutoff choose it from a `(createdAt, id)` cursor (e.g. the
+    // memory-retrospective job, via `getMessagesAfter`), so slicing through
+    // `throughMessageId` under the unstable order could include same-timestamp
+    // siblings the cursor considers *after* the cutoff (reprocessed next run)
+    // or exclude ones it considers *before* it (skipped forever). Re-sort on
+    // `(createdAt, id)` so the slice agrees with the cutoff. The unpinned full
+    // fork copies every row regardless of order, so it keeps source order.
+    sourceMessages.sort(
+      (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+    );
+  }
 
   if (sourceMessages.length === 0) {
     throw new UserError(


### PR DESCRIPTION
## Summary

Addresses Codex review on #31588.

`memory-retrospective-job.ts` pins its fork to a `cutoffMessageId` chosen from
`getMessagesAfter`'s `(createdAt, id)` cursor, but `forkConversation` located
that boundary using `getMessages`, which orders by `createdAt` **only**. When
multiple rows share an identical millisecond `createdAt` (imported/historical
data or rapid sequential inserts), SQLite's tie order is unspecified, so the
fork slice could diverge from the cursor-implied slice — some same-timestamp
siblings were reprocessed (and potentially re-`remember`ed) on the next run,
others skipped forever.

## Fix

- `forkConversation` re-sorts source rows by `(createdAt, id)` **only on the
  pinned `throughMessageId` path**, matching the cursor used to pick the cutoff.
  The unpinned full-fork path is untouched and keeps source display order.
  Comparator follows the existing codebase idiom
  (`a.createdAt - b.createdAt || a.id.localeCompare(b.id)`).

## Tests

- New regression test: a pinned fork through a `(createdAt, id)` cutoff returns
  exactly the cursor slice even when insertion order is the reverse of
  `(createdAt, id)` order.
- Hardened the pre-compaction-metadata fork test with explicit, distinct
  timestamps so it tests its actual intent (compaction/metadata inheritance)
  rather than relying on millisecond tie ordering.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/conversation-fork-crud.test.ts src/memory/__tests__/memory-retrospective-job.test.ts` — 54 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)