### PR TITLE
fix(web): resolve inline subagent card via spawning toolUseId

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -161,20 +161,32 @@ function lookupSubagentEntriesForMessage(
 
 /**
  * Resolve the spawned `subagentId` for each `subagent_spawn` tool call in
- * `toolCalls`. Prefers the id encoded in `toolCall.result`; falls back to a
- * positional match against `linkedEntries` (subagent-store entries already
- * filtered to those spawned by the current message, sorted by `spawnedAt`)
- * when the result hasn't landed yet (running spawns, mid-stream reloads).
+ * `toolCalls`. Resolution priority per tool call:
+ *
+ *  1. `byToolUseId.get(tc.id)` — the deterministic, reconcile-proof anchor.
+ *     During streaming `tc.id === parentToolUseId` (see `tool-call-handlers.ts`
+ *     where the tool-call id is set to `event.toolUseId`), and `reconcile.ts`
+ *     preserves local tool-call ids (`keepLocalToolState`), so this match holds
+ *     the instant the spawn lands and survives message reconcile — no dependence
+ *     on `message.id` or the tool result.
+ *  2. The id encoded in `toolCall.result` — present once the spawn tool result
+ *     has landed.
+ *  3. A positional match against `linkedEntries` (subagent-store entries
+ *     already filtered to those spawned by the current message, sorted by
+ *     `spawnedAt`) — covers older daemons, history-synthesized tool ids, and
+ *     forks where no tool-use id is available.
  *
  * Positional fallback: the caller owns the `claimed` Set so it persists
  * across every invocation within a single message — that's what stops two
  * non-consecutive spawn tool-call groups (each producing a separate
  * `ToolCallProgressCard` mount) from both pulling the same first unclaimed
- * entry and rendering duplicate cards.
+ * entry and rendering duplicate cards. The by-id matches also feed `claimed`
+ * so a later positional match can't re-pick an already-anchored entry.
  */
 function resolveSpawnedSubagentIds(
   toolCalls: ChatMessageToolCall[],
   linkedEntries: readonly SubagentEntry[],
+  byToolUseId: Map<string, string>,
   claimed: Set<string>,
 ): string[] {
   const spawnToolCalls = toolCalls.filter(isSubagentSpawnCall);
@@ -183,6 +195,12 @@ function resolveSpawnedSubagentIds(
   const ids: string[] = [];
 
   for (const tc of spawnToolCalls) {
+    const byId = byToolUseId.get(tc.id);
+    if (byId && !claimed.has(byId)) {
+      ids.push(byId);
+      claimed.add(byId);
+      continue;
+    }
     const fromResult = extractSubagentIdFromResult(tc);
     if (fromResult) {
       ids.push(fromResult);
@@ -473,6 +491,14 @@ export function TranscriptMessageBody({
     useShallow((s) => lookupSubagentEntriesForMessage(s.byParent, message)),
   );
 
+  // Subscribe to the tool-use-id index alongside the per-message bucket above.
+  // Spawns are infrequent, so subscribing to the whole map is acceptable; PR 2
+  // keeps the map reference stable across non-spawn mutations, so this does not
+  // re-render message bodies on unrelated subagent activity. This anchors each
+  // `subagent_spawn` tool call to its subagent by `tc.id`, independent of the
+  // (optimistic→server) message id.
+  const byToolUseId = useSubagentStore(useShallow((s) => s.byToolUseId));
+
   // Message-scoped: two non-consecutive `subagent_spawn` tool-call groups
   // must not both positional-match the same linked entry. Accumulates across
   // every `renderInlineSubagentCards` invocation within a single render.
@@ -492,6 +518,7 @@ export function TranscriptMessageBody({
     const spawnedIds = resolveSpawnedSubagentIds(
       toolCalls,
       linkedSubagentEntries,
+      byToolUseId,
       claimedSpawnIds,
     );
     if (spawnedIds.length === 0) return null;

--- a/apps/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
@@ -374,6 +374,66 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
   });
 });
 
+describe("Transcript — toolUseId anchor (PR 3)", () => {
+  test("renders inline card via byToolUseId match with no result and a mismatched message id", () => {
+    // Live + orphaned window: the spawn tool call has no result yet, and the
+    // store entry is keyed under a stable id that does NOT match the rendered
+    // message's id — so neither the result branch nor the positional byParent
+    // fallback can resolve it. Only the deterministic toolUseId anchor
+    // (tc.id === parentToolUseId) can.
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-anchored",
+      label: "agent-0",
+      objective: "do a thing",
+      status: "running",
+      timestamp: 1000,
+      // Orphaned: parent anchored to a different (e.g. pre-reconcile) id, so
+      // byParent has no bucket for the rendered message's id.
+      parentMessageStableId: "some-other-stable-id",
+      parentToolUseId: "tool-use-abc",
+    });
+
+    const msg: DisplayMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "spawning",
+      contentOrder: [{ type: "toolCall", id: "tool-use-abc" }],
+      toolCalls: [
+        {
+          id: "tool-use-abc",
+          toolName: "subagent_spawn",
+          input: { label: "agent-0", objective: "do a thing" },
+          status: "running",
+          // No `result` — the daemon hasn't acked the spawn yet.
+        },
+      ],
+    };
+
+    const items: TranscriptItem[] = [
+      userMessage("u1", "spawn one"),
+      { kind: "message", key: "a1", message: msg },
+    ];
+
+    const { getAllByTestId, container } = render(
+      <Transcript
+        items={items}
+        onSecretSubmit={noop}
+        onConfirmationDecision={noop}
+        onSurfaceAction={noop}
+        onRetryError={noop}
+      />,
+    );
+
+    const cards = getAllByTestId("subagent-inline-card");
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-anchored");
+    // The spawn-only group must not surface a generic progress card.
+    expect(
+      container.querySelector('[data-testid="tool-call-progress-card"]'),
+    ).toBeNull();
+  });
+});
+
 describe("Transcript — cross-group claimed-set (fix-r1-c)", () => {
   test("two non-consecutive running spawns in one message map 1:1 to distinct subagentIds without duplicates", () => {
     // Two store entries linked to the same parent message, neither with a


### PR DESCRIPTION
## Summary
- Subscribe to the store's byToolUseId index in the transcript
- Anchor each subagent_spawn tool call to its subagent by tc.id (deterministic, reconcile-proof), before the existing result/positional fallbacks
- Add a transcript test for the live + orphaned window (no result, mismatched message id)

Part of plan: subagent-card-loading-state.md (PR 3 of 8)