### PR TITLE
Run background wake leases from daemon

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1838,6 +1838,8 @@ paths:
               schema:
                 type: object
                 properties:
+                  accepted:
+                    type: boolean
                   leaseId:
                     type: string
                   reason:
@@ -1848,87 +1850,13 @@ paths:
                     type: number
                   deadlineAt:
                     type: number
-                  counts:
-                    type: object
-                    properties:
-                      heartbeat:
-                        type: number
-                      scheduler:
-                        type: number
-                      total:
-                        type: number
-                      completed:
-                        type: number
-                      failed:
-                        type: number
-                      skipped:
-                        type: number
-                      claimed:
-                        type: number
-                      stillPending:
-                        type: number
-                    required:
-                      - heartbeat
-                      - scheduler
-                      - total
-                      - completed
-                      - failed
-                      - skipped
-                      - claimed
-                      - stillPending
-                    additionalProperties: false
-                  completed:
-                    type: number
-                  failed:
-                    type: number
-                  skipped:
-                    type: number
-                  nextIntent:
-                    anyOf:
-                      - type: object
-                        properties:
-                          nextWakeAt:
-                            type: number
-                          actualNextDueAt:
-                            type: number
-                          reason:
-                            type: string
-                            enum:
-                              - heartbeat
-                              - schedule
-                              - mixed
-                          sourceGeneration:
-                            type: string
-                          computedAt:
-                            type: number
-                          sourcePayload:
-                            type: object
-                            propertyNames:
-                              type: string
-                            additionalProperties: {}
-                        required:
-                          - nextWakeAt
-                          - actualNextDueAt
-                          - reason
-                          - sourceGeneration
-                          - computedAt
-                          - sourcePayload
-                        additionalProperties: false
-                      - type: "null"
-                  dueWorkRemaining:
-                    type: boolean
                 required:
+                  - accepted
                   - leaseId
                   - reason
                   - sourceGeneration
                   - startedAt
                   - deadlineAt
-                  - counts
-                  - completed
-                  - failed
-                  - skipped
-                  - nextIntent
-                  - dueWorkRemaining
                 additionalProperties: false
       requestBody:
         required: true

--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -11,9 +11,21 @@ type MockIntent = BackgroundWakeIntent;
 
 let computedIntent: MockIntent | null;
 let computeCalls: number;
+const mockRenewBackgroundWakeLease = mock(async () => ({
+  status: "renewed" as const,
+  httpStatus: 200,
+}));
+const mockCompleteBackgroundWakeLease = mock(async () => ({
+  status: "completed" as const,
+  httpStatus: 200,
+}));
 
-const { ROUTES, setBackgroundWakeIntentComputerForTest } =
-  await import("../runtime/routes/background-wake-routes.js");
+const {
+  ROUTES,
+  flushBackgroundWakeDrainsForTest,
+  setBackgroundWakeIntentComputerForTest,
+  setBackgroundWakeLeaseClientForTest,
+} = await import("../runtime/routes/background-wake-routes.js");
 
 function findHandler(operationId: string) {
   const route = ROUTES.find(
@@ -45,9 +57,60 @@ function firstCallArg(fn: {
   return (call?.[0] ?? {}) as Record<string, unknown>;
 }
 
+function acceptedResponse(
+  overrides: Partial<{
+    leaseId: string;
+    reason: string;
+    sourceGeneration: string;
+    startedAt: number;
+    deadlineAt: number;
+  }> = {},
+) {
+  return {
+    accepted: true,
+    leaseId: "lease-123",
+    reason: "schedule",
+    sourceGeneration: "source-generation",
+    startedAt: NOW,
+    deadlineAt: NOW + 30_000,
+    ...overrides,
+  };
+}
+
+function lastCompletionPayload(): {
+  leaseId: string;
+  status: "completed" | "failed" | "expired";
+  error?: string;
+  nextIntent?: MockIntent | null;
+} {
+  const calls = mockCompleteBackgroundWakeLease.mock.calls;
+  const call = calls[calls.length - 1] as unknown[] | undefined;
+  if (!call) throw new Error("completeBackgroundWakeLease was not called");
+  return call[0] as {
+    leaseId: string;
+    status: "completed" | "failed" | "expired";
+    error?: string;
+    nextIntent?: MockIntent | null;
+  };
+}
+
 describe("background wake runtime routes", () => {
   beforeEach(() => {
     clearBackgroundWakeRuntime();
+    mockRenewBackgroundWakeLease.mockClear();
+    mockCompleteBackgroundWakeLease.mockClear();
+    mockRenewBackgroundWakeLease.mockImplementation(async () => ({
+      status: "renewed" as const,
+      httpStatus: 200,
+    }));
+    mockCompleteBackgroundWakeLease.mockImplementation(async () => ({
+      status: "completed" as const,
+      httpStatus: 200,
+    }));
+    setBackgroundWakeLeaseClientForTest({
+      renew: mockRenewBackgroundWakeLease,
+      complete: mockCompleteBackgroundWakeLease,
+    });
     computeCalls = 0;
     computedIntent = intentFixture({ nextWakeAt: Date.now() + 10 * 60_000 });
     setBackgroundWakeIntentComputerForTest(() => {
@@ -56,8 +119,11 @@ describe("background wake runtime routes", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await flushBackgroundWakeDrainsForTest();
     setBackgroundWakeIntentComputerForTest(null);
+    setBackgroundWakeLeaseClientForTest(null);
+    clearBackgroundWakeRuntime();
   });
 
   test("intent route returns the current computed wake intent", async () => {
@@ -137,6 +203,7 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "mixed" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).toHaveBeenCalledTimes(1);
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
@@ -144,27 +211,11 @@ describe("background wake runtime routes", () => {
     );
     expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
-    expect(response).toEqual({
+    expect(response).toEqual(acceptedResponse({ reason: "mixed" }));
+    expect(lastCompletionPayload()).toEqual({
       leaseId: "lease-123",
-      reason: "mixed",
-      sourceGeneration: "source-generation",
-      startedAt: NOW,
-      deadlineAt: NOW + 30_000,
-      counts: {
-        heartbeat: 1,
-        scheduler: 2,
-        total: 3,
-        completed: 3,
-        failed: 0,
-        skipped: 0,
-        claimed: 2,
-        stillPending: 0,
-      },
-      completed: 3,
-      failed: 0,
-      skipped: 0,
+      status: "completed",
       nextIntent: recomputedIntent,
-      dueWorkRemaining: false,
     });
   });
 
@@ -187,30 +238,15 @@ describe("background wake runtime routes", () => {
     });
     const handler = findHandler("drainDueBackgroundWake");
 
-    const response = (await handler({ body: drainBodyFixture() })) as {
-      counts: {
-        heartbeat: number;
-        scheduler: number;
-        total: number;
-        completed: number;
-        failed: number;
-        skipped: number;
-        claimed: number;
-        stillPending: number;
-      };
-    };
+    const response = await handler({ body: drainBodyFixture() });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).not.toHaveBeenCalled();
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
-    expect(response.counts).toEqual({
-      heartbeat: 0,
-      scheduler: 0,
-      total: 0,
-      completed: 0,
-      failed: 0,
-      skipped: 0,
-      claimed: 0,
-      stillPending: 0,
+    expect(response).toEqual(acceptedResponse());
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 
@@ -239,11 +275,11 @@ describe("background wake runtime routes", () => {
     });
     const handler = findHandler("drainDueBackgroundWake");
 
-    const response = (await handler({ body: drainBodyFixture() })) as {
-      nextIntent: MockIntent | null;
-    };
+    const response = await handler({ body: drainBodyFixture() });
+    await flushBackgroundWakeDrainsForTest();
 
-    expect(response.nextIntent).toEqual(recomputedIntent);
+    expect(response).toEqual(acceptedResponse());
+    expect(lastCompletionPayload().nextIntent).toEqual(recomputedIntent);
   });
 
   test("drain-due runs scheduler backlog on heartbeat-only drains", async () => {
@@ -281,6 +317,7 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "heartbeat" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -289,11 +326,11 @@ describe("background wake runtime routes", () => {
     );
     expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
-    expect(response).toMatchObject({
-      completed: 2,
-      failed: 0,
-      skipped: 0,
-      dueWorkRemaining: false,
+    expect(response).toEqual(acceptedResponse({ reason: "heartbeat" }));
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
+      nextIntent: recomputedIntent,
     });
   });
 
@@ -319,14 +356,14 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "heartbeat" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).not.toHaveBeenCalled();
     expect(schedulerRunDue).not.toHaveBeenCalled();
-    expect(response).toMatchObject({
-      completed: 0,
-      failed: 0,
-      skipped: 0,
-      dueWorkRemaining: false,
+    expect(response).toEqual(acceptedResponse({ reason: "heartbeat" }));
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 
@@ -354,12 +391,16 @@ describe("background wake runtime routes", () => {
     });
     const handler = findHandler("drainDueBackgroundWake");
 
-    await handler({ body: drainBodyFixture({ reason: "refresh" }) });
+    const response = await handler({
+      body: drainBodyFixture({ reason: "refresh" }),
+    });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
       expect.objectContaining({ scheduledFor: NOW }),
     );
     expect(firstCallArg(heartbeatRunManaged)).not.toHaveProperty("assumeDue");
+    expect(response).toEqual(acceptedResponse({ reason: "refresh" }));
   });
 
   test("drain-due runs scheduler when schedule work is due at wake", async () => {
@@ -391,12 +432,13 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "refresh" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
-    expect(response).toMatchObject({
-      completed: 1,
-      failed: 0,
-      skipped: 0,
+    expect(response).toEqual(acceptedResponse({ reason: "refresh" }));
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 
@@ -437,16 +479,17 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "schedule" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).toHaveBeenCalledWith(
       expect.objectContaining({ scheduledFor: NOW }),
     );
     expect(schedulerRunDue).toHaveBeenCalledTimes(1);
-    expect(response).toMatchObject({
-      completed: 2,
-      failed: 0,
-      skipped: 0,
-      dueWorkRemaining: false,
+    expect(response).toEqual(acceptedResponse({ reason: "schedule" }));
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
+      nextIntent: recomputedIntent,
     });
   });
 
@@ -474,14 +517,14 @@ describe("background wake runtime routes", () => {
     const response = await handler({
       body: drainBodyFixture({ reason: "refresh" }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).not.toHaveBeenCalled();
     expect(schedulerRunDue).not.toHaveBeenCalled();
-    expect(response).toMatchObject({
-      completed: 0,
-      failed: 0,
-      skipped: 0,
-      dueWorkRemaining: false,
+    expect(response).toEqual(acceptedResponse({ reason: "refresh" }));
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 
@@ -518,16 +561,19 @@ describe("background wake runtime routes", () => {
         deadlineAt: Date.now() + 1_000,
       }),
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(heartbeatRunManaged).not.toHaveBeenCalled();
     expect(schedulerRunDue).toHaveBeenCalledWith(
       expect.objectContaining({ minStartBudgetMs: 5_000 }),
     );
     expect(response).toMatchObject({
-      completed: 0,
-      failed: 0,
-      skipped: 3,
-      dueWorkRemaining: true,
+      accepted: true,
+      reason: "mixed",
+    });
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 
@@ -552,12 +598,44 @@ describe("background wake runtime routes", () => {
     const handler = findHandler("drainDueBackgroundWake");
 
     const response = await handler({ body: drainBodyFixture() });
+    await flushBackgroundWakeDrainsForTest();
 
-    expect(response).toMatchObject({
-      completed: 1,
-      failed: 0,
-      skipped: 0,
-      dueWorkRemaining: true,
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    expect(response).toEqual(acceptedResponse());
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
+    });
+  });
+
+  test("drain-due completes failed when due work throws", async () => {
+    const schedulerRunDue = mock(async () => {
+      throw new Error("scheduler exploded");
+    });
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: null,
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
+      },
+      scheduler: {
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({ body: drainBodyFixture() });
+    await flushBackgroundWakeDrainsForTest();
+
+    expect(response).toEqual(acceptedResponse());
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "failed",
+      error: "scheduler exploded",
     });
   });
 
@@ -588,13 +666,19 @@ describe("background wake runtime routes", () => {
         deadline_at: String(NOW + 30_000),
       },
     });
+    await flushBackgroundWakeDrainsForTest();
 
     expect(response).toMatchObject({
+      accepted: true,
       leaseId: "lease-snake",
       reason: "refresh",
       sourceGeneration: "generation-snake",
       startedAt: NOW,
       deadlineAt: NOW + 30_000,
+    });
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-snake",
+      status: "completed",
     });
   });
 });

--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -8,17 +8,25 @@ import {
 } from "./runtime-registry.js";
 
 type MockIntent = BackgroundWakeIntent;
+type MockCompletionPayload = {
+  leaseId: string;
+  status: "completed" | "failed" | "expired";
+  error?: string;
+  nextIntent?: MockIntent | null;
+};
 
 let computedIntent: MockIntent | null;
 let computeCalls: number;
-const mockRenewBackgroundWakeLease = mock(async () => ({
+const mockRenewBackgroundWakeLease = mock(async (_leaseId: string) => ({
   status: "renewed" as const,
   httpStatus: 200,
 }));
-const mockCompleteBackgroundWakeLease = mock(async () => ({
-  status: "completed" as const,
-  httpStatus: 200,
-}));
+const mockCompleteBackgroundWakeLease = mock(
+  async (_args: MockCompletionPayload) => ({
+    status: "completed" as const,
+    httpStatus: 200,
+  }),
+);
 
 const {
   ROUTES,
@@ -77,21 +85,11 @@ function acceptedResponse(
   };
 }
 
-function lastCompletionPayload(): {
-  leaseId: string;
-  status: "completed" | "failed" | "expired";
-  error?: string;
-  nextIntent?: MockIntent | null;
-} {
+function lastCompletionPayload(): MockCompletionPayload {
   const calls = mockCompleteBackgroundWakeLease.mock.calls;
   const call = calls[calls.length - 1] as unknown[] | undefined;
   if (!call) throw new Error("completeBackgroundWakeLease was not called");
-  return call[0] as {
-    leaseId: string;
-    status: "completed" | "failed" | "expired";
-    error?: string;
-    nextIntent?: MockIntent | null;
-  };
+  return call[0] as MockCompletionPayload;
 }
 
 describe("background wake runtime routes", () => {
@@ -99,14 +97,18 @@ describe("background wake runtime routes", () => {
     clearBackgroundWakeRuntime();
     mockRenewBackgroundWakeLease.mockClear();
     mockCompleteBackgroundWakeLease.mockClear();
-    mockRenewBackgroundWakeLease.mockImplementation(async () => ({
-      status: "renewed" as const,
-      httpStatus: 200,
-    }));
-    mockCompleteBackgroundWakeLease.mockImplementation(async () => ({
-      status: "completed" as const,
-      httpStatus: 200,
-    }));
+    mockRenewBackgroundWakeLease.mockImplementation(
+      async (_leaseId: string) => ({
+        status: "renewed" as const,
+        httpStatus: 200,
+      }),
+    );
+    mockCompleteBackgroundWakeLease.mockImplementation(
+      async (_args: MockCompletionPayload) => ({
+        status: "completed" as const,
+        httpStatus: 200,
+      }),
+    );
     setBackgroundWakeLeaseClientForTest({
       renew: mockRenewBackgroundWakeLease,
       complete: mockCompleteBackgroundWakeLease,
@@ -577,7 +579,7 @@ describe("background wake runtime routes", () => {
     });
   });
 
-  test("drain-due reports due work remaining from scheduler counts", async () => {
+  test("drain-due runs scheduler work even when pending work remains", async () => {
     const schedulerRunDue = mock(async () =>
       schedulerResultFixture({ claimed: 1, completed: 1, stillPending: 1 }),
     );
@@ -636,6 +638,42 @@ describe("background wake runtime routes", () => {
       leaseId: "lease-123",
       status: "failed",
       error: "scheduler exploded",
+    });
+  });
+
+  test("drain-due does not reclassify successful work when completion reporting fails", async () => {
+    const completionError = new Error("platform unavailable");
+    mockCompleteBackgroundWakeLease.mockImplementation(async (args) => {
+      if (args.status === "completed" || args.status === "expired") {
+        throw completionError;
+      }
+      return { status: "completed" as const, httpStatus: 200 };
+    });
+    const schedulerRunDue = mock(async () => schedulerResultFixture());
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: null,
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
+      },
+      scheduler: {
+        runOnce: mock(async () => 0),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({ body: drainBodyFixture() });
+    await flushBackgroundWakeDrainsForTest();
+
+    expect(response).toEqual(acceptedResponse());
+    expect(mockCompleteBackgroundWakeLease).toHaveBeenCalledTimes(1);
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "completed",
     });
   });
 

--- a/assistant/src/background-wake/platform-client.test.ts
+++ b/assistant/src/background-wake/platform-client.test.ts
@@ -201,6 +201,20 @@ describe("background wake platform client", () => {
     });
   });
 
+  test("completes background wake lease with an explicit null next intent", async () => {
+    await completeBackgroundWakeLease({
+      leaseId: "lease-123",
+      status: "completed",
+      nextIntent: null,
+    });
+
+    const [, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      status: "completed",
+      next_intent: null,
+    });
+  });
+
   test("skips when platform prerequisites are missing", async () => {
     mockCreateClient = mock(async () => null);
 

--- a/assistant/src/background-wake/platform-client.test.ts
+++ b/assistant/src/background-wake/platform-client.test.ts
@@ -12,8 +12,12 @@ mock.module("../platform/client.js", () => ({
   },
 }));
 
-const { clearBackgroundWakeIntent, publishBackgroundWakeIntent } =
-  await import("./platform-client.js");
+const {
+  clearBackgroundWakeIntent,
+  completeBackgroundWakeLease,
+  publishBackgroundWakeIntent,
+  renewBackgroundWakeLease,
+} = await import("./platform-client.js");
 
 const NOW = 1_800_000_000_000;
 
@@ -131,6 +135,72 @@ describe("background wake platform client", () => {
     expect(JSON.parse(String(init.body))).toEqual({});
   });
 
+  test("renews background wake lease through Django", async () => {
+    const result = await renewBackgroundWakeLease("lease/with/slash");
+
+    expect(result).toEqual({ status: "renewed", httpStatus: 200 });
+    expect(mockClientFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe(
+      "/v1/assistants/asst-123/background-wake-leases/lease%2Fwith%2Fslash/renew/",
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+
+  test("completes background wake lease with the next intent", async () => {
+    const result = await completeBackgroundWakeLease({
+      leaseId: "lease-123",
+      status: "completed",
+      nextIntent: intentFixture({ sourceGeneration: "bw1:next-hash" }),
+    });
+
+    expect(result).toEqual({ status: "completed", httpStatus: 200 });
+    expect(mockClientFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe(
+      "/v1/assistants/asst-123/background-wake-leases/lease-123/complete/",
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      status: "completed",
+      next_intent: {
+        reason: "schedule",
+        source_generation: "bw1:next-hash",
+        computed_at: new Date(NOW - 1_000).toISOString(),
+        next_wake_at: new Date(NOW + 60_000).toISOString(),
+        actual_next_due_at: new Date(NOW + 60_000).toISOString(),
+        source_payload: {
+          heartbeat: null,
+          schedules: [
+            {
+              id: "schedule-1",
+              nextRunAt: NOW + 60_000,
+              mode: "wake",
+              createdBy: "defer",
+              status: "active",
+              updatedAt: NOW - 5_000,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  test("completes failed background wake lease with an error", async () => {
+    await completeBackgroundWakeLease({
+      leaseId: "lease-123",
+      status: "failed",
+      error: "scheduler exploded",
+    });
+
+    const [, init] = mockClientFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      status: "failed",
+      error: "scheduler exploded",
+    });
+  });
+
   test("skips when platform prerequisites are missing", async () => {
     mockCreateClient = mock(async () => null);
 
@@ -185,6 +255,14 @@ describe("background wake platform client", () => {
     );
     await expect(clearBackgroundWakeIntent(intentFixture())).rejects.toThrow(
       "Failed to clear background wake intent: HTTP 502: bad gateway",
+    );
+    await expect(renewBackgroundWakeLease("lease-123")).rejects.toThrow(
+      "Failed to renew background wake lease: HTTP 502: bad gateway",
+    );
+    await expect(
+      completeBackgroundWakeLease({ leaseId: "lease-123", status: "failed" }),
+    ).rejects.toThrow(
+      "Failed to complete background wake lease: HTTP 502: bad gateway",
     );
   });
 });

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -7,6 +7,12 @@ export type BackgroundWakeIntentClientResult = {
   reason?: "missing_platform_client" | "missing_platform_assistant_id";
 };
 
+export type BackgroundWakeLeaseClientResult = {
+  status: "renewed" | "completed" | "skipped";
+  httpStatus?: number;
+  reason?: "missing_platform_client" | "missing_platform_assistant_id";
+};
+
 type BackgroundWakeIntentSnapshot = Pick<
   BackgroundWakeIntent,
   "sourceGeneration" | "computedAt"
@@ -63,9 +69,81 @@ export async function clearBackgroundWakeIntent(
   return { status: "cleared", httpStatus: response.status };
 }
 
+export async function renewBackgroundWakeLease(
+  leaseId: string,
+): Promise<BackgroundWakeLeaseClientResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) return { status: "skipped", reason: "missing_platform_client" };
+  if (!client.platformAssistantId) {
+    return { status: "skipped", reason: "missing_platform_assistant_id" };
+  }
+
+  const response = await client.fetch(
+    leasePath(client.platformAssistantId, leaseId, "renew"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  );
+
+  await throwIfNotOk(response, "renew background wake lease");
+  return { status: "renewed", httpStatus: response.status };
+}
+
+export async function completeBackgroundWakeLease(args: {
+  leaseId: string;
+  status: "completed" | "failed" | "expired";
+  error?: string;
+  nextIntent?: BackgroundWakeIntent | null;
+}): Promise<BackgroundWakeLeaseClientResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) return { status: "skipped", reason: "missing_platform_client" };
+  if (!client.platformAssistantId) {
+    return { status: "skipped", reason: "missing_platform_assistant_id" };
+  }
+
+  const body: Record<string, unknown> = {
+    status: args.status,
+  };
+  if (args.error) body.error = args.error;
+  if (args.nextIntent) {
+    body.next_intent = {
+      reason: args.nextIntent.reason,
+      source_generation: args.nextIntent.sourceGeneration,
+      computed_at: toIsoString(args.nextIntent.computedAt),
+      next_wake_at: toIsoString(args.nextIntent.nextWakeAt),
+      actual_next_due_at: toIsoString(args.nextIntent.actualNextDueAt),
+      source_payload: args.nextIntent.sourcePayload,
+    };
+  }
+
+  const response = await client.fetch(
+    leasePath(client.platformAssistantId, args.leaseId, "complete"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+
+  await throwIfNotOk(response, "complete background wake lease");
+  return { status: "completed", httpStatus: response.status };
+}
+
 function intentPath(assistantId: string): string {
   const encodedAssistantId = encodeURIComponent(assistantId);
   return `/v1/assistants/${encodedAssistantId}/background-wake-intent/`;
+}
+
+function leasePath(
+  assistantId: string,
+  leaseId: string,
+  action: "renew" | "complete",
+): string {
+  const encodedAssistantId = encodeURIComponent(assistantId);
+  const encodedLeaseId = encodeURIComponent(leaseId);
+  return `/v1/assistants/${encodedAssistantId}/background-wake-leases/${encodedLeaseId}/${action}/`;
 }
 
 function toIsoString(timestampMs: number): string {

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -107,7 +107,7 @@ export async function completeBackgroundWakeLease(args: {
     status: args.status,
   };
   if (args.error) body.error = args.error;
-  if (args.nextIntent) {
+  if (args.nextIntent != null) {
     body.next_intent = {
       reason: args.nextIntent.reason,
       source_generation: args.nextIntent.sourceGeneration,

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -107,15 +107,17 @@ export async function completeBackgroundWakeLease(args: {
     status: args.status,
   };
   if (args.error) body.error = args.error;
-  if (args.nextIntent != null) {
-    body.next_intent = {
-      reason: args.nextIntent.reason,
-      source_generation: args.nextIntent.sourceGeneration,
-      computed_at: toIsoString(args.nextIntent.computedAt),
-      next_wake_at: toIsoString(args.nextIntent.nextWakeAt),
-      actual_next_due_at: toIsoString(args.nextIntent.actualNextDueAt),
-      source_payload: args.nextIntent.sourcePayload,
-    };
+  if ("nextIntent" in args) {
+    body.next_intent = args.nextIntent
+      ? {
+          reason: args.nextIntent.reason,
+          source_generation: args.nextIntent.sourceGeneration,
+          computed_at: toIsoString(args.nextIntent.computedAt),
+          next_wake_at: toIsoString(args.nextIntent.nextWakeAt),
+          actual_next_due_at: toIsoString(args.nextIntent.actualNextDueAt),
+          source_payload: args.nextIntent.sourcePayload,
+        }
+      : null;
   }
 
   const response = await client.fetch(

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -14,7 +14,8 @@ const PREPARE_SLEEP_DEFER_WINDOW_MS = 60_000;
 const HEARTBEAT_DUE_TOLERANCE_MS = 1_000;
 const MIN_DRAIN_START_BUDGET_MS = 5_000;
 const LEASE_RENEW_INTERVAL_MS = 120_000;
-const MAX_TIMEOUT_MS = 2_147_483_647;
+// JS timers use signed 32-bit delays; larger values can overflow or clamp.
+const MAX_SET_TIMEOUT_DELAY_MS = 2_147_483_647;
 const log = getLogger("background-wake-routes");
 
 type RenewWakeLease = (leaseId: string) => Promise<unknown>;
@@ -248,7 +249,7 @@ async function withDrainDeadline<T>(
   }
 
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutMs = Math.min(remainingMs, MAX_TIMEOUT_MS);
+  const timeoutMs = Math.min(remainingMs, MAX_SET_TIMEOUT_DELAY_MS);
   const deadline = new Promise<never>((_, reject) => {
     timeout = setTimeout(() => {
       reject(new Error("background wake lease deadline elapsed"));

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -4,6 +4,7 @@ import {
   type BackgroundWakeIntent,
   computeNextBackgroundWakeIntent,
 } from "../../background-wake/next-wake.js";
+import type { BackgroundWakeRuntime } from "../../background-wake/runtime-registry.js";
 import { getBackgroundWakeRuntime } from "../../background-wake/runtime-registry.js";
 import type { SchedulerDueWorkResult } from "../../schedule/scheduler.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
@@ -12,8 +13,22 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 const PREPARE_SLEEP_DEFER_WINDOW_MS = 60_000;
 const HEARTBEAT_DUE_TOLERANCE_MS = 1_000;
 const MIN_DRAIN_START_BUDGET_MS = 5_000;
+const LEASE_RENEW_INTERVAL_MS = 120_000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+type RenewWakeLease = (leaseId: string) => Promise<unknown>;
+type CompleteWakeLease = (args: {
+  leaseId: string;
+  status: "completed" | "failed" | "expired";
+  error?: string;
+  nextIntent?: BackgroundWakeIntent | null;
+}) => Promise<unknown>;
 
 let computeWakeIntent = computeNextBackgroundWakeIntent;
+let renewWakeLease: RenewWakeLease = defaultRenewWakeLease;
+let completeWakeLease: CompleteWakeLease = defaultCompleteWakeLease;
+const activeDrainLeases = new Set<string>();
+const activeDrainPromises = new Set<Promise<void>>();
 const timestampInputSchema = z.union([z.number(), z.string()]);
 
 const wakeIntentSchema = z
@@ -71,7 +86,8 @@ function normalizeTimestamp(value: unknown): unknown {
   return Number.isFinite(parsed) ? parsed : value;
 }
 
-function parseDrainDueBody(body: Record<string, unknown>) {
+type DrainDueRequest = z.infer<typeof normalizedDrainDueRequestSchema>;
+function parseDrainDueBody(body: Record<string, unknown>): DrainDueRequest {
   const parsed = normalizedDrainDueRequestSchema.safeParse(
     normalizeDrainDueBody(body),
   );
@@ -81,6 +97,20 @@ function parseDrainDueBody(body: Record<string, unknown>) {
     );
   }
   return parsed.data;
+}
+
+async function defaultRenewWakeLease(leaseId: string): Promise<unknown> {
+  const { renewBackgroundWakeLease } =
+    await import("../../background-wake/platform-client.js");
+  return renewBackgroundWakeLease(leaseId);
+}
+
+async function defaultCompleteWakeLease(
+  args: Parameters<CompleteWakeLease>[0],
+): Promise<unknown> {
+  const { completeBackgroundWakeLease } =
+    await import("../../background-wake/platform-client.js");
+  return completeBackgroundWakeLease(args);
 }
 
 function handleGetIntent() {
@@ -107,6 +137,60 @@ async function handleDrainDue(body: Record<string, unknown>) {
     );
   }
 
+  if (!activeDrainLeases.has(request.leaseId)) {
+    activeDrainLeases.add(request.leaseId);
+    const drainPromise = runDrainDueLease(request, runtime);
+    activeDrainPromises.add(drainPromise);
+    void drainPromise.finally(() => activeDrainPromises.delete(drainPromise));
+  }
+
+  return {
+    accepted: true,
+    leaseId: request.leaseId,
+    reason: request.reason,
+    sourceGeneration: request.sourceGeneration,
+    startedAt: request.startedAt,
+    deadlineAt: request.deadlineAt,
+  };
+}
+
+async function runDrainDueLease(
+  request: DrainDueRequest,
+  runtime: BackgroundWakeRuntime,
+): Promise<void> {
+  let renewTimer: ReturnType<typeof setInterval> | undefined;
+  try {
+    renewTimer = setInterval(() => {
+      void renewWakeLease(request.leaseId).catch(() => {});
+    }, LEASE_RENEW_INTERVAL_MS);
+    renewTimer.unref?.();
+
+    const result = await withDrainDeadline(
+      performDrainDue(request, runtime),
+      request.deadlineAt,
+    );
+    await completeWakeLease({
+      leaseId: request.leaseId,
+      status: Date.now() >= request.deadlineAt ? "expired" : "completed",
+      nextIntent: result.nextIntent,
+    });
+  } catch (error) {
+    await completeWakeLease({
+      leaseId: request.leaseId,
+      status: Date.now() >= request.deadlineAt ? "expired" : "failed",
+      error: error instanceof Error ? error.message : String(error),
+      nextIntent: computeWakeIntent(),
+    }).catch(() => {});
+  } finally {
+    if (renewTimer) clearInterval(renewTimer);
+    activeDrainLeases.delete(request.leaseId);
+  }
+}
+
+async function performDrainDue(
+  request: DrainDueRequest,
+  runtime: BackgroundWakeRuntime,
+) {
   const now = Date.now();
   const currentIntent = computeWakeIntent(now);
   const heartbeatDue = isHeartbeatTimerDue(runtime.heartbeat.nextRunAt, now);
@@ -179,6 +263,31 @@ async function handleDrainDue(body: Record<string, unknown>) {
   };
 }
 
+async function withDrainDeadline<T>(
+  work: Promise<T>,
+  deadlineAt: number,
+): Promise<T> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    throw new Error("background wake lease deadline elapsed");
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutMs = Math.min(remainingMs, MAX_TIMEOUT_MS);
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error("background wake lease deadline elapsed"));
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function reasonIncludesSource(
   reason: string,
   source: "heartbeat" | "schedule",
@@ -230,6 +339,24 @@ export function setBackgroundWakeIntentComputerForTest(
   computeWakeIntent = nextCompute ?? computeNextBackgroundWakeIntent;
 }
 
+/** @internal Test helper for route-only tests. */
+export function setBackgroundWakeLeaseClientForTest(
+  nextClient: {
+    renew: RenewWakeLease;
+    complete: CompleteWakeLease;
+  } | null,
+): void {
+  renewWakeLease = nextClient?.renew ?? defaultRenewWakeLease;
+  completeWakeLease = nextClient?.complete ?? defaultCompleteWakeLease;
+}
+
+/** @internal Test helper for route-only tests. */
+export async function flushBackgroundWakeDrainsForTest(): Promise<void> {
+  while (activeDrainPromises.size > 0) {
+    await Promise.allSettled([...activeDrainPromises]);
+  }
+}
+
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "getBackgroundWakeIntent",
@@ -270,26 +397,12 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["background-wake"],
     requestBody: drainDueRequestSchema,
     responseBody: z.object({
+      accepted: z.boolean(),
       leaseId: z.string(),
       reason: z.string(),
       sourceGeneration: z.string(),
       startedAt: z.number(),
       deadlineAt: z.number(),
-      counts: z.object({
-        heartbeat: z.number(),
-        scheduler: z.number(),
-        total: z.number(),
-        completed: z.number(),
-        failed: z.number(),
-        skipped: z.number(),
-        claimed: z.number(),
-        stillPending: z.number(),
-      }),
-      completed: z.number(),
-      failed: z.number(),
-      skipped: z.number(),
-      nextIntent: wakeIntentSchema,
-      dueWorkRemaining: z.boolean(),
     }),
     handler: ({ body }: RouteHandlerArgs) => handleDrainDue(body ?? {}),
   },

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -6,7 +6,7 @@ import {
 } from "../../background-wake/next-wake.js";
 import type { BackgroundWakeRuntime } from "../../background-wake/runtime-registry.js";
 import { getBackgroundWakeRuntime } from "../../background-wake/runtime-registry.js";
-import type { SchedulerDueWorkResult } from "../../schedule/scheduler.js";
+import { getLogger } from "../../util/logger.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -15,6 +15,7 @@ const HEARTBEAT_DUE_TOLERANCE_MS = 1_000;
 const MIN_DRAIN_START_BUDGET_MS = 5_000;
 const LEASE_RENEW_INTERVAL_MS = 120_000;
 const MAX_TIMEOUT_MS = 2_147_483_647;
+const log = getLogger("background-wake-routes");
 
 type RenewWakeLease = (leaseId: string) => Promise<unknown>;
 type CompleteWakeLease = (args: {
@@ -169,21 +170,34 @@ async function runDrainDueLease(
       performDrainDue(request, runtime),
       request.deadlineAt,
     );
-    await completeWakeLease({
+    await reportLeaseCompletion({
       leaseId: request.leaseId,
       status: Date.now() >= request.deadlineAt ? "expired" : "completed",
       nextIntent: result.nextIntent,
     });
   } catch (error) {
-    await completeWakeLease({
+    await reportLeaseCompletion({
       leaseId: request.leaseId,
       status: Date.now() >= request.deadlineAt ? "expired" : "failed",
       error: error instanceof Error ? error.message : String(error),
       nextIntent: computeWakeIntent(),
-    }).catch(() => {});
+    });
   } finally {
     if (renewTimer) clearInterval(renewTimer);
     activeDrainLeases.delete(request.leaseId);
+  }
+}
+
+async function reportLeaseCompletion(
+  args: Parameters<CompleteWakeLease>[0],
+): Promise<void> {
+  try {
+    await completeWakeLease(args);
+  } catch (err) {
+    log.warn(
+      { err, leaseId: args.leaseId, status: args.status },
+      "Failed to report background wake lease completion",
+    );
   }
 }
 
@@ -199,67 +213,28 @@ async function performDrainDue(
     reasonIncludesSource(request.reason, "schedule") ||
     intentHasDueSource(currentIntent, "schedule", now);
 
-  let heartbeatCompleted = 0;
-  let heartbeatSkipped = 0;
-  let heartbeatDueRemaining = false;
   if (heartbeatDue) {
     if (hasStartBudget(request.deadlineAt)) {
-      const heartbeatResult = await runtime.heartbeat.runManagedWakeIfDue({
+      await runtime.heartbeat.runManagedWakeIfDue({
         now,
         toleranceMs: HEARTBEAT_DUE_TOLERANCE_MS,
         scheduledFor: request.startedAt,
       });
-      heartbeatCompleted = heartbeatResult.completed;
-      heartbeatSkipped = heartbeatResult.skipped;
-      heartbeatDueRemaining =
-        heartbeatResult.due && heartbeatResult.completed === 0;
-    } else {
-      heartbeatSkipped = 1;
-      heartbeatDueRemaining = true;
     }
   }
 
-  const schedulerResult = schedulerDue
-    ? await runtime.scheduler.runDueWorkOnce({
-        deadlineAt: request.deadlineAt,
-        minStartBudgetMs: MIN_DRAIN_START_BUDGET_MS,
-        includeStillPending: true,
-      })
-    : emptySchedulerDueWorkResult();
+  if (schedulerDue) {
+    await runtime.scheduler.runDueWorkOnce({
+      deadlineAt: request.deadlineAt,
+      minStartBudgetMs: MIN_DRAIN_START_BUDGET_MS,
+      includeStillPending: true,
+    });
+  }
+
   const nextIntent = computeWakeIntent();
-  const completed = heartbeatCompleted + schedulerResult.completed;
-  const failed = schedulerResult.failed;
-  const skipped = heartbeatSkipped + schedulerResult.skipped;
-  const schedulerProcessed =
-    schedulerResult.completed +
-    schedulerResult.failed +
-    schedulerResult.skipped;
-  const dueWorkRemaining =
-    heartbeatDueRemaining ||
-    schedulerResult.stillPending > 0 ||
-    intentIsDue(nextIntent);
 
   return {
-    leaseId: request.leaseId,
-    reason: request.reason,
-    sourceGeneration: request.sourceGeneration,
-    startedAt: request.startedAt,
-    deadlineAt: request.deadlineAt,
-    counts: {
-      heartbeat: heartbeatCompleted,
-      scheduler: schedulerProcessed,
-      total: heartbeatCompleted + schedulerProcessed,
-      completed,
-      failed,
-      skipped,
-      claimed: schedulerResult.claimed,
-      stillPending: schedulerResult.stillPending,
-    },
-    completed,
-    failed,
-    skipped,
     nextIntent,
-    dueWorkRemaining,
   };
 }
 
@@ -311,25 +286,8 @@ function intentHasDueSource(
   );
 }
 
-function intentIsDue(intent: BackgroundWakeIntent | null): boolean {
-  return (
-    intent != null &&
-    intent.actualNextDueAt <= Date.now() + HEARTBEAT_DUE_TOLERANCE_MS
-  );
-}
-
 function hasStartBudget(deadlineAt: number): boolean {
   return deadlineAt - Date.now() >= MIN_DRAIN_START_BUDGET_MS;
-}
-
-function emptySchedulerDueWorkResult(): SchedulerDueWorkResult {
-  return {
-    claimed: 0,
-    completed: 0,
-    failed: 0,
-    skipped: 0,
-    stillPending: 0,
-  };
 }
 
 /** @internal Test helper for route-only tests. */


### PR DESCRIPTION
## Summary
- Change `/v1/background-wake/drain-due` into an accepted/start response instead of waiting for all background work to finish.
- Add platform-client helpers for Django lease renew/complete routes and run the heartbeat/scheduler drain in a daemon-owned background lease runner.
- Complete leases with `completed`, `failed`, or `expired`, include the next wake intent on completion, and enforce the lease deadline locally.

## Original prompt
We changed the background wake design so vembda wakes assistants and health-checks/starts work, then moves on. The assistant daemon should own the actual heartbeat or scheduled-task run, renewing the lease while work is active or completing it when done, with idle sleep waiting for that lease lifecycle.

## Testing
- `bun test src/background-wake/background-wake-routes.test.ts src/background-wake/platform-client.test.ts` from `assistant/`
- `bun run lint` from `assistant/`
- `bunx tsc --noEmit` from `assistant/`
- pre-push hook also ran assistant typecheck and changed-file lint

## Stack
Base: `do/platform-wake-intent-client`. Merge after the platform lease lifecycle PR is available on the platform stack.