### PR TITLE
feat(home-feed): strip feed conversationIds on conversation delete

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -26,6 +26,7 @@ import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import type { TrustContext } from "../daemon/trust-context.js";
+import { clearAllConversationIds } from "../home/feed-writer.js";
 import { UserError } from "../util/errors.js";
 import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
@@ -1864,6 +1865,8 @@ export async function clearAll(): Promise<{
   } catch (err) {
     log.warn({ err }, "clearAll: failed to reset conversations directory");
   }
+
+  void clearAllConversationIds();
 
   return { conversations: convCount, messages: msgCount };
 }

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -28,6 +28,7 @@ import {
   undoLastMessage,
 } from "../../daemon/handlers/conversations.js";
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
+import { stripConversationIds } from "../../home/feed-writer.js";
 import {
   archiveConversation,
   batchSetDisplayOrders,
@@ -114,7 +115,10 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   };
 }
 
-async function handleForkConversation({ body = {}, headers }: RouteHandlerArgs) {
+async function handleForkConversation({
+  body = {},
+  headers,
+}: RouteHandlerArgs) {
   const conversationId = body.conversationId as string | undefined;
   if (!conversationId || typeof conversationId !== "string") {
     throw new BadRequestError("Missing conversationId");
@@ -223,9 +227,7 @@ function handleRenameConversation({
   return { ok: true };
 }
 
-async function handleClearAllConversations({
-  headers = {},
-}: RouteHandlerArgs) {
+async function handleClearAllConversations({ headers = {} }: RouteHandlerArgs) {
   const confirm = headers["x-confirm-destructive"];
   if (confirm !== "clear-all-conversations") {
     throw new BadRequestError(
@@ -241,7 +243,10 @@ async function handleClearAllConversations({
   return undefined;
 }
 
-function handleWipeConversation({ pathParams = {}, headers }: RouteHandlerArgs) {
+function handleWipeConversation({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
   const resolvedId = resolveOrThrow(pathParams.id!);
 
   cancelScheduleIfLast(resolvedId);
@@ -273,6 +278,9 @@ function handleWipeConversation({ pathParams = {}, headers }: RouteHandlerArgs) 
     resolvedId,
     headers?.["x-vellum-client-id"]?.trim() || undefined,
   );
+
+  void stripConversationIds(resolvedId);
+
   return {
     wiped: true,
     unsupersededItems: 0,
@@ -310,6 +318,8 @@ function handleDeleteConversation({
     resolvedId,
     headers?.["x-vellum-client-id"]?.trim() || undefined,
   );
+
+  void stripConversationIds(resolvedId);
 
   return undefined;
 }
@@ -445,9 +455,7 @@ export const ROUTES: RouteDefinition[] = [
         ),
       conversationKey: z
         .string()
-        .describe(
-          "Echo of the optional external key supplied by the client.",
-        ),
+        .describe("Echo of the optional external key supplied by the client."),
       conversationType: z.string(),
       created: z.boolean(),
     }),


### PR DESCRIPTION
## Summary
- Wire `stripConversationIds()` into `handleDeleteConversation()` and `handleWipeConversation()` as fire-and-forget side-effects
- Wire `clearAllConversationIds()` into `clearAll()` to strip all references on full wipe
- Deletion response is not blocked — feed cleanup runs asynchronously via the coalescing write queue

Part of plan: feed-dead-link-cleanup.md (PR 2 of 3)