### PR TITLE
fix(messages): shrink cap-truncation test seed to fix flaky CI timeout

### DIFF
--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -26,6 +26,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import {
+  _setPaginationScanCapForTesting,
   addMessage,
   createConversation,
   getMessages,
@@ -179,74 +180,81 @@ describe("handleListMessages metadata.hidden filtering", () => {
   });
 
   test("pagination keeps hasMore + a cursor when a >cap hidden block truncates the scan", () => {
-    // PAGINATION_SCAN_CAP is 10_000. Seed a contiguous block of hidden rows
-    // longer than the cap on top of a couple of older visible rows. The first
-    // page scans the cap's worth of (all hidden) rows without filling the page;
-    // the buggy implementation returned `hasMore: false` with no cursor here,
-    // stalling the client before it ever reached the visible rows below.
-    const conv = createConversation();
-    const db = getDb();
-    const HIDDEN_COUNT = 10_050; // > PAGINATION_SCAN_CAP
-    const VISIBLE_COUNT = 2;
-    let createdAt = 0;
-    // Older visible rows first (lowest createdAt), then the hidden block.
-    db.transaction((tx) => {
-      for (let i = 0; i < VISIBLE_COUNT; i++) {
-        createdAt += 1;
-        tx.insert(messages)
-          .values({
-            id: `visible-${i}`,
-            conversationId: conv.id,
-            role: "user",
-            content: JSON.stringify([{ type: "text", text: `visible ${i}` }]),
-            createdAt,
-          })
-          .run();
-      }
-      for (let i = 0; i < HIDDEN_COUNT; i++) {
-        createdAt += 1;
-        tx.insert(messages)
-          .values({
-            id: `hidden-${i}`,
-            conversationId: conv.id,
-            role: "assistant",
-            content: JSON.stringify([{ type: "text", text: `hidden ${i}` }]),
-            createdAt,
-            metadata: JSON.stringify({ hidden: true }),
-          })
-          .run();
-      }
-    });
+    // Exercise cap-truncation with a small cap + a few hundred rows rather than
+    // >10k: the large seed made the post-test resetTables DELETE slow enough to
+    // time out the next test's beforeEach under parallel CI load.
+    // SCAN_CAP must span a couple of PAGINATION_CHUNK_MIN (50) chunks so the cap
+    // (not DB exhaustion) stops the loop, and HIDDEN_COUNT sits just past it so
+    // the newest cap-worth of rows are all hidden.
+    const SCAN_CAP = 100;
+    _setPaginationScanCapForTesting(SCAN_CAP);
+    try {
+      const conv = createConversation();
+      const db = getDb();
+      const HIDDEN_COUNT = SCAN_CAP + 20; // > scan cap
+      const VISIBLE_COUNT = 2;
+      let createdAt = 0;
+      // Older visible rows first (lowest createdAt), then the hidden block.
+      db.transaction((tx) => {
+        for (let i = 0; i < VISIBLE_COUNT; i++) {
+          createdAt += 1;
+          tx.insert(messages)
+            .values({
+              id: `visible-${i}`,
+              conversationId: conv.id,
+              role: "user",
+              content: JSON.stringify([{ type: "text", text: `visible ${i}` }]),
+              createdAt,
+            })
+            .run();
+        }
+        for (let i = 0; i < HIDDEN_COUNT; i++) {
+          createdAt += 1;
+          tx.insert(messages)
+            .values({
+              id: `hidden-${i}`,
+              conversationId: conv.id,
+              role: "assistant",
+              content: JSON.stringify([{ type: "text", text: `hidden ${i}` }]),
+              createdAt,
+              metadata: JSON.stringify({ hidden: true }),
+            })
+            .run();
+        }
+      });
 
-    const latest = handleListMessages({
-      queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
-    }) as {
-      messages: MessagePayload[];
-      hasMore: boolean;
-      oldestTimestamp: number | null;
-    };
+      const latest = handleListMessages({
+        queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
+      }) as {
+        messages: MessagePayload[];
+        hasMore: boolean;
+        oldestTimestamp: number | null;
+      };
 
-    // Page is empty (the cap was consumed entirely by hidden rows) but the
-    // client must still be told to keep paginating and given a cursor.
-    expect(latest.messages).toHaveLength(0);
-    expect(latest.hasMore).toBe(true);
-    expect(latest.oldestTimestamp).not.toBeNull();
+      // Page is empty (the cap was consumed entirely by hidden rows) but the
+      // client must still be told to keep paginating and given a cursor.
+      expect(latest.messages).toHaveLength(0);
+      expect(latest.hasMore).toBe(true);
+      expect(latest.oldestTimestamp).not.toBeNull();
 
-    // Resuming from the surfaced cursor drains the remaining hidden rows and
-    // surfaces the visible ones below the cap.
-    const older = handleListMessages({
-      queryParams: {
-        conversationId: conv.id,
-        beforeTimestamp: String(latest.oldestTimestamp),
-        limit: "2",
-      },
-    }) as { messages: MessagePayload[]; hasMore: boolean };
+      // Resuming from the surfaced cursor drains the remaining hidden rows and
+      // surfaces the visible ones below the cap.
+      const older = handleListMessages({
+        queryParams: {
+          conversationId: conv.id,
+          beforeTimestamp: String(latest.oldestTimestamp),
+          limit: "2",
+        },
+      }) as { messages: MessagePayload[]; hasMore: boolean };
 
-    expect(older.messages.map((m) => m.content)).toEqual([
-      "visible 0",
-      "visible 1",
-    ]);
-    expect(older.hasMore).toBe(false);
+      expect(older.messages.map((m) => m.content)).toEqual([
+        "visible 0",
+        "visible 1",
+      ]);
+      expect(older.hasMore).toBe(false);
+    } finally {
+      _setPaginationScanCapForTesting(undefined);
+    }
   });
 
   test("pagination drains DB when every row in a page is hidden", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1317,6 +1317,15 @@ interface PaginatedMessagesResult {
 const PAGINATION_CHUNK_MIN = 50;
 const PAGINATION_SCAN_CAP = 10_000;
 
+// Test-only override for PAGINATION_SCAN_CAP so tests can exercise the
+// cap-truncation branch with a small cap instead of seeding >10k rows (which
+// makes the suite slow and the post-test DELETE flaky under parallel CI load).
+// `undefined` restores the production cap.
+let paginationScanCapOverride: number | undefined;
+export function _setPaginationScanCapForTesting(cap: number | undefined): void {
+  paginationScanCapOverride = cap;
+}
+
 export function getMessagesPaginated(
   conversationId: string,
   limit: number | undefined,
@@ -1363,9 +1372,10 @@ export function getMessagesPaginated(
   // scanned position as a resume cursor (the visible page may be empty).
   let scanCapTruncated = false;
   let lastScanned: { createdAt: number; id: string } | undefined;
+  const scanCap = paginationScanCapOverride ?? PAGINATION_SCAN_CAP;
 
   while (visible.length < limit + 1) {
-    if (rowsScanned >= PAGINATION_SCAN_CAP) {
+    if (rowsScanned >= scanCap) {
       scanCapTruncated = true;
       break;
     }


### PR DESCRIPTION
## Summary
- The "pagination keeps hasMore + a cursor when a >cap hidden block truncates the scan" test (added in #32121) seeded **10,050 rows** to exceed `PAGINATION_SCAN_CAP` (10,000). The *next* test's `beforeEach` (`resetTables`) then had to `DELETE` all 10,050 rows; under `synchronous=FULL` WAL on a 16-worker CI runner that delete ran long enough to time out the hook — surfacing as a `beforeEach` timeout on **"pagination drains DB when every row in a page is hidden"** (the actual failure in run 26466442890).
- Added a test-only `_setPaginationScanCapForTesting` seam (matching the existing `_set*ForTesting` convention) so the test lowers the cap to 100 and seeds ~122 rows. Same branch coverage; file runtime drops from ~4s to ~0.48s locally and the worst-case post-test `DELETE` drops from 10,050 to 122 rows.
- Production behavior is unchanged: the override defaults to `undefined`, so `getMessagesPaginated` still uses `PAGINATION_SCAN_CAP`.

## Original prompt
Fix the specific CI failure in the "Test" job of run 26466442890 on `main` — `list-messages-hidden-metadata.test.ts` failing with a `beforeEach` hook timeout on the "pagination drains DB…" case. Investigation traced the timeout to the neighboring >cap-truncation test's 10k-row seed making the shared `resetTables` delete too slow under parallel CI load, so the fix shrinks the seed via an injectable scan cap rather than bumping timeouts.