### PR TITLE
fix(memory-v3): collapse multi-line summaries in node index (and traversal budget)

### DIFF
--- a/assistant/src/memory/v3/__tests__/index-composition.test.ts
+++ b/assistant/src/memory/v3/__tests__/index-composition.test.ts
@@ -230,4 +230,62 @@ describe("composeNodeIndex", () => {
 
     expect(composeNodeIndex("root", tree, pageIndex([]))).toBe("[node:empty]");
   });
+
+  test("collapses a multi-line node summary to a single index line", () => {
+    const tree = treeIndex(
+      [
+        treeNode("root", {}),
+        treeNode("multiline", {
+          summary: "First sentence.\nSecond sentence.\n  Third.",
+        }),
+      ],
+      { root: [{ kind: "node", ref: "multiline" }] },
+    );
+
+    const block = composeNodeIndex("root", tree, pageIndex([]));
+
+    expect(block).toBe(
+      "[node:multiline] First sentence. Second sentence. Third.",
+    );
+    expect(block.split("\n")).toHaveLength(1);
+  });
+
+  test("collapses a multi-line page summary to a single index line", () => {
+    const tree = treeIndex([treeNode("root", {})], {
+      root: [{ kind: "page", ref: "notes" }],
+    });
+    const pages = pageIndex([
+      pageEntry("notes", "Line one\nLine two\n\nLine three"),
+    ]);
+
+    const block = composeNodeIndex("root", tree, pages);
+
+    expect(block).toBe("[page:notes] Line one Line two Line three");
+    expect(block.split("\n")).toHaveLength(1);
+  });
+
+  test("a multi-line summary cannot inject extra index lines", () => {
+    // A summary crafted to look like another child entry must not become its
+    // own parsed line once collapsed.
+    const tree = treeIndex(
+      [
+        treeNode("root", {}),
+        treeNode("a", { summary: "Real summary\n[node:injected] fake entry" }),
+        treeNode("b", { summary: "Sibling" }),
+      ],
+      {
+        root: [
+          { kind: "node", ref: "a" },
+          { kind: "node", ref: "b" },
+        ],
+      },
+    );
+
+    const block = composeNodeIndex("root", tree, pageIndex([]));
+
+    expect(block.split("\n")).toEqual([
+      "[node:a] Real summary [node:injected] fake entry",
+      "[node:b] Sibling",
+    ]);
+  });
 });

--- a/assistant/src/memory/v3/__tests__/traversal.test.ts
+++ b/assistant/src/memory/v3/__tests__/traversal.test.ts
@@ -228,6 +228,45 @@ describe("walkTree — breadthBudget", () => {
     expect([...pages].sort()).toEqual(["pa", "pb"]);
     expect(levels.map((l) => l.node).sort()).toEqual(["_root", "a", "b"]);
   });
+
+  test("spends the budget only on unvisited siblings, not already-visited picks", async () => {
+    // `_root` → {p1, p2}. `p1` descends `shared`, marking it visited. `p2`
+    // then offers `[shared, x, y]` under a budget of 2. If the budget were
+    // applied before filtering visited nodes, `shared` would consume a slot
+    // and `y` would be skipped. Filtering visited first spends the budget on
+    // `x` and `y`, so both unvisited siblings are descended.
+    const tree = makeTree("_root", {
+      _root: [node("p1"), node("p2")],
+      p1: [node("shared")],
+      p2: [node("shared"), node("x"), node("y")],
+      shared: [page("ps")],
+      x: [page("px")],
+      y: [page("py")],
+    });
+
+    const { pages, levels } = await walkTree(tree, {
+      breadthBudget: 2,
+      maxDepth: 8,
+      descend: descendAll,
+    });
+
+    const p2Level = levels.find((l) => l.node === "p2")!;
+    // `shared` is offered but already visited; the budget goes to x and y.
+    expect(p2Level.considered).toEqual(["shared", "x", "y"]);
+    expect(p2Level.descended).toEqual(["x", "y"]);
+    expect(p2Level.skipped).toEqual(["shared"]);
+
+    // The previously-skipped sibling `y` (and its page) is now reached.
+    expect([...pages].sort()).toEqual(["ps", "px", "py"]);
+    expect(levels.map((l) => l.node).sort()).toEqual([
+      "_root",
+      "p1",
+      "p2",
+      "shared",
+      "x",
+      "y",
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v3/index-composition.ts
+++ b/assistant/src/memory/v3/index-composition.ts
@@ -36,6 +36,16 @@ import type { TreeNode } from "./types.js";
 const ROUTING_HINTS_LABEL = "Routing hints:";
 
 /**
+ * Flatten a summary to a single line. The index is parsed by the descender as
+ * one child per line, so any embedded newline (or other whitespace run) in a
+ * summary would corrupt that format — collapse every whitespace run to a single
+ * space and trim the ends.
+ */
+function collapseToSingleLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
  * Resolve a node's display summary: its frontmatter `summary` if non-empty,
  * otherwise the first non-empty line of its body, otherwise the empty string.
  * Whitespace is trimmed so a leading blank line in the body never wins.
@@ -54,9 +64,11 @@ function nodeSummary(node: TreeNode): string {
  * Render one child ref into its index line, or `null` when the ref's target is
  * absent from the supplied indices (validation owns reporting those).
  *
- * A resolvable `node:` child always yields a line — its header (`[node:<id>]`)
- * with a trailing summary when one exists. A `page:` child yields
- * `[page:<slug>] <summary>`; the v2 page index already truncates `summary`.
+ * A resolvable child always yields a line — its header (`[node:<id>]` /
+ * `[page:<slug>]`) with a trailing summary when one exists. Each summary is
+ * collapsed to a single line so an embedded newline can't break the one-child-
+ * per-line format the descender parses; the v2 page index already truncates
+ * `page:` summaries.
  */
 function renderChild(
   kind: "page" | "node",
@@ -67,12 +79,13 @@ function renderChild(
   if (kind === "node") {
     const child = tree.nodes.get(ref);
     if (!child) return null;
-    const summary = nodeSummary(child);
+    const summary = collapseToSingleLine(nodeSummary(child));
     return summary ? `[node:${ref}] ${summary}` : `[node:${ref}]`;
   }
   const entry = pages.bySlug.get(ref);
   if (!entry) return null;
-  return `[page:${ref}] ${entry.summary}`;
+  const summary = collapseToSingleLine(entry.summary);
+  return summary ? `[page:${ref}] ${summary}` : `[page:${ref}]`;
 }
 
 /**

--- a/assistant/src/memory/v3/traversal.ts
+++ b/assistant/src/memory/v3/traversal.ts
@@ -165,13 +165,18 @@ export async function walkTree(
       const offeredRefs = new Set(offeredNodes.map((c) => c.ref));
 
       // Honor the descend pick in the order it was returned, dedup'd, filtered
-      // to genuinely-offered node children, and capped by `breadthBudget`.
+      // to genuinely-offered node children, skipping nodes already visited
+      // elsewhere in the DAG, and capped by `breadthBudget`. Filtering visited
+      // nodes *before* the budget check ensures the budget is spent only on
+      // nodes the walk will actually descend — an already-visited pick must not
+      // consume a slot that an unvisited sibling could use.
       const descended: string[] = [];
       const descendedSet = new Set<string>();
       for (const choice of result.descend) {
         if (choice.kind !== "node") continue;
         if (!offeredRefs.has(choice.ref)) continue;
         if (descendedSet.has(choice.ref)) continue;
+        if (visited.has(nodeKey(choice.ref))) continue;
         if (descended.length >= breadthBudget) break;
         descendedSet.add(choice.ref);
         descended.push(choice.ref);


### PR DESCRIPTION
## Summary
- Node-index lines now collapse multi-line summaries to a single line, so a summary with newlines can no longer corrupt the one-child-per-line format the descender parses. Applies to both `node:` and `page:` summaries in `composeNodeIndex`.
- Tree-walk breadth budget now filters already-visited nodes before applying the budget, so a node already covered elsewhere in the DAG no longer consumes a budget slot and unvisited siblings are no longer skipped (recall loss). Verified the bug survives the recent per-node-page-selection `walkTree` redesign.

## Original prompt
Fix two memory-v3 descender/traversal issues: multi-line node summaries breaking the one-child-per-line index, and the tree-walk breadth budget being spent on already-visited nodes (verify the latter survived the recent tree-walk redesign before changing it).