### PR TITLE
feat(web): polish Auto profile UI

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -414,6 +414,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
                   leftIcon={<Sparkles className="h-3.5 w-3.5" />}
                   className={isActive ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]" : ""}
                   shortcut={isActive ? <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" /> : undefined}
+                  title={entry.name === "auto" ? "Automatically switches profiles based on the query" : undefined}
                 >
                   {profilePickerLabel(entry)}
                 </Menu.Item>

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -2003,6 +2003,13 @@ export function AiPage() {
                 label: profilePickerLabel(p),
               }))}
             />
+            {activeProfile === "auto" && (
+              <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
+                <span className="text-body-small-default text-[var(--content-warning)]">
+                  Auto may use more powerful models when needed, which can increase costs.
+                </span>
+              </div>
+            )}
             {defaultProfilePickerEntries.length === 0 ? (
               <Typography
                 variant="body-small-default"

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -2000,7 +2000,10 @@ export function AiPage() {
               placeholder="Select a default profile…"
               options={defaultProfilePickerEntries.map((p) => ({
                 value: p.name,
-                label: profilePickerLabel(p),
+                label:
+                  p.name === "auto"
+                    ? "Automatically switch between profiles"
+                    : profilePickerLabel(p),
               }))}
             />
             {activeProfile === "auto" && (

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -686,6 +686,7 @@ function ManageProfilesModalInner({
 
                 const isActive = profile.status !== "disabled";
                 const isToggling = togglingNames.has(profile.name);
+                const isAutoProfile = profile.name === "auto";
 
                 return (
                   <div key={profile.name} className="relative">
@@ -754,7 +755,7 @@ function ManageProfilesModalInner({
                           >
                             {profile.label ?? profile.name}
                           </Typography>
-                          {isManaged && (
+                          {isManaged && profile.name !== "auto" && (
                             <Tag
                               tone="positive"
                               title="Managed by Platform — auth is locked, but you can rename or disable this profile."
@@ -783,14 +784,12 @@ function ManageProfilesModalInner({
                         ) : null}
                       </div>
 
-                      {/* Actions — top-aligned so they sit next to the
-                          profile title regardless of description length. */}
-                      <div className="flex shrink-0 items-center gap-2 self-start mt-1">
-                        {/* Inline status toggle — works for managed profiles
-                            too. `status` is a UI-level preference the user
-                            always owns; auth/managed-edit rules don't apply.
-                            Mirrors `manage-providers-modal`. */}
-                        <span
+                      {/* Actions */}
+                      <div className="flex shrink-0 items-center gap-2">
+                        {/* Keep toggle first in the action order; align it by
+                            reserving a fixed-width slot for trailing buttons. */}
+                        <div
+                          className="flex shrink-0 items-center"
                           title={
                             isActive
                               ? "Active — toggle to hide from pickers"
@@ -805,26 +804,30 @@ function ManageProfilesModalInner({
                             disabled={isToggling}
                             aria-label={`${isActive ? "Disable" : "Enable"} ${profile.label ?? profile.name}`}
                           />
-                        </span>
-                        <Button
-                          variant="ghost"
-                          size="compact"
-                          onClick={() => onEditClick(profile)}
+                        </div>
+                        <div
+                          className={`flex w-[92px] items-center justify-end gap-2${isAutoProfile ? " invisible" : ""}`}
                         >
-                          {isManaged ? "View" : "Edit"}
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="compact"
-                          iconOnly={<Trash2 />}
-                          aria-label={`Delete ${profile.label ?? profile.name}`}
-                          disabled={isManaged || isDeleting}
-                          title={
-                            isManaged ? "Managed profiles cannot be deleted" : undefined
-                          }
-                          onClick={() => handleDeleteClick(profile.name)}
-                          tintColor="var(--system-negative-strong)"
-                        />
+                          <Button
+                            variant="ghost"
+                            size="compact"
+                            onClick={() => onEditClick(profile)}
+                          >
+                            {isManaged ? "View" : "Edit"}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="compact"
+                            iconOnly={<Trash2 />}
+                            aria-label={`Delete ${profile.label ?? profile.name}`}
+                            disabled={isManaged || isDeleting}
+                            title={
+                              isManaged ? "Managed profiles cannot be deleted" : undefined
+                            }
+                            onClick={() => handleDeleteClick(profile.name)}
+                            tintColor="var(--system-negative-strong)"
+                          />
+                        </div>
                       </div>
                     </div>
                     {dropTarget?.name === profile.name && dropTarget.after && (
@@ -839,6 +842,9 @@ function ManageProfilesModalInner({
                         {deleteError}
                       </Typography>
                     ) : null}
+                    {profile.name === "auto" && (
+                      <div className="mx-2 mt-1 border-b border-[var(--border-subtle)]" />
+                    )}
                   </div>
                 );
               })}

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -783,8 +783,9 @@ function ManageProfilesModalInner({
                         ) : null}
                       </div>
 
-                      {/* Actions */}
-                      <div className="flex shrink-0 items-center gap-2">
+                      {/* Actions — top-aligned so they sit next to the
+                          profile title regardless of description length. */}
+                      <div className="flex shrink-0 items-center gap-2 self-start mt-1">
                         {/* Inline status toggle — works for managed profiles
                             too. `status` is a UI-level preference the user
                             always owns; auth/managed-edit rules don't apply.

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -1045,6 +1045,7 @@ function ProfileEditorModalInner({
             <Button variant="outlined" onClick={onCancel} disabled={saving} data-testid="modal-cancel-btn">
               Close
             </Button>
+            {!isAutoProfile && (
             <Button
               variant="outlined"
               onClick={() => {
@@ -1056,6 +1057,7 @@ function ProfileEditorModalInner({
             >
               Save As New
             </Button>
+            )}
             {/* Save in view mode persists ONLY label and status changes
                 (managed profile policy fields). The button is gated by
                 `hasViewModeChanges` so an unchanged view session can't

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -166,6 +166,7 @@ function ProfileEditorModalInner({
 }: ProfileEditorModalInnerProps) {
   const [effectiveMode, setEffectiveMode] = useState<"create" | "edit" | "view">(mode);
   const isReadOnly = effectiveMode === "view";
+  const isAutoProfile = profileName === "auto";
 
   // Managed profiles open the editor in view mode (mode === "view") so they
   // can't be reshaped (provider, model, advanced params) — those are
@@ -691,6 +692,19 @@ function ProfileEditorModalInner({
             label="Active"
           />
 
+          {isAutoProfile && (
+            <div className="rounded-lg bg-[var(--surface-info-subtle)] p-3">
+              <p className="text-body-small-default text-[var(--content-secondary)]">
+                Auto mode routes each query to the best profile automatically
+                — fast for simple questions, capable for complex ones. No
+                provider or model configuration needed.
+              </p>
+            </div>
+          )}
+
+          {/* Provider, Connection, Model, and advanced params are hidden for
+              the "auto" meta-profile which has no provider/model of its own. */}
+          {!isAutoProfile && <>
           {/* Provider — required. The old "None (inherits defaults)" option
               was removed because the inherit pathway encouraged accidental
               fallbacks to the global default model, defeating the point of
@@ -830,7 +844,10 @@ function ProfileEditorModalInner({
               </Typography>
             ) : null}
           </div>
+          </>}
 
+          {/* Advanced params — hidden for the auto meta-profile */}
+          {!isAutoProfile && <>
           {/* Max Output Tokens */}
           {visibility.maxTokens && (
             <div className="space-y-1">
@@ -1006,6 +1023,8 @@ function ProfileEditorModalInner({
               )}
             </div>
           )}
+
+          </>}
 
           {/* Save error */}
           {saveError ? (


### PR DESCRIPTION
## Summary
Follow-up to #32180. Polishes the Auto profile's UI surfaces based on Rok's design feedback:

- **Profile editor modal**: Hides Provider, Connection, Model, and advanced param fields for the "auto" meta-profile (it has no provider/model). Shows an info card explaining what Auto mode does instead.
- **Conversation settings popover**: Adds a tooltip on the Auto option — "Automatically switches profiles based on the query"
- **Settings > Models & Services**: Shows a cost warning when Auto is selected as the default profile — "Auto may use more powerful models when needed, which can increase costs."

## Test plan
- [x] `bunx tsc --noEmit` passes (pre-existing generated API type errors only)
- [ ] Open profile editor for Auto → verify Provider/Model/advanced params hidden, info card shown
- [ ] Hover Auto in conversation popover → verify tooltip appears
- [ ] Set Auto as default profile in Settings → verify cost warning shown
- [ ] Set non-Auto profile → verify warning hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)