### PR TITLE
Publish background wake intents to Django

### DIFF
--- a/assistant/src/background-wake/platform-client.test.ts
+++ b/assistant/src/background-wake/platform-client.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BackgroundWakeIntent } from "./next-wake.js";
+
+let mockPlatformAssistantId: string;
+let mockClientFetch: ReturnType<typeof mock>;
+let mockCreateClient: ReturnType<typeof mock>;
+
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: () => mockCreateClient(),
+  },
+}));
+
+const { clearBackgroundWakeIntent, publishBackgroundWakeIntent } =
+  await import("./platform-client.js");
+
+const NOW = 1_800_000_000_000;
+
+describe("background wake platform client", () => {
+  beforeEach(() => {
+    mockPlatformAssistantId = "asst-123";
+    mockClientFetch = mock(async () => new Response('{"status":"stored"}'));
+    mockCreateClient = mock(async () => ({
+      platformAssistantId: mockPlatformAssistantId,
+      fetch: mockClientFetch,
+    }));
+  });
+
+  test("publishes derived wake intent fields to Django", async () => {
+    const result = await publishBackgroundWakeIntent(intentFixture());
+
+    expect(result).toEqual({ status: "published", httpStatus: 200 });
+    expect(mockClientFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/v1/assistants/asst-123/background-wake-intent/");
+    expect(init.method).toBe("PUT");
+    expect(new Headers(init.headers).get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      reason: "schedule",
+      source_generation: NOW - 1_000,
+      computed_at: new Date(NOW - 1_000).toISOString(),
+      next_wake_at: new Date(NOW + 60_000).toISOString(),
+      actual_next_due_at: new Date(NOW + 60_000).toISOString(),
+      source_payload: {
+        heartbeat: null,
+        schedules: [
+          {
+            id: "schedule-1",
+            nextRunAt: NOW + 60_000,
+            mode: "wake",
+            createdBy: "defer",
+            status: "active",
+            updatedAt: NOW - 5_000,
+          },
+        ],
+      },
+    });
+  });
+
+  test("passes numeric sourceGeneration through when already compatible", async () => {
+    await publishBackgroundWakeIntent(
+      intentFixture({ sourceGeneration: "42" }),
+    );
+
+    const [, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body)).source_generation).toBe(42);
+  });
+
+  test("clears wake intent with the last computed snapshot when available", async () => {
+    mockClientFetch = mock(async () => new Response('{"status":"cleared"}'));
+    mockCreateClient = mock(async () => ({
+      platformAssistantId: mockPlatformAssistantId,
+      fetch: mockClientFetch,
+    }));
+
+    const result = await clearBackgroundWakeIntent(
+      intentFixture({ sourceGeneration: "99" }),
+    );
+
+    expect(result).toEqual({ status: "cleared", httpStatus: 200 });
+    expect(mockClientFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/v1/assistants/asst-123/background-wake-intent/");
+    expect(init.method).toBe("DELETE");
+    expect(JSON.parse(String(init.body))).toEqual({
+      source_generation: 99,
+      computed_at: new Date(NOW - 1_000).toISOString(),
+    });
+  });
+
+  test("clears wake intent without generation data when no snapshot is available", async () => {
+    await clearBackgroundWakeIntent(null);
+
+    const [, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("DELETE");
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+
+  test("skips when platform prerequisites are missing", async () => {
+    mockCreateClient = mock(async () => null);
+
+    await expect(publishBackgroundWakeIntent(intentFixture())).resolves.toEqual(
+      {
+        status: "skipped",
+        reason: "missing_platform_client",
+      },
+    );
+    expect(mockClientFetch).not.toHaveBeenCalled();
+
+    mockCreateClient = mock(async () => ({
+      platformAssistantId: "",
+      fetch: mockClientFetch,
+    }));
+
+    await expect(publishBackgroundWakeIntent(intentFixture())).resolves.toEqual(
+      {
+        status: "skipped",
+        reason: "missing_platform_assistant_id",
+      },
+    );
+    expect(mockClientFetch).not.toHaveBeenCalled();
+  });
+
+  test("treats Django disabled no-op responses as success", async () => {
+    mockClientFetch = mock(async () => new Response('{"status":"disabled"}'));
+    mockCreateClient = mock(async () => ({
+      platformAssistantId: mockPlatformAssistantId,
+      fetch: mockClientFetch,
+    }));
+
+    await expect(publishBackgroundWakeIntent(intentFixture())).resolves.toEqual(
+      {
+        status: "published",
+        httpStatus: 200,
+      },
+    );
+  });
+
+  test("throws on non-OK platform responses", async () => {
+    mockClientFetch = mock(
+      async () => new Response("bad gateway", { status: 502 }),
+    );
+    mockCreateClient = mock(async () => ({
+      platformAssistantId: mockPlatformAssistantId,
+      fetch: mockClientFetch,
+    }));
+
+    await expect(publishBackgroundWakeIntent(intentFixture())).rejects.toThrow(
+      "Failed to publish background wake intent: HTTP 502: bad gateway",
+    );
+    await expect(clearBackgroundWakeIntent(intentFixture())).rejects.toThrow(
+      "Failed to clear background wake intent: HTTP 502: bad gateway",
+    );
+  });
+});
+
+function intentFixture(
+  overrides: Partial<BackgroundWakeIntent> = {},
+): BackgroundWakeIntent {
+  return {
+    nextWakeAt: NOW + 60_000,
+    actualNextDueAt: NOW + 60_000,
+    reason: "schedule",
+    sourceGeneration: "bw1:opaque-hash",
+    computedAt: NOW - 1_000,
+    sourcePayload: {
+      heartbeat: null,
+      schedules: [
+        {
+          id: "schedule-1",
+          nextRunAt: NOW + 60_000,
+          mode: "wake",
+          createdBy: "defer",
+          status: "active",
+          updatedAt: NOW - 5_000,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}

--- a/assistant/src/background-wake/platform-client.test.ts
+++ b/assistant/src/background-wake/platform-client.test.ts
@@ -40,7 +40,7 @@ describe("background wake platform client", () => {
     );
     expect(JSON.parse(String(init.body))).toEqual({
       reason: "schedule",
-      source_generation: NOW - 1_000,
+      source_generation: "bw1:opaque-hash",
       computed_at: new Date(NOW - 1_000).toISOString(),
       next_wake_at: new Date(NOW + 60_000).toISOString(),
       actual_next_due_at: new Date(NOW + 60_000).toISOString(),
@@ -60,13 +60,45 @@ describe("background wake platform client", () => {
     });
   });
 
-  test("passes numeric sourceGeneration through when already compatible", async () => {
+  test("preserves stable string sourceGeneration across recomputes", async () => {
+    await publishBackgroundWakeIntent(
+      intentFixture({
+        computedAt: NOW - 1_000,
+        sourceGeneration: "bw1:stable-source-hash",
+      }),
+    );
+    await publishBackgroundWakeIntent(
+      intentFixture({
+        computedAt: NOW,
+        sourceGeneration: "bw1:stable-source-hash",
+      }),
+    );
+
+    const [, firstInit] = mockClientFetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const [, secondInit] = mockClientFetch.mock.calls[1] as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(String(firstInit.body))).toMatchObject({
+      source_generation: "bw1:stable-source-hash",
+      computed_at: new Date(NOW - 1_000).toISOString(),
+    });
+    expect(JSON.parse(String(secondInit.body))).toMatchObject({
+      source_generation: "bw1:stable-source-hash",
+      computed_at: new Date(NOW).toISOString(),
+    });
+  });
+
+  test("preserves numeric-looking sourceGeneration as a string", async () => {
     await publishBackgroundWakeIntent(
       intentFixture({ sourceGeneration: "42" }),
     );
 
     const [, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(String(init.body)).source_generation).toBe(42);
+    expect(JSON.parse(String(init.body)).source_generation).toBe("42");
   });
 
   test("clears wake intent with the last computed snapshot when available", async () => {
@@ -77,7 +109,7 @@ describe("background wake platform client", () => {
     }));
 
     const result = await clearBackgroundWakeIntent(
-      intentFixture({ sourceGeneration: "99" }),
+      intentFixture({ sourceGeneration: "bw1:opaque-hash" }),
     );
 
     expect(result).toEqual({ status: "cleared", httpStatus: 200 });
@@ -86,7 +118,7 @@ describe("background wake platform client", () => {
     expect(path).toBe("/v1/assistants/asst-123/background-wake-intent/");
     expect(init.method).toBe("DELETE");
     expect(JSON.parse(String(init.body))).toEqual({
-      source_generation: 99,
+      source_generation: "bw1:opaque-hash",
       computed_at: new Date(NOW - 1_000).toISOString(),
     });
   });

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -1,0 +1,103 @@
+import { VellumPlatformClient } from "../platform/client.js";
+import type { BackgroundWakeIntent } from "./next-wake.js";
+
+export type BackgroundWakeIntentClientResult = {
+  status: "published" | "cleared" | "skipped";
+  httpStatus?: number;
+  reason?: "missing_platform_client" | "missing_platform_assistant_id";
+};
+
+type BackgroundWakeIntentSnapshot = Pick<
+  BackgroundWakeIntent,
+  "sourceGeneration" | "computedAt"
+> | null;
+type BackgroundWakeIntentSourceSnapshot = Exclude<
+  BackgroundWakeIntentSnapshot,
+  null
+>;
+
+export async function publishBackgroundWakeIntent(
+  intent: BackgroundWakeIntent,
+): Promise<BackgroundWakeIntentClientResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) return { status: "skipped", reason: "missing_platform_client" };
+  if (!client.platformAssistantId) {
+    return { status: "skipped", reason: "missing_platform_assistant_id" };
+  }
+
+  const response = await client.fetch(intentPath(client.platformAssistantId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reason: intent.reason,
+      source_generation: sourceGenerationForPlatform(intent),
+      computed_at: toIsoString(intent.computedAt),
+      next_wake_at: toIsoString(intent.nextWakeAt),
+      actual_next_due_at: toIsoString(intent.actualNextDueAt),
+      source_payload: intent.sourcePayload,
+    }),
+  });
+
+  await throwIfNotOk(response, "publish background wake intent");
+  return { status: "published", httpStatus: response.status };
+}
+
+export async function clearBackgroundWakeIntent(
+  intentSnapshot: BackgroundWakeIntentSnapshot = null,
+): Promise<BackgroundWakeIntentClientResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) return { status: "skipped", reason: "missing_platform_client" };
+  if (!client.platformAssistantId) {
+    return { status: "skipped", reason: "missing_platform_assistant_id" };
+  }
+
+  const body: Record<string, unknown> = {};
+  if (intentSnapshot) {
+    body.source_generation = sourceGenerationForPlatform(intentSnapshot);
+    body.computed_at = toIsoString(intentSnapshot.computedAt);
+  }
+
+  const response = await client.fetch(intentPath(client.platformAssistantId), {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  await throwIfNotOk(response, "clear background wake intent");
+  return { status: "cleared", httpStatus: response.status };
+}
+
+function intentPath(assistantId: string): string {
+  const encodedAssistantId = encodeURIComponent(assistantId);
+  return `/v1/assistants/${encodedAssistantId}/background-wake-intent/`;
+}
+
+function sourceGenerationForPlatform(
+  snapshot: BackgroundWakeIntentSourceSnapshot,
+): number {
+  const numeric = Number(snapshot.sourceGeneration);
+  if (Number.isSafeInteger(numeric) && numeric >= 0) {
+    return numeric;
+  }
+  // Django/vembda expect an integer generation; local wake intents use a
+  // stable string hash, so fall back to the computed snapshot timestamp.
+  return Math.max(0, Math.floor(snapshot.computedAt));
+}
+
+function toIsoString(timestampMs: number): string {
+  return new Date(timestampMs).toISOString();
+}
+
+async function throwIfNotOk(response: Response, action: string): Promise<void> {
+  if (response.ok) return;
+
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+
+  const detail = body ? `: ${body}` : "";
+  throw new Error(`Failed to ${action}: HTTP ${response.status}${detail}`);
+}

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -11,10 +11,6 @@ type BackgroundWakeIntentSnapshot = Pick<
   BackgroundWakeIntent,
   "sourceGeneration" | "computedAt"
 > | null;
-type BackgroundWakeIntentSourceSnapshot = Exclude<
-  BackgroundWakeIntentSnapshot,
-  null
->;
 
 export async function publishBackgroundWakeIntent(
   intent: BackgroundWakeIntent,
@@ -30,7 +26,7 @@ export async function publishBackgroundWakeIntent(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       reason: intent.reason,
-      source_generation: sourceGenerationForPlatform(intent),
+      source_generation: intent.sourceGeneration,
       computed_at: toIsoString(intent.computedAt),
       next_wake_at: toIsoString(intent.nextWakeAt),
       actual_next_due_at: toIsoString(intent.actualNextDueAt),
@@ -53,7 +49,7 @@ export async function clearBackgroundWakeIntent(
 
   const body: Record<string, unknown> = {};
   if (intentSnapshot) {
-    body.source_generation = sourceGenerationForPlatform(intentSnapshot);
+    body.source_generation = intentSnapshot.sourceGeneration;
     body.computed_at = toIsoString(intentSnapshot.computedAt);
   }
 
@@ -70,18 +66,6 @@ export async function clearBackgroundWakeIntent(
 function intentPath(assistantId: string): string {
   const encodedAssistantId = encodeURIComponent(assistantId);
   return `/v1/assistants/${encodedAssistantId}/background-wake-intent/`;
-}
-
-function sourceGenerationForPlatform(
-  snapshot: BackgroundWakeIntentSourceSnapshot,
-): number {
-  const numeric = Number(snapshot.sourceGeneration);
-  if (Number.isSafeInteger(numeric) && numeric >= 0) {
-    return numeric;
-  }
-  // Django/vembda expect an integer generation; local wake intents use a
-  // stable string hash, so fall back to the computed snapshot timestamp.
-  return Math.max(0, Math.floor(snapshot.computedAt));
 }
 
 function toIsoString(timestampMs: number): string {

--- a/assistant/src/background-wake/publisher.ts
+++ b/assistant/src/background-wake/publisher.ts
@@ -1,0 +1,89 @@
+import { getLogger } from "../util/logger.js";
+import {
+  type BackgroundWakeIntent,
+  computeNextBackgroundWakeIntent,
+} from "./next-wake.js";
+import {
+  clearBackgroundWakeIntent,
+  publishBackgroundWakeIntent,
+} from "./platform-client.js";
+
+const log = getLogger("background-wake-publisher");
+const REFRESH_DEBOUNCE_MS = 250;
+
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingReason: string | null = null;
+let inFlightRefresh: Promise<void> | null = null;
+let lastIntentSnapshot: BackgroundWakeIntent | null = null;
+
+export function refreshBackgroundWakeIntent(reason: string): void {
+  pendingReason = reason;
+  schedulePendingRefresh();
+}
+
+function schedulePendingRefresh(): void {
+  if (refreshTimer || inFlightRefresh) return;
+  refreshTimer = setTimeout(runPendingRefresh, REFRESH_DEBOUNCE_MS);
+  refreshTimer.unref?.();
+}
+
+function runPendingRefresh(): void {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+
+  const reason = pendingReason ?? "unspecified";
+  pendingReason = null;
+  const refresh = runRefresh(reason).finally(() => {
+    if (inFlightRefresh === refresh) {
+      inFlightRefresh = null;
+    }
+    if (pendingReason) {
+      schedulePendingRefresh();
+    }
+  });
+  inFlightRefresh = refresh;
+}
+
+async function runRefresh(reason: string): Promise<void> {
+  try {
+    const intent = computeNextBackgroundWakeIntent();
+    if (intent) {
+      const result = await publishBackgroundWakeIntent(intent);
+      lastIntentSnapshot = intent;
+      log.debug({ reason, result }, "Background wake intent refreshed");
+      return;
+    }
+
+    const result = await clearBackgroundWakeIntent(lastIntentSnapshot);
+    lastIntentSnapshot = null;
+    log.debug({ reason, result }, "Background wake intent cleared");
+  } catch (err) {
+    log.warn({ err, reason }, "Failed to refresh background wake intent");
+  }
+}
+
+/** @internal Test helper. */
+export async function flushBackgroundWakeIntentRefreshForTest(): Promise<void> {
+  if (refreshTimer) {
+    runPendingRefresh();
+  }
+  if (inFlightRefresh) {
+    await inFlightRefresh;
+  }
+  if (refreshTimer) {
+    await flushBackgroundWakeIntentRefreshForTest();
+  }
+}
+
+/** @internal Test helper. */
+export function resetBackgroundWakeIntentPublisherForTest(): void {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+  pendingReason = null;
+  inFlightRefresh = null;
+  lastIntentSnapshot = null;
+}

--- a/assistant/src/background-wake/publisher.ts
+++ b/assistant/src/background-wake/publisher.ts
@@ -57,7 +57,9 @@ async function runRefresh(reason: string): Promise<void> {
     }
 
     const result = await clearBackgroundWakeIntent(lastIntentSnapshot);
-    lastIntentSnapshot = null;
+    if (result.status === "cleared") {
+      lastIntentSnapshot = null;
+    }
     log.debug({ reason, result }, "Background wake intent cleared");
   } catch (err) {
     log.warn({ err, reason }, "Failed to refresh background wake intent");

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -1,0 +1,215 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BackgroundWakeIntent } from "./next-wake.js";
+
+const mockPublishBackgroundWakeIntent = mock(async () => ({
+  status: "published" as const,
+}));
+const mockClearBackgroundWakeIntent = mock(async () => ({
+  status: "cleared" as const,
+}));
+let computedIntent: BackgroundWakeIntent | null = intentFixture();
+
+mock.module("./next-wake.js", () => ({
+  computeNextBackgroundWakeIntent: () => computedIntent,
+}));
+
+mock.module("./platform-client.js", () => ({
+  publishBackgroundWakeIntent: mockPublishBackgroundWakeIntent,
+  clearBackgroundWakeIntent: mockClearBackgroundWakeIntent,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishSchedulesChanged: () => {},
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => "/tmp/vellum-wake-intent-hooks",
+  getWorkspacePromptPath: (name: string) =>
+    `/tmp/vellum-wake-intent-hooks/${name}`,
+  vellumRoot: () => "/tmp/vellum-wake-intent-hooks",
+  getDataDir: () => "/tmp/vellum-wake-intent-hooks/data",
+  getConversationsDir: () => "/tmp/vellum-wake-intent-hooks/conversations",
+  isMacOS: () => false,
+  isLinux: () => true,
+  isWindows: () => false,
+  getPlatformName: () => "linux",
+  normalizeAssistantId: (id: string) => id,
+  getEmbeddingModelsDir: () => "/tmp/vellum-wake-intent-hooks/models",
+  getSandboxRootDir: () => "/tmp/vellum-wake-intent-hooks/sandbox",
+  getSandboxWorkingDir: () => "/tmp/vellum-wake-intent-hooks/sandbox/work",
+  getSoundsDir: () => "/tmp/vellum-wake-intent-hooks/sounds",
+  getAvatarDir: () => "/tmp/vellum-wake-intent-hooks/avatar",
+  AVATAR_IMAGE_FILENAME: "avatar-image.png",
+  getAvatarImagePath: () =>
+    "/tmp/vellum-wake-intent-hooks/avatar/avatar-image.png",
+  getXdgVellumConfigDirName: () => ".vellum",
+}));
+
+const {
+  flushBackgroundWakeIntentRefreshForTest,
+  refreshBackgroundWakeIntent,
+  resetBackgroundWakeIntentPublisherForTest,
+} = await import("./publisher.js");
+const { initializeDb } = await import("../memory/db-init.js");
+const { getDb } = await import("../memory/db-connection.js");
+const { createSchedule, deleteSchedule, updateSchedule } =
+  await import("../schedule/schedule-store.js");
+
+initializeDb();
+
+describe("background wake intent publisher hooks", () => {
+  beforeEach(() => {
+    computedIntent = intentFixture();
+    mockPublishBackgroundWakeIntent.mockClear();
+    mockClearBackgroundWakeIntent.mockClear();
+    mockPublishBackgroundWakeIntent.mockImplementation(async () => ({
+      status: "published" as const,
+    }));
+    mockClearBackgroundWakeIntent.mockImplementation(async () => ({
+      status: "cleared" as const,
+    }));
+    resetBackgroundWakeIntentPublisherForTest();
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("debounces repeated refreshes into one publish", async () => {
+    refreshBackgroundWakeIntent("first");
+    refreshBackgroundWakeIntent("second");
+    refreshBackgroundWakeIntent("third");
+
+    await flushBackgroundWakeIntentRefreshForTest();
+
+    expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(1);
+    expect(mockClearBackgroundWakeIntent).not.toHaveBeenCalled();
+  });
+
+  test("clears without throwing when no local intent exists", async () => {
+    computedIntent = null;
+
+    refreshBackgroundWakeIntent("no-intent");
+    await flushBackgroundWakeIntentRefreshForTest();
+
+    expect(mockClearBackgroundWakeIntent).toHaveBeenCalledTimes(1);
+    expect(mockClearBackgroundWakeIntent).toHaveBeenCalledWith(null);
+  });
+
+  test("does not throw into callers when platform publish fails", async () => {
+    mockPublishBackgroundWakeIntent.mockImplementation(async () => {
+      throw new Error("network down");
+    });
+
+    refreshBackgroundWakeIntent("publish-failure");
+    await expect(
+      flushBackgroundWakeIntentRefreshForTest(),
+    ).resolves.toBeUndefined();
+
+    expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(1);
+  });
+
+  test("schedule create, update, and delete mutations refresh the wake intent", async () => {
+    const job = createSchedule({
+      name: "Wake hook",
+      cronExpression: "* * * * *",
+      message: "wake",
+      syntax: "cron",
+    });
+    await flushQueuedWakeRefresh();
+    expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(1);
+
+    updateSchedule(job.id, { name: "Wake hook updated" });
+    await flushQueuedWakeRefresh();
+    expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(2);
+
+    expect(deleteSchedule(job.id)).toBe(true);
+    await flushQueuedWakeRefresh();
+    expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(3);
+  });
+
+  test("heartbeat scheduling and run-completion paths queue wake intent refreshes", () => {
+    const heartbeatSource = readFileSync(
+      new URL("../heartbeat/heartbeat-service.ts", import.meta.url),
+      "utf-8",
+    );
+
+    expect(heartbeatSource).toContain(
+      'refreshBackgroundWakeIntentSoon("heartbeat-disabled")',
+    );
+    expect(heartbeatSource).toContain(
+      'refreshBackgroundWakeIntentSoon("heartbeat-cron-scheduled")',
+    );
+    expect(heartbeatSource).toContain(
+      'refreshBackgroundWakeIntentSoon("heartbeat-interval-scheduled")',
+    );
+    expect(heartbeatSource).toContain(
+      'refreshBackgroundWakeIntentSoon("heartbeat-reconfigured")',
+    );
+    expect(heartbeatSource).toContain(
+      'refreshBackgroundWakeIntentSoon("heartbeat-run-complete")',
+    );
+  });
+
+  test("daemon lifecycle publishes once after heartbeat and scheduler startup", () => {
+    const lifecycleSource = readFileSync(
+      new URL("../daemon/lifecycle.ts", import.meta.url),
+      "utf-8",
+    );
+
+    expect(lifecycleSource).toContain(
+      [
+        "heartbeat.start();",
+        "registerBackgroundWakeRuntime({ scheduler, heartbeat });",
+        'refreshBackgroundWakeIntent("daemon-startup");',
+      ].join("\n    "),
+    );
+  });
+
+  test("shutdown paths do not clear background wake intents", () => {
+    const lifecycleSource = readFileSync(
+      new URL("../daemon/lifecycle.ts", import.meta.url),
+      "utf-8",
+    );
+    const shutdownSource = readFileSync(
+      new URL("../daemon/shutdown-handlers.ts", import.meta.url),
+      "utf-8",
+    );
+
+    expect(lifecycleSource).not.toContain("clearBackgroundWakeIntent");
+    expect(shutdownSource).not.toContain("clearBackgroundWakeIntent");
+    expect(shutdownSource).not.toContain("background-wake/platform-client");
+  });
+});
+
+async function flushQueuedWakeRefresh(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushBackgroundWakeIntentRefreshForTest();
+}
+
+function intentFixture(
+  overrides: Partial<BackgroundWakeIntent> = {},
+): BackgroundWakeIntent {
+  const nextWakeAt = 1_800_000_060_000;
+  return {
+    nextWakeAt,
+    actualNextDueAt: nextWakeAt,
+    reason: "schedule",
+    sourceGeneration: "bw1:source",
+    computedAt: nextWakeAt - 60_000,
+    sourcePayload: {
+      heartbeat: null,
+      schedules: [],
+    },
+    ...overrides,
+  };
+}

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -2,13 +2,18 @@ import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { BackgroundWakeIntent } from "./next-wake.js";
+import type { BackgroundWakeIntentClientResult } from "./platform-client.js";
 
-const mockPublishBackgroundWakeIntent = mock(async () => ({
-  status: "published" as const,
-}));
-const mockClearBackgroundWakeIntent = mock(async () => ({
-  status: "cleared" as const,
-}));
+const mockPublishBackgroundWakeIntent = mock(
+  async (): Promise<BackgroundWakeIntentClientResult> => ({
+    status: "published",
+  }),
+);
+const mockClearBackgroundWakeIntent = mock(
+  async (): Promise<BackgroundWakeIntentClientResult> => ({
+    status: "cleared",
+  }),
+);
 let computedIntent: BackgroundWakeIntent | null = intentFixture();
 
 mock.module("./next-wake.js", () => ({
@@ -103,6 +108,38 @@ describe("background wake intent publisher hooks", () => {
 
     expect(mockClearBackgroundWakeIntent).toHaveBeenCalledTimes(1);
     expect(mockClearBackgroundWakeIntent).toHaveBeenCalledWith(null);
+  });
+
+  test("keeps last intent snapshot when clear is skipped so it can retry", async () => {
+    const publishedIntent = intentFixture({
+      computedAt: 1_800_000_000_000,
+      sourceGeneration: "bw1:stable-source",
+    });
+    computedIntent = publishedIntent;
+
+    refreshBackgroundWakeIntent("publish");
+    await flushBackgroundWakeIntentRefreshForTest();
+
+    computedIntent = null;
+    mockClearBackgroundWakeIntent.mockImplementationOnce(async () => ({
+      status: "skipped" as const,
+      reason: "missing_platform_client" as const,
+    }));
+
+    refreshBackgroundWakeIntent("clear-skipped");
+    await flushBackgroundWakeIntentRefreshForTest();
+    refreshBackgroundWakeIntent("clear-retry");
+    await flushBackgroundWakeIntentRefreshForTest();
+
+    expect(mockClearBackgroundWakeIntent).toHaveBeenCalledTimes(2);
+    expect(mockClearBackgroundWakeIntent).toHaveBeenNthCalledWith(
+      1,
+      publishedIntent,
+    );
+    expect(mockClearBackgroundWakeIntent).toHaveBeenNthCalledWith(
+      2,
+      publishedIntent,
+    );
   });
 
   test("does not throw into callers when platform publish fails", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
 
+import { refreshBackgroundWakeIntent } from "../background-wake/publisher.js";
 import { registerBackgroundWakeRuntime } from "../background-wake/runtime-registry.js";
 import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
@@ -1271,11 +1272,9 @@ export async function runDaemon(): Promise<void> {
     })();
 
     if (config.auditLog.retentionDays > 0) {
-      void rotateToolInvocations(config.auditLog.retentionDays).catch(
-        (err) => {
-          log.warn({ err }, "Audit log rotation failed");
-        },
-      );
+      void rotateToolInvocations(config.auditLog.retentionDays).catch((err) => {
+        log.warn({ err }, "Audit log rotation failed");
+      });
     }
 
     const workspaceHeartbeat = new WorkspaceHeartbeatService();
@@ -1293,6 +1292,7 @@ export async function runDaemon(): Promise<void> {
     });
     heartbeat.start();
     registerBackgroundWakeRuntime({ scheduler, heartbeat });
+    refreshBackgroundWakeIntent("daemon-startup");
     log.info(
       {
         enabled: heartbeatConfig.enabled,

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -97,6 +97,16 @@ function recordReengagementTimestamp(): void {
   }
 }
 
+function refreshBackgroundWakeIntentSoon(reason: string): void {
+  void import("../background-wake/publisher.js")
+    .then(({ refreshBackgroundWakeIntent }) =>
+      refreshBackgroundWakeIntent(reason),
+    )
+    .catch((err) =>
+      log.warn({ err, reason }, "Failed to queue background wake refresh"),
+    );
+}
+
 export interface HeartbeatDeps {
   alerter: (alert: HeartbeatAlert) => void;
   onConversationCreated?: (info: {
@@ -206,6 +216,7 @@ export class HeartbeatService {
     if (!config.enabled) {
       log.info("Heartbeat disabled by config");
       this._nextRunAt = null;
+      refreshBackgroundWakeIntentSoon("heartbeat-disabled");
       return;
     }
     if (this.timer) return;
@@ -330,6 +341,7 @@ export class HeartbeatService {
         { nextRunAt: new Date(nextRunAt).toISOString(), delayMs },
         "Heartbeat cron run scheduled",
       );
+      refreshBackgroundWakeIntentSoon("heartbeat-cron-scheduled");
     } catch (err) {
       log.warn(
         { err },
@@ -356,6 +368,7 @@ export class HeartbeatService {
     this._nextRunAt = null;
     this.cronMode = false;
     this.start();
+    refreshBackgroundWakeIntentSoon("heartbeat-reconfigured");
   }
 
   /**
@@ -433,6 +446,7 @@ export class HeartbeatService {
 
     if (!force && !config.enabled) {
       if (runId) skipHeartbeatRun(runId, "disabled");
+      refreshBackgroundWakeIntentSoon("heartbeat-disabled");
       return false;
     }
 
@@ -557,6 +571,7 @@ export class HeartbeatService {
       if (!this.cronMode) {
         this.scheduleNextRun(getConfig().heartbeat.intervalMs);
       }
+      refreshBackgroundWakeIntentSoon("heartbeat-run-complete");
     }
     return true;
   }
@@ -567,6 +582,7 @@ export class HeartbeatService {
     }
     this._nextRunAt = Date.now() + intervalMs;
     this._pendingRunId = insertPendingHeartbeatRun(this._nextRunAt);
+    refreshBackgroundWakeIntentSoon("heartbeat-interval-scheduled");
   }
 
   /**

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -17,6 +17,13 @@ const logger = getLogger("schedule-store");
 
 function notifySchedulesChanged(): void {
   publishSchedulesChanged();
+  void import("../background-wake/publisher.js")
+    .then(({ refreshBackgroundWakeIntent }) =>
+      refreshBackgroundWakeIntent("schedule-changed"),
+    )
+    .catch((err) =>
+      logger.warn({ err }, "Failed to queue background wake refresh"),
+    );
 }
 
 export type ScheduleMode = "notify" | "execute" | "script" | "wake";


### PR DESCRIPTION
## Summary
- Added a Django-backed background wake intent client and debounced best-effort publisher.
- Hooked refreshes into heartbeat scheduling/run completion, schedule mutations, and daemon startup without clearing on shutdown.
- Added tests for publish/clear payloads, skipped/no-op cases, debounce/no-throw behavior, refresh hooks, startup publish, and shutdown preservation.

## Original prompt
This implements companion assistant plan PR 2 for the background wake intents rollout: add the assistant-side Django wake intent client and refresh hooks. It depends on assistant PR #31566 for wake intent calculation and platform PR #7628 for the Django/vembda wake intent proxy API; platform repo changes were intentionally kept out of scope.