### PR TITLE
feat(home-feed): add stripConversationIds to feed-writer

### DIFF
--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -44,9 +44,11 @@ const {
   HOME_FEED_FILENAME,
   HOME_FEED_VERSION,
   appendFeedItem,
+  clearAllConversationIds,
   getHomeFeedPath,
   patchFeedItemStatus,
   readHomeFeed,
+  stripConversationIds,
 } = await import("../feed-writer.js");
 
 type FeedItemStatus = "new" | "seen" | "acted_on";
@@ -60,6 +62,7 @@ interface TestFeedItem {
   timestamp: string;
   status: FeedItemStatus;
   expiresAt?: string;
+  conversationId?: string;
   createdAt: string;
 }
 
@@ -419,6 +422,163 @@ describe("feed-writer", () => {
       for (const item of items) {
         expect(ids.has(item.id)).toBe(true);
       }
+    });
+  });
+
+  describe("stripConversationIds", () => {
+    test("removes conversationId from matching items and leaves others untouched", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "item-a",
+          title: "Linked",
+          conversationId: "conv-123",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "item-b",
+          title: "Other conv",
+          conversationId: "conv-456",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "item-c",
+          title: "No conv",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      await stripConversationIds("conv-123");
+
+      const decoded = readFileJson();
+      const itemA = decoded.items.find((i) => i.id === "item-a")!;
+      const itemB = decoded.items.find((i) => i.id === "item-b")!;
+      const itemC = decoded.items.find((i) => i.id === "item-c")!;
+
+      expect(itemA.conversationId).toBeUndefined();
+      expect(itemB.conversationId).toBe("conv-456");
+      expect(itemC.conversationId).toBeUndefined();
+    });
+
+    test("returns the count of items modified", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "m1",
+          conversationId: "conv-abc",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "m2",
+          conversationId: "conv-abc",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "m3",
+          conversationId: "conv-other",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      const count = await stripConversationIds("conv-abc");
+      expect(count).toBe(2);
+    });
+
+    test("returns 0 when no items match", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "no-match",
+          conversationId: "conv-xyz",
+        }),
+      );
+
+      const count = await stripConversationIds("conv-nonexistent");
+      expect(count).toBe(0);
+    });
+
+    test("coalesces with pending appends correctly", async () => {
+      // Fire an append and a strip concurrently — both should land in
+      // the same coalesced write cycle.
+      const appendPromise = appendFeedItem(
+        makeItem({
+          id: "coalesce-item",
+          conversationId: "conv-coalesce",
+        }),
+      );
+      const stripPromise = stripConversationIds("conv-coalesce");
+
+      await Promise.all([appendPromise, stripPromise]);
+
+      const decoded = readFileJson();
+      const item = decoded.items.find((i) => i.id === "coalesce-item")!;
+      // The append lands first, then the strip runs — conversationId
+      // should be gone.
+      expect(item).toBeDefined();
+      expect(item.conversationId).toBeUndefined();
+    });
+
+    test("items retain all other fields after strip", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "retain-fields",
+          title: "Keep me",
+          summary: "Important summary",
+          conversationId: "conv-strip",
+          priority: 75,
+          status: "seen",
+        }),
+      );
+
+      await stripConversationIds("conv-strip");
+
+      const decoded = readFileJson();
+      const item = decoded.items.find((i) => i.id === "retain-fields")!;
+      expect(item.conversationId).toBeUndefined();
+      expect(item.id).toBe("retain-fields");
+      expect(item.title).toBe("Keep me");
+      expect(item.summary).toBe("Important summary");
+      expect(item.priority).toBe(75);
+      expect(item.status).toBe("seen");
+      expect(item.type).toBe("notification");
+    });
+  });
+
+  describe("clearAllConversationIds", () => {
+    test("strips conversationId from all items that have one", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "all-1",
+          conversationId: "conv-aaa",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "all-2",
+          conversationId: "conv-bbb",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "all-3",
+          title: "No conv link",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      const count = await clearAllConversationIds();
+      expect(count).toBe(2);
+
+      const decoded = readFileJson();
+      for (const item of decoded.items) {
+        expect(item.conversationId).toBeUndefined();
+      }
+      // All three items still exist.
+      expect(decoded.items).toHaveLength(3);
     });
   });
 

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -155,6 +155,46 @@ export async function patchFeedItemStatus(
   return resultPromise;
 }
 
+/**
+ * Remove the `conversationId` field from all feed items that reference
+ * the given conversation. Returns the number of items modified.
+ *
+ * This is the daemon-side cleanup path invoked when a conversation is
+ * deleted — it prevents "Go to Thread" buttons from linking to a
+ * conversation that no longer exists. Goes through the same coalescing
+ * queue as appends and patches so there are no file-I/O races.
+ */
+export async function stripConversationIds(
+  conversationId: string,
+): Promise<number> {
+  let resolveResult!: (count: number) => void;
+  const resultPromise = new Promise<number>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingStrips.push({ conversationId, resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
+/**
+ * Remove the `conversationId` field from ALL feed items that have one.
+ * Returns the number of items modified.
+ *
+ * Used by the clear-all-conversations flow to bulk-invalidate every
+ * "Go to Thread" link at once. Uses the same coalescing queue with a
+ * `"*"` sentinel that the strip loop in `runWrite` treats as "match
+ * all items with a conversationId".
+ */
+export async function clearAllConversationIds(): Promise<number> {
+  let resolveResult!: (count: number) => void;
+  const resultPromise = new Promise<number>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingStrips.push({ conversationId: "*", resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
 // ─── Internal: coalescing queue ────────────────────────────────────────
 
 /**
@@ -167,6 +207,10 @@ const pendingPatches: Array<{
   id: string;
   status: FeedItemStatus;
   resolve: (value: FeedItem | null) => void;
+}> = [];
+const pendingStrips: Array<{
+  conversationId: string;
+  resolve: (count: number) => void;
 }> = [];
 
 let writeInFlight: Promise<void> | null = null;
@@ -206,6 +250,7 @@ function scheduleWrite(): Promise<void> {
 async function runWrite(): Promise<void> {
   const appendsToApply = pendingAppends.splice(0, pendingAppends.length);
   const patchesToApply = pendingPatches.splice(0, pendingPatches.length);
+  const stripsToApply = pendingStrips.splice(0, pendingStrips.length);
 
   const current = readHomeFeed();
   let items = current.items.slice();
@@ -233,6 +278,24 @@ async function runWrite(): Promise<void> {
     patchResults.push({ resolve: patch.resolve, value: updated });
   }
 
+  // Strip conversationId from matching items.
+  const stripResults: Array<{
+    resolve: (count: number) => void;
+    count: number;
+  }> = [];
+  for (const strip of stripsToApply) {
+    let count = 0;
+    for (let i = 0; i < items.length; i++) {
+      const matchAll = strip.conversationId === "*";
+      const matchOne = items[i]!.conversationId === strip.conversationId;
+      if (matchAll ? items[i]!.conversationId != null : matchOne) {
+        items[i] = { ...items[i]!, conversationId: undefined };
+        count++;
+      }
+    }
+    stripResults.push({ resolve: strip.resolve, count });
+  }
+
   items.sort(compareFeedItems);
 
   const updatedAt = new Date().toISOString();
@@ -258,16 +321,20 @@ async function runWrite(): Promise<void> {
     publishHomeFeedUpdated(updatedAt, newItemCount);
   }
 
-  // Resolve pending patch promises AFTER we've emitted the SSE event
-  // so callers awaiting `patchFeedItemStatus` observe a fully
-  // consistent world: the on-disk file, the SSE event, and the
-  // returned `FeedItem` all reflect the same write.
+  // Resolve pending patch and strip promises AFTER we've emitted the
+  // SSE event so callers awaiting `patchFeedItemStatus` or
+  // `stripConversationIds` observe a fully consistent world: the
+  // on-disk file, the SSE event, and the returned value all reflect
+  // the same write.
   //
-  // If the write failed, resolve all patch promises with `null` — the
-  // state was not persisted, and callers (e.g. HTTP route handlers)
-  // must not report success when the underlying write failed.
+  // If the write failed, resolve patch promises with `null` and strip
+  // promises with `0` — the state was not persisted, and callers must
+  // not report success when the underlying write failed.
   for (const { resolve, value } of patchResults) {
     resolve(wrote ? value : null);
+  }
+  for (const { resolve, count } of stripResults) {
+    resolve(wrote ? count : 0);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `stripConversationIds(conversationId)` to remove conversation references from feed items when a conversation is deleted
- Add `clearAllConversationIds()` for the clear-all-conversations flow
- Both functions use the existing coalescing write queue for thread safety
- Includes comprehensive tests

Part of plan: feed-dead-link-cleanup.md (PR 1 of 3)