### PR TITLE
fix(assistant): clear processing flag if /compact initial persist fails

### DIFF
--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -370,6 +370,41 @@ describe("handleSendMessage slash command interception", () => {
     expect(runAgentLoop).not.toHaveBeenCalled();
   });
 
+  test("clears processing and drains the queue when /compact's initial persist fails", async () => {
+    const { conversation } = makeConversation();
+    const drainQueue = mock(async () => {});
+    (
+      conversation as unknown as { drainQueue: () => Promise<void> }
+    ).drainQueue = drainQueue;
+
+    // Force the user-message persist (the first addMessage in the /compact
+    // branch, on the synchronous pre-202 path) to throw.
+    addMessageMock.mockImplementationOnce(async () => {
+      throw new Error("disk full");
+    });
+
+    // The failure surfaces to the caller rather than silently 202-ing.
+    let caught: Error | undefined;
+    try {
+      await callHandler(
+        (args) => handleSendMessage(args, makeDeps(conversation)),
+        makeRequest("/compact"),
+        undefined,
+        202,
+      );
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught?.message).toBe("disk full");
+
+    // Regression: without the guard `processing` stays stuck true, leaving
+    // every later send queued forever; the queue must also be drained.
+    expect(
+      (conversation as unknown as { processing: boolean }).processing,
+    ).toBe(false);
+    expect(drainQueue).toHaveBeenCalledTimes(1);
+  });
+
   test("passes regular messages through to agent loop unchanged", async () => {
     const {
       conversation,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1820,12 +1820,22 @@ export async function handleSendMessage(
       assistantMessageInterface: sourceInterface,
     };
     const cleanMsg = createUserMessage(rawContent, attachments);
-    const persisted = await addMessage(
-      mapping.conversationId,
-      "user",
-      JSON.stringify(cleanMsg.content),
-      channelMeta,
-    );
+    let persisted: Awaited<ReturnType<typeof addMessage>>;
+    try {
+      persisted = await addMessage(
+        mapping.conversationId,
+        "user",
+        JSON.stringify(cleanMsg.content),
+        channelMeta,
+      );
+    } catch (err) {
+      // The fire-and-forget compaction below owns clearing `processing`, but a
+      // throw from this initial persist never reaches it — reset here so the
+      // conversation isn't stranded in queued mode.
+      conversation.processing = false;
+      silentlyWithLog(conversation.drainQueue(), "compact-command queue drain");
+      throw err;
+    }
     conversation.getMessages().push(cleanMsg);
 
     const conversationId = mapping.conversationId;


### PR DESCRIPTION
## Summary
The `/compact` slash-command branch in `conversation-routes.ts` set `conversation.processing = true`, then `await`ed the initial user-message `addMessage` **outside** any guard. The fire-and-forget compaction IIFE owns the `try/finally` that resets the flag, so a throw from that initial persist (transient SQLite/disk failure) never reaches it — leaving the conversation stuck in queued mode indefinitely (every later send silently queues forever).

This is the sibling of the `/clean` bug fixed in #32115; it was spotted during that work.

## Fix
An outer `try/finally` (as `/clean` uses) is **wrong** here: `/compact` returns 202 immediately and runs compaction async, so it would clear `processing` before compaction finished. Instead, guard just the synchronous pre-202 persist — on failure, reset `processing`, drain the queue, and rethrow so the caller still surfaces the error. The async IIFE keeps its own `finally` for the post-202 path.

## Test plan
- [x] Added regression test: `/compact` with a failing initial persist leaves `processing === false` and drains the queue.
- [x] `bun test conversation-routes-slash-commands.test.ts` — 8 pass.
- [x] `bunx tsc --noEmit` clean.