### PR TITLE
fix: clearAllConversationIds delegates to stripConversationIds

### DIFF
--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -186,13 +186,7 @@ export async function stripConversationIds(
  * all items with a conversationId".
  */
 export async function clearAllConversationIds(): Promise<number> {
-  let resolveResult!: (count: number) => void;
-  const resultPromise = new Promise<number>((resolve) => {
-    resolveResult = resolve;
-  });
-  pendingStrips.push({ conversationId: "*", resolve: resolveResult });
-  void scheduleWrite();
-  return resultPromise;
+  return stripConversationIds("*");
 }
 
 // ─── Internal: coalescing queue ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for feed-dead-link-cleanup.md.

**Gap:** clearAllConversationIds duplicates stripConversationIds body
**What was expected:** No duplicated function bodies
**What was found:** Copy-pasted body with hardcoded sentinel