### PR TITLE
feat(assistant): add responseBody Zod schemas to conversation list + group routes (LUM-1943)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4634,6 +4634,210 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          type: string
+                        createdAt:
+                          type: number
+                        updatedAt:
+                          type: number
+                        lastMessageAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        conversationType:
+                          type: string
+                          enum:
+                            - standard
+                            - background
+                            - scheduled
+                        source:
+                          type: string
+                        scheduleJobId:
+                          type: string
+                        channelBinding:
+                          type: object
+                          properties:
+                            sourceChannel:
+                              type: string
+                            externalChatId:
+                              type: string
+                            externalChatName:
+                              type: string
+                            externalThreadId:
+                              type: string
+                            externalUserId:
+                              type: string
+                            displayName:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            username:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            slackThread:
+                              type: object
+                              properties:
+                                channelId:
+                                  type: string
+                                threadTs:
+                                  type: string
+                                link:
+                                  type: object
+                                  properties:
+                                    desktopUrl:
+                                      type: string
+                                    webUrl:
+                                      type: string
+                                  additionalProperties: false
+                              required:
+                                - channelId
+                                - threadTs
+                              additionalProperties: false
+                            slackChannel:
+                              type: object
+                              properties:
+                                channelId:
+                                  type: string
+                                name:
+                                  type: string
+                                link:
+                                  type: object
+                                  properties:
+                                    webUrl:
+                                      type: string
+                                  required:
+                                    - webUrl
+                                  additionalProperties: false
+                              required:
+                                - channelId
+                              additionalProperties: false
+                          required:
+                            - sourceChannel
+                            - externalChatId
+                            - externalUserId
+                            - displayName
+                            - username
+                          additionalProperties: false
+                        conversationOriginChannel:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - telegram
+                                - phone
+                                - vellum
+                                - whatsapp
+                                - slack
+                                - email
+                                - platform
+                                - a2a
+                            - type: "null"
+                        assistantAttention:
+                          type: object
+                          properties:
+                            hasUnseenLatestAssistantMessage:
+                              type: boolean
+                            latestAssistantMessageAt:
+                              type: number
+                            lastSeenAssistantMessageAt:
+                              type: number
+                            lastSeenConfidence:
+                              type: string
+                              enum:
+                                - explicit
+                                - inferred
+                            lastSeenSignalType:
+                              type: string
+                              enum:
+                                - macos_notification_view
+                                - macos_conversation_opened
+                                - ios_conversation_opened
+                                - telegram_inbound_message
+                                - telegram_callback
+                                - slack_inbound_message
+                                - slack_callback
+                          required:
+                            - hasUnseenLatestAssistantMessage
+                          additionalProperties: false
+                        isPinned:
+                          type: boolean
+                          const: true
+                        displayOrder:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        groupId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        forkParent:
+                          type: object
+                          properties:
+                            conversationId:
+                              type: string
+                            messageId:
+                              type: string
+                            title:
+                              type: string
+                          required:
+                            - conversationId
+                            - messageId
+                            - title
+                          additionalProperties: false
+                        archivedAt:
+                          type: number
+                        inferenceProfile:
+                          type: string
+                      required:
+                        - id
+                        - title
+                        - createdAt
+                        - updatedAt
+                        - lastMessageAt
+                        - conversationType
+                        - source
+                        - groupId
+                      additionalProperties: false
+                  nextOffset:
+                    type: number
+                  hasMore:
+                    type: boolean
+                  groups:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        sortPosition:
+                          type: number
+                        isSystemGroup:
+                          type: boolean
+                      required:
+                        - id
+                        - name
+                        - sortPosition
+                        - isSystemGroup
+                      additionalProperties: false
+                required:
+                  - conversations
+                  - nextOffset
+                  - hasMore
+                additionalProperties: false
     post:
       operationId: conversations_post
       summary: Create a conversation
@@ -4752,6 +4956,183 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      createdAt:
+                        type: number
+                      updatedAt:
+                        type: number
+                      lastMessageAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      conversationType:
+                        type: string
+                        enum:
+                          - standard
+                          - background
+                          - scheduled
+                      source:
+                        type: string
+                      scheduleJobId:
+                        type: string
+                      channelBinding:
+                        type: object
+                        properties:
+                          sourceChannel:
+                            type: string
+                          externalChatId:
+                            type: string
+                          externalChatName:
+                            type: string
+                          externalThreadId:
+                            type: string
+                          externalUserId:
+                            type: string
+                          displayName:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          username:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          slackThread:
+                            type: object
+                            properties:
+                              channelId:
+                                type: string
+                              threadTs:
+                                type: string
+                              link:
+                                type: object
+                                properties:
+                                  desktopUrl:
+                                    type: string
+                                  webUrl:
+                                    type: string
+                                additionalProperties: false
+                            required:
+                              - channelId
+                              - threadTs
+                            additionalProperties: false
+                          slackChannel:
+                            type: object
+                            properties:
+                              channelId:
+                                type: string
+                              name:
+                                type: string
+                              link:
+                                type: object
+                                properties:
+                                  webUrl:
+                                    type: string
+                                required:
+                                  - webUrl
+                                additionalProperties: false
+                            required:
+                              - channelId
+                            additionalProperties: false
+                        required:
+                          - sourceChannel
+                          - externalChatId
+                          - externalUserId
+                          - displayName
+                          - username
+                        additionalProperties: false
+                      conversationOriginChannel:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - telegram
+                              - phone
+                              - vellum
+                              - whatsapp
+                              - slack
+                              - email
+                              - platform
+                              - a2a
+                          - type: "null"
+                      assistantAttention:
+                        type: object
+                        properties:
+                          hasUnseenLatestAssistantMessage:
+                            type: boolean
+                          latestAssistantMessageAt:
+                            type: number
+                          lastSeenAssistantMessageAt:
+                            type: number
+                          lastSeenConfidence:
+                            type: string
+                            enum:
+                              - explicit
+                              - inferred
+                          lastSeenSignalType:
+                            type: string
+                            enum:
+                              - macos_notification_view
+                              - macos_conversation_opened
+                              - ios_conversation_opened
+                              - telegram_inbound_message
+                              - telegram_callback
+                              - slack_inbound_message
+                              - slack_callback
+                        required:
+                          - hasUnseenLatestAssistantMessage
+                        additionalProperties: false
+                      isPinned:
+                        type: boolean
+                        const: true
+                      displayOrder:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      groupId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      forkParent:
+                        type: object
+                        properties:
+                          conversationId:
+                            type: string
+                          messageId:
+                            type: string
+                          title:
+                            type: string
+                        required:
+                          - conversationId
+                          - messageId
+                          - title
+                        additionalProperties: false
+                      archivedAt:
+                        type: number
+                      inferenceProfile:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - createdAt
+                      - updatedAt
+                      - lastMessageAt
+                      - conversationType
+                      - source
+                      - groupId
+                    additionalProperties: false
+                required:
+                  - conversation
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -5996,6 +6377,48 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                sourceChannel:
+                  type: string
+                signalType:
+                  type: string
+                confidence:
+                  type: string
+                  enum:
+                    - explicit
+                    - inferred
+                source:
+                  type: string
+                evidenceText:
+                  type: string
+                metadata:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                observedAt:
+                  type: number
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/switch:
     post:
       operationId: conversations_switch_post
@@ -6049,6 +6472,28 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/wake:
     post:
       operationId: conversations_wake_post
@@ -7988,6 +8433,33 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  groups:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        sortPosition:
+                          type: number
+                        isSystemGroup:
+                          type: boolean
+                      required:
+                        - id
+                        - name
+                        - sortPosition
+                        - isSystemGroup
+                      additionalProperties: false
+                required:
+                  - groups
+                additionalProperties: false
     post:
       operationId: groups_post
       summary: Create group
@@ -7997,6 +8469,25 @@ paths:
       responses:
         "201":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  sortPosition:
+                    type: number
+                  isSystemGroup:
+                    type: boolean
+                required:
+                  - id
+                  - name
+                  - sortPosition
+                  - isSystemGroup
+                additionalProperties: false
         "400":
           description: Missing or invalid name, or sort_position ceiling reached
       requestBody:
@@ -8041,6 +8532,25 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  sortPosition:
+                    type: number
+                  isSystemGroup:
+                    type: boolean
+                required:
+                  - id
+                  - name
+                  - sortPosition
+                  - isSystemGroup
+                additionalProperties: false
         "403":
           description: System group sort position cannot be changed
         "404":
@@ -8073,6 +8583,16 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
         "403":
           description: Cannot reorder system groups
       requestBody:

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -7,6 +7,8 @@
  * GET    /v1/conversations/:id      — conversation detail
  */
 
+import { z } from "zod";
+
 import {
   type Confidence,
   getAttentionStateByConversationIds,
@@ -42,6 +44,112 @@ import {
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("conversation-list-routes");
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const channelIdSchema = z.enum([
+  "telegram",
+  "phone",
+  "vellum",
+  "whatsapp",
+  "slack",
+  "email",
+  "platform",
+  "a2a",
+]);
+
+const assistantAttentionSchema = z.object({
+  hasUnseenLatestAssistantMessage: z.boolean(),
+  latestAssistantMessageAt: z.number().optional(),
+  lastSeenAssistantMessageAt: z.number().optional(),
+  lastSeenConfidence: z.enum(["explicit", "inferred"]).optional(),
+  lastSeenSignalType: z
+    .enum([
+      "macos_notification_view",
+      "macos_conversation_opened",
+      "ios_conversation_opened",
+      "telegram_inbound_message",
+      "telegram_callback",
+      "slack_inbound_message",
+      "slack_callback",
+    ])
+    .optional(),
+});
+
+const slackThreadSchema = z.object({
+  channelId: z.string(),
+  threadTs: z.string(),
+  link: z
+    .object({
+      desktopUrl: z.string().optional(),
+      webUrl: z.string().optional(),
+    })
+    .optional(),
+});
+
+const slackChannelSchema = z.object({
+  channelId: z.string(),
+  name: z.string().optional(),
+  link: z.object({ webUrl: z.string() }).optional(),
+});
+
+const channelBindingSchema = z.object({
+  sourceChannel: z.string(),
+  externalChatId: z.string(),
+  externalChatName: z.string().optional(),
+  externalThreadId: z.string().optional(),
+  externalUserId: z.string(),
+  displayName: z.string().nullable(),
+  username: z.string().nullable(),
+  slackThread: slackThreadSchema.optional(),
+  slackChannel: slackChannelSchema.optional(),
+});
+
+const forkParentSchema = z.object({
+  conversationId: z.string(),
+  messageId: z.string(),
+  title: z.string(),
+});
+
+const conversationSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  lastMessageAt: z.number().nullable(),
+  conversationType: z.enum(["standard", "background", "scheduled"]),
+  source: z.string(),
+  scheduleJobId: z.string().optional(),
+  channelBinding: channelBindingSchema.optional(),
+  conversationOriginChannel: channelIdSchema.nullable().optional(),
+  assistantAttention: assistantAttentionSchema.optional(),
+  isPinned: z.literal(true).optional(),
+  displayOrder: z.number().nullable().optional(),
+  groupId: z.string().nullable(),
+  forkParent: forkParentSchema.optional(),
+  archivedAt: z.number().optional(),
+  inferenceProfile: z.string().optional(),
+});
+
+const groupSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sortPosition: z.number(),
+  isSystemGroup: z.boolean(),
+});
+
+const listConversationsResponseSchema = z.object({
+  conversations: z.array(conversationSummarySchema),
+  nextOffset: z.number(),
+  hasMore: z.boolean(),
+  groups: z.array(groupSummarySchema).optional(),
+});
+
+const conversationDetailResponseSchema = z.object({
+  conversation: conversationSummarySchema,
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -204,6 +312,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Paginated list of conversations with attention state and display metadata.",
     tags: ["conversations"],
+    responseBody: listConversationsResponseSchema,
     handler: handleListConversations,
   },
   {
@@ -214,6 +323,17 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Record a seen signal",
     description: "Mark a conversation as seen, advancing the attention cursor.",
     tags: ["conversations"],
+    requestBody: z.object({
+      conversationId: z.string(),
+      sourceChannel: z.string().optional(),
+      signalType: z.string().optional(),
+      confidence: z.enum(["explicit", "inferred"]).optional(),
+      source: z.string().optional(),
+      evidenceText: z.string().optional(),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      observedAt: z.number().optional(),
+    }),
+    responseBody: z.object({ ok: z.boolean() }),
     handler: handleRecordSeen,
   },
   {
@@ -224,6 +344,10 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Mark conversation unread",
     description: "Reset the seen cursor so the conversation appears unread.",
     tags: ["conversations"],
+    requestBody: z.object({
+      conversationId: z.string(),
+    }),
+    responseBody: z.object({ ok: z.boolean() }),
     handler: handleMarkUnread,
   },
   {
@@ -234,6 +358,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Get conversation detail",
     description: "Retrieve a single conversation with full metadata.",
     tags: ["conversations"],
+    responseBody: conversationDetailResponseSchema,
     handler: handleGetConversation,
   },
 ];

--- a/assistant/src/runtime/routes/group-routes.ts
+++ b/assistant/src/runtime/routes/group-routes.ts
@@ -22,6 +22,13 @@ import { publishConversationListChanged } from "../sync/resource-sync-events.js"
 import { BadRequestError, ForbiddenError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
+const groupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sortPosition: z.number(),
+  isSystemGroup: z.boolean(),
+});
+
 function serializeGroup(group: ReturnType<typeof getGroup>) {
   if (!group) return null;
   return {
@@ -169,6 +176,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List groups",
     description: "Return all conversation groups.",
     tags: ["groups"],
+    responseBody: z.object({ groups: z.array(groupSchema) }),
   },
   {
     operationId: "groups_create",
@@ -184,6 +192,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: z.object({
       name: z.string().describe("Group name"),
     }),
+    responseBody: groupSchema,
     additionalResponses: {
       "400": {
         description:
@@ -204,6 +213,7 @@ export const ROUTES: RouteDefinition[] = [
       name: z.string().optional(),
       sortPosition: z.number().optional(),
     }),
+    responseBody: groupSchema,
     additionalResponses: {
       "403": {
         description: "System group sort position cannot be changed",
@@ -251,6 +261,7 @@ export const ROUTES: RouteDefinition[] = [
         )
         .describe("Array of { groupId, sortPosition } objects"),
     }),
+    responseBody: z.object({ ok: z.boolean() }),
     additionalResponses: {
       "403": {
         description: "Cannot reorder system groups",


### PR DESCRIPTION
## Prompt / plan

Add typed `responseBody` Zod schemas to 9 daemon route definitions (conversation list + group routes) so the generated OpenAPI spec has proper response types. This is part of the [daemon codegen pipeline](https://linear.app/vellum/issue/LUM-1943) — without these schemas, the web app's HeyAPI codegen produces `unknown` response types for these endpoints.

Depends on [PR #32214](https://github.com/vellum-ai/vellum-assistant/pull/32214) (LUM-1942) which wires the daemon spec into the web app's codegen pipeline.

### Changes

**Conversation list routes** (`conversation-list-routes.ts`) — 4 endpoints:
- `listConversations` (GET /v1/conversations): `{ conversations, nextOffset, hasMore, groups? }`
- `recordConversationSeen` (POST /v1/conversations/seen): `{ ok: boolean }` + requestBody schema
- `markConversationUnread` (POST /v1/conversations/unread): `{ ok: boolean }` + requestBody schema
- `getConversation` (GET /v1/conversations/:id): `{ conversation: ConversationSummary }`

**Group routes** (`group-routes.ts`) — 5 endpoints:
- `groups_list` (GET /v1/groups): `{ groups: Group[] }`
- `groups_create` (POST /v1/groups): `Group` + requestBody schema
- `groups_update` (PATCH /v1/groups/:groupId): `Group` + requestBody schema
- `groups_delete` (DELETE /v1/groups/:groupId): 204 no content (void handler, no responseBody needed)
- `groups_reorder` (POST /v1/groups/reorder): `{ ok: boolean }` + requestBody schema

Response schemas were derived from the actual serializer functions (`serializeConversationSummary`, `serializeGroup`, `buildConversationDetailResponse`) to ensure they match runtime output exactly. Sub-schemas (channelBinding, assistantAttention, slackThread, forkParent) mirror the conditional spread patterns in the serializer.

### Why this is safe

- **Additive only** — no runtime behavior changes, just schema declarations on existing route definitions
- **Schema accuracy verified** — each field traced through the serializer functions to the actual DB row types
- The OpenAPI spec generator already supports `responseBody` (281 routes already use it) — this just adds it to 9 more
- All 27 affected tests pass

## Test plan

- `bunx tsc --noEmit` passes in `assistant/`
- ESLint passes
- Pre-push hook ran 27 related tests — all pass
- Verified generated `openapi.yaml` has proper response schemas for both `/v1/conversations` and `/v1/groups` endpoints
- Response schema properties match serializer output: `conversations`, `nextOffset`, `hasMore`, `groups` for list; `groups` for group list

## CLI verb checklist

No new routes added — only `responseBody` schemas added to existing routes. No CLI verb changes needed.

Closes LUM-1943

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka