### PR TITLE
fix(web/settings): poll healthz after resize so CPU/memory allocation updates

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -126,12 +126,17 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     void fetchHealthz();
   }, [fetchHealthz]);
 
-  // Cancel any in-flight resize poll on unmount.
+  // Cancel any in-flight resize poll when the active assistant changes or on
+  // unmount. Otherwise a poll started for the previous assistant keeps writing
+  // its health data into the new assistant's view and holds its resize controls
+  // disabled until the timeout (reproducible when switching assistants with
+  // multiPlatformAssistant enabled).
   useEffect(() => {
     return () => {
       pollIdRef.current += 1;
+      setHealthzPolling(false);
     };
-  }, []);
+  }, [assistantId]);
 
   const refetch = useCallback(async () => {
     await refetchAssistant();

--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -126,15 +126,17 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     void fetchHealthz();
   }, [fetchHealthz]);
 
-  // Cancel any in-flight resize poll when the active assistant changes or on
-  // unmount. Otherwise a poll started for the previous assistant keeps writing
-  // its health data into the new assistant's view and holds its resize controls
-  // disabled until the timeout (reproducible when switching assistants with
-  // multiPlatformAssistant enabled).
+  // When the active assistant changes (or on unmount), cancel any in-flight
+  // resize poll and drop the previous assistant's cached health. Without the
+  // cancel, a poll for the previous assistant keeps writing its data and holds
+  // its resize controls disabled; without clearing `healthz`, the cards would
+  // render the previous assistant's CPU/memory/disk until the new fetch
+  // resolves (both reproducible when switching with multiPlatformAssistant).
   useEffect(() => {
     return () => {
       pollIdRef.current += 1;
       setHealthzPolling(false);
+      setHealthz(null);
     };
   }, [assistantId]);
 

--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -26,16 +26,15 @@ const HEALTHZ_POLL_TIMEOUT_MS = 90_000;
 
 /**
  * True when the reported CPU/memory allocation differs from `baseline` — i.e.
- * a resize has actually landed. Treats a missing reading on either side as a
- * change so the poll resolves once real data returns after the restart.
+ * a resize has actually landed.
  */
 function allocationChanged(
   next: AssistantHealthz,
-  baseline: AssistantHealthz | null,
+  baseline: AssistantHealthz,
 ): boolean {
   return (
-    (next.memory?.maxMb ?? null) !== (baseline?.memory?.maxMb ?? null) ||
-    (next.cpu?.maxCores ?? null) !== (baseline?.cpu?.maxCores ?? null)
+    (next.memory?.maxMb ?? null) !== (baseline.memory?.maxMb ?? null) ||
+    (next.cpu?.maxCores ?? null) !== (baseline.cpu?.maxCores ?? null)
   );
 }
 
@@ -150,6 +149,11 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
       const pollId = ++pollIdRef.current;
       const deadline = Date.now() + HEALTHZ_POLL_TIMEOUT_MS;
       setHealthzPolling(true);
+      // `baseline` is null when metrics weren't loaded yet at resize time. In
+      // that case the first reading could still be pre-resize values, so we
+      // can't treat it as the resized allocation — adopt it as the baseline and
+      // keep polling until it changes instead.
+      let reference = baseline;
       try {
         // The machine-size tag comes from the assistant record, which the
         // platform updates synchronously during resize — refresh it up front.
@@ -161,7 +165,12 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
           if (pollId !== pollIdRef.current) return;
           const data = await fetchHealthz({ keepStaleOnError: true });
           if (pollId !== pollIdRef.current) return;
-          if (data && allocationChanged(data, baseline)) return;
+          if (!data) continue;
+          if (reference == null) {
+            reference = data;
+            continue;
+          }
+          if (allocationChanged(data, reference)) return;
         }
       } finally {
         if (pollId === pollIdRef.current) setHealthzPolling(false);

--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -18,12 +18,41 @@ import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-ver
 
 const CURRENT_ASSISTANT_QUERY_KEY = ["currentAssistant"] as const;
 
+// A resize rolls the assistant pod, so the new allocation only appears once it
+// comes back up. Poll /v1/health for a bounded window, tolerating the restart
+// gap where the endpoint is briefly unreachable.
+const HEALTHZ_POLL_INTERVAL_MS = 4_000;
+const HEALTHZ_POLL_TIMEOUT_MS = 90_000;
+
+/**
+ * True when the reported CPU/memory allocation differs from `baseline` — i.e.
+ * a resize has actually landed. Treats a missing reading on either side as a
+ * change so the poll resolves once real data returns after the restart.
+ */
+function allocationChanged(
+  next: AssistantHealthz,
+  baseline: AssistantHealthz | null,
+): boolean {
+  return (
+    (next.memory?.maxMb ?? null) !== (baseline?.memory?.maxMb ?? null) ||
+    (next.cpu?.maxCores ?? null) !== (baseline?.cpu?.maxCores ?? null)
+  );
+}
+
 export interface AssistantWithHealthz {
   assistant: Assistant | null;
   assistantLoading: boolean;
   healthz: AssistantHealthz | null;
   healthzLoading: boolean;
+  /** True while a post-resize poll is waiting for the new allocation to appear. */
+  healthzPolling: boolean;
   refetch: () => Promise<void>;
+  /**
+   * Refetch repeatedly until the reported CPU/memory allocation differs from
+   * `baseline` (the resize has landed) or a timeout elapses. Tolerates the
+   * pod-restart window where /v1/health is briefly unreachable.
+   */
+  refetchUntilResized: (baseline: AssistantHealthz | null) => Promise<void>;
 }
 
 export function useAssistantWithHealthz(): AssistantWithHealthz {
@@ -43,48 +72,106 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
 
   const [healthz, setHealthz] = useState<AssistantHealthz | null>(null);
   const [healthzLoading, setHealthzLoading] = useState(false);
+  const [healthzPolling, setHealthzPolling] = useState(false);
   const healthzRequestIdRef = useRef(0);
+  // Bumped to supersede any in-flight resize poll (a new poll, or unmount).
+  const pollIdRef = useRef(0);
 
-  const fetchHealthz = useCallback(async () => {
-    if (!assistantId) {
-      setHealthz(null);
-      setHealthzLoading(false);
-      return;
-    }
-    healthzRequestIdRef.current += 1;
-    const requestId = healthzRequestIdRef.current;
-    setHealthzLoading(true);
-    try {
-      const result = await getAssistantHealthz(assistantId);
-      if (requestId !== healthzRequestIdRef.current) return;
-      setHealthz(result.ok ? result.data : null);
-    } catch (error) {
-      if (requestId !== healthzRequestIdRef.current) return;
-      setHealthz(null);
-      const isNetworkError =
-        error instanceof TypeError &&
-        /failed to fetch|load failed|networkerror/i.test(error.message);
-      if (!isNetworkError) {
-        reportError(error, {
-          context: "fetch_assistant_healthz",
-          userMessage: "Failed to load assistant info",
-        });
+  const fetchHealthz = useCallback(
+    async (
+      opts?: { keepStaleOnError?: boolean },
+    ): Promise<AssistantHealthz | null> => {
+      if (!assistantId) {
+        setHealthz(null);
+        setHealthzLoading(false);
+        return null;
       }
-    } finally {
-      if (requestId === healthzRequestIdRef.current) setHealthzLoading(false);
-    }
-  }, [assistantId]);
+      healthzRequestIdRef.current += 1;
+      const requestId = healthzRequestIdRef.current;
+      setHealthzLoading(true);
+      try {
+        const result = await getAssistantHealthz(assistantId);
+        if (requestId !== healthzRequestIdRef.current) return null;
+        if (result.ok) {
+          setHealthz(result.data);
+          return result.data;
+        }
+        // While polling through a resize restart, keep the last-known values
+        // rather than blanking the card on a transient non-200.
+        if (!opts?.keepStaleOnError) setHealthz(null);
+        return null;
+      } catch (error) {
+        if (requestId !== healthzRequestIdRef.current) return null;
+        if (!opts?.keepStaleOnError) setHealthz(null);
+        const isNetworkError =
+          error instanceof TypeError &&
+          /failed to fetch|load failed|networkerror/i.test(error.message);
+        // Transient unreachability during a resize restart is expected — don't
+        // report it while polling.
+        if (!isNetworkError && !opts?.keepStaleOnError) {
+          reportError(error, {
+            context: "fetch_assistant_healthz",
+            userMessage: "Failed to load assistant info",
+          });
+        }
+        return null;
+      } finally {
+        if (requestId === healthzRequestIdRef.current) setHealthzLoading(false);
+      }
+    },
+    [assistantId],
+  );
 
   useEffect(() => {
     void fetchHealthz();
   }, [fetchHealthz]);
+
+  // Cancel any in-flight resize poll on unmount.
+  useEffect(() => {
+    return () => {
+      pollIdRef.current += 1;
+    };
+  }, []);
 
   const refetch = useCallback(async () => {
     await refetchAssistant();
     await fetchHealthz();
   }, [refetchAssistant, fetchHealthz]);
 
-  return { assistant, assistantLoading, healthz, healthzLoading, refetch };
+  const refetchUntilResized = useCallback(
+    async (baseline: AssistantHealthz | null) => {
+      const pollId = ++pollIdRef.current;
+      const deadline = Date.now() + HEALTHZ_POLL_TIMEOUT_MS;
+      setHealthzPolling(true);
+      try {
+        // The machine-size tag comes from the assistant record, which the
+        // platform updates synchronously during resize — refresh it up front.
+        void refetchAssistant();
+        while (Date.now() < deadline && pollId === pollIdRef.current) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, HEALTHZ_POLL_INTERVAL_MS),
+          );
+          if (pollId !== pollIdRef.current) return;
+          const data = await fetchHealthz({ keepStaleOnError: true });
+          if (pollId !== pollIdRef.current) return;
+          if (data && allocationChanged(data, baseline)) return;
+        }
+      } finally {
+        if (pollId === pollIdRef.current) setHealthzPolling(false);
+      }
+    },
+    [fetchHealthz, refetchAssistant],
+  );
+
+  return {
+    assistant,
+    assistantLoading,
+    healthz,
+    healthzLoading,
+    healthzPolling,
+    refetch,
+    refetchUntilResized,
+  };
 }
 
 export interface AssistantStatusPanelProps {

--- a/apps/web/src/domains/settings/components/resize-card.tsx
+++ b/apps/web/src/domains/settings/components/resize-card.tsx
@@ -99,17 +99,24 @@ export function ResizeCard({
 
   const resizeMutation = useMutation({
     ...assistantsResizeMutation(),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       toast.success("Resize started. Changes will apply shortly.", {
         id: "assistant-resize",
       });
       setResizeError(null);
       setSelectedSize(null);
       setResizeModalOpen(false);
-      // The resize rolls the pod asynchronously, so a single immediate refetch
-      // would just re-read the pre-resize values. Poll against the current
-      // allocation as a baseline until the new size lands.
-      void refetchUntilResized(healthz);
+      if (variables.body?.machine_size != null) {
+        // A machine resize rolls the pod asynchronously, so a single immediate
+        // refetch would just re-read the pre-resize CPU/memory. Poll against the
+        // current allocation as a baseline until the new size lands.
+        void refetchUntilResized(healthz);
+      } else {
+        // Storage-only resize: CPU/memory don't change (and the disk ceiling is
+        // driven off the provisioned quota, not healthz), so the allocation poll
+        // would never resolve. A single refresh is enough.
+        void refetch();
+      }
     },
     onError: (error) => {
       setResizeError(

--- a/apps/web/src/domains/settings/components/resize-card.tsx
+++ b/apps/web/src/domains/settings/components/resize-card.tsx
@@ -32,14 +32,20 @@ export interface ResizeCardProps {
   assistant: Assistant;
   healthz: AssistantHealthz | null;
   healthzLoading: boolean;
+  /** True while a post-resize poll is waiting for the new allocation to appear. */
+  healthzPolling: boolean;
   refetch: () => Promise<void> | void;
+  /** Poll /v1/health until the allocation changes from `baseline` after a resize. */
+  refetchUntilResized: (baseline: AssistantHealthz | null) => Promise<void> | void;
 }
 
 export function ResizeCard({
   assistant,
   healthz,
   healthzLoading,
+  healthzPolling,
   refetch,
+  refetchUntilResized,
 }: ResizeCardProps) {
   const navigate = useNavigate();
   const subscriptionQuery = useQuery(
@@ -100,7 +106,10 @@ export function ResizeCard({
       setResizeError(null);
       setSelectedSize(null);
       setResizeModalOpen(false);
-      void refetch();
+      // The resize rolls the pod asynchronously, so a single immediate refetch
+      // would just re-read the pre-resize values. Poll against the current
+      // allocation as a baseline until the new size lands.
+      void refetchUntilResized(healthz);
     },
     onError: (error) => {
       setResizeError(
@@ -141,7 +150,9 @@ export function ResizeCard({
     allowedSizes.length > 0 &&
     machineSizeRank(currentSize) < machineSizeRank(allowedSizes[allowedSizes.length - 1]);
 
-  const isLoading = resizeMutation.isPending;
+  // Keep resize CTAs disabled while the post-resize poll is in flight so the
+  // user can't kick off a second resize before the first lands.
+  const isLoading = resizeMutation.isPending || healthzPolling;
 
   // Fall back to the filesystem total only when no quota is known (free plan).
   const diskMaxMb =
@@ -228,15 +239,19 @@ export function ResizeCard({
             variant="ghost"
             size="compact"
             iconOnly={
-              healthzLoading ? (
+              healthzLoading || healthzPolling ? (
                 <Loader2 className="animate-spin" />
               ) : (
                 <RefreshCw />
               )
             }
-            tooltip="Refresh resource metrics"
+            tooltip={
+              healthzPolling
+                ? "Applying resize…"
+                : "Refresh resource metrics"
+            }
             aria-label="Refresh resource metrics"
-            disabled={healthzLoading}
+            disabled={healthzLoading || healthzPolling}
             onClick={() => void refetch()}
           />
         }
@@ -259,16 +274,16 @@ export function ResizeCard({
               <span className="text-label-medium-default text-[var(--content-tertiary)]">
                 Storage
               </span>
-              {healthzLoading ? (
-                <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                </div>
-              ) : diskBar ? (
+              {diskBar ? (
                 <CapacityBar
                   value={diskBar.value}
                   max={diskBar.max}
                   caption={diskBar.caption}
                 />
+              ) : healthzLoading ? (
+                <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                </div>
               ) : (
                 <span className="text-label-medium-default text-[var(--content-tertiary)]">
                   Unavailable
@@ -296,16 +311,16 @@ export function ResizeCard({
                 <span className="text-label-medium-default text-[var(--content-tertiary)]">
                   CPU
                 </span>
-                {healthzLoading ? (
-                  <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  </div>
-                ) : cpuBar ? (
+                {cpuBar ? (
                   <CapacityBar
                     value={cpuBar.value}
                     max={cpuBar.max}
                     caption={cpuBar.caption}
                   />
+                ) : healthzLoading ? (
+                  <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  </div>
                 ) : (
                   <span className="text-label-medium-default text-[var(--content-tertiary)]">—</span>
                 )}
@@ -314,16 +329,16 @@ export function ResizeCard({
                 <span className="text-label-medium-default text-[var(--content-tertiary)]">
                   Memory
                 </span>
-                {healthzLoading ? (
-                  <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  </div>
-                ) : memoryBar ? (
+                {memoryBar ? (
                   <CapacityBar
                     value={memoryBar.value}
                     max={memoryBar.max}
                     caption={memoryBar.caption}
                   />
+                ) : healthzLoading ? (
+                  <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  </div>
                 ) : (
                   <span className="text-label-medium-default text-[var(--content-tertiary)]">—</span>
                 )}

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -135,8 +135,15 @@ function TimezoneCard() {
 }
 
 export function GeneralPage() {
-  const { assistant, assistantLoading, healthz, healthzLoading, refetch } =
-    useAssistantWithHealthz();
+  const {
+    assistant,
+    assistantLoading,
+    healthz,
+    healthzLoading,
+    healthzPolling,
+    refetch,
+    refetchUntilResized,
+  } = useAssistantWithHealthz();
   const accountDeletion = useAssistantFeatureFlagStore.use.accountDeletion();
   const multiPlatformAssistant = useAssistantFeatureFlagStore.use.multiPlatformAssistant();
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
@@ -177,7 +184,9 @@ export function GeneralPage() {
           assistant={assistant}
           healthz={healthz}
           healthzLoading={healthzLoading}
+          healthzPolling={healthzPolling}
           refetch={refetch}
+          refetchUntilResized={refetchUntilResized}
         />
       )}
 


### PR DESCRIPTION
## Summary
- After an assistant resize, poll `/v1/health` until the reported CPU/memory allocation changes from the pre-resize baseline (or a 90s timeout), instead of the single immediate refetch that just re-read the not-yet-rolled pod.
- Tolerate the pod-restart window: keep last-known values on transient errors and suppress error reporting while polling; disable resize CTAs and show an "Applying resize…" spinner while the poll runs.
- Render the resource bars whenever data is present so background polling no longer flickers them to a spinner.

## Original prompt
Investigating why the General Settings "Compute & Resources" card shows stale CPU/memory after a machine resize. Root cause is two-fold: (1) the platform's config-only StatefulSet patch updates `resources.limits` but not the `VELLUM_MEMORY_LIMIT`/`VELLUM_CPU_LIMIT` env vars the daemon reads first (separate PR in vellum-assistant-platform), and (2) the web UI fired a single refetch the instant the resize API returned, before the pod rolled, and never re-checked. This PR is the web half — it makes the card poll until the new allocation lands. The two PRs are two halves of one fix; both are required.