### PR TITLE
docs(skills): google guide defers to managed mode when supported

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T10:12:39-07:00"
+      "updatedAt": "2026-05-26T17:32:52-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-26T17:49:12-04:00"
+      "updatedAt": "2026-05-27T09:50:10-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-26T17:36:07-04:00"
+      "updatedAt": "2026-05-26T17:49:12-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-26T17:32:52-04:00"
+      "updatedAt": "2026-05-26T17:36:07-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -24,7 +24,7 @@ assistant oauth mode google
 - If the result is `managed`, **stop reading this file** and follow [CONNECTING_ACCOUNTS.md](../CONNECTING_ACCOUNTS.md) instead.
 - If the result is `your-own`, ask the user whether they'd prefer the simpler managed flow before continuing:
   > "Google can connect through Vellum's managed integration — no Google Cloud Console setup needed, just a login. The custom-app path takes a few minutes and involves several developer console screens. Want to use the managed flow, or do you want to set up your own?"
-  If they prefer managed, run `assistant oauth mode google --set managed` and switch to the managed flow.
+  > If they prefer managed, run `assistant oauth mode google --set managed` and switch to the managed flow.
 - If the user already has an active Google connection (`assistant oauth status google` returns a live connection), do not switch modes — respect their existing setup.
 
 Only proceed with Path A or Path B below if the user has explicitly chosen `your-own` mode.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -9,7 +9,29 @@ The included `vellum-oauth-integrations` skill handles the generic parts of the 
 - **Credential type (Path A):** Desktop app
 - **Credential type (Path B):** Web application (callback through public gateway)
 
+## Check Managed Mode First
+
+**Before guiding the user through Google Cloud Console setup, check whether they should be using Vellum-managed Google OAuth instead.**
+
+Google supports managed mode (see `assistant oauth providers get google`). Setting up a Google Cloud project, OAuth consent screen, and credentials is a multi-step, technical process that takes 3-5 minutes minimum and frequently hits edge cases (consent screen verification, scope mismatches, redirect URI errors). The managed flow takes ~30 seconds: log in with Google, grant scopes, done.
+
+To check:
+
+```bash
+assistant oauth mode google
+```
+
+- If the result is `managed`, **stop reading this file** and follow [CONNECTING_ACCOUNTS.md](../CONNECTING_ACCOUNTS.md) instead.
+- If the result is `your-own`, ask the user whether they'd prefer the simpler managed flow before continuing:
+  > "Google can connect through Vellum's managed integration — no Google Cloud Console setup needed, just a login. The custom-app path takes a few minutes and involves several developer console screens. Want to use the managed flow, or do you want to set up your own?"
+  If they prefer managed, run `assistant oauth mode google --set managed` and switch to the managed flow.
+- If the user already has an active Google connection (`assistant oauth status google` returns a live connection), do not switch modes — respect their existing setup.
+
+Only proceed with Path A or Path B below if the user has explicitly chosen `your-own` mode.
+
 ## Path A: macOS Desktop App
+
+> Path A and Path B apply only if the user has opted into your-own mode (see "Check Managed Mode First" above).
 
 On the macOS desktop app, this is a collaborative Google Chrome flow. For every `Open:` URL in this file:
 


### PR DESCRIPTION
## Summary
- Add a Check Managed Mode First section at the top of the Google provider setup guide so the assistant defers to the managed flow by default.
- Note that the existing Path A and Path B (Google Cloud Console) flows only apply when the user has explicitly opted into your-own.

Part of plan: managed-oauth-preferred.md (PR 4 of 4)