### PR TITLE
feat(memory-v3): add shadow-diff CLI comparing v3 shadow vs v2 selections

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11806,6 +11806,40 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v3/shadow-diff:
+    post:
+      operationId: memory_v3_shadowdiff_post
+      summary: Diff v3 shadow selections against live v2 router selections (read-only)
+      description:
+        Compares the v3 shadow-mode selections against the live v2 router selections turn-for-turn, from the memory
+        activation log. Pairs each v3_shadow row with the nearest v2 router row in the same conversation (by timestamp,
+        within a tolerance — the turn columns use different counters), then reports per-turn and aggregate overlap, what
+        v3 surfaced that v2 did not, and what v2 had that v3 dropped, broken down by v3 provenance lane. The v2
+        comparand is the router's fresh per-turn pick (status='injected'), not its accumulated in-context set. Requires
+        that v3 shadow mode has been running so v3_shadow rows exist; the route runs no LLM and writes nothing.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sinceDays:
+                  type: number
+                  exclusiveMinimum: 0
+                toleranceSec:
+                  type: number
+                  exclusiveMinimum: 0
+                limit:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+              additionalProperties: false
   /v1/memory/v3/simulate:
     post:
       operationId: memory_v3_simulate_post

--- a/assistant/src/cli/commands/memory-v3-render.ts
+++ b/assistant/src/cli/commands/memory-v3-render.ts
@@ -14,6 +14,8 @@ import type {
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
+  ShadowDiffResult,
+  ShadowDiffTurn,
 } from "../../runtime/routes/memory-v3-routes.js";
 
 /**
@@ -247,6 +249,135 @@ export function renderSimulation(result: MemoryV3SimulateResult): string {
   }
   if (result.failureReason) {
     lines.push(`Failure: ${result.failureReason}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ── Shadow-diff ───────────────────────────────────────────────────────────
+
+/** Max slugs to list per side of a per-turn detail block (full set in --json). */
+const SHADOW_DIFF_SLUG_CAP = 12;
+
+/** Format an epoch-ms timestamp as local `YYYY-MM-DD HH:MM:SS`. */
+function fmtTime(ms: number): string {
+  const d = new Date(ms);
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+  );
+}
+
+/** Render a lane/slug tally as `key: n` pairs, count-descending. */
+function renderTally(tally: Record<string, number>): string {
+  const entries = Object.entries(tally).sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  );
+  if (entries.length === 0) return "none";
+  return entries.map(([k, v]) => `${k}: ${v}`).join("   ");
+}
+
+/** Render a capped slug list with an overflow note. */
+function renderSlugList(slugs: readonly string[]): string {
+  if (slugs.length === 0) return "—";
+  const shown = slugs.slice(0, SHADOW_DIFF_SLUG_CAP).join(", ");
+  const extra = slugs.length - SHADOW_DIFF_SLUG_CAP;
+  return extra > 0 ? `${shown}  (+${extra} more)` : shown;
+}
+
+/** Render one paired turn's sizes + the v3-only / v2-only slug lists. */
+function renderShadowDiffTurn(turn: ShadowDiffTurn, lines: string[]): void {
+  const dt = `${turn.deltaMs >= 0 ? "+" : ""}${(turn.deltaMs / 1000).toFixed(1)}s`;
+  lines.push(
+    `  [${turn.conversationId.slice(0, 12)}] ${fmtTime(turn.shadowAt)}  Δ${dt}`,
+  );
+  lines.push(
+    `    v2=${turn.v2Count}  v3=${turn.v3Count}  overlap=${turn.overlap.length}` +
+      `  jaccard=${turn.jaccard.toFixed(2)}  (v2 cached: ${turn.v2CachedCount})`,
+  );
+  lines.push(
+    `    v3-only (${turn.v3Only.length}): ${renderSlugList(turn.v3Only)}`,
+  );
+  lines.push(
+    `    v2-only (${turn.v2Only.length}): ${renderSlugList(turn.v2Only)}`,
+  );
+}
+
+/**
+ * Render a {@link ShadowDiffResult}: the read window, the aggregate v2-vs-v3
+ * comparison, the v3 lane breakdowns (extra recall + recovered overlap), the
+ * most-dropped / most-added slug lists, and the capped per-turn detail.
+ */
+export function renderShadowDiff(result: ShadowDiffResult): string {
+  const { agg } = result;
+  const lines: string[] = [
+    "Memory v3 Shadow Diff",
+    "=====================",
+    `Window: ${result.shadowRows} shadow row(s), ${result.turnsCompared} paired, ` +
+      `${result.unpaired.length} unpaired   (tolerance ${result.toleranceMs / 1000}s)`,
+  ];
+
+  if (result.turnsCompared === 0) {
+    lines.push(
+      "",
+      "No paired turns. Either v3 shadow mode has not run (no v3_shadow rows),",
+      "or no v2 router row landed within tolerance of a shadow row. Enable",
+      "memory.v3.enabled + memory.v3.shadow and let a few turns accrue.",
+    );
+    if (result.unpaired.length > 0) {
+      lines.push("", `Unpaired shadow rows (${result.unpaired.length}):`);
+      for (const u of result.unpaired) {
+        lines.push(
+          `  [${u.conversationId.slice(0, 12)}] ${fmtTime(u.shadowAt)}  v3=${u.v3Count}`,
+        );
+      }
+    }
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "",
+    `Aggregate (${result.turnsCompared} turns):`,
+    `  v2 picked (injected):  mean ${agg.meanV2.toFixed(1)}   total ${agg.totalOverlap + agg.totalV2Only}`,
+    `  v3 selected:           mean ${agg.meanV3.toFixed(1)}   total ${agg.totalOverlap + agg.totalV3Only}`,
+    `  overlap:               mean ${agg.meanOverlap.toFixed(1)}   total ${agg.totalOverlap}   (mean Jaccard ${agg.meanJaccard.toFixed(2)})`,
+    `  v3-only (v3 added):    total ${agg.totalV3Only}`,
+    `  v2-only (v3 dropped):  total ${agg.totalV2Only}`,
+    "",
+    "v3 extra recall by lane (v3-only):",
+    `  ${renderTally(agg.v3OnlyByLane)}`,
+    "",
+    "overlap recovered by lane:",
+    `  ${renderTally(agg.overlapByLane)}`,
+  );
+
+  if (agg.v2OnlyTop.length > 0) {
+    lines.push("", "Most-dropped v2 pages (v2-only):");
+    for (const { slug, count } of agg.v2OnlyTop) {
+      lines.push(`  ${count}×  ${slug}`);
+    }
+  }
+  if (agg.v3OnlyTop.length > 0) {
+    lines.push("", "Most-frequent v3 extras (v3-only):");
+    for (const { slug, count } of agg.v3OnlyTop) {
+      lines.push(`  ${count}×  ${slug}`);
+    }
+  }
+
+  lines.push("", `Per-turn (newest first, showing ${result.turns.length}):`);
+  for (const turn of result.turns) {
+    lines.push("");
+    renderShadowDiffTurn(turn, lines);
+  }
+
+  if (result.unpaired.length > 0) {
+    lines.push("", `Unpaired shadow rows (${result.unpaired.length}):`);
+    for (const u of result.unpaired) {
+      lines.push(
+        `  [${u.conversationId.slice(0, 12)}] ${fmtTime(u.shadowAt)}  v3=${u.v3Count}`,
+      );
+    }
   }
 
   return lines.join("\n");

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -13,10 +13,13 @@
  *     marking shared-DAG re-entries.
  *   - `simulate` — dry-run the v3 retrieval loop against an ad-hoc query and
  *     print the per-pass descent trace plus the lane-grouped selection.
+ *   - `shadow-diff` — compare logged v3 shadow selections against the live v2
+ *     router selections, turn-for-turn, and print the overlap / v3-only /
+ *     v2-only breakdown by provenance lane.
  *
- * All are read-only: they mutate nothing. `validate`/`tree` run no LLM;
- * `simulate` invokes the loop (filter + gate LLM calls) but persists nothing.
- * `--json` emits the raw daemon payload for any subcommand.
+ * All are read-only: they mutate nothing. `validate`/`tree`/`shadow-diff` run
+ * no LLM; `simulate` invokes the loop (filter + gate LLM calls) but persists
+ * nothing. `--json` emits the raw daemon payload for any subcommand.
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -29,16 +32,35 @@ import type {
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
+  ShadowDiffResult,
 } from "../../runtime/routes/memory-v3-routes.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import {
   renderLlmCalls,
+  renderShadowDiff,
   renderSimulation,
   renderTree,
   renderValidationReport,
   reportHasDefects,
 } from "./memory-v3-render.js";
+
+/**
+ * Parse a positive numeric CLI flag. Returns `{ value }` when valid (or omitted,
+ * with `value` undefined) and `{ error: true }` when present but not a positive
+ * number — or not an integer when `int` is set.
+ */
+function parsePositiveFlag(
+  raw: string | undefined,
+  opts: { int: boolean },
+): { value?: number; error?: boolean } {
+  if (raw === undefined) return {};
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || (opts.int && !Number.isInteger(n))) {
+    return { error: true };
+  }
+  return { value: n };
+}
 
 /** Valid lane names accepted by `--lanes` (matches memory.v3.lanes keys). */
 const V3_LANE_NAMES = ["hot", "sparse", "dense", "tree", "edges"] as const;
@@ -72,7 +94,8 @@ Examples:
   $ assistant memory v3 validate
   $ assistant memory v3 tree
   $ assistant memory v3 tree --json | jq '.nodes | length'
-  $ assistant memory v3 simulate -q "what should we ship next"`,
+  $ assistant memory v3 simulate -q "what should we ship next"
+  $ assistant memory v3 shadow-diff`,
       );
 
       // ── validate ──────────────────────────────────────────────────────────
@@ -309,6 +332,113 @@ Examples:
                 `\nWrote ${payload.llmCalls.length} LLM-call file(s) to ${opts.dumpLlm}`,
               );
             }
+          },
+        );
+
+      // ── shadow-diff ─────────────────────────────────────────────────────────
+
+      v3.command("shadow-diff")
+        .description(
+          "Compare v3 shadow selections against live v2 router selections (read-only)",
+        )
+        .option(
+          "--since-days <n>",
+          "Only consider shadow rows newer than N days (default: all)",
+        )
+        .option(
+          "--tolerance-sec <n>",
+          "Max seconds between a shadow row and its paired router row (default: 10)",
+        )
+        .option(
+          "--limit <n>",
+          "Cap per-turn detail rows shown, newest first (default: 50)",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted report")
+        .addHelpText(
+          "after",
+          `
+Pairs each v3 shadow-mode selection (mode='v3_shadow' rows) with the live v2
+router selection (mode='router') from the same turn and reports where they
+agree, what v3 surfaced that v2 missed, and what v2 had that v3 dropped — the
+v3-only / v2-only sets — broken down by v3 provenance lane.
+
+Pairing is by timestamp within --tolerance-sec, not by turn number (the shadow
+and router rows count turns with different counters). The v2 comparand is the
+router's fresh per-turn pick (status='injected'), not its accumulated
+in-context set, so it is comparable to v3's fresh per-turn selection.
+
+Requires that v3 shadow mode has been running (memory.v3.enabled +
+memory.v3.shadow) so v3_shadow rows exist. Read-only — runs no LLM, writes
+nothing.
+
+Examples:
+  $ assistant memory v3 shadow-diff
+  $ assistant memory v3 shadow-diff --since-days 2
+  $ assistant memory v3 shadow-diff --json | jq '.agg.v3OnlyByLane'`,
+        )
+        .action(
+          async (opts: {
+            sinceDays?: string;
+            toleranceSec?: string;
+            limit?: string;
+            json?: boolean;
+          }) => {
+            const sinceDays = parsePositiveFlag(opts.sinceDays, {
+              int: false,
+            });
+            if (sinceDays.error) {
+              log.error(
+                `--since-days must be a positive number (got "${opts.sinceDays}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const toleranceSec = parsePositiveFlag(opts.toleranceSec, {
+              int: false,
+            });
+            if (toleranceSec.error) {
+              log.error(
+                `--tolerance-sec must be a positive number (got "${opts.toleranceSec}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const limit = parsePositiveFlag(opts.limit, { int: true });
+            if (limit.error) {
+              log.error(
+                `--limit must be a positive integer (got "${opts.limit}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+
+            const result = await cliIpcCall<ShadowDiffResult>(
+              "memory_v3_shadow_diff",
+              {
+                body: {
+                  ...(sinceDays.value !== undefined
+                    ? { sinceDays: sinceDays.value }
+                    : {}),
+                  ...(toleranceSec.value !== undefined
+                    ? { toleranceSec: toleranceSec.value }
+                    : {}),
+                  ...(limit.value !== undefined ? { limit: limit.value } : {}),
+                },
+              },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to diff v3 shadow selections");
+              process.exitCode = 1;
+              return;
+            }
+
+            const payload = result.result!;
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+            log.info(renderShadowDiff(payload));
           },
         );
     },

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "./db-connection.js";
 import { memoryV2ActivationLogs } from "./schema.js";
+import type { ShadowDiffLogRow } from "./v3/shadow-diff.js";
 
 export interface MemoryV2ConceptRowRecord {
   slug: string;
@@ -209,4 +210,85 @@ export function getMemoryV2ActivationLogByMessageIds(
     concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
     config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
   };
+}
+
+function parseConcepts(conceptsJson: string): MemoryV2ConceptRowRecord[] {
+  try {
+    const parsed = JSON.parse(conceptsJson);
+    return Array.isArray(parsed) ? (parsed as MemoryV2ConceptRowRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the activation-log rows the v3 shadow-diff needs: every `v3_shadow` row
+ * (optionally newer than `sinceMs`), plus the `router` rows that could pair
+ * with them. The router read is bounded to the shadow rows' conversations and
+ * their time span (padded by `paddingMs`) so a shadow-diff over a few turns
+ * never scans the entire multi-GB log table. Returns `{ shadow, router }` for
+ * {@link computeShadowDiff} to pair and diff.
+ */
+export function readActivationLogsForShadowDiff(opts: {
+  sinceMs: number | null;
+  paddingMs: number;
+}): { shadow: ShadowDiffLogRow[]; router: ShadowDiffLogRow[] } {
+  const db = getDb();
+
+  const shadow = db
+    .select({
+      conversationId: memoryV2ActivationLogs.conversationId,
+      createdAt: memoryV2ActivationLogs.createdAt,
+      conceptsJson: memoryV2ActivationLogs.conceptsJson,
+    })
+    .from(memoryV2ActivationLogs)
+    .where(
+      opts.sinceMs !== null
+        ? and(
+            eq(memoryV2ActivationLogs.mode, "v3_shadow"),
+            gte(memoryV2ActivationLogs.createdAt, opts.sinceMs),
+          )
+        : eq(memoryV2ActivationLogs.mode, "v3_shadow"),
+    )
+    .orderBy(memoryV2ActivationLogs.createdAt)
+    .all()
+    .map((row) => ({
+      conversationId: row.conversationId,
+      createdAt: row.createdAt,
+      concepts: parseConcepts(row.conceptsJson),
+    }));
+
+  if (shadow.length === 0) return { shadow: [], router: [] };
+
+  const convIds = [...new Set(shadow.map((s) => s.conversationId))];
+  let tMin = Number.POSITIVE_INFINITY;
+  let tMax = Number.NEGATIVE_INFINITY;
+  for (const s of shadow) {
+    if (s.createdAt < tMin) tMin = s.createdAt;
+    if (s.createdAt > tMax) tMax = s.createdAt;
+  }
+
+  const router = db
+    .select({
+      conversationId: memoryV2ActivationLogs.conversationId,
+      createdAt: memoryV2ActivationLogs.createdAt,
+      conceptsJson: memoryV2ActivationLogs.conceptsJson,
+    })
+    .from(memoryV2ActivationLogs)
+    .where(
+      and(
+        eq(memoryV2ActivationLogs.mode, "router"),
+        inArray(memoryV2ActivationLogs.conversationId, convIds),
+        gte(memoryV2ActivationLogs.createdAt, tMin - opts.paddingMs),
+        lte(memoryV2ActivationLogs.createdAt, tMax + opts.paddingMs),
+      ),
+    )
+    .all()
+    .map((row) => ({
+      conversationId: row.conversationId,
+      createdAt: row.createdAt,
+      concepts: parseConcepts(row.conceptsJson),
+    }));
+
+  return { shadow, router };
 }

--- a/assistant/src/memory/v3/__tests__/shadow-diff.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-diff.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
+import { computeShadowDiff, type ShadowDiffLogRow } from "../shadow-diff.js";
+
+const ZERO = {
+  finalActivation: 0,
+  ownActivation: 0,
+  priorActivation: 0,
+  simUser: 0,
+  simAssistant: 0,
+  simNow: 0,
+  simUserRerankBoost: 0,
+  simAssistantRerankBoost: 0,
+  inRerankPool: false,
+  spreadContribution: 0,
+} as const;
+
+/** A v2 router concept row with the given selection status. */
+function v2concept(
+  slug: string,
+  status: MemoryV2ConceptRowRecord["status"],
+): MemoryV2ConceptRowRecord {
+  return { slug, status, source: "tier3:0", ...ZERO };
+}
+
+/** A v3 shadow concept row (always status 'injected') tagged with its lane. */
+function v3concept(slug: string, lane: string): MemoryV2ConceptRowRecord {
+  return { slug, status: "injected", source: "router", lane, ...ZERO };
+}
+
+function shadowRow(
+  conversationId: string,
+  createdAt: number,
+  slugLanes: Array<[string, string]>,
+): ShadowDiffLogRow {
+  return {
+    conversationId,
+    createdAt,
+    concepts: slugLanes.map(([slug, lane]) => v3concept(slug, lane)),
+  };
+}
+
+function routerRow(
+  conversationId: string,
+  createdAt: number,
+  opts: { injected?: string[]; cached?: string[]; rejected?: string[] },
+): ShadowDiffLogRow {
+  return {
+    conversationId,
+    createdAt,
+    concepts: [
+      ...(opts.injected ?? []).map((s) => v2concept(s, "injected")),
+      ...(opts.cached ?? []).map((s) => v2concept(s, "in_context")),
+      ...(opts.rejected ?? []).map((s) => v2concept(s, "not_injected")),
+    ],
+  };
+}
+
+const OPTS = { toleranceMs: 10_000, detailLimit: 50 };
+
+describe("computeShadowDiff", () => {
+  test("pairs nearest router row and diffs fresh-injected vs shadow sets", () => {
+    const shadow = [
+      shadowRow("conv1", 1000, [
+        ["a", "tree"],
+        ["b", "edge"],
+        ["c", "hot"],
+      ]),
+    ];
+    const router = [
+      routerRow("conv1", 1500, {
+        injected: ["a", "b", "x", "y"],
+        cached: ["cached1", "cached2"],
+        rejected: ["rej1"],
+      }),
+    ];
+
+    const result = computeShadowDiff(shadow, router, OPTS);
+
+    expect(result.turnsCompared).toBe(1);
+    expect(result.unpaired).toHaveLength(0);
+
+    const turn = result.turns[0]!;
+    expect(turn.deltaMs).toBe(500);
+    expect(turn.v2Count).toBe(4);
+    expect(turn.v3Count).toBe(3);
+    expect(turn.v2CachedCount).toBe(2);
+    expect(turn.overlap).toEqual(["a", "b"]);
+    expect(turn.v3Only).toEqual(["c"]);
+    expect(turn.v2Only).toEqual(["x", "y"]);
+    // cached / rejected v2 rows are NOT counted as dropped picks.
+    expect(turn.v2Only).not.toContain("cached1");
+    expect(turn.v2Only).not.toContain("rej1");
+    expect(turn.jaccard).toBeCloseTo(2 / 5, 10);
+  });
+
+  test("attributes overlap and v3-only to the v3 provenance lane", () => {
+    const shadow = [
+      shadowRow("conv1", 1000, [
+        ["a", "tree"],
+        ["b", "edge"],
+        ["c", "hot"],
+      ]),
+    ];
+    const router = [routerRow("conv1", 1100, { injected: ["a", "b"] })];
+
+    const { agg } = computeShadowDiff(shadow, router, OPTS);
+
+    expect(agg.overlapByLane).toEqual({ tree: 1, edge: 1 });
+    expect(agg.v3OnlyByLane).toEqual({ hot: 1 });
+  });
+
+  test("defaults a missing lane to 'unknown'", () => {
+    const shadow: ShadowDiffLogRow[] = [
+      {
+        conversationId: "conv1",
+        createdAt: 1000,
+        concepts: [
+          { slug: "a", status: "injected", source: "router", ...ZERO },
+        ],
+      },
+    ];
+    const router = [routerRow("conv1", 1100, { injected: [] })];
+
+    const { agg } = computeShadowDiff(shadow, router, OPTS);
+
+    expect(agg.v3OnlyByLane).toEqual({ unknown: 1 });
+  });
+
+  test("sends a shadow row with no router row within tolerance to unpaired", () => {
+    const shadow = [shadowRow("conv1", 1000, [["a", "tree"]])];
+    const router = [routerRow("conv1", 1000 + 20_000, { injected: ["a"] })];
+
+    const result = computeShadowDiff(shadow, router, OPTS);
+
+    expect(result.turnsCompared).toBe(0);
+    expect(result.unpaired).toEqual([
+      { conversationId: "conv1", shadowAt: 1000, v3Count: 1 },
+    ]);
+  });
+
+  test("greedily pairs each router row to at most one shadow row", () => {
+    const shadow = [
+      shadowRow("conv1", 1000, [["a", "tree"]]),
+      shadowRow("conv1", 5000, [["b", "edge"]]),
+    ];
+    const router = [
+      routerRow("conv1", 1200, { injected: ["a", "z"] }),
+      routerRow("conv1", 5200, { injected: ["b"] }),
+    ];
+
+    const result = computeShadowDiff(shadow, router, OPTS);
+
+    expect(result.turnsCompared).toBe(2);
+    const byShadow = new Map(result.turns.map((t) => [t.shadowAt, t]));
+    expect(byShadow.get(1000)!.routerAt).toBe(1200);
+    expect(byShadow.get(1000)!.v2Only).toEqual(["z"]);
+    expect(byShadow.get(5000)!.routerAt).toBe(5200);
+    expect(byShadow.get(5000)!.overlap).toEqual(["b"]);
+  });
+
+  test("caps per-turn detail newest-first but aggregates over all turns", () => {
+    const shadow = [
+      shadowRow("c1", 1000, [["a", "tree"]]),
+      shadowRow("c2", 2000, [["b", "tree"]]),
+      shadowRow("c3", 3000, [["c", "tree"]]),
+    ];
+    const router = [
+      routerRow("c1", 1000, { injected: ["a"] }),
+      routerRow("c2", 2000, { injected: ["b"] }),
+      routerRow("c3", 3000, { injected: ["c"] }),
+    ];
+
+    const result = computeShadowDiff(shadow, router, {
+      toleranceMs: 10_000,
+      detailLimit: 2,
+    });
+
+    expect(result.turnsCompared).toBe(3);
+    expect(result.turns.map((t) => t.shadowAt)).toEqual([3000, 2000]);
+  });
+
+  test("ranks the most-dropped and most-added slugs across turns", () => {
+    const shadow = [
+      shadowRow("c1", 1000, [["extra", "edge"]]),
+      shadowRow("c2", 2000, [["extra", "edge"]]),
+    ];
+    const router = [
+      routerRow("c1", 1000, { injected: ["dropped", "kept"] }),
+      routerRow("c2", 2000, { injected: ["dropped"] }),
+    ];
+
+    const { agg } = computeShadowDiff(shadow, router, OPTS);
+
+    expect(agg.totalV3Only).toBe(2);
+    expect(agg.totalV2Only).toBe(3);
+    expect(agg.v3OnlyTop[0]).toEqual({ slug: "extra", count: 2 });
+    expect(agg.v2OnlyTop[0]).toEqual({ slug: "dropped", count: 2 });
+    expect(agg.meanV3).toBeCloseTo(1, 10);
+    expect(agg.meanV2).toBeCloseTo(1.5, 10);
+  });
+
+  test("returns zeroed aggregates with no rows", () => {
+    const result = computeShadowDiff([], [], OPTS);
+    expect(result.turnsCompared).toBe(0);
+    expect(result.shadowRows).toBe(0);
+    expect(result.agg.meanJaccard).toBe(0);
+    expect(result.agg.v2OnlyTop).toEqual([]);
+    expect(result.turns).toEqual([]);
+  });
+
+  test("treats two empty selections as jaccard 0, not NaN", () => {
+    const shadow: ShadowDiffLogRow[] = [
+      { conversationId: "c1", createdAt: 1000, concepts: [] },
+    ];
+    const router = [routerRow("c1", 1000, { cached: ["only-cached"] })];
+
+    const result = computeShadowDiff(shadow, router, OPTS);
+
+    expect(result.turnsCompared).toBe(1);
+    expect(result.turns[0]!.jaccard).toBe(0);
+    expect(result.turns[0]!.v2CachedCount).toBe(1);
+  });
+});

--- a/assistant/src/memory/v3/shadow-diff.ts
+++ b/assistant/src/memory/v3/shadow-diff.ts
@@ -1,0 +1,287 @@
+/**
+ * Memory v3 shadow-diff — compare the v3 shadow selection against the live v2
+ * router selection, turn-for-turn, from the `memory_v2_activation_logs` table.
+ *
+ * When v3 runs in shadow mode it logs its per-turn selection as a `v3_shadow`
+ * row while the live v2 router logs its own selection as a `router` row on the
+ * same turn. This module pairs the two and reports where they agree, what v3
+ * surfaced that v2 did not, and what v2 had that v3 dropped — broken down by the
+ * v3 provenance lane so a shadow run is analyzable by where its recall comes
+ * from.
+ *
+ * Pairing is by timestamp, NOT by the `turn` column: the shadow middleware logs
+ * the orchestrator's per-runtime turn counter while v2 logs the cumulative
+ * conversation turn, so the two numbers diverge. The shadow row and its sibling
+ * router row are written within the same turn (a second or two apart), so each
+ * shadow row is matched to the nearest router row in the same conversation
+ * within a tolerance window.
+ *
+ * The v2 comparand is the router's FRESH per-turn pick (`status: "injected"`),
+ * not its full in-context set. v2 accumulates pages across turns (`in_context`
+ * carry-over can reach the hundreds on a long conversation) whereas v3 selects
+ * fresh each turn; comparing fresh-against-fresh keeps the diff meaningful. The
+ * carried-over count is surfaced per turn as context, not folded into the sets.
+ *
+ * Pure and DB-free: the route handler reads the rows and hands them here.
+ */
+
+import type { MemoryV2ConceptRowRecord } from "../memory-v2-activation-log-store.js";
+
+/** An activation-log row reduced to what the diff needs. */
+export interface ShadowDiffLogRow {
+  conversationId: string;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  concepts: MemoryV2ConceptRowRecord[];
+}
+
+/** One paired (v2 router ↔ v3 shadow) turn. */
+export interface ShadowDiffTurn {
+  conversationId: string;
+  /** Epoch ms of the v3 shadow row. */
+  shadowAt: number;
+  /** Epoch ms of the paired v2 router row. */
+  routerAt: number;
+  /** `routerAt - shadowAt`; small (within tolerance) by construction. */
+  deltaMs: number;
+  /** Size of the v2 fresh pick (`status: "injected"`). */
+  v2Count: number;
+  /** Size of the v3 shadow selection. */
+  v3Count: number;
+  /** v2 pages carried over from prior turns (`in_context`); annotation only. */
+  v2CachedCount: number;
+  /** `|overlap| / |v2 ∪ v3|`; 0 when both sets are empty. */
+  jaccard: number;
+  /** Slugs both systems picked, sorted. */
+  overlap: string[];
+  /** Slugs v3 surfaced but v2 did not freshly inject, sorted. */
+  v3Only: string[];
+  /** Slugs v2 freshly injected but v3 missed, sorted. */
+  v2Only: string[];
+  /** Provenance lane for each v3 slug (overlap + v3-only). */
+  laneBySlug: Record<string, string>;
+}
+
+/** A shadow row with no router row inside the tolerance window. */
+export interface UnpairedShadowTurn {
+  conversationId: string;
+  shadowAt: number;
+  v3Count: number;
+}
+
+/** A slug with how many paired turns it appeared in. */
+export interface SlugFrequency {
+  slug: string;
+  count: number;
+}
+
+export interface ShadowDiffResult {
+  /** Pairing tolerance actually used (ms). */
+  toleranceMs: number;
+  /** Total v3 shadow rows in the read window. */
+  shadowRows: number;
+  /** Shadow rows that paired to a router row. */
+  turnsCompared: number;
+  /** Shadow rows that did not pair. */
+  unpaired: UnpairedShadowTurn[];
+  agg: {
+    meanV2: number;
+    meanV3: number;
+    meanOverlap: number;
+    meanJaccard: number;
+    totalOverlap: number;
+    totalV3Only: number;
+    totalV2Only: number;
+    /** v3-only slug count by the lane that surfaced it — v3's extra reach. */
+    v3OnlyByLane: Record<string, number>;
+    /** overlap slug count by the v3 lane that recovered v2's pick. */
+    overlapByLane: Record<string, number>;
+    /** Most frequently dropped v2 pages (recall-regression watchlist). */
+    v2OnlyTop: SlugFrequency[];
+    /** Most frequent v3 extras (associative reach beyond v2). */
+    v3OnlyTop: SlugFrequency[];
+  };
+  /** Per-turn detail, newest first, capped at the requested limit. */
+  turns: ShadowDiffTurn[];
+}
+
+/** Status on a v2 router row that counts as a fresh per-turn selection. */
+const V2_PICKED_STATUS = "injected";
+/** Status on a v2 router row that means carried-over from a prior turn. */
+const V2_CACHED_STATUS = "in_context";
+/** How many slugs to list in the top-frequency aggregates. */
+const TOP_FREQUENCY_LIMIT = 15;
+
+function selectedV2Slugs(concepts: MemoryV2ConceptRowRecord[]): Set<string> {
+  const slugs = new Set<string>();
+  for (const c of concepts) {
+    if (c.status === V2_PICKED_STATUS) slugs.add(c.slug);
+  }
+  return slugs;
+}
+
+function cachedV2Count(concepts: MemoryV2ConceptRowRecord[]): number {
+  let n = 0;
+  for (const c of concepts) {
+    if (c.status === V2_CACHED_STATUS) n += 1;
+  }
+  return n;
+}
+
+function v3LaneBySlug(
+  concepts: MemoryV2ConceptRowRecord[],
+): Map<string, string> {
+  const bySlug = new Map<string, string>();
+  for (const c of concepts) {
+    bySlug.set(c.slug, c.lane ?? "unknown");
+  }
+  return bySlug;
+}
+
+/** Increment a string-keyed tally in place. */
+function bump(tally: Record<string, number>, key: string): void {
+  tally[key] = (tally[key] ?? 0) + 1;
+}
+
+/** Sort a frequency map into the top-N slugs, ties broken by slug name. */
+function topSlugs(freq: Map<string, number>, limit: number): SlugFrequency[] {
+  return [...freq.entries()]
+    .map(([slug, count]) => ({ slug, count }))
+    .sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug))
+    .slice(0, limit);
+}
+
+/**
+ * Pair each shadow row to the nearest unconsumed router row in the same
+ * conversation within `toleranceMs`, then diff the two selections. Pairing is
+ * greedy by absolute time delta; since real turns are minutes apart while a
+ * shadow/router sibling pair lands a second or two apart, the greedy match is a
+ * clean bijection in practice.
+ */
+export function computeShadowDiff(
+  shadow: readonly ShadowDiffLogRow[],
+  router: readonly ShadowDiffLogRow[],
+  opts: { toleranceMs: number; detailLimit: number },
+): ShadowDiffResult {
+  const { toleranceMs, detailLimit } = opts;
+
+  // Index router rows by conversation, time-sorted, with a consumed flag so a
+  // router row pairs to at most one shadow row.
+  const routerByConv = new Map<
+    string,
+    Array<{ row: ShadowDiffLogRow; consumed: boolean }>
+  >();
+  for (const row of router) {
+    const bucket = routerByConv.get(row.conversationId) ?? [];
+    bucket.push({ row, consumed: false });
+    routerByConv.set(row.conversationId, bucket);
+  }
+  for (const bucket of routerByConv.values()) {
+    bucket.sort((a, b) => a.row.createdAt - b.row.createdAt);
+  }
+
+  const sortedShadow = [...shadow].sort((a, b) => a.createdAt - b.createdAt);
+
+  const turns: ShadowDiffTurn[] = [];
+  const unpaired: UnpairedShadowTurn[] = [];
+  const v3OnlyByLane: Record<string, number> = {};
+  const overlapByLane: Record<string, number> = {};
+  const v2OnlyFreq = new Map<string, number>();
+  const v3OnlyFreq = new Map<string, number>();
+
+  for (const sh of sortedShadow) {
+    const bucket = routerByConv.get(sh.conversationId);
+    let best: { row: ShadowDiffLogRow; consumed: boolean } | undefined;
+    let bestDelta = Number.POSITIVE_INFINITY;
+    for (const candidate of bucket ?? []) {
+      if (candidate.consumed) continue;
+      const delta = Math.abs(candidate.row.createdAt - sh.createdAt);
+      if (delta < bestDelta) {
+        bestDelta = delta;
+        best = candidate;
+      }
+    }
+
+    if (!best || bestDelta > toleranceMs) {
+      unpaired.push({
+        conversationId: sh.conversationId,
+        shadowAt: sh.createdAt,
+        v3Count: new Set(sh.concepts.map((c) => c.slug)).size,
+      });
+      continue;
+    }
+    best.consumed = true;
+
+    const v2Set = selectedV2Slugs(best.row.concepts);
+    const laneBySlug = v3LaneBySlug(sh.concepts);
+    const v3Set = new Set(laneBySlug.keys());
+
+    const overlap: string[] = [];
+    const v3Only: string[] = [];
+    for (const slug of v3Set) {
+      if (v2Set.has(slug)) {
+        overlap.push(slug);
+        bump(overlapByLane, laneBySlug.get(slug)!);
+      } else {
+        v3Only.push(slug);
+        bump(v3OnlyByLane, laneBySlug.get(slug)!);
+        v3OnlyFreq.set(slug, (v3OnlyFreq.get(slug) ?? 0) + 1);
+      }
+    }
+    const v2Only: string[] = [];
+    for (const slug of v2Set) {
+      if (!v3Set.has(slug)) {
+        v2Only.push(slug);
+        v2OnlyFreq.set(slug, (v2OnlyFreq.get(slug) ?? 0) + 1);
+      }
+    }
+
+    const unionSize = new Set([...v2Set, ...v3Set]).size;
+    turns.push({
+      conversationId: sh.conversationId,
+      shadowAt: sh.createdAt,
+      routerAt: best.row.createdAt,
+      deltaMs: best.row.createdAt - sh.createdAt,
+      v2Count: v2Set.size,
+      v3Count: v3Set.size,
+      v2CachedCount: cachedV2Count(best.row.concepts),
+      jaccard: unionSize === 0 ? 0 : overlap.length / unionSize,
+      overlap: overlap.sort(),
+      v3Only: v3Only.sort(),
+      v2Only: v2Only.sort(),
+      laneBySlug: Object.fromEntries(laneBySlug),
+    });
+  }
+
+  const n = turns.length;
+  const sum = (pick: (t: ShadowDiffTurn) => number): number =>
+    turns.reduce((acc, t) => acc + pick(t), 0);
+  const mean = (pick: (t: ShadowDiffTurn) => number): number =>
+    n === 0 ? 0 : sum(pick) / n;
+
+  // Newest-first for the detail listing; aggregates are order-independent.
+  const detail = [...turns]
+    .sort((a, b) => b.shadowAt - a.shadowAt)
+    .slice(0, detailLimit);
+
+  return {
+    toleranceMs,
+    shadowRows: shadow.length,
+    turnsCompared: n,
+    unpaired,
+    agg: {
+      meanV2: mean((t) => t.v2Count),
+      meanV3: mean((t) => t.v3Count),
+      meanOverlap: mean((t) => t.overlap.length),
+      meanJaccard: mean((t) => t.jaccard),
+      totalOverlap: sum((t) => t.overlap.length),
+      totalV3Only: sum((t) => t.v3Only.length),
+      totalV2Only: sum((t) => t.v2Only.length),
+      v3OnlyByLane,
+      overlapByLane,
+      v2OnlyTop: topSlugs(v2OnlyFreq, TOP_FREQUENCY_LIMIT),
+      v3OnlyTop: topSlugs(v3OnlyFreq, TOP_FREQUENCY_LIMIT),
+    },
+    turns: detail,
+  };
+}

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -491,6 +491,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v3/validate:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v3/tree:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v3/simulate:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v3/shadow-diff:POST", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { loadConfig } from "../../config/loader.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../../memory/db-connection.js";
+import { readActivationLogsForShadowDiff } from "../../memory/memory-v2-activation-log-store.js";
 import type {
   RetrievalCost,
   RetrievalInput,
@@ -30,6 +31,13 @@ import type { DescentTrace } from "../../memory/v2/harness/trace.js";
 import { loadNowText } from "../../memory/v2/now-text.js";
 import type { LlmCallRecord } from "../../memory/v3/llm-capture.js";
 import { runRetrievalLoop } from "../../memory/v3/loop.js";
+import type {
+  ShadowDiffResult,
+  ShadowDiffTurn,
+  SlugFrequency,
+  UnpairedShadowTurn,
+} from "../../memory/v3/shadow-diff.js";
+import { computeShadowDiff } from "../../memory/v3/shadow-diff.js";
 import { getTreeIndex } from "../../memory/v3/tree-index.js";
 import type { TreeValidationReport } from "../../memory/v3/validate.js";
 import { validateTree } from "../../memory/v3/validate.js";
@@ -49,6 +57,12 @@ export type {
   TreeLevel,
 } from "../../memory/v2/harness/trace.js";
 export type { LlmCallRecord };
+export type {
+  ShadowDiffResult,
+  ShadowDiffTurn,
+  SlugFrequency,
+  UnpairedShadowTurn,
+};
 
 // ── Validate ────────────────────────────────────────────────────────────
 
@@ -276,6 +290,66 @@ async function handleSimulate({
   };
 }
 
+// ── Shadow-diff ─────────────────────────────────────────────────────────
+
+/** Default pairing tolerance: a shadow row + its router sibling land ~1-2s apart. */
+const DEFAULT_SHADOW_DIFF_TOLERANCE_SEC = 10;
+/** Default cap on per-turn detail rows returned (aggregates are unbounded). */
+const DEFAULT_SHADOW_DIFF_LIMIT = 50;
+/** Milliseconds per day, for the `sinceDays` read-window cutoff. */
+const MS_PER_DAY = 86_400_000;
+
+const MemoryV3ShadowDiffParams = z
+  .object({
+    /** Only consider shadow rows newer than this many days. Omit for all rows. */
+    sinceDays: z
+      .number()
+      .positive("memory.v3.shadow-diff sinceDays must be positive")
+      .optional(),
+    /** Max |Δt| (seconds) to pair a shadow row with a router row. */
+    toleranceSec: z
+      .number()
+      .positive("memory.v3.shadow-diff toleranceSec must be positive")
+      .optional(),
+    /** Cap on per-turn detail rows in the response (newest first). */
+    limit: z
+      .number()
+      .int("memory.v3.shadow-diff limit must be an integer")
+      .positive("memory.v3.shadow-diff limit must be positive")
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Compare the v3 shadow selections against the live v2 router selections,
+ * turn-for-turn, from the activation log. Read-only: reads `v3_shadow` rows and
+ * the `router` rows they pair with (bounded to those conversations + time
+ * span), then diffs each pair. Requires v3 shadow mode to have been running
+ * (`memory.v3.enabled` + `.shadow`) so the `v3_shadow` rows exist; the route
+ * itself runs no LLM and writes nothing.
+ */
+async function handleShadowDiff({
+  body = {},
+}: RouteHandlerArgs): Promise<ShadowDiffResult> {
+  const { sinceDays, toleranceSec, limit } =
+    MemoryV3ShadowDiffParams.parse(body);
+
+  const sinceMs =
+    sinceDays !== undefined ? Date.now() - sinceDays * MS_PER_DAY : null;
+  const toleranceMs =
+    (toleranceSec ?? DEFAULT_SHADOW_DIFF_TOLERANCE_SEC) * 1000;
+
+  const { shadow, router } = readActivationLogsForShadowDiff({
+    sinceMs,
+    paddingMs: toleranceMs,
+  });
+
+  return computeShadowDiff(shadow, router, {
+    toleranceMs,
+    detailLimit: limit ?? DEFAULT_SHADOW_DIFF_LIMIT,
+  });
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -312,5 +386,17 @@ export const ROUTES: RouteDefinition[] = [
       "Runs the v3 multi-lane bounded-descent retrieval loop read-only against a single synthetic turn built from the supplied query plus the live (or supplied) NOW context. Returns the selected page slugs, per-lane provenance, the full multi-pass descent trace, and accumulated cost. Optional passCap / lane-allowlist overrides apply on top of live config. Invoked directly (not gated by memory.v3.enabled/shadow) so operators can probe v3 retrieval before flipping the flags; writes nothing (co-activation persistence is forced off), though each pass still spends the loop's filter + gate LLM calls.",
     tags: ["memory"],
     requestBody: MemoryV3SimulateParams,
+  },
+  {
+    operationId: "memory_v3_shadow_diff",
+    method: "POST",
+    endpoint: "memory/v3/shadow-diff",
+    handler: handleShadowDiff,
+    summary:
+      "Diff v3 shadow selections against live v2 router selections (read-only)",
+    description:
+      "Compares the v3 shadow-mode selections against the live v2 router selections turn-for-turn, from the memory activation log. Pairs each v3_shadow row with the nearest v2 router row in the same conversation (by timestamp, within a tolerance — the turn columns use different counters), then reports per-turn and aggregate overlap, what v3 surfaced that v2 did not, and what v2 had that v3 dropped, broken down by v3 provenance lane. The v2 comparand is the router's fresh per-turn pick (status='injected'), not its accumulated in-context set. Requires that v3 shadow mode has been running so v3_shadow rows exist; the route runs no LLM and writes nothing.",
+    tags: ["memory"],
+    requestBody: MemoryV3ShadowDiffParams,
   },
 ];


### PR DESCRIPTION
## Summary
- Adds `assistant memory v3 shadow-diff`: a read-only CLI that compares v3 shadow-mode selections against the live v2 router selections, turn-for-turn, from the `memory_v2_activation_logs` table.
- Pairs each `v3_shadow` row with the nearest v2 `router` row in the same conversation by timestamp (the two modes count turns with different counters), then reports per-turn and aggregate overlap, v3-only additions, and v2-only drops, broken down by v3 provenance lane (hot/sparse/dense/tree/edge).
- The v2 comparand is the router's fresh per-turn pick (`status='injected'`), not its accumulated in-context carry-over, so the sets are fresh-against-fresh. New pure compute module + bounded store reader + route (+ policy) + CLI/renderer + unit tests; OpenAPI regenerated.

## Original prompt
With v3 retrieval running in shadow mode (logging its per-turn selection alongside the live v2 router's), build an analysis tool to compare the two — what v3 adds, what it drops, and which retrieval lane each came from — so v3's recall can be evaluated against v2 as shadow telemetry accrues. Pair shadow and router rows by timestamp rather than turn index, since they use different turn counters.