### PR TITLE
fix(chat): include bootstrapTemplate, initialMessage, skills in onboarding serialization

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -520,6 +520,12 @@ export async function postChatMessage(
       onboardingDict.priorAssistants = normalizedOnboarding.priorAssistants;
     if (normalizedOnboarding.cohort !== undefined)
       onboardingDict.cohort = normalizedOnboarding.cohort;
+    if (normalizedOnboarding.bootstrapTemplate !== undefined)
+      onboardingDict.bootstrapTemplate = normalizedOnboarding.bootstrapTemplate;
+    if (normalizedOnboarding.initialMessage !== undefined)
+      onboardingDict.initialMessage = normalizedOnboarding.initialMessage;
+    if (normalizedOnboarding.skills !== undefined)
+      onboardingDict.skills = normalizedOnboarding.skills;
     body.onboarding = onboardingDict;
   }
   if (normalizedOnboarding) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for onboarding-recipe-arch.md.

**Gap:** Web client drops bootstrapTemplate, initialMessage, and skills during message serialization
**What was expected:** New recipe fields reach the daemon via the onboarding payload
**What was found:** onboardingDict construction omitted the three new fields