### PR TITLE
fix(ios): clear biometric Keychain token on logout

### DIFF
--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -10,6 +10,11 @@ let sessionUser: MockSessionUser | null = null;
 const syncOnboardingUserMock = mock((_userId: string | null) => {});
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
+const deleteBiometricTokenMock = mock(async () => {});
+
+mock.module("@/runtime/native-biometric.js", () => ({
+  deleteBiometricToken: deleteBiometricTokenMock,
+}));
 
 mock.module("@/lib/auth/allauth-client.js", () => ({
   getSession: async () => {
@@ -52,6 +57,7 @@ beforeEach(() => {
   syncOnboardingUserMock.mockClear();
   clearOrganizationMock.mockClear();
   logoutMock.mockClear();
+  deleteBiometricTokenMock.mockClear();
   resetAuthStore();
 });
 
@@ -81,5 +87,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(logoutMock).toHaveBeenCalled();
     expect(syncOnboardingUserMock).toHaveBeenCalledWith(null);
     expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+});
+
+describe("biometric cleanup on logout", () => {
+  test("logout clears biometric token", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(deleteBiometricTokenMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,6 +19,7 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
+import { deleteBiometricToken } from "@/runtime/native-biometric.js";
 import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
@@ -132,6 +133,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     try {
       await allauthLogout();
     } finally {
+      void deleteBiometricToken();
       syncUserScopedState(null);
       set({ isLoggedIn: false, user: null });
       broadcastAuthChange();


### PR DESCRIPTION
## Summary
- Call deleteBiometricToken() in auth store logout to clear stale Keychain entries
- Fire-and-forget — never blocks or throws on cleanup failure
- Prevents stale biometric token from restoring a session after explicit logout

Part of plan: ios-session-persist.md (PR 3 of 4)