### PR TITLE
fix(web): clear session state on logout via hard navigation (LUM-1697)

### DIFF
--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -124,23 +124,32 @@ References:
 
 ## Logout destroys the JS context via hard navigation
 
-Logout uses `window.location.href` (hard navigation), not
-`navigate()` (SPA navigation). A hard navigation destroys the entire
-JavaScript execution context — every Zustand module-level singleton,
-every closure, every in-flight timer — guaranteeing no in-memory
-state leaks across auth boundaries.
+Logout uses `hardNavigate()` from `lib/auth/hard-navigate.ts`, not
+React Router's `navigate()`. `hardNavigate()` calls
+`window.location.href`, which destroys the entire JavaScript
+execution context — every Zustand module-level singleton, every
+closure, every in-flight timer — guaranteeing no in-memory state
+leaks across auth boundaries. React Router intentionally does not
+provide a "destroy everything" helper because SPA routers are
+designed to *preserve* state across navigations; for logout,
+preservation is the problem.
 
 Before the hard navigation, the auth store's `logout()` action
-clears user-scoped browser storage (`lib/auth/session-cleanup.ts`)
-and onboarding flags. Device-level preferences (theme,
-analytics/diagnostics consent) are preserved.
+clears user-scoped browser storage (`lib/auth/session-cleanup.ts`).
+The cleanup uses a preserve-list strategy: any localStorage key
+matching app prefixes (`vellum`, `onboarding.`, `ff:client:`,
+`voice:`, `integrations.`) is removed unless it's in the device-level
+preserve set (`vellum_theme`, `vellum_share_analytics`,
+`vellum_share_diagnostics`, `onboarding.lastUserId`). New app keys
+are cleared by default without requiring updates to a removal list.
 
-Cross-tab logout uses `BroadcastChannel` → `window.location.reload()`
-so other tabs also destroy their JS context.
+Cross-tab logout uses `BroadcastChannel` → `clearUserScopedStorage()`
++ `window.location.reload()` so other tabs also destroy their JS
+context and clean storage.
 
-**Do not replace `window.location.href` with `navigate()` on logout
-call sites.** SPA navigation preserves module-level Zustand state,
-which is a privacy/security concern on shared devices.
+**Do not replace `hardNavigate()` with `navigate()` on logout call
+sites.** SPA navigation preserves module-level Zustand state, which
+is a privacy/security concern on shared devices.
 
 References:
 - [web.dev — Sign-out best practices](https://web.dev/articles/sign-out-best-practices)

--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -141,6 +141,8 @@ matching app prefixes (`vellum`, `onboarding.`, `ff:client:`,
 `voice:`, `integrations.`) is removed unless it's in the device-level
 preserve set (`vellum_theme`, `vellum_share_analytics`,
 `vellum_share_diagnostics`, `vellum_biometric_enabled`,
+`vellum_llm_log_retention`, `vellum_timezone`,
+`vellum_media_embeds_enabled`, `vellum_media_embed_domains`,
 `onboarding.lastUserId`). New app keys
 are cleared by default without requiring updates to a removal list.
 

--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -126,13 +126,15 @@ References:
 
 Logout uses `hardNavigate()` from `lib/auth/hard-navigate.ts`, not
 React Router's `navigate()`. `hardNavigate()` calls
-`window.location.href`, which destroys the entire JavaScript
+`window.location.replace()`, which destroys the entire JavaScript
 execution context — every Zustand module-level singleton, every
 closure, every in-flight timer — guaranteeing no in-memory state
-leaks across auth boundaries. React Router intentionally does not
-provide a "destroy everything" helper because SPA routers are
-designed to *preserve* state across navigations; for logout,
-preservation is the problem.
+leaks across auth boundaries. Using `replace` instead of assigning
+`location.href` removes the pre-logout page from session history,
+preventing back-navigation and bfcache restoration of stale state.
+React Router intentionally does not provide a "destroy everything"
+helper because SPA routers are designed to *preserve* state across
+navigations; for logout, preservation is the problem.
 
 Before the hard navigation, the auth store's `logout()` action
 clears user-scoped browser storage (`lib/auth/session-cleanup.ts`).

--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -122,6 +122,30 @@ References:
 - [Zustand — Reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
 - [React Router — Middleware](https://reactrouter.com/how-to/middleware)
 
+## Logout destroys the JS context via hard navigation
+
+Logout uses `window.location.href` (hard navigation), not
+`navigate()` (SPA navigation). A hard navigation destroys the entire
+JavaScript execution context — every Zustand module-level singleton,
+every closure, every in-flight timer — guaranteeing no in-memory
+state leaks across auth boundaries.
+
+Before the hard navigation, the auth store's `logout()` action
+clears user-scoped browser storage (`lib/auth/session-cleanup.ts`)
+and onboarding flags. Device-level preferences (theme,
+analytics/diagnostics consent) are preserved.
+
+Cross-tab logout uses `BroadcastChannel` → `window.location.reload()`
+so other tabs also destroy their JS context.
+
+**Do not replace `window.location.href` with `navigate()` on logout
+call sites.** SPA navigation preserves module-level Zustand state,
+which is a privacy/security concern on shared devices.
+
+References:
+- [web.dev — Sign-out best practices](https://web.dev/articles/sign-out-best-practices)
+- [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
+
 ## Turn state lives in `domains/messaging/turn-store.ts`
 
 Turn lifecycle (sending, thinking, streaming, idle, errored), queue

--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -140,7 +140,8 @@ The cleanup uses a preserve-list strategy: any localStorage key
 matching app prefixes (`vellum`, `onboarding.`, `ff:client:`,
 `voice:`, `integrations.`) is removed unless it's in the device-level
 preserve set (`vellum_theme`, `vellum_share_analytics`,
-`vellum_share_diagnostics`, `onboarding.lastUserId`). New app keys
+`vellum_share_diagnostics`, `vellum_biometric_enabled`,
+`onboarding.lastUserId`). New app keys
 are cleared by default without requiring updates to a removal list.
 
 Cross-tab logout uses `BroadcastChannel` → `clearUserScopedStorage()`

--- a/apps/web/src/domains/account/pages/account-page.tsx
+++ b/apps/web/src/domains/account/pages/account-page.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import { AccountHeading } from "@/components/account/account-form.js";
 import { AccountShell } from "@/components/account/account-shell.js";
 import { PROVIDER_CALLBACK_URL, PROVIDER_ID } from "@/domains/account/login-flow.js";
+import { hardNavigate } from "@/lib/auth/hard-navigate.js";
 import { startAuthFlow } from "@/runtime/native-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
@@ -83,7 +84,7 @@ export function AccountPage() {
           type="button"
           onClick={async () => {
             await logout();
-            window.location.href = routes.account.login;
+            hardNavigate(routes.account.login);
           }}
           className="cursor-pointer bg-transparent text-sm font-normal text-stone-400 transition-colors hover:text-stone-300"
         >

--- a/apps/web/src/domains/account/pages/account-page.tsx
+++ b/apps/web/src/domains/account/pages/account-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 
 import { AccountHeading } from "@/components/account/account-form.js";
 import { AccountShell } from "@/components/account/account-shell.js";
@@ -13,7 +13,6 @@ import { routes } from "@/utils/routes.js";
  * or a "Go to your assistant" link + sign-out button when logged in.
  */
 export function AccountPage() {
-  const navigate = useNavigate();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const isLoading = useAuthStore.use.isLoading();
   const user = useAuthStore.use.user();
@@ -84,7 +83,7 @@ export function AccountPage() {
           type="button"
           onClick={async () => {
             await logout();
-            navigate(routes.account.login);
+            window.location.href = routes.account.login;
           }}
           className="cursor-pointer bg-transparent text-sm font-normal text-stone-400 transition-colors hover:text-stone-300"
         >

--- a/apps/web/src/domains/account/pages/logout-page.tsx
+++ b/apps/web/src/domains/account/pages/logout-page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "react-router";
 import { AccountHeading } from "@/components/account/account-form.js";
 import { AccountShell } from "@/components/account/account-shell.js";
 import { sanitizeReturnTo } from "@/domains/account/return-to.js";
+import { hardNavigate } from "@/lib/auth/hard-navigate.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
 
@@ -30,8 +31,8 @@ export function LogoutPage() {
 
     let cancelled = false;
     logout().then(
-      () => { if (!cancelled) window.location.href = target; },
-      () => { if (!cancelled) window.location.href = target; },
+      () => { if (!cancelled) hardNavigate(target); },
+      () => { if (!cancelled) hardNavigate(target); },
     );
     return () => { cancelled = true; };
   }, [logout, searchParams]);

--- a/apps/web/src/domains/account/pages/logout-page.tsx
+++ b/apps/web/src/domains/account/pages/logout-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 
 import { AccountHeading } from "@/components/account/account-form.js";
 import { AccountShell } from "@/components/account/account-shell.js";
@@ -8,7 +8,6 @@ import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
 
 export function LogoutPage() {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const logout = useAuthStore.use.logout();
   const logoutInitiated = useRef(false);
@@ -29,21 +28,13 @@ export function LogoutPage() {
         ? returnTo
         : `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`;
 
-    const redirect = (url: string) => {
-      if (url.startsWith("http")) {
-        window.location.href = url;
-      } else {
-        navigate(url);
-      }
-    };
-
     let cancelled = false;
     logout().then(
-      () => { if (!cancelled) redirect(target); },
-      () => { if (!cancelled) redirect(target); },
+      () => { if (!cancelled) window.location.href = target; },
+      () => { if (!cancelled) window.location.href = target; },
     );
     return () => { cancelled = true; };
-  }, [logout, navigate, searchParams]);
+  }, [logout, searchParams]);
 
   return (
     <AccountShell>

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -162,7 +162,7 @@ function PreferencesMenuContent({
         onSelect={async () => {
           await logout();
           onClose();
-          navigate(routes.account.login);
+          window.location.href = routes.account.login;
         }}
       />
     </>

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -19,6 +19,7 @@ import {
 } from "@vellum/design-library";
 
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
+import { hardNavigate } from "@/lib/auth/hard-navigate.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { adminUrl, routes } from "@/utils/routes.js";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal.js";
@@ -162,7 +163,7 @@ function PreferencesMenuContent({
         onSelect={async () => {
           await logout();
           onClose();
-          window.location.href = routes.account.login;
+          hardNavigate(routes.account.login);
         }}
       />
     </>

--- a/apps/web/src/domains/settings/components/delete-account-section.tsx
+++ b/apps/web/src/domains/settings/components/delete-account-section.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
-import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog";
@@ -11,7 +10,6 @@ import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
 
 export function DeleteAccountSection() {
-  const navigate = useNavigate();
   const logout = useAuthStore.use.logout();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -22,7 +20,7 @@ export function DeleteAccountSection() {
         "Account deletion requested. You will be logged out shortly.",
       );
       await logout();
-      navigate(routes.account.login);
+      window.location.href = routes.account.login;
     },
     onError: () => {
       toast.error("Failed to request account deletion. Please try again.");

--- a/apps/web/src/domains/settings/components/delete-account-section.tsx
+++ b/apps/web/src/domains/settings/components/delete-account-section.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog"
 import { toast } from "@vellum/design-library/components/toast";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 import { userDeletionRequestCreateMutation } from "@/generated/api/@tanstack/react-query.gen.js";
+import { hardNavigate } from "@/lib/auth/hard-navigate.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
 
@@ -20,7 +21,7 @@ export function DeleteAccountSection() {
         "Account deletion requested. You will be logged out shortly.",
       );
       await logout();
-      window.location.href = routes.account.login;
+      hardNavigate(routes.account.login);
     },
     onError: () => {
       toast.error("Failed to request account deletion. Please try again.");

--- a/apps/web/src/lib/auth/hard-navigate.ts
+++ b/apps/web/src/lib/auth/hard-navigate.ts
@@ -5,8 +5,11 @@
  * `navigate()` is an SPA transition — it swaps route components but
  * preserves the entire JavaScript execution context: every Zustand
  * module-level singleton, every closure, every module variable.
- * `window.location.href` triggers a full page load, which is the
- * only browser primitive that guarantees complete state destruction.
+ * `window.location.replace()` triggers a full page load, which is
+ * the only browser primitive that guarantees complete state destruction.
+ * Using `replace` instead of assigning `location.href` removes the
+ * pre-logout page from session history so the user cannot navigate
+ * back into it, and prevents bfcache from restoring stale state.
  *
  * This is the standard pattern used by GitHub, Slack, and other
  * production SPAs for logout. React Router intentionally does not
@@ -19,5 +22,5 @@
  * - https://web.dev/articles/bfcache (hard nav prevents bfcache restoration)
  */
 export function hardNavigate(url: string): void {
-  window.location.href = url;
+  window.location.replace(url);
 }

--- a/apps/web/src/lib/auth/hard-navigate.ts
+++ b/apps/web/src/lib/auth/hard-navigate.ts
@@ -1,0 +1,23 @@
+/**
+ * Navigate by replacing the current page, destroying the JS context.
+ *
+ * Logout MUST use this instead of React Router's `navigate()`.
+ * `navigate()` is an SPA transition — it swaps route components but
+ * preserves the entire JavaScript execution context: every Zustand
+ * module-level singleton, every closure, every module variable.
+ * `window.location.href` triggers a full page load, which is the
+ * only browser primitive that guarantees complete state destruction.
+ *
+ * This is the standard pattern used by GitHub, Slack, and other
+ * production SPAs for logout. React Router intentionally does not
+ * provide a "destroy everything" helper because SPA routers are
+ * designed to preserve state across navigations — for logout,
+ * preservation is the problem.
+ *
+ * References:
+ * - https://web.dev/articles/sign-out-best-practices
+ * - https://web.dev/articles/bfcache (hard nav prevents bfcache restoration)
+ */
+export function hardNavigate(url: string): void {
+  window.location.href = url;
+}

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -33,7 +33,6 @@ describe("clearUserScopedStorage", () => {
     localStorage.setItem("vellum:ctxwindow:asst-1", "4096");
     localStorage.setItem("vellum:dismissed-surfaces:asst-1", "[]");
     localStorage.setItem("ff:client:some-flag", "true");
-    localStorage.setItem("vellum_biometric_enabled", "true");
     localStorage.setItem("onboarding.tosAccepted", "true");
     localStorage.setItem("onboarding.aiDataConsent", "true");
     localStorage.setItem("onboarding.completed", "true");
@@ -48,6 +47,14 @@ describe("clearUserScopedStorage", () => {
     clearUserScopedStorage();
 
     expect(localStorage.length).toBe(0);
+  });
+
+  test("preserves biometric opt-out preference", () => {
+    localStorage.setItem("vellum_biometric_enabled", "false");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("vellum_biometric_enabled")).toBe("false");
   });
 
   test("automatically clears future app keys without needing explicit registration", () => {
@@ -67,6 +74,7 @@ describe("clearUserScopedStorage", () => {
     localStorage.setItem("vellum_theme", "dark");
     localStorage.setItem("vellum_share_analytics", "true");
     localStorage.setItem("vellum_share_diagnostics", "false");
+    localStorage.setItem("vellum_biometric_enabled", "true");
     localStorage.setItem("onboarding.lastUserId", "user-123");
 
     clearUserScopedStorage();
@@ -74,6 +82,7 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("vellum_theme")).toBe("dark");
     expect(localStorage.getItem("vellum_share_analytics")).toBe("true");
     expect(localStorage.getItem("vellum_share_diagnostics")).toBe("false");
+    expect(localStorage.getItem("vellum_biometric_enabled")).toBe("true");
     expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
   });
 

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -75,6 +75,10 @@ describe("clearUserScopedStorage", () => {
     localStorage.setItem("vellum_share_analytics", "true");
     localStorage.setItem("vellum_share_diagnostics", "false");
     localStorage.setItem("vellum_biometric_enabled", "true");
+    localStorage.setItem("vellum_llm_log_retention", "dontRetain");
+    localStorage.setItem("vellum_timezone", "America/New_York");
+    localStorage.setItem("vellum_media_embeds_enabled", "false");
+    localStorage.setItem("vellum_media_embed_domains", '["youtube.com"]');
     localStorage.setItem("onboarding.lastUserId", "user-123");
 
     clearUserScopedStorage();
@@ -83,6 +87,10 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("vellum_share_analytics")).toBe("true");
     expect(localStorage.getItem("vellum_share_diagnostics")).toBe("false");
     expect(localStorage.getItem("vellum_biometric_enabled")).toBe("true");
+    expect(localStorage.getItem("vellum_llm_log_retention")).toBe("dontRetain");
+    expect(localStorage.getItem("vellum_timezone")).toBe("America/New_York");
+    expect(localStorage.getItem("vellum_media_embeds_enabled")).toBe("false");
+    expect(localStorage.getItem("vellum_media_embed_domains")).toBe('["youtube.com"]');
     expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
   });
 

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -22,13 +22,16 @@ describe("clearUserScopedStorage", () => {
     expect(sessionStorage.length).toBe(0);
   });
 
-  test("removes user-scoped localStorage keys", () => {
+  test("removes all user-scoped app keys from localStorage", () => {
     localStorage.setItem("vellum:pinnedApps", "[]");
     localStorage.setItem("vellum:lastViewedConversation:asst-1", "conv-1");
     localStorage.setItem("vellum:sidebar-open-categories:asst-1", "{}");
     localStorage.setItem("vellum:sidebar-open-custom-groups:asst-1", "{}");
     localStorage.setItem("vellum_current_assistant_id__org-1", "asst-1");
     localStorage.setItem("vellum:nudge-prefs", "{}");
+    localStorage.setItem("vellum:chatDrafts:asst-1", '{"text":"hi"}');
+    localStorage.setItem("vellum:ctxwindow:asst-1", "4096");
+    localStorage.setItem("vellum:dismissed-surfaces:asst-1", "[]");
     localStorage.setItem("ff:client:some-flag", "true");
     localStorage.setItem("vellum_biometric_enabled", "true");
     localStorage.setItem("onboarding.tosAccepted", "true");
@@ -41,6 +44,19 @@ describe("clearUserScopedStorage", () => {
     localStorage.setItem("voice:ttsApiKey:openai", "test-value");
     // eslint-disable-next-line no-restricted-syntax -- test: verifying cleanup of user-scoped storage keys
     localStorage.setItem("voice:sttApiKey:openai", "test-value");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.length).toBe(0);
+  });
+
+  test("automatically clears future app keys without needing explicit registration", () => {
+    localStorage.setItem("vellum:some-future-feature:asst-1", "data");
+    localStorage.setItem("vellum_new_preference", "value");
+    localStorage.setItem("onboarding.newFlag", "true");
+    localStorage.setItem("ff:client:new-experiment", "variant-b");
+    localStorage.setItem("voice:newSetting", "on");
+    localStorage.setItem("integrations.newBanner", "dismissed");
 
     clearUserScopedStorage();
 
@@ -61,19 +77,33 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
   });
 
-  test("removes user-scoped keys while preserving device-level keys", () => {
+  test("leaves third-party keys untouched", () => {
+    localStorage.setItem("_ga", "GA1.2.123456");
+    localStorage.setItem("intercom-session", "abc");
+    localStorage.setItem("some-other-sdk", "data");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("_ga")).toBe("GA1.2.123456");
+    expect(localStorage.getItem("intercom-session")).toBe("abc");
+    expect(localStorage.getItem("some-other-sdk")).toBe("data");
+  });
+
+  test("removes user-scoped keys while preserving device-level and third-party keys", () => {
     localStorage.setItem("vellum_theme", "dark");
     localStorage.setItem("vellum:pinnedApps", "[]");
     localStorage.setItem("vellum_share_analytics", "true");
     localStorage.setItem("ff:client:my-flag", "true");
     localStorage.setItem("onboarding.lastUserId", "user-123");
     localStorage.setItem("onboarding.completed", "true");
+    localStorage.setItem("_ga", "GA1.2.123456");
 
     clearUserScopedStorage();
 
     expect(localStorage.getItem("vellum_theme")).toBe("dark");
     expect(localStorage.getItem("vellum_share_analytics")).toBe("true");
     expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
+    expect(localStorage.getItem("_ga")).toBe("GA1.2.123456");
     expect(localStorage.getItem("vellum:pinnedApps")).toBeNull();
     expect(localStorage.getItem("ff:client:my-flag")).toBeNull();
     expect(localStorage.getItem("onboarding.completed")).toBeNull();

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearUserScopedStorage } from "./session-cleanup.js";
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+describe("clearUserScopedStorage", () => {
+  test("clears sessionStorage entirely", () => {
+    sessionStorage.setItem("vellum_active_organization_id", "org-123");
+    sessionStorage.setItem("vellum:edit-chat:asst-1:app-1", "conv-xyz");
+
+    clearUserScopedStorage();
+
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  test("removes user-scoped localStorage keys", () => {
+    localStorage.setItem("vellum:pinnedApps", "[]");
+    localStorage.setItem("vellum:lastViewedConversation:asst-1", "conv-1");
+    localStorage.setItem("vellum:sidebar-open-categories:asst-1", "{}");
+    localStorage.setItem("vellum:sidebar-open-custom-groups:asst-1", "{}");
+    localStorage.setItem("vellum_current_assistant_id__org-1", "asst-1");
+    localStorage.setItem("vellum:nudge-prefs", "{}");
+    localStorage.setItem("ff:client:some-flag", "true");
+    localStorage.setItem("vellum_biometric_enabled", "true");
+    localStorage.setItem("onboarding.tosAccepted", "true");
+    localStorage.setItem("onboarding.aiDataConsent", "true");
+    localStorage.setItem("onboarding.completed", "true");
+    localStorage.setItem("onboarding.selectedVersion", "v1.0");
+    localStorage.setItem("integrations.bannerDismissed", "true");
+    localStorage.setItem("voice:activationKey", "Space");
+    // eslint-disable-next-line no-restricted-syntax -- test: verifying cleanup of user-scoped storage keys
+    localStorage.setItem("voice:ttsApiKey:openai", "test-value");
+    // eslint-disable-next-line no-restricted-syntax -- test: verifying cleanup of user-scoped storage keys
+    localStorage.setItem("voice:sttApiKey:openai", "test-value");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.length).toBe(0);
+  });
+
+  test("preserves device-level preferences", () => {
+    localStorage.setItem("vellum_theme", "dark");
+    localStorage.setItem("vellum_share_analytics", "true");
+    localStorage.setItem("vellum_share_diagnostics", "false");
+    localStorage.setItem("onboarding.lastUserId", "user-123");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("vellum_theme")).toBe("dark");
+    expect(localStorage.getItem("vellum_share_analytics")).toBe("true");
+    expect(localStorage.getItem("vellum_share_diagnostics")).toBe("false");
+    expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
+  });
+
+  test("removes user-scoped keys while preserving device-level keys", () => {
+    localStorage.setItem("vellum_theme", "dark");
+    localStorage.setItem("vellum:pinnedApps", "[]");
+    localStorage.setItem("vellum_share_analytics", "true");
+    localStorage.setItem("ff:client:my-flag", "true");
+    localStorage.setItem("onboarding.lastUserId", "user-123");
+    localStorage.setItem("onboarding.completed", "true");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("vellum_theme")).toBe("dark");
+    expect(localStorage.getItem("vellum_share_analytics")).toBe("true");
+    expect(localStorage.getItem("onboarding.lastUserId")).toBe("user-123");
+    expect(localStorage.getItem("vellum:pinnedApps")).toBeNull();
+    expect(localStorage.getItem("ff:client:my-flag")).toBeNull();
+    expect(localStorage.getItem("onboarding.completed")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -1,0 +1,55 @@
+/**
+ * Clear user-scoped browser storage on logout.
+ *
+ * Removes localStorage keys that hold per-user or per-assistant data
+ * while preserving device-level preferences (theme, analytics/diagnostics
+ * consent, returning-user signal). sessionStorage is cleared entirely —
+ * all keys are session-scoped user data.
+ *
+ * Called from the auth store's `logout()` action and from the
+ * cross-tab BroadcastChannel handler before a hard page reload.
+ *
+ * References:
+ * - https://web.dev/articles/sign-out-best-practices
+ */
+
+const USER_SCOPED_PREFIXES = [
+  "vellum:pinnedApps",
+  "vellum:lastViewedConversation:",
+  "vellum:sidebar-open-categories:",
+  "vellum:sidebar-open-custom-groups:",
+  "vellum_current_assistant_id__",
+  "vellum:nudge-prefs",
+  "vellum:edit-chat:",
+  "ff:client:",
+  "vellum_biometric_enabled",
+  "onboarding.tosAccepted",
+  "onboarding.aiDataConsent",
+  "onboarding.completed",
+  "onboarding.selectedVersion",
+  "integrations.bannerDismissed",
+  "voice:activationKey",
+  "voice:ttsApiKey:",
+  "voice:sttApiKey:",
+];
+
+export function clearUserScopedStorage(): void {
+  try {
+    sessionStorage.clear();
+  } catch {
+    // Storage unavailable (e.g. private browsing quota exceeded).
+  }
+
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && USER_SCOPED_PREFIXES.some((p) => key.startsWith(p))) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    // Storage unavailable.
+  }
+}

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -1,10 +1,14 @@
 /**
  * Clear user-scoped browser storage on logout.
  *
- * Removes localStorage keys that hold per-user or per-assistant data
- * while preserving device-level preferences (theme, analytics/diagnostics
- * consent, returning-user signal). sessionStorage is cleared entirely —
- * all keys are session-scoped user data.
+ * Uses a preserve-list strategy: any localStorage key matching a known
+ * app prefix is removed UNLESS it appears in the device-level preserve
+ * set. This is future-proof — new app keys are cleared by default
+ * without needing to update a removal list. Third-party keys (analytics
+ * SDKs, Sentry, etc.) are untouched because they don't match app
+ * prefixes.
+ *
+ * sessionStorage is cleared entirely — all keys are user-session-scoped.
  *
  * Called from the auth store's `logout()` action and from the
  * cross-tab BroadcastChannel handler before a hard page reload.
@@ -13,25 +17,29 @@
  * - https://web.dev/articles/sign-out-best-practices
  */
 
-const USER_SCOPED_PREFIXES = [
-  "vellum:pinnedApps",
-  "vellum:lastViewedConversation:",
-  "vellum:sidebar-open-categories:",
-  "vellum:sidebar-open-custom-groups:",
-  "vellum_current_assistant_id__",
-  "vellum:nudge-prefs",
-  "vellum:edit-chat:",
+/** Prefixes that identify keys owned by this app. */
+const APP_KEY_PREFIXES = [
+  "vellum",
+  "onboarding.",
   "ff:client:",
-  "vellum_biometric_enabled",
-  "onboarding.tosAccepted",
-  "onboarding.aiDataConsent",
-  "onboarding.completed",
-  "onboarding.selectedVersion",
-  "integrations.bannerDismissed",
-  "voice:activationKey",
-  "voice:ttsApiKey:",
-  "voice:sttApiKey:",
+  "voice:",
+  "integrations.",
 ];
+
+/**
+ * Device-level keys that must survive logout. These are preferences
+ * scoped to the physical device, not to a user account.
+ */
+const DEVICE_LEVEL_KEYS = new Set([
+  "vellum_theme",
+  "vellum_share_analytics",
+  "vellum_share_diagnostics",
+  "onboarding.lastUserId",
+]);
+
+function isAppKey(key: string): boolean {
+  return APP_KEY_PREFIXES.some((p) => key.startsWith(p));
+}
 
 export function clearUserScopedStorage(): void {
   try {
@@ -44,7 +52,7 @@ export function clearUserScopedStorage(): void {
     const keysToRemove: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key && USER_SCOPED_PREFIXES.some((p) => key.startsWith(p))) {
+      if (key && isAppKey(key) && !DEVICE_LEVEL_KEYS.has(key)) {
         keysToRemove.push(key);
       }
     }

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -35,6 +35,10 @@ const DEVICE_LEVEL_KEYS = new Set([
   "vellum_share_analytics",
   "vellum_share_diagnostics",
   "vellum_biometric_enabled",
+  "vellum_llm_log_retention",
+  "vellum_timezone",
+  "vellum_media_embeds_enabled",
+  "vellum_media_embed_domains",
   "onboarding.lastUserId",
 ]);
 

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -34,6 +34,7 @@ const DEVICE_LEVEL_KEYS = new Set([
   "vellum_theme",
   "vellum_share_analytics",
   "vellum_share_diagnostics",
+  "vellum_biometric_enabled",
   "onboarding.lastUserId",
 ]);
 

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -10,6 +10,7 @@ let sessionUser: MockSessionUser | null = null;
 let getSessionCallCount = 0;
 let getSessionFailFirstCall = false;
 const syncOnboardingUserMock = mock((_userId: string | null) => {});
+const clearOnboardingFlagsMock = mock(() => {});
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
 const deleteBiometricTokenMock = mock(async () => {});
@@ -46,8 +47,15 @@ mock.module("@/runtime/native-biometric.js", () => ({
   retrieveBiometricToken: retrieveBiometricTokenMock,
 }));
 
+const clearUserScopedStorageMock = mock(() => {});
+
 mock.module("@/domains/onboarding/prefs.js", () => ({
   syncOnboardingUser: syncOnboardingUserMock,
+  clearOnboardingFlags: clearOnboardingFlagsMock,
+}));
+
+mock.module("@/lib/auth/session-cleanup.js", () => ({
+  clearUserScopedStorage: clearUserScopedStorageMock,
 }));
 
 mock.module("@/stores/organization-store.js", () => ({
@@ -80,7 +88,9 @@ beforeEach(() => {
   mockIsBiometricEnabled = false;
   mockBiometricToken = null;
   syncOnboardingUserMock.mockClear();
+  clearOnboardingFlagsMock.mockClear();
   clearOrganizationMock.mockClear();
+  clearUserScopedStorageMock.mockClear();
   logoutMock.mockClear();
   deleteBiometricTokenMock.mockClear();
   installSessionCookiesMock.mockClear();
@@ -108,20 +118,32 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().user?.id).toBe("user-2");
   });
 
-  test("logout keeps onboarding reconciliation on the shared auth path", async () => {
+  test("logout clears onboarding flags directly", async () => {
     await useAuthStore.getState().logout();
 
     expect(logoutMock).toHaveBeenCalled();
-    expect(syncOnboardingUserMock).toHaveBeenCalledWith(null);
+    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
     expect(useAuthStore.getState().isLoggedIn).toBe(false);
   });
 });
 
-describe("biometric cleanup on logout", () => {
+describe("session cleanup on logout", () => {
   test("logout clears biometric token", async () => {
     await useAuthStore.getState().logout();
 
     expect(deleteBiometricTokenMock).toHaveBeenCalled();
+  });
+
+  test("logout clears organization state", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(clearOrganizationMock).toHaveBeenCalled();
+  });
+
+  test("logout clears user-scoped browser storage", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(clearUserScopedStorageMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -20,8 +20,9 @@ import {
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
 import { deleteBiometricToken } from "@/runtime/native-biometric.js";
-import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
+import { syncOnboardingUser, clearOnboardingFlags } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
+import { clearUserScopedStorage } from "@/lib/auth/session-cleanup.js";
 import { useEventBusStore } from "@/stores/event-bus-store.js";
 import { isNativePlatform, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth.js";
 import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric.js";
@@ -158,7 +159,9 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       await allauthLogout();
     } finally {
       void deleteBiometricToken();
-      syncUserScopedState(null);
+      clearOnboardingFlags();
+      clearOrganization();
+      clearUserScopedStorage();
       set({ isLoggedIn: false, user: null });
       broadcastAuthChange();
     }
@@ -193,7 +196,10 @@ export function setupAuthListeners(): () => void {
 
   if (typeof BroadcastChannel !== "undefined") {
     broadcastChannel = new BroadcastChannel("auth");
-    broadcastChannel.onmessage = () => safeRefresh();
+    broadcastChannel.onmessage = () => {
+      clearUserScopedStorage();
+      window.location.reload();
+    };
     cleanups.push(() => {
       broadcastChannel?.close();
       broadcastChannel = null;


### PR DESCRIPTION
## Prompt / plan

Fix LUM-1697: user sees all chats after logout because session state is not fully cleared.

**Root cause:** The logout flow used React Router's `navigate()` (SPA navigation), which preserves the entire JavaScript execution context — all Zustand module-level singletons, closures, and module variables survive. Additionally, user-scoped localStorage/sessionStorage keys were never cleared.

**Fix (3 layers):**

1. **Hard navigation** — All 4 logout call sites use `hardNavigate()` from `lib/auth/hard-navigate.ts` instead of `navigate()`. This calls `window.location.replace()`, destroying the JS context entirely and removing the pre-logout page from session history (preventing bfcache restoration of stale state). The helper includes a docstring explaining why SPA navigation is wrong for logout and why React Router intentionally doesn't provide this.

2. **Storage cleanup** — `lib/auth/session-cleanup.ts` clears user-scoped browser storage using a **preserve-list strategy**: any localStorage key matching app prefixes (`vellum`, `onboarding.`, `ff:client:`, `voice:`, `integrations.`) is removed unless it's in the device-level preserve set (`vellum_theme`, `vellum_share_analytics`, `vellum_share_diagnostics`, `vellum_biometric_enabled`, `onboarding.lastUserId`). This is future-proof — new app keys are cleared automatically without needing to update a removal list. Third-party keys (analytics SDKs, etc.) are untouched. sessionStorage is cleared entirely.

3. **Cross-tab reload** — The BroadcastChannel handler now calls `clearUserScopedStorage()` + `window.location.reload()` so other tabs destroy their JS context and clean storage too.

Also fixes the `syncOnboardingUser(null)` no-op by calling `clearOnboardingFlags()` directly in the logout action.

**Why hard navigation, not `resetAllStores()`?** Hard navigation is the standard pattern used by GitHub, Slack, and other production SPAs for logout. `resetAllStores()` (Zustand's official recipe) is fragile — new stores can escape if a developer uses the real `create`, and it doesn't clear non-Zustand in-memory state (module-level closures, BroadcastChannel instances, etc.). Hard navigation is the only mechanism that guarantees complete state destruction. See [web.dev sign-out best practices](https://web.dev/articles/sign-out-best-practices).

**Why `location.replace()` instead of `location.href`?** `location.href` (like `Location.assign()`) keeps the pre-logout page in session history — the user can navigate back to it, and browsers may restore it from bfcache with stale JS state. `location.replace()` removes the history entry entirely. See [web.dev bfcache](https://web.dev/articles/bfcache).

**Why a preserve-list, not a removal-list?** The original implementation used `USER_SCOPED_PREFIXES` — a blocklist requiring manual updates when new keys are added. The preserve-list approach inverts this: clear everything matching app prefixes except the small set of device-level keys. New keys are cleaned up by default.

**Root cause analysis:**
1. *How did the code get here?* The web SPA was ported from `vellum-assistant-platform` in phases. The `navigate()` pattern for logout was carried over from Next.js conventions where server-side rendering naturally resets client state — that assumption doesn't hold in a Vite SPA.
2. *What was missed?* No logout cleanup contract was established when the stores were created. Each store was built independently.
3. *Prevention?* `STATE_MANAGEMENT.md` now documents the hard-navigation contract and the `hardNavigate()` helper.

References:
- [web.dev — Sign-out best practices](https://web.dev/articles/sign-out-best-practices)
- [web.dev — bfcache](https://web.dev/articles/bfcache)
- [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)

## Test plan

- Typecheck (`bunx tsc --noEmit`) passes
- Lint (`bun run lint`) passes
- Unit tests pass: `session-cleanup.test.ts` (7 tests) and `auth-store.test.ts` (10 tests)
- CI checks

Link to Devin session: https://app.devin.ai/sessions/b4b03c203ade4ff3a2f55fa824288410
Requested by: @ashleeradka