### PR TITLE
fix(web): fix contacts Enable button navigation losing prompt param (LUM-1696)

### DIFF
--- a/apps/web/src/contacts-page-route.tsx
+++ b/apps/web/src/contacts-page-route.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from "react-router";
+
+import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { ContactsPage } from "@/domains/contacts/contacts-page.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
+import { routes } from "@/utils/routes.js";
+
+export function ContactsPageRoute() {
+  const navigate = useNavigate();
+  const { assistantId } = useActiveAssistantContext();
+
+  return (
+    <ContactsPage
+      key={assistantId}
+      assistantId={assistantId}
+      onStartSetupConversation={(prompt) => {
+        useViewerStore.getState().setMainView("chat");
+        const draftConversationId = createDraftConversationId();
+        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        void navigate(
+          `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(prompt)}`,
+        );
+      }}
+    />
+  );
+}

--- a/apps/web/src/domains/contacts/contacts-page.tsx
+++ b/apps/web/src/domains/contacts/contacts-page.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 
 import { toast } from "@vellum/design-library/components/toast";
 
@@ -39,10 +38,8 @@ import type {
   ContactPayload,
   ContactSelection,
 } from "@/domains/contacts/types.js";
-import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { fetchAssistantIdentity } from "@/assistant/identity.js";
 import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store.js";
-import { routes } from "@/utils/routes.js";
 
 const ASSISTANT_SETUP_PROMPTS: Record<AssistantChannelState["key"], string> = {
   slack: "I want to reach you on Slack. Let's set it up.",
@@ -52,30 +49,15 @@ const ASSISTANT_SETUP_PROMPTS: Record<AssistantChannelState["key"], string> = {
 
 const READINESS_REFETCH_MS = 15000;
 
-export function ContactsPage() {
-  const { assistantId } = useActiveAssistantContext();
-  const navigate = useNavigate();
-
-  return (
-    <ContactsPageInner
-      key={assistantId}
-      assistantId={assistantId}
-      onStartSetupConversation={(prompt) => {
-        void navigate(`${routes.assistant}?prompt=${encodeURIComponent(prompt)}`);
-      }}
-    />
-  );
-}
-
-interface ContactsPageInnerProps {
+export interface ContactsPageProps {
   assistantId: string;
   onStartSetupConversation?: (prompt: string) => void;
 }
 
-function ContactsPageInner({
+export function ContactsPage({
   assistantId,
   onStartSetupConversation,
-}: ContactsPageInnerProps) {
+}: ContactsPageProps) {
   const a2aChannel = useAssistantFeatureFlagStore.use.a2aChannel();
   const queryClient = useQueryClient();
   const [loadedName, setLoadedName] = useState<{

--- a/apps/web/src/domains/intelligence/identity-page.tsx
+++ b/apps/web/src/domains/intelligence/identity-page.tsx
@@ -1,25 +1,12 @@
-import { useCallback } from "react";
-import { useNavigate } from "react-router";
-
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { IdentityTab } from "@/domains/intelligence/components/identity-tab.js";
-import { routes } from "@/utils/routes.js";
-import { useViewerStore } from "@/stores/viewer-store.js";
 
-export function IdentityPage() {
+interface IdentityPageProps {
+  onOpenThread?: (message: string) => void;
+}
+
+export function IdentityPage({ onOpenThread }: IdentityPageProps) {
   const { assistantId } = useActiveAssistantContext();
-  const navigate = useNavigate();
 
-  const handleOpenThread = useCallback(
-    (message: string) => {
-      useViewerStore.getState().setMainView("chat");
-      const draftKey = crypto.randomUUID();
-      navigate(
-        `${routes.conversation(draftKey)}?prompt=${encodeURIComponent(message)}`,
-      );
-    },
-    [navigate],
-  );
-
-  return <IdentityTab assistantId={assistantId} onOpenThread={handleOpenThread} />;
+  return <IdentityTab assistantId={assistantId} onOpenThread={onOpenThread} />;
 }

--- a/apps/web/src/identity-page-route.tsx
+++ b/apps/web/src/identity-page-route.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from "react-router";
+
+import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection.js";
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { IdentityPage } from "@/domains/intelligence/identity-page.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
+import { routes } from "@/utils/routes.js";
+
+export function IdentityPageRoute() {
+  const navigate = useNavigate();
+  const { assistantId } = useActiveAssistantContext();
+
+  return (
+    <IdentityPage
+      key={assistantId}
+      onOpenThread={(message) => {
+        useViewerStore.getState().setMainView("chat");
+        const draftConversationId = createDraftConversationId();
+        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        void navigate(
+          `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(message)}`,
+        );
+      }}
+    />
+  );
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -140,7 +140,7 @@ export const router = createBrowserRouter(
                 {
                   lazy: { Component: () => import("@/domains/intelligence/intelligence-layout.js").then((m) => m.IntelligenceLayout) },
                   children: [
-                    { path: "identity", lazy: { Component: () => import("@/domains/intelligence/identity-page.js").then((m) => m.IdentityPage) } },
+                    { path: "identity", lazy: { Component: () => import("@/identity-page-route.js").then((m) => m.IdentityPageRoute) } },
                     { path: "plugins", lazy: { Component: () => import("@/domains/intelligence/plugins-page.js").then((m) => m.PluginsPage) } },
                     { path: "skills", lazy: { Component: () => import("@/domains/intelligence/skills-page.js").then((m) => m.SkillsPage) } },
                     { path: "workspace", lazy: { Component: () => import("@/domains/workspace/workspace-page.js").then((m) => m.WorkspacePage) } },

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -144,7 +144,7 @@ export const router = createBrowserRouter(
                     { path: "plugins", lazy: { Component: () => import("@/domains/intelligence/plugins-page.js").then((m) => m.PluginsPage) } },
                     { path: "skills", lazy: { Component: () => import("@/domains/intelligence/skills-page.js").then((m) => m.SkillsPage) } },
                     { path: "workspace", lazy: { Component: () => import("@/domains/workspace/workspace-page.js").then((m) => m.WorkspacePage) } },
-                    { path: "contacts", lazy: { Component: () => import("@/domains/contacts/contacts-page.js").then((m) => m.ContactsPage) } },
+                    { path: "contacts", lazy: { Component: () => import("@/contacts-page-route.js").then((m) => m.ContactsPageRoute) } },
                   ],
                 },
                 { path: "library", lazy: { Component: () => import("@/domains/library/library-page.js").then((m) => m.LibraryPage) } },


### PR DESCRIPTION
## Prompt / plan

Fix LUM-1696: The ENABLE button on the Contacts/Guardian detail view creates a new thread but never transitions into it — the user is left in an empty conversation with no message sent. The BACK arrow also does not navigate back.

**Root cause:** `onStartSetupConversation` navigated to `/assistant?prompt=...` (the index route). The bootstrap routing effect in `useConversationLoader` resolved a conversation and called `navigate(routes.conversation(key), { replace: true })`, stripping the `?prompt=` search param. By the time `activeConversationId` was set and the auto-send effect fired, the prompt was gone from the URL.

**Fix:** Follow the same pattern used by `home-page-route.tsx`'s `onSuggestionSelected`:
1. Create a draft conversation ID upfront
2. Set it active in the Zustand store
3. Navigate directly to `/assistant/conversations/{draftId}?prompt=...`

This bypasses bootstrap routing (which is a no-op when `urlConversationId` matches the store), preserves the `?prompt=` param for the auto-send effect, and the BACK arrow works because the history push from `/assistant/contacts` → `/assistant/conversations/{draftId}` gives `canGoBack = true`.

**Structural change:** Extracted route-level composition into `src/contacts-page-route.tsx` and `src/identity-page-route.tsx` (matching the `home-page-route.tsx` pattern) to satisfy the `no-cross-domain-imports` lint rule — domain components can't import from other domains.

### Root cause analysis

1. **How did the code get into this state?** The contacts page was ported from the platform repo (`2bb894688f feat(web): port contacts pages from platform (LUM-1653)`) with a naive navigation pattern (`navigate('/assistant?prompt=...')`). The home page route was written later with the correct pattern but the contacts page was never updated.
2. **What mistakes or decisions led to it?** The port assumed the index route (`/assistant`) would handle the `?prompt=` param end-to-end, but bootstrap routing replaces the URL before the auto-send effect runs — a race condition between effects.
3. **Were there warning signs?** The `home-page-route.tsx` already demonstrated the correct pattern (create draft ID, set store, navigate to conversation URL with prompt). The contacts handler diverged without explanation.
4. **Prevention:** Routes that need to start a new conversation with a prompt should always create a draft ID and navigate to the conversation URL directly — never rely on the index route to forward search params through bootstrap routing.
5. **AGENTS.md update:** Not needed — the existing `docs/CONVENTIONS.md` route-level code splitting guidance and the `home-page-route.tsx` pattern are sufficient documentation.

### Alternatives rejected

- **Preserving `?prompt=` through bootstrap routing**: Would require modifying `useConversationLoader`'s redirect to forward unknown search params. Rejected because it's fragile (every new param would need forwarding) and the draft-ID-first pattern is already proven.
- **Keeping cross-domain imports in domain components**: Would require suppressing the lint rule. Rejected in favor of the established route-wrapper pattern.

### Additional fix (from review feedback)

`identity-page.tsx` had the same latent bug — used raw `crypto.randomUUID()` without calling `setActiveConversationId()`. Extracted `IdentityPageRoute` wrapper following the same pattern established here.

Closes LUM-1696

## Test plan

- Lint passes (`bun run lint`)
- TypeScript type-check passes (`bunx tsc --noEmit`)
- Pre-commit hooks pass (lint + typecheck)
- End-to-end browser test via Vite dev server + Playwright CDP route interception:
  - Enable button navigates to `/assistant/conversations/{uuid}?prompt=...` ✓
  - `?prompt=` parameter survives bootstrap routing ✓
  - BACK arrow returns to `/assistant/contacts` ✓
- CI: 7/7 checks passing

Link to Devin session: https://app.devin.ai/sessions/94324ff2232f47a3b550f63967793916
Requested by: @ashleeradka