### PR TITLE
feat(web): show skeleton subagent metrics until usage is reported

### DIFF
--- a/apps/web/src/domains/chat/components/chat-skeleton.tsx
+++ b/apps/web/src/domains/chat/components/chat-skeleton.tsx
@@ -1,4 +1,4 @@
-function SkeletonBar({ className }: { className?: string }) {
+export function SkeletonBar({ className }: { className?: string }) {
   return (
     <div
       className={`animate-pulse rounded bg-[var(--surface-active)] ${className ?? ""}`}

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The detail panel shows skeleton Input/Output/Cost cards while a subagent is
+ * still active and the daemon has not yet reported usage (all zeros). Once any
+ * usage arrives — or the subagent reaches a terminal status — real formatted
+ * values render, including a legitimate `0` / `0.00` for a trivial run.
+ *
+ * Heavy children (avatar, status badge, timeline) are stubbed so we can assert
+ * the metric-row behavior without depending on their internals.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+mock.module("@/components/avatar-renderer.js", () => ({
+  AvatarRenderer: () => <div data-testid="avatar" />,
+}));
+
+mock.module("@/domains/chat/components/subagent-status-badge.js", () => ({
+  StatusBadge: ({ status }: { status: string }) => (
+    <div data-testid="status-badge" data-status={status} />
+  ),
+}));
+
+mock.module("@/domains/chat/components/subagent-timeline.js", () => ({
+  SubagentTimeline: () => <div data-testid="timeline" />,
+}));
+
+import { SubagentDetailPanel } from "@/domains/chat/components/subagent-detail-panel.js";
+import type { SubagentEntry } from "@/domains/subagents/subagent-store.js";
+
+const noop = () => {};
+
+function makeEntry(overrides: Partial<SubagentEntry> = {}): SubagentEntry {
+  return {
+    subagentId: "sub-1",
+    label: "Research agent",
+    objective: "Do the thing",
+    status: "running",
+    isFork: false,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCost: 0,
+    spawnedAt: Date.now(),
+    events: [],
+    ...overrides,
+  };
+}
+
+/** A skeleton metric value is a pulsing bar; real values are plain text. */
+function skeletonCount(container: HTMLElement): number {
+  return container.querySelectorAll(".animate-pulse").length;
+}
+
+afterEach(() => {
+  cleanup();
+});
+afterAll(() => {
+  mock.restore();
+});
+
+describe("SubagentDetailPanel — metric skeletons", () => {
+  test("running with zero usage renders three skeleton metric cards", () => {
+    const { container } = render(
+      <SubagentDetailPanel
+        entry={makeEntry({ status: "running", inputTokens: 0, outputTokens: 0, totalCost: 0 })}
+        onClose={noop}
+      />,
+    );
+
+    // One skeleton bar per metric card (Input / Output / Cost).
+    expect(skeletonCount(container)).toBe(3);
+    // Labels (card shape) stay visible so there's no reflow when values land.
+    expect(screen.getByText("Input")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("Cost")).toBeDefined();
+    // The literal zeros must NOT be shown while metrics are pending.
+    expect(screen.queryByText("0.00")).toBeNull();
+  });
+
+  test("running with usage renders real values, not skeletons", () => {
+    const { container } = render(
+      <SubagentDetailPanel
+        entry={makeEntry({ status: "running", inputTokens: 1200, outputTokens: 340, totalCost: 0.68 })}
+        onClose={noop}
+      />,
+    );
+
+    expect(skeletonCount(container)).toBe(0);
+    expect(screen.getByText("1.2K")).toBeDefined();
+    expect(screen.getByText("340")).toBeDefined();
+    expect(screen.getByText("0.68")).toBeDefined();
+  });
+
+  test("terminal subagent renders real values including a legitimate zero", () => {
+    const { container } = render(
+      <SubagentDetailPanel
+        entry={makeEntry({ status: "completed", inputTokens: 0, outputTokens: 0, totalCost: 0 })}
+        onClose={noop}
+      />,
+    );
+
+    // A completed run is never a skeleton, even with zeroed usage.
+    expect(skeletonCount(container)).toBe(0);
+    // Two "0" inputs/outputs and one "0.00" cost render as real text.
+    expect(screen.getAllByText("0").length).toBe(2);
+    expect(screen.getByText("0.00")).toBeDefined();
+  });
+});

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -18,6 +18,7 @@ import type { SubagentEntry } from "@/domains/subagents/subagent-store.js";
 import { isActiveStatus } from "@/domains/subagents/status-helpers.js";
 
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline.js";
+import { SkeletonBar } from "@/domains/chat/components/chat-skeleton.js";
 
 /** Format a number compactly (e.g. 257400 -> "257.4K"). */
 function formatNumber(n: number): string {
@@ -47,10 +48,12 @@ function MetricCard({
   icon,
   value,
   label,
+  loading = false,
 }: {
   icon: ReactNode;
   value: string;
   label: string;
+  loading?: boolean;
 }) {
   return (
     <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
@@ -58,12 +61,20 @@ function MetricCard({
         {icon}
       </div>
       <div className="min-w-0">
-        <Typography
-          variant="title-small"
-          className="block text-[var(--content-default)]"
-        >
-          {value}
-        </Typography>
+        {loading ? (
+          // Match the title-small line-box height so the card does not reflow
+          // when the real value lands.
+          <span className="flex h-5 items-center" aria-hidden="true">
+            <SkeletonBar className="h-3 w-10" />
+          </span>
+        ) : (
+          <Typography
+            variant="title-small"
+            className="block text-[var(--content-default)]"
+          >
+            {value}
+          </Typography>
+        )}
         <Typography
           variant="body-small-default"
           className="block text-[var(--content-secondary)]"
@@ -97,6 +108,15 @@ export function SubagentDetailPanel({
   onRequestDetail,
 }: SubagentDetailPanelProps) {
   const isRunning = isActiveStatus(entry.status);
+  // The daemon ships zeroed usage until a subagent completes, so all-zero
+  // while still active is our "metrics not yet available" signal. Once any
+  // usage arrives or the status is terminal, render real numbers — including
+  // a legitimate 0 for a trivial run.
+  const metricsPending =
+    isRunning &&
+    entry.inputTokens === 0 &&
+    entry.outputTokens === 0 &&
+    entry.totalCost === 0;
   const requestedRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -161,16 +181,19 @@ export function SubagentDetailPanel({
             icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             value={formatNumber(entry.inputTokens)}
             label="Input"
+            loading={metricsPending}
           />
           <MetricCard
             icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             value={formatNumber(entry.outputTokens)}
             label="Output"
+            loading={metricsPending}
           />
           <MetricCard
             icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             value={formatCost(entry.totalCost)}
             label="Cost"
+            loading={metricsPending}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Add an optional loading state to MetricCard that renders a SkeletonBar in place of the value
- Show skeleton Input/Output/Cost while a subagent is active and usage is still zero
- Render real values (including a legitimate 0) once usage arrives or status is terminal
- Add subagent-detail-panel tests for the skeleton/real/terminal cases

Part of plan: subagent-card-loading-state.md (PR 8 of 8)