### PR TITLE
fix(memory-v3): harden config/route schemas and tree validator

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11900,6 +11900,7 @@ paths:
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
                 lanes:
+                  minItems: 1
                   type: array
                   items:
                     type: string

--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -272,6 +272,20 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed.denseQuota).toEqual({ activeDomain: 50, offDomain: 12 });
   });
 
+  test("accepts a partial denseQuota override and defaults the rest", () => {
+    // Overriding only one leaf must merge with defaults, not fail validation
+    // (which would discard the entire user config).
+    const onlyActive = MemoryV3ConfigSchema.parse({
+      denseQuota: { activeDomain: 50 },
+    });
+    expect(onlyActive.denseQuota).toEqual({ activeDomain: 50, offDomain: 8 });
+
+    const onlyOff = MemoryV3ConfigSchema.parse({
+      denseQuota: { offDomain: 12 },
+    });
+    expect(onlyOff.denseQuota).toEqual({ activeDomain: 30, offDomain: 12 });
+  });
+
   test("accepts a partial lanes override and defaults the rest", () => {
     const parsed = MemoryV3ConfigSchema.parse({ lanes: { dense: false } });
     expect(parsed.lanes).toEqual({

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -466,11 +466,13 @@ export const MemoryV3ConfigSchema = z
           .number({
             error: "memory.v3.denseQuota.activeDomain must be a number",
           })
+          .default(30)
           .describe(
             "Dense-lane candidate quota allocated to the conversation's active domain.",
           ),
         offDomain: z
           .number({ error: "memory.v3.denseQuota.offDomain must be a number" })
+          .default(8)
           .describe(
             "Dense-lane candidate quota allocated to off-domain (exploratory) retrieval.",
           ),

--- a/assistant/src/memory/v3/__tests__/validate.test.ts
+++ b/assistant/src/memory/v3/__tests__/validate.test.ts
@@ -178,6 +178,38 @@ describe("validateTree — cycles", () => {
 
     expect(report.cycles).toEqual([]);
   });
+
+  test("detects a cycle in a component unreachable from the root", async () => {
+    // _root is a leaf with no edges; the x ↔ y cycle lives in a disconnected
+    // component the root can never reach. The sweep over unvisited nodes must
+    // still surface it.
+    await writeNode(workspaceDir, node(ROOT_NODE_ID, []));
+    await writeNode(workspaceDir, node("x", ["node:y"]));
+    await writeNode(workspaceDir, node("y", ["node:x"]));
+    resetCaches();
+
+    const report = await validateTree(workspaceDir);
+
+    expect(report.cycleCount).toBe(1);
+    // The back-edge closes on whichever of the pair the sweep enters second.
+    const [{ from, to }] = report.cycles;
+    expect(new Set([from, to])).toEqual(new Set(["x", "y"]));
+  });
+
+  test("a page off an unreachable cyclic node stays an orphan", async () => {
+    // The disconnected-component sweep covers x/y for cycle detection but must
+    // not mark them root-reachable — `detached` therefore remains an orphan.
+    await writeNode(workspaceDir, node(ROOT_NODE_ID, []));
+    await writeNode(workspaceDir, node("x", ["node:y", "page:detached"]));
+    await writeNode(workspaceDir, node("y", ["node:x"]));
+    await writePage(workspaceDir, page("detached"));
+    resetCaches();
+
+    const report = await validateTree(workspaceDir);
+
+    expect(report.cycleCount).toBe(1);
+    expect(report.orphanPages).toEqual(["detached"]);
+  });
 });
 
 describe("validateTree — staleIndex", () => {

--- a/assistant/src/memory/v3/validate.ts
+++ b/assistant/src/memory/v3/validate.ts
@@ -134,58 +134,81 @@ function nodeChildrenOf(tree: TreeIndex, nodeId: string): string[] {
 }
 
 /**
- * Full DFS over `node:` adjacency from `tree.root`. Returns the set of
- * reachable node ids (for orphan-page reachability) and the back-edges that
- * close a cycle. A back-edge is an edge into a node still on the active
- * recursion stack (classic gray-node cycle detection); `visited` (black)
- * prevents re-walking shared DAG sub-nodes.
+ * Full DFS over `node:` adjacency. Returns the set of nodes reachable from
+ * `tree.root` (for orphan-page reachability) and the back-edges that close a
+ * cycle. A back-edge is an edge into a node still on the active recursion stack
+ * (classic gray-node cycle detection); `visited` (black) prevents re-walking
+ * shared DAG sub-nodes.
+ *
+ * The walk runs in two phases. The first seeds from the root and records every
+ * node it reaches in `reachableNodes`. The second sweeps any node still
+ * unvisited — a disconnected component that the root cannot reach — so cycles
+ * living entirely outside the root's reach are still reported. Sweep-only nodes
+ * are deliberately kept out of `reachableNodes`: they are *not* reachable from
+ * the root, and pages hanging off them must still surface as orphans.
  */
 function descend(tree: TreeIndex): {
   reachableNodes: Set<string>;
   cycles: Array<{ from: string; to: string }>;
 } {
   const reachableNodes = new Set<string>();
-  const onStack = new Set<string>();
+  const visited = new Set<string>();
   const cycles: Array<{ from: string; to: string }> = [];
 
   // Iterative DFS with an explicit stack so deep trees don't blow the call
   // stack. Each frame tracks its child cursor; we push a child frame, and on
   // exhaustion pop the parent off the recursion stack (`onStack`).
   type Frame = { node: string; children: string[]; cursor: number };
-  const stack: Frame[] = [];
 
-  function enter(nodeId: string): void {
-    reachableNodes.add(nodeId);
-    onStack.add(nodeId);
-    stack.push({
-      node: nodeId,
-      children: nodeChildrenOf(tree, nodeId),
-      cursor: 0,
-    });
+  function walkFrom(start: string, trackReachable: boolean): void {
+    const onStack = new Set<string>();
+    const stack: Frame[] = [];
+
+    function enter(nodeId: string): void {
+      visited.add(nodeId);
+      if (trackReachable) reachableNodes.add(nodeId);
+      onStack.add(nodeId);
+      stack.push({
+        node: nodeId,
+        children: nodeChildrenOf(tree, nodeId),
+        cursor: 0,
+      });
+    }
+
+    enter(start);
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      if (frame.cursor >= frame.children.length) {
+        onStack.delete(frame.node);
+        stack.pop();
+        continue;
+      }
+      const child = frame.children[frame.cursor++];
+      if (onStack.has(child)) {
+        // Edge into an ancestor still on the stack → cycle-closing back-edge.
+        cycles.push({ from: frame.node, to: child });
+        continue;
+      }
+      if (visited.has(child)) {
+        // Already fully explored (shared DAG sub-node or an earlier sweep).
+        continue;
+      }
+      enter(child);
+    }
   }
 
   if (tree.nodes.has(tree.root)) {
-    enter(tree.root);
+    walkFrom(tree.root, true);
   }
 
-  while (stack.length > 0) {
-    const frame = stack[stack.length - 1];
-    if (frame.cursor >= frame.children.length) {
-      onStack.delete(frame.node);
-      stack.pop();
-      continue;
+  // Cover nodes the root never reached (disconnected components) so a cycle
+  // among them is not silently missed. These are not root-reachable, so their
+  // pages stay eligible for the orphan-page report.
+  for (const nodeId of tree.nodes.keys()) {
+    if (!visited.has(nodeId)) {
+      walkFrom(nodeId, false);
     }
-    const child = frame.children[frame.cursor++];
-    if (onStack.has(child)) {
-      // Edge into an ancestor still on the stack → cycle-closing back-edge.
-      cycles.push({ from: frame.node, to: child });
-      continue;
-    }
-    if (reachableNodes.has(child)) {
-      // Already fully explored via another parent (shared DAG sub-node).
-      continue;
-    }
-    enter(child);
   }
 
   cycles.sort(

--- a/assistant/src/runtime/routes/__tests__/memory-v3-simulate-params.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v3-simulate-params.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Schema tests for the `memory_v3_simulate` route request params.
+ *
+ * Focus: the `lanes` allowlist. Omitting it inherits the live lane toggles, but
+ * an explicit empty array would force every lane off — a guaranteed no-op gate
+ * LLM call — so it must be rejected at the schema. A non-empty allowlist and an
+ * omitted `lanes` both parse.
+ *
+ * Pure schema test: no `mock.module`, so it is safe to run alongside others.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { MemoryV3SimulateParams } from "../memory-v3-routes.js";
+
+describe("MemoryV3SimulateParams — lanes", () => {
+  test("rejects an empty lanes array", () => {
+    expect(() =>
+      MemoryV3SimulateParams.parse({ query: "x", lanes: [] }),
+    ).toThrow();
+  });
+
+  test("accepts a non-empty lanes allowlist", () => {
+    const parsed = MemoryV3SimulateParams.parse({
+      query: "x",
+      lanes: ["tree", "edges"],
+    });
+    expect(parsed.lanes).toEqual(["tree", "edges"]);
+  });
+
+  test("accepts an omitted lanes (inherits live toggles)", () => {
+    const parsed = MemoryV3SimulateParams.parse({ query: "x" });
+    expect(parsed.lanes).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -133,7 +133,7 @@ async function handleTree({
 /** The five v3 retrieval lanes, in fanout order. */
 const V3_LANE_NAMES = ["hot", "sparse", "dense", "tree", "edges"] as const;
 
-const MemoryV3SimulateParams = z
+export const MemoryV3SimulateParams = z
   .object({
     /** The ad-hoc user query to route a single synthetic turn against. */
     query: z.string().min(1, "memory.v3.simulate query must be non-empty"),
@@ -152,7 +152,10 @@ const MemoryV3SimulateParams = z
      * Restrict the run to this allowlist of lanes (others forced off). Omit to
      * inherit the live `memory.v3.lanes` toggles.
      */
-    lanes: z.array(z.enum(V3_LANE_NAMES)).optional(),
+    lanes: z
+      .array(z.enum(V3_LANE_NAMES))
+      .min(1, "memory.v3.simulate lanes must list at least one lane")
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Partial `denseQuota` config overrides now merge with defaults instead of discarding the whole user config (defaulted the nested `activeDomain`/`offDomain` leaves; effective defaults unchanged at 30/8).
- Tree validator now detects cycles in components unreachable from the root (DFS sweep from all still-unvisited nodes after the root-seeded walk). Sweep-only nodes are kept out of `reachableNodes`, so orphan-page detection is unchanged.
- Simulate route rejects an empty `lanes` array (`.min(1)`), avoiding a guaranteed no-op gate LLM call; OpenAPI regenerated (only diff: `minItems: 1` on the simulate request `lanes`).

## Not included
- The proposed tree-node `children` ref-prefix tightening was **dropped**. `TreeNodeFrontmatterSchema` is the shared read+write schema (`readNode`/`writeNode`/`parseNodeContent`/`renderNodeContent` all `.parse` through it). Tightening it would throw on reading existing on-disk nodes that carry a malformed ref — a backwards-compat hazard mid-migration — and it contradicts the existing intentional design in `tree-index.ts`, which deliberately *drops* malformed refs with a warning (and has a passing test asserting that). Enforcing the prefix correctly belongs at the index layer, not the persisted schema, and that file is out of scope here.

## Original prompt
Harden memory-v3 input validation: make partial denseQuota overrides valid, detect disconnected-component cycles in the tree validator, require well-formed child refs, and reject empty simulate lane lists at the schema.