### PR TITLE
fix(messages): preserve hasMore when pagination scan cap truncates (address Codex review on #31591)

### DIFF
--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { messages } from "../memory/schema.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
 initializeDb();
@@ -175,6 +176,77 @@ describe("handleListMessages metadata.hidden filtering", () => {
       "old visible 3",
     ]);
     expect(older.hasMore).toBe(true);
+  });
+
+  test("pagination keeps hasMore + a cursor when a >cap hidden block truncates the scan", () => {
+    // PAGINATION_SCAN_CAP is 10_000. Seed a contiguous block of hidden rows
+    // longer than the cap on top of a couple of older visible rows. The first
+    // page scans the cap's worth of (all hidden) rows without filling the page;
+    // the buggy implementation returned `hasMore: false` with no cursor here,
+    // stalling the client before it ever reached the visible rows below.
+    const conv = createConversation();
+    const db = getDb();
+    const HIDDEN_COUNT = 10_050; // > PAGINATION_SCAN_CAP
+    const VISIBLE_COUNT = 2;
+    let createdAt = 0;
+    // Older visible rows first (lowest createdAt), then the hidden block.
+    db.transaction((tx) => {
+      for (let i = 0; i < VISIBLE_COUNT; i++) {
+        createdAt += 1;
+        tx.insert(messages)
+          .values({
+            id: `visible-${i}`,
+            conversationId: conv.id,
+            role: "user",
+            content: JSON.stringify([{ type: "text", text: `visible ${i}` }]),
+            createdAt,
+          })
+          .run();
+      }
+      for (let i = 0; i < HIDDEN_COUNT; i++) {
+        createdAt += 1;
+        tx.insert(messages)
+          .values({
+            id: `hidden-${i}`,
+            conversationId: conv.id,
+            role: "assistant",
+            content: JSON.stringify([{ type: "text", text: `hidden ${i}` }]),
+            createdAt,
+            metadata: JSON.stringify({ hidden: true }),
+          })
+          .run();
+      }
+    });
+
+    const latest = handleListMessages({
+      queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
+    }) as {
+      messages: MessagePayload[];
+      hasMore: boolean;
+      oldestTimestamp: number | null;
+    };
+
+    // Page is empty (the cap was consumed entirely by hidden rows) but the
+    // client must still be told to keep paginating and given a cursor.
+    expect(latest.messages).toHaveLength(0);
+    expect(latest.hasMore).toBe(true);
+    expect(latest.oldestTimestamp).not.toBeNull();
+
+    // Resuming from the surfaced cursor drains the remaining hidden rows and
+    // surfaces the visible ones below the cap.
+    const older = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        beforeTimestamp: String(latest.oldestTimestamp),
+        limit: "2",
+      },
+    }) as { messages: MessagePayload[]; hasMore: boolean };
+
+    expect(older.messages.map((m) => m.content)).toEqual([
+      "visible 0",
+      "visible 1",
+    ]);
+    expect(older.hasMore).toBe(false);
   });
 
   test("pagination drains DB when every row in a page is hidden", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1302,6 +1302,16 @@ export function hasMessages(conversationId: string): boolean {
 interface PaginatedMessagesResult {
   messages: MessageRow[];
   hasMore: boolean;
+  /**
+   * Position of the last row scanned when the loop stops on
+   * `PAGINATION_SCAN_CAP` rather than DB exhaustion. Callers derive their
+   * client cursor from the visible page's oldest row, but a cap-truncated
+   * page can be empty (a contiguous block of filtered-out rows longer than
+   * the cap), leaving nothing to resume from. Surfacing the last scanned
+   * `(createdAt, id)` lets the caller hand the client a cursor so it can
+   * request the next window and keep draining instead of stalling.
+   */
+  nextCursor?: { createdAt: number; id: string };
 }
 
 const PAGINATION_CHUNK_MIN = 50;
@@ -1347,8 +1357,18 @@ export function getMessagesPaginated(
   // row — otherwise a pathological filter against a huge conversation would
   // tie up a connection for thousands of roundtrips.
   let rowsScanned = 0;
+  // Distinguish "stopped because we hit the scan cap" from "stopped because the
+  // DB ran out of rows". On a cap-truncated stop there may be more visible rows
+  // past the scanned window, so `hasMore` must stay true and we record the last
+  // scanned position as a resume cursor (the visible page may be empty).
+  let scanCapTruncated = false;
+  let lastScanned: { createdAt: number; id: string } | undefined;
 
-  while (visible.length < limit + 1 && rowsScanned < PAGINATION_SCAN_CAP) {
+  while (visible.length < limit + 1) {
+    if (rowsScanned >= PAGINATION_SCAN_CAP) {
+      scanCapTruncated = true;
+      break;
+    }
     const cursorPredicate =
       cursorCreatedAt === undefined
         ? undefined
@@ -1381,15 +1401,25 @@ export function getMessagesPaginated(
 
     if (chunk.length < chunkSize) break;
     const lastRow = chunk[chunk.length - 1];
+    lastScanned = { createdAt: lastRow.createdAt, id: lastRow.id };
     cursorCreatedAt = lastRow.createdAt;
     cursorMessageId = lastRow.id;
   }
 
-  const hasMore = visible.length > limit;
-  if (hasMore) visible.splice(limit);
+  const filledPage = visible.length > limit;
+  // A cap-truncated stop means the DB may still hold older visible rows past
+  // the scanned window, so report `hasMore: true` to keep the client draining
+  // — returning `false` here is the stall this loop exists to prevent.
+  const hasMore = filledPage || scanCapTruncated;
+  if (filledPage) visible.splice(limit);
   visible.reverse();
 
-  return { messages: visible, hasMore };
+  // Only hand back a resume cursor when the cap (not DB exhaustion) cut the
+  // search short; callers fall back to it when the visible page came back
+  // empty and has no oldest row to anchor the next request.
+  const nextCursor = scanCapTruncated ? lastScanned : undefined;
+
+  return { messages: visible, hasMore, nextCursor };
 }
 
 export function getLastUserTimestampBefore(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -510,6 +510,10 @@ export function handleListMessages({
 
   let rawMessages: MessageRow[];
   let hasMore = false;
+  // Resume cursor surfaced when the paginated scan stops on its row cap with a
+  // (possibly empty) page — lets us still emit an oldest cursor so the client
+  // can request the next window instead of stalling.
+  let scanResumeCursor: { createdAt: number; id: string } | undefined;
 
   // Drop messages flagged as hidden in metadata (e.g. internal scaffolding
   // like retrospective instructions). The LLM-side history loader
@@ -533,6 +537,7 @@ export function handleListMessages({
     );
     rawMessages = result.messages;
     hasMore = result.hasMore;
+    scanResumeCursor = result.nextCursor;
   } else {
     rawMessages = getMessages(resolvedConversationId).filter(visibleFilter);
   }
@@ -834,10 +839,16 @@ export function handleListMessages({
   });
 
   if (isPaginated) {
+    // Prefer the page's oldest visible row (the documented cursor semantic).
+    // When a scan-cap-truncated page comes back empty there's no visible row
+    // to anchor on, so fall back to the resume cursor so the client still gets
+    // a `(timestamp, id)` to continue paginating from instead of stalling.
     const oldestTimestamp =
-      rawMessages.length > 0 ? rawMessages[0].createdAt : undefined;
+      rawMessages.length > 0
+        ? rawMessages[0].createdAt
+        : scanResumeCursor?.createdAt;
     const oldestMessageId =
-      rawMessages.length > 0 ? rawMessages[0].id : undefined;
+      rawMessages.length > 0 ? rawMessages[0].id : scanResumeCursor?.id;
     // `page=latest` always emits both metadata fields so the web client has
     // a stable contract; emit `null` when the conversation is empty.
     // The existing `beforeTimestamp` branch keeps its conditional shape to


### PR DESCRIPTION
## Summary

Addresses Codex review on #31591.

Codex flagged that in `getMessagesPaginated` (assistant/src/memory/conversation-crud.ts), the pagination loop exits when `rowsScanned >= PAGINATION_SCAN_CAP` and then computes `hasMore = visible.length > limit`. When the newest portion of a conversation has a contiguous block of filtered-out rows (e.g. hidden messages) larger than the scan cap, the loop exits early **without** filling the page, so `hasMore` could come back `false` (with an empty/partial page) even though older visible messages still exist past the cap — a pagination stall, the same bug class #31591 set out to fix.

## Fix

- Track whether the loop stopped because of the scan cap vs. DB exhaustion (`scanCapTruncated`).
- On a cap-truncated stop, report `hasMore: true` and surface the last-scanned `(createdAt, id)` as `nextCursor`.
- `handleListMessages` falls back to `nextCursor` for `oldestTimestamp`/`oldestMessageId` when the visible page is empty, so the client always gets a resume cursor and keeps draining. Genuine DB exhaustion still returns `hasMore: false`.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] New regression test: a >cap hidden block returns an empty first page with `hasMore: true` + a non-null cursor, and resuming from that cursor surfaces the visible rows below the cap
- [x] Existing list-messages pagination tests pass (20 tests across 2 files)