### PR TITLE
fix(web): remove double-bubble padding on chat messages

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -747,8 +747,12 @@ export function TranscriptMessageBody({
         {(contentElements.some((el) => !!el) ||
           (!message.toolCalls?.length &&
             !(message.attachments && message.attachments.length > 0))) && (
+          // Layout-only column: the bubble styling (textBubbleClass) is applied
+          // per text segment inside renderTextWithInlineSurfaces, mirroring the
+          // interleaved path above. Applying textBubbleClass here too would
+          // double-wrap text in two nested bubbles (doubled padding/background).
           <div
-            className={`text-[15px] break-words ${textBubbleClass}`}
+            className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
           >
             {contentElements}
           </div>


### PR DESCRIPTION
## Summary
- Plain user/text messages were rendering inside **two nested bubbles** (doubled padding, background, and rounded corners) — a regression from #32068.
- Root cause: `renderTextWithInlineSurfaces` (added in #32068) wraps each text segment in a div with `textBubbleClass`, but the legacy (non-interleaved) path in `transcript-message-body.tsx` *also* wrapped the resulting `contentElements` in an outer div with `textBubbleClass`.
- Fix: make the legacy outer wrapper a layout-only flex column (mirroring the interleaved path, which has no outer bubble), so the bubble styling is applied exactly once — per text segment inside the helper. Surfaces inside `contentElements` keep rendering full-width without a bubble background.

## Original prompt
While reviewing the chat UI, a sent/user message bubble looked heavily over-padded — DevTools showed two nested padded containers. Investigation traced the regression to PR #32068 (merged 2026-05-26), which introduced `renderTextWithInlineSurfaces` and caused the legacy render path to double-wrap message text in two `textBubbleClass` bubbles. The ask was a quick PR to revert this regression while preserving the inline `<ui_show>` surface parsing from #32068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)