### PR TITLE
fix(memory-v3): gate shadow on trust and stop mis-attributing shadow rows

### DIFF
--- a/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -187,4 +187,35 @@ describe("memory-v2-activation-log-store", () => {
     expect(byTurn.get(2)!.messageId).toBe("msg-a");
     expect(byTurn.get(3)!.messageId).toBe("msg-b");
   });
+
+  test("backfill skips v3_shadow rows, leaving their messageId null", () => {
+    const conversationId = "conv-shadow-backfill";
+
+    // A live router row (null messageId) and a detached v3_shadow row (null
+    // messageId) coexist in the same conversation.
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 5,
+      mode: "router",
+      concepts: sampleConcepts,
+      config: sampleConfig,
+    });
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 5,
+      mode: "v3_shadow",
+      concepts: sampleConcepts,
+      config: sampleConfig,
+    });
+
+    backfillMemoryV2ActivationMessageId(conversationId, "msg-live");
+
+    const db = getDb();
+    const rows = db.select().from(memoryV2ActivationLogs).all();
+    const byMode = new Map(rows.map((r) => [r.mode, r]));
+    // The live router row got stamped; the shadow row stayed null (not
+    // mis-attributed to the live message).
+    expect(byMode.get("router")!.messageId).toBe("msg-live");
+    expect(byMode.get("v3_shadow")!.messageId).toBeNull();
+  });
 });

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNull, lte } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lte, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "./db-connection.js";
@@ -166,12 +166,16 @@ export function backfillMemoryV2ActivationMessageId(
   messageId: string,
 ): void {
   const db = getDb();
+  // `v3_shadow` rows are detached telemetry written outside the live turn with
+  // a null messageId; they are not tied to any specific message. Excluding them
+  // keeps their messageId null instead of stamping them with a later turn's id.
   db.update(memoryV2ActivationLogs)
     .set({ messageId })
     .where(
       and(
         eq(memoryV2ActivationLogs.conversationId, conversationId),
         isNull(memoryV2ActivationLogs.messageId),
+        ne(memoryV2ActivationLogs.mode, "v3_shadow"),
       ),
     )
     .run();

--- a/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-middleware.test.ts
@@ -35,6 +35,16 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
+// Mirror the real `isUntrustedTrustClass` predicate (anything that is not the
+// guardian is untrusted) without pulling the resolver's contact-store graph
+// into the test module set.
+mock.module("../../../runtime/actor-trust-resolver.js", () => ({
+  isUntrustedTrustClass: (trustClass: string | undefined) =>
+    trustClass === "trusted_contact" ||
+    trustClass === "unknown" ||
+    trustClass === undefined,
+}));
+
 // ── Mutable test doubles, rewired per test ───────────────────────────────
 
 /** Drives `config.memory.v3.{enabled,shadow}` and `historical_pairs`. */
@@ -131,10 +141,13 @@ function makeCtx(): TurnContext {
   };
 }
 
-function makeArgs(signal?: AbortSignal): MemoryArgs {
+function makeArgs(
+  signal?: AbortSignal,
+  trustContext: TrustContext | undefined = trust,
+): MemoryArgs {
   return {
     conversationId: "conv-shadow",
-    trustContext: trust,
+    trustContext,
     turnIndex: 3,
     signal: signal ?? new AbortController().signal,
   };
@@ -314,5 +327,72 @@ describe("memory-v3 shadow middleware", () => {
     await flush();
     expect(loopCalls.length).toBe(0);
     expect(logCalls.length).toBe(0);
+  });
+
+  test("untrusted actor → no v3 work, even with shadow on", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+
+    for (const trustClass of ["trusted_contact", "unknown"] as const) {
+      loopCalls.length = 0;
+      logCalls.length = 0;
+      const untrusted: TrustContext = { sourceChannel: "vellum", trustClass };
+      const result = await memoryV3ShadowMiddleware(
+        makeArgs(undefined, untrusted),
+        async () => DOWNSTREAM_RESULT,
+        makeCtx(),
+      );
+      expect(result).toBe(DOWNSTREAM_RESULT);
+
+      await flush();
+      // Untrusted turn never spends shadow retrieval LLM calls.
+      expect(loopCalls.length).toBe(0);
+      expect(logCalls.length).toBe(0);
+    }
+  });
+
+  test("absent trust context → treated as untrusted, no v3 work", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+
+    // Build args with an explicitly-undefined trustContext (the `makeArgs`
+    // default would substitute the guardian fixture, so construct directly).
+    const args: MemoryArgs = {
+      conversationId: "conv-shadow",
+      trustContext: undefined,
+      turnIndex: 3,
+      signal: new AbortController().signal,
+    };
+    const result = await memoryV3ShadowMiddleware(
+      args,
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+    expect(result).toBe(DOWNSTREAM_RESULT);
+
+    await flush();
+    expect(loopCalls.length).toBe(0);
+    expect(logCalls.length).toBe(0);
+  });
+
+  test("guardian actor → shadow runs (trust gate lets trusted turns through)", async () => {
+    v3Enabled = true;
+    v3Shadow = true;
+    const guardian: TrustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    };
+
+    const result = await memoryV3ShadowMiddleware(
+      makeArgs(undefined, guardian),
+      async () => DOWNSTREAM_RESULT,
+      makeCtx(),
+    );
+    expect(result).toBe(DOWNSTREAM_RESULT);
+
+    await flush();
+    // Trusted turn fires the v3 loop and logs its selection.
+    expect(loopCalls.length).toBe(1);
+    expect(logCalls.length).toBe(1);
   });
 });

--- a/assistant/src/memory/v3/shadow-middleware.ts
+++ b/assistant/src/memory/v3/shadow-middleware.ts
@@ -34,6 +34,7 @@ import {
   PluginExecutionError,
 } from "../../plugins/types.js";
 import type { ContentBlock } from "../../providers/types.js";
+import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import type { DrizzleDb } from "../db-connection.js";
@@ -283,12 +284,23 @@ async function runShadowAndLog(
  * Flag-gated INSIDE the middleware (per-turn, live-toggle): when v3 shadow is
  * off it is a pure pass-through. When on, it fires the v3 loop detached and
  * returns the unchanged downstream (v2) result immediately.
+ *
+ * The shadow loop spends filter + gate LLM calls, so — like the other
+ * guardian-trust background memory loops (`enqueueAutoAnalysisOnCompaction`,
+ * `enqueueMemoryRetrospectiveOnCompaction`) — it is gated on actor trust: an
+ * untrusted turn passes through without kicking off the v3 loop.
  */
 export const memoryV3ShadowMiddleware: Middleware<MemoryArgs, MemoryResult> =
   async function memoryV3Shadow(args, next) {
     const v3 = getConfig().memory.v3;
     if (!v3?.enabled || !v3?.shadow) {
       // Inert: byte-for-byte pass-through, zero extra work.
+      return next(args);
+    }
+
+    if (isUntrustedTrustClass(args.trustContext?.trustClass)) {
+      // Untrusted actor: don't spend shadow retrieval LLM calls — mirrors the
+      // live path's trust gate. Pure pass-through, no detached work.
       return next(args);
     }
 


### PR DESCRIPTION
## Summary
- The v3 shadow middleware now skips running LLM retrieval on untrusted turns (mirrors the live path's trust gate) instead of spending filter/gate calls unconditionally.
- The activation-log messageId backfill now excludes `mode='v3_shadow'` rows, so detached shadow telemetry is no longer stamped with (and mis-attributed to) a later turn's messageId.

## Original prompt
Fix two issues in v3 shadow logging: add a guardian-trust gate so detached shadow retrieval doesn't run LLM calls for untrusted turns, and exclude shadow rows from the messageId backfill so their null messageId isn't overwritten with a wrong message's id.