### PR TITLE
fix(web): silence React Router HydrateFallback warning (LUM-1947)

### DIFF
--- a/apps/web/src/components/root-hydrate-fallback.tsx
+++ b/apps/web/src/components/root-hydrate-fallback.tsx
@@ -1,0 +1,22 @@
+import { Loader2 } from "lucide-react";
+
+/**
+ * Rendered by React Router during initial hydration while the matched
+ * route's lazy chunk is loading. Without this, the router logs a
+ * `No HydrateFallback element provided…` warning and renders `null`
+ * (blank screen) during the brief async resolution window.
+ *
+ * Reference: https://reactrouter.com/start/data/route-object#hydratefallback
+ */
+export function RootHydrateFallback() {
+  return (
+    <div
+      data-slot="root-hydrate-fallback"
+      className="flex min-h-svh items-center justify-center"
+      role="status"
+      aria-label="Loading"
+    >
+      <Loader2 className="size-6 animate-spin text-[var(--content-tertiary)]" />
+    </div>
+  );
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -7,6 +7,7 @@ import { ChatPage } from "@/domains/chat/chat-page";
 import { ConversationRedirect } from "@/domains/chat/conversation-redirect";
 import { NotFound } from "@/components/not-found";
 import { RootErrorBoundary } from "@/components/root-error-boundary";
+import { RootHydrateFallback } from "@/components/root-hydrate-fallback";
 import { ActiveAssistantGate } from "@/components/layout/active-assistant-gate";
 
 // Route tree — no basename, routes are absolute browser paths.
@@ -31,6 +32,7 @@ export const router = createBrowserRouter(
     {
       path: "/account",
       ErrorBoundary: RootErrorBoundary,
+      HydrateFallback: RootHydrateFallback,
       children: [
         { index: true, lazy: { Component: () => import("@/domains/account/pages/account-page").then((m) => m.AccountPage) } },
         { path: "login", lazy: { Component: () => import("@/domains/account/pages/login-page").then((m) => m.LoginPage) } },
@@ -45,13 +47,14 @@ export const router = createBrowserRouter(
     },
 
     // Logout — standalone page, no app chrome
-    { path: "/logout", ErrorBoundary: RootErrorBoundary, lazy: { Component: () => import("@/domains/account/pages/logout-page").then((m) => m.LogoutPage) } },
+    { path: "/logout", ErrorBoundary: RootErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/domains/account/pages/logout-page").then((m) => m.LogoutPage) } },
 
     // Assistant routes — auth-protected app with layout
     {
       path: "/assistant",
       middleware: [authMiddleware],
       ErrorBoundary: RootErrorBoundary,
+      HydrateFallback: RootHydrateFallback,
       Component: RootLayout,
       children: [
         // Onboarding routes — full-screen (no ChatLayout sidebar).


### PR DESCRIPTION
Linear: https://linear.app/vellum/issue/LUM-1947

## Summary

- React Router v7 was logging `No HydrateFallback element provided to render during initial hydration` every time a lazy-resolved route hit on initial load, and rendering `null` (blank screen) during the brief async chunk fetch.
- Add `RootHydrateFallback` — a centered spinner matching the `RootErrorBoundary` shape — and attach it to each top-level route (`/account`, `/logout`, `/assistant`).

Surfaced during the LUM-1939 verification run, but the warning has been there since the move to lazy routes.

## Test plan

- [x] `bun run build` — no behavior change to bundle output
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] Driving the production preview build with a headless browser: warning count drops from 1 → 0 on landing, no new errors
- [ ] Manual: refresh `/assistant/` on a cold cache → spinner shows briefly, then route resolves

Reference: https://reactrouter.com/start/data/route-object#hydratefallback

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_