### PR TITLE
feat(settings): gate managed email on managed_email entitlement, not plan

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Gate tests for `EmailServiceCard`'s managed-email subscription gate.
+ *
+ * The gate keys off the `managed_email` entitlement, NOT `plan_id`, so an
+ * admin `EntitlementOverride` that grants managed email to a Base org is
+ * honored in-product. We verify both directions:
+ *
+ *  - Base org WITHOUT the entitlement → "Upgrade to Pro" notice, form gated.
+ *  - Base org WITH the entitlement (override) → domain/address form renders,
+ *    proving the gate reads the entitlement and not the plan.
+ *
+ * Strategy mirrors `plugins-tab.test.tsx`: pre-populate the React Query cache
+ * via the generated query-key helper so `renderToStaticMarkup` (single-pass,
+ * never resolves a pending queryFn) renders the loaded state directly.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { SubscriptionResponse } from "@/generated/api/types.gen.js";
+import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen.js";
+
+// The settings-card barrel re-exports toast surfaces; stub them so barrel
+// resolution doesn't pull the real toast module during the static render.
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+const { EmailServiceCard } = await import("@/domains/settings/ai/ai-page.js");
+
+const ASSISTANT_ID = "asst-1";
+
+function makeSubscription(
+  managedEmail: boolean,
+  planId: SubscriptionResponse["plan_id"] = "base",
+): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    entitlements: { managed_email: managedEmail, phone_number: false },
+  };
+}
+
+function renderCard(subscription: SubscriptionResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <EmailServiceCard assistantId={ASSISTANT_ID} assistantHandle="my-assistant" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("EmailServiceCard managed-email gate", () => {
+  test("Base org without the managed_email entitlement sees the upgrade notice", () => {
+    const html = renderCard(makeSubscription(false, "base"));
+    expect(html).toContain("Upgrade to Pro");
+    expect(html).toContain("Get a dedicated email address for your assistant");
+    // The domain registration form must NOT render when gated.
+    expect(html).not.toContain("Register");
+  });
+
+  test("Base org WITH the managed_email entitlement sees the form, not the notice", () => {
+    // plan_id stays "base" — only the entitlement (admin override) is true.
+    const html = renderCard(makeSubscription(true, "base"));
+    expect(html).not.toContain("Upgrade to Pro");
+    expect(html).not.toContain("Get a dedicated email address for your assistant");
+    // The domain registration form renders for entitled orgs.
+    expect(html).toContain("Subdomain");
+    expect(html).toContain("Register");
+  });
+});

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -929,7 +929,7 @@ interface EmailServiceCardProps {
   assistantHandle: string | undefined;
 }
 
-function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProps) {
+export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -960,21 +960,24 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
     setSubdomainPrefilled(true);
   }, [assistantHandle, subdomainPrefilled, subdomainDraft]);
 
-  // -- Subscription gate (managed mode requires Pro) -------------------------
-  // We separate "definitely not Pro" from "unknown" so a failed subscription
-  // fetch (transient 5xx, network blip) doesn't lock Pro users out of their
-  // own managed email. React Query preserves last-known `data` across failed
-  // refetches, so `isExplicitlyNotPro` only flips true when the server told
-  // us so. The backend `MANAGED_EMAIL` entitlement remains the source of
-  // truth — this gate is just a UX hint to keep Base orgs out of a form that
-  // would 403 anyway.
+  // -- Subscription gate (managed mode requires the managed_email entitlement)
+  // We read the `managed_email` entitlement directly rather than inferring it
+  // from the plan, so an admin `EntitlementOverride` (which flips a Base org to
+  // entitled) is honored in-product. We separate "definitely not entitled"
+  // from "unknown" so a failed subscription fetch (transient 5xx, network
+  // blip) doesn't lock entitled users out of their own managed email. React
+  // Query preserves last-known `data` across failed refetches, so
+  // `isExplicitlyNotEntitled` only flips true when the server told us so. The
+  // backend `assert_entitlement` remains the source of truth — this gate is
+  // just a UX hint to keep non-entitled orgs out of a form that would 403
+  // anyway.
   const subscriptionQuery = useQuery({
     ...organizationsBillingSubscriptionRetrieveOptions(),
     enabled: mode === "managed",
   });
   const subscriptionData = subscriptionQuery.data;
-  const isPro = subscriptionData?.plan_id === "pro";
-  const isExplicitlyNotPro = !!subscriptionData && !isPro;
+  const hasManagedEmail = subscriptionData?.entitlements?.managed_email === true;
+  const isExplicitlyNotEntitled = !!subscriptionData && !hasManagedEmail;
   const subscriptionUnknown =
     !subscriptionData &&
     subscriptionQuery.isError &&
@@ -985,13 +988,13 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
     ...assistantsDomainsListOptions({
       path: { assistant_id: assistantId ?? "" },
     }),
-    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotPro,
+    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled,
   });
   const addressesQuery = useQuery({
     ...assistantsEmailAddressesListOptions({
       path: { assistant_id: assistantId ?? "" },
     }),
-    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotPro,
+    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled,
   });
 
   const domain = domainsQuery.data?.results?.[0];
@@ -1214,7 +1217,7 @@ function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceCardProp
               <Loader2 className="h-4 w-4 animate-spin" />
               Checking subscription…
             </div>
-          ) : isExplicitlyNotPro ? (
+          ) : isExplicitlyNotEntitled ? (
             <Notice
               tone="info"
               icon={<Crown className="h-4 w-4" aria-hidden />}


### PR DESCRIPTION
## Summary
- Gate the managed-email/custom-domain UI in ai-page.tsx on subscriptionData.entitlements.managed_email instead of plan_id === 'pro'
- Comped Base orgs (admin EntitlementOverride) now see the managed-email form; genuinely non-entitled Base orgs still see the upgrade notice
- Add/extend gate tests covering entitled-Base and non-entitled-Base cases

Part of plan: entitlement-ui-gating.md (PR 2 of 2)