### PR TITLE
fix: gate HomeRecapRow Go to Thread button on validConversationIds

### DIFF
--- a/apps/web/src/domains/home/home-feed-list.tsx
+++ b/apps/web/src/domains/home/home-feed-list.tsx
@@ -26,6 +26,7 @@ const TIME_GROUP_LABELS: Record<FeedTimeGroup, string> = {
 
 export interface HomeFeedListProps {
   items: FeedItem[];
+  validConversationIds?: Set<string>;
   onSelectItem: (item: FeedItem) => void;
   onDismissItem: (itemId: string) => void;
   onRestoreItem: (itemId: string) => void;
@@ -35,6 +36,7 @@ export interface HomeFeedListProps {
 
 export function HomeFeedList({
   items,
+  validConversationIds,
   onSelectItem,
   onDismissItem,
   onRestoreItem,
@@ -111,6 +113,7 @@ export function HomeFeedList({
                 <HomeRecapRow
                   key={item.id}
                   item={item}
+                  validConversationIds={validConversationIds}
                   onSelect={onSelectItem}
                   onDismiss={onDismissItem}
                   onToggleRead={onToggleRead}

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -151,6 +151,7 @@ export function HomePage({
       />
       <HomeFeedList
         items={feedQuery.data?.items ?? []}
+        validConversationIds={validConversationIds}
         onSelectItem={handleSelectItem}
         onDismissItem={handleDismissItem}
         onRestoreItem={handleRestoreItem}

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -54,6 +54,7 @@ export type HomeRecapRowTrailingAction = "dismiss" | "restore";
 
 export interface HomeRecapRowProps {
   item: FeedItem;
+  validConversationIds?: Set<string>;
   onSelect: (item: FeedItem) => void;
   onDismiss: (itemId: string) => void;
   onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
@@ -63,6 +64,7 @@ export interface HomeRecapRowProps {
 
 export function HomeRecapRow({
   item,
+  validConversationIds,
   onSelect,
   onDismiss,
   onToggleRead,
@@ -126,7 +128,7 @@ export function HomeRecapRow({
               {isUnread ? <MailOpen width={14} height={14} /> : <Mail width={14} height={14} />}
             </HoverIconButton>
           )}
-          {onGoToThread && item.conversationId && (
+          {onGoToThread && item.conversationId && (!validConversationIds || validConversationIds.has(item.conversationId)) && (
             <HoverIconButton
               title="Go to thread"
               onClick={() => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for feed-dead-link-cleanup.md.

**Gap:** HomeRecapRow Go to Thread button not gated by validConversationIds
**What was expected:** All navigation surfaces validate conversation existence
**What was found:** Only HomeDetailPanel was gated, HomeRecapRow hover button bypassed the check

- Threads `validConversationIds` from `HomePage` → `HomeFeedList` → `HomeRecapRow`
- Gates the "Go to Thread" hover button to only render when the conversation exists in `validConversationIds`
- Props are optional (`Set<string> | undefined`) so the component remains backward-compatible

## Test plan
- [ ] Verify "Go to Thread" button does not appear on hover for feed items with deleted conversations
- [ ] Verify "Go to Thread" button still appears for feed items with valid conversations
- [ ] Verify HomeDetailPanel "Go to Thread" still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)