### PR TITLE
feat(web): re-anchor subagents to server message id in subagent store

### DIFF
--- a/apps/web/src/domains/subagents/subagent-store.test.ts
+++ b/apps/web/src/domains/subagents/subagent-store.test.ts
@@ -833,3 +833,150 @@ describe("byParent index", () => {
     ).toEqual(["sa-b", "sa-c"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// reanchorToMessage — migrate entries from the optimistic streaming bubble id
+// to the durable server messageId so the subagent card survives reconcile.
+// ---------------------------------------------------------------------------
+
+describe("reanchorToMessage", () => {
+  it("makes matching entries reachable under both stableId and messageId", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "stable-1",
+    });
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    const { byParent, byId } = getState();
+    expect(byParent.get("msg-1")?.map((e) => e.subagentId)).toEqual(["sa-1"]);
+    expect(byParent.get("stable-1")?.map((e) => e.subagentId)).toEqual(["sa-1"]);
+    expect(byId["sa-1"]!.parentMessageId).toBe("msg-1");
+    expect(byId["sa-1"]!.parentMessageStableId).toBe("stable-1");
+  });
+
+  it("sorts the messageId bucket by spawnedAt for multiple entries under one stableId", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-late",
+      label: "agent",
+      objective: "",
+      timestamp: NOW + 100,
+      parentMessageStableId: "stable-1",
+    });
+    getState().spawnSubagent({
+      subagentId: "sa-early",
+      label: "agent",
+      objective: "",
+      timestamp: NOW + 10,
+      parentMessageStableId: "stable-1",
+    });
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    expect(
+      getState().byParent.get("msg-1")?.map((e) => e.subagentId),
+    ).toEqual(["sa-early", "sa-late"]);
+  });
+
+  it("merges into an existing messageId bucket without duplicating", () => {
+    // One entry already indexed under msg-1, another under the stable id only.
+    getState().spawnSubagent({
+      subagentId: "sa-existing",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageId: "msg-1",
+    });
+    getState().spawnSubagent({
+      subagentId: "sa-stable",
+      label: "agent",
+      objective: "",
+      timestamp: NOW + 50,
+      parentMessageStableId: "stable-1",
+    });
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    expect(
+      getState().byParent.get("msg-1")?.map((e) => e.subagentId),
+    ).toEqual(["sa-existing", "sa-stable"]);
+  });
+
+  it("is a no-op when stableId equals messageId", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "msg-1",
+    });
+    const beforeById = getState().byId;
+    const beforeByParent = getState().byParent;
+
+    getState().reanchorToMessage({ stableId: "msg-1", messageId: "msg-1" });
+
+    expect(getState().byId).toBe(beforeById);
+    expect(getState().byParent).toBe(beforeByParent);
+  });
+
+  it("is a no-op when no entry matches the stableId", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "other-stable",
+    });
+    const beforeById = getState().byId;
+    const beforeByParent = getState().byParent;
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    expect(getState().byId).toBe(beforeById);
+    expect(getState().byParent).toBe(beforeByParent);
+  });
+
+  it("is a no-op when matching entries already carry that parentMessageId", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "stable-1",
+      parentMessageId: "msg-1",
+    });
+    const beforeById = getState().byId;
+    const beforeByParent = getState().byParent;
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    expect(getState().byId).toBe(beforeById);
+    expect(getState().byParent).toBe(beforeByParent);
+  });
+
+  it("preserves unrelated bucket references", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-other",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "stable-other",
+    });
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW + 1,
+      parentMessageStableId: "stable-1",
+    });
+    const otherBucketBefore = getState().byParent.get("stable-other");
+
+    getState().reanchorToMessage({ stableId: "stable-1", messageId: "msg-1" });
+
+    // The unrelated bucket reference is untouched.
+    expect(getState().byParent.get("stable-other")).toBe(otherBucketBefore);
+  });
+});

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -124,6 +124,16 @@ export interface SubagentActions {
 
   setConversationId: (subagentId: string, conversationId: string) => void;
 
+  /**
+   * Attach the durable server `messageId` to every entry currently anchored
+   * to `stableId` (the optimistic streaming bubble id) and re-index `byParent`
+   * so those entries are reachable under the server id after the parent
+   * message reconciles. No-op when stableId === messageId, when no entry
+   * matches, or when the entry already carries that parentMessageId. Strengthens
+   * the positional/byParent fallback; the toolUseId anchor (PR 2/3) is primary.
+   */
+  reanchorToMessage: (params: { stableId: string; messageId: string }) => void;
+
   reset: () => void;
 }
 
@@ -173,6 +183,47 @@ function addEntryToByParent(
     merged.sort((a, b) => a.spawnedAt - b.spawnedAt);
     next.set(key, merged);
   }
+  return next;
+}
+
+/**
+ * Re-index `byParent` after a set of entries gains a new `parentMessageId`.
+ * Only the two affected buckets are rebuilt — the old `stableId` bucket (whose
+ * entry objects are swapped for their updated copies) and the new `messageId`
+ * bucket (which gains any updated entries not already present), each re-sorted
+ * by `spawnedAt`. Every other bucket reference is preserved so unrelated
+ * message subscribers don't see their selector output change.
+ */
+function reindexByParentForReanchor(
+  byParent: Map<string, SubagentEntry[]>,
+  stableId: string,
+  messageId: string,
+  updatedById: Map<string, SubagentEntry>,
+): Map<string, SubagentEntry[]> {
+  const next = new Map(byParent);
+
+  const stableBucket = next.get(stableId);
+  if (stableBucket) {
+    next.set(
+      stableId,
+      stableBucket.map((entry) => updatedById.get(entry.subagentId) ?? entry),
+    );
+  }
+
+  const messageBucket = [...(next.get(messageId) ?? [])];
+  for (const updated of updatedById.values()) {
+    const idx = messageBucket.findIndex(
+      (entry) => entry.subagentId === updated.subagentId,
+    );
+    if (idx === -1) {
+      messageBucket.push(updated);
+    } else {
+      messageBucket[idx] = updated;
+    }
+  }
+  messageBucket.sort((a, b) => a.spawnedAt - b.spawnedAt);
+  next.set(messageId, messageBucket);
+
   return next;
 }
 
@@ -383,6 +434,37 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         ...byId,
         [subagentId]: { ...existing, conversationId },
       },
+    });
+  },
+
+  reanchorToMessage: ({ stableId, messageId }) => {
+    if (stableId === messageId) return;
+
+    const { byId } = get();
+    const updatedById = new Map<string, SubagentEntry>();
+    for (const entry of Object.values(byId)) {
+      if (
+        entry.parentMessageStableId === stableId &&
+        entry.parentMessageId !== messageId
+      ) {
+        updatedById.set(entry.subagentId, { ...entry, parentMessageId: messageId });
+      }
+    }
+    if (updatedById.size === 0) return;
+
+    const nextById = { ...byId };
+    for (const [subagentId, updated] of updatedById) {
+      nextById[subagentId] = updated;
+    }
+
+    set({
+      byId: nextById,
+      byParent: reindexByParentForReanchor(
+        get().byParent,
+        stableId,
+        messageId,
+        updatedById,
+      ),
     });
   },
 


### PR DESCRIPTION
## Summary
- Add reanchorToMessage action that migrates subagents from the optimistic streaming message id to the durable server messageId
- Re-index only the touched byParent buckets, preserving unrelated bucket references
- Add store tests for happy path, no-ops, and reference stability

Part of plan: subagent-card-loading-state.md (PR 4 of 8)