### PR TITLE
fix(web): stop button no longer overlaps subagent card helper text

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
@@ -213,6 +213,31 @@ describe("ToolProgressCardShell — headerActionSlot", () => {
     expect(queryByTestId("tool-progress-card-action-slot")).toBeNull();
   });
 
+  test("reserves header space (pr-[88px]) on the title cluster only when an action slot is present", () => {
+    // With an action slot, the title/info cluster gets right-padding so the
+    // helper text truncates to the left of the absolutely-positioned slot
+    // instead of painting under it.
+    const withSlot = renderShell({
+      headerActionSlot: (
+        <button data-testid="action-button" type="button">
+          stop
+        </button>
+      ),
+    });
+    const slotted = withSlot.container.querySelector(".pr-\\[88px\\]");
+    expect(slotted).not.toBeNull();
+    // The reserved-space cluster keeps min-w-0 so the inner truncate applies.
+    expect(slotted?.className).toContain("min-w-0");
+    cleanup();
+
+    // Without an action slot, no extra padding is applied — other tool cards
+    // (web search, skills) stay visually unchanged.
+    const withoutSlot = renderShell();
+    expect(
+      withoutSlot.container.querySelector(".pr-\\[88px\\]"),
+    ).toBeNull();
+  });
+
   test("action-slot children are NOT nested inside the toggle button", () => {
     // Regression guard for the nested-<button> HTML invalidity. The action
     // slot must render as a sibling of the toggle Button, not a descendant.

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -244,7 +244,19 @@ export function ToolProgressCardShell({
             : "rounded-[var(--radius-lg)]"
         }`}
       >
-        <span className="flex min-w-0 flex-1 items-center gap-1">
+        <span
+          // When an action slot is present it floats over the right end of
+          // the header (absolute, at `right-[56px]`). Reserve horizontal
+          // space here so the carousel's info text truncates to the LEFT of
+          // the slot instead of painting under it (slot offset + the ~20px
+          // Stop button + a gap). `min-w-0` is preserved so
+          // `HeaderStepCarousel`'s inner `truncate` still clips. Applied ONLY
+          // when `headerActionSlot` is set so cards without a slot (web
+          // search, skills) stay visually unchanged.
+          className={`flex min-w-0 flex-1 items-center gap-1 ${
+            headerActionSlot ? "pr-[88px]" : ""
+          }`}
+        >
           <StatusIndicator state={state} testId={statusIndicatorTestId} />
           {leadingIcon ? (
             // `mx-1` adds 4px on each side on top of the parent's `gap-1`
@@ -298,8 +310,12 @@ export function ToolProgressCardShell({
           chrome later only requires a single edit here. */}
       {headerActionSlot ? (
         <div
+          // `right-[56px]` parks the slot just left of the step-count pill
+          // with ~8px of clear space on the pill side; the reserved `pr-[88px]`
+          // on the title cluster guarantees the helper text truncates ~8px to
+          // the left of the button. Net layout: text → gap → Stop → gap → pill.
           data-testid="tool-progress-card-action-slot"
-          className="pointer-events-none absolute right-[64px] top-[14px] flex items-center gap-1"
+          className="pointer-events-none absolute right-[56px] top-[14px] flex items-center gap-1"
         >
           <div className="pointer-events-auto flex items-center gap-1">
             {headerActionSlot}


### PR DESCRIPTION
## Summary
- Reserve header space for the action slot so helper text truncates before the Stop button
- Give the Stop button symmetric left/right spacing from the helper text and step-count pill
- Padding applied only when headerActionSlot is present; other tool cards unaffected

Part of plan: subagent-card-loading-state.md (PR 7 of 8)