### PR TITLE
feat(config): default notion-oauth and google-oauth to managed mode

### DIFF
--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -1,9 +1,11 @@
 /**
  * When IS_PLATFORM=true and no config.json exists yet, loadConfig() must
- * write all eight managed-capable service modes as "managed" instead of the
- * schema default "your-own". When IS_PLATFORM is absent/false, or when
- * config.json already exists, the schema defaults and existing values are
- * preserved unchanged.
+ * write all managed-capable service modes as "managed" instead of the
+ * per-service schema default. When IS_PLATFORM is absent/false, or when
+ * config.json already exists, the Zod schema defaults and existing values
+ * are preserved unchanged — note that `google-oauth` and `notion-oauth`
+ * default to "managed" at the schema level (per JARVIS-966), while every
+ * other managed-capable service defaults to "your-own".
  */
 
 import {
@@ -101,6 +103,29 @@ const MANAGED_SERVICES = [
   "notion-oauth",
 ] as const;
 
+/**
+ * Services whose Zod schema default is `"managed"` rather than `"your-own"`.
+ * For these, the fresh-write and in-memory paths produce `"managed"` even
+ * when IS_PLATFORM is false/unset — the schema default applies regardless of
+ * deployment context. See `assistant/src/config/schemas/services.ts` and
+ * JARVIS-966: managed mode is the optimization target for new users on
+ * managed-capable infra, since the BYO flow requires a Google Cloud /
+ * Notion integration setup that most users never complete.
+ */
+const SCHEMA_MANAGED_DEFAULT_SERVICES = [
+  "google-oauth",
+  "notion-oauth",
+] as const;
+
+const SCHEMA_YOUR_OWN_DEFAULT_SERVICES = MANAGED_SERVICES.filter(
+  (
+    svc,
+  ): svc is Exclude<
+    (typeof MANAGED_SERVICES)[number],
+    (typeof SCHEMA_MANAGED_DEFAULT_SERVICES)[number]
+  > => !(SCHEMA_MANAGED_DEFAULT_SERVICES as readonly string[]).includes(svc),
+);
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -139,7 +164,7 @@ describe("platform-managed config defaults", () => {
     }
   });
 
-  test("IS_PLATFORM=false, no config file → managed service modes default to 'your-own'", () => {
+  test("IS_PLATFORM=false, no config file → service modes follow schema defaults (your-own except google/notion-oauth which are managed)", () => {
     process.env.IS_PLATFORM = "false";
 
     loadConfig();
@@ -148,12 +173,15 @@ describe("platform-managed config defaults", () => {
     const written = readConfig() as { services?: Record<string, unknown> };
     expect(written.services).toBeDefined();
     const services = written.services!;
-    for (const svc of MANAGED_SERVICES) {
+    for (const svc of SCHEMA_YOUR_OWN_DEFAULT_SERVICES) {
       expect((services[svc] as { mode?: string })?.mode).toBe("your-own");
+    }
+    for (const svc of SCHEMA_MANAGED_DEFAULT_SERVICES) {
+      expect((services[svc] as { mode?: string })?.mode).toBe("managed");
     }
   });
 
-  test("IS_PLATFORM unset, no config file → managed service modes default to 'your-own'", () => {
+  test("IS_PLATFORM unset, no config file → service modes follow schema defaults (your-own except google/notion-oauth which are managed)", () => {
     delete process.env.IS_PLATFORM;
 
     loadConfig();
@@ -162,8 +190,11 @@ describe("platform-managed config defaults", () => {
     const written = readConfig() as { services?: Record<string, unknown> };
     expect(written.services).toBeDefined();
     const services = written.services!;
-    for (const svc of MANAGED_SERVICES) {
+    for (const svc of SCHEMA_YOUR_OWN_DEFAULT_SERVICES) {
       expect((services[svc] as { mode?: string })?.mode).toBe("your-own");
+    }
+    for (const svc of SCHEMA_MANAGED_DEFAULT_SERVICES) {
+      expect((services[svc] as { mode?: string })?.mode).toBe("managed");
     }
   });
 
@@ -228,12 +259,8 @@ describe("platform-managed config defaults", () => {
     // missing service-mode fields.
     for (const svc of MANAGED_SERVICES) {
       expect(
-        (
-          config.services as unknown as Record<
-            string,
-            { mode: string }
-          >
-        )[svc]!.mode,
+        (config.services as unknown as Record<string, { mode: string }>)[svc]!
+          .mode,
       ).toBe("managed");
     }
 
@@ -277,9 +304,11 @@ describe("platform-managed config defaults", () => {
     expect(imageGen.provider).toBe("openai");
   });
 
-  test("IS_PLATFORM=false, config file exists without services key → in-memory config keeps schema your-own defaults", () => {
+  test("IS_PLATFORM=false, config file exists without services key → in-memory config keeps schema defaults (your-own except google/notion-oauth which are managed)", () => {
     // Sanity guard: deployment-context defaults are a no-op when IS_PLATFORM
-    // is not enabled, regardless of whether config.json existed.
+    // is not enabled, regardless of whether config.json existed. The Zod
+    // schema defaults still apply, so google-oauth and notion-oauth resolve
+    // to "managed" while the remaining services resolve to "your-own".
     process.env.IS_PLATFORM = "false";
 
     writeFileSync(
@@ -300,15 +329,17 @@ describe("platform-managed config defaults", () => {
 
     const config = loadConfig();
 
-    for (const svc of MANAGED_SERVICES) {
+    for (const svc of SCHEMA_YOUR_OWN_DEFAULT_SERVICES) {
       expect(
-        (
-          config.services as unknown as Record<
-            string,
-            { mode: string }
-          >
-        )[svc]!.mode,
+        (config.services as unknown as Record<string, { mode: string }>)[svc]!
+          .mode,
       ).toBe("your-own");
+    }
+    for (const svc of SCHEMA_MANAGED_DEFAULT_SERVICES) {
+      expect(
+        (config.services as unknown as Record<string, { mode: string }>)[svc]!
+          .mode,
+      ).toBe("managed");
     }
   });
 });

--- a/assistant/src/config/schemas/__tests__/services.test.ts
+++ b/assistant/src/config/schemas/__tests__/services.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { ServicesSchema } from "../services.js";
+
+describe("ServicesSchema OAuth mode defaults", () => {
+  test("notion-oauth defaults to managed", () => {
+    const parsed = ServicesSchema.parse({});
+    expect(parsed["notion-oauth"].mode).toBe("managed");
+  });
+
+  test("google-oauth defaults to managed", () => {
+    const parsed = ServicesSchema.parse({});
+    expect(parsed["google-oauth"].mode).toBe("managed");
+  });
+
+  test("linear-oauth default is unchanged (your-own)", () => {
+    const parsed = ServicesSchema.parse({});
+    expect(parsed["linear-oauth"].mode).toBe("your-own");
+  });
+
+  test("explicit notion-oauth mode 'your-own' is preserved", () => {
+    const parsed = ServicesSchema.parse({
+      "notion-oauth": { mode: "your-own" },
+    });
+    expect(parsed["notion-oauth"].mode).toBe("your-own");
+  });
+});

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -52,7 +52,7 @@ const WebSearchServiceSchema = BaseServiceSchema.extend({
 });
 
 const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("your-own"),
+  mode: ServiceModeSchema.default("managed"),
 });
 
 const OutlookOAuthServiceSchema = BaseServiceSchema.extend({
@@ -68,7 +68,7 @@ const GitHubOAuthServiceSchema = BaseServiceSchema.extend({
 });
 
 const NotionOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("your-own"),
+  mode: ServiceModeSchema.default("managed"),
 });
 
 const TwitterOAuthServiceSchema = BaseServiceSchema.extend({


### PR DESCRIPTION
## Summary
- Flip ServicesSchema defaults for notion-oauth and google-oauth from your-own to managed.
- Add a schema test that locks in the new defaults and verifies explicit your-own settings still parse through.

Part of plan: managed-oauth-preferred.md (PR 1 of 4)