### PR TITLE
fix(memory-v3): fail open to keep pages when gate/descender omit selections

### DIFF
--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -211,6 +211,53 @@ describe("runGate — ready decision", () => {
     expect(userText).toContain("an earlier reply");
   });
 
+  test("omitted selected_slugs falls back to all candidates (recall-safe)", async () => {
+    const calls: ProviderCall[] = [];
+    // `ready` verdict with no `selected_slugs` field at all. A silent omission
+    // must keep everything surfaced, not drop all non-sticky context.
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready" }),
+      calls,
+    );
+
+    const result = await runGate({
+      input: makeInput(),
+      candidates: new Set(["frames/example-a", "people/alice", "people/bob"]),
+      sticky: new Set(["people/bob"]),
+      passNumber: 1,
+      provider,
+    });
+
+    expect(result.decision).toEqual({ decision: "ready" });
+    expect([...result.selectedSlugs].sort()).toEqual([
+      "frames/example-a",
+      "people/alice",
+      "people/bob",
+    ]);
+  });
+
+  test("explicit empty selected_slugs selects nothing but sticky", async () => {
+    const calls: ProviderCall[] = [];
+    // An *explicit* `[]` is the model genuinely choosing nothing — honored as-is
+    // (only sticky survives), unlike an omitted field.
+    const provider = makeProvider(
+      gateToolResponse({ decision: "ready", selected_slugs: [] }),
+      calls,
+    );
+
+    const result = await runGate({
+      input: makeInput(),
+      candidates: new Set(["frames/example-a", "people/alice", "people/bob"]),
+      sticky: new Set(["people/bob"]),
+      passNumber: 1,
+      provider,
+    });
+
+    expect(result.decision).toEqual({ decision: "ready" });
+    // Only sticky carries over; the model dropped everything else.
+    expect(result.selectedSlugs).toEqual(["people/bob"]);
+  });
+
   test("drops a model-selected slug outside the candidate set", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(

--- a/assistant/src/memory/v3/__tests__/loop.test.ts
+++ b/assistant/src/memory/v3/__tests__/loop.test.ts
@@ -405,6 +405,46 @@ describe("runRetrievalLoop — multi pass", () => {
     expect(out.selectedSlugs).toEqual(["p1", "p2"]);
   });
 
+  test("candidates accumulate across passes so the final gate sees pass-1 hits", async () => {
+    // Each pass surfaces a distinct dense hit. Without cross-pass accumulation
+    // the pass-2 gate would only see "p2"; with it, the cumulative pool carries
+    // pass-1's "p1" into the final gate input.
+    lane.scouts = [
+      {
+        scouts: [scout("dense", ["p1"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+      {
+        scouts: [scout("dense", ["p2"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    lane.filter = [
+      { kept: ["p1"], trace: { judged: ["p1"], dropped: [] } },
+      { kept: ["p2"], trace: { judged: ["p2"], dropped: [] } },
+    ];
+    lane.walk = [
+      { pages: new Set(), levels: [] },
+      { pages: new Set(), levels: [] },
+    ];
+    lane.edges = [
+      { pulled: new Set(), expansions: [] },
+      { pulled: new Set(), expansions: [] },
+    ];
+    lane.gate = [moreGate(["p1"], ["more?"]), readyGate(["p1", "p2"])];
+
+    const out = await runRetrievalLoop(makeInput({ passCap: 3 }), { db });
+
+    // Pass 1's gate saw only p1; pass 2's gate saw the cumulative pool.
+    expect(laneCalls.gate[0].candidates).toEqual(["p1"]);
+    expect(laneCalls.gate[1].candidates).toEqual(
+      expect.arrayContaining(["p1", "p2"]),
+    );
+    expect(out.selectedSlugs).toEqual(["p1", "p2"]);
+  });
+
   test("passCap force-exits with the current selection when the gate keeps asking for more", async () => {
     lane.scouts = [
       { scouts: [scout("dense", ["p"])], sticky: new Set(), bypass: new Set() },

--- a/assistant/src/memory/v3/__tests__/tree-walk.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree-walk.test.ts
@@ -279,6 +279,83 @@ describe("runTreeWalk — scripted descent", () => {
     expect(levels.map((l) => l.node).sort()).toEqual(["_root", "a"]);
   });
 
+  test("omitted keep_pages keeps every offered page at the node (recall-safe)", async () => {
+    // _root → a, a leaf bucket of two pages. The model descends but returns NO
+    // keep_pages field at all — a silent omission must keep every offered page,
+    // not drop them all.
+    const tree = makeTree("_root", {
+      _root: [node("a")],
+      a: [page("frames/example-a"), page("people/alice")],
+    });
+    const pages = makePages(["frames/example-a", "people/alice"]);
+    const calls: ProviderCall[] = [];
+    // Bespoke stub: emits tool input WITHOUT a `keep_pages` key for node "a".
+    const provider: Provider = {
+      name: "omit-keep-pages",
+      sendMessage: async (messages, tools, systemPrompt, options) => {
+        calls.push({ messages, tools, systemPrompt, options });
+        const nodeId =
+          nodeIdFromCall({ messages, tools, systemPrompt, options }) ?? "";
+        const input: Record<string, unknown> =
+          nodeId === "_root"
+            ? { descend: ["a"], keep_pages: [] }
+            : { descend: [] }; // node "a": keep_pages omitted entirely
+        return {
+          model: "stub-model",
+          stopReason: "tool_use",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          content: [
+            {
+              type: "tool_use",
+              id: `tu-${nodeId}`,
+              name: "choose_branches",
+              input,
+            },
+          ],
+        };
+      },
+    };
+
+    const { pages: collected } = await runTreeWalk({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    // Both offered pages survive the omission.
+    expect([...collected].sort()).toEqual(["frames/example-a", "people/alice"]);
+  });
+
+  test("explicit empty keep_pages keeps no pages at the node", async () => {
+    // Same tree, but node "a" returns an *explicit* empty keep_pages — honored
+    // as the model genuinely keeping nothing here.
+    const tree = makeTree("_root", {
+      _root: [node("a")],
+      a: [page("frames/example-a"), page("people/alice")],
+    });
+    const pages = makePages(["frames/example-a", "people/alice"]);
+    const calls: ProviderCall[] = [];
+    const provider = makeProvider(
+      {
+        _root: { descend: ["a"], keep: [] },
+        a: { descend: [], keep: [] },
+      },
+      calls,
+    );
+
+    const { pages: collected } = await runTreeWalk({
+      input: makeInput(),
+      tree,
+      pages,
+      scouts: [],
+      provider,
+    });
+
+    expect([...collected]).toEqual([]);
+  });
+
   test("keeps only the pages the model selects at a node", async () => {
     // _root → a, a leaf bucket of two pages. The model keeps only one.
     const tree = makeTree("_root", {

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -144,7 +144,7 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
             "candidates were kept or dropped.",
         },
       },
-      required: ["decision"],
+      required: ["decision", "selected_slugs"],
     },
   };
 }
@@ -310,11 +310,12 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     return failSafe(candidates, sticky);
   }
 
-  const selectedSlugs = orderSelection(
-    parsed.data.selected_slugs ?? [],
-    candidates,
-    sticky,
-  );
+  // Recall-safe fallback: an *omitted* `selected_slugs` means the model gave no
+  // instruction, so keep everything that was surfaced — dropping all non-sticky
+  // context on a silent omission is the worse failure. An *explicit* `[]` is the
+  // model genuinely choosing nothing and is honored as-is.
+  const modelSlugs = parsed.data.selected_slugs ?? [...candidates];
+  const selectedSlugs = orderSelection(modelSlugs, candidates, sticky);
 
   const reasoning = parsed.data.reasoning?.trim() || undefined;
 

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -36,12 +36,13 @@
  * {@link runScouts}. Toggling a lane off removes its contribution from the
  * candidate set so the offline harness can measure each lane's marginal recall.
  *
- * Cross-pass accumulation. A `visited` candidate accumulator deduplicates slugs
- * across passes by canonical slug, tagging each with the first lane that
- * surfaced it (`sourceBySlug`). The full {@link DescentTrace} carries one
- * {@link DescentPass} per pass (scouts / treeLevels / edgeExpansions / gate),
- * and {@link RetrievalCost} (wall-clock `ms`, the one dimension observable at
- * this composition layer) accumulates across every pass.
+ * Cross-pass accumulation. The `candidates` pool is unioned across every pass
+ * and the gate judges that cumulative pool, so a multi-pass `more` never drops
+ * the non-sticky hits earlier passes surfaced. Each slug is tagged with the
+ * first lane that surfaced it (`sourceBySlug`). The full {@link DescentTrace}
+ * carries one {@link DescentPass} per pass (scouts / treeLevels /
+ * edgeExpansions / gate), and {@link RetrievalCost} (wall-clock `ms`, the one
+ * dimension observable at this composition layer) accumulates across every pass.
  */
 
 import { getLogger } from "../../util/logger.js";
@@ -113,6 +114,11 @@ export async function runRetrievalLoop(
 
   // Cross-pass accumulators.
   const sourceBySlug = new Map<string, LaneSource>();
+  // Candidate pool unioned across every pass. Each pass adds its own surfaced
+  // slugs (hot/sparse, dense-filter survivors, tree, edge) and the gate judges
+  // the cumulative pool, so a multi-pass `more` never discards earlier passes'
+  // non-sticky hits.
+  const candidates = new Set<string>();
   // The first pass each slug entered the candidate set. Drives co-activation
   // emission below — pass-1 hits (gap source) vs. later-surfaced pages (target).
   const firstPassBySlug = new Map<string, number>();
@@ -156,10 +162,10 @@ export async function runRetrievalLoop(
       for (const slug of scout.slugs) tagSlug(sourceBySlug, slug, scout.lane);
     }
 
-    // 2. Dense filter — judges only the dense lane (hot/sparse bypass it). The
-    // surviving dense slugs replace the raw dense candidates in the running set.
+    // 2. Dense filter — judges only the dense lane (hot/sparse bypass it). Only
+    // the surviving dense slugs enter the candidate pool; a dropped dense
+    // near-neighbor never joins it (and so never reaches the gate).
     const denseScout = scoutResult.scouts.find((s) => s.lane === "dense");
-    const candidates = new Set<string>();
 
     // Hot + sparse lane hits enter the candidate set directly.
     for (const scout of scoutResult.scouts) {

--- a/assistant/src/memory/v3/tree-walk.ts
+++ b/assistant/src/memory/v3/tree-walk.ts
@@ -320,8 +320,13 @@ export function createDescender(args: CreateDescenderArgs): DescendDecision {
       parsed.data.descend,
       new Map(offeredNodes.map((c) => [c.ref, c])),
     );
+    // Recall-safe fallback: an *omitted* `keep_pages` means the model gave no
+    // instruction at this node, so keep every offered page — dropping all pages
+    // a node presented on a silent omission is the worse failure. An *explicit*
+    // `[]` is the model genuinely keeping nothing here and is honored as-is.
+    const keepSlugs = parsed.data.keep_pages ?? offeredPageSlugs;
     const keep = resolveOffered(
-      parsed.data.keep_pages ?? [],
+      keepSlugs,
       new Map(offeredPages.map((c) => [c.ref, c])),
     );
     return { descend, keep, reasoning: parsed.data.reasoning ?? "" };


### PR DESCRIPTION
## Summary
- Gate `selected_slugs`: an omitted field now falls back to the full candidate set instead of dropping all context (explicit empty still honored).
- Descender `keep_pages`: an omitted field now keeps all offered pages at the node instead of dropping them (explicit empty still honored).
- Retrieval loop: candidates now accumulate across passes, so a multi-pass `more` no longer discards earlier non-sticky hits.

## Original prompt
Harden the memory-v3 retrieval loop so that when an LLM omits a tool field, the system fails toward KEEPING surfaced pages rather than silently dropping all context — addressing three recall-loss bugs (optional gate selected_slugs, optional descender keep_pages, per-pass candidate reset).