### PR TITLE
fix(ios): enable CapacitorCookies to persist session cookies across app kills

### DIFF
--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -59,6 +59,11 @@ const config: CapacitorConfig = {
     contentInset: "never",
     scheme: SCHEME_NAMES[env] ?? "App",
   },
+  plugins: {
+    CapacitorCookies: {
+      enabled: true,
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Enable CapacitorCookies plugin in capacitor.config.ts to route document.cookie through native HTTPCookieStorage
- This fixes iOS session cookies being lost when WKWebView is killed on app close
- No new dependencies needed — CapacitorCookies is bundled with @capacitor/core 8.x

Part of plan: ios-session-persist.md (PR 1 of 4)