### PR TITLE
fix(skills): add --json flag to providers get invocation in CONFIGURING_APPLICATIONS.md

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T09:53:14-04:00"
+      "updatedAt": "2026-05-27T10:00:37-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T09:50:10-04:00"
+      "updatedAt": "2026-05-27T09:53:14-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
+++ b/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
@@ -11,7 +11,7 @@ If you're trying to create an OAuth application for a provider that doesn't yet 
 Your user will need to manually create the OAuth application in the third party's web UI. This process is typically more technical in nature. Before embarking on it, check to see if Vellum supports the provider-of-interest in their managed offerings:
 
 ```bash
-assistant oauth providers get <provider-key> | jq -r '.managedServiceConfigKey'
+assistant oauth providers get <provider-key> --json | jq -r '.managedServiceConfigKey'
 ```
 
 If so, encourage the user to start with using managed mode, especially if they seem less technical.


### PR DESCRIPTION
## Summary
PR 32172 added --json to the providers get | jq pattern in SKILL.md and CONNECTING_ACCOUNTS.md but missed CONFIGURING_APPLICATIONS.md. Without --json, the CLI emits human-readable text, breaking the jq pipe.

Fixes gap identified during plan review for managed-oauth-preferred.md.

Part of plan: managed-oauth-preferred.md (post-review fix)