### PR TITLE
fix(ios): remove CapacitorCookies — splits cookie store and breaks auth

### DIFF
--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -59,11 +59,6 @@ const config: CapacitorConfig = {
     contentInset: "never",
     scheme: SCHEME_NAMES[env] ?? "App",
   },
-  plugins: {
-    CapacitorCookies: {
-      enabled: true,
-    },
-  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Remove `plugins.CapacitorCookies.enabled: true` from `capacitor.config.ts`
- CapacitorCookies patches `document.cookie` to write to native `HTTPCookieStorage`, but `fetch()` still reads from WKWebView's own cookie jar — creating a split-brain where `installSessionCookies()` writes to one store and `getSession()` reads from another
- This caused both the initial login flow and biometric recovery to fail: cookies were written but never seen by fetch-based session checks
- Biometric Keychain recovery (merged in #32153) is the correct session persistence mechanism and doesn't depend on cookie store behavior

## Test plan
- [ ] Build and run on physical iOS device
- [ ] Sign in → verify successful authentication (no double sign-in)
- [ ] Force-quit and reopen → Face ID should restore session
- [ ] Sign out → reopen → should show login screen (no stale recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)