### PR TITLE
fix(skills): use --json with assistant oauth mode for reliable bare-token parsing

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T10:00:37-04:00"
+      "updatedAt": "2026-05-27T10:17:21-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -20,7 +20,7 @@ If this returns a non-null value, managed mode is supported. Unless the user has
 ### Step 2: Check the current mode
 
 ```bash
-assistant oauth mode <provider-key>
+assistant oauth mode <provider-key> --json | jq -r '.mode'
 ```
 
 - **Returns `managed`**: proceed to "Initiating the Connection".

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -18,7 +18,7 @@ Google supports managed mode (see `assistant oauth providers get google`). Setti
 To check:
 
 ```bash
-assistant oauth mode google
+assistant oauth mode google --json | jq -r '.mode'
 ```
 
 - If the result is `managed`, **stop reading this file** and follow [CONNECTING_ACCOUNTS.md](../CONNECTING_ACCOUNTS.md) instead.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion.md
@@ -17,7 +17,7 @@ Notion supports managed mode (see `assistant oauth providers get notion`). The f
 To check:
 
 ```bash
-assistant oauth mode notion
+assistant oauth mode notion --json | jq -r '.mode'
 ```
 
 - If the result is `managed`, **stop reading this file** and follow [CONNECTING_ACCOUNTS.md](../CONNECTING_ACCOUNTS.md) instead. The user logs in with Notion and is done.


### PR DESCRIPTION
## Summary
The plan's new mode-check guidance assumes 'assistant oauth mode <provider>' returns a bare token, but the CLI's non-JSON output is '<provider> mode: <value>'. Switch to '--json | jq -r .mode' so the result is a bare token matching the surrounding prose.

Fixes gap identified during plan review for managed-oauth-preferred.md.

Part of plan: managed-oauth-preferred.md (post-review fix)