### PR TITLE
fix(ios): revert WKAppBoundDomains + wait for cookie propagation in biometric recovery

### DIFF
--- a/apps/ios/App/App/Info.plist
+++ b/apps/ios/App/App/Info.plist
@@ -77,11 +77,5 @@
 	<true/>
 	<key>VellumAssociatedDomain</key>
 	<string>$(ASSOCIATED_DOMAIN)</string>
-	<key>WKAppBoundDomains</key>
-	<array>
-		<string>www.vellum.ai</string>
-		<string>dev-assistant.vellum.ai</string>
-		<string>staging-assistant.vellum.ai</string>
-	</array>
 </dict>
 </plist>

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -159,7 +159,7 @@ export async function startNativeLogin(options?: {
  * finally settles, and a stuck loop here would block the user worse
  * than a possible re-login.
  */
-async function waitForNativeSessionCookie(): Promise<void> {
+export async function waitForNativeSessionCookie(): Promise<void> {
   const MAX_ATTEMPTS = 6;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -37,6 +37,7 @@ mock.module("@/lib/auth/allauth-client.js", () => ({
 mock.module("@/runtime/native-auth.js", () => ({
   isNativePlatform: () => mockIsNativePlatform,
   installSessionCookies: installSessionCookiesMock,
+  waitForNativeSessionCookie: async () => {},
 }));
 
 mock.module("@/runtime/native-biometric.js", () => ({

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -23,7 +23,7 @@ import { deleteBiometricToken } from "@/runtime/native-biometric.js";
 import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
-import { isNativePlatform, installSessionCookies } from "@/runtime/native-auth.js";
+import { isNativePlatform, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth.js";
 import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric.js";
 
 export interface AuthUser {
@@ -118,6 +118,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
         const token = await retrieveBiometricToken();
         if (token) {
           installSessionCookies(token);
+          await waitForNativeSessionCookie();
           const retryResult = await getSession();
           if (retryResult.ok && retryResult.data.user) {
             const user = toAuthUser(retryResult.data.user);


### PR DESCRIPTION
## Summary
- **Remove `WKAppBoundDomains` from Info.plist** — this key puts WKWebView into a restrictive mode that denies `window.webkit.messageHandlers` access, breaking the Capacitor native bridge. Causes `Capacitor.isNativePlatform()` to return `false`, rendering the web login form ("Continue with Google") instead of the native `ASWebAuthenticationSession` flow.
- **Wait for cookie propagation in biometric recovery** — export `waitForNativeSessionCookie` and call it after `installSessionCookies` in the biometric recovery path. WKWebView cookie writes can lag behind JS execution; without the polling wait, a valid recovered token can be missed.

Supersedes #32160 (which couldn't merge because the feature branch was already squash-merged into main).

## Test plan
- [ ] Build and run on physical iOS device
- [ ] Verify login page shows single "Sign in" button (native form), NOT "Continue with Google/Apple/Email"
- [ ] Verify sign-in opens Safari sheet in-app, not an external browser
- [ ] Verify biometric session recovery works after app kill + reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)