### PR TITLE
style(web): finish dark: semantic token migration

### DIFF
--- a/apps/web/src/components/avatar/avatar-customization-panel.tsx
+++ b/apps/web/src/components/avatar/avatar-customization-panel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 import { ChevronLeft, ChevronRight, Dices, Save, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -101,7 +100,7 @@ export function AvatarCustomizationPanel({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-stone-300 border-t-stone-600 dark:border-stone-600 dark:border-t-stone-300" />
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--border-element)] border-t-[var(--content-tertiary)]" />
       </div>
     );
   }
@@ -121,7 +120,7 @@ export function AvatarCustomizationPanel({
   return (
     <div className="space-y-6">
       <div className="flex justify-center">
-        <div className="rounded-2xl bg-stone-100 p-6 dark:bg-moss-700">
+        <div className="rounded-2xl bg-[var(--surface-sunken)] p-6">
           <AvatarRenderer
             components={components}
             bodyShapeId={currentBody.id}
@@ -158,7 +157,7 @@ export function AvatarCustomizationPanel({
         <button
           type="button"
           onClick={handleRandomize}
-          className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg border border-stone-200 bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-stone-50 dark:border-moss-600 dark:hover:bg-moss-600"
+          className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-[var(--surface-hover)]"
         >
           <Dices className="h-4 w-4" />
           Randomize
@@ -167,7 +166,7 @@ export function AvatarCustomizationPanel({
           type="button"
           onClick={handleSave}
           disabled={isSaving}
-          className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg border border-forest-600 bg-forest-100 px-3 py-2 text-body-medium-default text-forest-700 transition-colors hover:bg-forest-200 disabled:opacity-50 dark:border-forest-400 dark:bg-forest-950 dark:text-forest-300 dark:hover:bg-forest-900"
+          className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg border border-[var(--system-positive-strong)] bg-[var(--system-positive-weak)] px-3 py-2 text-body-medium-default text-[var(--system-positive-strong)] transition-colors hover:opacity-90 disabled:opacity-50"
         >
           <Save className="h-4 w-4" />
           {isSaving ? "Saving..." : "Save Avatar"}
@@ -176,7 +175,7 @@ export function AvatarCustomizationPanel({
           <button
             type="button"
             onClick={onCancel}
-            className="flex cursor-pointer items-center justify-center rounded-lg border border-stone-200 bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-stone-50 dark:border-moss-600 dark:hover:bg-moss-600"
+            className="flex cursor-pointer items-center justify-center rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-[var(--surface-hover)]"
           >
             <X className="h-4 w-4" />
           </button>
@@ -196,7 +195,7 @@ interface CycleRowProps {
 
 function CycleRow({ label, value, colorHex, onPrev, onNext }: CycleRowProps) {
   return (
-    <div className="flex items-center justify-between rounded-lg border border-stone-200 bg-[var(--surface-lift)] px-3 py-2 dark:border-moss-600">
+    <div className="flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] px-3 py-2">
       <span className="text-body-small-default uppercase tracking-wider text-[var(--content-quiet)]">
         {label}
       </span>
@@ -204,14 +203,14 @@ function CycleRow({ label, value, colorHex, onPrev, onNext }: CycleRowProps) {
         <button
           type="button"
           onClick={onPrev}
-          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-stone-500 transition-colors hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-moss-600"
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-[var(--content-quiet)] transition-colors hover:bg-[var(--surface-active)]"
         >
           <ChevronLeft className="h-4 w-4" />
         </button>
         <div className="flex min-w-[80px] items-center justify-center gap-2">
           {colorHex && (
             <div
-              className="h-4 w-4 rounded-full border border-stone-300 dark:border-stone-500"
+              className="h-4 w-4 rounded-full border border-[var(--border-element)]"
               style={{ backgroundColor: colorHex }}
             />
           )}
@@ -222,7 +221,7 @@ function CycleRow({ label, value, colorHex, onPrev, onNext }: CycleRowProps) {
         <button
           type="button"
           onClick={onNext}
-          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-stone-500 transition-colors hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-moss-600"
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-[var(--content-quiet)] transition-colors hover:bg-[var(--surface-active)]"
         >
           <ChevronRight className="h-4 w-4" />
         </button>

--- a/apps/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/apps/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 /**
  * Chat-domain MarkdownMessage that composes the design-library primitive
  * with OAuth-aware link handling for authorization URLs in chat responses.
@@ -31,7 +30,7 @@ function OAuthAwareLink({
           event.preventDefault();
         }
       }}
-      className="text-forest-600 underline hover:text-forest-700 dark:text-forest-400 dark:hover:text-forest-300"
+      className="text-[var(--system-positive-strong)] underline hover:opacity-80"
     >
       {children}
     </a>

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 
 import { Check, Copy, FileCode, GitBranch } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -113,7 +112,7 @@ export function MessageHoverActions({
           type="button"
           onClick={handleCopy}
           title={showCopied ? "Copied" : "Copy"}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-stone-200 hover:text-[var(--content-secondary)] dark:hover:bg-moss-600 dark:hover:text-stone-200"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
         >
           {showCopied ? (
             <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
@@ -128,7 +127,7 @@ export function MessageHoverActions({
           type="button"
           onClick={onFork}
           title="Fork from here"
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-stone-200 hover:text-[var(--content-secondary)] dark:hover:bg-moss-600 dark:hover:text-stone-200"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
         >
           <GitBranch className="h-3.5 w-3.5" />
         </button>
@@ -139,7 +138,7 @@ export function MessageHoverActions({
           type="button"
           onClick={onInspect}
           title="Inspect"
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-stone-200 hover:text-[var(--content-secondary)] dark:hover:bg-moss-600 dark:hover:text-stone-200"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
         >
           <FileCode className="h-3.5 w-3.5" />
         </button>

--- a/apps/web/src/domains/chat/components/surfaces/browser-view-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/browser-view-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { ExternalLink } from "lucide-react";
 
 import type { Surface } from "@/domains/chat/types/types.js";
@@ -35,7 +33,7 @@ export function BrowserViewSurface({ surface, onAction }: BrowserViewSurfaceProp
               href={data.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-1 inline-flex items-center gap-1.5 text-body-medium-lighter text-forest-600 underline decoration-forest-600/30 transition-colors hover:text-forest-700 hover:decoration-forest-700/50 dark:text-forest-400 dark:decoration-forest-400/30 dark:hover:text-forest-300"
+              className="mt-1 inline-flex items-center gap-1.5 text-body-medium-lighter text-[var(--system-positive-strong)] underline decoration-[var(--system-positive-strong)]/30 transition-colors hover:opacity-80"
             >
               <ExternalLink className="h-3.5 w-3.5 shrink-0" />
               <span className="break-all">{data.url}</span>

--- a/apps/web/src/domains/chat/components/surfaces/call-summary-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/call-summary-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { ChevronDown, ChevronRight, Phone, PhoneMissed, PhoneOff } from "lucide-react";
 import { useState } from "react";
 
@@ -50,9 +48,9 @@ export function CallSummarySurface({
         : Phone;
 
   return (
-    <div className="rounded-lg border border-stone-200 bg-[var(--surface-lift)] dark:border-moss-600">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)]">
       <button
-        className="flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-50 dark:hover:bg-moss-600 rounded-lg"
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-[var(--surface-hover)] rounded-lg"
         onClick={() => setExpanded((v) => !v)}
       >
         <StatusIcon className="h-4 w-4 shrink-0 text-[var(--content-faint)]" />
@@ -71,13 +69,13 @@ export function CallSummarySurface({
       </button>
 
       {expanded && events.length > 0 && (
-        <div className="border-t border-stone-100 dark:border-moss-600 px-3 py-2 space-y-1">
+        <div className="border-t border-[var(--border-base)] px-3 py-2 space-y-1">
           {events.map((e, i) => (
             <div
               key={i}
               className="flex items-center justify-between gap-4 py-1"
             >
-              <span className="text-body-small-default font-mono text-stone-600 dark:text-stone-400">
+              <span className="text-body-small-default font-mono text-[var(--content-tertiary)]">
                 {prettifyEventType(e.eventType)}
               </span>
               <span className="text-body-small-default text-[var(--content-faint)] shrink-0">

--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { Circle, CircleCheck, CircleX, Clock, Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
@@ -103,7 +101,7 @@ function TaskProgressBar({ templateData }: { templateData: Record<string, unknow
         </span>
         <span>{percent}%</span>
       </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-stone-200 dark:bg-moss-600">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--border-subtle)]">
         <div
           className="h-full rounded-full bg-forest-500 transition-all"
           style={{ width: `${percent}%` }}
@@ -141,7 +139,7 @@ function TaskStepList({ steps }: { steps: TaskStepItem[] }) {
         const showDetailOnRight = step.status === "in_progress" && !!step.detail;
         return (
           <div key={step.id || index} className="flex items-center gap-2.5 py-2 first:pt-0 last:pb-0">
-            <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-stone-100 px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)] dark:bg-moss-600">
+            <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)]">
               {index + 1}
             </span>
             <div className="min-w-0 flex-1">
@@ -220,14 +218,14 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
           <WeatherForecastDisplay templateData={data.templateData!} fallback={
             <ChatMarkdownMessage
               content={data.body}
-              className="mt-2 text-body-medium-lighter text-stone-600 dark:text-stone-300"
+              className="mt-2 text-body-medium-lighter text-[var(--content-tertiary)]"
             />
           } />
         ) : (
           <>
             <ChatMarkdownMessage
               content={data.body}
-              className="mt-2 text-body-medium-lighter text-stone-600 dark:text-stone-300"
+              className="mt-2 text-body-medium-lighter text-[var(--content-tertiary)]"
             />
 
             {data.metadata && data.metadata.length > 0 && (

--- a/apps/web/src/domains/chat/components/surfaces/document-preview-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/document-preview-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { ArrowUpRight, FileText } from "lucide-react";
 import type { KeyboardEvent } from "react";
 
@@ -74,7 +72,7 @@ export function DocumentPreviewSurface({
             {data.documentName}
           </h3>
           {data.mimeType && (
-            <span className="rounded-full bg-stone-100 px-2 py-0.5 text-body-small-default text-stone-600 dark:bg-moss-600 dark:text-stone-300">
+            <span className="rounded-full bg-[var(--tag-bg-neutral)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
               {data.mimeType}
             </span>
           )}
@@ -84,7 +82,7 @@ export function DocumentPreviewSurface({
         </div>
 
         {data.content && (
-          <pre className="mt-3 max-h-60 overflow-auto whitespace-pre-wrap rounded-md bg-stone-50 p-3 text-body-small-default text-stone-700 dark:bg-moss-800 dark:text-stone-300">
+          <pre className="mt-3 max-h-60 overflow-auto whitespace-pre-wrap rounded-md bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-default)]">
             {data.content}
           </pre>
         )}

--- a/apps/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { Minimize2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -175,7 +173,7 @@ function StatusPill({ text }: { text: string }) {
   if (state.hidden) return null;
 
   return (
-    <div className="absolute top-2 right-2 z-10 rounded-full bg-stone-800/80 px-3 py-1 text-body-small-default text-white shadow-sm backdrop-blur-sm transition-opacity duration-300 dark:bg-stone-200/80 dark:text-stone-900">
+    <div className="absolute top-2 right-2 z-10 rounded-full bg-[var(--primary-base)]/80 px-3 py-1 text-body-small-default text-[var(--content-inset)] shadow-sm backdrop-blur-sm transition-opacity duration-300">
       {text}
     </div>
   );
@@ -396,9 +394,9 @@ export function DynamicPageSurface({
   const height = data.height ? `${data.height}px` : "400px";
 
   return (
-    <div className="rounded-lg border border-stone-200 bg-[var(--surface-lift)] dark:border-moss-600">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)]">
       {(surface.title || expanded) && (
-        <div className="flex items-center justify-between border-b border-stone-200 px-4 py-2 dark:border-moss-600">
+        <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-2">
           <span className="text-title-small text-[var(--content-strong)]">
             {surface.title}
           </span>
@@ -406,7 +404,7 @@ export function DynamicPageSurface({
             <button
               type="button"
               onClick={handleCollapse}
-              className="flex items-center gap-1 rounded p-1 text-body-small-default text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-moss-600 dark:hover:text-stone-200"
+              className="flex items-center gap-1 rounded p-1 text-body-small-default text-[var(--content-quiet)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
             >
               <Minimize2 className="h-3.5 w-3.5" />
             </button>

--- a/apps/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { AlertTriangle, File, Loader2, Upload, X } from "lucide-react";
 import { type ChangeEvent, type DragEvent, useCallback, useRef, useState } from "react";
 
@@ -257,7 +255,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
   }, [selectedFiles, onAction, surface.surfaceId]);
 
   return (
-    <div className="rounded-lg border border-stone-200 bg-[var(--surface-lift)] p-4 dark:border-moss-600">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
       {surface.title && (
         <div className="mb-3 flex items-center gap-2">
           <span className="text-title-small text-[var(--content-strong)]">
@@ -279,14 +277,14 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
         onClick={() => fileInputRef.current?.click()}
         className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-6 transition-colors ${
           isDragOver
-            ? "border-forest-500 bg-forest-50 dark:border-forest-400 dark:bg-forest-950"
-            : "border-stone-300 bg-stone-50 hover:border-stone-400 dark:border-moss-500 dark:bg-moss-800 dark:hover:border-moss-400"
+            ? "border-[var(--system-positive-strong)] bg-[var(--system-positive-weak)]"
+            : "border-[var(--border-element)] bg-[var(--surface-sunken)] hover:border-[var(--content-faint)]"
         }`}
       >
         <Upload
           className={`h-8 w-8 ${
             isDragOver
-              ? "text-forest-500 dark:text-forest-400"
+              ? "text-[var(--system-positive-strong)]"
               : "text-[var(--content-faint)]"
           }`}
         />
@@ -320,7 +318,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
           {selectedFiles.map((sf) => (
             <li
               key={sf.id}
-              className="flex items-center gap-2 rounded-md bg-stone-50 px-3 py-2 text-body-medium-lighter dark:bg-moss-800"
+              className="flex items-center gap-2 rounded-md bg-[var(--surface-sunken)] px-3 py-2 text-body-medium-lighter"
             >
               <File className="h-4 w-4 shrink-0 text-[var(--content-faint)]" />
               <span className="min-w-0 flex-1 truncate text-[var(--content-strong)]">
@@ -336,7 +334,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
                   e.stopPropagation();
                   removeFile(sf.id);
                 }}
-                className="shrink-0 rounded p-0.5 text-stone-400 transition-colors hover:bg-stone-200 hover:text-stone-600 disabled:opacity-50 dark:text-stone-500 dark:hover:bg-moss-600 dark:hover:text-stone-300"
+                className="shrink-0 rounded p-0.5 text-[var(--content-faint)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-secondary)] disabled:opacity-50"
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -350,7 +348,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
 
       {/* Suspicious extension warning */}
       {extensionWarning && (
-        <div className="mt-2 flex items-center gap-1.5 text-body-small-default text-amber-600 dark:text-amber-400">
+        <div className="mt-2 flex items-center gap-1.5 text-body-small-default text-[var(--system-mid-strong)]">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
           {extensionWarning}
         </div>

--- a/apps/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { ChevronLeft, ChevronRight, Loader2, Lock, Send, Shield } from "lucide-react";
 import { type FormEvent, useCallback, useMemo, useState } from "react";
 
@@ -63,9 +61,9 @@ function renderField(
 ) {
   const errorMsg = validationErrors[field.id];
   const inputClasses =
-    "w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-body-medium-lighter focus:border-forest-600 focus:outline-none focus:ring-1 focus:ring-forest-600 dark:border-moss-600 dark:bg-moss-800 dark:text-white";
+    "w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--field-bg)] px-3 py-2 text-body-medium-lighter text-[var(--content-default)] focus:border-forest-600 focus:outline-none focus:ring-1 focus:ring-forest-600";
   const errorClasses = errorMsg
-    ? " border-danger-400 dark:border-danger-500"
+    ? " border-[var(--system-negative-strong)]"
     : "";
 
   switch (field.type) {
@@ -171,7 +169,7 @@ function PageProgress({ current, total }: { current: number; total: number }) {
         <div
           key={i}
           className={`h-1.5 flex-1 rounded-full transition-colors ${
-            i <= current ? "bg-forest-500" : "bg-stone-200 dark:bg-moss-600"
+            i <= current ? "bg-forest-500" : "bg-[var(--border-subtle)]"
           }`}
         />
       ))}
@@ -285,7 +283,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
     : (formData.submitLabel ?? "Submit");
 
   return (
-    <div className="rounded-lg border border-stone-200 bg-[var(--surface-lift)] p-4 dark:border-moss-600">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
       {surface.title && (
         <div className="mb-3 flex items-center gap-2">
           <span className="text-title-small text-[var(--content-strong)]">
@@ -336,7 +334,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
                 type="button"
                 onClick={handleBack}
                 disabled={isSubmitting}
-                className="flex items-center gap-1 rounded-lg border border-stone-300 bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-stone-50 disabled:opacity-50 dark:border-moss-600 dark:hover:bg-moss-600"
+                className="flex items-center gap-1 rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] px-3 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-[var(--surface-hover)] disabled:opacity-50"
               >
                 <ChevronLeft className="h-4 w-4" />
                 {backLabel}

--- a/apps/web/src/domains/chat/components/surfaces/list-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/list-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { Check, icons } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
@@ -85,7 +83,7 @@ export function ListSurface({ surface, onAction }: ListSurfaceProps) {
 
   return (
     <SurfaceContainer surface={surface} onAction={handleAction}>
-      <ul className="divide-y divide-stone-100 dark:divide-moss-600">
+      <ul className="divide-y divide-[var(--border-base)]">
         {data.items.map((item) => {
           const isSelected = selectedIds.includes(item.id);
 
@@ -97,11 +95,11 @@ export function ListSurface({ surface, onAction }: ListSurfaceProps) {
                 onClick={() => handleToggle(item.id)}
                 className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
                   isSelectable
-                    ? "cursor-pointer hover:bg-stone-50 dark:hover:bg-moss-600"
+                    ? "cursor-pointer hover:bg-[var(--surface-hover)]"
                     : "cursor-default"
                 } ${
                   isSelected
-                    ? "bg-forest-50 dark:bg-forest-950"
+                    ? "bg-[var(--system-positive-weak)]"
                     : ""
                 }`}
               >
@@ -111,7 +109,7 @@ export function ListSurface({ surface, onAction }: ListSurfaceProps) {
                     className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
                       isSelected
                         ? "border-forest-600 bg-forest-600 text-white"
-                        : "border-stone-300 dark:border-moss-500"
+                        : "border-[var(--border-element)]"
                     } ${selectionMode === "single" ? "rounded-full" : "rounded"}`}
                   >
                     {isSelected && <Check className="h-3 w-3" />}

--- a/apps/web/src/domains/chat/components/surfaces/surface-container.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/surface-container.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 
 import { CheckCircle, Loader2 } from "lucide-react";
 import { type ReactNode, useState } from "react";
@@ -25,7 +24,7 @@ export function SurfaceContainer({ surface, onAction, children }: SurfaceContain
   };
 
   return (
-    <div className="rounded-lg border border-stone-200 bg-[var(--surface-lift)] p-4 dark:border-moss-600">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
       {surface.title && (
         <div className="mb-3 flex items-center gap-2">
           <span className="text-title-small text-[var(--content-strong)]">
@@ -57,7 +56,7 @@ export function SurfaceContainer({ surface, onAction, children }: SurfaceContain
                 className={
                   action.style === "primary"
                     ? "flex items-center gap-2 rounded-lg bg-forest-600 px-4 py-2 text-body-medium-default text-white transition-colors hover:bg-forest-700 disabled:opacity-50"
-                    : "flex items-center gap-2 rounded-lg border border-stone-300 bg-[var(--surface-lift)] px-4 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-stone-50 disabled:opacity-50 dark:border-moss-600 dark:hover:bg-moss-600"
+                    : "flex items-center gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] px-4 py-2 text-body-medium-default text-[var(--content-strong)] transition-colors hover:bg-[var(--surface-hover)] disabled:opacity-50"
                 }
               >
                 {submittingAction === action.id && (

--- a/apps/web/src/domains/chat/components/surfaces/table-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/table-surface.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { Check, Copy, icons } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -164,7 +162,7 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
           <button
             type="button"
             onClick={handleCopy}
-            className="flex items-center gap-1 rounded p-1 text-body-small-default text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-moss-600 dark:hover:text-stone-200"
+            className="flex items-center gap-1 rounded p-1 text-body-small-default text-[var(--content-quiet)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
             aria-label="Copy table as markdown"
           >
             {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
@@ -188,7 +186,7 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-stone-100 dark:divide-moss-600">
+          <tbody className="divide-y divide-[var(--border-base)]">
             {data.rows.map((row) => {
               const isSelected = selectedIds.includes(row.id);
               const rowSelectable = isSelectable && row.selectable !== false;
@@ -199,11 +197,11 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                   onClick={() => rowSelectable && handleToggle(row.id)}
                   className={`transition-colors ${
                     rowSelectable
-                      ? "cursor-pointer hover:bg-stone-50 dark:hover:bg-moss-600"
+                      ? "cursor-pointer hover:bg-[var(--surface-hover)]"
                       : ""
                   } ${
                     isSelected
-                      ? "bg-forest-50 dark:bg-forest-950"
+                      ? "bg-[var(--system-positive-weak)]"
                       : ""
                   }`}
                 >
@@ -214,7 +212,7 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                           className={`flex h-5 w-5 items-center justify-center rounded border transition-colors ${
                             isSelected
                               ? "border-forest-600 bg-forest-600 text-white"
-                              : "border-stone-300 dark:border-moss-500"
+                              : "border-[var(--border-element)]"
                           } ${selectionMode === "single" ? "rounded-full" : "rounded"}`}
                         >
                           {isSelected && <Check className="h-3 w-3" />}
@@ -227,7 +225,7 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                     return (
                       <td
                         key={col.id}
-                        className="px-3 py-2 text-stone-700 dark:text-stone-300"
+                        className="px-3 py-2 text-[var(--content-default)]"
                         style={col.width ? { width: `${col.width}px` } : undefined}
                       >
                         {isRichCell(cell) ? (

--- a/apps/web/src/domains/chat/components/surfaces/weather-forecast-display.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/weather-forecast-display.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import {
   Cloud,
   CloudFog,
@@ -300,7 +298,7 @@ function UnitToggle({
   onToggle: (f: boolean) => void;
 }) {
   return (
-    <div className="flex overflow-hidden rounded-md border border-stone-200 dark:border-moss-500">
+    <div className="flex overflow-hidden rounded-md border border-[var(--border-element)]">
       <button
         type="button"
         onClick={() => onToggle(true)}
@@ -363,13 +361,13 @@ function HeroSection({
     <div>
       <div className="flex items-start justify-between">
         <div>
-          <div className="text-body-medium-default text-stone-600 dark:text-stone-300">
+          <div className="text-body-medium-default text-[var(--content-tertiary)]">
             {locationName}
           </div>
           {currentTempStr !== null && (
             // typography: off-scale -- large hero temperature display matching macOS weather widget
              
-            <div className="mt-1 text-4xl font-light text-stone-800 dark:text-stone-100">
+            <div className="mt-1 text-4xl font-light text-[var(--content-default)]">
               {currentTempStr}&deg;{unitSymbol}
             </div>
           )}
@@ -394,13 +392,13 @@ function HeroSection({
           </span>
         )}
         {windStr && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-label-medium-default text-stone-600 dark:bg-moss-600 dark:text-stone-300">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[var(--tag-bg-neutral)] px-2 py-0.5 text-label-medium-default text-[var(--content-tertiary)]">
             <Wind width={12} height={12} />
             {windStr}
           </span>
         )}
         {data.humidity !== undefined && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-label-medium-default text-stone-600 dark:bg-moss-600 dark:text-stone-300">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[var(--tag-bg-neutral)] px-2 py-0.5 text-label-medium-default text-[var(--content-tertiary)]">
             <Droplets width={12} height={12} />
             {data.humidity}%
           </span>
@@ -420,7 +418,7 @@ function HourlySection({
   useFahrenheit: boolean;
 }) {
   return (
-    <div className="mt-3 border-t border-stone-200 pt-3 dark:border-moss-500">
+    <div className="mt-3 border-t border-[var(--border-element)] pt-3">
       <div className="flex gap-3 overflow-x-auto">
         {hourly.map((item, i) => {
           const isNow = item.time.toLowerCase() === "now";
@@ -433,7 +431,7 @@ function HourlySection({
               <span
                 className={
                   isNow
-                    ? "text-body-small-emphasised text-stone-800 dark:text-stone-100"
+                    ? "text-body-small-emphasised text-[var(--content-default)]"
                     : "text-label-medium-default text-[var(--content-quiet)]"
                 }
               >
@@ -441,7 +439,7 @@ function HourlySection({
               </span>
               <WeatherIcon icon={item.icon} size={18} />
               {tempStr !== null && (
-                <span className="text-body-small-default text-stone-700 dark:text-stone-200">
+                <span className="text-body-small-default text-[var(--content-default)]">
                   {tempStr}&deg;
                 </span>
               )}
@@ -480,7 +478,7 @@ function DailySection({
   const range = globalMax - globalMin || 1;
 
   return (
-    <div className="mt-3 border-t border-stone-200 pt-3 dark:border-moss-500">
+    <div className="mt-3 border-t border-[var(--border-element)] pt-3">
       <div className="flex flex-col gap-2">
         {forecast.map((item, i) => {
           const dayName = item.dayLabel ?? item.day ?? `Day ${i + 1}`;
@@ -515,7 +513,7 @@ function DailySection({
               <span
                 className={`w-12 shrink-0 truncate text-body-small-default ${
                   isToday
-                    ? "text-stone-800 dark:text-stone-100"
+                    ? "text-[var(--content-default)]"
                     : "text-[var(--content-quiet)]"
                 }`}
               >
@@ -535,7 +533,7 @@ function DailySection({
                 {lowStr !== null ? `${lowStr}°` : "--"}
               </span>
 
-              <div className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-stone-200 dark:bg-moss-600">
+              <div className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--border-subtle)]">
                 <div
                   className="absolute top-0 h-full rounded-full bg-forest-500"
                   style={{
@@ -545,7 +543,7 @@ function DailySection({
                 />
                 {dotPosition !== null && (
                   <div
-                    className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-white shadow-sm dark:border-moss-700 dark:bg-stone-200"
+                    className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-[var(--aux-white)] bg-[var(--aux-white)] shadow-sm"
                     style={{
                       left: `${barLeft + (dotPosition / 100) * barWidth}%`,
                     }}
@@ -553,7 +551,7 @@ function DailySection({
                 )}
               </div>
 
-              <span className="w-7 shrink-0 text-right text-body-small-default text-stone-700 dark:text-stone-200">
+              <span className="w-7 shrink-0 text-right text-body-small-default text-[var(--content-default)]">
                 {highStr !== null ? `${highStr}°` : "--"}
               </span>
             </div>

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -458,7 +458,7 @@ function ServiceCard({ id, title, subtitle, mode, onModeChange, children }: Serv
       subtitle={subtitle}
       accessory={<ModeToggle mode={mode} onChange={onModeChange} />}
     >
-      <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
+      <div className="h-px bg-[var(--surface-active)]" />
       <div className="mt-4">{children}</div>
     </SettingsCard>
   );
@@ -501,7 +501,7 @@ interface ByoServiceCardProps {
 function ByoServiceCard({ title, subtitle, children }: ByoServiceCardProps) {
   return (
     <SettingsCard title={title} subtitle={subtitle}>
-      <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
+      <div className="h-px bg-[var(--surface-active)]" />
       <div className="mt-4">{children}</div>
     </SettingsCard>
   );
@@ -1957,7 +1957,7 @@ export function AiPage() {
           alongside 3 lines of body text, which read as two competing
           blocks. `items-start` plus a small mt-0.5 on the Info icon
           keep the icon aligned with the first line of wrapping text. */}
-      <div className="flex items-start gap-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] px-4 py-2.5 dark:border-[var(--border-base)] dark:bg-[var(--surface-lift)]">
+      <div className="flex items-start gap-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] px-4 py-2.5">
         <Info className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-tertiary)]" />
         <p className="text-body-medium-lighter text-[var(--content-secondary)]">
           Managed services are metered and deducted from your Vellum account

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 import {
   AlertCircle,
   Check,
@@ -514,15 +513,15 @@ interface CredentialsGuideProps {
 
 function CredentialsGuide({ guide }: CredentialsGuideProps) {
   return (
-    <div className="flex items-start gap-2 rounded-lg border border-stone-200 bg-stone-50 p-3 text-body-small-default text-stone-600 dark:border-moss-600 dark:bg-moss-800 dark:text-stone-300">
-      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-forest-700 dark:text-forest-400" />
+    <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
       <div className="flex flex-col gap-1">
         <span>{guide.description}</span>
         <a
           href={guide.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-forest-700 underline hover:text-forest-800 dark:text-forest-400"
+          className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
         >
           {guide.linkLabel}
           <ExternalLink className="h-3 w-3" />
@@ -872,7 +871,7 @@ function DomainVerificationChip({
 }) {
   if (isLoading) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2.5 py-0.5 text-body-small-default text-stone-500 dark:bg-moss-800 dark:text-stone-400">
+      <span className="inline-flex items-center gap-1 rounded-full bg-[var(--tag-bg-neutral)] px-2.5 py-0.5 text-body-small-default text-[var(--content-quiet)]">
         <Loader2 className="h-3 w-3 animate-spin" />
         Checking domain…
       </span>
@@ -882,7 +881,7 @@ function DomainVerificationChip({
   if (!status) {
     return (
       <span
-        className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2.5 py-0.5 text-body-small-default text-stone-500 dark:bg-moss-800 dark:text-stone-400"
+        className="inline-flex items-center gap-1 rounded-full bg-[var(--tag-bg-neutral)] px-2.5 py-0.5 text-body-small-default text-[var(--content-quiet)]"
         title="Unable to retrieve domain verification status."
       >
         Unknown status
@@ -905,7 +904,7 @@ function DomainVerificationChip({
   if (status === "pending" || status === "not_started") {
     return (
       <span
-        className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-0.5 text-body-small-default text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+        className="inline-flex items-center gap-1 rounded-full bg-[var(--system-mid-weak)] px-2.5 py-0.5 text-body-small-default text-[var(--system-mid-strong)]"
         title="DNS records have been provisioned. Waiting for the email provider to verify them — this usually takes a few minutes."
       >
         <Clock className="h-3 w-3" />
@@ -916,7 +915,7 @@ function DomainVerificationChip({
 
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-0.5 text-body-small-default text-red-700 dark:bg-red-900/30 dark:text-red-400"
+      className="inline-flex items-center gap-1 rounded-full bg-[var(--system-negative-weak)] px-2.5 py-0.5 text-body-small-default text-[var(--system-negative-strong)]"
       title="Domain verification failed. DNS records may not have propagated correctly. You could try releasing and re-registering the domain."
     >
       <AlertCircle className="h-3 w-3" />
@@ -1407,8 +1406,8 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
             />
           </div>
 
-          <div className="flex items-start gap-2 rounded-lg border border-stone-200 bg-stone-50 p-3 text-body-small-default text-stone-600 dark:border-moss-600 dark:bg-moss-800 dark:text-stone-300">
-            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-forest-700 dark:text-forest-400" />
+          <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
             <div className="flex flex-col gap-1">
               <span>
                 Configure {selectedByoProvider.displayName} via the assistant
@@ -1423,7 +1422,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
                 href={selectedByoProvider.docsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-forest-700 underline hover:text-forest-800 dark:text-forest-400"
+                className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
               >
                 Open {selectedByoProvider.displayName}
                 <ExternalLink className="h-3 w-3" />

--- a/apps/web/src/domains/settings/components/assistant-backups.tsx
+++ b/apps/web/src/domains/settings/components/assistant-backups.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
-
 import { AlertTriangle, Clock, Loader2, RotateCcw, Save } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
@@ -133,7 +131,7 @@ export function AssistantBackups({ assistantId }: { assistantId: string }) {
 
   if (error) {
     return (
-      <div className="flex items-center gap-2 text-body-medium-lighter text-red-600 dark:text-red-400">
+      <div className="flex items-center gap-2 text-body-medium-lighter text-[var(--system-negative-strong)]">
         <AlertTriangle className="h-4 w-4 shrink-0" />
         {error}
       </div>

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeft,
@@ -122,11 +121,11 @@ function StatusDot({ status }: { status: string | null }) {
 
 function EmptyState({ onCreate }: { onCreate: () => void }) {
   return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center rounded-lg border border-stone-200 bg-white px-6 py-16 text-center dark:border-moss-600 dark:bg-moss-700/50">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-stone-100 dark:bg-moss-600">
-        <Calendar className="h-6 w-6 text-stone-400 dark:text-stone-300" />
+    <div className="flex min-h-[400px] flex-col items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] px-6 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--tag-bg-neutral)]">
+        <Calendar className="h-6 w-6 text-[var(--content-faint)]" />
       </div>
-      <h2 className="mt-4 text-title-small text-stone-900 dark:text-white">
+      <h2 className="mt-4 text-title-small text-[var(--content-default)]">
         No schedules
       </h2>
       <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
@@ -181,7 +180,7 @@ function RunLogView({ run, onBack }: { run: ScheduleRun; onBack: () => void }) {
 
       {run.output && (
         <SettingsCard title="Output">
-          <pre className="max-h-80 overflow-auto rounded-md bg-stone-50 p-3 text-body-small-default font-mono text-stone-800 dark:bg-moss-800 dark:text-stone-200 whitespace-pre-wrap break-all">
+          <pre className="max-h-80 overflow-auto rounded-md bg-[var(--surface-sunken)] p-3 text-body-small-default font-mono text-[var(--content-default)] whitespace-pre-wrap break-all">
             {run.output}
           </pre>
         </SettingsCard>
@@ -189,7 +188,7 @@ function RunLogView({ run, onBack }: { run: ScheduleRun; onBack: () => void }) {
 
       {run.error && (
         <SettingsCard title="Error">
-          <pre className="max-h-80 overflow-auto rounded-md bg-red-50 p-3 text-body-small-default font-mono text-red-800 dark:bg-red-950/30 dark:text-red-300 whitespace-pre-wrap break-all">
+          <pre className="max-h-80 overflow-auto rounded-md bg-[var(--system-negative-weak)] p-3 text-body-small-default font-mono text-[var(--system-negative-strong)] whitespace-pre-wrap break-all">
             {run.error}
           </pre>
         </SettingsCard>
@@ -378,7 +377,7 @@ export function ScheduleDetailView({
               <span className="text-[var(--content-secondary)] text-body-small-default">
                 Command
               </span>
-              <pre className="mt-1 rounded-md bg-stone-50 p-2 text-body-small-default font-mono text-stone-800 dark:bg-moss-800 dark:text-stone-200 whitespace-pre-wrap break-all">
+              <pre className="mt-1 rounded-md bg-[var(--surface-sunken)] p-2 text-body-small-default font-mono text-[var(--content-default)] whitespace-pre-wrap break-all">
                 {schedule.script}
               </pre>
             </div>

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 import { ArrowUpRight, Info } from "lucide-react";
 import {
   useCallback,
@@ -61,7 +60,7 @@ type ConversationTimeoutValue =
 const DEFAULT_CONVERSATION_TIMEOUT: ConversationTimeoutValue = "30";
 
 const labelClasses =
-  "text-body-small-default text-stone-600 dark:text-stone-300";
+  "text-body-small-default text-[var(--content-tertiary)]";
 
 export function VoicePage() {
   return (
@@ -75,14 +74,14 @@ export function VoicePage() {
 
 function SpeechServicesBanner() {
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 py-2 dark:border-moss-600 dark:bg-moss-800">
+    <div className="flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--field-bg)] px-3 py-2">
       <Info className="h-3.5 w-3.5 shrink-0 text-forest-700" />
-      <span className="text-body-medium-lighter text-stone-600 dark:text-stone-300">
+      <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
         Looking to configure Speech-to-Text or Text-to-Speech models?
       </span>
       <Link
         to={routes.settings.ai}
-        className="inline-flex items-center gap-1 text-body-medium-lighter text-forest-700 underline hover:text-forest-800 dark:text-forest-500 dark:hover:text-forest-400"
+        className="inline-flex items-center gap-1 text-body-medium-lighter text-[var(--system-positive-strong)] underline hover:opacity-80"
       >
         Go to Models &amp; Services
         <ArrowUpRight className="h-3 w-3" />
@@ -310,8 +309,8 @@ function ActivationKeyOption({
     "inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-body-medium-lighter transition-colors",
     "border-[var(--border-subtle)]",
     selected
-      ? "bg-stone-100 dark:bg-moss-700"
-      : "bg-white hover:bg-[var(--surface-sunken)] dark:hover:bg-moss-700",
+      ? "bg-[var(--surface-active)]"
+      : "bg-[var(--surface-lift)] hover:bg-[var(--surface-hover)]",
     recording ? "animate-pulse" : "",
   ]
     .filter(Boolean)
@@ -324,10 +323,10 @@ function ActivationKeyOption({
           "inline-block h-2.5 w-2.5 rounded-full border",
           selected
             ? "border-forest-700 bg-forest-700"
-            : "border-stone-300 dark:border-moss-500",
+            : "border-[var(--border-element)]",
         ].join(" ")}
       />
-      <span className="text-stone-900 dark:text-white">{label}</span>
+      <span className="text-[var(--content-default)]">{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Prompt / plan

Completes the `dark:` semantic token migration started in LUM-1768. That issue ported most of the codebase to mode-aware CSS custom properties from `design-library/tokens.css`, but left ~80 raw color-scale violations suppressed behind `eslint-disable` comments. This PR replaces every remaining `dark:bg-moss-*`, `dark:text-stone-*`, `dark:border-moss-*`, etc. pair with the correct semantic token so that light, dark, and velvet themes all resolve correctly without the `dark:` selector.

### Why needed

The `dark:` Tailwind prefix maps to `[data-theme=dark]`, but velvet mode uses `[data-theme=velvet]`. Any `dark:bg-moss-700` class is invisible to velvet — the element falls back to its light-mode color, breaking the theme. Semantic tokens (`--surface-active`, `--border-subtle`, etc.) are defined for all three themes and resolve automatically.

### What changed

**18 files across 4 clusters:**

- **surfaces/** (11 files): `surface-container`, `call-summary-surface`, `form-surface`, `weather-forecast-display`, `file-upload-surface`, `table-surface`, `dynamic-page-surface`, `card-surface`, `document-preview-surface`, `browser-view-surface`, `list-surface`
- **settings/** (3 files): `voice-page`, `schedules-page`, `ai-page`
- **remaining** (4 files): `avatar-customization-panel`, `chat-markdown-message`, `assistant-backups`, `message-hover-actions`

**Replacement patterns applied:**

| Before | After |
|---|---|
| `dark:border-moss-600` | `border-[var(--border-subtle)]` or `border-[var(--border-element)]` |
| `dark:bg-moss-700/50` | `bg-[var(--surface-active)]` or `bg-[var(--surface-hover)]` |
| `dark:text-stone-300` | `text-[var(--content-tertiary)]` or `text-[var(--content-default)]` |
| `dark:hover:bg-moss-600` | `hover:bg-[var(--surface-hover)]` or `hover:bg-[var(--surface-active)]` |
| `dark:text-forest-400` | `text-[var(--system-positive-strong)]` |
| `dark:bg-red-950/30` / `dark:text-red-400` | `bg-[var(--system-negative-weak)]` / `text-[var(--system-negative-strong)]` |
| `dark:bg-amber-900/30` / `dark:text-amber-400` | `bg-[var(--system-mid-weak)]` / `text-[var(--system-mid-strong)]` |

All `/* eslint-disable no-restricted-syntax -- LUM-1768 */` comments removed since the violations they suppressed are now fixed.

### Additional fix: `dark:` + semantic-token bugs in ai-page.tsx

Devin Review flagged 3 lines in `ai-page.tsx` that used `dark:` paired with semantic tokens (not raw color scales, so lint didn't catch them). Investigation revealed these were actual bugs:

1. **Invisible dividers in dark mode** (lines 461, 504): `SettingsCard` wraps content in `Card` which uses `bg-[var(--surface-lift)]`. The divider `dark:bg-[var(--surface-lift)]` resolved to the **same color** as the card background, making the divider invisible in dark mode. Removed the override — `bg-[var(--surface-active)]` provides correct contrast against the card in all 3 themes.

2. **No-op border** (line 1960): `dark:border-[var(--border-base)]` re-applied the same semantic token — pure noise. Removed.

3. **Info banner blending** (line 1960): `dark:bg-[var(--surface-lift)]` made the info banner match the card background in dark mode, losing its "sunken" visual distinction. `bg-[var(--surface-base)]` alone gives the correct recessed appearance in all themes since `--surface-base` is darker than `--surface-lift` in dark/velvet.

### Safety

- **Purely mechanical className replacements** — no logic, structure, or TypeScript changes.
- Every token used already exists in `packages/design-library/src/tokens.css` with definitions for light, dark, and velvet themes.
- `bun run lint` passes clean (0 violations for the `local/no-dark-color-scale` rule).
- Pre-existing typecheck failures in `node_modules/@vellum/design-library` (React ref type mismatch) are unrelated — confirmed identical on `main`.

### References

- [Tailwind CSS v4 — Theme variables](https://tailwindcss.com/docs/theme)
- Design tokens: `packages/design-library/src/tokens.css`

Closes LUM-1909

## Test plan

- `bun run lint` — passes clean, zero `no-restricted-syntax` violations for dark color scales
- `rg "dark:(bg|text|border)-(moss|stone|forest|red|amber)-"` across `apps/web/src` returns 0 matches
- `rg "eslint-disable.*LUM-1768"` returns 0 matches
- `rg "dark:" apps/web/src/domains/settings/ai/ai-page.tsx` returns 0 matches (all `dark:` removed from touched file)
- Typecheck: no new errors introduced (pre-existing design-library ref errors confirmed on `main`)
- CSS token verification: all semantic tokens resolve to correct values for light (`data-theme="light"`), dark (`data-theme="dark"`), and velvet (`data-theme="velvet"`) themes via `getComputedStyle` inspection

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka
