### PR TITLE
fix(web/chat): match collapsed sidebar group icon size to nav icons

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -88,7 +88,7 @@ export function CollapsedGroupIcon({
         title="No conversations"
         className="relative flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--content-disabled)]"
       >
-        <Icon size={18} />
+        <Icon size={14} />
       </div>
     );
   }
@@ -102,7 +102,7 @@ export function CollapsedGroupIcon({
           aria-haspopup="dialog"
           className="relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
         >
-          <Icon size={18} />
+          <Icon size={14} />
           {indicatorState != null ? (
             <span
               aria-hidden


### PR DESCRIPTION
## Summary
- Reduced `CollapsedGroupIcon` icon size from 18px to 14px to match the `SideMenu.Item` nav icon size
- The mismatch was introduced in #32078 — system group icons (pin, clock, calendar, layers, hash) rendered 28% larger than nav icons (brain, grid, globe) in the collapsed sidebar

## Test plan
- [ ] Open the web app with collapsed sidebar
- [ ] Verify system group icons (pin, clock, calendar, layers, hash) are the same visual size as nav icons (brain, grid, globe) above the divider
- [ ] Verify indicator dots still render correctly on group icons
- [ ] Verify popover still opens on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)