### PR TITLE
fix(ios): add WKAppBoundDomains for reliable cookie persistence

### DIFF
--- a/apps/ios/App/App/Info.plist
+++ b/apps/ios/App/App/Info.plist
@@ -77,5 +77,11 @@
 	<true/>
 	<key>VellumAssociatedDomain</key>
 	<string>$(ASSOCIATED_DOMAIN)</string>
+	<key>WKAppBoundDomains</key>
+	<array>
+		<string>www.vellum.ai</string>
+		<string>dev-assistant.vellum.ai</string>
+		<string>staging-assistant.vellum.ai</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add WKAppBoundDomains to Info.plist with www.vellum.ai, dev-assistant.vellum.ai, and staging-assistant.vellum.ai
- Declares app-bound domains so iOS allows full cookie and storage access for the Capacitor shell
- Recommended by Apple for apps using WKWebView with remote server.url

Part of plan: ios-session-persist.md (PR 4 of 4)