### PR TITLE
Onboarding Recipe Architecture — daemon as generic executor

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -520,6 +520,12 @@ export async function postChatMessage(
       onboardingDict.priorAssistants = normalizedOnboarding.priorAssistants;
     if (normalizedOnboarding.cohort !== undefined)
       onboardingDict.cohort = normalizedOnboarding.cohort;
+    if (normalizedOnboarding.bootstrapTemplate !== undefined)
+      onboardingDict.bootstrapTemplate = normalizedOnboarding.bootstrapTemplate;
+    if (normalizedOnboarding.initialMessage !== undefined)
+      onboardingDict.initialMessage = normalizedOnboarding.initialMessage;
+    if (normalizedOnboarding.skills !== undefined)
+      onboardingDict.skills = normalizedOnboarding.skills;
     body.onboarding = onboardingDict;
   }
   if (normalizedOnboarding) {

--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -522,7 +522,11 @@ export async function postChatMessage(
       onboardingDict.cohort = normalizedOnboarding.cohort;
     if (normalizedOnboarding.bootstrapTemplate !== undefined)
       onboardingDict.bootstrapTemplate = normalizedOnboarding.bootstrapTemplate;
-    if (normalizedOnboarding.initialMessage !== undefined)
+    if (
+      normalizedOnboarding.initialMessage !== undefined &&
+      normalizedOnboarding.initialMessage.trim().toLowerCase().replace(/[.!?]+$/, "") !==
+        "wake up, my friend"
+    )
       onboardingDict.initialMessage = normalizedOnboarding.initialMessage;
     if (normalizedOnboarding.skills !== undefined)
       onboardingDict.skills = normalizedOnboarding.skills;

--- a/apps/web/src/domains/onboarding/content-automation.test.ts
+++ b/apps/web/src/domains/onboarding/content-automation.test.ts
@@ -74,6 +74,8 @@ describe("content automation onboarding handoff", () => {
       googleConnected: false,
       cohort: "content-automation",
       initialMessage: CONTENT_AUTOMATION_INITIAL_MESSAGE,
+      bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
+      skills: ["geo-writing", "document-editor"],
     });
   });
 

--- a/apps/web/src/domains/onboarding/content-automation.ts
+++ b/apps/web/src/domains/onboarding/content-automation.ts
@@ -15,6 +15,8 @@ export function buildContentAutomationPreChatContext(): PreChatOnboardingContext
     googleConnected: false,
     cohort: "content-automation",
     initialMessage: CONTENT_AUTOMATION_INITIAL_MESSAGE,
+    bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
+    skills: ["geo-writing", "document-editor"],
   };
 }
 

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -50,6 +50,10 @@ export interface PreChatOnboardingContext {
   cohort?: string;
   /** Auto-send this message on first load instead of waiting for user input. */
   initialMessage?: string;
+  /** Bootstrap template filename for the daemon to use. */
+  bootstrapTemplate?: string;
+  /** Skills to eagerly load. */
+  skills?: string[];
 }
 
 /**
@@ -226,6 +230,13 @@ function isPreChatOnboardingContext(
   }
   if (candidate.initialMessage !== undefined && typeof candidate.initialMessage !== "string") {
     return false;
+  }
+  if (candidate.bootstrapTemplate !== undefined && typeof candidate.bootstrapTemplate !== "string") {
+    return false;
+  }
+  if (candidate.skills !== undefined) {
+    if (!Array.isArray(candidate.skills)) return false;
+    if (!candidate.skills.every((s) => typeof s === "string")) return false;
   }
   return true;
 }

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -58,7 +58,7 @@ mock.module("../../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
-const { buildSystemPrompt, maybeReseedBootstrapForCohort } =
+const { buildSystemPrompt, maybeReseedBootstrap } =
   await import("../system-prompt.js");
 
 describe("buildSystemPrompt — tool routing guidance", () => {
@@ -73,12 +73,12 @@ describe("buildSystemPrompt — tool routing guidance", () => {
   });
 });
 
-describe("maybeReseedBootstrapForCohort — content-automation template", () => {
+describe("maybeReseedBootstrap — content-automation template", () => {
   const templatesDir = join(import.meta.dirname!, "..", "templates");
 
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
-    // Seed the workspace with the generic BOOTSTRAP.md so the cohort
+    // Seed the workspace with the generic BOOTSTRAP.md so the bootstrap
     // reseed detects it as an unmodified template and overwrites it.
     copyFileSync(
       join(templatesDir, "BOOTSTRAP.md"),
@@ -87,7 +87,7 @@ describe("maybeReseedBootstrapForCohort — content-automation template", () => 
   });
 
   function reseedAndRead(): string {
-    maybeReseedBootstrapForCohort("content-automation");
+    maybeReseedBootstrap("BOOTSTRAP-CONTENT-AUTOMATION.md");
     return readFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "utf-8");
   }
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -21,24 +21,11 @@ import {
 } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { cleanupBootstrapFiles } from "./bootstrap-cleanup.js";
-import {
-  resolveGuardianPersona,
-  resolveUserSlug,
-} from "./persona-resolver.js";
+import { resolveGuardianPersona, resolveUserSlug } from "./persona-resolver.js";
 import { renderWorkspaceSections } from "./sections.js";
 import { isTemplateContent } from "./template-detection.js";
 
 export { isTemplateContent };
-
-/**
- * Maps onboarding cohort identifiers to their cohort-specific bootstrap
- * template filenames.  When a cohort key is present in OnboardingContext,
- * `maybeReseedBootstrapForCohort` swaps the generic BOOTSTRAP.md with the
- * cohort-specific variant — but only if the workspace file is still pristine.
- */
-const COHORT_BOOTSTRAP_TEMPLATES: Record<string, string> = {
-  "content-automation": "BOOTSTRAP-CONTENT-AUTOMATION.md",
-};
 
 const log = getLogger("system-prompt");
 
@@ -215,23 +202,34 @@ export function ensurePromptFiles(): void {
 
 /**
  * One-shot swap: if the workspace BOOTSTRAP.md is still the unmodified generic
- * template AND a cohort-specific template exists, overwrite the workspace file
- * with the cohort variant.  No-op when BOOTSTRAP.md has been deleted, modified,
- * or the cohort has no mapped template.
+ * template AND a matching template file exists in the bundled templates dir,
+ * overwrite the workspace file with the specified variant.  No-op when
+ * BOOTSTRAP.md has been deleted, modified, or the template file is missing.
  */
-export function maybeReseedBootstrapForCohort(cohort: string): void {
-  const templateFileName = COHORT_BOOTSTRAP_TEMPLATES[cohort];
-  if (!templateFileName) return;
+export function maybeReseedBootstrap(templateFileName: string): void {
+  // Path traversal guard: reject filenames containing directory separators or
+  // parent-directory references, and require a `.md` extension.
+  if (
+    templateFileName.includes("/") ||
+    templateFileName.includes("..") ||
+    !templateFileName.endsWith(".md")
+  ) {
+    log.warn(
+      { templateFileName },
+      "Rejected bootstrap template filename: invalid characters or extension",
+    );
+    return;
+  }
 
   const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
   if (!existsSync(bootstrapPath)) return;
 
   const currentContent = readPromptFile(bootstrapPath);
-  // Compare against the GENERIC "BOOTSTRAP.md" template, not the cohort-
-  // specific one.  After the swap, the workspace content no longer matches
-  // the generic template, so this guard returns false on subsequent calls —
-  // making the swap idempotent.  Do NOT change the comparison target to the
-  // cohort template filename; that would re-swap on every prompt build.
+  // Compare against the GENERIC "BOOTSTRAP.md" template, not the specified
+  // one.  After the swap, the workspace content no longer matches the generic
+  // template, so this guard returns false on subsequent calls — making the
+  // swap idempotent.  Do NOT change the comparison target to the provided
+  // template filename; that would re-swap on every prompt build.
   if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return;
 
   const templatesDir = resolveBundledDir(
@@ -239,26 +237,26 @@ export function maybeReseedBootstrapForCohort(cohort: string): void {
     "templates",
     "templates",
   );
-  const cohortTemplatePath = join(templatesDir, templateFileName);
-  if (!existsSync(cohortTemplatePath)) {
+  const templatePath = join(templatesDir, templateFileName);
+  if (!existsSync(templatePath)) {
     log.warn(
-      { cohort, templateFileName },
-      "Cohort bootstrap template not found, keeping generic BOOTSTRAP.md",
+      { templateFileName },
+      "Bootstrap template not found, keeping generic BOOTSTRAP.md",
     );
     return;
   }
 
   try {
-    const cohortContent = readFileSync(cohortTemplatePath, "utf-8");
-    writeFileSync(bootstrapPath, cohortContent, "utf-8");
+    const templateContent = readFileSync(templatePath, "utf-8");
+    writeFileSync(bootstrapPath, templateContent, "utf-8");
     log.info(
-      { cohort, templateFileName },
-      "Replaced generic BOOTSTRAP.md with cohort-specific template",
+      { templateFileName },
+      "Replaced generic BOOTSTRAP.md with specified template",
     );
   } catch (err) {
     log.warn(
-      { err, cohort, templateFileName },
-      "Failed to reseed BOOTSTRAP.md for cohort",
+      { err, templateFileName },
+      "Failed to reseed BOOTSTRAP.md with template",
     );
   }
 }
@@ -280,11 +278,11 @@ export interface BuildSystemPromptOptions {
  * file-backed bodies, and runtime-computed transforms.
  */
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
-  // One-shot cohort swap: if the user has a cohort and BOOTSTRAP.md is still
-  // the generic template, replace it with the cohort-specific variant before
-  // the prompt reads the file.
-  if (options?.onboardingContext?.cohort) {
-    maybeReseedBootstrapForCohort(options.onboardingContext.cohort);
+  // One-shot bootstrap swap: if the onboarding context specifies a bootstrap
+  // template and BOOTSTRAP.md is still the generic template, replace it with
+  // the specified variant before the prompt reads the file.
+  if (options?.onboardingContext?.bootstrapTemplate) {
+    maybeReseedBootstrap(options.onboardingContext.bootstrapTemplate);
   }
 
   // Slugs used by the persona sections (`10-user-persona`,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -974,13 +974,15 @@ export async function handleSendMessage(
       cohort?: string;
       websiteUrl?: string;
       contentSourceUrl?: string;
+      bootstrapTemplate?: string;
+      initialMessage?: string;
+      skills?: string[];
     };
   };
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   const principalType = headers?.["x-vellum-principal-type"];
-  const originClientId =
-    headers?.["x-vellum-client-id"]?.trim() || undefined;
+  const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
 
   const { conversationKey, content, attachmentIds } = body;
   const inboundConversationId =
@@ -2032,8 +2034,8 @@ async function generateLlmSuggestion(
     "",
     "CRITICAL — write from the USER'S perspective only, NEVER from the assistant's:",
     "- The suggestion is what the USER will type into the chat input",
-    "- Use first-person \"I\" only if the user has used it in their prior messages",
-    "- NEVER start with phrases like \"I can help\", \"Here's what\", \"Let me\", \"I'd suggest\" — those are assistant-voice",
+    '- Use first-person "I" only if the user has used it in their prior messages',
+    '- NEVER start with phrases like "I can help", "Here\'s what", "Let me", "I\'d suggest" — those are assistant-voice',
     "- Think: if you were the user reading the assistant's reply, what question or follow-up would you ask next?",
     "",
     "Output only the reply text inside the requested tags — no preamble, no commentary.",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1362,10 +1362,8 @@ export async function handleSendMessage(
       : ("content-source" as const);
     effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
     // Fall through to normal inference path below
-  } else if (isWakeUp && body.onboarding?.cohort === "content-automation") {
-    effectiveContent = "I want to write articles that rank better in GEO";
-    // Fall through to normal inference path — the bootstrap template
-    // and geo-writing skill handle this message.
+  } else if (isWakeUp && body.onboarding?.initialMessage) {
+    effectiveContent = body.onboarding.initialMessage;
   } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -10,4 +10,10 @@ export interface OnboardingContext {
   cohort?: string;
   websiteUrl?: string;
   contentSourceUrl?: string;
+  /** Filename of the bootstrap template to use (e.g. "BOOTSTRAP-CONTENT-AUTOMATION.md"). When set, replaces generic BOOTSTRAP.md if still pristine. */
+  bootstrapTemplate?: string;
+  /** Override the first user message content. When set during a wake-up greeting, this replaces the canned greeting. */
+  initialMessage?: string;
+  /** Skills to eagerly load on first turn (e.g. ["geo-writing", "document-editor"]). Informational — the bootstrap template drives actual loading. */
+  skills?: string[];
 }

--- a/clients/shared/Models/PreChatOnboardingContext.swift
+++ b/clients/shared/Models/PreChatOnboardingContext.swift
@@ -2,18 +2,30 @@
 /// Serialized to JSON and sent with the first message so the assistant
 /// can personalize its opener.
 public struct PreChatOnboardingContext: Codable, Sendable {
-    public let tools: [String]       // e.g. ["slack", "linear", "figma"]
-    public let tasks: [String]       // e.g. ["code-building", "writing"]
-    public let tone: String          // "grounded", "warm", "energetic", or "poetic"
-    public let userName: String?     // nil if skipped
-    public let assistantName: String? // nil if kept default
+    public let tools: [String]              // e.g. ["slack", "linear", "figma"]
+    public let tasks: [String]              // e.g. ["code-building", "writing"]
+    public let tone: String                 // "grounded", "warm", "energetic", or "poetic"
+    public let userName: String?            // nil if skipped
+    public let assistantName: String?       // nil if kept default
+    public let cohort: String?              // onboarding cohort identifier
+    public let bootstrapTemplate: String?   // recipe template slug for initial setup
+    public let initialMessage: String?      // pre-filled first message from the recipe
+    public let skills: [String]?            // skill slugs to activate for the recipe
 
     public init(tools: [String], tasks: [String], tone: String,
-                userName: String?, assistantName: String?) {
+                userName: String?, assistantName: String?,
+                cohort: String? = nil,
+                bootstrapTemplate: String? = nil,
+                initialMessage: String? = nil,
+                skills: [String]? = nil) {
         self.tools = tools
         self.tasks = tasks
         self.tone = tone
         self.userName = userName
         self.assistantName = assistantName
+        self.cohort = cohort
+        self.bootstrapTemplate = bootstrapTemplate
+        self.initialMessage = initialMessage
+        self.skills = skills
     }
 }

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -120,18 +120,9 @@ public struct MessageClient: MessageClientProtocol {
         if let clientTimezone, !clientTimezone.isEmpty {
             body["clientTimezone"] = clientTimezone
         }
-        if let onboarding {
-            var onboardingDict: [String: Any] = [
-                "tools": onboarding.tools,
-                "tasks": onboarding.tasks,
-                "tone": onboarding.tone
-            ]
-            if let userName = onboarding.userName {
-                onboardingDict["userName"] = userName
-            }
-            if let assistantName = onboarding.assistantName {
-                onboardingDict["assistantName"] = assistantName
-            }
+        if let onboarding,
+           let encodedData = try? JSONEncoder().encode(onboarding),
+           let onboardingDict = try? JSONSerialization.jsonObject(with: encodedData) as? [String: Any] {
             body["onboarding"] = onboardingDict
         }
 


### PR DESCRIPTION
## Summary
Refactors the daemon from a cohort-aware system (hardcoded `if (cohort === "content-automation")` branches) into a generic recipe executor. The platform tells the daemon *what to do* via new `OnboardingContext` fields (`bootstrapTemplate`, `initialMessage`, `skills`), and the daemon executes without needing cohort-specific knowledge.

This keeps business logic in the closed-source platform and makes the open-source daemon a clean, extensible executor. Adding a new onboarding flow = adding a recipe entry on the platform side + dropping a bootstrap template in the daemon. No daemon code changes needed.

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs (web serialization, test assertion, Swift MessageClient)

## PRs merged into feature branch
- #32100: feat(types): add bootstrapTemplate, initialMessage, and skills to OnboardingContext
- #32099: feat(web): add bootstrapTemplate and skills to local PreChatOnboardingContext
- #32107: feat(macos): add cohort, bootstrapTemplate, initialMessage, skills to PreChatOnboardingContext.swift
- #32111: feat(routes): accept bootstrapTemplate, initialMessage, skills in POST /v1/messages onboarding payload
- #32117: refactor(routes): use onboarding.initialMessage for first message override
- #32118: refactor(prompts): use onboarding.bootstrapTemplate for bootstrap swap
- #32120: refactor(web): content-automation uses recipe fields instead of cohort-implied behavior

### Fix PRs
- #32125: fix(chat): include bootstrapTemplate, initialMessage, skills in onboarding serialization
- #32123: fix(macos): serialize all PreChatOnboardingContext fields in MessageClient
- #32122: fix(test): update content-automation test with new recipe fields

Part of plan: onboarding-recipe-arch.md