### PR TITLE
fix(ios): persist session across app kills via CapacitorCookies + biometric recovery

### DIFF
--- a/apps/ios/App/App/Info.plist
+++ b/apps/ios/App/App/Info.plist
@@ -77,5 +77,11 @@
 	<true/>
 	<key>VellumAssociatedDomain</key>
 	<string>$(ASSOCIATED_DOMAIN)</string>
+	<key>WKAppBoundDomains</key>
+	<array>
+		<string>www.vellum.ai</string>
+		<string>dev-assistant.vellum.ai</string>
+		<string>staging-assistant.vellum.ai</string>
+	</array>
 </dict>
 </plist>

--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -59,6 +59,11 @@ const config: CapacitorConfig = {
     contentInset: "never",
     scheme: SCHEME_NAMES[env] ?? "App",
   },
+  plugins: {
+    CapacitorCookies: {
+      enabled: true,
+    },
+  },
 };
 
 export default config;

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -7,18 +7,40 @@ type MockSessionUser = {
 };
 
 let sessionUser: MockSessionUser | null = null;
+let getSessionCallCount = 0;
+let getSessionFailFirstCall = false;
 const syncOnboardingUserMock = mock((_userId: string | null) => {});
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
 
 mock.module("@/lib/auth/allauth-client.js", () => ({
   getSession: async () => {
+    getSessionCallCount++;
+    if (getSessionFailFirstCall && getSessionCallCount === 1) {
+      return { ok: false, status: 401, error: { detail: "Unauthorized" } };
+    }
     if (!sessionUser) {
       return { ok: false, status: 401, error: { detail: "Unauthorized" } };
     }
     return { ok: true, data: { user: sessionUser } };
   },
   logout: logoutMock,
+}));
+
+let mockIsNativePlatform = false;
+let mockIsBiometricEnabled = false;
+let mockBiometricToken: string | null = null;
+const installSessionCookiesMock = mock((_token: string) => {});
+const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
+
+mock.module("@/runtime/native-auth.js", () => ({
+  isNativePlatform: () => mockIsNativePlatform,
+  installSessionCookies: installSessionCookiesMock,
+}));
+
+mock.module("@/runtime/native-biometric.js", () => ({
+  isBiometricEnabled: () => mockIsBiometricEnabled,
+  retrieveBiometricToken: retrieveBiometricTokenMock,
 }));
 
 mock.module("@/domains/onboarding/prefs.js", () => ({
@@ -49,9 +71,16 @@ function resetAuthStore(): void {
 
 beforeEach(() => {
   sessionUser = null;
+  getSessionCallCount = 0;
+  getSessionFailFirstCall = false;
+  mockIsNativePlatform = false;
+  mockIsBiometricEnabled = false;
+  mockBiometricToken = null;
   syncOnboardingUserMock.mockClear();
   clearOrganizationMock.mockClear();
   logoutMock.mockClear();
+  installSessionCookiesMock.mockClear();
+  retrieveBiometricTokenMock.mockClear();
   resetAuthStore();
 });
 
@@ -81,5 +110,57 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(logoutMock).toHaveBeenCalled();
     expect(syncOnboardingUserMock).toHaveBeenCalledWith(null);
     expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+});
+
+describe("biometric session recovery", () => {
+  test("initSession falls through to biometric recovery on native when session probe fails", async () => {
+    mockIsNativePlatform = true;
+    mockIsBiometricEnabled = true;
+    mockBiometricToken = "recovered-session-token";
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    getSessionFailFirstCall = true;
+
+    await useAuthStore.getState().initSession();
+
+    expect(installSessionCookiesMock).toHaveBeenCalledWith(
+      "recovered-session-token",
+    );
+    expect(useAuthStore.getState().isLoggedIn).toBe(true);
+    expect(useAuthStore.getState().user?.id).toBe("user-1");
+  });
+
+  test("initSession skips biometric recovery on web", async () => {
+    mockIsNativePlatform = false;
+    sessionUser = null;
+
+    await useAuthStore.getState().initSession();
+
+    expect(retrieveBiometricTokenMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+
+  test("initSession skips biometric recovery when biometrics disabled", async () => {
+    mockIsNativePlatform = true;
+    mockIsBiometricEnabled = false;
+    sessionUser = null;
+
+    await useAuthStore.getState().initSession();
+
+    expect(retrieveBiometricTokenMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+
+  test("initSession falls through to unauthenticated when biometric token is expired", async () => {
+    mockIsNativePlatform = true;
+    mockIsBiometricEnabled = true;
+    mockBiometricToken = "expired-token";
+    sessionUser = null;
+
+    await useAuthStore.getState().initSession();
+
+    expect(installSessionCookiesMock).toHaveBeenCalledWith("expired-token");
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
+    expect(useAuthStore.getState().user).toBeNull();
   });
 });

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -81,7 +81,6 @@ beforeEach(() => {
   syncOnboardingUserMock.mockClear();
   clearOrganizationMock.mockClear();
   logoutMock.mockClear();
-<<<<<<< HEAD
   deleteBiometricTokenMock.mockClear();
   installSessionCookiesMock.mockClear();
   retrieveBiometricTokenMock.mockClear();

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -12,6 +12,13 @@ let getSessionFailFirstCall = false;
 const syncOnboardingUserMock = mock((_userId: string | null) => {});
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
+const deleteBiometricTokenMock = mock(async () => {});
+
+let mockIsNativePlatform = false;
+let mockIsBiometricEnabled = false;
+let mockBiometricToken: string | null = null;
+const installSessionCookiesMock = mock((_token: string) => {});
+const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 
 mock.module("@/lib/auth/allauth-client.js", () => ({
   getSession: async () => {
@@ -27,18 +34,13 @@ mock.module("@/lib/auth/allauth-client.js", () => ({
   logout: logoutMock,
 }));
 
-let mockIsNativePlatform = false;
-let mockIsBiometricEnabled = false;
-let mockBiometricToken: string | null = null;
-const installSessionCookiesMock = mock((_token: string) => {});
-const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
-
 mock.module("@/runtime/native-auth.js", () => ({
   isNativePlatform: () => mockIsNativePlatform,
   installSessionCookies: installSessionCookiesMock,
 }));
 
 mock.module("@/runtime/native-biometric.js", () => ({
+  deleteBiometricToken: deleteBiometricTokenMock,
   isBiometricEnabled: () => mockIsBiometricEnabled,
   retrieveBiometricToken: retrieveBiometricTokenMock,
 }));
@@ -79,6 +81,8 @@ beforeEach(() => {
   syncOnboardingUserMock.mockClear();
   clearOrganizationMock.mockClear();
   logoutMock.mockClear();
+<<<<<<< HEAD
+  deleteBiometricTokenMock.mockClear();
   installSessionCookiesMock.mockClear();
   retrieveBiometricTokenMock.mockClear();
   resetAuthStore();
@@ -110,6 +114,14 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(logoutMock).toHaveBeenCalled();
     expect(syncOnboardingUserMock).toHaveBeenCalledWith(null);
     expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+});
+
+describe("biometric cleanup on logout", () => {
+  test("logout clears biometric token", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(deleteBiometricTokenMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -22,6 +22,8 @@ import {
 import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
+import { isNativePlatform, installSessionCookies } from "@/runtime/native-auth.js";
+import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric.js";
 
 export interface AuthUser {
   id: string | null;
@@ -107,6 +109,27 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     } catch (err) {
       console.error("auth.initSession failed", err);
     }
+
+    // Biometric recovery: on iOS, the session cookie may have been lost
+    // when WKWebView was killed. Try to restore from Keychain via Face ID.
+    if (isNativePlatform() && isBiometricEnabled()) {
+      try {
+        const token = await retrieveBiometricToken();
+        if (token) {
+          installSessionCookies(token);
+          const retryResult = await getSession();
+          if (retryResult.ok && retryResult.data.user) {
+            const user = toAuthUser(retryResult.data.user);
+            syncUserScopedState(user?.id ?? null);
+            set({ isLoggedIn: true, isLoading: false, user });
+            return;
+          }
+        }
+      } catch (err) {
+        console.warn("auth.initSession biometric recovery failed", err);
+      }
+    }
+
     syncUserScopedState(null);
     set({ isLoggedIn: false, isLoading: false, user: null });
   },

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,6 +19,7 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
+import { deleteBiometricToken } from "@/runtime/native-biometric.js";
 import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
@@ -155,6 +156,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     try {
       await allauthLogout();
     } finally {
+      void deleteBiometricToken();
       syncUserScopedState(null);
       set({ isLoggedIn: false, user: null });
       broadcastAuthChange();


### PR DESCRIPTION
## Summary
Fix iOS app losing authentication state every time the user closes and reopens the app. Two independent layers address different parts of the problem:

1. **CapacitorCookies** — routes `document.cookie` through native `HTTPCookieStorage` instead of WKWebView's unreliable cookie jar, so session cookies survive app kills
2. **Biometric recovery** — wires up the existing but uncalled `retrieveBiometricToken()` as a fallback in `initSession()`, so when the server-side Django session expires, Face ID / Touch ID can restore the session without a full WorkOS re-login
3. **Logout cleanup** — ensures `deleteBiometricToken()` is called on logout so stale Keychain entries can't restore a session after explicit logout
4. **WKAppBoundDomains** — declares app-bound domains in Info.plist so iOS allows full cookie and storage access for the Capacitor shell

## PRs merged into feature branch
- #32147: fix(ios): enable CapacitorCookies to persist session cookies across app kills
- #32150: fix(ios): recover session from biometric Keychain when cookies are missing
- #32149: fix(ios): clear biometric Keychain token on logout
- #32148: fix(ios): add WKAppBoundDomains for reliable cookie persistence

## Test plan
- [ ] Build and run the iOS app on a device
- [ ] Sign in, then force-quit the app
- [ ] Reopen — should be authenticated without re-login (CapacitorCookies)
- [ ] If cookies somehow lost, Face ID should prompt and restore session (biometric recovery)
- [ ] Sign out, then reopen — should NOT auto-recover via biometric (logout cleanup)
- [ ] Verify dev/staging builds also work (WKAppBoundDomains covers all environments)
- [ ] Run `bun test` in apps/web — all new auth-store tests pass

Part of plan: ios-session-persist.md