### PR TITLE
docs(skills): lead OAuth integrations flow with managed-mode check

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T10:12:39-07:00"
+      "updatedAt": "2026-05-26T17:32:24-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-26T17:32:24-04:00"
+      "updatedAt": "2026-05-26T17:39:09-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-26T17:39:09-04:00"
+      "updatedAt": "2026-05-26T17:48:46-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -65,7 +65,7 @@ Your-own mode is typically best if:
 **Default to managed mode whenever the provider supports it.** Check support with:
 
 ```bash
-assistant oauth providers get <provider-key> | jq -r '.managedServiceConfigKey'
+assistant oauth providers get <provider-key> --json | jq -r '.managedServiceConfigKey'
 ```
 
 If this returns a non-null value, managed mode is supported and should be your starting recommendation. Only fall back to your-own mode if:

--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -38,7 +38,7 @@ assistant oauth providers list --provider-key google
 
 All providers support "your-own" mode and some support "managed" mode.
 
-### Managed Mode
+### Default: Managed Mode
 
 "managed" mode relies on a first-class integration with the Vellum Platform. Managed mode is typically easier to set up and get going, often only requiring the user to log in with no additional configuration needed before they can begin using the integration. Managed mode is the recommended method for most users, especially those that are less technical or newer to their Vellum assistant.
 
@@ -59,6 +59,22 @@ Your-own mode is typically best if:
 - The user does not want to create an account with the Vellum Platform
 - The user is more sensitive to potential billing implications
 - The user is sensitive to their data going to the Vellum Platform
+
+### How to Choose
+
+**Default to managed mode whenever the provider supports it.** Check support with:
+
+```bash
+assistant oauth providers get <provider-key> | jq -r '.managedServiceConfigKey'
+```
+
+If this returns a non-null value, managed mode is supported and should be your starting recommendation. Only fall back to your-own mode if:
+
+- The provider does not support managed mode (`managedServiceConfigKey` is null), OR
+- The user explicitly wants their own OAuth app (e.g. they're running self-hosted, they're privacy-sensitive, they're configuring a per-assistant Slack app), OR
+- The user already has a working your-own connection — don't re-recommend managed mid-flow for already-connected providers.
+
+Do not present managed and your-own as equivalent choices to a fresh user. Lead with managed, then offer your-own as an alternative if they push back.
 
 ### Differentiating & Setting a Provider's Mode
 

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -4,24 +4,40 @@ Your user must connect their account for you to be able to make requests on thei
 
 ## Pre-Requisites
 
-Before the user can connect to a provider, they must:
+Before the user can connect to a provider, they must have it in one of two states:
 
-1. Have the provider configured to use "managed" mode, and the provider must support it; or
-2. Have the provider configured to use "your-own" mode, and have created an OAuth app
+1. **Managed mode** (preferred when supported), or
+2. **Your-own mode** with at least one OAuth app already created.
 
-Check to see what mode the provider is configured to use with:
+### Step 1: Check whether managed mode is supported
+
+```bash
+assistant oauth providers get <provider-key> | jq -r '.managedServiceConfigKey'
+```
+
+If this returns a non-null value, managed mode is supported. Unless the user has already chosen your-own mode for a deliberate reason, prefer managed mode.
+
+### Step 2: Check the current mode
 
 ```bash
 assistant oauth mode <provider-key>
 ```
 
-If set to "your-own", then check to see if at least one OAuth app has been created with:
+- **Returns `managed`**: proceed to "Initiating the Connection".
+- **Returns `your-own` and managed mode IS supported**: ask the user whether they'd like to switch to managed mode (it's simpler — no app to create). If yes, run `assistant oauth mode <provider-key> --set managed` and proceed. If no, continue to Step 3.
+- **Returns `your-own` and managed mode is NOT supported**: continue to Step 3.
+
+Do not perform this step if the user already has an active connection — `assistant oauth status <provider-key>` returning a live connection means the user has already chosen a mode; respect it.
+
+### Step 3: Verify your-own setup (only if you reached this step)
+
+Check whether at least one OAuth app exists:
 
 ```bash
 assistant oauth apps list --provider-key <provider-key>
 ```
 
-If there are none, they will either need to opt in to using "managed" mode or they will need to create an OAuth app (see [Configuring a New OAuth Application](CONFIGURING_APPLICATIONS.md)).
+If there are none, see [Configuring a New OAuth Application](CONFIGURING_APPLICATIONS.md).
 
 ## Choosing Scopes
 

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -12,7 +12,7 @@ Before the user can connect to a provider, they must have it in one of two state
 ### Step 1: Check whether managed mode is supported
 
 ```bash
-assistant oauth providers get <provider-key> | jq -r '.managedServiceConfigKey'
+assistant oauth providers get <provider-key> --json | jq -r '.managedServiceConfigKey'
 ```
 
 If this returns a non-null value, managed mode is supported. Unless the user has already chosen your-own mode for a deliberate reason, prefer managed mode.


### PR DESCRIPTION
## Summary
- Reorder Managed Mode before Your-Own Mode in SKILL.md and add a How-to-Choose section that directs the assistant to default to managed.
- Restructure CONNECTING_ACCOUNTS.md Pre-Requisites into a managed-first decision tree with an already-connected-user guard.

Part of plan: managed-oauth-preferred.md (PR 2 of 4)