### PR TITLE
refactor(web): content-automation uses recipe fields instead of cohort-implied behavior

### DIFF
--- a/apps/web/src/domains/onboarding/content-automation.ts
+++ b/apps/web/src/domains/onboarding/content-automation.ts
@@ -15,6 +15,8 @@ export function buildContentAutomationPreChatContext(): PreChatOnboardingContext
     googleConnected: false,
     cohort: "content-automation",
     initialMessage: CONTENT_AUTOMATION_INITIAL_MESSAGE,
+    bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
+    skills: ["geo-writing", "document-editor"],
   };
 }
 


### PR DESCRIPTION
## Summary
- Update buildContentAutomationPreChatContext to include bootstrapTemplate, initialMessage, and skills
- bootstrapTemplate and skills are now explicit in the context instead of being derived by the daemon from the cohort field
- cohort field kept for telemetry attribution

Part of plan: onboarding-recipe-arch.md (PR 6 of 7)