### PR TITLE
feat(gateway): add session cookie auth infrastructure (M1, LUM-1788)

### DIFF
--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -1,0 +1,10 @@
+export async function probeGatewayAuthState(): Promise<{
+  authenticated: boolean;
+  mode: string;
+}> {
+  const res = await fetch("/auth/state", { credentials: "include" });
+  if (!res.ok) {
+    throw new Error(`Gateway auth probe failed: ${res.status}`);
+  }
+  return res.json();
+}

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -440,6 +440,14 @@
       "label": "Memory Router Playground",
       "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
       "defaultEnabled": false
+    },
+    {
+      "id": "gateway-web-auth",
+      "scope": "client",
+      "key": "gateway-web-auth",
+      "label": "Gateway Web Auth",
+      "description": "Enable web SPA authentication via gateway session cookies (BFF pattern). M1: infrastructure probe only.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -446,7 +446,7 @@
       "scope": "client",
       "key": "gateway-web-auth",
       "label": "Gateway Web Auth",
-      "description": "Enable web SPA authentication via gateway session cookies (BFF pattern). M1: infrastructure probe only.",
+      "description": "Enable web SPA authentication via gateway session cookies.",
       "defaultEnabled": false
     }
   ]

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,6 +19,8 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
+import { probeGatewayAuthState } from "@/lib/auth/gateway-session.js";
+import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store.js";
 import { deleteBiometricToken } from "@/runtime/native-biometric.js";
 import { syncOnboardingUser } from "@/domains/onboarding/prefs.js";
 import { clearOrganization } from "@/stores/organization-store.js";
@@ -134,6 +136,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
     syncUserScopedState(null);
     set({ isLoggedIn: false, isLoading: false, user: null });
+
+    if (useClientFeatureFlagStore.getState().gatewayWebAuth) {
+      probeGatewayAuthState()
+        .then((s) => console.debug("[gateway-auth] state:", s))
+        .catch((e: unknown) =>
+          console.debug("[gateway-auth] probe failed:", e),
+        );
+    }
   },
 
   refreshSession: async () => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,9 +9,10 @@ export default defineConfig(({ mode }) => {
   // loadEnv with empty prefix loads all .env variables, not just VITE_-prefixed ones.
   const env = { ...process.env, ...loadEnv(mode, process.cwd(), "") };
 
-  // Server-only proxy target — never embedded in the client bundle.
+  // Server-only proxy targets — never embedded in the client bundle.
   // Reference: https://vite.dev/config/server-options#server-proxy
   const apiProxyTarget = env.API_PROXY_TARGET || "http://localhost:8000";
+  const gatewayProxyTarget = env.GATEWAY_PROXY_TARGET || "http://localhost:7830";
 
   // Only enable Sentry source map upload for deploy builds.
   // Reference: https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/uploading/vite/
@@ -61,6 +62,7 @@ export default defineConfig(({ mode }) => {
         "/v1": { target: apiProxyTarget, changeOrigin: true },
         "/_allauth": { target: apiProxyTarget, changeOrigin: true },
         "/accounts": { target: apiProxyTarget, changeOrigin: true },
+        "/auth": { target: gatewayProxyTarget, changeOrigin: true },
       },
     },
     build: {

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -175,6 +175,9 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/.well-known/agent-card.json",
   // Internal-only: reachable only via vembda's trusted gateway-query proxy
   "/v1/contacts/guardian/channel",
+  // BFF session auth — loopback-only, not part of the public gateway API
+  "/auth/session",
+  "/auth/state",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/auth/session-cookie.ts
+++ b/gateway/src/auth/session-cookie.ts
@@ -1,0 +1,56 @@
+import { CURRENT_POLICY_EPOCH } from "./policy.js";
+import { mintToken, verifyToken, type VerifyResult } from "./token-service.js";
+
+const SESSION_COOKIE_NAME = "__vellum_gw_session";
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+export function mintSessionCookie(params: {
+  guardianPrincipalId: string;
+  secure?: boolean;
+}): string {
+  const token = mintToken({
+    aud: "vellum-gateway-session",
+    sub: `actor:self:${params.guardianPrincipalId}`,
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: SESSION_TTL_SECONDS,
+  });
+
+  const parts = [
+    `${SESSION_COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    `Max-Age=${SESSION_TTL_SECONDS}`,
+  ];
+  if (params.secure) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+export function validateSessionCookie(req: Request): VerifyResult {
+  const cookieHeader = req.headers.get("cookie");
+  if (!cookieHeader) {
+    return { ok: false, reason: "no_cookie_header" };
+  }
+
+  let token: string | null = null;
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(`${SESSION_COOKIE_NAME}=`)) {
+      token = trimmed.slice(SESSION_COOKIE_NAME.length + 1);
+      break;
+    }
+  }
+
+  if (!token) {
+    return { ok: false, reason: "session_cookie_not_found" };
+  }
+
+  return verifyToken(token, "vellum-gateway-session");
+}
+
+export function clearSessionCookie(): string {
+  return `${SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`;
+}

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -48,7 +48,10 @@ export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "local";
 // Token audience — which service the JWT is intended for
 // ---------------------------------------------------------------------------
 
-export type TokenAudience = "vellum-gateway" | "vellum-daemon";
+export type TokenAudience =
+  | "vellum-gateway"
+  | "vellum-daemon"
+  | "vellum-gateway-session";
 
 // ---------------------------------------------------------------------------
 // JWT claims — the payload inside the token

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -2,6 +2,7 @@ import type { Server } from "bun";
 
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
+import { validateSessionCookie } from "../../auth/session-cookie.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
 import type { Scope } from "../../auth/types.js";
@@ -285,10 +286,47 @@ export function createAuthMiddleware(
     return null;
   }
 
+  async function requireEdgeOrSessionAuth(
+    req: Request,
+    server?: Server<unknown>,
+  ): Promise<Response | null> {
+    if (server && isLoopbackPeer(server, req)) return null;
+    if (isPlatformAuthBypassActive()) {
+      return requirePlatformUserHeader(req);
+    }
+
+    const bearerToken = extractBearerToken(req);
+    if (bearerToken) {
+      const result = validateEdgeToken(bearerToken);
+      if (!result.ok) {
+        authRateLimiter.recordFailure(getClientIp());
+        log.warn(
+          { path: new URL(req.url).pathname, reason: result.reason },
+          "Edge-or-session auth rejected: bearer token validation failed",
+        );
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
+      return null;
+    }
+
+    const cookieResult = validateSessionCookie(req);
+    if (cookieResult.ok) {
+      return null;
+    }
+
+    authRateLimiter.recordFailure(getClientIp());
+    log.warn(
+      { path: new URL(req.url).pathname },
+      "Edge-or-session auth rejected: no valid bearer token or session cookie",
+    );
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   return {
     requireEdgeAuth,
     requireEdgeAuthWithScope,
     requireEdgeGuardianAuth,
+    requireEdgeOrSessionAuth,
   };
 }
 

--- a/gateway/src/http/middleware/cors.ts
+++ b/gateway/src/http/middleware/cors.ts
@@ -115,6 +115,64 @@ export function withExtensionCorsHeaders(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Web SPA CORS (localhost origins, credentials mode)
+// ---------------------------------------------------------------------------
+
+const WEB_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+export function resolveWebOrigin(req: Request): string | null {
+  const origin = req.headers.get("origin");
+  if (!origin) return null;
+  if (!WEB_ORIGIN_RE.test(origin)) return null;
+  return origin;
+}
+
+export function webCorsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": ALLOWED_METHODS,
+    "Access-Control-Allow-Headers": ALLOWED_HEADERS,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Max-Age": "86400",
+  };
+}
+
+export function handleWebPreflight(origin: string): Response {
+  log.debug({ origin }, "Web SPA CORS preflight response");
+  return new Response(null, {
+    status: 204,
+    headers: webCorsHeaders(origin),
+  });
+}
+
+export function withWebCorsHeaders(
+  response: Response,
+  origin: string,
+): Response {
+  const headers = webCorsHeaders(origin);
+  try {
+    for (const [key, value] of Object.entries(headers)) {
+      response.headers.set(key, value);
+    }
+    return response;
+  } catch {
+    const merged = new Headers(response.headers);
+    for (const [key, value] of Object.entries(headers)) {
+      merged.set(key, value);
+    }
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: merged,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WKWebView CORS
+// ---------------------------------------------------------------------------
+
 /**
  * Check whether the request `Origin` header matches a known webview origin.
  * Returns the validated origin string, or null if CORS headers should not be

--- a/gateway/src/http/middleware/cors.ts
+++ b/gateway/src/http/middleware/cors.ts
@@ -119,6 +119,14 @@ export function withExtensionCorsHeaders(
 // Web SPA CORS (localhost origins, credentials mode)
 // ---------------------------------------------------------------------------
 
+/**
+ * Matches any localhost / 127.0.0.1 origin on any port. This is intentionally
+ * broad because all auth guards already bypass JWT validation for loopback
+ * peers via `isLoopbackPeer()` — any local process can call the gateway
+ * unauthenticated. CORS is a browser-only restriction; the session cookie's
+ * `SameSite=Strict` attribute prevents cross-site credential leakage. The
+ * meaningful trust boundary is the loopback bind, not the CORS origin.
+ */
 const WEB_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 export function resolveWebOrigin(req: Request): string | null {

--- a/gateway/src/http/router.ts
+++ b/gateway/src/http/router.ts
@@ -34,6 +34,7 @@ type AuthStrategy =
   | "edge"
   | "edge-scoped"
   | "edge-guardian"
+  | "edge-or-session"
   | "track-failures"
   | "custom";
 
@@ -146,6 +147,16 @@ export function createRouter(
             getClientIp,
           );
           const authError = await requireEdgeGuardianAuth(req, server);
+          if (authError) return authError;
+          return route.handler(req, matchResult.params, getClientIp);
+        }
+
+        case "edge-or-session": {
+          const { requireEdgeOrSessionAuth } = createAuthMiddleware(
+            authRateLimiter,
+            getClientIp,
+          );
+          const authError = await requireEdgeOrSessionAuth(req, server);
           if (authError) return authError;
           return route.handler(req, matchResult.params, getClientIp);
         }

--- a/gateway/src/http/routes/auth-session.ts
+++ b/gateway/src/http/routes/auth-session.ts
@@ -1,0 +1,54 @@
+import type { Server } from "bun";
+
+import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
+import {
+  mintSessionCookie,
+  clearSessionCookie,
+} from "../../auth/session-cookie.js";
+import { getLogger } from "../../logger.js";
+import { isLoopbackPeer } from "../../util/is-loopback-address.js";
+
+const log = getLogger("auth-session");
+
+const WEB_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+export async function handleCreateSession(
+  req: Request,
+  server: Server<unknown> | undefined,
+): Promise<Response> {
+  if (!server || !isLoopbackPeer(server, req)) {
+    log.warn("Session create rejected: not a loopback peer");
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const origin = req.headers.get("origin");
+  if (!origin || !WEB_ORIGIN_RE.test(origin)) {
+    log.warn({ origin }, "Session create rejected: missing or invalid Origin");
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const guardianPrincipalId = await ensureVellumGuardianBinding();
+
+  const cookie = mintSessionCookie({ guardianPrincipalId });
+  log.info("Session cookie minted for local auto-pair");
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": cookie,
+    },
+  });
+}
+
+export async function handleDeleteSession(
+  _req: Request,
+): Promise<Response> {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": clearSessionCookie(),
+    },
+  });
+}

--- a/gateway/src/http/routes/auth-state.ts
+++ b/gateway/src/http/routes/auth-state.ts
@@ -1,0 +1,11 @@
+import { validateSessionCookie } from "../../auth/session-cookie.js";
+
+export async function handleAuthState(req: Request): Promise<Response> {
+  const result = validateSessionCookie(req);
+
+  if (result.ok) {
+    return Response.json({ authenticated: true, mode: "session" });
+  }
+
+  return Response.json({ authenticated: false, mode: "none" });
+}

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -6,6 +6,7 @@ import {
   stripHopByHop,
 } from "@vellumai/assistant-client";
 
+import { validateSessionCookie } from "../../auth/session-cookie.js";
 import {
   validateEdgeToken,
   mintExchangeToken,
@@ -61,26 +62,35 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     const authHeader = req.headers.get("authorization");
 
     if (config.runtimeProxyRequireAuth && req.method !== "OPTIONS") {
-      if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-        log.warn(
-          { method: req.method, path: url.pathname },
-          "Runtime proxy auth rejected: missing or malformed Authorization header",
+      if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
+        const edgeJwt = authHeader.slice(7);
+        const result = validateEdgeToken(edgeJwt);
+        if (!result.ok) {
+          log.warn(
+            { method: req.method, path: url.pathname, reason: result.reason },
+            "Runtime proxy auth rejected: edge token validation failed",
+          );
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        exchangeToken = mintExchangeToken(
+          result.claims,
+          result.claims.scope_profile,
         );
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      } else {
+        const cookieResult = validateSessionCookie(req);
+        if (cookieResult.ok) {
+          exchangeToken = mintExchangeToken(
+            cookieResult.claims,
+            cookieResult.claims.scope_profile,
+          );
+        } else {
+          log.warn(
+            { method: req.method, path: url.pathname },
+            "Runtime proxy auth rejected: no valid bearer token or session cookie",
+          );
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
       }
-      const edgeJwt = authHeader.slice(7);
-      const result = validateEdgeToken(edgeJwt);
-      if (!result.ok) {
-        log.warn(
-          { method: req.method, path: url.pathname, reason: result.reason },
-          "Runtime proxy auth rejected: edge token validation failed",
-        );
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
-      }
-      exchangeToken = mintExchangeToken(
-        result.claims,
-        result.claims.scope_profile,
-      );
     } else {
       exchangeToken = mintServiceToken();
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -147,10 +147,18 @@ import {
   resolveExtensionOrigin,
   handleExtensionPreflight,
   withExtensionCorsHeaders,
+  resolveWebOrigin,
+  handleWebPreflight,
+  withWebCorsHeaders,
   resolveWebviewOrigin,
   handlePreflight,
   withCorsHeaders,
 } from "./http/middleware/cors.js";
+import { handleAuthState } from "./http/routes/auth-state.js";
+import {
+  handleCreateSession,
+  handleDeleteSession,
+} from "./http/routes/auth-session.js";
 import {
   createRouter,
   type RouteDefinition,
@@ -1414,6 +1422,28 @@ async function main() {
     },
   ];
 
+  // ── Web session auth ──
+  routes.push(
+    {
+      path: "/auth/state",
+      method: "GET",
+      auth: "none",
+      handler: handleAuthState,
+    },
+    {
+      path: "/auth/session",
+      method: "POST",
+      auth: "custom",
+      handler: (req) => handleCreateSession(req, server),
+    },
+    {
+      path: "/auth/session",
+      method: "DELETE",
+      auth: "none",
+      handler: handleDeleteSession,
+    },
+  );
+
   // Runtime proxy catch-all — must be last so specific routes are checked first.
   routes.push({
     path: /^\//, // match everything
@@ -1529,6 +1559,11 @@ async function main() {
       return handleExtensionPreflight(extensionOrigin);
     }
 
+    const webOrigin = resolveWebOrigin(req);
+    if (webOrigin && req.method === "OPTIONS") {
+      return handleWebPreflight(webOrigin);
+    }
+
     const webviewOrigin = resolveWebviewOrigin(req);
     if (webviewOrigin && req.method === "OPTIONS") {
       return handlePreflight(webviewOrigin);
@@ -1614,6 +1649,8 @@ async function main() {
     if (rateLimitResponse) {
       if (extensionOrigin)
         return withExtensionCorsHeaders(rateLimitResponse, extensionOrigin);
+      if (webOrigin)
+        return withWebCorsHeaders(rateLimitResponse, webOrigin);
       if (webviewOrigin)
         return withCorsHeaders(rateLimitResponse, webviewOrigin);
       return rateLimitResponse;
@@ -1662,6 +1699,9 @@ async function main() {
         if (extensionOrigin) {
           return withExtensionCorsHeaders(response, extensionOrigin);
         }
+        if (webOrigin) {
+          return withWebCorsHeaders(response, webOrigin);
+        }
         if (webviewOrigin) {
           return withCorsHeaders(response, webviewOrigin);
         }
@@ -1671,7 +1711,7 @@ async function main() {
       // Mirror the error() handler logic while retaining CORS context.
       // Bun's error() callback doesn't receive the request, so thrown
       // errors during webview/extension requests would otherwise lose CORS headers.
-      if (!webviewOrigin && !extensionOrigin) throw err;
+      if (!webviewOrigin && !extensionOrigin && !webOrigin) throw err;
       if (err instanceof CircuitBreakerOpenError) {
         const body = Response.json(
           {
@@ -1685,6 +1725,7 @@ async function main() {
         );
         if (extensionOrigin)
           return withExtensionCorsHeaders(body, extensionOrigin);
+        if (webOrigin) return withWebCorsHeaders(body, webOrigin);
         return withCorsHeaders(body, webviewOrigin!);
       }
       log.error({ err }, "Unhandled gateway error");
@@ -1694,6 +1735,7 @@ async function main() {
       );
       if (extensionOrigin)
         return withExtensionCorsHeaders(errBody, extensionOrigin);
+      if (webOrigin) return withWebCorsHeaders(errBody, webOrigin);
       return withCorsHeaders(errBody, webviewOrigin!);
     }
 
@@ -1703,6 +1745,7 @@ async function main() {
     );
     if (extensionOrigin)
       return withExtensionCorsHeaders(notFound, extensionOrigin);
+    if (webOrigin) return withWebCorsHeaders(notFound, webOrigin);
     if (webviewOrigin) return withCorsHeaders(notFound, webviewOrigin);
     return notFound;
   }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -440,6 +440,14 @@
       "label": "Memory Router Playground",
       "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
       "defaultEnabled": false
+    },
+    {
+      "id": "gateway-web-auth",
+      "scope": "client",
+      "key": "gateway-web-auth",
+      "label": "Gateway Web Auth",
+      "description": "Enable web SPA authentication via gateway session cookies (BFF pattern). M1: infrastructure probe only.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -446,7 +446,7 @@
       "scope": "client",
       "key": "gateway-web-auth",
       "label": "Gateway Web Auth",
-      "description": "Enable web SPA authentication via gateway session cookies (BFF pattern). M1: infrastructure probe only.",
+      "description": "Enable web SPA authentication via gateway session cookies.",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary

- **Gateway session cookie module** (`session-cookie.ts`): mint, validate, and clear `HttpOnly` `SameSite=Strict` session cookies using the existing HMAC signing key with a dedicated `vellum-gateway-session` audience. Prevents cross-use with Bearer JWTs or daemon exchange tokens.
- **Auth infrastructure**: new `edge-or-session` router strategy that accepts Bearer JWT or session cookie (with confused-deputy prevention — invalid Bearer rejects immediately, no fallthrough). Three new endpoints: `GET /auth/state` (cookie probe), `POST /auth/session` (local auto-pair with loopback + Origin check), `DELETE /auth/session` (clear cookie). Runtime proxy accepts session cookies as an alternative to Bearer JWTs.
- **Web SPA changes**: CORS with `Access-Control-Allow-Credentials: true` for localhost origins, Vite proxy `/auth` → gateway, `gateway-web-auth` feature flag (client scope, default off), and a flag-gated diagnostic probe in `auth-store.ts` that logs gateway auth state to console without affecting app behavior.

## Original prompt

The goal is to update the web UI's auth layer to act more like the macOS client's — authenticating with the gateway as the primary auth boundary rather than requiring a Django platform account. This is Milestone 1 of the Gateway-as-BFF auth redesign (LUM-1788): build the session cookie infrastructure on the gateway so that future milestones can wire it into the SPA flow. M1 is purely additive — no production auth flows change, the feature flag is off by default, and managed assistants are completely unaffected.