### PR TITLE
fix(web): remove native auth code paths from SPA callback page

### DIFF
--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -56,26 +56,6 @@ function redirectToNativeApp(
 }
 
 /**
- * True if the current browser is iOS or iPadOS. iPadOS 13+ reports a
- * Macintosh user agent by default, so we disambiguate via
- * `maxTouchPoints > 1` on a Mac platform — real Macs report 0 or 1.
- * `"ontouchend" in document` is NOT a reliable touch-device signal on
- * desktop Safari (the API exists on desktop too), which is why we don't
- * use it. Same discriminator as `isIOSBrowser` in
- * `domains/nudges/ios-app-platform.ts`.
- *
- * Ref: https://developer.apple.com/forums/thread/119186
- */
-function isIOSBrowser(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent;
-  if (/iPhone|iPad|iPod/.test(ua)) return true;
-  const isMacPlatform = navigator.platform.toLowerCase().includes("mac");
-  return isMacPlatform && navigator.maxTouchPoints > 1;
-}
-
-
-/**
  * OAuth provider callback handler. Probes the allauth session after the
  * IdP redirect and routes the user to the correct next step:
  * - Authenticated → navigate to returnTo or home
@@ -139,15 +119,8 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            // Skip the native-scheme bounce on iOS only: it tears the
-            // `ASWebAuthenticationSession` Safari sheet down before
-            // WebKit finishes committing the session cookie set by
-            // allauth's social callback, turning a recoverable
-            // post-WorkOS failure into a permanent one. macOS does
-            // not exhibit this and still needs the bounce so its
-            // auth sheet closes cleanly into the native UI.
-            if (nativeParams && !isIOSBrowser()) {
-              redirectToNativeApp(nativeParams, outcome.message);
+            if (nativeParams && returnTo) {
+              window.location.href = returnTo;
               return;
             }
             setFallbackError(outcome.message);

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import * as Sentry from "@sentry/react";
 
@@ -10,57 +10,18 @@ import { classifyCallbackFlows } from "@/domains/account/social-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
 
-const NATIVE_CALLBACK_PREFIX = "/accounts/native/callback";
-
-/** Mirrors NATIVE_AUTH_ALLOWED_SCHEMES in django/config/settings/base.py. */
-const ALLOWED_SCHEMES = new Set([
-  "vellum",
-  "vellum-assistant",
-  "vellum-assistant-dev",
-  "vellum-assistant-staging",
-  "vellum-assistant-local",
-]);
-
 /**
- * When the provider callback is reached via the native iOS/macOS auth flow
- * (returnTo points to the native callback endpoint), extract the custom
- * URL scheme and state so we can redirect back to the app — even on error.
- */
-function parseNativeReturnTo(
-  returnTo: string | null,
-): { scheme: string; state: string } | null {
-  if (!returnTo?.startsWith(NATIVE_CALLBACK_PREFIX)) return null;
-  try {
-    const params = new URL(returnTo, "https://placeholder").searchParams;
-    const scheme = params.get("scheme");
-    const state = params.get("state");
-    if (scheme && state && ALLOWED_SCHEMES.has(scheme)) {
-      return { scheme, state };
-    }
-  } catch {
-    // Malformed returnTo — fall through
-  }
-  return null;
-}
-
-/**
- * Bounce back to the native app via its custom URL scheme. The macOS/iOS
- * client treats any `?error=…` query param as a failed login.
- */
-function redirectToNativeApp(
-  nativeParams: { scheme: string; state: string },
-  error: string,
-): void {
-  const { scheme, state } = nativeParams;
-  window.location.href = `${scheme}://auth/callback?error=${encodeURIComponent(error)}&state=${encodeURIComponent(state)}`;
-}
-
-/**
- * OAuth provider callback handler. Probes the allauth session after the
- * IdP redirect and routes the user to the correct next step:
+ * OAuth provider callback handler for the **web** login flow.
+ *
+ * After the IdP redirect, probes the allauth session and routes the user
+ * to the correct next step:
  * - Authenticated → navigate to returnTo or home
  * - Provider signup needed → redirect to provider signup page
  * - Error → display inline error with back-to-login link
+ *
+ * Native auth flows (iOS / macOS) no longer route through this page.
+ * The server-side native auth flow redirects directly from the allauth
+ * callback to `/accounts/native/callback` without loading any SPA.
  */
 export function ProviderCallbackPage() {
   const [searchParams] = useSearchParams();
@@ -71,17 +32,9 @@ export function ProviderCallbackPage() {
   const didRun = useRef(false);
 
   const returnTo = searchParams.get("returnTo");
-  const nativeParams = useMemo(() => parseNativeReturnTo(returnTo), [returnTo]);
 
   useEffect(() => {
     if (didRun.current) return;
-
-    if (error && nativeParams) {
-      didRun.current = true;
-      redirectToNativeApp(nativeParams, error);
-      return;
-    }
-
     if (error) return;
     didRun.current = true;
 
@@ -107,10 +60,6 @@ export function ProviderCallbackPage() {
             break;
           }
           case "provider_signup": {
-            if (nativeParams) {
-              redirectToNativeApp(nativeParams, "provider_signup_required");
-              return;
-            }
             const returnToParam = searchParams.get("returnTo");
             const signupUrl = returnToParam
               ? `${routes.account.providerSignup}?returnTo=${encodeURIComponent(returnToParam)}`
@@ -119,10 +68,6 @@ export function ProviderCallbackPage() {
             break;
           }
           case "error":
-            if (nativeParams && returnTo) {
-              window.location.href = returnTo;
-              return;
-            }
             setFallbackError(outcome.message);
             break;
         }
@@ -133,7 +78,7 @@ export function ProviderCallbackPage() {
         setFallbackError("Something went wrong. Please try signing in again.");
       }
     })();
-  }, [error, nativeParams, refreshSession, returnTo, navigate, searchParams]);
+  }, [error, refreshSession, returnTo, navigate, searchParams]);
 
   if (error === "signup_closed") {
     return (


### PR DESCRIPTION
## Prompt / plan

Companion cleanup to [vellum-assistant-platform#7750](https://github.com/vellum-ai/vellum-assistant-platform/pull/7750) which eliminates the SPA intermediary from the native auth flow. Native auth flows (iOS and macOS) no longer route through this SPA callback page — the server-side flow redirects directly from the allauth callback to the Django native callback endpoint without loading any JavaScript inside the `ASWebAuthenticationSession` Safari sheet.

This PR removes the now-dead native auth code from `provider-callback-page.tsx`:
- `parseNativeReturnTo()` — parsed native scheme/state from `returnTo` param
- `redirectToNativeApp()` — bounced errors back to native app via custom URL scheme
- `NATIVE_CALLBACK_PREFIX` and `ALLOWED_SCHEMES` constants
- All native-specific branching in the `useEffect` (error+nativeParams early return, provider_signup native redirect, error case fallback navigation to returnTo)
- Removed `useMemo` import (no longer needed)

The page now handles only the **web** login flow. Net -55 lines.

### Why this is safe

- Native auth flows are handled entirely server-side after the platform PR lands — they never reach this page
- The web login flow is completely unchanged — same `getSession()` → `classifyCallbackFlows()` → navigate logic
- No changes to routing, imports used by other files, or component API
- `isIOSBrowser()` (used by nudges) is unaffected — it lives in a separate module

## Test plan

- Lint passes (`bun run lint`)
- TypeScript type check passes (`bunx tsc --noEmit`)
- No other files import the removed functions (`parseNativeReturnTo`, `redirectToNativeApp`, `NATIVE_CALLBACK_PREFIX`, `ALLOWED_SCHEMES`)
- Web login flow is architecturally unchanged — same code paths, same behavior

Link to Devin session: https://app.devin.ai/sessions/67886aaf1d26446b8bd5535792de95ce
Requested by: @ashleeradka