### PR TITLE
fix(assistant): preserve pin state when isPinned omitted from reorder request

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -2250,7 +2250,7 @@ export function batchSetDisplayOrders(
   updates: Array<{
     id: string;
     displayOrder: number | null;
-    isPinned: boolean;
+    isPinned?: boolean;
     groupId?: string | null;
   }>,
 ): void {
@@ -2283,35 +2283,36 @@ export function batchSetDisplayOrders(
           safeGroupId,
           update.id,
         );
+      } else if (update.isPinned === undefined) {
+        // Only displayOrder provided — preserve existing pin state and group.
+        rawRun(
+          "UPDATE conversations SET display_order = ? WHERE id = ?",
+          update.displayOrder,
+          update.id,
+        );
+      } else if (update.isPinned) {
+        rawRun(
+          "UPDATE conversations SET display_order = ?, is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
+          update.displayOrder,
+          update.id,
+        );
       } else {
-        // Old client: no groupId in payload
-        // isPinned true -> set group_id = system:pinned
-        // isPinned false -> clear group_id ONLY IF currently system:pinned
-        //                   otherwise preserve existing group_id
-        if (update.isPinned) {
-          rawRun(
-            "UPDATE conversations SET display_order = ?, is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
-            update.displayOrder,
-            update.id,
-          );
-        } else {
-          // Restore system group from source/conversationType when old clients
-          // unpin, instead of clearing to NULL (which would lose provenance).
-          rawRun(
-            `UPDATE conversations SET display_order = ?, is_pinned = 0,
-             group_id = CASE WHEN group_id = 'system:pinned' THEN
-               CASE
-                 WHEN source IN ('schedule', 'reminder') THEN 'system:scheduled'
-                 WHEN source IN ('heartbeat', 'task') THEN 'system:background'
-                 WHEN conversation_type = 'background' AND COALESCE(source, '') != 'notification' THEN 'system:background'
-                 ELSE 'system:all'
-               END
-             ELSE group_id END
-             WHERE id = ?`,
-            update.displayOrder,
-            update.id,
-          );
-        }
+        // Restore system group from source/conversationType when unpinning,
+        // instead of clearing to NULL (which would lose provenance).
+        rawRun(
+          `UPDATE conversations SET display_order = ?, is_pinned = 0,
+           group_id = CASE WHEN group_id = 'system:pinned' THEN
+             CASE
+               WHEN source IN ('schedule', 'reminder') THEN 'system:scheduled'
+               WHEN source IN ('heartbeat', 'task') THEN 'system:background'
+               WHEN conversation_type = 'background' AND COALESCE(source, '') != 'notification' THEN 'system:background'
+               ELSE 'system:all'
+             END
+           ELSE group_id END
+           WHERE id = ?`,
+          update.displayOrder,
+          update.id,
+        );
       }
     }
     rawExec("COMMIT");

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -411,7 +411,7 @@ function handleReorderConversations({ body = {}, headers }: RouteHandlerArgs) {
     updates.map((u) => ({
       id: u.conversationId,
       displayOrder: u.displayOrder ?? null,
-      isPinned: u.isPinned ?? false,
+      isPinned: u.isPinned,
       groupId: u.groupId,
     })),
   );


### PR DESCRIPTION
Closes JARVIS-972

## Prompt / plan

Fix the `isPinned` default behavior identified by Codex review on PR #32218 (LUM-1944). When callers of `batchSetDisplayOrders` omit `isPinned` (meaning "don't change pin state"), the handler was defaulting it to `false`, silently unpinning pinned conversations.

## Root cause

In `conversation-management-routes.ts`, the handler mapped incoming updates with:
```typescript
isPinned: u.isPinned ?? false
```

This meant any caller sending only `{ conversationId, displayOrder }` (to reorder without changing pin state) would unintentionally unpin pinned conversations. The `z.array(z.unknown())` schema previously hid this contract — once LUM-1944 added typed schemas, the destructive default became visible.

### How did the code get into this state?
The `?? false` default was added when `batchSetDisplayOrders` required a boolean `isPinned` parameter — there was no concept of "preserve existing state." The untyped schema (`z.unknown()`) meant callers never saw the field was expected, so the destructive default was invisible.

### What can we prevent?
When adding default values for optional fields in mutation handlers, consider the semantics of "absent" vs "explicitly false." Optional fields in update operations should default to "no change" (undefined/null passthrough), not a concrete value.

## Changes

1. **Handler** (`conversation-management-routes.ts`): Removed `?? false` — passes `undefined` through when `isPinned` is omitted
2. **Function** (`conversation-crud.ts`): Made `isPinned` optional in the type signature. Added a new branch for `isPinned === undefined` that only updates `displayOrder`, preserving existing pin state

## Test plan

- Existing conversation management tests (22 tests) continue passing
- TypeCheck + lint pass
- CI green (8/8)

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka