### PR TITLE
feat(assistant): add responseBody schemas to conversation management routes (LUM-1944)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4678,7 +4678,9 @@ paths:
                             externalThreadId:
                               type: string
                             externalUserId:
-                              type: string
+                              anyOf:
+                                - type: string
+                                - type: "null"
                             displayName:
                               anyOf:
                                 - type: string
@@ -4697,7 +4699,7 @@ paths:
                                 link:
                                   type: object
                                   properties:
-                                    desktopUrl:
+                                    appUrl:
                                       type: string
                                     webUrl:
                                       type: string
@@ -4998,7 +5000,9 @@ paths:
                           externalThreadId:
                             type: string
                           externalUserId:
-                            type: string
+                            anyOf:
+                              - type: string
+                              - type: "null"
                           displayName:
                             anyOf:
                               - type: string
@@ -5017,7 +5021,7 @@ paths:
                               link:
                                 type: object
                                 properties:
-                                  desktopUrl:
+                                  appUrl:
                                     type: string
                                   webUrl:
                                     type: string
@@ -5165,6 +5169,19 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  conversationId:
+                    type: string
+                required:
+                  - ok
+                  - conversationId
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -5405,6 +5422,16 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -5525,6 +5552,19 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  conversationId:
+                    type: string
+                required:
+                  - ok
+                  - conversationId
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -5890,6 +5930,185 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      createdAt:
+                        type: number
+                      updatedAt:
+                        type: number
+                      lastMessageAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      conversationType:
+                        type: string
+                        enum:
+                          - standard
+                          - background
+                          - scheduled
+                      source:
+                        type: string
+                      scheduleJobId:
+                        type: string
+                      channelBinding:
+                        type: object
+                        properties:
+                          sourceChannel:
+                            type: string
+                          externalChatId:
+                            type: string
+                          externalChatName:
+                            type: string
+                          externalThreadId:
+                            type: string
+                          externalUserId:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          displayName:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          username:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          slackThread:
+                            type: object
+                            properties:
+                              channelId:
+                                type: string
+                              threadTs:
+                                type: string
+                              link:
+                                type: object
+                                properties:
+                                  appUrl:
+                                    type: string
+                                  webUrl:
+                                    type: string
+                                additionalProperties: false
+                            required:
+                              - channelId
+                              - threadTs
+                            additionalProperties: false
+                          slackChannel:
+                            type: object
+                            properties:
+                              channelId:
+                                type: string
+                              name:
+                                type: string
+                              link:
+                                type: object
+                                properties:
+                                  webUrl:
+                                    type: string
+                                required:
+                                  - webUrl
+                                additionalProperties: false
+                            required:
+                              - channelId
+                            additionalProperties: false
+                        required:
+                          - sourceChannel
+                          - externalChatId
+                          - externalUserId
+                          - displayName
+                          - username
+                        additionalProperties: false
+                      conversationOriginChannel:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - telegram
+                              - phone
+                              - vellum
+                              - whatsapp
+                              - slack
+                              - email
+                              - platform
+                              - a2a
+                          - type: "null"
+                      assistantAttention:
+                        type: object
+                        properties:
+                          hasUnseenLatestAssistantMessage:
+                            type: boolean
+                          latestAssistantMessageAt:
+                            type: number
+                          lastSeenAssistantMessageAt:
+                            type: number
+                          lastSeenConfidence:
+                            type: string
+                            enum:
+                              - explicit
+                              - inferred
+                          lastSeenSignalType:
+                            type: string
+                            enum:
+                              - macos_notification_view
+                              - macos_conversation_opened
+                              - ios_conversation_opened
+                              - telegram_inbound_message
+                              - telegram_callback
+                              - slack_inbound_message
+                              - slack_callback
+                        required:
+                          - hasUnseenLatestAssistantMessage
+                        additionalProperties: false
+                      isPinned:
+                        type: boolean
+                        const: true
+                      displayOrder:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      groupId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      forkParent:
+                        type: object
+                        properties:
+                          conversationId:
+                            type: string
+                          messageId:
+                            type: string
+                          title:
+                            type: string
+                        required:
+                          - conversationId
+                          - messageId
+                          - title
+                        additionalProperties: false
+                      archivedAt:
+                        type: number
+                      inferenceProfile:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - createdAt
+                      - updatedAt
+                      - lastMessageAt
+                      - conversationType
+                      - source
+                      - groupId
+                    additionalProperties: false
+                required:
+                  - conversation
+                additionalProperties: false
       requestBody:
         required: true
         content:
@@ -6310,6 +6529,16 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
       requestBody:
         required: true
         content:
@@ -6319,8 +6548,22 @@ paths:
               properties:
                 updates:
                   type: array
-                  items: {}
-                  description: Array of { conversationId, displayOrder?, isPinned? } objects
+                  items:
+                    type: object
+                    properties:
+                      conversationId:
+                        type: string
+                      displayOrder:
+                        type: number
+                      isPinned:
+                        type: boolean
+                      groupId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - conversationId
+                    additionalProperties: false
               required:
                 - updates
               additionalProperties: false

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -83,7 +83,7 @@ const slackThreadSchema = z.object({
   threadTs: z.string(),
   link: z
     .object({
-      desktopUrl: z.string().optional(),
+      appUrl: z.string().optional(),
       webUrl: z.string().optional(),
     })
     .optional(),
@@ -100,7 +100,7 @@ const channelBindingSchema = z.object({
   externalChatId: z.string(),
   externalChatName: z.string().optional(),
   externalThreadId: z.string().optional(),
-  externalUserId: z.string(),
+  externalUserId: z.string().nullable(),
   displayName: z.string().nullable(),
   username: z.string().nullable(),
   slackThread: slackThreadSchema.optional(),
@@ -113,7 +113,7 @@ const forkParentSchema = z.object({
   title: z.string(),
 });
 
-const conversationSummarySchema = z.object({
+export const conversationSummarySchema = z.object({
   id: z.string(),
   title: z.string(),
   createdAt: z.number(),

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -55,6 +55,7 @@ import {
   publishConversationListChanged,
   publishConversationTitleChanged,
 } from "../sync/resource-sync-events.js";
+import { conversationSummarySchema } from "./conversation-list-routes.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import { setInferenceProfileSession } from "./inference-profile-session-handler.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -477,6 +478,9 @@ export const ROUTES: RouteDefinition[] = [
         .describe("Truncate the fork at this message")
         .optional(),
     }),
+    responseBody: z.object({
+      conversation: conversationSummarySchema,
+    }),
     handler: handleForkConversation,
   },
   {
@@ -546,6 +550,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: z.object({
       name: z.string(),
     }),
+    responseBody: z.object({ ok: z.boolean() }),
     handler: handleRenameConversation,
   },
   {
@@ -598,6 +603,10 @@ export const ROUTES: RouteDefinition[] = [
     description: "Move a conversation to the archived state.",
     tags: ["conversations"],
     pathParams: [{ name: "id", type: "uuid" }],
+    responseBody: z.object({
+      ok: z.boolean(),
+      conversationId: z.string(),
+    }),
     handler: handleArchiveConversation,
   },
   {
@@ -610,6 +619,10 @@ export const ROUTES: RouteDefinition[] = [
       "Restore an archived conversation back to the default sidebar.",
     tags: ["conversations"],
     pathParams: [{ name: "id", type: "uuid" }],
+    responseBody: z.object({
+      ok: z.boolean(),
+      conversationId: z.string(),
+    }),
     handler: handleUnarchiveConversation,
   },
   {
@@ -667,12 +680,16 @@ export const ROUTES: RouteDefinition[] = [
     description: "Batch-update display order and pin state for conversations.",
     tags: ["conversations"],
     requestBody: z.object({
-      updates: z
-        .array(z.unknown())
-        .describe(
-          "Array of { conversationId, displayOrder?, isPinned? } objects",
-        ),
+      updates: z.array(
+        z.object({
+          conversationId: z.string(),
+          displayOrder: z.number().optional(),
+          isPinned: z.boolean().optional(),
+          groupId: z.string().nullable().optional(),
+        }),
+      ),
     }),
+    responseBody: z.object({ ok: z.boolean() }),
     handler: handleReorderConversations,
   },
 ];


### PR DESCRIPTION
## Prompt / plan

Add typed `responseBody` Zod schemas to 5 conversation management endpoints that were missing them, and fix 2 schema inaccuracies in conversation-list-routes.ts found by Codex review of LUM-1943.

### New responseBody schemas

| Endpoint | Response shape |
|----------|---------------|
| `forkConversation` | `{ conversation: ConversationSummary }` |
| `renameConversation` | `{ ok: boolean }` |
| `archiveConversation` | `{ ok: boolean, conversationId: string }` |
| `unarchiveConversation` | `{ ok: boolean, conversationId: string }` |
| `reorderConversations` | `{ ok: boolean }` |

Also properly types the `reorderConversations` requestBody (was `z.array(z.unknown())`).

### Schema fixes from Codex review of LUM-1943

1. **Slack thread link**: `desktopUrl` → `appUrl` — the runtime's `buildSlackMessageDeepLinks()` returns `{ appUrl?, webUrl? }`, not `desktopUrl`
2. **channelBinding externalUserId**: `z.string()` → `z.string().nullable()` — `upsertOutboundBinding()` stores `null` for outbound-only bindings

### Shared schema export

Exports `conversationSummarySchema` from `conversation-list-routes.ts` so `forkConversation` can reference it rather than duplicating the ~20-field schema.

### Routes that already had responseBody (no changes needed)

- `createConversation`, `switchConversation`, `setConversationInferenceProfile`, `wipeConversation`, `cancelConversationGeneration`, `undoLastMessage` — already typed
- `clearAllConversations`, `deleteConversation` — return 204 (void)
- `regenerateResponse` — returns 202 (void, triggers SSE)

### Why this is safe

- **Additive only** — no runtime behavior changes
- **Schema accuracy verified** — each return value traced through the handler function
- All 31 affected tests pass

## Test plan

- `bunx tsc --noEmit` passes
- ESLint passes
- Pre-push hook ran 31 related tests — all pass
- Generated `openapi.yaml` verified to have proper response schemas for fork, archive, unarchive, reorder endpoints

## CLI verb checklist

No new routes added — only `responseBody` schemas added to existing routes.

Closes LUM-1944

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka