### PR TITLE
fix(ios): wire keyboard-open detection to chat composer padding

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -19,6 +19,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router";
 import { ChevronDown } from "lucide-react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
+import { useVisibleViewport } from "@/hooks/use-visible-viewport.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { useAssistantContext } from "@/components/layout/assistant-context.js";
 import { useShallow } from "zustand/shallow";
@@ -118,6 +119,9 @@ export function ChatPage() {
   const authUser = useAuthStore.use.user();
   const showLlmInspector = canUseLlmInspector(authUser);
   const isMobile = useIsMobile();
+  const visibleViewport = useVisibleViewport();
+  const keyboardOpen =
+    isMobile && visibleViewport !== null && visibleViewport.keyboardHeight > 100;
   const isNative = useIsNativePlatform();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -1392,7 +1396,7 @@ export function ChatPage() {
     deployToVercel,
     doctor,
     isMobile,
-    isKeyboardOpen: false,
+    isKeyboardOpen: keyboardOpen,
     messages,
     setMessages,
     input,


### PR DESCRIPTION
## Summary
- `isKeyboardOpen` was hardcoded to `false` in ChatPage, so ChatBody's conditional bottom padding (`pb-2` when keyboard open vs `pb-4` when closed) and conversation-starters hiding never activated
- Import `useVisibleViewport` and compute `keyboardOpen` using the same 100px threshold as RootLayout
- Shrinks the composer-to-keyboard gap from ~16px to 8px on iOS

## Test plan
- [ ] Open the iOS app, tap the composer to open the keyboard
- [ ] Verify the gap between the composer and keyboard is ~8px (was ~16px+)
- [ ] Verify conversation starter chips are hidden when keyboard is open
- [ ] Verify no change on web (desktop) — `keyboardOpen` is always `false` when `isMobile` is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)