### PR TITLE
feat(apps-web): hide "Go to Convo" for deleted conversations

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -22,6 +22,7 @@ function resolveCategoryStyle(category?: FeedItemCategory) {
 
 export interface HomeDetailPanelProps {
   item: FeedItem | null;
+  validConversationIds: Set<string>;
   onClose: () => void;
   onGoToThread: (conversationId: string) => void;
   onUpdateStatus: (itemId: string, status: FeedItemStatus) => void;
@@ -30,6 +31,7 @@ export interface HomeDetailPanelProps {
 
 export function HomeDetailPanel({
   item,
+  validConversationIds,
   onClose,
   onGoToThread,
   onUpdateStatus,
@@ -72,8 +74,8 @@ export function HomeDetailPanel({
           {item.title ?? item.summary}
         </Typography>
 
-        {/* Go to Convo button — only when conversationId exists */}
-        {item.conversationId ? (
+        {/* Go to Convo button — only when conversationId exists and is valid */}
+        {item.conversationId && validConversationIds.has(item.conversationId) ? (
           <Button
             variant="outlined"
             size="compact"

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -42,6 +42,7 @@ function HomePageSkeleton() {
 
 export interface HomePageProps {
   assistantId: string;
+  validConversationIds: Set<string>;
   onStartNewChat: () => void;
   onOpenConversation: (conversationId: string) => void;
   onSuggestionSelected: (prompt: string) => void;
@@ -49,6 +50,7 @@ export interface HomePageProps {
 
 export function HomePage({
   assistantId,
+  validConversationIds,
   onStartNewChat,
   onOpenConversation,
   onSuggestionSelected,
@@ -163,6 +165,7 @@ export function HomePage({
       <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
         <HomeDetailPanel
           item={selectedItem}
+          validConversationIds={validConversationIds}
           onClose={handleCloseDetail}
           onGoToThread={handleGoToThread}
           onUpdateStatus={handleUpdateStatus}
@@ -187,6 +190,7 @@ export function HomePage({
         right={
           <HomeDetailPanel
             item={selectedItem}
+            validConversationIds={validConversationIds}
             onClose={handleCloseDetail}
             onGoToThread={handleGoToThread}
             onUpdateStatus={handleUpdateStatus}

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from "react";
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationListQuery } from "@/domains/conversations/conversation-queries.js";
 import { useConversationStore } from "@/domains/conversations/conversation-store.js";
 import { HomePage } from "@/domains/home/home-page.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
@@ -10,9 +12,15 @@ import { routes } from "@/utils/routes.js";
 export function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useActiveAssistantContext();
+  const { conversations } = useConversationListQuery(assistantId);
+  const validConversationIds = useMemo(
+    () => new Set(conversations.map((c) => c.conversationId)),
+    [conversations],
+  );
   return (
     <HomePage
       assistantId={assistantId}
+      validConversationIds={validConversationIds}
       onStartNewChat={() => navigate(routes.assistant)}
       onOpenConversation={(conversationId) =>
         navigate(routes.conversation(conversationId))


### PR DESCRIPTION
## Summary
- Build a Set of valid conversation IDs from the TanStack Query cache at the route level
- Thread it through HomePage to HomeDetailPanel
- "Go to Convo" button only renders when the conversation exists in the cached list
- No cross-domain imports — composition happens in routes.tsx per CONVENTIONS.md

Part of plan: feed-dead-link-cleanup.md (PR 3 of 3)