### PR TITLE
Keep background wake lease active during drain

### DIFF
--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -579,6 +579,117 @@ describe("background wake runtime routes", () => {
     });
   });
 
+  test("drain-due completes expired without starting when the lease deadline already elapsed", async () => {
+    const dueAt = Date.now() - 1;
+    computedIntent = intentFixture({
+      nextWakeAt: dueAt,
+      actualNextDueAt: dueAt,
+      reason: "mixed",
+    });
+    const heartbeatRunManaged = mock(async () => ({
+      due: true,
+      completed: 1,
+      skipped: 0,
+    }));
+    const schedulerRunDue = mock(async () =>
+      schedulerResultFixture({ claimed: 1, completed: 1 }),
+    );
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: dueAt,
+        runManagedWakeIfDue: heartbeatRunManaged,
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+
+    const response = await handler({
+      body: drainBodyFixture({
+        reason: "mixed",
+        deadlineAt: Date.now() - 1,
+      }),
+    });
+    await flushBackgroundWakeDrainsForTest();
+
+    expect(heartbeatRunManaged).not.toHaveBeenCalled();
+    expect(schedulerRunDue).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      accepted: true,
+      reason: "mixed",
+    });
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-123",
+      status: "expired",
+      error: "background wake lease deadline elapsed before starting work",
+    });
+  });
+
+  test("drain-due keeps a lease active until slow work settles after the original deadline", async () => {
+    const schedulerResolvers: Array<() => void> = [];
+    const schedulerRunDue = mock(async () => {
+      await new Promise<void>((resolve) => schedulerResolvers.push(resolve));
+      return schedulerResultFixture({ claimed: 1, completed: 1 });
+    });
+    registerBackgroundWakeRuntime({
+      heartbeat: {
+        nextRunAt: Date.now() + 60_000,
+        runManagedWakeIfDue: mock(async () => ({
+          due: false,
+          completed: 0,
+          skipped: 0,
+        })),
+      },
+      scheduler: {
+        runOnce: mock(async () => 1),
+        runDueWorkOnce: schedulerRunDue,
+      },
+    });
+    const handler = findHandler("drainDueBackgroundWake");
+    const deadlineAt = Date.now() + 10;
+
+    const firstResponse = await handler({
+      body: drainBodyFixture({
+        leaseId: "lease-long-running",
+        deadlineAt,
+      }),
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(mockCompleteBackgroundWakeLease).not.toHaveBeenCalled();
+
+      const duplicateResponse = await handler({
+        body: drainBodyFixture({
+          leaseId: "lease-long-running",
+          deadlineAt,
+        }),
+      });
+
+      expect(firstResponse).toMatchObject({
+        accepted: true,
+        leaseId: "lease-long-running",
+      });
+      expect(duplicateResponse).toMatchObject({
+        accepted: true,
+        leaseId: "lease-long-running",
+      });
+      expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    } finally {
+      for (const resolve of schedulerResolvers) resolve();
+    }
+
+    await flushBackgroundWakeDrainsForTest();
+    expect(schedulerRunDue).toHaveBeenCalledTimes(1);
+    expect(mockCompleteBackgroundWakeLease).toHaveBeenCalledTimes(1);
+    expect(lastCompletionPayload()).toMatchObject({
+      leaseId: "lease-long-running",
+      status: "completed",
+    });
+  });
+
   test("drain-due runs scheduler work even when pending work remains", async () => {
     const schedulerRunDue = mock(async () =>
       schedulerResultFixture({ claimed: 1, completed: 1, stillPending: 1 }),

--- a/assistant/src/runtime/routes/background-wake-routes.ts
+++ b/assistant/src/runtime/routes/background-wake-routes.ts
@@ -14,9 +14,14 @@ const PREPARE_SLEEP_DEFER_WINDOW_MS = 60_000;
 const HEARTBEAT_DUE_TOLERANCE_MS = 1_000;
 const MIN_DRAIN_START_BUDGET_MS = 5_000;
 const LEASE_RENEW_INTERVAL_MS = 120_000;
-// JS timers use signed 32-bit delays; larger values can overflow or clamp.
-const MAX_SET_TIMEOUT_DELAY_MS = 2_147_483_647;
 const log = getLogger("background-wake-routes");
+
+class DrainDeadlineElapsedError extends Error {
+  constructor() {
+    super("background wake lease deadline elapsed before starting work");
+    this.name = "DrainDeadlineElapsedError";
+  }
+}
 
 type RenewWakeLease = (leaseId: string) => Promise<unknown>;
 type CompleteWakeLease = (args: {
@@ -167,19 +172,17 @@ async function runDrainDueLease(
     }, LEASE_RENEW_INTERVAL_MS);
     renewTimer.unref?.();
 
-    const result = await withDrainDeadline(
-      performDrainDue(request, runtime),
-      request.deadlineAt,
-    );
+    assertDrainCanStart(request.deadlineAt);
+    const result = await performDrainDue(request, runtime);
     await reportLeaseCompletion({
       leaseId: request.leaseId,
-      status: Date.now() >= request.deadlineAt ? "expired" : "completed",
+      status: "completed",
       nextIntent: result.nextIntent,
     });
   } catch (error) {
     await reportLeaseCompletion({
       leaseId: request.leaseId,
-      status: Date.now() >= request.deadlineAt ? "expired" : "failed",
+      status: completionStatusForError(error),
       error: error instanceof Error ? error.message : String(error),
       nextIntent: computeWakeIntent(),
     });
@@ -239,29 +242,14 @@ async function performDrainDue(
   };
 }
 
-async function withDrainDeadline<T>(
-  work: Promise<T>,
-  deadlineAt: number,
-): Promise<T> {
-  const remainingMs = deadlineAt - Date.now();
-  if (remainingMs <= 0) {
-    throw new Error("background wake lease deadline elapsed");
+function assertDrainCanStart(deadlineAt: number): void {
+  if (deadlineAt <= Date.now()) {
+    throw new DrainDeadlineElapsedError();
   }
+}
 
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutMs = Math.min(remainingMs, MAX_SET_TIMEOUT_DELAY_MS);
-  const deadline = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error("background wake lease deadline elapsed"));
-    }, timeoutMs);
-    timeout.unref?.();
-  });
-
-  try {
-    return await Promise.race([work, deadline]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
+function completionStatusForError(error: unknown): "failed" | "expired" {
+  return error instanceof DrainDeadlineElapsedError ? "expired" : "failed";
 }
 
 function reasonIncludesSource(


### PR DESCRIPTION
## Summary
- Removed the local Promise.race deadline timeout so drain work is not reported expired while it continues running.
- Preserve active lease tracking until heartbeat/scheduler work actually settles, preventing duplicate drain execution for the same lease.
- Added regression coverage for already-expired leases and slow drains that outlive the original deadline.

## Original prompt
After PR #32184 merged, late review feedback pointed out that withDrainDeadline raced the drain work without cancellation. That could report a lease as expired, clear activeDrainLeases, and allow a duplicate drain while the original heartbeat or scheduler work was still running. This follow-up keeps the lease lifecycle tied to the actual work promise and only marks expired when the lease deadline has already elapsed before work starts.