### PR TITLE
feat(memory-v3): gate selects by numbered ids, not a slug enum

### DIFF
--- a/assistant/src/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/memory/v3/__tests__/gate.test.ts
@@ -2,8 +2,8 @@
  * Tests for `assistant/src/memory/v3/gate.ts`.
  *
  * Coverage matrix:
- *   - ready + selection → selection maps from candidates, in model order, and
- *     includes sticky slugs even when the model omits them.
+ *   - ready + selection → numbered `[N]` candidate ids map back to slugs in
+ *     model order, and includes sticky slugs even when the model omits them.
  *   - more + questions → `decision.questions` surfaced; selection still returned.
  *   - more with no/blank questions → decision is `{ decision: "more" }` (no
  *     empty `questions` array).
@@ -12,7 +12,7 @@
  *   - provider throws → fail-safe (ready, all candidates).
  *   - missing tool_use block → fail-safe (ready, all candidates).
  *   - tool input failing schema → fail-safe (ready, all candidates).
- *   - model selecting a slug outside the candidate set → dropped.
+ *   - model returning an out-of-range id (0 / past the end) → dropped.
  *   - request shape: forced tool_choice on `decide_selection`, candidate set in
  *     the user message, abort signal forwarded.
  *
@@ -132,7 +132,7 @@ describe("runGate — ready decision", () => {
     const provider = makeProvider(
       // Model selects b, a (its own order). Sticky `c` is omitted by the
       // model but must survive in the final selection.
-      gateToolResponse({ decision: "ready", selected_slugs: ["b", "a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [2, 1] }),
       calls,
     );
 
@@ -153,7 +153,7 @@ describe("runGate — ready decision", () => {
   test("forces tool_choice on decide_selection and surfaces candidates", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -172,18 +172,30 @@ describe("runGate — ready decision", () => {
     });
     expect(call.options?.config?.callSite).toBe("memoryV3Gate");
     expect(call.tools?.[0].name).toBe("decide_selection");
+    // The output schema is candidate-independent: selected_ids is a plain
+    // integer array (no per-candidate enum), so it stays byte-identical per turn.
+    const schema = call.tools![0].input_schema as {
+      properties: Record<
+        string,
+        { type?: string; items?: { type?: string; enum?: unknown } }
+      >;
+    };
+    expect(schema.properties.selected_ids?.type).toBe("array");
+    expect(schema.properties.selected_ids?.items?.type).toBe("integer");
+    expect(schema.properties.selected_ids?.items?.enum).toBeUndefined();
     const userText = call.messages[0].content
       .map((b) => (b.type === "text" ? b.text : ""))
       .join("\n");
     expect(userText).toContain("NOW-MARKER");
-    expect(userText).toContain("a");
-    expect(userText).toContain("b");
+    // Candidates are numbered from 1 in candidate order.
+    expect(userText).toContain("[1] a");
+    expect(userText).toContain("[2] b");
   });
 
   test("includes the just-arrived turn so the selection is query-aware", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -211,9 +223,9 @@ describe("runGate — ready decision", () => {
     expect(userText).toContain("an earlier reply");
   });
 
-  test("omitted selected_slugs falls back to all candidates (recall-safe)", async () => {
+  test("omitted selected_ids falls back to all candidates (recall-safe)", async () => {
     const calls: ProviderCall[] = [];
-    // `ready` verdict with no `selected_slugs` field at all. A silent omission
+    // `ready` verdict with no `selected_ids` field at all. A silent omission
     // must keep everything surfaced, not drop all non-sticky context.
     const provider = makeProvider(
       gateToolResponse({ decision: "ready" }),
@@ -236,12 +248,12 @@ describe("runGate — ready decision", () => {
     ]);
   });
 
-  test("explicit empty selected_slugs selects nothing but sticky", async () => {
+  test("explicit empty selected_ids selects nothing but sticky", async () => {
     const calls: ProviderCall[] = [];
     // An *explicit* `[]` is the model genuinely choosing nothing — honored as-is
     // (only sticky survives), unlike an omitted field.
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: [] }),
+      gateToolResponse({ decision: "ready", selected_ids: [] }),
       calls,
     );
 
@@ -258,10 +270,11 @@ describe("runGate — ready decision", () => {
     expect(result.selectedSlugs).toEqual(["people/bob"]);
   });
 
-  test("drops a model-selected slug outside the candidate set", async () => {
+  test("drops out-of-range ids (0, past the end) without throwing", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a", "ghost"] }),
+      // id 1 -> "a"; 0 and 99 are out of range (1-based, only 2 candidates).
+      gateToolResponse({ decision: "ready", selected_ids: [1, 0, 99] }),
       calls,
     );
 
@@ -281,7 +294,7 @@ describe("runGate — ready decision", () => {
     const controller = new AbortController();
     controller.abort();
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -304,7 +317,8 @@ describe("runGate — candidate summaries", () => {
   test("renders candidates as `slug — summary` when summaryBySlug is provided", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a/one"] }),
+      // id 1 -> "a/one".
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -320,19 +334,20 @@ describe("runGate — candidate summaries", () => {
       provider,
     });
 
-    // The model still answers in bare slugs (the enum is slug-only).
+    // The model answers with the [N] numbers, mapped back to slugs by the gate.
     expect(result.selectedSlugs).toEqual(["a/one"]);
     const userText = calls[0].messages[0].content
       .map((b) => (b.type === "text" ? b.text : ""))
       .join("\n");
-    expect(userText).toContain("a/one — first summary");
-    expect(userText).toContain("b/two — second summary");
+    // Candidates are numbered `[N] slug — summary`, in candidate order.
+    expect(userText).toContain("[1] a/one — first summary");
+    expect(userText).toContain("[2] b/two — second summary");
   });
 
   test("falls back to the bare slug when no summary is available", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: [] }),
+      gateToolResponse({ decision: "ready", selected_ids: [] }),
       calls,
     );
 
@@ -347,7 +362,7 @@ describe("runGate — candidate summaries", () => {
     const userText = calls[0].messages[0].content
       .map((b) => (b.type === "text" ? b.text : ""))
       .join("\n");
-    expect(userText).toContain("a/one");
+    expect(userText).toContain("[1] a/one");
     expect(userText).not.toContain("a/one —");
   });
 });
@@ -358,7 +373,7 @@ describe("runGate — more decision", () => {
     const provider = makeProvider(
       gateToolResponse({
         decision: "more",
-        selected_slugs: ["a"],
+        selected_ids: [1],
         questions: ["What is the user's deadline?", "Who else is involved?"],
       }),
       calls,
@@ -385,7 +400,7 @@ describe("runGate — more decision", () => {
     const provider = makeProvider(
       gateToolResponse({
         decision: "more",
-        selected_slugs: ["a"],
+        selected_ids: [1],
         questions: ["   ", ""],
       }),
       calls,
@@ -407,7 +422,7 @@ describe("runGate — more decision", () => {
     const provider = makeProvider(
       gateToolResponse({
         decision: "more",
-        selected_slugs: ["a"],
+        selected_ids: [1],
         questions: ["follow-up?"],
       }),
       calls,
@@ -429,7 +444,7 @@ describe("runGate — system prompt", () => {
   test("uses the bundled default when no override is configured", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -447,7 +462,7 @@ describe("runGate — system prompt", () => {
   test("uses the configured inline override as the system prompt", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -515,10 +530,7 @@ describe("runGate — fail-safe", () => {
       sticky: new Set(),
       passNumber: 1,
       // `decision` is required; missing it fails the Zod schema.
-      provider: makeProvider(
-        gateToolResponse({ selected_slugs: ["a"] }),
-        calls,
-      ),
+      provider: makeProvider(gateToolResponse({ selected_ids: [1] }), calls),
     });
 
     expect(result.decision).toEqual({ decision: "ready" });
@@ -531,7 +543,7 @@ describe("runGate — capture", () => {
     const calls: ProviderCall[] = [];
     const captured: Omit<LlmCallRecord, "pass">[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -573,7 +585,7 @@ describe("runGate — reasoning field", () => {
   test("exposes an optional reasoning property in the forced tool schema", async () => {
     const calls: ProviderCall[] = [];
     const provider = makeProvider(
-      gateToolResponse({ decision: "ready", selected_slugs: ["a"] }),
+      gateToolResponse({ decision: "ready", selected_ids: [1] }),
       calls,
     );
 
@@ -599,7 +611,7 @@ describe("runGate — reasoning field", () => {
     const provider = makeProvider(
       gateToolResponse({
         decision: "ready",
-        selected_slugs: ["b", "a"],
+        selected_ids: [2, 1],
         reasoning: "kept the two query-relevant pages, dropped the rest",
       }),
       calls,

--- a/assistant/src/memory/v3/gate.ts
+++ b/assistant/src/memory/v3/gate.ts
@@ -79,9 +79,9 @@ export interface RunGateArgs {
    * Per-candidate one-line summaries, keyed by slug. When present, candidates
    * are rendered to the model as `slug — summary` so the gate can judge
    * relevance on page content rather than the slug alone. Missing entries fall
-   * back to the bare slug; the forced tool's `selected_slugs` enum stays
-   * slug-only. The loop passes this only when `memory.v3.gateCandidateSummaries`
-   * is set.
+   * back to the bare slug; the model answers with the candidate's `[N]` number
+   * (`selected_ids`) regardless, so summaries never change the answer format. The
+   * loop passes this only when `memory.v3.gateCandidateSummaries` is set.
    */
   summaryBySlug?: ReadonlyMap<string, string>;
   /** Optional debug sink — emits one record for the gate's LLM call. */
@@ -102,17 +102,20 @@ export interface RunGateResult {
 }
 
 /**
- * Build the forced tool definition. `selected_slugs` is the ordered final
- * selection; `decision` is the ready/more verdict; `questions` carries the
- * generated follow-up queries on "more" (ignored on "ready"). Mirrors the
- * forced-tool pattern of v2's `select_pages_to_inject`.
+ * Build the forced tool definition. `selected_ids` is the list of bracketed
+ * `[N]` candidate numbers to keep; `decision` is the ready/more verdict;
+ * `questions` carries the generated follow-up queries on "more" (ignored on
+ * "ready"). The schema is candidate-independent — no per-turn enum — so it stays
+ * byte-identical across turns (cache-friendly) and the model answers with the
+ * line numbers rather than reproducing exact slug strings, mirroring the
+ * integer-id output of v2's `select_pages_to_inject`.
  */
-function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
+function buildGateTool(): ToolDefinition {
   return {
     name: GATE_TOOL_NAME,
     description:
       "Decide whether the accumulated candidate pages are sufficient to answer " +
-      "the next turn. Return decision='ready' with the final ordered selection " +
+      "the next turn. Return decision='ready' with the final selection " +
       "when the candidates cover the turn; return decision='more' with one or " +
       "more generated follow-up questions (NOT the original message) to seed " +
       "another retrieval pass when coverage is incomplete.",
@@ -120,16 +123,14 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
       type: "object",
       properties: {
         decision: { type: "string", enum: ["ready", "more"] },
-        selected_slugs: {
+        selected_ids: {
           type: "array",
-          items: { type: "string", enum: [...candidateSlugs] },
+          items: { type: "integer" },
           description:
-            "Final ordered page slugs to inject. Each candidate is listed as " +
-            "`slug — summary` when summaries are available; return only the slug " +
-            "(left of the em-dash), and only from the candidate set. Prefer keeping " +
-            "a plausibly-relevant page over dropping it; for a list / 'all of X' / " +
-            "breadth request, include every candidate that plausibly applies rather " +
-            "than trimming to the most prominent few.",
+            "The bracketed `[N]` numbers of the candidate pages to keep. Prefer " +
+            "keeping a plausibly-relevant page over dropping it; for a list / " +
+            "'all of X' / breadth request, include every candidate that plausibly " +
+            "applies rather than trimming to the most prominent few.",
         },
         questions: {
           type: "array",
@@ -144,32 +145,33 @@ function buildGateTool(candidateSlugs: readonly string[]): ToolDefinition {
             "candidates were kept or dropped.",
         },
       },
-      required: ["decision", "selected_slugs"],
+      required: ["decision", "selected_ids"],
     },
   };
 }
 
 const GateToolResultSchema = z.object({
   decision: z.enum(["ready", "more"]),
-  selected_slugs: z.array(z.string()).optional(),
+  selected_ids: z.array(z.coerce.number()).optional(),
   questions: z.array(z.string()).optional(),
   reasoning: z.string().optional(),
 });
 
 /**
- * Render the candidate list for the prompt. With summaries available each line
- * is `slug — summary` so the model can judge relevance on content; without them
- * it falls back to the bare slug. The slug (left of the em-dash) is what the
- * `selected_slugs` enum constrains, so the model always answers in slugs.
+ * Render the candidate list for the prompt. Each line is `[N] slug — summary`
+ * (or `[N] slug` without a summary), numbered from 1 in candidate order. The
+ * model answers with the `[N]` numbers via `selected_ids`, which the caller maps
+ * back to slugs by index — so the tool schema stays candidate-independent.
  */
 function renderCandidateLines(
   slugs: readonly string[],
   summaryBySlug: ReadonlyMap<string, string> | undefined,
 ): string {
   return slugs
-    .map((slug) => {
+    .map((slug, i) => {
       const summary = summaryBySlug?.get(slug);
-      return summary ? `${slug} — ${summary}` : slug;
+      const body = summary ? `${slug} — ${summary}` : slug;
+      return `[${i + 1}] ${body}`;
     })
     .join("\n");
 }
@@ -267,7 +269,7 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     ],
   };
 
-  const gateTool = buildGateTool(candidateSlugs);
+  const gateTool = buildGateTool();
 
   const startedAt = Date.now();
   let response;
@@ -310,11 +312,17 @@ export async function runGate(args: RunGateArgs): Promise<RunGateResult> {
     return failSafe(candidates, sticky);
   }
 
-  // Recall-safe fallback: an *omitted* `selected_slugs` means the model gave no
+  // Recall-safe fallback: an *omitted* `selected_ids` means the model gave no
   // instruction, so keep everything that was surfaced — dropping all non-sticky
   // context on a silent omission is the worse failure. An *explicit* `[]` is the
-  // model genuinely choosing nothing and is honored as-is.
-  const modelSlugs = parsed.data.selected_slugs ?? [...candidates];
+  // model genuinely choosing nothing and is honored as-is. Ids are 1-based
+  // indices into the rendered candidate list; out-of-range ids are dropped.
+  const modelSlugs =
+    parsed.data.selected_ids === undefined
+      ? [...candidates]
+      : parsed.data.selected_ids
+          .map((id) => candidateSlugs[Math.trunc(id) - 1])
+          .filter((slug): slug is string => slug !== undefined);
   const selectedSlugs = orderSelection(modelSlugs, candidates, sticky);
 
   const reasoning = parsed.data.reasoning?.trim() || undefined;


### PR DESCRIPTION
## Summary
- Port the v3 selection gate from `selected_slugs` (a string `enum` of **every** candidate slug, rebuilt every turn) to v2's numbered-index mechanism: candidates render as `[N] slug — summary` and the forced `decide_selection` tool returns `selected_ids: integer[]`, which the gate maps back to slugs by 1-based index.
- **Cache + schema win:** the tool schema is now candidate-independent (no per-turn enum), so it's byte-identical across turns — it no longer busts the prompt-cache prefix and no longer serializes a ~560-value enum into every gate call.
- **Breadth win:** in a fixed-pool head-to-head (same 562-candidate pool, same gate prompt), the numbered-id mechanism selected ~1.7× more pages (16–21 vs 11–13) — the slug-enum was suppressing selection volume.
- Recall-safe fallbacks preserved exactly: an omitted `selected_ids` keeps **all** candidates; an explicit `[]` keeps only sticky; out-of-range / `0` ids are dropped; sticky always present; every failure path (no provider, throw, missing tool_use, schema mismatch) still fails open to `ready` + all candidates.

**This is a breadth + cache improvement, NOT a recall-correctness fix.** The same head-to-head showed numbered-ids does *not* reliably catch a specific relevant page better than the enum — the gate occasionally dropping an obviously-relevant page is stochastic attention over a large candidate pool, a separate problem tracked elsewhere. v2's router already uses this numbered-id mechanism; this brings the v3 gate in line.

Scope: `gate.ts` + its tests only. v3 is flag-gated / shadow-only, so this changes how the v3 gate selects with zero live-v2 impact. The deployed workspace gate prompt (`v3-gate-prompt.md`) still says "selected_slugs" in prose — the forced-tool schema governs, so it's non-breaking; refresh it to mention the `[N]` numbers in a follow-up workspace deploy.

## Original prompt
While debugging why the v3 gate dropped an obviously-relevant page on a clearly on-topic turn, we found the gate forces the model to return `selected_slugs` constrained to a string enum of all ~560 candidates, whereas v2's proven high-recall router numbers the pages and returns integer ids. A fixed-pool head-to-head confirmed the enum suppresses selection volume (and bloats/cache-busts the schema). This ports v2's numbered-id mechanism to the v3 gate. It was explicitly validated as a breadth/cache win, not a fix for the (stochastic) recall miss.