### PR TITLE
feat(web): index subagents by spawning toolUseId in the store

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -756,6 +756,10 @@ function parseLegacyEvent(data: Record<string, unknown>): AssistantEvent {
         label,
         objective: typeof data.objective === "string" ? data.objective : "",
         isFork: typeof data.isFork === "boolean" ? data.isFork : undefined,
+        parentToolUseId:
+          typeof data.parentToolUseId === "string"
+            ? data.parentToolUseId
+            : undefined,
         conversationId:
           typeof data.conversationId === "string"
             ? data.conversationId

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -466,6 +466,13 @@ export interface SubagentSpawnedEvent {
   label: string;
   objective: string;
   isFork?: boolean;
+  /**
+   * Tool-use block ID of the spawning tool call in the parent conversation.
+   * Lets the client anchor the inline subagent card to its exact spawn tool
+   * call (survives optimistic→reconciled message id swaps). Optional — older
+   * daemons omit it.
+   */
+  parentToolUseId?: string;
   conversationId?: string;
 }
 

--- a/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -13,6 +13,7 @@ export function handleSubagentSpawned(
     isFork: event.isFork,
     timestamp: Date.now(),
     parentMessageStableId: ctx.currentAssistantMessageIdRef.current,
+    parentToolUseId: event.parentToolUseId,
   });
 }
 

--- a/apps/web/src/domains/subagents/subagent-store.test.ts
+++ b/apps/web/src/domains/subagents/subagent-store.test.ts
@@ -833,3 +833,97 @@ describe("byParent index", () => {
     ).toEqual(["sa-b", "sa-c"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// byToolUseId index — lets the transcript anchor the inline card to its exact
+// spawn tool call (toolUseId → subagentId), surviving optimistic message-id
+// reconciliation.
+// ---------------------------------------------------------------------------
+
+describe("byToolUseId index", () => {
+  it("indexes the subagent by parentToolUseId and sets the entry field", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentToolUseId: "tool-use-1",
+    });
+
+    expect(getState().byToolUseId.get("tool-use-1")).toBe("sa-1");
+    expect(getState().byId["sa-1"]!.parentToolUseId).toBe("tool-use-1");
+  });
+
+  it("leaves byToolUseId reference-equal when parentToolUseId is omitted", () => {
+    const before = getState().byToolUseId;
+
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+    });
+
+    expect(getState().byToolUseId).toBe(before);
+    expect(getState().byToolUseId.size).toBe(0);
+    expect(getState().byId["sa-1"]!.parentToolUseId).toBeUndefined();
+  });
+
+  it("does not touch the index when a duplicate spawn is replayed", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-dup",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentToolUseId: "tool-use-dup",
+    });
+    const afterFirst = getState().byToolUseId;
+
+    // Replay with a different toolUseId — guard short-circuits, index unchanged.
+    getState().spawnSubagent({
+      subagentId: "sa-dup",
+      label: "agent",
+      objective: "",
+      timestamp: NOW + 5000,
+      parentToolUseId: "tool-use-other",
+    });
+
+    expect(getState().byToolUseId).toBe(afterFirst);
+    expect(getState().byToolUseId.get("tool-use-dup")).toBe("sa-dup");
+    expect(getState().byToolUseId.has("tool-use-other")).toBe(false);
+  });
+
+  it("keeps the index reference stable across changeStatus and receiveEvent", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentToolUseId: "tool-use-1",
+    });
+    const before = getState().byToolUseId;
+
+    getState().changeStatus({ subagentId: "sa-1", status: "running" });
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "assistant_text_delta", content: "Hello" },
+      timestamp: NOW + 100,
+    });
+
+    expect(getState().byToolUseId).toBe(before);
+  });
+
+  it("clears byToolUseId on reset()", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      timestamp: NOW,
+      parentToolUseId: "tool-use-1",
+    });
+    expect(getState().byToolUseId.size).toBe(1);
+
+    getState().reset();
+    expect(getState().byToolUseId.size).toBe(0);
+  });
+});

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -53,6 +53,13 @@ export interface SubagentEntry {
   parentMessageStableId?: string;
   /** Daemon UUID of the parent assistant message. Stable across reloads. */
   parentMessageId?: string;
+  /**
+   * Tool-use block ID of the spawning tool call in the parent conversation.
+   * Lets the transcript anchor the inline card to its exact spawn tool call
+   * regardless of optimistic→reconciled message id swaps. Indexed in
+   * `byToolUseId`. Optional — older daemons omit it.
+   */
+  parentToolUseId?: string;
 }
 
 export interface SubagentState {
@@ -73,6 +80,17 @@ export interface SubagentState {
    * the bucket untouched so message-body subscribers don't re-render.
    */
   byParent: Map<string, SubagentEntry[]>;
+  /**
+   * Index of spawning tool-use block id → subagentId. Populated when a
+   * `subagent_spawned` event carries `parentToolUseId`, letting the
+   * transcript anchor the inline card to its exact spawn tool call even
+   * after the optimistic streaming message id is reconciled away.
+   *
+   * The map reference is only replaced when a new `parentToolUseId` is
+   * indexed; unrelated mutations keep it stable so subscribers don't
+   * re-render.
+   */
+  byToolUseId: Map<string, string>;
 }
 
 /** Stable empty array returned for parent ids with no spawned subagents.
@@ -95,6 +113,7 @@ export interface SubagentActions {
     error?: string;
     parentMessageStableId?: string;
     parentMessageId?: string;
+    parentToolUseId?: string;
   }) => void;
 
   changeStatus: (params: {
@@ -137,6 +156,7 @@ const INITIAL_STATE: SubagentState = {
   byId: {},
   orderedIds: [],
   byParent: new Map<string, SubagentEntry[]>(),
+  byToolUseId: new Map<string, string>(),
 };
 
 /** Parent-id keys an entry contributes to in the `byParent` index. */
@@ -255,13 +275,22 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       conversationId: params.conversationId,
       parentMessageStableId: params.parentMessageStableId,
       parentMessageId: params.parentMessageId,
+      parentToolUseId: params.parentToolUseId,
     };
 
     const nextById = { ...byId, [params.subagentId]: entry };
+    // Only clone the tool-use index when this spawn carries a
+    // `parentToolUseId`; otherwise keep the existing reference stable so
+    // index subscribers don't re-render.
+    const prevByToolUseId = get().byToolUseId;
+    const nextByToolUseId = params.parentToolUseId
+      ? new Map(prevByToolUseId).set(params.parentToolUseId, params.subagentId)
+      : prevByToolUseId;
     set({
       byId: nextById,
       orderedIds: [...orderedIds, params.subagentId],
       byParent: addEntryToByParent(get().byParent, entry),
+      byToolUseId: nextByToolUseId,
     });
   },
 
@@ -391,6 +420,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       byId: {},
       orderedIds: [],
       byParent: new Map<string, SubagentEntry[]>(),
+      byToolUseId: new Map<string, string>(),
     }),
 }));
 


### PR DESCRIPTION
## Summary
- Carry parentToolUseId through SubagentSpawnedEvent, the event parser, and the spawn handler
- Store parentToolUseId on SubagentEntry and add a byToolUseId index (toolUseId -> subagentId)
- Add store tests covering the index and the no-op/absent path

Part of plan: subagent-card-loading-state.md (PR 2 of 8)