### PR TITLE
fix(web): guard against missing properties in usage API responses

### DIFF
--- a/apps/web/src/domains/logs/group-labels.ts
+++ b/apps/web/src/domains/logs/group-labels.ts
@@ -41,6 +41,10 @@ export function decorateUsageBreakdownGroups(
   groupBy: UsageGroupBy,
   metadata: UsageGroupLabelMetadata,
 ): UsageGroupBreakdown[] {
+  if (!groups || groups.length === 0) {
+    return [];
+  }
+
   return groups.map((group) => {
     const resolvedGroup = resolveUsageGroupLabel(groupBy, group, metadata);
     if (resolvedGroup === group.group) {

--- a/apps/web/src/domains/logs/usage-api.ts
+++ b/apps/web/src/domains/logs/usage-api.ts
@@ -149,7 +149,7 @@ export async function fetchUsageTotals(
   if (!response || !response.ok) {
     return throwOnBadResponse(response, "Failed to load usage totals.");
   }
-  return data ?? EMPTY_TOTALS;
+  return { ...EMPTY_TOTALS, ...data };
 }
 
 export async function fetchUsageDaily(
@@ -165,12 +165,9 @@ export async function fetchUsageDaily(
   if (!response || !response.ok) {
     return throwOnBadResponse(response, "Failed to load usage buckets.");
   }
-  if (!data) {
-    return { buckets: [] };
-  }
+  const buckets = data?.buckets ?? [];
   return {
-    ...data,
-    buckets: data.buckets.map((bucket) => ({
+    buckets: buckets.map((bucket) => ({
       ...bucket,
       bucketId: bucket.bucketId ?? bucket.date,
     })),
@@ -190,7 +187,7 @@ export async function fetchUsageBreakdown(
   if (!response || !response.ok) {
     return throwOnBadResponse(response, "Failed to load usage breakdown.");
   }
-  return data ?? { breakdown: [] };
+  return { breakdown: data?.breakdown ?? [] };
 }
 
 export async function fetchUsageSeries(
@@ -206,12 +203,9 @@ export async function fetchUsageSeries(
   if (!response || !response.ok) {
     return throwOnBadResponse(response, "Failed to load usage series.");
   }
-  if (!data) {
-    return { buckets: [] };
-  }
+  const seriesBuckets = data?.buckets ?? [];
   return {
-    ...data,
-    buckets: data.buckets.map((bucket) => ({
+    buckets: seriesBuckets.map((bucket) => ({
       ...bucket,
       bucketId: bucket.bucketId ?? bucket.date,
       groups: bucket.groups ?? {},


### PR DESCRIPTION
## Prompt / plan

Fix pre-existing `TypeError: Cannot read properties of undefined (reading 'map')` crash on the `/assistant/logs/usage` page. Discovered during LUM-1918 testing when navigating to the usage tab with mocked API data.

## Problem

All four `fetchUsage*` functions in `usage-api.ts` used nullish coalescing (`data ?? fallback`) to provide defaults when the HeyAPI client returns no data. This only guards against `null`/`undefined` — if the daemon returns `200 OK` with a response body missing expected properties (e.g. `{}` instead of `{ breakdown: [] }`), the truthy object passes through the `??` check unchanged, and downstream `.map()` calls crash:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at decorateUsageBreakdownGroups (group-labels.ts:44)
```

The call chain: `fetchUsageBreakdown` returns `data` (which is `{}`) → `breakdownQuery.data.response.breakdown` is `undefined` → `decorateUsageBreakdownGroups(undefined, ...)` → `undefined.map(...)` → crash.

## Fix

**Root cause fix** (`usage-api.ts`): Explicitly destructure and default each required property so the return type contract is always satisfied regardless of response shape:

| Function | Before | After |
|---|---|---|
| `fetchUsageTotals` | `data ?? EMPTY_TOTALS` | `{ ...EMPTY_TOTALS, ...data }` |
| `fetchUsageDaily` | `if (!data) return ...` then `data.buckets.map(...)` | `const buckets = data?.buckets ?? []` then `buckets.map(...)` |
| `fetchUsageBreakdown` | `data ?? { breakdown: [] }` | `{ breakdown: data?.breakdown ?? [] }` |
| `fetchUsageSeries` | `if (!data) return ...` then `data.buckets.map(...)` | `const seriesBuckets = data?.buckets ?? []` then `seriesBuckets.map(...)` |

**Defense-in-depth** (`group-labels.ts`): `decorateUsageBreakdownGroups` now returns `[]` early when `groups` is falsy or empty, preventing the `.map()` crash even if a caller bypasses the API function defaults.

## Root cause analysis

1. **How did the code get into this state?** These usage endpoints are daemon-proxied routes not covered by the OpenAPI spec, so the fetch wrappers and types are hand-maintained. The original author used `??` (nullish coalescing) as a shorthand for "default when no data," but `??` only triggers on `null`/`undefined` — a common JavaScript pitfall when the actual risk is a truthy-but-incomplete response object.

2. **What mistakes or decisions led to it?** The `fetchUsageDaily` and `fetchUsageSeries` functions show awareness of the issue (they check `if (!data)`) but then access `data.buckets` without guarding the property itself. The `fetchUsageBreakdown` and `fetchUsageTotals` functions skip even the top-level check. The inconsistency suggests the guard was added reactively after a crash in daily/series, but the same pattern wasn't applied to breakdown/totals.

3. **Were there warning signs we missed?** The TypeScript types (`UsageBreakdownResponse`, `UsageSeriesResponse`) define `breakdown` and `buckets` as non-optional arrays, which gives a false sense of safety. Runtime data from untyped daemon endpoints doesn't respect compile-time types.

4. **What can we do to prevent this pattern from recurring?** For hand-typed daemon endpoints, always default individual properties rather than the entire response object. The `??` operator is safe for primitives but not for objects with required nested properties.

5. **Should we add a guideline?** Not adding an AGENTS.md rule — this is a general JavaScript/TypeScript best practice (prefer optional chaining + property-level defaults over object-level nullish coalescing for API responses) that doesn't warrant a project-specific rule.

## Safety

- **Additive guards only** — no behavior change when the API returns well-formed data. The `??` and `?.` operators are no-ops when the left-hand side is defined.
- **`fetchUsageTotals`** change from `data ?? EMPTY_TOTALS` to `{ ...EMPTY_TOTALS, ...data }` preserves all existing fields when `data` is well-formed (spread overwrites defaults), and provides safe defaults when `data` is `null`/`undefined`/`{}`.
- **No new dependencies, no API contract changes, no wire format changes.**

## References

- [MDN — Nullish coalescing operator (??)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) — documents that `??` only checks `null`/`undefined`, not falsy or incomplete objects
- [MDN — Optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) — safe property access for potentially undefined intermediate objects

## Test plan

- Lint (`bun run lint`) — passes clean
- Typecheck (`bunx tsc --noEmit`) — passes clean
- Manual verification: navigated to `/assistant/logs/usage` via Vite dev server + Playwright CDP mocking; page no longer crashes with TypeError

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka