### PR TITLE
fix(web): keep subagent byParent link across message reconcile

### DIFF
--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -8,6 +8,7 @@ import {
   handleGenerationHandoff,
   handleGenerationCancelled,
 } from "@/domains/chat/utils/stream-handlers/message-handlers.js";
+import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 
 describe("handleAssistantTextDelta", () => {
   it("cancels reconciliation and dispatches ASSISTANT_TEXT_DELTA", () => {
@@ -149,6 +150,83 @@ describe("handleMessageComplete", () => {
     expect(ctx.turnActions.completeTurn).toHaveBeenCalled();
     expect(ctx.clearProcessingKey).toHaveBeenCalledWith("conv-1");
     expect(ctx.startReconciliationLoop).not.toHaveBeenCalled();
+  });
+
+  it("re-anchors a spawned subagent from the streaming id to the server messageId", () => {
+    useSubagentStore.getState().reset();
+    // Spawn stamped with the optimistic streaming bubble id.
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Researcher",
+      objective: "Investigate",
+      timestamp: 1,
+      parentMessageStableId: "stream-bubble-1",
+    });
+    expect(
+      useSubagentStore.getState().byParent.get("stream-bubble-1"),
+    ).toHaveLength(1);
+
+    const ctx = makeCtx({
+      currentAssistantMessageIdRef: { current: "stream-bubble-1" },
+    });
+    handleMessageComplete(
+      { type: "message_complete", messageId: "server-msg-1", content: "Done" },
+      ctx,
+    );
+
+    // Entry is now reachable via the durable server messageId.
+    const byServer = useSubagentStore.getState().byParent.get("server-msg-1");
+    expect(byServer).toHaveLength(1);
+    expect(byServer?.[0]?.subagentId).toBe("sa-1");
+    expect(useSubagentStore.getState().byId["sa-1"]?.parentMessageId).toBe(
+      "server-msg-1",
+    );
+  });
+
+  it("does not re-anchor when the event has no messageId", () => {
+    useSubagentStore.getState().reset();
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Researcher",
+      objective: "Investigate",
+      timestamp: 1,
+      parentMessageStableId: "stream-bubble-1",
+    });
+
+    const ctx = makeCtx({
+      currentAssistantMessageIdRef: { current: "stream-bubble-1" },
+    });
+    handleMessageComplete({ type: "message_complete", content: "Done" }, ctx);
+
+    expect(useSubagentStore.getState().byId["sa-1"]?.parentMessageId).toBe(
+      undefined,
+    );
+  });
+
+  it("does not re-anchor when there is no current assistant message id", () => {
+    useSubagentStore.getState().reset();
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Researcher",
+      objective: "Investigate",
+      timestamp: 1,
+      parentMessageStableId: "stream-bubble-1",
+    });
+
+    const ctx = makeCtx({
+      currentAssistantMessageIdRef: { current: undefined },
+    });
+    handleMessageComplete(
+      { type: "message_complete", messageId: "server-msg-1", content: "Done" },
+      ctx,
+    );
+
+    expect(
+      useSubagentStore.getState().byParent.get("server-msg-1"),
+    ).toBeUndefined();
+    expect(useSubagentStore.getState().byId["sa-1"]?.parentMessageId).toBe(
+      undefined,
+    );
   });
 });
 

--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -7,6 +7,7 @@ import {
 } from "@/domains/chat/hooks/stream-message-updaters.js";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types.js";
 import type { AssistantActivityStateEvent, AssistantTextDeltaEvent, GenerationCancelledEvent, GenerationHandoffEvent, MessageCompleteEvent } from "@/domains/chat/api/event-types.js";
+import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 
 export function handleAssistantTextDelta(
   event: AssistantTextDeltaEvent,
@@ -88,6 +89,20 @@ export function handleMessageComplete(
   ctx: StreamHandlerContext,
 ): void {
   ctx.setMessages((prev) => finalizeMessageComplete(prev, event));
+
+  // Re-anchor subagents spawned in this turn from the optimistic streaming
+  // bubble id (`currentAssistantMessageIdRef`, the same id used as
+  // `parentMessageStableId` at spawn time) onto the durable server
+  // `messageId`, which survives reconcile. Multi-LLM-call turns collapse onto
+  // the first row's id daemon-side; the common single-call spawn turn is
+  // unaffected because entries are indexed under both ids in `byParent`.
+  const stableId = ctx.currentAssistantMessageIdRef.current;
+  if (event.messageId && stableId) {
+    useSubagentStore
+      .getState()
+      .reanchorToMessage({ stableId, messageId: event.messageId });
+  }
+
   const turnPhaseBefore = ctx.getTurnState().phase;
   ctx.turnActions.completeTurn();
   const convId = ctx.streamContextRef.current?.conversationId;
@@ -100,6 +115,7 @@ export function handleMessageComplete(
     messageId: event.messageId,
     hasContent: !!event.content,
     hasAttachments: !!event.attachments?.length,
+    reanchored: !!(event.messageId && stableId),
   });
 }
 


### PR DESCRIPTION
## Summary
- On message_complete, re-anchor subagents spawned in the turn from the optimistic streaming id to the durable server messageId
- Guarded to no-op when messageId or the current assistant message ref is absent
- Add message-handler tests for the re-anchor and the no-op guards

Part of plan: subagent-card-loading-state.md (PR 5 of 8)