### PR TITLE
fix: unwrap data.results in global search response parsing

### DIFF
--- a/apps/web/src/domains/chat/api/global-search.ts
+++ b/apps/web/src/domains/chat/api/global-search.ts
@@ -81,18 +81,24 @@ export async function searchGlobal(
     }
 
     // Validate the shape minimally — the daemon may evolve its response.
+    // The daemon wraps category arrays inside a `results` object:
+    //   { query: string, results: { conversations, schedules, contacts } }
     if (data && typeof data === "object") {
-      return {
-        conversations: Array.isArray((data as GlobalSearchResponse).conversations)
-          ? (data as GlobalSearchResponse).conversations
-          : [],
-        schedules: Array.isArray((data as GlobalSearchResponse).schedules)
-          ? (data as GlobalSearchResponse).schedules
-          : [],
-        contacts: Array.isArray((data as GlobalSearchResponse).contacts)
-          ? (data as GlobalSearchResponse).contacts
-          : [],
-      };
+      const results =
+        (data as unknown as Record<string, unknown>).results ?? data;
+      if (results && typeof results === "object") {
+        return {
+          conversations: Array.isArray((results as GlobalSearchResponse).conversations)
+            ? (results as GlobalSearchResponse).conversations
+            : [],
+          schedules: Array.isArray((results as GlobalSearchResponse).schedules)
+            ? (results as GlobalSearchResponse).schedules
+            : [],
+          contacts: Array.isArray((results as GlobalSearchResponse).contacts)
+            ? (results as GlobalSearchResponse).contacts
+            : [],
+        };
+      }
     }
 
     return EMPTY_RESULTS;


### PR DESCRIPTION
## Summary

- **Bug**: The daemon's `/v1/search/global` endpoint wraps category arrays inside a `results` object (`{ query, results: { conversations, schedules, contacts } }`), but the client code was reading `data.conversations` directly. Since `data.conversations` is `undefined`, `Array.isArray(undefined)` returns `false` and all categories silently fall back to empty arrays — causing the UI to always show "No results."
- **Fix**: Unwrap `data.results` before accessing the category arrays, with a fallback to `data` itself for forward-compatibility.

## Test plan

- [ ] Trigger a global search query that the daemon returns results for
- [ ] Verify conversations, schedules, and contacts all render in the search UI
- [ ] Verify empty queries still show "No results" correctly
- [ ] Verify a search with no matches still shows "No results" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)