### PR TITLE
refactor(routes): use onboarding.initialMessage for first message override

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1362,10 +1362,8 @@ export async function handleSendMessage(
       : ("content-source" as const);
     effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
     // Fall through to normal inference path below
-  } else if (isWakeUp && body.onboarding?.cohort === "content-automation") {
-    effectiveContent = "I want to write articles that rank better in GEO";
-    // Fall through to normal inference path — the bootstrap template
-    // and geo-writing skill handle this message.
+  } else if (isWakeUp && body.onboarding?.initialMessage) {
+    effectiveContent = body.onboarding.initialMessage;
   } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 


### PR DESCRIPTION
## Summary
- Replace hardcoded cohort === content-automation check with generic onboarding.initialMessage field
- Daemon no longer needs to know what content-automation means in terms of first message content
- Uses whatever initialMessage the platform sends, making the daemon a generic executor

Part of plan: onboarding-recipe-arch.md (PR 3 of 7)