### PR TITLE
fix(release): upload signed CRX to Chrome Web Store instead of zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,14 @@ jobs:
           path: clients/chrome-extension/vellum-browser-relay.crx
           retention-days: 90
 
+      - name: Upload extension CRX (zipped for download)
+        if: hashFiles('clients/chrome-extension/vellum-browser-relay.crx.zip') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: chrome-extension-crx-zip
+          path: clients/chrome-extension/vellum-browser-relay.crx.zip
+          retention-days: 90
+
       - name: Upload extension zip
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -348,10 +356,10 @@ jobs:
         id: read-extension-id
         run: echo "id=$(jq -r '.production.extensionId' clients/chrome-extension/extension-environments.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Download extension zip
+      - name: Download extension CRX
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: chrome-extension-zip
+          name: chrome-extension-crx
           path: /tmp/chrome-extension
 
       - name: Install chrome-webstore-upload-cli
@@ -366,8 +374,8 @@ jobs:
           PUBLISHER_ID: ${{ vars.CWS_PUBLISHER_ID }}
           E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
-          # CWS API requires a zip — it handles signing server-side
-          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.zip)
+          # Extension has CRX Verified Uploads enabled — CWS requires a signed .crx
+          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.crx)
           echo "Uploading: $UPLOAD_FILE"
           set +e
           OUTPUT=$(chrome-webstore-upload upload \
@@ -2446,11 +2454,11 @@ jobs:
           name: chrome-extension-zip
           path: chrome-extension-artifacts
 
-      - name: Download Chrome extension CRX
+      - name: Download Chrome extension CRX (zipped)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
-          name: chrome-extension-crx
+          name: chrome-extension-crx-zip
           path: chrome-extension-artifacts
 
       - name: Create GitHub Releases
@@ -2484,8 +2492,8 @@ jobs:
           if [ -d "chrome-extension-artifacts" ]; then
             CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay.zip" -type f | head -1)
             [ -n "$CRX_ZIP" ] && ASSETS+=("$CRX_ZIP#vellum-browser-relay-${VERSION}.zip")
-            CRX_FILE=$(find chrome-extension-artifacts -name "vellum-browser-relay.crx" -type f | head -1)
-            [ -n "$CRX_FILE" ] && ASSETS+=("$CRX_FILE#vellum-browser-relay-${VERSION}.crx")
+            CRX_FILE_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay.crx.zip" -type f | head -1)
+            [ -n "$CRX_FILE_ZIP" ] && ASSETS+=("$CRX_FILE_ZIP#vellum-browser-relay-${VERSION}.crx.zip")
           fi
 
           echo "Release assets: ${ASSETS[*]}"

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -258,12 +258,15 @@ if [ "$CMD" = "run" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Packaging: produce a signed .crx for Verified CRX Uploads (CWS) and a .zip
-# for local/fallback use. The private key is expected at privatekey.pem in the
-# chrome-extension directory; CI injects it via secrets.
+# Packaging: produce a signed .crx (wrapped in a zip to prevent browser
+# interception on download) for manual CWS uploads, and a plain .zip of the
+# unpacked extension for the automated CWS API upload and "Load unpacked".
+# The private key is expected at privatekey.pem in the chrome-extension
+# directory; CI injects it via secrets.
 # ---------------------------------------------------------------------------
 CRX_KEY_FILE="${CRX_KEY_PATH:-$SCRIPT_DIR/privatekey.pem}"
 CRX_OUT="$SCRIPT_DIR/vellum-browser-relay.crx"
+CRX_ZIP_OUT="$SCRIPT_DIR/vellum-browser-relay.crx.zip"
 ZIP_OUT="$SCRIPT_DIR/vellum-browser-relay.zip"
 
 # Detect Chrome/Chromium binary (macOS & Linux)
@@ -292,6 +295,10 @@ if [ -f "$CRX_KEY_FILE" ]; then
     if [ -f "$DIST_DIR.crx" ]; then
       mv "$DIST_DIR.crx" "$CRX_OUT"
       echo "  Signed CRX: $CRX_OUT"
+      # Wrap the CRX in a zip so browsers don't intercept the download
+      # when it's served as a GitHub Release asset.
+      (cd "$(dirname "$CRX_OUT")" && zip "$CRX_ZIP_OUT" "$(basename "$CRX_OUT")")
+      echo "  Signed CRX (zipped): $CRX_ZIP_OUT"
     else
       echo "  Warning: Chrome did not produce a .crx file"
     fi


### PR DESCRIPTION
## Summary
- **Fix CWS auto-publish**: The extension has CRX Verified Uploads enabled, so CWS requires a signed `.crx` file — but `publish-chrome-extension` was uploading the plain `.zip`, causing every production CWS publish to fail with "uploaded package was invalid"
- **Fix CRX download from GitHub Releases**: Wrap the `.crx` in a `.crx.zip` for GitHub Release assets so Chrome doesn't intercept the download and reject it with `CRX_REQUIRED_PROOF_MISSING`

## Context
The v0.8.5 release's `publish-chrome-extension` job failed with:
```
❌ The uploaded package was invalid. Check the additional details for more information.
```
And manually downloading the `.crx` from the GitHub Release also fails because Chrome intercepts `.crx` downloads and requires a Web Store proof token.

## Test plan
- [ ] Verify next production release's `publish-chrome-extension` job succeeds
- [ ] Verify the `.crx.zip` asset on the GitHub Release can be downloaded, extracted, and manually uploaded to CWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)