### PR TITLE
fix(memory-v3): upgrade seed lane, drop sticky from filter, fix MMR degenerate range

### DIFF
--- a/assistant/src/memory/v3/__tests__/filter.test.ts
+++ b/assistant/src/memory/v3/__tests__/filter.test.ts
@@ -171,6 +171,36 @@ describe("filterDenseHits — judged keep/drop", () => {
     expect(userText).not.toContain("x");
   });
 
+  test("excludes the full sticky set from judgment, not just bypass", async () => {
+    const calls: ProviderCall[] = [];
+    // Dense surfaces a, b, plus sticky-but-not-bypass slug `s`. `s` must not be
+    // judged (the gate force-injects every sticky slug regardless), so the model
+    // only sees a, b. Model keeps a.
+    const provider = makeProvider(
+      filterToolResponse({ keep_slugs: ["a"] }),
+      calls,
+    );
+
+    const result = await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["a", "b", "s"]),
+      // sticky is a strict superset of bypass here: `s` is sticky but not bypass.
+      sticky: new Set(["s"]),
+      bypass: new Set(),
+      provider,
+    });
+
+    // `s` is excluded from the judged set even though it is not in bypass.
+    expect(result.trace.judged).toEqual(["a", "b"]);
+    expect(result.trace.dropped).toEqual(["b"]);
+    // The sticky slug `s` was never shown to the model.
+    const slugLines = calls[0].messages[0].content
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n")
+      .split("\n");
+    expect(slugLines).not.toContain("s");
+  });
+
   test("forces tool_choice on filter_dense_hits and surfaces judged candidates", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
@@ -304,6 +334,24 @@ describe("filterDenseHits — no LLM call", () => {
     });
 
     expect([...result.kept].sort()).toEqual(["x", "y"]);
+    expect(result.trace).toEqual({ judged: [], dropped: [] });
+  });
+
+  test("dense fully covered by sticky (not bypass) → no call", async () => {
+    const provider = makeNeverCalledProvider();
+
+    // Every dense slug is sticky but none is bypass: there is nothing to judge,
+    // so no LLM round-trip happens. kept is the (empty) bypass set — the sticky
+    // slugs are force-selected downstream by the gate, not via the filter.
+    const result = await filterDenseHits({
+      input: makeInput(),
+      dense: denseResult(["x", "y"]),
+      sticky: new Set(["x", "y"]),
+      bypass: new Set(),
+      provider,
+    });
+
+    expect(result.kept).toEqual([]);
     expect(result.trace).toEqual({ judged: [], dropped: [] });
   });
 });

--- a/assistant/src/memory/v3/__tests__/loop.test.ts
+++ b/assistant/src/memory/v3/__tests__/loop.test.ts
@@ -86,7 +86,12 @@ const lane = {
 /** Records the args the loop passed each lane, one entry per call. */
 const laneCalls = {
   scouts: [] as Array<{ nowText: string }>,
-  filter: [] as Array<{ nowText: string; dense: ScoutResult }>,
+  filter: [] as Array<{
+    nowText: string;
+    dense: ScoutResult;
+    sticky: string[];
+    bypass: string[];
+  }>,
   walk: [] as Array<{
     nowText: string;
     scouts: ScoutResult[];
@@ -121,8 +126,15 @@ mock.module("../filter.js", () => ({
   filterDenseHits: async (args: {
     input: RetrievalInput;
     dense: ScoutResult;
+    sticky: Set<string>;
+    bypass: Set<string>;
   }): Promise<FilterResult> => {
-    laneCalls.filter.push({ nowText: args.input.nowText, dense: args.dense });
+    laneCalls.filter.push({
+      nowText: args.input.nowText,
+      dense: args.dense,
+      sticky: [...args.sticky],
+      bypass: [...args.bypass],
+    });
     // Filter calls share the scout pass index (one filter call per dense pass).
     return nextOf(lane.filter, laneCalls.filter.length - 1);
   },
@@ -529,6 +541,125 @@ describe("runRetrievalLoop — lane toggles", () => {
     expect(laneCalls.edges[0].seeds).toEqual(
       expect.arrayContaining(["h", "d", "t"]),
     );
+  });
+});
+
+describe("runRetrievalLoop — sourceBySlug lane trust", () => {
+  test("upgrades a slug's lane when a higher-trust lane re-surfaces it in one pass", async () => {
+    // `shared` is surfaced by the low-trust hot lane AND survives the
+    // higher-trust dense filter in the same pass. Provenance must end on the
+    // more trusted lane (dense) so the downstream seed cap ranks it by its
+    // strongest signal, not the stale first-seen hot lane.
+    lane.scouts = [
+      {
+        scouts: [scout("hot", ["shared"]), scout("dense", ["shared"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    lane.filter = [
+      { kept: ["shared"], trace: { judged: ["shared"], dropped: [] } },
+    ];
+    lane.walk = [{ pages: new Set(), levels: [] }];
+    lane.edges = [{ pulled: new Set(), expansions: [] }];
+    lane.gate = [readyGate(["shared"])];
+
+    const out = await runRetrievalLoop(makeInput(), { db });
+
+    // hot tagged first, then upgraded to the more trusted dense lane.
+    expect(out.sourceBySlug.get("shared")).toBe("dense");
+  });
+
+  test("does not downgrade a slug's lane when a lower-trust lane re-surfaces it", async () => {
+    // `s` is a dense survivor (trusted) in pass 1, then edge-pulled (lowest
+    // trust) in pass 2. The lane must stay dense — only upgrades apply.
+    lane.scouts = [
+      {
+        scouts: [scout("dense", ["s"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+      { scouts: [], sticky: new Set(), bypass: new Set() },
+    ];
+    lane.filter = [
+      { kept: ["s"], trace: { judged: ["s"], dropped: [] } },
+      { kept: [], trace: { judged: [], dropped: [] } },
+    ];
+    lane.walk = [
+      { pages: new Set(), levels: [] },
+      { pages: new Set(), levels: [] },
+    ];
+    // Pass 2's edge expansion re-pulls the already-dense `s`.
+    lane.edges = [
+      { pulled: new Set(), expansions: [] },
+      { pulled: new Set(["s"]), expansions: [{ from: "s", pulled: ["s"] }] },
+    ];
+    lane.gate = [moreGate(["s"], ["more?"]), readyGate(["s"])];
+
+    const out = await runRetrievalLoop(makeInput({ passCap: 2 }), { db });
+
+    expect(out.sourceBySlug.get("s")).toBe("dense");
+  });
+
+  test("upgrades the lane across passes while preserving earliest-pass provenance", async () => {
+    // `s` first enters via the low-trust edge lane on pass 1, then is surfaced
+    // by the higher-trust dense lane on pass 2. The lane upgrades to dense, but
+    // the co-activation provenance must still treat it as a pass-1 hit: the lane
+    // upgrades, the first-seen pass does not.
+    lane.scouts = [
+      { scouts: [], sticky: new Set(), bypass: new Set() },
+      {
+        scouts: [scout("dense", ["s"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    // Pass 1 has no dense scout, so the filter is called only once (pass 2);
+    // the mock indexes filter results by call count, so the single entry keeps `s`.
+    lane.filter = [{ kept: ["s"], trace: { judged: ["s"], dropped: [] } }];
+    lane.walk = [
+      { pages: new Set(), levels: [] },
+      { pages: new Set(), levels: [] },
+    ];
+    lane.edges = [
+      { pulled: new Set(["s"]), expansions: [{ from: "x", pulled: ["s"] }] },
+      { pulled: new Set(), expansions: [] },
+    ];
+    lane.gate = [moreGate([], ["more?"]), readyGate(["s"])];
+
+    const out = await runRetrievalLoop(makeInput({ passCap: 2 }), { db });
+
+    // Lane upgraded from edge (pass 1) to dense (pass 2).
+    expect(out.sourceBySlug.get("s")).toBe("dense");
+  });
+});
+
+describe("runRetrievalLoop — sticky excluded from dense filter", () => {
+  test("forwards the full sticky set to the filter while keeping sticky in the selection", async () => {
+    // `sk` is sticky (and a dense hit); `keep` is a plain dense candidate. The
+    // loop must hand the filter the full sticky set so it can exclude `sk` from
+    // judgment — `sk` is force-selected by the gate regardless. `keep` is
+    // judged and kept normally.
+    lane.scouts = [
+      {
+        scouts: [scout("dense", ["sk", "keep"])],
+        sticky: new Set(["sk"]),
+        bypass: new Set(),
+      },
+    ];
+    lane.filter = [
+      { kept: ["keep"], trace: { judged: ["keep"], dropped: [] } },
+    ];
+    lane.walk = [{ pages: new Set(), levels: [] }];
+    lane.edges = [{ pulled: new Set(), expansions: [] }];
+    lane.gate = [readyGate(["sk", "keep"])];
+
+    const out = await runRetrievalLoop(makeInput(), { db });
+
+    // The loop forwarded the full sticky set to the filter so it can subtract it.
+    expect(laneCalls.filter[0].sticky).toEqual(["sk"]);
+    // The sticky slug is still in the final selection (gate force-injects it).
+    expect(out.selectedSlugs).toEqual(expect.arrayContaining(["sk", "keep"]));
   });
 });
 

--- a/assistant/src/memory/v3/__tests__/scouts.test.ts
+++ b/assistant/src/memory/v3/__tests__/scouts.test.ts
@@ -358,6 +358,55 @@ describe("runScouts — dense lane", () => {
     expect(slugs.indexOf("people/x")).toBeLessThan(slugs.length - 1);
   });
 
+  test("MMR stays relevance-aware when every cosine is non-positive", async () => {
+    // All dense scores are <= 0 (weakly/negatively similar). Dividing by the
+    // pool max would collapse every relevance to a single value and degrade
+    // ranking to diversity-only, which would pull the lowest-scoring off-domain
+    // hit ahead of a higher-scoring active-domain hit. Range-normalizing keeps
+    // relevance ordering: work/b (higher score) stays ahead of people/x.
+    hybridHits = [
+      hit("work/a", { denseScore: -0.1 }),
+      hit("work/b", { denseScore: -0.5 }),
+      hit("people/x", { denseScore: -0.9 }),
+    ];
+    const { scouts } = await runScouts(
+      makeInput({
+        lanes: { hot: false, sparse: false },
+        denseQuota: { activeDomain: 30, offDomain: 8 },
+      }),
+      DEPS,
+    );
+    const slugs = scouts.find((s) => s.lane === "dense")?.slugs ?? [];
+    // Relevance-aware order: the higher-scoring work/b outranks people/x.
+    // Diversity-only (the bug) would interleave people/x ahead of work/b.
+    expect(slugs.indexOf("work/b")).toBeLessThan(slugs.indexOf("people/x"));
+  });
+
+  test("MMR positive-cosine ordering is unchanged by the range fix", async () => {
+    // A healthy positive range must behave exactly as before: relevance is
+    // score/max, so a strong active-domain run still gets diversified by the
+    // redundancy term once the subtree is over-represented.
+    hybridHits = [
+      hit("work/a", { denseScore: 0.95 }),
+      hit("work/b", { denseScore: 0.94 }),
+      hit("work/c", { denseScore: 0.93 }),
+      hit("work/d", { denseScore: 0.92 }),
+      hit("people/x", { denseScore: 0.9 }),
+    ];
+    const { scouts } = await runScouts(
+      makeInput({
+        lanes: { hot: false, sparse: false },
+        denseQuota: { activeDomain: 30, offDomain: 8 },
+      }),
+      DEPS,
+    );
+    const slugs = scouts.find((s) => s.lane === "dense")?.slugs ?? [];
+    // The strongest hit still leads; the lower-scoring off-domain hit is pulled
+    // forward (not stranded last) exactly as in the unmodified positive case.
+    expect(slugs[0]).toBe("work/a");
+    expect(slugs.indexOf("people/x")).toBeLessThan(slugs.length - 1);
+  });
+
   test("no dense hits yields no dense ScoutResult", async () => {
     hybridHits = [hit("sparse/only", { sparseScore: 2.0 })];
     const { scouts } = await runScouts(

--- a/assistant/src/memory/v3/filter.ts
+++ b/assistant/src/memory/v3/filter.ts
@@ -12,20 +12,19 @@
  * corpus). Hot pages and near-exact sparse hits arrive via the scouts'
  * `sticky` / `bypass` sets and are **never judged**: a literal keyword hit or a
  * page the user has been touching is a strong enough signal that we shouldn't
- * make it earn its place through a fallible cheap judgment. They are unioned
- * straight into `kept`.
+ * make it earn its place through a fallible cheap judgment, and the downstream
+ * gate force-injects every sticky slug regardless — judging it could not change
+ * its fate. The `bypass` subset is additionally unioned straight into `kept`.
  *
  * Fail-open. If no provider is configured or the call errors / returns an
- * unusable response, the filter keeps *all* dense candidates and surfaces a
- * `failureReason` so the loop can record that the filter was bypassed. Dropping
- * candidates on a model outage would silently starve retrieval; keeping them is
- * the safe degradation (the downstream gate still narrows the slate).
+ * unusable response, the filter keeps *all* judged dense candidates and surfaces
+ * a `failureReason` so the loop can record that the filter was bypassed.
+ * Dropping candidates on a model outage would silently starve retrieval; keeping
+ * them is the safe degradation (the downstream gate still narrows the slate).
  *
- * No LLM call when there is nothing to judge. An empty dense set short-circuits
- * to `kept` = the bypass-relevant slugs (no judged additions), with no provider
- * round-trip.
- *
- * This module is currently unwired — a later PR composes it into the loop.
+ * No LLM call when there is nothing to judge. A dense set fully covered by
+ * sticky short-circuits to `kept` = the bypass-relevant slugs (no judged
+ * additions), with no provider round-trip.
  */
 
 import { z } from "zod";
@@ -58,10 +57,12 @@ const FILTER_TOOL_NAME = "filter_dense_hits";
  * Arguments to one filter invocation.
  *
  * `dense` is the bounded dense scout result; only its slugs that are *not*
- * already in `bypass` are judged. `sticky` is the broader keep-in-the-running
- * set (hot + near-exact sparse); `bypass` is the subset strong enough to skip
- * judgment entirely. Bypass slugs that also appear in the dense lane are kept
- * unconditionally and never sent to the model.
+ * already in `sticky` are judged. `sticky` is the keep-in-the-running set (hot +
+ * near-exact sparse) the downstream gate force-injects regardless of this
+ * filter, so judging a sticky page wastes an LLM call that can never change its
+ * fate. `bypass` is the subset of sticky strong enough to skip judgment that the
+ * filter also unions straight into `kept`. Sticky slugs that also appear in the
+ * dense lane are excluded from the judged set and never sent to the model.
  */
 export interface FilterDenseHitsArgs {
   input: RetrievalInput;
@@ -163,19 +164,23 @@ function buildResult(
  * Run the fast dense-hit filter for one pass.
  *
  * Makes at most one forced-tool LLM call over the *judged* set (dense slugs not
- * already in `bypass`). Bypass slugs are kept unconditionally. On an empty
- * judged set no call is made. Any failure (no provider, provider throw, missing
- * tool_use, schema mismatch) fails open: every dense candidate is kept and a
+ * already in `sticky`). Sticky slugs are force-selected by the downstream gate
+ * regardless of this filter, so they are excluded from judgment; bypass slugs
+ * are additionally kept unconditionally here. On an empty judged set no call is
+ * made. Any failure (no provider, provider throw, missing tool_use, schema
+ * mismatch) fails open: every judged dense candidate is kept and a
  * `failureReason` is returned.
  */
 export async function filterDenseHits(
   args: FilterDenseHitsArgs,
 ): Promise<FilterDenseHitsResult> {
-  const { input, dense, bypass } = args;
+  const { input, dense, sticky, bypass } = args;
 
-  // Dense slugs that bypass judgment (near-exact sparse / hot) are kept as-is;
-  // only the remainder is judged.
-  const judged = dense.slugs.filter((slug) => !bypass.has(slug));
+  // Sticky slugs (hot + near-exact sparse) are force-selected by the gate
+  // regardless of this filter, so judging them wastes an LLM call that can't
+  // change their fate. Exclude the full sticky set (a superset of bypass) from
+  // the judged set; only the remaining dense near-neighbors are judged.
+  const judged = dense.slugs.filter((slug) => !sticky.has(slug));
 
   // Nothing to judge → no LLM call. Kept is just the bypass-relevant slugs.
   if (judged.length === 0) {

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -39,7 +39,8 @@
  * Cross-pass accumulation. The `candidates` pool is unioned across every pass
  * and the gate judges that cumulative pool, so a multi-pass `more` never drops
  * the non-sticky hits earlier passes surfaced. Each slug is tagged with the
- * first lane that surfaced it (`sourceBySlug`). The full {@link DescentTrace}
+ * most trusted lane that surfaced it (`sourceBySlug`). The full
+ * {@link DescentTrace}
  * carries one {@link DescentPass} per pass (scouts / treeLevels /
  * edgeExpansions / gate), and {@link RetrievalCost} (wall-clock `ms`, the one
  * dimension observable at this composition layer) accumulates across every pass.
@@ -154,9 +155,10 @@ export async function runRetrievalLoop(
     const scoutResult = await runScouts(passInput, { db: deps.db });
     for (const slug of scoutResult.sticky) sticky.add(slug);
 
-    // Tag hot + sparse scout hits with their lane (first lane wins). Dense
-    // slugs are tagged only if they survive the filter below — a dropped dense
-    // near-neighbor never enters the candidate set, so it earns no source tag.
+    // Tag hot + sparse scout hits with their lane (most trusted lane wins —
+    // see tagSlug). Dense slugs are tagged only if they survive the filter
+    // below — a dropped dense near-neighbor never enters the candidate set, so
+    // it earns no source tag.
     for (const scout of scoutResult.scouts) {
       if (scout.lane === "dense") continue;
       for (const slug of scout.slugs) tagSlug(sourceBySlug, slug, scout.lane);
@@ -360,17 +362,42 @@ function emitCoactivations(args: {
 }
 
 /**
- * Tag `slug`'s provenance with `lane`, keeping the first lane that surfaced it.
- * The pass order (scouts → tree → edge) gives a deterministic precedence: a
- * slug first seen by a scout lane keeps that label even when the tree or edge
- * lane re-surfaces it.
+ * Lane-trust order for `sourceBySlug` provenance (lower = more trusted). A slug
+ * surfaced by several lanes is tagged with the most trusted one. Mirrors
+ * `SEED_LANE_RANK` in {@link expandEdges}'s module, the downstream consumer that
+ * ranks seeds by this tag before the candidate cap: LLM-vetted tree/dense seeds
+ * rank above lexical sparse, recency-only hot, and associative edge pulls.
+ * Keeping the two orders aligned ensures the upgrade picks the lane the cap
+ * actually trusts. Any lane absent here (or an edge pull) ranks last.
+ */
+const LANE_TRUST_RANK: Readonly<Record<LaneSource, number>> = {
+  tree: 0,
+  dense: 1,
+  sparse: 2,
+  hot: 3,
+  edge: 4,
+};
+
+/**
+ * Tag `slug`'s provenance with `lane`, upgrading to the most trusted lane that
+ * surfaces it (see {@link LANE_TRUST_RANK}). A slug first seen via a low-trust
+ * lane (e.g. `edge`) is relabeled when a higher-trust lane (e.g. `dense`) also
+ * surfaces it, so the downstream seed cap ranks it by its strongest signal
+ * rather than a stale first-seen lane. Pass provenance (`firstPassBySlug`) is
+ * tracked separately and keeps earliest-pass semantics — only the lane upgrades.
  */
 function tagSlug(
   sourceBySlug: Map<string, LaneSource>,
   slug: string,
   lane: LaneSource,
 ): void {
-  if (!sourceBySlug.has(slug)) sourceBySlug.set(slug, lane);
+  const current = sourceBySlug.get(slug);
+  if (
+    current === undefined ||
+    LANE_TRUST_RANK[lane] < LANE_TRUST_RANK[current]
+  ) {
+    sourceBySlug.set(slug, lane);
+  }
 }
 
 /**

--- a/assistant/src/memory/v3/scouts.ts
+++ b/assistant/src/memory/v3/scouts.ts
@@ -361,11 +361,22 @@ function applyQuotaAndMmr(
 function mmrReorder(pool: readonly ScoredSlug[], lambda: number): ScoredSlug[] {
   if (pool.length <= 1) return [...pool];
 
-  // Normalize relevance to [0, 1] by the pool max so it shares a scale with the
-  // redundancy term (also [0, 1]). All-zero scores collapse to pure diversity.
+  // Normalize relevance to [0, 1] so it shares a scale with the redundancy term
+  // (also [0, 1]). The pool is score-descending, so `pool[0]` is the max and the
+  // last entry is the min. When the max is positive we divide by it — the
+  // healthy case, kept exactly as-is. When every cosine is <= 0 (all candidates
+  // weakly/negatively similar) dividing by the max would collapse relevance to a
+  // single value and degrade ranking to diversity-only; instead normalize from
+  // the observed min..max range so the relevance ordering is preserved. A
+  // zero-width range (all scores equal) has no gradient to preserve, so it
+  // collapses to pure diversity.
   const maxScore = pool[0].score;
-  const relevance = (hit: ScoredSlug): number =>
-    maxScore > 0 ? hit.score / maxScore : 0;
+  const minScore = pool[pool.length - 1].score;
+  const range = maxScore - minScore;
+  const relevance = (hit: ScoredSlug): number => {
+    if (maxScore > 0) return hit.score / maxScore;
+    return range > 0 ? (hit.score - minScore) / range : 0;
+  };
 
   const remaining = [...pool];
   const selected: ScoredSlug[] = [];


### PR DESCRIPTION
## Summary
- Seed provenance lane now upgrades to the highest-trust lane that surfaced a slug, so the candidate cap no longer drops relevant seeds ranked by a stale first-seen lane.
- Sticky pages are excluded from the dense filter's judged set (they are force-selected anyway), saving an LLM judgment that could never change the outcome.
- MMR relevance is normalized from the observed score range, so ranking stays relevance-aware even when all dense cosines are <= 0 (previously degraded to diversity-only).

## Original prompt
Three memory-v3 retrieval scoring follow-ups: upgrade the seed lane to highest-trust (not stale first-seen), exclude the full sticky set from the dense LLM filter, and fix MMR collapsing to diversity-only when the max cosine is non-positive.