### PR TITLE
fix: prevent ConnectionResolutionError from leaking internal details to users

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -7,6 +7,7 @@ mock.module("../providers/registry.js", () => ({
     providerRoutingSources[provider],
 }));
 
+import { ConnectionResolutionError } from "../providers/connection-resolution.js";
 import type { ErrorContext } from "../daemon/conversation-error.js";
 import {
   budgetYieldUnrecoveredClassification,
@@ -976,5 +977,34 @@ describe("budgetYieldUnrecoveredClassification", () => {
     expect(envelope.retryable).toBe(true);
     expect(envelope.errorCategory).toBe("budget_yield_unrecovered");
     expect(envelope.userMessage).toBe(classified.userMessage);
+  });
+});
+
+describe("ConnectionResolutionError classification", () => {
+  const errCtx: ErrorContext = { phase: "agent_loop" };
+
+  it("classifies provider_mismatch as PROVIDER_NOT_CONFIGURED with user-friendly message", () => {
+    const err = new ConnectionResolutionError(
+      "anthropic-managed",
+      "provider_mismatch",
+      'provider_connection "anthropic-managed" has provider="anthropic" but resolving profile declared provider="openai"',
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(result.userMessage).toContain("No compatible provider connection");
+    expect(result.userMessage).toContain("Settings");
+    expect(result.userMessage).not.toContain("provider_connection");
+    expect(result.connectionName).toBe("anthropic-managed");
+  });
+
+  it("classifies not_found as PROVIDER_NOT_CONFIGURED", () => {
+    const err = new ConnectionResolutionError(
+      "deleted-connection",
+      "not_found",
+      'provider_connection "deleted-connection" not found in DB',
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(result.userMessage).not.toContain("not found in DB");
   });
 });

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -7,7 +7,6 @@ mock.module("../providers/registry.js", () => ({
     providerRoutingSources[provider],
 }));
 
-import { ConnectionResolutionError } from "../providers/connection-resolution.js";
 import type { ErrorContext } from "../daemon/conversation-error.js";
 import {
   budgetYieldUnrecoveredClassification,
@@ -15,6 +14,7 @@ import {
   classifyConversationError,
   isUserCancellation,
 } from "../daemon/conversation-error.js";
+import { ConnectionResolutionError } from "../providers/connection-resolution.js";
 import {
   type AbortReasonKind,
   createAbortReason,

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -1,3 +1,4 @@
+import { ConnectionResolutionError } from "../providers/connection-resolution.js";
 import { getProviderRoutingSource } from "../providers/registry.js";
 import { isAbortReason } from "../util/abort-reasons.js";
 import { ProviderError, ProviderNotConfiguredError } from "../util/errors.js";
@@ -256,6 +257,23 @@ export function classifyConversationError(
         profileName: error.profileName ?? attribution.profileName,
       }),
       debugDetails,
+    };
+  }
+
+  if (error instanceof ConnectionResolutionError) {
+    return {
+      code: "PROVIDER_NOT_CONFIGURED",
+      userMessage:
+        "No compatible provider connection found for this profile. Check your provider connections in Settings.",
+      retryable: true,
+      debugDetails,
+      errorCategory: "provider_not_configured",
+      ...(error.connectionName
+        ? { connectionName: error.connectionName }
+        : {}),
+      ...(attribution.profileName
+        ? { profileName: attribution.profileName }
+        : {}),
     };
   }
 


### PR DESCRIPTION
## Summary
- `ConnectionResolutionError` (e.g. provider mismatch, connection not found) was falling through to the default `CONVERSATION_PROCESSING_FAILED` classifier, which includes the raw error message verbatim in the user-facing `userMessage` field.
- Added an `instanceof ConnectionResolutionError` check in `classifyConversationError` that maps these errors to `PROVIDER_NOT_CONFIGURED` with a friendly message: "No compatible provider connection found for this profile. Check your provider connections in Settings."
- Added tests covering `provider_mismatch` and `not_found` reason codes, verifying internal details are not leaked.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/conversation-error.test.ts` — all 126 tests pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)