### PR TITLE
fix(chat): omit wake-up greeting from initialMessage wire payload (JARVIS-967)

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -522,7 +522,11 @@ export async function postChatMessage(
       onboardingDict.cohort = normalizedOnboarding.cohort;
     if (normalizedOnboarding.bootstrapTemplate !== undefined)
       onboardingDict.bootstrapTemplate = normalizedOnboarding.bootstrapTemplate;
-    if (normalizedOnboarding.initialMessage !== undefined)
+    if (
+      normalizedOnboarding.initialMessage !== undefined &&
+      normalizedOnboarding.initialMessage.trim().toLowerCase().replace(/[.!?]+$/, "") !==
+        "wake up, my friend"
+    )
       onboardingDict.initialMessage = normalizedOnboarding.initialMessage;
     if (normalizedOnboarding.skills !== undefined)
       onboardingDict.skills = normalizedOnboarding.skills;


### PR DESCRIPTION
## Summary
- Don't send `initialMessage` to the daemon when it matches the wake-up greeting ("Wake up, my friend!")
- This preserves the existing canned greeting path for normal onboarding users
- Recipe-driven flows with a different `initialMessage` still work as expected

Addresses Devin's review feedback on #32127: the `initialMessage` field was being sent for ALL onboarding users (not just recipe flows), causing normal users to bypass the fast canned greeting path.