### PR TITLE
Home Feed Dead Conversation Link Cleanup

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -22,6 +22,7 @@ function resolveCategoryStyle(category?: FeedItemCategory) {
 
 export interface HomeDetailPanelProps {
   item: FeedItem | null;
+  validConversationIds: Set<string>;
   onClose: () => void;
   onGoToThread: (conversationId: string) => void;
   onUpdateStatus: (itemId: string, status: FeedItemStatus) => void;
@@ -30,6 +31,7 @@ export interface HomeDetailPanelProps {
 
 export function HomeDetailPanel({
   item,
+  validConversationIds,
   onClose,
   onGoToThread,
   onUpdateStatus,
@@ -72,8 +74,8 @@ export function HomeDetailPanel({
           {item.title ?? item.summary}
         </Typography>
 
-        {/* Go to Convo button — only when conversationId exists */}
-        {item.conversationId ? (
+        {/* Go to Convo button — only when conversationId exists and is valid */}
+        {item.conversationId && validConversationIds.has(item.conversationId) ? (
           <Button
             variant="outlined"
             size="compact"

--- a/apps/web/src/domains/home/home-feed-list.tsx
+++ b/apps/web/src/domains/home/home-feed-list.tsx
@@ -26,6 +26,7 @@ const TIME_GROUP_LABELS: Record<FeedTimeGroup, string> = {
 
 export interface HomeFeedListProps {
   items: FeedItem[];
+  validConversationIds?: Set<string>;
   onSelectItem: (item: FeedItem) => void;
   onDismissItem: (itemId: string) => void;
   onRestoreItem: (itemId: string) => void;
@@ -35,6 +36,7 @@ export interface HomeFeedListProps {
 
 export function HomeFeedList({
   items,
+  validConversationIds,
   onSelectItem,
   onDismissItem,
   onRestoreItem,
@@ -111,6 +113,7 @@ export function HomeFeedList({
                 <HomeRecapRow
                   key={item.id}
                   item={item}
+                  validConversationIds={validConversationIds}
                   onSelect={onSelectItem}
                   onDismiss={onDismissItem}
                   onToggleRead={onToggleRead}

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -42,6 +42,7 @@ function HomePageSkeleton() {
 
 export interface HomePageProps {
   assistantId: string;
+  validConversationIds: Set<string>;
   onStartNewChat: () => void;
   onOpenConversation: (conversationId: string) => void;
   onSuggestionSelected: (prompt: string) => void;
@@ -49,6 +50,7 @@ export interface HomePageProps {
 
 export function HomePage({
   assistantId,
+  validConversationIds,
   onStartNewChat,
   onOpenConversation,
   onSuggestionSelected,
@@ -163,6 +165,7 @@ export function HomePage({
       <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
         <HomeDetailPanel
           item={selectedItem}
+          validConversationIds={validConversationIds}
           onClose={handleCloseDetail}
           onGoToThread={handleGoToThread}
           onUpdateStatus={handleUpdateStatus}
@@ -187,6 +190,7 @@ export function HomePage({
         right={
           <HomeDetailPanel
             item={selectedItem}
+            validConversationIds={validConversationIds}
             onClose={handleCloseDetail}
             onGoToThread={handleGoToThread}
             onUpdateStatus={handleUpdateStatus}

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -151,6 +151,7 @@ export function HomePage({
       />
       <HomeFeedList
         items={feedQuery.data?.items ?? []}
+        validConversationIds={validConversationIds}
         onSelectItem={handleSelectItem}
         onDismissItem={handleDismissItem}
         onRestoreItem={handleRestoreItem}

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -54,6 +54,7 @@ export type HomeRecapRowTrailingAction = "dismiss" | "restore";
 
 export interface HomeRecapRowProps {
   item: FeedItem;
+  validConversationIds?: Set<string>;
   onSelect: (item: FeedItem) => void;
   onDismiss: (itemId: string) => void;
   onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
@@ -63,6 +64,7 @@ export interface HomeRecapRowProps {
 
 export function HomeRecapRow({
   item,
+  validConversationIds,
   onSelect,
   onDismiss,
   onToggleRead,
@@ -126,7 +128,7 @@ export function HomeRecapRow({
               {isUnread ? <MailOpen width={14} height={14} /> : <Mail width={14} height={14} />}
             </HoverIconButton>
           )}
-          {onGoToThread && item.conversationId && (
+          {onGoToThread && item.conversationId && (!validConversationIds || validConversationIds.has(item.conversationId)) && (
             <HoverIconButton
               title="Go to thread"
               onClick={() => {

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from "react";
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationListQuery } from "@/domains/conversations/conversation-queries.js";
 import { useConversationStore } from "@/domains/conversations/conversation-store.js";
 import { HomePage } from "@/domains/home/home-page.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
@@ -10,9 +12,15 @@ import { routes } from "@/utils/routes.js";
 export function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useActiveAssistantContext();
+  const { conversations } = useConversationListQuery(assistantId);
+  const validConversationIds = useMemo(
+    () => new Set(conversations.map((c) => c.conversationId)),
+    [conversations],
+  );
   return (
     <HomePage
       assistantId={assistantId}
+      validConversationIds={validConversationIds}
       onStartNewChat={() => navigate(routes.assistant)}
       onOpenConversation={(conversationId) =>
         navigate(routes.conversation(conversationId))

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -44,9 +44,11 @@ const {
   HOME_FEED_FILENAME,
   HOME_FEED_VERSION,
   appendFeedItem,
+  clearAllConversationIds,
   getHomeFeedPath,
   patchFeedItemStatus,
   readHomeFeed,
+  stripConversationIds,
 } = await import("../feed-writer.js");
 
 type FeedItemStatus = "new" | "seen" | "acted_on";
@@ -60,6 +62,7 @@ interface TestFeedItem {
   timestamp: string;
   status: FeedItemStatus;
   expiresAt?: string;
+  conversationId?: string;
   createdAt: string;
 }
 
@@ -419,6 +422,163 @@ describe("feed-writer", () => {
       for (const item of items) {
         expect(ids.has(item.id)).toBe(true);
       }
+    });
+  });
+
+  describe("stripConversationIds", () => {
+    test("removes conversationId from matching items and leaves others untouched", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "item-a",
+          title: "Linked",
+          conversationId: "conv-123",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "item-b",
+          title: "Other conv",
+          conversationId: "conv-456",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "item-c",
+          title: "No conv",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      await stripConversationIds("conv-123");
+
+      const decoded = readFileJson();
+      const itemA = decoded.items.find((i) => i.id === "item-a")!;
+      const itemB = decoded.items.find((i) => i.id === "item-b")!;
+      const itemC = decoded.items.find((i) => i.id === "item-c")!;
+
+      expect(itemA.conversationId).toBeUndefined();
+      expect(itemB.conversationId).toBe("conv-456");
+      expect(itemC.conversationId).toBeUndefined();
+    });
+
+    test("returns the count of items modified", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "m1",
+          conversationId: "conv-abc",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "m2",
+          conversationId: "conv-abc",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "m3",
+          conversationId: "conv-other",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      const count = await stripConversationIds("conv-abc");
+      expect(count).toBe(2);
+    });
+
+    test("returns 0 when no items match", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "no-match",
+          conversationId: "conv-xyz",
+        }),
+      );
+
+      const count = await stripConversationIds("conv-nonexistent");
+      expect(count).toBe(0);
+    });
+
+    test("coalesces with pending appends correctly", async () => {
+      // Fire an append and a strip concurrently — both should land in
+      // the same coalesced write cycle.
+      const appendPromise = appendFeedItem(
+        makeItem({
+          id: "coalesce-item",
+          conversationId: "conv-coalesce",
+        }),
+      );
+      const stripPromise = stripConversationIds("conv-coalesce");
+
+      await Promise.all([appendPromise, stripPromise]);
+
+      const decoded = readFileJson();
+      const item = decoded.items.find((i) => i.id === "coalesce-item")!;
+      // The append lands first, then the strip runs — conversationId
+      // should be gone.
+      expect(item).toBeDefined();
+      expect(item.conversationId).toBeUndefined();
+    });
+
+    test("items retain all other fields after strip", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "retain-fields",
+          title: "Keep me",
+          summary: "Important summary",
+          conversationId: "conv-strip",
+          priority: 75,
+          status: "seen",
+        }),
+      );
+
+      await stripConversationIds("conv-strip");
+
+      const decoded = readFileJson();
+      const item = decoded.items.find((i) => i.id === "retain-fields")!;
+      expect(item.conversationId).toBeUndefined();
+      expect(item.id).toBe("retain-fields");
+      expect(item.title).toBe("Keep me");
+      expect(item.summary).toBe("Important summary");
+      expect(item.priority).toBe(75);
+      expect(item.status).toBe("seen");
+      expect(item.type).toBe("notification");
+    });
+  });
+
+  describe("clearAllConversationIds", () => {
+    test("strips conversationId from all items that have one", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "all-1",
+          conversationId: "conv-aaa",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "all-2",
+          conversationId: "conv-bbb",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "all-3",
+          title: "No conv link",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      const count = await clearAllConversationIds();
+      expect(count).toBe(2);
+
+      const decoded = readFileJson();
+      for (const item of decoded.items) {
+        expect(item.conversationId).toBeUndefined();
+      }
+      // All three items still exist.
+      expect(decoded.items).toHaveLength(3);
     });
   });
 

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -155,6 +155,46 @@ export async function patchFeedItemStatus(
   return resultPromise;
 }
 
+/**
+ * Remove the `conversationId` field from all feed items that reference
+ * the given conversation. Returns the number of items modified.
+ *
+ * This is the daemon-side cleanup path invoked when a conversation is
+ * deleted — it prevents "Go to Thread" buttons from linking to a
+ * conversation that no longer exists. Goes through the same coalescing
+ * queue as appends and patches so there are no file-I/O races.
+ */
+export async function stripConversationIds(
+  conversationId: string,
+): Promise<number> {
+  let resolveResult!: (count: number) => void;
+  const resultPromise = new Promise<number>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingStrips.push({ conversationId, resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
+/**
+ * Remove the `conversationId` field from ALL feed items that have one.
+ * Returns the number of items modified.
+ *
+ * Used by the clear-all-conversations flow to bulk-invalidate every
+ * "Go to Thread" link at once. Uses the same coalescing queue with a
+ * `"*"` sentinel that the strip loop in `runWrite` treats as "match
+ * all items with a conversationId".
+ */
+export async function clearAllConversationIds(): Promise<number> {
+  let resolveResult!: (count: number) => void;
+  const resultPromise = new Promise<number>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingStrips.push({ conversationId: "*", resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
 // ─── Internal: coalescing queue ────────────────────────────────────────
 
 /**
@@ -167,6 +207,10 @@ const pendingPatches: Array<{
   id: string;
   status: FeedItemStatus;
   resolve: (value: FeedItem | null) => void;
+}> = [];
+const pendingStrips: Array<{
+  conversationId: string;
+  resolve: (count: number) => void;
 }> = [];
 
 let writeInFlight: Promise<void> | null = null;
@@ -206,6 +250,7 @@ function scheduleWrite(): Promise<void> {
 async function runWrite(): Promise<void> {
   const appendsToApply = pendingAppends.splice(0, pendingAppends.length);
   const patchesToApply = pendingPatches.splice(0, pendingPatches.length);
+  const stripsToApply = pendingStrips.splice(0, pendingStrips.length);
 
   const current = readHomeFeed();
   let items = current.items.slice();
@@ -233,6 +278,24 @@ async function runWrite(): Promise<void> {
     patchResults.push({ resolve: patch.resolve, value: updated });
   }
 
+  // Strip conversationId from matching items.
+  const stripResults: Array<{
+    resolve: (count: number) => void;
+    count: number;
+  }> = [];
+  for (const strip of stripsToApply) {
+    let count = 0;
+    for (let i = 0; i < items.length; i++) {
+      const matchAll = strip.conversationId === "*";
+      const matchOne = items[i]!.conversationId === strip.conversationId;
+      if (matchAll ? items[i]!.conversationId != null : matchOne) {
+        items[i] = { ...items[i]!, conversationId: undefined };
+        count++;
+      }
+    }
+    stripResults.push({ resolve: strip.resolve, count });
+  }
+
   items.sort(compareFeedItems);
 
   const updatedAt = new Date().toISOString();
@@ -258,16 +321,20 @@ async function runWrite(): Promise<void> {
     publishHomeFeedUpdated(updatedAt, newItemCount);
   }
 
-  // Resolve pending patch promises AFTER we've emitted the SSE event
-  // so callers awaiting `patchFeedItemStatus` observe a fully
-  // consistent world: the on-disk file, the SSE event, and the
-  // returned `FeedItem` all reflect the same write.
+  // Resolve pending patch and strip promises AFTER we've emitted the
+  // SSE event so callers awaiting `patchFeedItemStatus` or
+  // `stripConversationIds` observe a fully consistent world: the
+  // on-disk file, the SSE event, and the returned value all reflect
+  // the same write.
   //
-  // If the write failed, resolve all patch promises with `null` — the
-  // state was not persisted, and callers (e.g. HTTP route handlers)
-  // must not report success when the underlying write failed.
+  // If the write failed, resolve patch promises with `null` and strip
+  // promises with `0` — the state was not persisted, and callers must
+  // not report success when the underlying write failed.
   for (const { resolve, value } of patchResults) {
     resolve(wrote ? value : null);
+  }
+  for (const { resolve, count } of stripResults) {
+    resolve(wrote ? count : 0);
   }
 }
 

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -186,13 +186,7 @@ export async function stripConversationIds(
  * all items with a conversationId".
  */
 export async function clearAllConversationIds(): Promise<number> {
-  let resolveResult!: (count: number) => void;
-  const resultPromise = new Promise<number>((resolve) => {
-    resolveResult = resolve;
-  });
-  pendingStrips.push({ conversationId: "*", resolve: resolveResult });
-  void scheduleWrite();
-  return resultPromise;
+  return stripConversationIds("*");
 }
 
 // ─── Internal: coalescing queue ────────────────────────────────────────

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -26,6 +26,7 @@ import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import type { TrustContext } from "../daemon/trust-context.js";
+import { clearAllConversationIds } from "../home/feed-writer.js";
 import { UserError } from "../util/errors.js";
 import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
@@ -1864,6 +1865,8 @@ export async function clearAll(): Promise<{
   } catch (err) {
     log.warn({ err }, "clearAll: failed to reset conversations directory");
   }
+
+  void clearAllConversationIds();
 
   return { conversations: convCount, messages: msgCount };
 }

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -28,6 +28,7 @@ import {
   undoLastMessage,
 } from "../../daemon/handlers/conversations.js";
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
+import { stripConversationIds } from "../../home/feed-writer.js";
 import {
   archiveConversation,
   batchSetDisplayOrders,
@@ -114,7 +115,10 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   };
 }
 
-async function handleForkConversation({ body = {}, headers }: RouteHandlerArgs) {
+async function handleForkConversation({
+  body = {},
+  headers,
+}: RouteHandlerArgs) {
   const conversationId = body.conversationId as string | undefined;
   if (!conversationId || typeof conversationId !== "string") {
     throw new BadRequestError("Missing conversationId");
@@ -223,9 +227,7 @@ function handleRenameConversation({
   return { ok: true };
 }
 
-async function handleClearAllConversations({
-  headers = {},
-}: RouteHandlerArgs) {
+async function handleClearAllConversations({ headers = {} }: RouteHandlerArgs) {
   const confirm = headers["x-confirm-destructive"];
   if (confirm !== "clear-all-conversations") {
     throw new BadRequestError(
@@ -241,7 +243,10 @@ async function handleClearAllConversations({
   return undefined;
 }
 
-function handleWipeConversation({ pathParams = {}, headers }: RouteHandlerArgs) {
+function handleWipeConversation({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
   const resolvedId = resolveOrThrow(pathParams.id!);
 
   cancelScheduleIfLast(resolvedId);
@@ -273,6 +278,9 @@ function handleWipeConversation({ pathParams = {}, headers }: RouteHandlerArgs) 
     resolvedId,
     headers?.["x-vellum-client-id"]?.trim() || undefined,
   );
+
+  void stripConversationIds(resolvedId);
+
   return {
     wiped: true,
     unsupersededItems: 0,
@@ -310,6 +318,8 @@ function handleDeleteConversation({
     resolvedId,
     headers?.["x-vellum-client-id"]?.trim() || undefined,
   );
+
+  void stripConversationIds(resolvedId);
 
   return undefined;
 }
@@ -445,9 +455,7 @@ export const ROUTES: RouteDefinition[] = [
         ),
       conversationKey: z
         .string()
-        .describe(
-          "Echo of the optional external key supplied by the client.",
-        ),
+        .describe("Echo of the optional external key supplied by the client."),
       conversationType: z.string(),
       created: z.boolean(),
     }),

--- a/assistant/src/runtime/routes/wipe-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wipe-conversation-routes.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 
 import { destroyActiveConversation } from "../../daemon/conversation-store.js";
+import { stripConversationIds } from "../../home/feed-writer.js";
 import {
   countConversationsByScheduleJobId,
   getConversation,
@@ -53,6 +54,8 @@ async function handleWipeConversation({ body = {} }: RouteHandlerArgs) {
       targetId: summaryId,
     });
   }
+
+  void stripConversationIds(conversationId);
 
   return {
     wiped: true,


### PR DESCRIPTION
## Summary
Prevent the home page "Go to Convo" button from linking to deleted conversations. Implements a two-layer defense:
1. **Daemon-side cleanup**: strips `conversationId` from feed items when the referenced conversation is deleted/wiped/cleared
2. **Client-side validation**: hides the "Go to Convo" button when the conversation isn't in the already-loaded conversation list cache

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs:
- HomeRecapRow "Go to Thread" button was not gated by validConversationIds
- `wipe-conversation-routes.ts` (CLI wipe path) was missing `stripConversationIds` call
- `clearAllConversationIds` was a copy-pasted wrapper instead of delegating

## PRs merged into feature branch
- #32126: feat(home-feed): add stripConversationIds to feed-writer
- #32124: feat(apps-web): hide "Go to Convo" for deleted conversations
- #32129: feat(home-feed): strip feed conversationIds on conversation delete

### Fix PRs
- #32133: fix: add stripConversationIds to wipe-conversation-routes
- #32134: fix: clearAllConversationIds delegates to stripConversationIds
- #32135: fix: gate HomeRecapRow Go to Thread button on validConversationIds

Part of plan: feed-dead-link-cleanup.md