### PR TITLE
fix(assistant): include messageId on canned-response message_complete events (LUM-1902)

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -151,6 +151,34 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
   );
 }
 
+// ---------------------------------------------------------------------------
+// LUM-1902 temporary fix — remove when #31994 lands
+// ---------------------------------------------------------------------------
+//
+// The canned-response paths in this file (canned greeting, inline approval
+// reply, slash command, /compact, /clean) bypass the agent loop and so don't
+// pick up the per-turn anchor id allocated in conversation-agent-loop.ts.
+// Their `message_complete` events therefore went out without `messageId`, and
+// the macOS client filter at ChatActionHandler.swift:507 dropped those events
+// when they raced past the 50 ms streaming-buffer flush — leaving `isSending`
+// stuck for the full 60 s watchdog window. See LUM-1902.
+//
+// Centralized here so the patch surface is one helper + N one-line callers
+// rather than N duplicated literals. When #31994 lands and stamps these
+// sites with `state.assistantTurnId` directly, grep for
+// `emitCannedMessageComplete` to find every call site and inline-then-delete.
+function emitCannedMessageComplete(
+  send: (msg: ServerMessage) => void,
+  conversationId: string,
+  persistedAssistantId: string,
+): void {
+  send({
+    type: "message_complete",
+    conversationId,
+    messageId: persistedAssistantId,
+  });
+}
+
 /**
  * True when a message's persisted metadata explicitly flags it as hidden.
  * Used to suppress internal scaffolding messages from UI history while
@@ -404,7 +432,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
         ? "Decision applied."
         : "Request already resolved.");
     const assistantMessage = createAssistantMessage(replyText);
-    await addMessage(
+    const persistedAssistant = await addMessage(
       conversationId,
       "assistant",
       JSON.stringify(assistantMessage.content),
@@ -419,7 +447,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
         text: replyText,
         conversationId: conversationId,
       });
-      onEvent({ type: "message_complete", conversationId: conversationId });
+      emitCannedMessageComplete(onEvent, conversationId, persistedAssistant.id);
     }
     publishConversationMessagesChanged(conversationId, originClientId);
   } catch (err) {
@@ -1465,15 +1493,11 @@ export async function handleSendMessage(
           text: cannedGreeting,
           conversationId,
         });
-        // The macOS client filters `message_complete` events lacking a
-        // `messageId` while a turn is in flight (treats them as aux-style
-        // notifications), so a bare event would leave the 3-dot indicator
-        // stuck. LUM-1902.
-        broadcastMessage({
-          type: "message_complete",
+        emitCannedMessageComplete(
+          broadcastMessage,
           conversationId,
-          messageId: persistedAssistant.id,
-        });
+          persistedAssistant.id,
+        );
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.processing = false;
         silentlyWithLog(
@@ -1741,7 +1765,7 @@ export async function handleSendMessage(
       conversation.getMessages().push(llmMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      await addMessage(
+      const persistedAssistant = await addMessage(
         mapping.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
@@ -1796,10 +1820,11 @@ export async function handleSendMessage(
           text: message,
           conversationId,
         });
-        broadcastMessage({
-          type: "message_complete",
-          conversationId: conversationId,
-        });
+        emitCannedMessageComplete(
+          broadcastMessage,
+          conversationId,
+          persistedAssistant.id,
+        );
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.processing = false;
         silentlyWithLog(conversation.drainQueue(), "slash-command queue drain");
@@ -1873,7 +1898,7 @@ export async function handleSendMessage(
         const responseText = formatCompactResult(result);
 
         const assistantMsg = createAssistantMessage(responseText);
-        await addMessage(
+        const persistedAssistant = await addMessage(
           conversationId,
           "assistant",
           JSON.stringify(assistantMsg.content),
@@ -1887,7 +1912,11 @@ export async function handleSendMessage(
           text: responseText,
           conversationId,
         });
-        broadcastMessage({ type: "message_complete", conversationId });
+        emitCannedMessageComplete(
+          broadcastMessage,
+          conversationId,
+          persistedAssistant.id,
+        );
         publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
         if (assistantMessagePersisted) {
@@ -1957,7 +1986,7 @@ export async function handleSendMessage(
         const responseText = formatCleanResult(result);
 
         const assistantMsg = createAssistantMessage(responseText);
-        await addMessage(
+        const persistedAssistant = await addMessage(
           conversationId,
           "assistant",
           JSON.stringify(assistantMsg.content),
@@ -1971,7 +2000,11 @@ export async function handleSendMessage(
           text: responseText,
           conversationId,
         });
-        broadcastMessage({ type: "message_complete", conversationId });
+        emitCannedMessageComplete(
+          broadcastMessage,
+          conversationId,
+          persistedAssistant.id,
+        );
         publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
         if (assistantMessagePersisted) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1421,7 +1421,7 @@ export async function handleSendMessage(
       const conversationId = mapping.conversationId;
 
       const assistantMsg = createAssistantMessage(cannedGreeting);
-      await addMessage(
+      const persistedAssistant = await addMessage(
         mapping.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
@@ -1465,7 +1465,15 @@ export async function handleSendMessage(
           text: cannedGreeting,
           conversationId,
         });
-        broadcastMessage({ type: "message_complete", conversationId });
+        // The macOS client filters `message_complete` events lacking a
+        // `messageId` while a turn is in flight (treats them as aux-style
+        // notifications), so a bare event would leave the 3-dot indicator
+        // stuck. LUM-1902.
+        broadcastMessage({
+          type: "message_complete",
+          conversationId,
+          messageId: persistedAssistant.id,
+        });
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.processing = false;
         silentlyWithLog(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -152,21 +152,21 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
 }
 
 // ---------------------------------------------------------------------------
-// LUM-1902 temporary fix — remove when #31994 lands
+// Temporary fix — remove when #31994 lands
 // ---------------------------------------------------------------------------
 //
 // The canned-response paths in this file (canned greeting, inline approval
 // reply, slash command, /compact, /clean) bypass the agent loop and so don't
 // pick up the per-turn anchor id allocated in conversation-agent-loop.ts.
-// Their `message_complete` events therefore went out without `messageId`, and
-// the macOS client filter at ChatActionHandler.swift:507 dropped those events
-// when they raced past the 50 ms streaming-buffer flush — leaving `isSending`
-// stuck for the full 60 s watchdog window. See LUM-1902.
+// Their `message_complete` events therefore went out without `messageId`,
+// and the macOS client filter at ChatActionHandler.swift:507 dropped those
+// events when they raced past the 50 ms streaming-buffer flush — leaving
+// `isSending` stuck for the full 60 s watchdog window.
 //
-// Centralized here so the patch surface is one helper + N one-line callers
-// rather than N duplicated literals. When #31994 lands and stamps these
-// sites with `state.assistantTurnId` directly, grep for
-// `emitCannedMessageComplete` to find every call site and inline-then-delete.
+// Centralized so the patch surface is one helper + N one-line callers rather
+// than N duplicated literals. When #31994 lands and stamps these sites with
+// `state.assistantTurnId` directly, grep for `emitCannedMessageComplete` to
+// find every call site and inline-then-delete.
 function emitCannedMessageComplete(
   send: (msg: ServerMessage) => void,
   conversationId: string,


### PR DESCRIPTION
## Summary

Quick fix for [LUM-1902](https://linear.app/vellum/issue/LUM-1902/initial-hatch-can-leave-chat-stuck-in-busy-or-empty-draft-state). The reported symptom (3-dot loading indicator stuck after initial hatch) is one instance of a broader class — five paths in `conversation-routes.ts` that bypass the agent loop and emit `message_complete` without `messageId`, hitting a race with the macOS streaming-buffer flush:

- canned first greeting (`:1451`) — the reported case, hit by every new user on hatch
- inline approval reply (`:422`)
- slash command output (`:1774`)
- `/compact` (`:1855`)
- `/clean` (`:1855`)

All five capture the persisted assistant row id and pass `messageId` to the broadcast. Centralized into a single `emitCannedMessageComplete` helper so the temporary patch is one helper + five one-line call sites, easy to grep and remove when [#31994](https://github.com/vellum-ai/vellum-assistant/pull/31994) lands (see "Relationship to #31994" below).

## Why it's stuck — actual causal chain (race, not deterministic)

The bug only manifests when SSE events are delivered far enough apart for a 50 ms timer to fire between them — heavier daemon work between events (onboarding artifact persistence, telemetry, `forceCompact()`, `forceClean()`, etc.) reliably hits that window.

1. User triggers one of the canned paths → `isSending = true` → 3-dot indicator renders.
2. Server persists messages, returns `202`, then broadcasts `user_message_echo` → `assistant_text_delta` → `message_complete`.
3. `handleAssistantTextDelta` (`ChatActionHandler.swift:463`):
   - sets `isThinking = false` (line 484)
   - **buffers** text into `streamingDeltaBuffer` and calls `scheduleStreamingFlush()` — a 50 ms timer (`ChatViewModel.swift:916`)
   - does **not** create the streaming bubble yet; `currentAssistantMessageId` stays nil until the flush fires
4. `handleMessageComplete` arrives. Filter at `ChatActionHandler.swift:507`:
   ```swift
   if (complete.messageId == nil || complete.source == "aux") && (vm.currentAssistantMessageId != nil || vm.isThinking) {
       return
   }
   ```
   - **<50 ms gap (delta → complete)**: flush hasn't fired → `currentAssistantMessageId == nil` and `isThinking == false` → guard's second clause is false → guard does **not** fire → handler proceeds. ✓
   - **≥50 ms gap**: flush has fired → `currentAssistantMessageId` is set → guard fires → terminal cleanup is skipped → `isSending` stays true until the 60-s watchdog at `ChatViewModel.swift:328`. ✗

No recovery on the canned paths: the normal agent loop emits `assistant_activity_state{phase:idle}` which runs its own cleanup and schedules a 5-s `scheduleIdleFallbackCleanup()` (`ChatActionHandler.swift:1583`). The canned paths emit neither, so the 60-s watchdog is the only safety net.

Populating `messageId` flips the guard's first clause to false regardless of timing, the guard no longer fires, `isSending` clears.

## Scope decisions

**Why include the other four sites:** Same bug class, same trivial 2-line shape, and `/compact`'s "everything froze right after I compacted a long chat" UX is particularly bad. Inline approval, slash, `/clean` are lower-frequency but identical-cost fixes. All five live in the same file, so we end up with one helper + five callers.

**Why a single helper:** Per [reviewer guidance], temporary fixes should be confined to easy-to-rip-out surfaces. `emitCannedMessageComplete` carries the full LUM-1902 context comment in one place; each call site is a one-liner. When #31994 lands, `grep emitCannedMessageComplete` finds every site, and the inline-then-delete is mechanical.

**Why not the wake-target adapter:** Same bug shape but **not** a quick fix. `AgentEvent.message_complete` (`agent/loop.ts:121-124`) carries `{ type, message }` — there's no persisted id to forward at the point of relay. Needs the pre-allocated anchor pattern (same approach #31994 took for the loop path, explicitly deferred for wakes via `TODO(PR-2b-followup)`). Tracked in LUM-1904.

## Relationship to PR #31994 (apollo workstream)

[#31994 (draft)](https://github.com/vellum-ai/vellum-assistant/pull/31994) "assistant,web: pre-allocate assistant turn anchor id + stamp SSE events (PR 2b)" pre-allocates an `assistantTurnId` at agent-loop entry and stamps every assistant-channel event (including `message_complete`) with that anchor id. Its scope explicitly includes the same five `conversation-routes.ts` emit sites.

When #31994 lands it subsumes this PR entirely. The diff will conflict at the five call sites; resolution is mechanical (delete the helper + each `emitCannedMessageComplete(...)` call, take their stamped `state.assistantTurnId` version). [I posted a heads-up on #31994.](https://github.com/vellum-ai/vellum-assistant/pull/31994#issuecomment-4547655321)

This PR exists because #31994 is still in draft and LUM-1902 is hitting every new user on hatch — we need something we can ship on the next daemon roll.

## Web impact: none

The web client's `handleMessageComplete` (`apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts:86`) has no `messageId`-based filter — it always calls `completeTurn()`. Adding `messageId` to these events is a no-op for web: `finalizeMessageComplete` (`stream-message-updaters.ts:173-210`) keeps `tail.id` when an assistant bubble is already streaming, so `event.messageId` is unused on these paths.

## Recent area history checked

- **#32057 (0c1695a)** `fix(web): isSending honors activeTurnId so thinking indicator survives stale terminal events` — adjacent web turn-store fix, doesn't touch server or macOS.
- **#32024 (871b0d6)** chat refactor that extracted `ChatActionHandler.swift`; carried the filter forward unchanged.
- **#31994 (apollo PR 2b, draft)** — broader anchor-id refactor that will subsume this fix at all five sites when it lands.
- Filter provenance: PR #23075 narrowed the guard from `isSending` to `currentAssistantMessageId`; #23145 extended it to cover the thinking phase; #25539 added the `source == "aux"` clause. The `messageId == nil` heuristic is a load-bearing artifact from that evolution.

## Risk

- Adds a previously-omitted optional field to one event type at five call sites. Both Swift (`MessageComplete.messageId: String?`) and TS schemas already model `messageId?`. Zero compatibility risk.
- No client release needed — ships on next daemon update.

## Out of scope

- Wake-target adapter (`wake-target-adapter.ts:130`) — needs anchor-id pattern, not a quick fix. Tracked in [LUM-1904](https://linear.app/vellum/issue/LUM-1904/tighten-message-complete-contract-enforce-messageid-on-all-main-turn).
- Removing the brittle `messageId == nil` heuristic from the macOS Swift filter — tracked in LUM-1904 (becomes moot post Electron cutover #32081).
- LUM-1902 feedback bundle #2 (empty-draft "creating new chat") — confirmed mechanically correct; UX-perception issue worth a separate ticket.

## Test plan

- [ ] Manual: fresh hatch → initial greeting completes → 3-dot indicator disappears immediately (not after 60-s watchdog).
- [ ] Manual: `/compact` on a long chat → indicator clears immediately on completion.
- [ ] Manual: regression — normal LLM turn after a canned-response path still terminates correctly.
- [ ] Manual: regression — aux events (call notifier completions) still don't stomp main turn state.
- [x] `bunx tsc --noEmit` passes for `assistant/`.

https://claude.ai/code/session_01TtNewUqyRWwaE9eRo1QMZk