### PR TITLE
fix: add stripConversationIds to wipe-conversation-routes

### DIFF
--- a/assistant/src/runtime/routes/wipe-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wipe-conversation-routes.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 
 import { destroyActiveConversation } from "../../daemon/conversation-store.js";
+import { stripConversationIds } from "../../home/feed-writer.js";
 import {
   countConversationsByScheduleJobId,
   getConversation,
@@ -53,6 +54,8 @@ async function handleWipeConversation({ body = {} }: RouteHandlerArgs) {
       targetId: summaryId,
     });
   }
+
+  void stripConversationIds(conversationId);
 
   return {
     wiped: true,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for feed-dead-link-cleanup.md.

**Gap:** wipe-conversation-routes.ts missing stripConversationIds call
**What was expected:** All wipe paths strip conversationIds from feed
**What was found:** The body-based wipe route used by CLI was not updated