### PR TITLE
Add assistant client support for the managed search proxy

### DIFF
--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -10,6 +10,7 @@ let mockManagedProxyCtx = {
   assistantApiKey: "",
 };
 let mockAssistantId = "";
+let mockSecureKeys: Record<string, string | null | undefined> = {};
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -26,7 +27,7 @@ mock.module("../config/env.js", () => ({
 // Stub the credential-store fallback so tests stay hermetic and do not
 // read real values from the host credential backend.
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => null,
+  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 
 mock.module("../security/credential-key.js", () => ({
@@ -54,6 +55,7 @@ describe("VellumPlatformClient", () => {
       assistantApiKey: "sk-test-key",
     };
     mockAssistantId = "asst-123";
+    mockSecureKeys = {};
   });
 
   afterEach(() => {
@@ -93,6 +95,27 @@ describe("VellumPlatformClient", () => {
 
       const client = await VellumPlatformClient.create();
       expect(client!.baseUrl).toBe("https://platform.example.com");
+    });
+
+    test("falls back to credential store values when managed context is not rehydrated", async () => {
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+      mockAssistantId = "";
+      mockSecureKeys = {
+        "vellum:platform_base_url": "https://stored-platform.example.com/",
+        "vellum:assistant_api_key": "stored-api-key",
+        "vellum:platform_assistant_id": " stored-assistant-id ",
+      };
+
+      const client = await VellumPlatformClient.create();
+
+      expect(client).not.toBeNull();
+      expect(client!.baseUrl).toBe("https://stored-platform.example.com");
+      expect(client!.assistantApiKey).toBe("stored-api-key");
+      expect(client!.platformAssistantId).toBe("stored-assistant-id");
     });
   });
 

--- a/assistant/src/tools/network/__tests__/managed-search-proxy.test.ts
+++ b/assistant/src/tools/network/__tests__/managed-search-proxy.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface MockPlatformClient {
+  platformAssistantId: string;
+  fetch: ReturnType<typeof mock>;
+}
+
+let mockClient: MockPlatformClient | null = null;
+
+mock.module("../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockClient,
+  },
+}));
+
+import { callManagedSearchProxy } from "../managed-search-proxy.js";
+
+describe("callManagedSearchProxy", () => {
+  beforeEach(() => {
+    mockClient = {
+      platformAssistantId: "asst-123",
+      fetch: mock(async () => {
+        return new Response(
+          JSON.stringify({
+            status: 200,
+            headers: { "content-type": "application/json" },
+            body: { web: { results: [] } },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    };
+  });
+
+  afterEach(() => {
+    mockClient = null;
+  });
+
+  test("posts to the managed search proxy endpoint for the assistant and provider", async () => {
+    await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(mockClient!.fetch).toHaveBeenCalledTimes(1);
+    expect(mockClient!.fetch.mock.calls[0][0]).toBe(
+      "/v1/assistants/asst-123/managed-search-proxy/brave/",
+    );
+  });
+
+  test("encodes URL path segments", async () => {
+    mockClient!.platformAssistantId = "asst/123";
+
+    await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(mockClient!.fetch.mock.calls[0][0]).toBe(
+      "/v1/assistants/asst%2F123/managed-search-proxy/brave/",
+    );
+  });
+
+  test("sends the platform contract request envelope", async () => {
+    await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+      query: {
+        q: "kimi k2 fireworks web search",
+        count: "10",
+        offset: "0",
+        freshness: "pw",
+      },
+      headers: {
+        Accept: "application/json",
+      },
+      body: null,
+    });
+
+    const init = mockClient!.fetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      request: {
+        method: "GET",
+        path: "/res/v1/web/search",
+        query: {
+          q: "kimi k2 fireworks web search",
+          count: "10",
+          offset: "0",
+          freshness: "pw",
+        },
+        headers: {
+          Accept: "application/json",
+        },
+        body: null,
+      },
+    });
+  });
+
+  test("fills absent query, headers, and body with contract defaults", async () => {
+    await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    const init = mockClient!.fetch.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      request: {
+        method: "GET",
+        path: "/res/v1/web/search",
+        query: {},
+        headers: {},
+        body: null,
+      },
+    });
+  });
+
+  test("passes the abort signal through to platform fetch", async () => {
+    const controller = new AbortController();
+
+    await callManagedSearchProxy(
+      "brave",
+      {
+        method: "GET",
+        path: "/res/v1/web/search",
+      },
+      controller.signal,
+    );
+
+    const init = mockClient!.fetch.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  test("parses the response envelope and preserves provider JSON body", async () => {
+    const providerBody = {
+      web: {
+        results: [{ title: "Result", url: "https://example.com" }],
+      },
+    };
+    mockClient!.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": "req-123",
+          },
+          body: providerBody,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const result = await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-123",
+      },
+      body: providerBody,
+    });
+  });
+
+  test("returns a typed platform error for non-2xx platform responses", async () => {
+    mockClient!.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({ detail: "unsupported managed search provider" }),
+        {
+          status: 400,
+          headers: {
+            "content-type": "application/json",
+            "x-platform-request-id": "platform-req-123",
+          },
+        },
+      );
+    });
+
+    const result = await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      kind: "platform-error",
+      status: 400,
+      headers: {
+        "content-type": "application/json",
+        "x-platform-request-id": "platform-req-123",
+      },
+      body: { detail: "unsupported managed search provider" },
+      message:
+        "Managed search proxy returned status 400: unsupported managed search provider",
+    });
+  });
+
+  test("returns unavailable when platform context is missing", async () => {
+    mockClient = null;
+
+    const result = await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      kind: "unavailable",
+      message: "Managed search proxy is unavailable in this environment.",
+    });
+  });
+
+  test("returns unavailable when platform assistant ID is missing", async () => {
+    mockClient!.platformAssistantId = "";
+
+    const result = await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      kind: "unavailable",
+      message:
+        "Managed search proxy is unavailable: platform assistant ID is missing.",
+    });
+  });
+
+  test("returns an invalid-response result for malformed platform envelopes", async () => {
+    mockClient!.fetch = mock(async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const result = await callManagedSearchProxy("brave", {
+      method: "GET",
+      path: "/res/v1/web/search",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      kind: "invalid-response",
+      body: { ok: true },
+      message: "Managed search proxy returned an invalid response envelope.",
+    });
+  });
+});

--- a/assistant/src/tools/network/managed-search-proxy.ts
+++ b/assistant/src/tools/network/managed-search-proxy.ts
@@ -1,0 +1,183 @@
+import { VellumPlatformClient } from "../../platform/client.js";
+
+export type ManagedSearchProxyProvider = "brave";
+
+export interface ManagedSearchProxyRequest {
+  method: string;
+  path: string;
+  query?: Record<string, string>;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export interface ManagedSearchProxyResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export type ManagedSearchProxyResult =
+  | ({ ok: true } & ManagedSearchProxyResponse)
+  | {
+      ok: false;
+      kind: "unavailable";
+      message: string;
+    }
+  | {
+      ok: false;
+      kind: "platform-error";
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+      message: string;
+    }
+  | {
+      ok: false;
+      kind: "invalid-response";
+      body: unknown;
+      message: string;
+    };
+
+interface ManagedSearchProxyEnvelope {
+  request: {
+    method: string;
+    path: string;
+    query: Record<string, string>;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+}
+
+export async function callManagedSearchProxy(
+  provider: ManagedSearchProxyProvider,
+  request: ManagedSearchProxyRequest,
+  signal?: AbortSignal,
+): Promise<ManagedSearchProxyResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    return {
+      ok: false,
+      kind: "unavailable",
+      message: "Managed search proxy is unavailable in this environment.",
+    };
+  }
+
+  if (!client.platformAssistantId) {
+    return {
+      ok: false,
+      kind: "unavailable",
+      message:
+        "Managed search proxy is unavailable: platform assistant ID is missing.",
+    };
+  }
+
+  const path = `/v1/assistants/${encodeURIComponent(
+    client.platformAssistantId,
+  )}/managed-search-proxy/${encodeURIComponent(provider)}/`;
+
+  const envelope: ManagedSearchProxyEnvelope = {
+    request: {
+      method: request.method,
+      path: request.path,
+      query: request.query ?? {},
+      headers: request.headers ?? {},
+      body: request.body ?? null,
+    },
+  };
+
+  const response = await client.fetch(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(envelope),
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = await readResponseBody(response);
+    return {
+      ok: false,
+      kind: "platform-error",
+      status: response.status,
+      headers: responseHeadersToRecord(response.headers),
+      body,
+      message: platformErrorMessage(response.status, body),
+    };
+  }
+
+  const body = await readResponseBody(response);
+  if (!isManagedSearchProxyResponse(body)) {
+    return {
+      ok: false,
+      kind: "invalid-response",
+      body,
+      message: "Managed search proxy returned an invalid response envelope.",
+    };
+  }
+
+  return {
+    ok: true,
+    status: body.status,
+    headers: body.headers,
+    body: body.body,
+  };
+}
+
+function isManagedSearchProxyResponse(
+  value: unknown,
+): value is ManagedSearchProxyResponse {
+  if (!isRecord(value)) return false;
+  if (typeof value.status !== "number") return false;
+  if (!isStringRecord(value.headers)) return false;
+  return "body" in value;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => "");
+  if (!text) return null;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  return text;
+}
+
+function responseHeadersToRecord(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+function platformErrorMessage(status: number, body: unknown): string {
+  const detail = extractErrorDetail(body);
+  if (detail) {
+    return `Managed search proxy returned status ${status}: ${detail}`;
+  }
+  return `Managed search proxy returned status ${status}.`;
+}
+
+function extractErrorDetail(body: unknown): string | undefined {
+  if (typeof body === "string") return body || undefined;
+  if (!isRecord(body)) return undefined;
+
+  for (const key of ["detail", "error", "message"]) {
+    const value = body[key];
+    if (typeof value === "string" && value) return value;
+  }
+
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) return false;
+  return Object.values(value).every((entry) => typeof entry === "string");
+}


### PR DESCRIPTION
## Summary
- Add a typed managed search proxy helper for the platform Brave proxy path.
- Route proxy calls through `VellumPlatformClient.create()` so callers do not know the platform base URL or assistant API key directly.
- Return typed unavailable/platform-error/invalid-response results for clean local and BYOK fallback behavior.
- Add focused tests for request envelope shape, URL construction, response parsing, platform errors, abort signals, and missing platform context.

## Validation
- `bun test src/tools/network/__tests__/managed-search-proxy.test.ts src/platform/client.test.ts`
- `bunx tsc --noEmit`
- Commit hook: Prettier, ESLint, and assistant typecheck

## Notes
- Depends on the platform managed search proxy endpoint from platform PR 5.
- This PR only adds the assistant-side client helper; it does not route `web_search` through the managed path yet.