### PR TITLE
fix(macos): serialize all PreChatOnboardingContext fields in MessageClient

### DIFF
--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -120,18 +120,9 @@ public struct MessageClient: MessageClientProtocol {
         if let clientTimezone, !clientTimezone.isEmpty {
             body["clientTimezone"] = clientTimezone
         }
-        if let onboarding {
-            var onboardingDict: [String: Any] = [
-                "tools": onboarding.tools,
-                "tasks": onboarding.tasks,
-                "tone": onboarding.tone
-            ]
-            if let userName = onboarding.userName {
-                onboardingDict["userName"] = userName
-            }
-            if let assistantName = onboarding.assistantName {
-                onboardingDict["assistantName"] = assistantName
-            }
+        if let onboarding,
+           let encodedData = try? JSONEncoder().encode(onboarding),
+           let onboardingDict = try? JSONSerialization.jsonObject(with: encodedData) as? [String: Any] {
             body["onboarding"] = onboardingDict
         }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for onboarding-recipe-arch.md.

**Gap:** Swift MessageClient drops new recipe fields during serialization
**What was expected:** All PreChatOnboardingContext fields reach the daemon
**What was found:** Manual dict construction only included tools, tasks, tone, userName, assistantName

**Fix:** Replaced manual dict construction with JSONEncoder to serialize the full Codable struct. This eliminates the class of bug permanently — any new fields added to PreChatOnboardingContext will be automatically serialized without requiring manual dict updates.