### PR TITLE
feat(memory-v3): seed learned edge graph from v2 co-selection history

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11833,6 +11833,45 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v3/seed-edges:
+    post:
+      operationId: memory_v3_seededges_post
+      summary: Seed the learned co-retrieval edge graph from v2 router history
+      description:
+        Builds an NPMI-scored co-retrieval graph from the v2 router's per-turn selections
+        (memory_v2_activation_logs, status='injected') and persists it into memory_v3_auto_edges, warm-starting the
+        learned edge graph that the v3 edge-expansion lane merges with curated edges when
+        memory.v3.edges.learnedAdjacencyThreshold > 0. NPMI plus a min co-occurrence floor and an always-on frequency
+        ceiling keep the neighborhoods associative rather than base-rate noise. Idempotent (upserts to a flat seed
+        weight). Runs no LLM; the only write among the v3 routes.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                minCount:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                topK:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                maxNeighborFreqRatio:
+                  type: number
+                  exclusiveMinimum: 0
+                  maximum: 1
+                seedWeight:
+                  type: number
+                  exclusiveMinimum: 0
+              additionalProperties: false
   /v1/memory/v3/shadow-diff:
     post:
       operationId: memory_v3_shadowdiff_post

--- a/assistant/src/cli/commands/memory-v3-render.ts
+++ b/assistant/src/cli/commands/memory-v3-render.ts
@@ -14,6 +14,7 @@ import type {
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
+  SeedCoretrievalResult,
   ShadowDiffResult,
   ShadowDiffTurn,
 } from "../../runtime/routes/memory-v3-routes.js";
@@ -472,4 +473,19 @@ export function renderLlmCalls(
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * Render a {@link SeedCoretrievalResult} into a one-block summary of the seeding
+ * run: how many router turns were scanned and how many nodes/edges were written.
+ */
+export function renderSeedEdges(result: SeedCoretrievalResult): string {
+  return [
+    "Memory v3 Co-Retrieval Edge Seed",
+    "================================",
+    `Router turns scanned: ${result.turnsScanned}`,
+    `Nodes (sources):      ${result.nodes}`,
+    `Edges written:        ${result.edgesWritten}`,
+    `Avg out-degree:       ${result.avgDegree.toFixed(1)}`,
+  ].join("\n");
 }

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -32,12 +32,14 @@ import type {
   MemoryV3SimulateResult,
   MemoryV3TreeResult,
   MemoryV3ValidateResult,
+  SeedCoretrievalResult,
   ShadowDiffResult,
 } from "../../runtime/routes/memory-v3-routes.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import {
   renderLlmCalls,
+  renderSeedEdges,
   renderShadowDiff,
   renderSimulation,
   renderTree,
@@ -439,6 +441,125 @@ Examples:
               return;
             }
             log.info(renderShadowDiff(payload));
+          },
+        );
+
+      // ── seed-edges ────────────────────────────────────────────────────────
+
+      v3.command("seed-edges")
+        .description(
+          "Seed the learned co-retrieval edge graph from v2 router history",
+        )
+        .option(
+          "--min-count <n>",
+          "Min co-occurrence turns for an edge (positive integer, default: 5)",
+        )
+        .option(
+          "--top-k <n>",
+          "Neighbors kept per source node (positive integer, default: 20)",
+        )
+        .option(
+          "--max-neighbor-freq-ratio <n>",
+          "Exclude neighbors selected on more than this fraction of turns (0-1, default: 0.4)",
+        )
+        .option(
+          "--seed-weight <n>",
+          "Weight each seeded edge is written at (positive, default: 2.0)",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted summary")
+        .addHelpText(
+          "after",
+          `
+Builds an NPMI-scored co-retrieval graph from the v2 router's per-turn
+selections (memory_v2_activation_logs, status='injected') and writes it into
+memory_v3_auto_edges, warm-starting the learned edge graph. This is the only
+'memory v3' subcommand that WRITES. Idempotent — re-running refreshes the
+seeded edges to the seed weight. Runs no LLM.
+
+The edge-expansion lane only merges the learned graph once
+memory.v3.edges.learnedAdjacencyThreshold is set above 0 (default off); seed
+first, then enable the threshold to A/B via 'memory v3 simulate'.
+
+Examples:
+  $ assistant memory v3 seed-edges
+  $ assistant memory v3 seed-edges --min-count 8 --top-k 15
+  $ assistant memory v3 seed-edges --json | jq '.edgesWritten'`,
+        )
+        .action(
+          async (opts: {
+            minCount?: string;
+            topK?: string;
+            maxNeighborFreqRatio?: string;
+            seedWeight?: string;
+            json?: boolean;
+          }) => {
+            const minCount = parsePositiveFlag(opts.minCount, { int: true });
+            if (minCount.error) {
+              log.error(
+                `--min-count must be a positive integer (got "${opts.minCount}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const topK = parsePositiveFlag(opts.topK, { int: true });
+            if (topK.error) {
+              log.error(
+                `--top-k must be a positive integer (got "${opts.topK}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const ratio = parsePositiveFlag(opts.maxNeighborFreqRatio, {
+              int: false,
+            });
+            if (ratio.error || (ratio.value !== undefined && ratio.value > 1)) {
+              log.error(
+                `--max-neighbor-freq-ratio must be a number in (0, 1] (got "${opts.maxNeighborFreqRatio}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+            const seedWeight = parsePositiveFlag(opts.seedWeight, {
+              int: false,
+            });
+            if (seedWeight.error) {
+              log.error(
+                `--seed-weight must be a positive number (got "${opts.seedWeight}")`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+
+            const result = await cliIpcCall<SeedCoretrievalResult>(
+              "memory_v3_seed_edges",
+              {
+                body: {
+                  ...(minCount.value !== undefined
+                    ? { minCount: minCount.value }
+                    : {}),
+                  ...(topK.value !== undefined ? { topK: topK.value } : {}),
+                  ...(ratio.value !== undefined
+                    ? { maxNeighborFreqRatio: ratio.value }
+                    : {}),
+                  ...(seedWeight.value !== undefined
+                    ? { seedWeight: seedWeight.value }
+                    : {}),
+                },
+              },
+            );
+
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to seed co-retrieval edges");
+              process.exitCode = 1;
+              return;
+            }
+
+            const payload = result.result!;
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+            log.info(renderSeedEdges(payload));
           },
         );
     },

--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -224,6 +224,7 @@ describe("MemoryV3ConfigSchema", () => {
       denseQuota: { activeDomain: 30, offDomain: 8 },
       hotLimit: 50,
       lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
+      edges: { learnedAdjacencyThreshold: 0 },
       ks: [5, 10, 25, 50],
       write: {
         enabled: false,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -522,6 +522,22 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Per-lane on/off toggles for the v3 multi-lane retrieval fanout. All lanes on by default.",
       ),
+    edges: z
+      .object({
+        learnedAdjacencyThreshold: z
+          .number({
+            error: "memory.v3.edges.learnedAdjacencyThreshold must be a number",
+          })
+          .min(0, "memory.v3.edges.learnedAdjacencyThreshold must be >= 0")
+          .default(0)
+          .describe(
+            "Weight cutoff for merging the learned co-retrieval graph (memory_v3_auto_edges) into the edge-expansion lane. When > 0, edges at or above this weight are read via aboveThreshold() and merged with the curated frontmatter graph as expandEdges' extraAdjacency. 0 (default) = OFF: the edge lane uses curated edges only and behavior is unchanged. Seed the learned graph with `assistant memory v3 seed-edges`.",
+          ),
+      })
+      .default({ learnedAdjacencyThreshold: 0 })
+      .describe(
+        "Edge-expansion lane configuration. Gates whether the learned co-retrieval graph augments the curated edge graph.",
+      ),
     ks: z
       .array(z.number({ error: "memory.v3.ks entries must be numbers" }))
       .default([5, 10, 25, 50])
@@ -599,6 +615,7 @@ export const MemoryV3ConfigSchema = z
     denseQuota: { activeDomain: 30, offDomain: 8 },
     hotLimit: 50,
     lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
+    edges: { learnedAdjacencyThreshold: 0 },
     ks: [5, 10, 25, 50],
     write: {
       enabled: false,

--- a/assistant/src/memory/v3/__tests__/coretrieval-seed.test.ts
+++ b/assistant/src/memory/v3/__tests__/coretrieval-seed.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for `assistant/src/memory/v3/coretrieval-seed.ts`.
+ *
+ *   - `buildCoretrievalGraph` (pure): co-occurrence counting, the min-count
+ *     floor, the always-on frequency exclusion, NPMI ranking, and the top-K cap.
+ *   - `seedCoretrievalEdges` (driver): reads router selections from
+ *     `memory_v2_activation_logs`, persists the graph into `memory_v3_auto_edges`
+ *     in the shape `aboveThreshold` reads back, and is idempotent.
+ *
+ * Generic slugs only (page-a, topic-x, …) — no real content.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import type { DrizzleDb } from "../../db-connection.js";
+import {
+  buildCoretrievalGraph,
+  seedCoretrievalEdges,
+} from "../coretrieval-seed.js";
+
+describe("buildCoretrievalGraph", () => {
+  const opts = { minCount: 2, maxNeighborFreqRatio: 1, topK: 10 };
+
+  test("ignores turns with fewer than two distinct slugs", () => {
+    const graph = buildCoretrievalGraph(
+      [["page-a"], ["page-b"], ["page-a", "page-a"]],
+      opts,
+    );
+    expect(graph.size).toBe(0);
+  });
+
+  test("ranks a surprising association above a high-frequency one (NPMI)", () => {
+    // page-b appears only ever alongside page-a (perfectly associated); topic-c
+    // is high-frequency (appears all over), so its co-occurrence with page-a is
+    // unsurprising. NPMI must rank page-b above topic-c for source page-a.
+    const turns = [
+      ["page-a", "page-b"],
+      ["page-a", "page-b"],
+      ["page-a", "page-b"],
+      ["page-a", "page-b"],
+      ["page-a", "topic-c"],
+      ["page-a", "topic-c"],
+      ["page-a", "topic-c"],
+      ["page-a", "topic-c"],
+      ["topic-c", "page-d"],
+      ["topic-c", "page-d"],
+      ["topic-c", "page-d"],
+      ["topic-c", "page-d"],
+      ["topic-c", "page-d"],
+      ["topic-c", "page-d"],
+    ];
+    const graph = buildCoretrievalGraph(turns, opts);
+    const neighbors = graph.get("page-a")!;
+    expect(neighbors[0].target).toBe("page-b");
+    const bScore = neighbors.find((n) => n.target === "page-b")!.score;
+    const cScore = neighbors.find((n) => n.target === "topic-c")?.score ?? -1;
+    expect(bScore).toBeGreaterThan(cScore);
+  });
+
+  test("drops pairs below the min-count floor", () => {
+    const turns = [
+      ["page-a", "page-b"],
+      ["page-a", "page-b"], // page-a↔page-b co-occur twice
+      ["page-a", "page-c"], // page-a↔page-c co-occur once
+    ];
+    const strict = buildCoretrievalGraph(turns, { ...opts, minCount: 2 });
+    const targets = (strict.get("page-a") ?? []).map((n) => n.target);
+    expect(targets).toContain("page-b");
+    expect(targets).not.toContain("page-c");
+  });
+
+  test("excludes always-on neighbors above the frequency ratio", () => {
+    // topic-hub appears on every turn (always-on); page-b appears on few. With a
+    // 0.5 ratio cap, topic-hub is excluded as a neighbor even though it co-occurs.
+    const turns = [
+      ["page-a", "page-b", "topic-hub"],
+      ["page-a", "page-b", "topic-hub"],
+      ["page-x", "topic-hub"],
+      ["page-y", "topic-hub"],
+    ];
+    const graph = buildCoretrievalGraph(turns, {
+      minCount: 2,
+      maxNeighborFreqRatio: 0.5,
+      topK: 10,
+    });
+    const targets = (graph.get("page-a") ?? []).map((n) => n.target);
+    expect(targets).toContain("page-b");
+    expect(targets).not.toContain("topic-hub");
+  });
+
+  test("caps neighbors at top-K", () => {
+    const turns = [
+      ["src", "n1", "n2", "n3", "n4"],
+      ["src", "n1", "n2", "n3", "n4"],
+    ];
+    const graph = buildCoretrievalGraph(turns, { ...opts, topK: 2 });
+    expect(graph.get("src")!.length).toBe(2);
+  });
+});
+
+describe("seedCoretrievalEdges", () => {
+  function freshDb(): { db: DrizzleDb; sqlite: Database } {
+    const sqlite = new Database(":memory:");
+    sqlite.run(
+      `CREATE TABLE memory_v2_activation_logs (
+         id TEXT PRIMARY KEY, mode TEXT NOT NULL, concepts_json TEXT NOT NULL
+       )`,
+    );
+    sqlite.run(
+      `CREATE TABLE memory_v3_auto_edges (
+         source_slug TEXT NOT NULL, target_slug TEXT NOT NULL,
+         weight REAL NOT NULL, last_reinforced_at INTEGER NOT NULL,
+         PRIMARY KEY (source_slug, target_slug)
+       )`,
+    );
+    return { db: drizzle(sqlite) as unknown as DrizzleDb, sqlite };
+  }
+
+  function insertRouterTurn(
+    sqlite: Database,
+    id: string,
+    slugs: string[],
+  ): void {
+    const concepts = slugs.map((slug) => ({ slug, status: "injected" }));
+    sqlite.run(
+      `INSERT INTO memory_v2_activation_logs (id, mode, concepts_json) VALUES (?, 'router', ?)`,
+      [id, JSON.stringify(concepts)],
+    );
+  }
+
+  test("persists the co-retrieval graph in the shape aboveThreshold reads", () => {
+    const { db, sqlite } = freshDb();
+    for (let i = 0; i < 4; i++) {
+      insertRouterTurn(sqlite, `t${i}`, ["page-a", "page-b"]);
+    }
+    // A non-router row must be ignored.
+    sqlite.run(
+      `INSERT INTO memory_v2_activation_logs (id, mode, concepts_json) VALUES ('x', 'v3_shadow', ?)`,
+      [JSON.stringify([{ slug: "noise-a", status: "injected" }])],
+    );
+
+    const result = seedCoretrievalEdges(db, {
+      minCount: 2,
+      maxNeighborFreqRatio: 1,
+      topK: 10,
+      seedWeight: 2,
+    });
+
+    expect(result.turnsScanned).toBe(4);
+    expect(result.edgesWritten).toBeGreaterThan(0);
+
+    // Assert via a direct table read (not auto-edges' aboveThreshold, which a
+    // sibling test file mocks) so the seed's persistence is verified in
+    // isolation. The edge is symmetric: both directions are written.
+    const pairs = (
+      sqlite
+        .query(
+          `SELECT source_slug, target_slug FROM memory_v3_auto_edges WHERE weight >= 1`,
+        )
+        .all() as Array<{ source_slug: string; target_slug: string }>
+    ).map((r) => `${r.source_slug}->${r.target_slug}`);
+    expect(pairs).toContain("page-a->page-b");
+    expect(pairs).toContain("page-b->page-a");
+  });
+
+  test("is idempotent — re-running does not inflate weights", () => {
+    const { db, sqlite } = freshDb();
+    for (let i = 0; i < 4; i++) {
+      insertRouterTurn(sqlite, `t${i}`, ["page-a", "page-b"]);
+    }
+    const seedOpts = {
+      minCount: 2,
+      maxNeighborFreqRatio: 1,
+      topK: 10,
+      seedWeight: 2,
+    };
+    seedCoretrievalEdges(db, seedOpts);
+    seedCoretrievalEdges(db, seedOpts);
+
+    const row = sqlite
+      .query(
+        `SELECT weight FROM memory_v3_auto_edges WHERE source_slug = 'page-a' AND target_slug = 'page-b'`,
+      )
+      .get() as { weight: number };
+    expect(row.weight).toBe(2);
+  });
+
+  test("returns an empty summary when there are no router turns", () => {
+    const { db } = freshDb();
+    const result = seedCoretrievalEdges(db);
+    expect(result).toEqual({
+      turnsScanned: 0,
+      nodes: 0,
+      edgesWritten: 0,
+      avgDegree: 0,
+    });
+  });
+});

--- a/assistant/src/memory/v3/__tests__/loop.test.ts
+++ b/assistant/src/memory/v3/__tests__/loop.test.ts
@@ -96,7 +96,10 @@ const laneCalls = {
     nowText: string;
     scouts: ScoutResult[];
   }>,
-  edges: [] as Array<{ seeds: string[] }>,
+  edges: [] as Array<{
+    seeds: string[];
+    extraAdjacency?: ReadonlyMap<string, ReadonlySet<string>>;
+  }>,
   gate: [] as Array<{
     nowText: string;
     passNumber: number;
@@ -114,6 +117,14 @@ let scoutCallCount = 0;
 let walkCallCount = 0;
 let edgeCallCount = 0;
 let gateCallCount = 0;
+
+// Learned-adjacency mock state: what `aboveThreshold` returns, and a recorder of
+// the thresholds the loop read it at (empty when the loop never reads it).
+let aboveThresholdCalls: Array<{ threshold: number }> = [];
+let learnedAdjacencyResult: ReadonlyMap<
+  string,
+  ReadonlySet<string>
+> = new Map();
 
 mock.module("../scouts.js", () => ({
   runScouts: async (input: RetrievalInput): Promise<RunScoutsResult> => {
@@ -156,9 +167,20 @@ mock.module("../tree-walk.js", () => ({
 mock.module("../edges.js", () => ({
   expandEdges: async (args: {
     seeds: Iterable<string>;
+    extraAdjacency?: ReadonlyMap<string, ReadonlySet<string>>;
   }): Promise<ExpandResult> => {
-    laneCalls.edges.push({ seeds: [...args.seeds] });
+    laneCalls.edges.push({
+      seeds: [...args.seeds],
+      extraAdjacency: args.extraAdjacency,
+    });
     return nextOf(lane.edges, edgeCallCount++);
+  },
+}));
+
+mock.module("../auto-edges.js", () => ({
+  aboveThreshold: (_db: unknown, threshold: number) => {
+    aboveThresholdCalls.push({ threshold });
+    return learnedAdjacencyResult;
   },
 }));
 
@@ -225,6 +247,7 @@ function makeInput(opts?: {
   nowText?: string;
   passCap?: number;
   lanes?: LaneConfig;
+  edgesThreshold?: number;
 }): RetrievalInput {
   const lanes = {
     hot: true,
@@ -240,7 +263,13 @@ function makeInput(opts?: {
     nowText: opts?.nowText ?? "NOW",
     priorEverInjected: [],
     config: {
-      memory: { v3: { passCap: opts?.passCap ?? 3, lanes } },
+      memory: {
+        v3: {
+          passCap: opts?.passCap ?? 3,
+          lanes,
+          edges: { learnedAdjacencyThreshold: opts?.edgesThreshold ?? 0 },
+        },
+      },
     } as unknown as RetrievalInput["config"],
   };
 }
@@ -272,6 +301,8 @@ function reset(): void {
   walkCallCount = 0;
   edgeCallCount = 0;
   gateCallCount = 0;
+  aboveThresholdCalls = [];
+  learnedAdjacencyResult = new Map();
 }
 
 beforeEach(reset);
@@ -697,5 +728,48 @@ describe("runRetrievalLoop — failure + cost", () => {
 
     expect(out.trace?.passes).toHaveLength(3);
     expect(out.cost?.ms).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("runRetrievalLoop — learned edge adjacency", () => {
+  /** Minimal single-pass fixture; the edge lane is the subject under test. */
+  function singlePassFixture(): void {
+    lane.scouts = [
+      {
+        scouts: [scout("hot", ["seed-x"])],
+        sticky: new Set(),
+        bypass: new Set(),
+      },
+    ];
+    lane.filter = [{ kept: [], trace: { judged: [], dropped: [] } }];
+    lane.walk = [{ pages: new Set(), levels: [] }];
+    lane.edges = [
+      {
+        pulled: new Set(["learned-y"]),
+        expansions: [{ from: "seed-x", pulled: ["learned-y"] }],
+      },
+    ];
+    lane.gate = [readyGate(["seed-x", "learned-y"])];
+  }
+
+  test("reads and merges learned adjacency into edge expansion when threshold > 0", async () => {
+    singlePassFixture();
+    learnedAdjacencyResult = new Map([["seed-x", new Set(["learned-y"])]]);
+
+    await runRetrievalLoop(makeInput({ edgesThreshold: 1.5 }), { db });
+
+    // The loop reads the learned graph once at the configured threshold and
+    // hands it to the edge lane as extraAdjacency.
+    expect(aboveThresholdCalls).toEqual([{ threshold: 1.5 }]);
+    expect(laneCalls.edges[0].extraAdjacency).toBe(learnedAdjacencyResult);
+  });
+
+  test("does not read or pass learned adjacency when the threshold is 0", async () => {
+    singlePassFixture();
+
+    await runRetrievalLoop(makeInput({ edgesThreshold: 0 }), { db });
+
+    expect(aboveThresholdCalls).toHaveLength(0);
+    expect(laneCalls.edges[0].extraAdjacency).toBeUndefined();
   });
 });

--- a/assistant/src/memory/v3/coretrieval-seed.ts
+++ b/assistant/src/memory/v3/coretrieval-seed.ts
@@ -1,0 +1,239 @@
+/**
+ * Memory v3 — co-retrieval edge seeding.
+ *
+ * Warm-starts the learned association graph (`memory_v3_auto_edges`, migration
+ * 263) from the v2 router's selection history. The live edge-learning job
+ * (`edge-learning-job.ts`) only accrues edges from v3's own retrievals, which is
+ * cold until v3 has run for a long time; the v2 router has thousands of turns of
+ * co-selection data already. Seeding projects that history into the same table
+ * the `aboveThreshold` read path already consumes, so the edge-expansion lane
+ * can merge it (via `expandEdges`'s `extraAdjacency` seam) the moment it's wired.
+ *
+ * Signal: two pages that the router *selected together* on a turn are associated.
+ * Scoring is **NPMI** (normalized pointwise mutual information), not raw
+ * co-occurrence — NPMI discounts high-frequency pages, so an always-injected page
+ * doesn't edge to everything it merely co-occurs with. A min co-occurrence floor
+ * drops noise, and an "always-on" frequency ceiling drops pages selected on a
+ * large fraction of all turns (heartbeat/now-md-style infrastructure) that carry
+ * no associative signal.
+ *
+ * `buildCoretrievalGraph` is pure (no I/O) so it is unit-testable; the
+ * `seedCoretrievalEdges` driver reads the rows and writes the table.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("memory-v3-coretrieval-seed");
+
+/** A pair must co-occur on at least this many turns to earn an edge. */
+export const DEFAULT_MIN_COUNT = 5;
+/**
+ * A candidate *neighbor* selected on more than this fraction of all turns is
+ * "always-on" infrastructure (co-occurs with everything) and is excluded — it
+ * carries no associative signal, only base-rate noise.
+ */
+export const DEFAULT_MAX_NEIGHBOR_FREQ_RATIO = 0.4;
+/** Neighbors kept per source node, ranked by NPMI descending. */
+export const DEFAULT_TOP_K = 20;
+/**
+ * Flat weight each seeded edge is written at. Chosen above a typical read
+ * threshold so seeded edges traverse immediately, and above a single live
+ * reinforcement so the edge-learning decay doesn't age a fresh seed straight
+ * out on its first pass.
+ */
+export const DEFAULT_SEED_WEIGHT = 2.0;
+
+/** Tuning knobs for {@link buildCoretrievalGraph}. */
+export interface CoretrievalGraphOptions {
+  minCount: number;
+  maxNeighborFreqRatio: number;
+  topK: number;
+}
+
+/** Driver knobs: graph tuning plus the persisted seed weight. */
+export interface SeedCoretrievalOptions extends CoretrievalGraphOptions {
+  seedWeight: number;
+}
+
+export const DEFAULT_SEED_OPTIONS: SeedCoretrievalOptions = {
+  minCount: DEFAULT_MIN_COUNT,
+  maxNeighborFreqRatio: DEFAULT_MAX_NEIGHBOR_FREQ_RATIO,
+  topK: DEFAULT_TOP_K,
+  seedWeight: DEFAULT_SEED_WEIGHT,
+};
+
+/** One scored outgoing edge. */
+export interface ScoredEdge {
+  target: string;
+  score: number;
+}
+
+/** Summary of one seeding run, for the CLI/route report. */
+export interface SeedCoretrievalResult {
+  turnsScanned: number;
+  nodes: number;
+  edgesWritten: number;
+  avgDegree: number;
+}
+
+/**
+ * Build the co-retrieval adjacency from per-turn selected-slug sets.
+ *
+ * Pure: takes the already-extracted selection sets (one array per turn) and
+ * returns `source -> ScoredEdge[]` (top-K NPMI neighbors, heaviest first). Turns
+ * with fewer than two distinct slugs contribute no pairs and are ignored.
+ */
+export function buildCoretrievalGraph(
+  turns: ReadonlyArray<ReadonlyArray<string>>,
+  options: CoretrievalGraphOptions = DEFAULT_SEED_OPTIONS,
+): Map<string, ScoredEdge[]> {
+  const sets = turns.map((t) => [...new Set(t)]).filter((s) => s.length >= 2);
+  const n = sets.length;
+  const graph = new Map<string, ScoredEdge[]>();
+  if (n === 0) return graph;
+
+  const freq = new Map<string, number>();
+  const cooccur = new Map<string, Map<string, number>>();
+  const bump = (a: string, b: string) => {
+    let row = cooccur.get(a);
+    if (!row) cooccur.set(a, (row = new Map()));
+    row.set(b, (row.get(b) ?? 0) + 1);
+  };
+  for (const slugs of sets) {
+    for (const slug of slugs) freq.set(slug, (freq.get(slug) ?? 0) + 1);
+    for (let i = 0; i < slugs.length; i++) {
+      for (let j = i + 1; j < slugs.length; j++) {
+        bump(slugs[i], slugs[j]);
+        bump(slugs[j], slugs[i]);
+      }
+    }
+  }
+
+  const freqCap = options.maxNeighborFreqRatio * n;
+  for (const [source, neighbors] of cooccur) {
+    const fSource = freq.get(source)!;
+    const scored: ScoredEdge[] = [];
+    for (const [target, pairCount] of neighbors) {
+      if (pairCount < options.minCount) continue;
+      const fTarget = freq.get(target)!;
+      if (fTarget > freqCap) continue;
+      // NPMI = pmi / -ln(p(a,b)), in [-1, 1]. Higher = stronger association.
+      // p(a,b)=1 (the pair co-occurs on every turn) is perfect association — its
+      // NPMI limit is 1, but the formula is 0/0, so pin it to avoid NaN.
+      const pab = pairCount / n;
+      if (pab >= 1) {
+        scored.push({ target, score: 1 });
+        continue;
+      }
+      const pmi = Math.log(pab / ((fSource / n) * (fTarget / n)));
+      scored.push({ target, score: pmi / -Math.log(pab) });
+    }
+    scored.sort((a, b) => b.score - a.score);
+    if (scored.length > 0) graph.set(source, scored.slice(0, options.topK));
+  }
+  return graph;
+}
+
+/**
+ * Extract one selection set per v2 router turn from `memory_v2_activation_logs`.
+ * The set is the router's *fresh* per-turn pick (`status === 'injected'`), which
+ * is the co-selection signal we want — not the accumulated in-context carry-over.
+ *
+ * Best-effort: a missing table (db predates the activation log) or an unparseable
+ * row yields no turns rather than throwing — the caller degrades to "no seed".
+ */
+function readRouterSelections(database: DrizzleDb): string[][] {
+  const turns: string[][] = [];
+  try {
+    const raw = getSqliteFrom(database);
+    const rows = raw
+      .query(
+        `SELECT concepts_json FROM memory_v2_activation_logs WHERE mode = 'router'`,
+      )
+      .all() as Array<{ concepts_json: string }>;
+    for (const row of rows) {
+      let concepts: unknown;
+      try {
+        concepts = JSON.parse(row.concepts_json);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(concepts)) continue;
+      const selected = new Set<string>();
+      for (const entry of concepts) {
+        if (
+          entry &&
+          typeof entry === "object" &&
+          (entry as { status?: unknown }).status === "injected" &&
+          typeof (entry as { slug?: unknown }).slug === "string"
+        ) {
+          selected.add((entry as { slug: string }).slug);
+        }
+      }
+      if (selected.size >= 2) turns.push([...selected]);
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to read router selections for seeding; continuing",
+    );
+  }
+  return turns;
+}
+
+/**
+ * Build the co-retrieval graph from the v2 router history and persist it into
+ * `memory_v3_auto_edges` at a flat seed weight.
+ *
+ * Idempotent: each edge is upserted with `weight = MAX(existing, seedWeight)`, so
+ * re-running refreshes seeded edges to the seed weight without unbounded growth
+ * and without lowering any weight a live reinforcement already drove higher.
+ */
+export function seedCoretrievalEdges(
+  database: DrizzleDb,
+  options: SeedCoretrievalOptions = DEFAULT_SEED_OPTIONS,
+): SeedCoretrievalResult {
+  const turns = readRouterSelections(database);
+  const graph = buildCoretrievalGraph(turns, options);
+
+  const now = Date.now();
+  let edgesWritten = 0;
+  try {
+    const raw = getSqliteFrom(database);
+    const upsert = raw.prepare(
+      `INSERT INTO memory_v3_auto_edges
+         (source_slug, target_slug, weight, last_reinforced_at)
+         VALUES (?, ?, ?, ?)
+       ON CONFLICT(source_slug, target_slug) DO UPDATE SET
+         weight = MAX(weight, ?),
+         last_reinforced_at = ?`,
+    );
+    const apply = raw.transaction(() => {
+      for (const [source, edges] of graph) {
+        for (const edge of edges) {
+          upsert.run(
+            source,
+            edge.target,
+            options.seedWeight,
+            now,
+            options.seedWeight,
+            now,
+          );
+          edgesWritten += 1;
+        }
+      }
+    });
+    apply();
+  } catch (err) {
+    log.warn({ err }, "failed to persist seeded co-retrieval edges");
+  }
+
+  return {
+    turnsScanned: turns.length,
+    nodes: graph.size,
+    edgesWritten,
+    avgDegree: graph.size > 0 ? edgesWritten / graph.size : 0,
+  };
+}

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -59,6 +59,7 @@ import type {
   GateDecision,
 } from "../v2/harness/trace.js";
 import { getPageIndex } from "../v2/page-index.js";
+import { aboveThreshold } from "./auto-edges.js";
 import {
   type CoactivationRow,
   recordCoactivations,
@@ -112,6 +113,15 @@ export async function runRetrievalLoop(
   const v3 = input.config.memory.v3;
   const passCap = Math.max(1, v3.passCap);
   const lanes = v3.lanes;
+
+  // Learned co-retrieval adjacency (memory_v3_auto_edges), read once and merged
+  // into the edge lane's curated graph when the threshold is set. At threshold 0
+  // (the default) this is undefined and edge behavior is identical to before.
+  const learnedAdjacencyThreshold = v3.edges?.learnedAdjacencyThreshold ?? 0;
+  const learnedAdjacency =
+    learnedAdjacencyThreshold > 0
+      ? aboveThreshold(deps.db, learnedAdjacencyThreshold)
+      : undefined;
 
   // Cross-pass accumulators.
   const sourceBySlug = new Map<string, LaneSource>();
@@ -226,6 +236,9 @@ export async function runRetrievalLoop(
         // hot) so the seed cap spends its budget on query-relevant seeds, not
         // recency. `sourceBySlug` holds each candidate's first-seen lane.
         laneBySlug: sourceBySlug,
+        // Merge the learned co-retrieval graph with the curated edges when
+        // enabled (undefined = curated-only, the default).
+        ...(learnedAdjacency ? { extraAdjacency: learnedAdjacency } : {}),
       });
       edgeExpansions = expansion.expansions;
       for (const slug of expansion.pulled) {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -492,6 +492,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v3/tree:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v3/simulate:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v3/shadow-diff:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v3/seed-edges:POST", scopes: ["settings.write"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -29,6 +29,11 @@ import type {
 } from "../../memory/v2/harness/retriever.js";
 import type { DescentTrace } from "../../memory/v2/harness/trace.js";
 import { loadNowText } from "../../memory/v2/now-text.js";
+import {
+  DEFAULT_SEED_OPTIONS,
+  seedCoretrievalEdges,
+  type SeedCoretrievalResult,
+} from "../../memory/v3/coretrieval-seed.js";
 import type { LlmCallRecord } from "../../memory/v3/llm-capture.js";
 import { runRetrievalLoop } from "../../memory/v3/loop.js";
 import type {
@@ -63,6 +68,7 @@ export type {
   SlugFrequency,
   UnpairedShadowTurn,
 };
+export type { SeedCoretrievalResult };
 
 // ── Validate ────────────────────────────────────────────────────────────
 
@@ -353,6 +359,58 @@ async function handleShadowDiff({
   });
 }
 
+// ── Seed co-retrieval edges ───────────────────────────────────────────────
+
+const MemoryV3SeedEdgesParams = z
+  .object({
+    /** A pair must co-occur on at least this many router turns to earn an edge. */
+    minCount: z
+      .number()
+      .int("memory.v3.seed-edges minCount must be an integer")
+      .positive("memory.v3.seed-edges minCount must be positive")
+      .optional(),
+    /** Neighbors kept per source node, ranked by NPMI descending. */
+    topK: z
+      .number()
+      .int("memory.v3.seed-edges topK must be an integer")
+      .positive("memory.v3.seed-edges topK must be positive")
+      .optional(),
+    /** Exclude neighbors selected on more than this fraction of all turns. */
+    maxNeighborFreqRatio: z
+      .number()
+      .positive("memory.v3.seed-edges maxNeighborFreqRatio must be positive")
+      .max(1, "memory.v3.seed-edges maxNeighborFreqRatio must be <= 1")
+      .optional(),
+    /** Flat weight each seeded edge is written at. */
+    seedWeight: z
+      .number()
+      .positive("memory.v3.seed-edges seedWeight must be positive")
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Build the co-retrieval graph from the v2 router's selection history and
+ * persist it into `memory_v3_auto_edges`. This is the one write surface among
+ * the v3 routes — it warm-starts the learned edge graph that the edge-expansion
+ * lane merges (when `memory.v3.edges.learnedAdjacencyThreshold > 0`). Idempotent:
+ * re-running upserts each seeded edge to the flat seed weight without unbounded
+ * growth. Runs no LLM.
+ */
+async function handleSeedEdges({
+  body = {},
+}: RouteHandlerArgs): Promise<SeedCoretrievalResult> {
+  const { minCount, topK, maxNeighborFreqRatio, seedWeight } =
+    MemoryV3SeedEdgesParams.parse(body);
+  return seedCoretrievalEdges(getDb(), {
+    minCount: minCount ?? DEFAULT_SEED_OPTIONS.minCount,
+    topK: topK ?? DEFAULT_SEED_OPTIONS.topK,
+    maxNeighborFreqRatio:
+      maxNeighborFreqRatio ?? DEFAULT_SEED_OPTIONS.maxNeighborFreqRatio,
+    seedWeight: seedWeight ?? DEFAULT_SEED_OPTIONS.seedWeight,
+  });
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -401,5 +459,16 @@ export const ROUTES: RouteDefinition[] = [
       "Compares the v3 shadow-mode selections against the live v2 router selections turn-for-turn, from the memory activation log. Pairs each v3_shadow row with the nearest v2 router row in the same conversation (by timestamp, within a tolerance — the turn columns use different counters), then reports per-turn and aggregate overlap, what v3 surfaced that v2 did not, and what v2 had that v3 dropped, broken down by v3 provenance lane. The v2 comparand is the router's fresh per-turn pick (status='injected'), not its accumulated in-context set. Requires that v3 shadow mode has been running so v3_shadow rows exist; the route runs no LLM and writes nothing.",
     tags: ["memory"],
     requestBody: MemoryV3ShadowDiffParams,
+  },
+  {
+    operationId: "memory_v3_seed_edges",
+    method: "POST",
+    endpoint: "memory/v3/seed-edges",
+    handler: handleSeedEdges,
+    summary: "Seed the learned co-retrieval edge graph from v2 router history",
+    description:
+      "Builds an NPMI-scored co-retrieval graph from the v2 router's per-turn selections (memory_v2_activation_logs, status='injected') and persists it into memory_v3_auto_edges, warm-starting the learned edge graph that the v3 edge-expansion lane merges with curated edges when memory.v3.edges.learnedAdjacencyThreshold > 0. NPMI plus a min co-occurrence floor and an always-on frequency ceiling keep the neighborhoods associative rather than base-rate noise. Idempotent (upserts to a flat seed weight). Runs no LLM; the only write among the v3 routes.",
+    tags: ["memory"],
+    requestBody: MemoryV3SeedEdgesParams,
   },
 ];


### PR DESCRIPTION
## Summary
- Warm-start v3's learned association graph (`memory_v3_auto_edges`) from the v2 router's per-turn co-selection history (`memory_v2_activation_logs`, `status='injected'`), scored with **NPMI** plus a min co-occurrence floor and an always-on frequency ceiling so neighborhoods stay associative rather than dominated by always-injected pages. Exposed as a new `assistant memory v3 seed-edges` CLI command (the only write among the `memory v3` routes; idempotent).
- Wire the learned graph into the edge-expansion lane through `expandEdges`' existing `extraAdjacency` seam (`curated ∪ learned`), gated by a new `memory.v3.edges.learnedAdjacencyThreshold` knob — **default 0 = off**, so edge behavior is byte-for-byte unchanged until explicitly enabled.
- New `coretrieval-seed.ts` (pure `buildCoretrievalGraph` + driver), config schema knob, route + policy + OpenAPI, CLI subcommand + renderer, and tests (pure-function coverage + a loop-wiring test asserting the merge only happens when the threshold > 0).

## Original prompt
v3's edge-expansion lane is the de-facto source of the relationship/canon associations the selection gate surfaces, but it only walks hand-authored curated edges; the learned auto-edge graph it could also consume is cold because v3 shadow has barely run. This change warm-starts that learned graph from the v2 router's thousands of turns of co-selection data and wires it into the edge lane via the existing merge seam, behind a default-off threshold so it can be A/B'd via `memory v3 simulate` before any rollout. It is pre-production / flag-gated / shadow-only, so there is zero live-user impact; reuses `memory_v3_auto_edges` (no new table/migration).