### PR TITLE
fix(settings): reword subscription-unknown notice to reference entitlement not Pro

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1208,8 +1208,8 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
               }
             >
               We couldn&apos;t reach the billing service. The form below
-              assumes you&apos;re on Pro — if you&apos;re not, registering a
-              domain will fail.
+              assumes managed email is enabled for your org — if it isn&apos;t,
+              registering a domain will fail.
             </Notice>
           )}
           {subscriptionQuery.isLoading ? (


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for entitlement-ui-gating.md.

**Gap:** Stale 'assumes you're on Pro' copy in the subscription-unknown notice
**What was expected:** Gate copy should reference the managed_email entitlement, not the Pro plan
**What was found:** The subscription-fetch-failure notice still said 'assumes you're on Pro'