### PR TITLE
feat(memory-v3): weight seeded co-retrieval edges by NPMI

### DIFF
--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -464,7 +464,7 @@ Examples:
         )
         .option(
           "--seed-weight <n>",
-          "Weight each seeded edge is written at (positive, default: 2.0)",
+          "Weight of a perfect-NPMI (1.0) edge; each edge stored at this × its NPMI (positive, default: 2.0)",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .addHelpText(

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -531,7 +531,7 @@ export const MemoryV3ConfigSchema = z
           .min(0, "memory.v3.edges.learnedAdjacencyThreshold must be >= 0")
           .default(0)
           .describe(
-            "Weight cutoff for merging the learned co-retrieval graph (memory_v3_auto_edges) into the edge-expansion lane. When > 0, edges at or above this weight are read via aboveThreshold() and merged with the curated frontmatter graph as expandEdges' extraAdjacency. 0 (default) = OFF: the edge lane uses curated edges only and behavior is unchanged. Seed the learned graph with `assistant memory v3 seed-edges`.",
+            "Association-strength cutoff for merging the learned co-retrieval graph (memory_v3_auto_edges) into the edge-expansion lane. Seeded edges are weighted seedWeight × NPMI, so this is effectively a minimum-NPMI gate: NPMI ≥ threshold / seedWeight (e.g. with the default seedWeight 2.0, threshold 1.0 ≈ NPMI ≥ 0.5, 1.2 ≈ NPMI ≥ 0.6). When > 0, edges at or above this weight are read via aboveThreshold() and merged with the curated frontmatter graph as expandEdges' extraAdjacency. 0 (default) = OFF: the edge lane uses curated edges only and behavior is unchanged. Seed the learned graph with `assistant memory v3 seed-edges`.",
           ),
       })
       .default({ learnedAdjacencyThreshold: 0 })

--- a/assistant/src/memory/v3/__tests__/coretrieval-seed.test.ts
+++ b/assistant/src/memory/v3/__tests__/coretrieval-seed.test.ts
@@ -194,6 +194,69 @@ describe("seedCoretrievalEdges", () => {
     expect(row.weight).toBe(2);
   });
 
+  test("weights edges by NPMI — a stronger association gets a higher weight", () => {
+    const { db, sqlite } = freshDb();
+    // page-b co-occurs with page-a more than page-c does (both exclusive to
+    // page-a), so NPMI(a,b) > NPMI(a,c) > 0; the filler turns lower base rates.
+    for (let i = 0; i < 3; i++)
+      insertRouterTurn(sqlite, `ab${i}`, ["page-a", "page-b"]);
+    for (let i = 0; i < 2; i++)
+      insertRouterTurn(sqlite, `ac${i}`, ["page-a", "page-c"]);
+    for (let i = 0; i < 5; i++)
+      insertRouterTurn(sqlite, `de${i}`, ["topic-d", "topic-e"]);
+
+    seedCoretrievalEdges(db, {
+      minCount: 2,
+      maxNeighborFreqRatio: 1,
+      topK: 10,
+      seedWeight: 2,
+    });
+
+    const weightOf = (s: string, t: string) =>
+      (
+        sqlite
+          .query(
+            `SELECT weight FROM memory_v3_auto_edges WHERE source_slug = ? AND target_slug = ?`,
+          )
+          .get(s, t) as { weight: number } | null
+      )?.weight;
+    const wAB = weightOf("page-a", "page-b");
+    const wAC = weightOf("page-a", "page-c");
+    expect(wAC).toBeGreaterThan(0);
+    expect(wAB!).toBeGreaterThan(wAC!);
+    // NPMI < 1 for a non-exclusive pair, so weight stays below the perfect-
+    // association seedWeight.
+    expect(wAB!).toBeLessThan(2);
+  });
+
+  test("skips edges with non-positive NPMI (co-occur at or below chance)", () => {
+    const { db, sqlite } = freshDb();
+    // page-a and page-b are each frequent but seldom together (below chance) =>
+    // negative NPMI => skipped. page-a/topic-x co-occur above chance => kept.
+    for (let i = 0; i < 4; i++)
+      insertRouterTurn(sqlite, `ax${i}`, ["page-a", "topic-x"]);
+    for (let i = 0; i < 4; i++)
+      insertRouterTurn(sqlite, `by${i}`, ["page-b", "topic-y"]);
+    for (let i = 0; i < 2; i++)
+      insertRouterTurn(sqlite, `ab${i}`, ["page-a", "page-b"]);
+
+    seedCoretrievalEdges(db, {
+      minCount: 2,
+      maxNeighborFreqRatio: 1,
+      topK: 10,
+      seedWeight: 2,
+    });
+
+    const has = (s: string, t: string) =>
+      sqlite
+        .query(
+          `SELECT 1 FROM memory_v3_auto_edges WHERE source_slug = ? AND target_slug = ?`,
+        )
+        .get(s, t) !== null;
+    expect(has("page-a", "topic-x")).toBe(true);
+    expect(has("page-a", "page-b")).toBe(false);
+  });
+
   test("returns an empty summary when there are no router turns", () => {
     const { db } = freshDb();
     const result = seedCoretrievalEdges(db);

--- a/assistant/src/memory/v3/coretrieval-seed.ts
+++ b/assistant/src/memory/v3/coretrieval-seed.ts
@@ -38,10 +38,10 @@ export const DEFAULT_MAX_NEIGHBOR_FREQ_RATIO = 0.4;
 /** Neighbors kept per source node, ranked by NPMI descending. */
 export const DEFAULT_TOP_K = 20;
 /**
- * Flat weight each seeded edge is written at. Chosen above a typical read
- * threshold so seeded edges traverse immediately, and above a single live
- * reinforcement so the edge-learning decay doesn't age a fresh seed straight
- * out on its first pass.
+ * Weight of a perfect-association (NPMI = 1) edge. Each edge is persisted at
+ * `seedWeight × its NPMI score`, so the read threshold
+ * (`memory.v3.edges.learnedAdjacencyThreshold`) acts as a minimum-association
+ * cutoff: with the default 2.0, threshold 1.0 ≈ NPMI ≥ 0.5 and 1.2 ≈ NPMI ≥ 0.6.
  */
 export const DEFAULT_SEED_WEIGHT = 2.0;
 
@@ -185,11 +185,17 @@ function readRouterSelections(database: DrizzleDb): string[][] {
 
 /**
  * Build the co-retrieval graph from the v2 router history and persist it into
- * `memory_v3_auto_edges` at a flat seed weight.
+ * `memory_v3_auto_edges`, weighting each edge by its association strength:
+ * `weight = seedWeight × NPMI`. Edges whose weight is non-positive (NPMI ≤ 0 —
+ * not an association) are skipped. This makes the read threshold a real
+ * minimum-association cutoff rather than all-or-nothing.
  *
- * Idempotent: each edge is upserted with `weight = MAX(existing, seedWeight)`, so
- * re-running refreshes seeded edges to the seed weight without unbounded growth
- * and without lowering any weight a live reinforcement already drove higher.
+ * Idempotent: each edge is upserted by OVERWRITING its weight to the current
+ * NPMI-derived value (the seed baseline), so re-running is stable. Tradeoff: the
+ * overwrite resets any reinforcement the edge-learning job accrued between seeds.
+ * That is acceptable while the seed is the dominant signal and organic
+ * co-activation reinforcement is minimal; revisit if/when live reinforcement
+ * becomes load-bearing.
  */
 export function seedCoretrievalEdges(
   database: DrizzleDb,
@@ -207,20 +213,15 @@ export function seedCoretrievalEdges(
          (source_slug, target_slug, weight, last_reinforced_at)
          VALUES (?, ?, ?, ?)
        ON CONFLICT(source_slug, target_slug) DO UPDATE SET
-         weight = MAX(weight, ?),
-         last_reinforced_at = ?`,
+         weight = excluded.weight,
+         last_reinforced_at = excluded.last_reinforced_at`,
     );
     const apply = raw.transaction(() => {
       for (const [source, edges] of graph) {
         for (const edge of edges) {
-          upsert.run(
-            source,
-            edge.target,
-            options.seedWeight,
-            now,
-            options.seedWeight,
-            now,
-          );
+          const weight = options.seedWeight * edge.score;
+          if (weight <= 0) continue;
+          upsert.run(source, edge.target, weight, now);
           edgesWritten += 1;
         }
       }


### PR DESCRIPTION
## Summary
- Persist `weight = seedWeight × NPMI` for each seeded co-retrieval edge instead of a flat `seedWeight` (2.0). This makes `memory.v3.edges.learnedAdjacencyThreshold` a real **association-strength cutoff** (with the default seedWeight 2.0, threshold 1.0 ≈ NPMI ≥ 0.5, 1.2 ≈ NPMI ≥ 0.6). The flat weight made the threshold all-or-nothing — any threshold in (0, 2] admitted every seeded edge.
- Skip edges whose `seedWeight × NPMI` is non-positive (co-occur at/below chance — not associations).
- The seed upsert now **overwrites** the weight to the current NPMI baseline (was `MAX(weight, …)`). `MAX` would freeze a prior higher value (e.g. a previously-seeded flat 2.0) and stop the NPMI weight from taking effect. Tradeoff: re-seeding resets any organic reinforcement accrued between seeds — acceptable while seeding is the dominant signal and live co-activation reinforcement is minimal pre-production.
- Doc/description updates (DEFAULT_SEED_WEIGHT, the config knob, the CLI `--seed-weight` help); two new tests (NPMI scaling: stronger association → higher weight; non-positive NPMI skipped).

## Original prompt
Follow-up to #32203, which seeds v3's learned edge graph from the v2 router's co-selection history but wrote every edge at a flat weight. An offline A/B showed the flat weight produced no canon-recall gain (the strength threshold was all-or-nothing), whereas weighting edges by their NPMI and applying a strength threshold turned it into a clear gain — the gate selected more relationship canon and, at a stronger threshold, re-targeted toward canon rather than just inflating volume. This change persists the NPMI score (already computed in `buildCoretrievalGraph`) as the edge weight so the threshold actually selects. Still default-off (threshold 0) and pre-production/shadow — zero live impact.