### PR TITLE
feat(assistant): add Auto profile for opt-in query complexity routing

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -123,9 +123,18 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
 };
 
-export const MANAGED_PROFILE_NAMES = new Set(
-  Object.keys(MANAGED_PROFILE_TEMPLATES),
-);
+/**
+ * The "auto" profile key. When active, the daemon injects the
+ * `switch_inference_profile` tool and lets the model self-select a profile
+ * per query. No provider/model — the resolver falls through to the call-site
+ * default (balanced or custom-balanced for BYOK).
+ */
+export const AUTO_PROFILE_KEY = "auto";
+
+export const MANAGED_PROFILE_NAMES = new Set([
+  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  AUTO_PROFILE_KEY,
+]);
 
 export type SeedInferenceProfilesOptions = {
   /**
@@ -263,6 +272,25 @@ export function seedInferenceProfiles(
     profiles[name] = next as ProfileEntry;
   }
 
+  // 1b. Auto profile — a metadata-only profile with no provider/model. When
+  //     the user selects "Auto", the resolver falls through to the call-site
+  //     default (balanced or custom-balanced), and the agent loop injects the
+  //     switch_inference_profile tool so the model can self-select per query.
+  if (!preservedProfileNames.has(AUTO_PROFILE_KEY)) {
+    const previousAuto = readObject(profiles[AUTO_PROFILE_KEY]);
+    const autoEntry: Record<string, unknown> = {
+      source: "managed",
+      label: "Auto",
+      description:
+        "Automatically routes each query to the best profile — fast for simple questions, capable for complex ones",
+    };
+    if (previousAuto) {
+      if ("label" in previousAuto) autoEntry.label = previousAuto.label;
+      if ("status" in previousAuto) autoEntry.status = previousAuto.status;
+    }
+    profiles[AUTO_PROFILE_KEY] = autoEntry as ProfileEntry;
+  }
+
   // 2. User profiles — only at hatch time for off-platform installations.
   let userConnectionName: string | undefined;
   if (options.isHatch && !isPlatform) {
@@ -336,10 +364,15 @@ export function seedInferenceProfiles(
   }
 
   // Profile ordering — ensure all seeded profiles appear in the order array.
+  // "auto" is prepended so it appears first in the picker.
   const profileOrder = Array.isArray(llm.profileOrder)
     ? (llm.profileOrder as string[])
     : [];
   const orderSet = new Set(profileOrder);
+  if (!orderSet.has(AUTO_PROFILE_KEY)) {
+    profileOrder.unshift(AUTO_PROFILE_KEY);
+    orderSet.add(AUTO_PROFILE_KEY);
+  }
   for (const name of Object.keys(MANAGED_PROFILE_TEMPLATES)) {
     if (!orderSet.has(name)) {
       profileOrder.push(name);

--- a/assistant/src/daemon/__tests__/switch-inference-profile-tool.test.ts
+++ b/assistant/src/daemon/__tests__/switch-inference-profile-tool.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProfileEntry } from "../../config/schemas/llm.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { buildSwitchInferenceProfileToolDef } from "../switch-inference-profile-tool.js";
+
+function getProfileEnum(toolDef: ToolDefinition): string[] {
+  const schema = toolDef.input_schema as {
+    properties: { profile: { enum: string[] } };
+  };
+  return schema.properties.profile.enum;
+}
+
+const balanced: ProfileEntry = {
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  label: "Balanced",
+  description: "Good balance of quality, cost, and speed",
+  source: "managed",
+};
+
+const quality: ProfileEntry = {
+  provider: "anthropic",
+  model: "claude-opus-4-6",
+  label: "Quality",
+  description: "Best results with the most capable model",
+  source: "managed",
+};
+
+const speed: ProfileEntry = {
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  label: "Speed",
+  description: "Fastest responses at lower cost",
+  source: "managed",
+};
+
+const auto: ProfileEntry = {
+  label: "Auto",
+  description: "Automatically routes each query to the best profile",
+  source: "managed",
+};
+
+describe("buildSwitchInferenceProfileToolDef", () => {
+  test("excludes the 'auto' profile from available switch targets", () => {
+    const profiles = { auto, balanced, "quality-optimized": quality, "cost-optimized": speed };
+    const toolDef = buildSwitchInferenceProfileToolDef(profiles, "auto");
+
+    expect(toolDef).not.toBeNull();
+    const enumValues = getProfileEnum(toolDef!);
+    expect(enumValues).not.toContain("auto");
+    expect(enumValues).toContain("balanced");
+    expect(enumValues).toContain("quality-optimized");
+    expect(enumValues).toContain("cost-optimized");
+  });
+
+  test("returns null when only 'auto' and one real profile exist", () => {
+    const profiles = { auto, balanced };
+    const toolDef = buildSwitchInferenceProfileToolDef(profiles, "auto");
+
+    expect(toolDef).toBeNull();
+  });
+
+  test("excludes disabled profiles alongside 'auto'", () => {
+    const disabled: ProfileEntry = { ...balanced, status: "disabled" };
+    const profiles = { auto, balanced: disabled, "quality-optimized": quality, "cost-optimized": speed };
+    const toolDef = buildSwitchInferenceProfileToolDef(profiles, "auto");
+
+    expect(toolDef).not.toBeNull();
+    const enumValues = getProfileEnum(toolDef!);
+    expect(enumValues).not.toContain("auto");
+    expect(enumValues).not.toContain("balanced");
+    expect(enumValues).toContain("quality-optimized");
+    expect(enumValues).toContain("cost-optimized");
+  });
+
+  test("shows 'Auto (starting on Balanced)' as the current profile label", () => {
+    const profiles = { auto, balanced, "quality-optimized": quality, "cost-optimized": speed };
+    const toolDef = buildSwitchInferenceProfileToolDef(profiles, "auto");
+
+    expect(toolDef).not.toBeNull();
+    expect(toolDef!.description).toContain("Auto (starting on Balanced)");
+  });
+
+  test("works with BYOK custom profiles", () => {
+    const customBalanced: ProfileEntry = {
+      ...balanced,
+      provider_connection: "anthropic-personal",
+      label: "Balanced",
+      source: "user",
+    };
+    const customQuality: ProfileEntry = {
+      ...quality,
+      provider_connection: "anthropic-personal",
+      label: "Quality",
+      source: "user",
+    };
+    const profiles = { auto, "custom-balanced": customBalanced, "custom-quality-optimized": customQuality };
+    const toolDef = buildSwitchInferenceProfileToolDef(profiles, "auto");
+
+    expect(toolDef).not.toBeNull();
+    const enumValues = getProfileEnum(toolDef!);
+    expect(enumValues).not.toContain("auto");
+    expect(enumValues).toContain("custom-balanced");
+    expect(enumValues).toContain("custom-quality-optimized");
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -565,12 +565,6 @@ export interface AgentLoopConversationContext {
    * turn start.
    */
   toolRoutedProfile?: string;
-  /**
-   * True when the user has explicitly selected an inference profile for this
-   * conversation (via the composer profile picker). When set, tool-based
-   * auto-routing is suppressed — the user's explicit choice takes precedence.
-   */
-  hasExplicitProfileOverride?: boolean;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   trustContext?: TrustContext;
   /** Task-run scope for the current turn. Cleared at turn end so queued/drained turns don't inherit it. */
@@ -747,8 +741,6 @@ export async function runAgentLoopImpl(
   const userExplicitOverride =
     options?.overrideProfile ??
     getConversationOverrideProfileFromRow(turnStartConversation);
-
-  ctx.hasExplicitProfileOverride = !!userExplicitOverride;
 
   const config = getConfig();
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -75,6 +75,7 @@ export function resolveTrustClass(
 }
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { AUTO_PROFILE_KEY } from "../config/seed-inference-profiles.js";
 import {
   buildSwitchInferenceProfileToolDef,
   SWITCH_INFERENCE_PROFILE_TOOL_NAME,
@@ -360,12 +361,6 @@ export interface SkillProjectionContext {
   readonly transportInterface?: InterfaceId;
   /** Per-turn override profile, read by the switch_inference_profile tool injection. */
   currentTurnOverrideProfile?: string;
-  /**
-   * True when the user has explicitly selected an inference profile for this
-   * conversation (via the composer profile picker). When set, tool-based
-   * auto-routing is suppressed — the user's explicit choice takes precedence.
-   */
-  hasExplicitProfileOverride?: boolean;
 }
 
 // ── Conditional tool sets ────────────────────────────────────────────
@@ -658,18 +653,19 @@ export function createResolveToolsCallback(
     const config = getConfig();
     if (
       isAssistantFeatureFlagEnabled("query-complexity-routing", config) &&
-      config.llm &&
-      !ctx.hasExplicitProfileOverride
+      config.llm
     ) {
-      const currentProfile =
+      const effectiveProfile =
         ctx.currentTurnOverrideProfile ?? config.llm.activeProfile;
-      const toolDef = buildSwitchInferenceProfileToolDef(
-        config.llm.profiles ?? {},
-        currentProfile,
-      );
-      if (toolDef) {
-        turnAllowed.add(SWITCH_INFERENCE_PROFILE_TOOL_NAME);
-        return [...baseDefs, toolDef];
+      if (effectiveProfile === AUTO_PROFILE_KEY) {
+        const toolDef = buildSwitchInferenceProfileToolDef(
+          config.llm.profiles ?? {},
+          effectiveProfile,
+        );
+        if (toolDef) {
+          turnAllowed.add(SWITCH_INFERENCE_PROFILE_TOOL_NAME);
+          return [...baseDefs, toolDef];
+        }
       }
     }
 

--- a/assistant/src/daemon/switch-inference-profile-tool.ts
+++ b/assistant/src/daemon/switch-inference-profile-tool.ts
@@ -1,4 +1,5 @@
 import type { ProfileEntry } from "../config/schemas/llm.js";
+import { AUTO_PROFILE_KEY } from "../config/seed-inference-profiles.js";
 import type { ToolDefinition } from "../providers/types.js";
 
 export const SWITCH_INFERENCE_PROFILE_TOOL_NAME = "switch_inference_profile";
@@ -16,7 +17,7 @@ export function buildSwitchInferenceProfileToolDef(
   currentProfile?: string,
 ): ToolDefinition | null {
   const entries = Object.entries(profiles).filter(
-    ([, entry]) => entry.status !== "disabled",
+    ([key, entry]) => entry.status !== "disabled" && key !== AUTO_PROFILE_KEY,
   );
   if (entries.length < 2) return null;
 
@@ -32,7 +33,10 @@ export function buildSwitchInferenceProfileToolDef(
     .join("\n");
 
   const currentEntry = currentProfile ? profiles[currentProfile] : undefined;
-  const currentLabel = currentEntry?.label ?? currentProfile ?? "current";
+  const currentLabel =
+    currentProfile === AUTO_PROFILE_KEY
+      ? "Auto (starting on Balanced)"
+      : (currentEntry?.label ?? currentProfile ?? "current");
 
   return {
     name: SWITCH_INFERENCE_PROFILE_TOOL_NAME,

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -64,10 +64,4 @@ export interface ToolSetupContext extends SurfaceConversationContext {
    * turn start.
    */
   toolRoutedProfile?: string;
-  /**
-   * True when the user has explicitly selected an inference profile for this
-   * conversation (via the composer profile picker). When set, tool-based
-   * auto-routing is suppressed — the user's explicit choice takes precedence.
-   */
-  hasExplicitProfileOverride?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds an **"Auto" inference profile** that, when selected by the user, injects the `switch_inference_profile` tool so the model can self-select per query
- Auto is a metadata-only profile (no provider/model) — the LLM resolver falls through to the call-site default (balanced or custom-balanced for BYOK), so it works for both managed and BYOK users identically
- Tool injection is now gated on `effectiveProfile === "auto"` instead of the old `!hasExplicitProfileOverride` check, making auto-routing explicitly opt-in
- Feature flag `query-complexity-routing` still gates whether the Auto profile is functional (tool injection requires the flag)
- Removes the now-unused `hasExplicitProfileOverride` field from the agent loop context

### How it works
1. "Auto" is seeded on every boot alongside the three real profiles (balanced, quality, speed)
2. When the user selects "Auto" as their workspace default or per-conversation profile, the `switch_inference_profile` tool is injected
3. The model starts on balanced-equivalent config and can switch up (Quality) or down (Speed) per query
4. If the user pins a specific profile (Quality, Balanced, Speed), the tool is NOT injected — explicit selection wins
5. "Auto" is excluded from the switch tool's available targets (you switch between real profiles, not back to auto)

### BYOK
Auto works with custom profiles (`custom-balanced`, `custom-quality-optimized`, `custom-cost-optimized`). The switch tool shows whatever non-disabled profiles exist — no special BYOK handling needed.

### Remaining work
- **Frontend**: Show "Auto" in the profile picker (gated by `query-complexity-routing` feature flag) — needs pairing with Rok
- **Frontend**: UI indicator showing which profile the model chose for the current turn

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All existing tests pass (122 tests across 4 affected files)
- [x] New tests verify: auto excluded from switch targets, null when only 1 real profile, BYOK custom profiles work, disabled profiles + auto both excluded
- [ ] Local testing: set `activeProfile: "auto"`, enable feature flag, verify tool injection and per-query switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)