### PR TITLE
perf(web): lazy-load BUNDLED_COMPONENTS avatar SVG data (LUM-1940)

### DIFF
--- a/apps/web/src/components/avatar/subagent-avatar-chip.tsx
+++ b/apps/web/src/components/avatar/subagent-avatar-chip.tsx
@@ -6,12 +6,14 @@
  * (16px default) avatar inline — e.g. as the leading icon slot of a
  * subagent tool-call card, per Figma node `4922-103839`.
  *
- * Does not introduce a new bundle; reuses `BUNDLED_COMPONENTS` already
- * consumed by `SubagentInlineProgressCard`.
+ * The 48 kB bundled-components payload is loaded lazily via
+ * `useBundledAvatarComponents` to keep it off the chat-critical bundle;
+ * the chip renders a transparent placeholder of the same size until the
+ * data chunk resolves so layout doesn't reflow when the avatar pops in.
  */
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
-import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { subagentTraits } from "@/utils/avatar-subagent";
 
 export interface SubagentAvatarChipProps {
@@ -27,6 +29,7 @@ export function SubagentAvatarChip({
   className,
 }: SubagentAvatarChipProps) {
   const traits = subagentTraits(subagentId);
+  const components = useBundledAvatarComponents();
 
   // `AvatarRenderer` renders a `<div>` — wrapping it in a `<span>` produces
   // invalid HTML (block element inside an inline element) which browsers
@@ -38,13 +41,17 @@ export function SubagentAvatarChip({
       aria-label={`Subagent ${subagentId}`}
       className={`inline-flex ${className ?? ""}`.trim()}
     >
-      <AvatarRenderer
-        components={BUNDLED_COMPONENTS}
-        bodyShapeId={traits.bodyShape}
-        eyeStyleId={traits.eyeStyle}
-        colorId={traits.color}
-        size={size}
-      />
+      {components ? (
+        <AvatarRenderer
+          components={components}
+          bodyShapeId={traits.bodyShape}
+          eyeStyleId={traits.eyeStyle}
+          colorId={traits.color}
+          size={size}
+        />
+      ) : (
+        <div style={{ width: size, height: size, flexShrink: 0 }} aria-hidden />
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -12,7 +12,7 @@ import { type ReactNode, useEffect, useRef } from "react";
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import { Button, Typography } from "@vellum/design-library";
 import { StatusBadge } from "@/domains/chat/components/subagent-status-badge";
-import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { subagentTraits } from "@/utils/avatar-subagent";
 import type { SubagentEntry } from "@/domains/subagents/subagent-store";
 import { isActiveStatus } from "@/domains/subagents/status-helpers";
@@ -98,6 +98,7 @@ export function SubagentDetailPanel({
 }: SubagentDetailPanelProps) {
   const isRunning = isActiveStatus(entry.status);
   const requestedRef = useRef<string | null>(null);
+  const components = useBundledAvatarComponents();
 
   useEffect(() => {
     if (
@@ -115,13 +116,17 @@ export function SubagentDetailPanel({
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
       {/* Header */}
       <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] px-5 py-4">
-        <AvatarRenderer
-          components={BUNDLED_COMPONENTS}
-          bodyShapeId={subagentTraits(entry.subagentId).bodyShape}
-          eyeStyleId={subagentTraits(entry.subagentId).eyeStyle}
-          colorId={subagentTraits(entry.subagentId).color}
-          size={32}
-        />
+        {components ? (
+          <AvatarRenderer
+            components={components}
+            bodyShapeId={subagentTraits(entry.subagentId).bodyShape}
+            eyeStyleId={subagentTraits(entry.subagentId).eyeStyle}
+            colorId={subagentTraits(entry.subagentId).color}
+            size={32}
+          />
+        ) : (
+          <div style={{ width: 32, height: 32, flexShrink: 0 }} aria-hidden />
+        )}
         <Typography
           variant="title-medium"
           className="min-w-0 shrink truncate text-[var(--content-default)]"

--- a/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
@@ -9,7 +9,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
 import { useSubagentStore } from "@/domains/subagents/subagent-store";
@@ -192,7 +192,7 @@ describe("SubagentInlineProgressCard — header action", () => {
 });
 
 describe("SubagentInlineProgressCard — deterministic avatar traits", () => {
-  test("different subagent IDs render different avatar DOM", () => {
+  test("different subagent IDs render different avatar DOM", async () => {
     spawn("sa-trait-a");
     spawn("sa-trait-b-something-different");
 
@@ -200,6 +200,23 @@ describe("SubagentInlineProgressCard — deterministic avatar traits", () => {
     const b = render(
       <SubagentInlineProgressCard subagentId="sa-trait-b-something-different" />,
     );
+
+    // `SubagentAvatarChip` lazy-loads the ~48 kB BUNDLED_COMPONENTS payload
+    // and renders a transparent placeholder until the chunk resolves; wait
+    // for the real SVG before comparing markup.
+    await waitFor(() => {
+      const svg = a.container.querySelector(
+        '[aria-label="Subagent sa-trait-a"] svg',
+      );
+      expect(svg).not.toBeNull();
+    });
+    await waitFor(() => {
+      const svg = b.container.querySelector(
+        '[aria-label="Subagent sa-trait-b-something-different"] svg',
+      );
+      expect(svg).not.toBeNull();
+    });
+
     // The two avatar SVG markup should differ (deterministic-per-id traits).
     const aAvatar = a.container.querySelector(
       '[aria-label="Subagent sa-trait-a"]',

--- a/apps/web/src/utils/use-bundled-avatar-components.ts
+++ b/apps/web/src/utils/use-bundled-avatar-components.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+import type { CharacterComponents } from "@/types/avatar";
+
+// Module-level cache so the dynamic import resolves once per session even if
+// multiple chips mount in parallel during the same render pass.
+let cached: CharacterComponents | null = null;
+let loadPromise: Promise<CharacterComponents> | null = null;
+
+function loadBundledComponents(): Promise<CharacterComponents> {
+  if (cached) return Promise.resolve(cached);
+  if (loadPromise) return loadPromise;
+  loadPromise = import("@/utils/avatar-bundled-components").then((m) => {
+    cached = m.BUNDLED_COMPONENTS;
+    loadPromise = null;
+    return cached;
+  });
+  return loadPromise;
+}
+
+/**
+ * Lazily loads the bundled avatar character-components data (~48 kB of
+ * inline SVG paths) on first mount of any consumer. Returns `null` until
+ * the chunk resolves; the caller renders a placeholder of the same size so
+ * layout doesn't reflow when the avatar pops in.
+ *
+ * Splitting the data out keeps it off the chat-critical bundle —
+ * `SubagentAvatarChip` consumes it inline in transcript items, and a
+ * static import would pull the whole payload into the main chunk.
+ */
+export function useBundledAvatarComponents(): CharacterComponents | null {
+  const [components, setComponents] = useState<CharacterComponents | null>(
+    () => cached,
+  );
+
+  useEffect(() => {
+    if (components) return;
+    let cancelled = false;
+    void loadBundledComponents().then((c) => {
+      if (!cancelled) setComponents(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [components]);
+
+  return components;
+}

--- a/apps/web/src/utils/use-bundled-avatar-components.ts
+++ b/apps/web/src/utils/use-bundled-avatar-components.ts
@@ -7,6 +7,12 @@ import type { CharacterComponents } from "@/types/avatar";
 let cached: CharacterComponents | null = null;
 let loadPromise: Promise<CharacterComponents> | null = null;
 
+// Subscribers fire exactly once, when `cached` is first populated, so that
+// hook instances that mounted *before* the load completed (and whose effect
+// observed only the still-null state) re-render and pick up the new value
+// instead of staying blank for their lifetime.
+const subscribers = new Set<() => void>();
+
 function loadBundledComponents(): Promise<CharacterComponents> {
   if (cached) return Promise.resolve(cached);
   if (loadPromise) return loadPromise;
@@ -14,6 +20,7 @@ function loadBundledComponents(): Promise<CharacterComponents> {
     .then((m) => {
       cached = m.BUNDLED_COMPONENTS;
       loadPromise = null;
+      for (const cb of subscribers) cb();
       return cached;
     })
     .catch((err) => {
@@ -36,22 +43,36 @@ function loadBundledComponents(): Promise<CharacterComponents> {
  * Splitting the data out keeps it off the chat-critical bundle —
  * `SubagentAvatarChip` consumes it inline in transcript items, and a
  * static import would pull the whole payload into the main chunk.
+ *
+ * If the first import rejects (network blip, stale deployed chunk), the
+ * loader clears its cached promise so a re-mount can retry, and mounted
+ * instances subscribe to the next successful resolution so a retry
+ * triggered by any other consumer fills their UI too.
  */
 export function useBundledAvatarComponents(): CharacterComponents | null {
-  const [components, setComponents] = useState<CharacterComponents | null>(
-    () => cached,
-  );
+  // We don't store `components` in local state — the module-level `cached`
+  // is the source of truth across all hook instances. `forceRender` exists
+  // only to schedule a re-read of `cached` when the subscriber notifies.
+  const [, forceRender] = useState(0);
 
   useEffect(() => {
-    if (components) return;
+    if (cached) return;
     let cancelled = false;
-    void loadBundledComponents().then((c) => {
-      if (!cancelled) setComponents(c);
+    const onLoaded = () => {
+      if (!cancelled) forceRender((n) => n + 1);
+    };
+    subscribers.add(onLoaded);
+    void loadBundledComponents().catch(() => {
+      // Swallowed here: the loader rethrows for any awaiting caller, so
+      // anything wrapping this in a Suspense/ErrorBoundary will still see
+      // the failure. The hook's job is just to stay in the placeholder
+      // state until a future retry succeeds.
     });
     return () => {
       cancelled = true;
+      subscribers.delete(onLoaded);
     };
-  }, [components]);
+  }, []);
 
-  return components;
+  return cached;
 }

--- a/apps/web/src/utils/use-bundled-avatar-components.ts
+++ b/apps/web/src/utils/use-bundled-avatar-components.ts
@@ -10,11 +10,20 @@ let loadPromise: Promise<CharacterComponents> | null = null;
 function loadBundledComponents(): Promise<CharacterComponents> {
   if (cached) return Promise.resolve(cached);
   if (loadPromise) return loadPromise;
-  loadPromise = import("@/utils/avatar-bundled-components").then((m) => {
-    cached = m.BUNDLED_COMPONENTS;
-    loadPromise = null;
-    return cached;
-  });
+  loadPromise = import("@/utils/avatar-bundled-components")
+    .then((m) => {
+      cached = m.BUNDLED_COMPONENTS;
+      loadPromise = null;
+      return cached;
+    })
+    .catch((err) => {
+      // Don't leave a rejected promise cached — that would permanently
+      // poison every future caller (re-mounts, new subagent spawns, etc.)
+      // and avatars would silently stay blank for the rest of the session.
+      // Clearing it here lets the next consumer kick off a fresh import.
+      loadPromise = null;
+      throw err;
+    });
   return loadPromise;
 }
 

--- a/apps/web/src/utils/use-bundled-avatar-components.ts
+++ b/apps/web/src/utils/use-bundled-avatar-components.ts
@@ -13,6 +13,14 @@ let loadPromise: Promise<CharacterComponents> | null = null;
 // instead of staying blank for their lifetime.
 const subscribers = new Set<() => void>();
 
+// One short-delay retry per session if the first import attempt fails (e.g.
+// a transient network blip). If the retry also fails we stop trying and let
+// the placeholder stand — the next re-mount will get a fresh shot via the
+// `loadPromise = null` path below. Keeping this single-shot avoids spamming
+// retries against a stale-deployed chunk that's genuinely gone.
+const RETRY_DELAY_MS = 3000;
+let retryScheduled = false;
+
 function loadBundledComponents(): Promise<CharacterComponents> {
   if (cached) return Promise.resolve(cached);
   if (loadPromise) return loadPromise;
@@ -29,6 +37,20 @@ function loadBundledComponents(): Promise<CharacterComponents> {
       // and avatars would silently stay blank for the rest of the session.
       // Clearing it here lets the next consumer kick off a fresh import.
       loadPromise = null;
+      // Schedule a single retry so already-mounted hooks recover from a
+      // transient failure even when no new consumer arrives to trigger
+      // another attempt. Gated on having active subscribers so we don't
+      // burn the retry on a no-longer-visible UI.
+      if (!retryScheduled && subscribers.size > 0) {
+        retryScheduled = true;
+        setTimeout(() => {
+          if (!cached && subscribers.size > 0) {
+            loadBundledComponents().catch(() => {
+              // Final attempt; placeholder stands.
+            });
+          }
+        }, RETRY_DELAY_MS);
+      }
       throw err;
     });
   return loadPromise;


### PR DESCRIPTION
Linear: https://linear.app/vellum/issue/LUM-1940

## Summary

- `avatar-bundled-components.ts` (~48 kB of inline body-shape / eye-style SVG paths) was the largest non-`react-dom` source file in the chat-critical bundle after LUM-1939. It shipped eagerly because `SubagentAvatarChip` (rendered inline in transcript items) statically imported `BUNDLED_COMPONENTS`, so Vite pulled the whole payload into the main chunk on every initial chat load.

## What changed

- New `useBundledAvatarComponents()` hook (`apps/web/src/utils/use-bundled-avatar-components.ts`) — module-cached `import()` of the data; returns `null` until the chunk resolves.
- `SubagentAvatarChip` and `SubagentDetailPanel` switched to the hook. Both render a transparent placeholder of the same size while the data loads, so the avatar pops in without reflow.
- `HatchingScreen` keeps its static import — it's already inside a lazy route (the onboarding flow) and uses every shape for the random-pick preview, so a flash there would be worse than the small extra bytes in that chunk.

Vite shares the resulting `avatar-bundled-components-*.js` chunk between the hatching screen (static dep) and the chat chips (dynamic dep), so the data is only paid for once across the app.

## Bundle impact

- Main `index-*.js`: **~1,001 kB → ~967 kB** minified (~34 kB shave on every initial chat load).
- New `avatar-bundled-components-*.js` chunk: ~45 kB, loaded on first subagent render or hatching-screen mount.

## Test plan

- [x] `bun run build` — main bundle drops as above; new lazy chunk emitted
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun test src/components/avatar/` — 7 pass (existing assertions are determinism + aria-label + size, all still hold with the placeholder)
- [ ] Manual: open a chat with a running subagent → small avatar chip appears (may briefly be blank on first ever load, then pops in)
- [ ] Manual: open the subagent detail panel → header avatar appears
- [ ] Manual: visit the hatching screen → random avatar still renders without a flash (uses the same lazy chunk via the hatching-screen route chunk)

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_