### PR TITLE
test(config): simplify SCHEMA_YOUR_OWN_DEFAULT_SERVICES to a static array

### DIFF
--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -93,6 +93,9 @@ function readConfig(): Record<string, unknown> {
   return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 }
 
+// When IS_PLATFORM=true, every managed-capable service defaults to "managed".
+// Without IS_PLATFORM, services split by Zod schema default: google/notion-oauth
+// resolve to "managed" (per JARVIS-966), the rest resolve to "your-own".
 const MANAGED_SERVICES = [
   "image-generation",
   "web-search",
@@ -117,14 +120,13 @@ const SCHEMA_MANAGED_DEFAULT_SERVICES = [
   "notion-oauth",
 ] as const;
 
-const SCHEMA_YOUR_OWN_DEFAULT_SERVICES = MANAGED_SERVICES.filter(
-  (
-    svc,
-  ): svc is Exclude<
-    (typeof MANAGED_SERVICES)[number],
-    (typeof SCHEMA_MANAGED_DEFAULT_SERVICES)[number]
-  > => !(SCHEMA_MANAGED_DEFAULT_SERVICES as readonly string[]).includes(svc),
-);
+const SCHEMA_YOUR_OWN_DEFAULT_SERVICES = [
+  "image-generation",
+  "web-search",
+  "outlook-oauth",
+  "linear-oauth",
+  "github-oauth",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## Summary
Replace the derived filter with a hand-written `as const` array. The Exclude<...> type predicate was over-engineered for a static 5-element list. Adds a brief comment explaining why some tests iterate the split lists while others iterate the full MANAGED_SERVICES (IS_PLATFORM forces all to managed).

Cleanup gap from plan review for managed-oauth-preferred.md.

Part of plan: managed-oauth-preferred.md (post-review fix)