### PR TITLE
feat(daemon): include spawning toolUseId in subagent_spawned event

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
@@ -318,6 +318,63 @@ describe("subagent_spawn fork parameter", () => {
     );
   });
 
+  test("threads context.toolUseId into config as parentToolUseId", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "tool-use-id-subagent";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Stamped task",
+          objective: "Do something",
+        },
+        makeContext("tool-use-conv", {
+          sendToClient: () => {},
+          toolUseId: "toolu_123",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig!.parentToolUseId).toBe("toolu_123");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("omits parentToolUseId when no toolUseId is in context", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "no-tool-use-id-subagent";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Unstamped task",
+          objective: "Do something",
+        },
+        makeContext("no-tool-use-conv", { sendToClient: () => {} }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig!.parentToolUseId).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
   test("fork: true shallow copies parent messages", async () => {
     const manager = getSubagentManager();
     const originalSpawn = manager.spawn.bind(manager);

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -12,6 +12,12 @@ export interface SubagentSpawned {
   label: string;
   objective: string;
   isFork?: boolean;
+  /**
+   * Tool-use id of the `skill_execute` call that spawned this subagent. Lets
+   * the client anchor the inline subagent card to the exact spawn tool call,
+   * independent of the (reconcile-volatile) parent message id.
+   */
+  parentToolUseId?: string;
 }
 
 export interface SubagentStatusChanged {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -365,6 +365,7 @@ export class SubagentManager {
       label: config.label,
       objective: config.objective,
       isFork: config.fork ?? false,
+      parentToolUseId: config.parentToolUseId,
     } as ServerMessage);
 
     log.info(

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -69,6 +69,12 @@ export interface SubagentConfig {
    * profile, every spawned subagent inherits it automatically.
    */
   overrideProfile?: string;
+  /**
+   * Tool-use id of the `skill_execute` call that spawned this subagent.
+   * Forwarded into the `subagent_spawned` event so the client can anchor the
+   * inline subagent card to the exact spawn tool call.
+   */
+  parentToolUseId?: string;
 }
 
 // ── State (runtime) ─────────────────────────────────────────────────────

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -102,6 +102,9 @@ export async function executeSubagentSpawn(
         ...(inheritedOverrideProfile
           ? { overrideProfile: inheritedOverrideProfile }
           : {}),
+        ...(context.toolUseId
+          ? { parentToolUseId: context.toolUseId }
+          : {}),
         ...forkFields,
       },
       sendToClient as (msg: unknown) => void,


### PR DESCRIPTION
## Summary
- Add optional parentToolUseId to the SubagentSpawned event type
- Thread context.toolUseId from executeSubagentSpawn through manager.spawn into the emitted subagent_spawned event
- Add a unit assertion covering the present/absent branches

Part of plan: subagent-card-loading-state.md (PR 1 of 8)