### PR TITLE
fix(memory-v3): exclude seeds from pulled and maximize unique neighbors at the edge cap

### DIFF
--- a/assistant/src/memory/v3/__tests__/edges.test.ts
+++ b/assistant/src/memory/v3/__tests__/edges.test.ts
@@ -5,9 +5,12 @@
  * Coverage matrix:
  *   - 1-hop and 2-hop outgoing expansion from a single seed.
  *   - Default hops (2) when omitted.
- *   - Seed excluded from its own `pulled`.
+ *   - Seed excluded from its own `pulled`, and from another seed's `pulled`
+ *     when one seed is reachable from another (seeds-excluded contract).
  *   - Multiple seeds: top-level `pulled` is the union; per-seed expansions
  *     attribute correctly; duplicate seeds collapse.
+ *   - Per-seed cap spends slots on unique neighbors, not duplicates an earlier
+ *     seed already pulled (recall at the cap).
  *   - `extraAdjacency` merges with the curated graph during traversal.
  *   - `extraAdjacency` bridges across hops (curated → extra → curated).
  *   - Cycles in the curated graph (and via extraAdjacency) terminate, bounded
@@ -491,6 +494,106 @@ describe("expandEdges — bounds", () => {
       { from: "people/alice", pulled: ["topics/alice-only", "topics/shared"] },
       { from: "people/bob", pulled: ["topics/bob-only", "topics/shared"] },
     ]);
+  });
+
+  test("a seed reachable from another seed is excluded from pulled", async () => {
+    // alice -> bob, and bob is itself a seed. bob is a confident hit in its own
+    // right, not a neighbor, so it must never appear in the pulled union — even
+    // though alice's outgoing walk reaches it. bob's own private neighbor is
+    // still pulled.
+    await writeGraph({
+      alice: ["bob"],
+      bob: ["carol"],
+      carol: [],
+    });
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "bob"],
+      hops: 1,
+    });
+
+    expect(pulled.has("bob")).toBe(false);
+    expect([...pulled].sort()).toEqual(["carol"]);
+    // alice reaches only bob, which is a seed, so alice contributes nothing.
+    expect(expansions).toEqual([
+      { from: "alice", pulled: [] },
+      { from: "bob", pulled: ["carol"] },
+    ]);
+  });
+
+  test("a seed two hops from another seed is still excluded from pulled", async () => {
+    // alice -> mid -> bob. With a 2-hop walk alice reaches bob, but bob is a
+    // seed and must not leak into pulled; the intermediate `mid` is a genuine
+    // neighbor and is kept.
+    await writeGraph({
+      alice: ["mid"],
+      mid: ["bob"],
+      bob: [],
+    });
+
+    const { pulled } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "bob"],
+      hops: 2,
+    });
+
+    expect(pulled.has("bob")).toBe(false);
+    expect([...pulled].sort()).toEqual(["mid"]);
+  });
+
+  test("per-seed cap is spent on unique neighbors, not duplicates", async () => {
+    // alice pulls 16 shared `dup/*` neighbors. bob reaches those same 16 dups
+    // plus 32 unique `fresh/*` neighbors. bob's per-seed budget is
+    // MAX_PULLS_PER_SEED (32) because the union is nowhere near the total cap.
+    //
+    // The old slice took bob's lexicographically-first 32 reached slugs — the
+    // 16 already-pulled dups plus only the first 16 fresh — wasting 16 budget
+    // slots on duplicates and dropping the other 16 unique neighbors. Filtering
+    // already-pulled slugs before the slice spends all 32 slots on fresh
+    // neighbors, so every unique one is retained (recall north star).
+    const dupCount = 16;
+    const freshCount = MAX_PULLS_PER_SEED; // 32, so old code drops 16 unique.
+    const dups: string[] = [];
+    const fresh: string[] = [];
+    const graph: Record<string, string[]> = {};
+    for (let i = 0; i < dupCount; i++) {
+      const slug = topicSlug("dup", i);
+      dups.push(slug);
+      graph[slug] = [];
+    }
+    for (let i = 0; i < freshCount; i++) {
+      const slug = topicSlug("fresh", i);
+      fresh.push(slug);
+      graph[slug] = [];
+    }
+    // "dup/*" sorts before "fresh/*", so the old front-of-list slice is exactly
+    // the 16 dups + first 16 fresh.
+    graph["alice"] = [...dups];
+    graph["bob"] = [...dups, ...fresh];
+    await writeGraph(graph);
+
+    const { pulled, expansions } = await expandEdges({
+      workspaceDir,
+      seeds: ["alice", "bob"],
+      hops: 1,
+    });
+
+    // All 32 unique fresh neighbors survive — none dropped to a duplicate slot.
+    for (const slug of fresh) expect(pulled.has(slug)).toBe(true);
+    // A unique neighbor the old code would have dropped (past the first 16) is
+    // now retained.
+    expect(pulled.has(topicSlug("fresh", freshCount - 1))).toBe(true);
+    // Union is the 16 dups + 32 fresh, all distinct.
+    expect(pulled.size).toBe(dupCount + freshCount);
+
+    // bob's budget (32 fresh slots) is fully spent on unique neighbors; the
+    // dups it also reaches stay in its trace for faithful attribution but did
+    // not consume the budget.
+    const bobExpansion = expansions.find((e) => e.from === "bob")!;
+    expect(bobExpansion.pulled).toEqual([...dups, ...fresh].sort());
+    // Every trace slug is genuinely in the union.
+    for (const slug of bobExpansion.pulled) expect(pulled.has(slug)).toBe(true);
   });
 });
 

--- a/assistant/src/memory/v3/edges.ts
+++ b/assistant/src/memory/v3/edges.ts
@@ -15,8 +15,9 @@
  * effective out-neighborhood of a node is `curated[node] ∪ extraAdjacency[node]`.
  *
  * The result is the union of every seed's reachable neighborhood (`pulled`,
- * with seeds themselves excluded) plus a per-seed `EdgeExpansion[]` trace so a
- * harness can attribute each pulled slug to the seed it came from.
+ * with the full seed set excluded — a seed reachable from another seed is still
+ * a seed, not a neighbor) plus a per-seed `EdgeExpansion[]` trace so a harness
+ * can attribute each pulled slug to the seed it came from.
  */
 
 import { getEdgeIndex, getReachable } from "../v2/edge-index.js";
@@ -171,10 +172,11 @@ function reachableMerged(
  * Expand a set of confident seed slugs to their 1–2 hop curated neighborhood.
  *
  * Each expanded seed produces one `EdgeExpansion { from, pulled }` entry (sorted
- * slugs for deterministic output); the seed itself is never in its own `pulled`.
- * The top-level `pulled` set is the union across all expanded seeds — a slug
- * pulled by more than one seed appears once there but in each contributing
- * seed's expansion.
+ * slugs for deterministic output); no seed ever appears in `pulled` — not its
+ * own entry and not another seed's, even when one seed is a neighbor of another
+ * (the seeds-excluded contract). The top-level `pulled` set is the union across
+ * all expanded seeds — a slug pulled by more than one seed appears once there
+ * but in each contributing seed's expansion.
  *
  * Bounded by {@link MAX_SEEDS_EXPANDED}, {@link MAX_PULLS_PER_SEED}, and
  * {@link MAX_TOTAL_PULLS} so a large seed union or a dense graph can't balloon
@@ -213,7 +215,14 @@ export async function expandEdges(
     );
   }
 
-  // De-dupe seeds while preserving (ranked) order for a stable trace.
+  // De-dupe seeds while preserving (ranked) order for a stable trace. The full
+  // de-duped seed set is also the exclusion set: a seed reachable from another
+  // seed is itself a confident hit, not a neighbor, so it must never land in
+  // `pulled` (the seeds-excluded contract) — `getReachable` only excludes the
+  // walk's own start node, so a B reachable from A would otherwise leak in.
+  const seedSet = new Set<string>();
+  for (const seed of orderedSeeds) seedSet.add(seed);
+
   const seenSeeds = new Set<string>();
 
   for (const seed of orderedSeeds) {
@@ -231,18 +240,30 @@ export async function expandEdges(
       ? reachableMerged(index.outgoing, extraAdjacency, seed, hops)
       : getReachable(index, seed, hops, "out");
 
-    // Per-seed fan-out cap, then trim to the union's remaining headroom so the
-    // total ceiling is hard (never overshot) and the trace entry lists exactly
-    // the slugs this seed contributed to the bounded union. Sorting first keeps
-    // truncation deterministic — a hub seed always yields the same slice. Slugs
-    // already pulled by an earlier seed don't consume headroom (the union Set
-    // de-dupes), so this is a conservative upper bound on what's admitted.
+    // Drop any other seed from this seed's neighborhood (seeds-excluded
+    // contract) and split the rest into slugs already in the union vs. fresh
+    // ones. The per-seed fan-out cap and the union's remaining headroom apply
+    // only to fresh slugs, so a slot is never spent on a duplicate an earlier
+    // seed already pulled — at the cap that would silently drop a unique
+    // neighbor. Sorting first keeps truncation deterministic. The trace lists
+    // every reached slug that made it into the bounded union (fresh admissions
+    // plus the duplicates this seed also reaches), so it stays a faithful
+    // attribution while the budget is reserved for new recall.
+    const sorted = [...reachable].sort();
+    const alreadyPulled = sorted.filter(
+      (slug) => !seedSet.has(slug) && pulled.has(slug),
+    );
+    const fresh = sorted.filter(
+      (slug) => !seedSet.has(slug) && !pulled.has(slug),
+    );
+
     const remaining = MAX_TOTAL_PULLS - pulled.size;
     const perSeedCap = Math.min(MAX_PULLS_PER_SEED, remaining);
-    const seedPulled = [...reachable].sort().slice(0, perSeedCap);
+    const admitted = fresh.slice(0, perSeedCap);
+    for (const slug of admitted) pulled.add(slug);
 
+    const seedPulled = [...alreadyPulled, ...admitted].sort();
     expansions.push({ from: seed, pulled: seedPulled });
-    for (const slug of seedPulled) pulled.add(slug);
   }
 
   return { pulled, expansions };


### PR DESCRIPTION
## Summary
- Edge expansion now subtracts the full seed set from `pulled`, honoring the seeds-excluded contract even when one seed is a neighbor of another.
- Near the cap, already-pulled/seed slugs are filtered before per-seed slicing, so cap slots are spent on unique neighbors instead of duplicates (improves recall).

## Original prompt
Fix two edge-expansion bugs in memory-v3: a seed reachable from another seed leaking into the pulled set, and per-seed slicing wasting cap slots on duplicate neighbors near the ~400 cap (dropping unique ones).