### PR TITLE
feat(web): isElectron() platform detector + share-feedback client signal

### DIFF
--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -36,6 +36,7 @@ import type { ClassificationEnum } from "@/generated/api/types.gen.js";
 import { buildVellumMutatingHeaders } from "@/lib/auth/request-headers.js";
 import type { ChatDebugApi } from "@/domains/chat/utils/debug-api.js";
 import { buildChatDiagnosticsSnapshot } from "@/domains/chat/utils/diagnostics.js";
+import { isElectron } from "@/runtime/is-electron.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 
 type Reason = "bug_report" | "feature_request" | "other";
@@ -85,7 +86,12 @@ const CLASSIFICATION_MAP: Record<Reason, ClassificationEnum> = {
   other: "other",
 };
 
-function getFeedbackClient(): "ios" | "web" {
+function getFeedbackClient(): "macos" | "ios" | "web" {
+  // The Electron shell wraps apps/web on macOS. Backend ClientEnum doesn't
+  // have a separate `electron` value; reporting `macos` keeps the
+  // platform-level signal accurate and matches the slot vacated by the
+  // retiring Swift macOS app.
+  if (isElectron()) return "macos";
   return Capacitor.getPlatform() === "ios" ? "ios" : "web";
 }
 

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -1,5 +1,3 @@
-import { useSyncExternalStore } from "react";
-
 /**
  * Minimal ambient declaration of the `window.vellum` bridge exposed by the
  * Electron preload script (see `apps/macos/src/preload/index.ts`). Only the
@@ -27,15 +25,4 @@ declare global {
  */
 export function isElectron(): boolean {
   return typeof window !== "undefined" && window.vellum?.platform === "electron";
-}
-
-/**
- * Hydration-safe hook that returns `false` on the server and during the
- * initial client render, then the live value after mount. Matches the
- * `useIsNativePlatform` pattern in `native-auth.ts` so server / client
- * reconciliation doesn't trigger a flicker.
- */
-const noop = () => () => {};
-export function useIsElectron(): boolean {
-  return useSyncExternalStore(noop, isElectron, () => false);
 }

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Minimal ambient declaration of the `window.vellum` bridge exposed by the
+ * Electron preload script (see `apps/macos/src/preload/index.ts`). Only the
+ * `platform` discriminator is declared here — additional bridge surfaces
+ * (`auth`, `settings`, `helper`, etc.) are added in the follow-up tickets
+ * that wire each feature so the renderer's view of the bridge stays honest
+ * about what's actually implemented at any given commit.
+ */
+declare global {
+  interface Window {
+    vellum?: {
+      platform: "electron";
+    };
+  }
+}
+
+/**
+ * True when the renderer is running inside the Electron host. Safe to call
+ * server-side / before hydration — falls through to `false` when `window`
+ * isn't defined yet.
+ *
+ * Use this to branch behavior that differs between the web host and the
+ * Electron host. For branches that differ between web and Capacitor iOS,
+ * use `isNativePlatform` from `@/runtime/native-auth.js` instead.
+ */
+export function isElectron(): boolean {
+  return typeof window !== "undefined" && window.vellum?.platform === "electron";
+}
+
+/**
+ * Hydration-safe hook that returns `false` on the server and during the
+ * initial client render, then the live value after mount. Matches the
+ * `useIsNativePlatform` pattern in `native-auth.ts` so server / client
+ * reconciliation doesn't trigger a flicker.
+ */
+const noop = () => () => {};
+export function useIsElectron(): boolean {
+  return useSyncExternalStore(noop, isElectron, () => false);
+}


### PR DESCRIPTION
## Summary

Adds the platform-detection seam ([LUM-1840](https://linear.app/vellum/issue/LUM-1840)) so renderer code can branch between web / Capacitor iOS / Electron without each call site re-deriving from `window.vellum`. First Phase 1 increment for the macOS Electron migration — the bridge from #32081 is now actually consulted from inside the renderer.

## What's in

- **`apps/web/src/runtime/is-electron.ts`**
  - `isElectron()` — SSR-safe (returns `false` before hydration).
  - Minimal ambient `Window.vellum` declaration covering only the `platform` discriminator. Additional bridge surfaces (`auth`, `settings`, `helper`) get added here as follow-up tickets wire each one, keeping the renderer's view of the bridge honest about what's actually implemented at any given commit.
  - Originally also exported a `useIsElectron()` hook mirroring `useIsNativePlatform`, removed in 47a3f04 per the AGENTS.md dead-code rule (no React consumer in this PR). The hook gets added back in the first PR that needs a hydration-safe Electron branch in a component.

- **`apps/web/src/components/share-feedback-modal.tsx`**
  - `getFeedbackClient()` now returns `"macos"` when `isElectron()` is true. The Electron shell is macOS-only; the backend `ClientEnum` already has a `macos` slot (vacated by the retiring Swift macOS app), so this keeps platform telemetry accurate without a backend change. Generated `ClientEnum = 'macos' | 'ios' | 'web' | 'cli'` already covers it — no schema work needed.

## Consumer audit — what *didn't* change

The ticket's "files known to need attention" list also includes `runtime/browser.ts` and `stores/event-bus-store.ts`. After reading them, neither needs a branch:

- **`runtime/browser.ts`** — the web fallback path uses `window.location.href`, which in Electron triggers the main process `will-navigate` handler that routes external `http(s)` to `shell.openExternal`. The effect is identical to the Capacitor `@capacitor/browser` path (open in system browser), so no Electron branch is required.
- **`hooks/use-event-bus-init.ts`** (where the Capacitor app-state listener actually lives — the store itself only has comments) — Chromium's `document.visibilitychange` + `window.online`/`offline` are reliable on Electron desktop. The Capacitor `App.appStateChange` branch only fires on iOS WKWebView, which misses the iOS-specific background snapshot. Electron falls through to the existing web event sources correctly.

## Auth-specific sites intentionally skipped

Per the note added to the LUM-1840 ticket: the audit lands in the middle of the Gateway-as-BFF Auth TDD ([LUM-1788](https://linear.app/vellum/issue/LUM-1788)) rework. Some current `Capacitor.isNativePlatform()` branches carry auth-specific behavior (`document.cookie` injection in `installSessionCookies()`, `X-Session-Token` plumbing in `native-auth.ts`, biometric flow in `auth-store.ts`, native login form in `login-page.tsx`, push-notification permission paths) that the TDD's end-state deletes outright. For those sites the right outcome is **remove the branch entirely** rather than **add an `isElectron()` parallel branch** — and that's owned by the team driving the TDD, not this PR.

Sites touched here are the ones that handle platform differences unrelated to auth.

## Blast radius

Zero for current users:

- `isElectron()` returns `false` for every web and iOS user today — no Electron build has shipped to anyone (no DMG, no auto-update push, no marketing-site change).
- The `getFeedbackClient()` branch only flips to `"macos"` when `isElectron()` is true, which never happens today, so feedback telemetry continues to report `"web"` / `"ios"` exactly as before.
- `Window.vellum` is an ambient TypeScript declaration — type-system only, no runtime change.

## Test plan

- [x] `bun install` clean.
- [x] `bun run openapi-ts` regenerates the API client.
- [x] `bun run typecheck` clean — confirms `"macos"` is a valid `ClientEnum`.
- [x] `bun run lint src/runtime/is-electron.ts src/components/share-feedback-modal.tsx` clean.
- [x] CI: Type Check, Test, Lint, Build, aggregate, Socket Security alerts, Socket project report — all ✅.

Pending on a real Mac (next person doing Electron Phase 1 work):

- [ ] `cd apps/web && bun run dev`; `cd apps/macos && bun run dev` opens a real `BrowserWindow` against the dev server.
- [ ] DevTools console: `window.vellum.platform === "electron"` returns `true`.
- [ ] Submit share feedback from the Electron window and confirm the backend receives `client: "macos"`.

## Out of scope (deferred)

- Bridge surface expansion for `auth.*`, `settings.*`, `helper.*` ([LUM-1924](https://linear.app/vellum/issue/LUM-1924) placeholder, blocked on LUM-1788; LUM-1846 for settings store).
- Notification API parity between iOS Capacitor and Electron (needs its own ticket — the existing `notifications.ts` is push-only and platform-specific).
- Removing auth-specific Capacitor branches — owned by the LUM-1788 team.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_