### PR TITLE
feat(memory-v3): make edge-lane pool cap configurable (maxPulls)

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -224,7 +224,7 @@ describe("MemoryV3ConfigSchema", () => {
       denseQuota: { activeDomain: 30, offDomain: 8 },
       hotLimit: 50,
       lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
-      edges: { learnedAdjacencyThreshold: 0 },
+      edges: { learnedAdjacencyThreshold: 0, maxPulls: 400 },
       ks: [5, 10, 25, 50],
       write: {
         enabled: false,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -533,8 +533,15 @@ export const MemoryV3ConfigSchema = z
           .describe(
             "Association-strength cutoff for merging the learned co-retrieval graph (memory_v3_auto_edges) into the edge-expansion lane. Seeded edges are weighted seedWeight × NPMI, so this is effectively a minimum-NPMI gate: NPMI ≥ threshold / seedWeight (e.g. with the default seedWeight 2.0, threshold 1.0 ≈ NPMI ≥ 0.5, 1.2 ≈ NPMI ≥ 0.6). When > 0, edges at or above this weight are read via aboveThreshold() and merged with the curated frontmatter graph as expandEdges' extraAdjacency. 0 (default) = OFF: the edge lane uses curated edges only and behavior is unchanged. Seed the learned graph with `assistant memory v3 seed-edges`.",
           ),
+        maxPulls: z
+          .number({ error: "memory.v3.edges.maxPulls must be a number" })
+          .min(0, "memory.v3.edges.maxPulls must be >= 0")
+          .default(400)
+          .describe(
+            "Hard cap on the edge lane's contribution to the gate's candidate pool (the unioned 1–2 hop curated∪learned neighborhood). The shipped default 400 lets a dense curated graph dominate the pool and drown the gate's recall of high-precision hits; lower values (~40) keep the lane focused. 0 effectively disables edge pulls.",
+          ),
       })
-      .default({ learnedAdjacencyThreshold: 0 })
+      .default({ learnedAdjacencyThreshold: 0, maxPulls: 400 })
       .describe(
         "Edge-expansion lane configuration. Gates whether the learned co-retrieval graph augments the curated edge graph.",
       ),
@@ -615,7 +622,7 @@ export const MemoryV3ConfigSchema = z
     denseQuota: { activeDomain: 30, offDomain: 8 },
     hotLimit: 50,
     lanes: { hot: true, sparse: true, dense: true, tree: true, edges: true },
-    edges: { learnedAdjacencyThreshold: 0 },
+    edges: { learnedAdjacencyThreshold: 0, maxPulls: 400 },
     ks: [5, 10, 25, 50],
     write: {
       enabled: false,

--- a/assistant/src/memory/v3/__tests__/edges.test.ts
+++ b/assistant/src/memory/v3/__tests__/edges.test.ts
@@ -466,6 +466,46 @@ describe("expandEdges — bounds", () => {
     }
   });
 
+  test("maxTotalPulls overrides the default union ceiling", async () => {
+    // 20 seeds × 32 disjoint targets = 640 reachable, far past any cap. A low
+    // per-call maxTotalPulls must bound the union to that value, not the 400
+    // default; an omitted or invalid value falls back to the default.
+    const seedCount = 20;
+    const graph: Record<string, string[]> = {};
+    const seeds: string[] = [];
+    for (let s = 0; s < seedCount; s++) {
+      const seed = topicSlug("people", s);
+      const targets: string[] = [];
+      for (let t = 0; t < MAX_PULLS_PER_SEED; t++) {
+        const target = topicSlug("targets", s * MAX_PULLS_PER_SEED + t);
+        targets.push(target);
+        graph[target] = [];
+      }
+      graph[seed] = targets;
+      seeds.push(seed);
+    }
+    await writeGraph(graph);
+
+    const capped = await expandEdges({
+      workspaceDir,
+      seeds,
+      hops: 1,
+      maxTotalPulls: 40,
+    });
+    expect(capped.pulled.size).toBeLessThanOrEqual(40);
+
+    // Omitted → the 400 default; an invalid (negative) value also falls back.
+    const dflt = await expandEdges({ workspaceDir, seeds, hops: 1 });
+    expect(dflt.pulled.size).toBe(MAX_TOTAL_PULLS);
+    const invalid = await expandEdges({
+      workspaceDir,
+      seeds,
+      hops: 1,
+      maxTotalPulls: -5,
+    });
+    expect(invalid.pulled.size).toBe(MAX_TOTAL_PULLS);
+  });
+
   test("duplicate slugs across seeds don't waste the total budget", async () => {
     // Two seeds, both pointing at the same shared target plus one private each.
     // The shared slug is counted once, so the union is 3 — well under the cap,

--- a/assistant/src/memory/v3/edges.ts
+++ b/assistant/src/memory/v3/edges.ts
@@ -62,10 +62,11 @@ const MAX_SEEDS_EXPANDED = 150;
 const MAX_PULLS_PER_SEED = 32;
 
 /**
- * Hard ceiling on the size of the unioned `pulled` set. This is the load-bearing
- * bound: it caps the lane's contribution to the gate's pool to a few hundred
- * slugs no matter how many seeds or how dense the graph. Once reached, no
- * further seeds are expanded.
+ * Default ceiling on the size of the unioned `pulled` set. This is the
+ * load-bearing bound: it caps the lane's contribution to the gate's pool no
+ * matter how many seeds or how dense the graph. Once reached, no further seeds
+ * are expanded. Overridable per call via {@link ExpandEdgesArgs.maxTotalPulls}
+ * (the loop wires it to `memory.v3.edges.maxPulls`).
  */
 const MAX_TOTAL_PULLS = 400;
 
@@ -120,6 +121,12 @@ export interface ExpandEdgesArgs {
    * above-threshold edges before passing them in.
    */
   extraAdjacency?: ReadonlyMap<string, ReadonlySet<string>>;
+  /**
+   * Hard ceiling on the unioned `pulled` set — the lane's contribution to the
+   * gate pool. Defaults to {@link MAX_TOTAL_PULLS} when omitted or not a finite
+   * number ≥ 0.
+   */
+  maxTotalPulls?: number;
 }
 
 export interface ExpandEdgesResult {
@@ -199,6 +206,15 @@ export async function expandEdges(
     laneBySlug,
   } = args;
 
+  // Per-call override of the union ceiling, falling back to the default constant
+  // for an omitted or invalid (negative/NaN) value.
+  const maxTotal =
+    typeof args.maxTotalPulls === "number" &&
+    Number.isFinite(args.maxTotalPulls) &&
+    args.maxTotalPulls >= 0
+      ? args.maxTotalPulls
+      : MAX_TOTAL_PULLS;
+
   const index = await getEdgeIndex(workspaceDir);
   const pulled = new Set<string>();
   const expansions: EdgeExpansion[] = [];
@@ -232,7 +248,7 @@ export async function expandEdges(
     // Bound the number of seeds expanded, and stop once the union is full —
     // the remaining seeds would only inflate the gate's pool. Checked before
     // doing any per-seed work so an oversized seed set is cheap to truncate.
-    if (seenSeeds.size > MAX_SEEDS_EXPANDED || pulled.size >= MAX_TOTAL_PULLS) {
+    if (seenSeeds.size > MAX_SEEDS_EXPANDED || pulled.size >= maxTotal) {
       break;
     }
 
@@ -257,7 +273,7 @@ export async function expandEdges(
       (slug) => !seedSet.has(slug) && !pulled.has(slug),
     );
 
-    const remaining = MAX_TOTAL_PULLS - pulled.size;
+    const remaining = maxTotal - pulled.size;
     const perSeedCap = Math.min(MAX_PULLS_PER_SEED, remaining);
     const admitted = fresh.slice(0, perSeedCap);
     for (const slug of admitted) pulled.add(slug);

--- a/assistant/src/memory/v3/loop.ts
+++ b/assistant/src/memory/v3/loop.ts
@@ -239,6 +239,8 @@ export async function runRetrievalLoop(
         // Merge the learned co-retrieval graph with the curated edges when
         // enabled (undefined = curated-only, the default).
         ...(learnedAdjacency ? { extraAdjacency: learnedAdjacency } : {}),
+        // Cap the lane's contribution to the gate pool (default 400).
+        maxTotalPulls: v3.edges?.maxPulls,
       });
       edgeExpansions = expansion.expansions;
       for (const slug of expansion.pulled) {


### PR DESCRIPTION
## Summary
- Make the v3 edge lane's total-pulls ceiling configurable via `memory.v3.edges.maxPulls` (default **400 = no behavior change**). `expandEdges` gains an optional `maxTotalPulls` arg (with a negative/NaN guard that falls back to the `MAX_TOTAL_PULLS` constant); the loop wires it from config.
- **Why:** a controlled experiment found the edge lane is ~**71%** of the gate's ~560-candidate pool, and that flood is the gate's recall ceiling. On a substrate turn the gate **missed an in-pool relevant page 0/3 times at the full ~560 pool, but caught it 3/3 at ~160** (and 2/3 at ~210) — a clean dose-response, same gate/prompt/mechanism, only pool size varied. The 400-page edge dump buries the high-precision (sparse/dense/tree) hits.
- This PR only adds the **knob** — safe and behavior-preserving at the default. Choosing and deploying a low value (~40) is validated across turns and rolled out separately.

## Original prompt
While hand-optimizing v3 retrieval against representative turns, we traced a recall miss (the gate dropping an obviously-relevant page on a "p-zombie" turn) to the size of the gate's candidate pool, which is dominated by the edge lane's structural 400-pull cap. A same-pool experiment confirmed shrinking the edge contribution restores the gate's recall. Make that cap a config knob (`memory.v3.edges.maxPulls`) so it can be tuned down, keeping the shipped default at 400 so this change is behavior-preserving. v3 is pre-production/shadow.