### PR TITLE
fix(auth): replace platform-specific error branching with unified fallback navigation

### DIFF
--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -56,26 +56,6 @@ function redirectToNativeApp(
 }
 
 /**
- * True if the current browser is iOS or iPadOS. iPadOS 13+ reports a
- * Macintosh user agent by default, so we disambiguate via
- * `maxTouchPoints > 1` on a Mac platform — real Macs report 0 or 1.
- * `"ontouchend" in document` is NOT a reliable touch-device signal on
- * desktop Safari (the API exists on desktop too), which is why we don't
- * use it. Same discriminator as `isIOSBrowser` in
- * `domains/nudges/ios-app-platform.ts`.
- *
- * Ref: https://developer.apple.com/forums/thread/119186
- */
-function isIOSBrowser(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent;
-  if (/iPhone|iPad|iPod/.test(ua)) return true;
-  const isMacPlatform = navigator.platform.toLowerCase().includes("mac");
-  return isMacPlatform && navigator.maxTouchPoints > 1;
-}
-
-
-/**
  * OAuth provider callback handler. Probes the allauth session after the
  * IdP redirect and routes the user to the correct next step:
  * - Authenticated → navigate to returnTo or home
@@ -139,15 +119,8 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            // Skip the native-scheme bounce on iOS only: it tears the
-            // `ASWebAuthenticationSession` Safari sheet down before
-            // WebKit finishes committing the session cookie set by
-            // allauth's social callback, turning a recoverable
-            // post-WorkOS failure into a permanent one. macOS does
-            // not exhibit this and still needs the bounce so its
-            // auth sheet closes cleanly into the native UI.
-            if (nativeParams && !isIOSBrowser()) {
-              redirectToNativeApp(nativeParams, outcome.message);
+            if (nativeParams && returnTo) {
+              window.location.href = returnTo;
               return;
             }
             setFallbackError(outcome.message);


### PR DESCRIPTION
## Why

When `getSession()` fails during a native auth flow (iOS or macOS `ASWebAuthenticationSession`), the previous code had platform-specific handling:

- **macOS**: bounced back to native app with an error via `redirectToNativeApp()` — user sees error, has to retry
- **iOS**: showed an "Authentication failed" page inside the Safari sheet — user stuck with no way back to the app

Both behaviors are suboptimal because the user IS likely authenticated (allauth just completed the OAuth flow and set the session cookie). The `getSession()` fetch is unreliable inside `ASWebAuthenticationSession` — on iOS it tears down the WebKit cookie store before the session commits; on macOS the fetch can race with cookie persistence.

## What

Replaces the `isIOSBrowser()` UA-sniffing branch in the `case "error"` path with a unified fallback: navigate directly to the Django native callback (`returnTo`). Django's `@login_required` is the authoritative session check — if the user IS authenticated, the flow completes (auth code generated → custom scheme redirect → native app receives callback). If not, Django redirects to the login page (graceful degradation).

Removes the `isIOSBrowser()` helper entirely — it's no longer needed.

### Behavior matrix

| Context | Before | After |
|---|---|---|
| macOS, `getSession()` error | `redirectToNativeApp(error)` — bounce with error | Navigate to Django callback — completes login if session exists |
| iOS, `getSession()` error | `setFallbackError()` — stuck on error page | Navigate to Django callback — completes login if session exists |
| Web flow (no `nativeParams`) | `setFallbackError()` | Unchanged |
| Success path (`authenticated`) | Navigate to `returnTo` | Unchanged |
| `provider_signup` | `redirectToNativeApp("provider_signup_required")` | Unchanged |
| URL-level `?error=` | `redirectToNativeApp(error)` | Unchanged |

### Benefits

- Fixes iOS native auth error path (previously stuck in Safari sheet)
- Improves macOS native auth error path (completes login instead of error bounce)
- Eliminates UA sniffing (`isIOSBrowser()`)
- Defers session verification to Django (the source of truth) rather than depending on a SPA-side fetch

### Safety

- Only the `case "error"` branch with `nativeParams && returnTo` is changed — all other paths are identical
- `returnTo` is already validated by `parseNativeReturnTo()` to start with `/accounts/native/callback` and contain a valid scheme
- Django's `@login_required` + `validate_native_state()` provide server-side verification
- No client-side changes needed — macOS/iOS apps are unaware of SPA internals
- Backwards compatible with older macOS clients (they don't know about the SPA intermediate step)

### Alternatives not taken

1. **Keep `isIOSBrowser()` branching**: treats symptoms (platform-specific cookie timing) rather than the cause (unreliable `getSession()` in `ASWebAuthenticationSession`). Requires maintaining UA detection logic that can drift.
2. **`redirectToNativeApp(error)` for both platforms**: closes the Safari sheet on macOS but breaks iOS (tears down WebKit cookie store prematurely). Also returns an error to the user even when they're authenticated.
3. **Retry `getSession()` with backoff**: adds latency without addressing the fundamental issue. The session cookie may never be visible to the SPA fetch in this browser context.

### Root cause analysis

1. **How did the code get here?** A debug block was added to diagnose iOS `getSession()` failures. PR #32093 replaced the debug block with `isIOSBrowser()` branching to restore macOS while keeping iOS suppressed.
2. **What led to it?** `getSession()` is unreliable inside `ASWebAuthenticationSession` on both platforms — the SPA-side session probe was treated as authoritative when Django is the actual source of truth.
3. **Warning signs?** The same `getSession()` failure affected both iOS and macOS but was treated as platform-specific. The iOS "fix" (suppress redirect) masked the macOS symptom until the debug code deployed.
4. **Prevention?** For native auth flows, prefer server-side session verification over client-side fetches. The SPA callback page should treat `getSession()` as an optimization, not a gate.

### References

- [Django `@login_required`](https://docs.djangoproject.com/en/5.0/topics/auth/default/#the-login-required-decorator): server-side session verification
- [Apple `ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession): custom scheme callback behavior

## Test plan

- Verify macOS native login: Safari sheet opens → WorkOS auth → sheet closes → app logged in
- Verify iOS native login: same flow via Capacitor NativeAuth
- Verify web login unaffected (no `nativeParams` → `setFallbackError()` path unchanged)
- `bun run lint` and `bun run typecheck` pass clean

Link to Devin session: https://app.devin.ai/sessions/67886aaf1d26446b8bd5535792de95ce
Requested by: @ashleeradka