### PR TITLE
fix(web): prevent onboarding connecting stalls

### DIFF
--- a/apps/web/src/domains/account/login-flow.test.ts
+++ b/apps/web/src/domains/account/login-flow.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildProviderCallbackUrl,
+  readAuthCallbackIntent,
+  resolvePostAuthDestination,
+} from "@/domains/account/login-flow";
+import { routes } from "@/utils/routes";
+
+describe("login flow routing", () => {
+  test("marks signup provider callbacks with an auth intent", () => {
+    expect(
+      buildProviderCallbackUrl(routes.assistant, { authIntent: "signup" }),
+    ).toBe(
+      `${routes.account.providerCallback}?returnTo=%2Fassistant&authIntent=signup`,
+    );
+  });
+
+  test("reads signup callback intent", () => {
+    expect(readAuthCallbackIntent(new URLSearchParams("authIntent=signup"))).toBe(
+      "signup",
+    );
+    expect(readAuthCallbackIntent(new URLSearchParams())).toBe("login");
+  });
+
+  test("routes completed signups into onboarding instead of chat", () => {
+    expect(
+      resolvePostAuthDestination({
+        returnTo: routes.assistant,
+        fallback: routes.assistant,
+        authIntent: "signup",
+      }),
+    ).toEqual({
+      destination: routes.onboarding.privacy,
+      requiresFullPageNavigation: false,
+    });
+  });
+
+  test("keeps normal login returnTo behavior", () => {
+    expect(
+      resolvePostAuthDestination({
+        returnTo: routes.home,
+        fallback: routes.assistant,
+        authIntent: "login",
+      }),
+    ).toEqual({
+      destination: routes.home,
+      requiresFullPageNavigation: false,
+    });
+  });
+});

--- a/apps/web/src/domains/account/login-flow.ts
+++ b/apps/web/src/domains/account/login-flow.ts
@@ -3,12 +3,34 @@ import { routes } from "@/utils/routes";
 
 export const PROVIDER_ID = "workos-oidc";
 export const PROVIDER_CALLBACK_URL = routes.account.providerCallback;
+export type AuthCallbackIntent = "login" | "signup";
 
-export function buildProviderCallbackUrl(returnTo: string | null): string {
-  if (!returnTo) {
+const AUTH_INTENT_QUERY_PARAM = "authIntent";
+
+export function buildProviderCallbackUrl(
+  returnTo: string | null,
+  options: { authIntent?: AuthCallbackIntent } = {},
+): string {
+  const params = new URLSearchParams();
+  if (returnTo) {
+    params.set("returnTo", returnTo);
+  }
+  if (options.authIntent) {
+    params.set(AUTH_INTENT_QUERY_PARAM, options.authIntent);
+  }
+  const qs = params.toString();
+  if (!qs) {
     return PROVIDER_CALLBACK_URL;
   }
-  return `${PROVIDER_CALLBACK_URL}?returnTo=${encodeURIComponent(returnTo)}`;
+  return `${PROVIDER_CALLBACK_URL}?${qs}`;
+}
+
+export function readAuthCallbackIntent(
+  searchParams: URLSearchParams,
+): AuthCallbackIntent {
+  return searchParams.get(AUTH_INTENT_QUERY_PARAM) === "signup"
+    ? "signup"
+    : "login";
 }
 
 export function requiresFullPageNavigation(destination: string): boolean {
@@ -32,4 +54,25 @@ export function resolvePostLoginDestination(
     destination,
     requiresFullPageNavigation: requiresFullPageNavigation(destination),
   };
+}
+
+export function resolvePostAuthDestination({
+  returnTo,
+  fallback,
+  authIntent,
+}: {
+  returnTo: string | null;
+  fallback: string;
+  authIntent: AuthCallbackIntent;
+}): {
+  destination: string;
+  requiresFullPageNavigation: boolean;
+} {
+  if (authIntent === "signup") {
+    return {
+      destination: routes.onboarding.privacy,
+      requiresFullPageNavigation: false,
+    };
+  }
+  return resolvePostLoginDestination(returnTo, fallback);
 }

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -5,7 +5,10 @@ import * as Sentry from "@sentry/react";
 import { AccountHeading } from "@/components/account/account-form";
 import { AccountShell } from "@/components/account/account-shell";
 import { getSession } from "@/lib/auth/allauth-client";
-import { resolvePostLoginDestination } from "@/domains/account/login-flow";
+import {
+  readAuthCallbackIntent,
+  resolvePostAuthDestination,
+} from "@/domains/account/login-flow";
 import { classifyCallbackFlows } from "@/domains/account/social-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -32,6 +35,7 @@ export function ProviderCallbackPage() {
   const didRun = useRef(false);
 
   const returnTo = searchParams.get("returnTo");
+  const authIntent = readAuthCallbackIntent(searchParams);
 
   useEffect(() => {
     if (didRun.current) return;
@@ -51,7 +55,7 @@ export function ProviderCallbackPage() {
             await refreshSession();
             const fallback = routes.assistant;
             const { destination, requiresFullPageNavigation } =
-              resolvePostLoginDestination(returnTo, fallback);
+              resolvePostAuthDestination({ returnTo, fallback, authIntent });
             if (requiresFullPageNavigation) {
               window.location.href = destination;
             } else {
@@ -78,7 +82,7 @@ export function ProviderCallbackPage() {
         setFallbackError("Something went wrong. Please try signing in again.");
       }
     })();
-  }, [error, refreshSession, returnTo, navigate, searchParams]);
+  }, [authIntent, error, refreshSession, returnTo, navigate, searchParams]);
 
   if (error === "signup_closed") {
     return (

--- a/apps/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-signup-page.tsx
@@ -12,7 +12,10 @@ import {
   isConflict,
   submitProviderSignup,
 } from "@/lib/auth/allauth-client";
-import { resolvePostLoginDestination } from "@/domains/account/login-flow";
+import {
+  resolvePostAuthDestination,
+  resolvePostLoginDestination,
+} from "@/domains/account/login-flow";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
@@ -82,7 +85,11 @@ export function ProviderSignupPage() {
       }
 
       await refreshSession();
-      const post = resolvePostLoginDestination(returnTo, routes.account.root);
+      const post = resolvePostAuthDestination({
+        returnTo,
+        fallback: routes.account.root,
+        authIntent: "signup",
+      });
       if (post.requiresFullPageNavigation) {
         window.location.href = post.destination;
       } else {

--- a/apps/web/src/domains/account/pages/signup-page.tsx
+++ b/apps/web/src/domains/account/pages/signup-page.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
-import { PROVIDER_CALLBACK_URL, PROVIDER_ID } from "@/domains/account/login-flow";
+import {
+  PROVIDER_ID,
+  buildProviderCallbackUrl,
+} from "@/domains/account/login-flow";
 import { startAuthFlow } from "@/runtime/native-auth";
 
 /**
@@ -23,9 +26,9 @@ export function SignupPage() {
     didRedirect.current = true;
 
     const returnTo = searchParams.get("returnTo");
-    const callbackUrl = returnTo
-      ? `${PROVIDER_CALLBACK_URL}?returnTo=${encodeURIComponent(returnTo)}`
-      : PROVIDER_CALLBACK_URL;
+    const callbackUrl = buildProviderCallbackUrl(returnTo, {
+      authIntent: "signup",
+    });
 
     startAuthFlow(PROVIDER_ID, callbackUrl, {
       intent: "signup",

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -18,6 +18,7 @@ import {
 import { createPortal } from "react-dom";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { ChevronDown } from "lucide-react";
+import * as Sentry from "@sentry/react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useVisibleViewport } from "@/hooks/use-visible-viewport";
@@ -118,6 +119,10 @@ import { abortSubagent, fetchSubagentDetail } from "@/domains/chat/api/conversat
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
+import {
+  type ChatConnectingReason,
+  resolveChatConnectingReason,
+} from "@/domains/chat/utils/connecting-reason";
 import { getEditChatConversationId, setEditChatConversationId } from "@/domains/chat/utils/edit-chat-session";
 import { routes } from "@/utils/routes";
 import { haptic } from "@/utils/haptics";
@@ -1313,10 +1318,36 @@ export function ChatPage() {
   };
   void _uiContext;
 
+  const connectingReason = resolveChatConnectingReason({
+    authLoading,
+    assistantStateKind: assistantState.kind,
+    autoGreetPending,
+  });
+  const lastConnectingReasonRef = useRef<ChatConnectingReason | null>(null);
+  useEffect(() => {
+    if (connectingReason === null) {
+      lastConnectingReasonRef.current = null;
+      return;
+    }
+    if (lastConnectingReasonRef.current === connectingReason) return;
+    lastConnectingReasonRef.current = connectingReason;
+    Sentry.addBreadcrumb({
+      category: "chat.connecting",
+      level: "info",
+      message: "ChatPage rendered Connecting",
+      data: {
+        reason: connectingReason,
+        assistantStateKind: assistantState.kind,
+        hasAssistantId: assistantId != null,
+        hasActiveConversationId: activeConversationId != null,
+      },
+    });
+  }, [activeConversationId, assistantId, assistantState.kind, connectingReason]);
+
   // -------------------------------------------------------------------------
   // Loading / error guards
   // -------------------------------------------------------------------------
-  if (authLoading || assistantState.kind === "loading" || autoGreetPending) {
+  if (connectingReason !== null) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-[var(--text-secondary)]">Connecting…</p>

--- a/apps/web/src/domains/chat/utils/connecting-reason.test.ts
+++ b/apps/web/src/domains/chat/utils/connecting-reason.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveChatConnectingReason } from "@/domains/chat/utils/connecting-reason";
+
+describe("resolveChatConnectingReason", () => {
+  test("prioritizes auth loading", () => {
+    expect(
+      resolveChatConnectingReason({
+        authLoading: true,
+        assistantStateKind: "loading",
+        autoGreetPending: true,
+      }),
+    ).toBe("auth_loading");
+  });
+
+  test("reports assistant lifecycle loading before auto-greet pending", () => {
+    expect(
+      resolveChatConnectingReason({
+        authLoading: false,
+        assistantStateKind: "loading",
+        autoGreetPending: true,
+      }),
+    ).toBe("assistant_loading");
+  });
+
+  test("reports auto-greet pending when lifecycle is otherwise ready", () => {
+    expect(
+      resolveChatConnectingReason({
+        authLoading: false,
+        assistantStateKind: "active",
+        autoGreetPending: true,
+      }),
+    ).toBe("auto_greet_pending");
+  });
+
+  test("returns null when chat can render", () => {
+    expect(
+      resolveChatConnectingReason({
+        authLoading: false,
+        assistantStateKind: "active",
+        autoGreetPending: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/domains/chat/utils/connecting-reason.ts
+++ b/apps/web/src/domains/chat/utils/connecting-reason.ts
@@ -1,0 +1,19 @@
+export type ChatConnectingReason =
+  | "auth_loading"
+  | "assistant_loading"
+  | "auto_greet_pending";
+
+export function resolveChatConnectingReason({
+  authLoading,
+  assistantStateKind,
+  autoGreetPending,
+}: {
+  authLoading: boolean;
+  assistantStateKind: string;
+  autoGreetPending: boolean;
+}): ChatConnectingReason | null {
+  if (authLoading) return "auth_loading";
+  if (assistantStateKind === "loading") return "assistant_loading";
+  if (autoGreetPending) return "auto_greet_pending";
+  return null;
+}

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { routes } from "@/utils/routes";
+
+let searchParams = new URLSearchParams();
+const navigateMock = mock(() => {});
+
+let checkAssistantImpl: () => Promise<void> = async () => {};
+const checkAssistantMock = mock(() => checkAssistantImpl());
+
+const hatchAssistantMock = mock(async () => ({
+  ok: true,
+  status: 201,
+  data: {
+    id: "asst-1",
+    status: "initializing",
+    is_local: false,
+    maintenance_mode: { enabled: false },
+  },
+}));
+
+const getAssistantMock = mock(async () => ({
+  ok: true,
+  status: 200,
+  data: {
+    id: "asst-1",
+    status: "active",
+    is_local: false,
+    maintenance_mode: { enabled: false },
+  },
+}));
+
+const fetchCharacterTraitsMock = mock(async () => null);
+const saveCharacterTraitsMock = mock(async () => undefined);
+const setOnboardingCompletedMock = mock(() => {});
+const writeSelectedVersionMock = mock(() => {});
+const markPrivacyConsentMock = mock(() => {});
+const clearPrivacyConsentMock = mock(() => {});
+const persistContentAutomationPreChatHandoffMock = mock(() => {});
+
+let onboardingCompleted = false;
+let resolvedCohort: string | null = null;
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParams],
+}));
+
+mock.module("@/root-layout", () => ({
+  useRootOutletContext: () => ({
+    lifecycle: {
+      checkAssistant: checkAssistantMock,
+    },
+  }),
+}));
+
+mock.module("@/assistant/api", () => ({
+  hatchAssistant: hatchAssistantMock,
+  getAssistant: getAssistantMock,
+}));
+
+mock.module("@/assistant/avatar-api", () => ({
+  fetchCharacterTraits: fetchCharacterTraitsMock,
+  saveCharacterTraits: saveCharacterTraitsMock,
+}));
+
+mock.module("@/utils/avatar-bundled-components", () => ({
+  BUNDLED_COMPONENTS: {},
+}));
+
+mock.module("@/utils/avatar-random", () => ({
+  randomCharacterTraits: () => ({
+    bodyShape: "round",
+    eyeStyle: "dot",
+    color: "green",
+  }),
+}));
+
+mock.module("@/utils/avatar-svg-compositor", () => ({
+  composeSvg: () => "<svg />",
+}));
+
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+mock.module("@vellum/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+mock.module("@vellum/design-library/components/progress-bar", () => ({
+  ProgressBar: ({ value }: { value: number }) => (
+    <div data-testid="progress" data-value={value} />
+  ),
+}));
+
+mock.module("@sentry/browser", () => ({
+  captureException: mock(() => {}),
+  captureMessage: mock(() => {}),
+}));
+
+mock.module("@/domains/onboarding/prefs", () => ({
+  readAiDataConsent: () => true,
+  readOnboardingCompleted: () => onboardingCompleted,
+  readSelectedVersion: () => null,
+  readTosAccepted: () => true,
+  useOnboardingCompleted: () =>
+    [onboardingCompleted, setOnboardingCompletedMock] as const,
+  writeSelectedVersion: writeSelectedVersionMock,
+}));
+
+mock.module("@/domains/onboarding/signals", () => ({
+  clearPrivacyConsent: clearPrivacyConsentMock,
+  hasRecentPrivacyConsent: () => true,
+  markPrivacyConsent: markPrivacyConsentMock,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+  useIsNativePlatform: () => false,
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    use: {
+      user: () => ({
+        id: "user-1",
+        firstName: "Alice",
+        lastName: "",
+      }),
+      isLoggedIn: () => true,
+      isLoading: () => false,
+    },
+  },
+}));
+
+mock.module("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: {
+      id: "asst-1",
+    },
+  }),
+}));
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  assistantsActiveRetrieveOptions: () => ({}),
+}));
+
+mock.module("@/hooks/use-prefilled-input", () => ({
+  usePrefilledInput: (initial: string) => ({
+    value: initial,
+    onChange: mock(() => {}),
+  }),
+}));
+
+mock.module("@/utils/platform-detection", () => ({
+  useIsIOSWeb: () => false,
+  useIsMacOSWeb: () => false,
+}));
+
+mock.module("@/hooks/use-ios-app-nudge", () => ({
+  readIOSAppDownloaded: () => true,
+}));
+
+mock.module("@/hooks/use-macos-app-nudge", () => ({
+  readMacOsAppDownloaded: () => true,
+}));
+
+mock.module("@/domains/onboarding/content-automation", () => ({
+  persistContentAutomationPreChatHandoff:
+    persistContentAutomationPreChatHandoffMock,
+}));
+
+mock.module("@/domains/onboarding/utm-cohort", () => ({
+  resolveUserCohort: async () => resolvedCohort,
+}));
+
+mock.module("@/domains/onboarding/screens/name-exchange-screen", () => ({
+  NameExchangeScreen: ({ onComplete }: { onComplete: () => void }) => (
+    <button type="button" data-testid="name-continue" onClick={onComplete}>
+      name
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/screens/task-tone-selection-screen", () => ({
+  TaskToneSelectionScreen: ({ onContinue }: { onContinue: () => void }) => (
+    <button type="button" data-testid="task-continue" onClick={onContinue}>
+      tasks
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/screens/tool-selection-screen", () => ({
+  ToolSelectionScreen: ({ onContinue }: { onContinue: () => void }) => (
+    <button type="button" data-testid="tool-continue" onClick={onContinue}>
+      tools
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/screens/prior-assistant-selection-screen", () => ({
+  PriorAssistantSelectionScreen: ({
+    onContinue,
+  }: {
+    onContinue: () => void;
+  }) => (
+    <button type="button" data-testid="prior-continue" onClick={onContinue}>
+      prior
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/screens/google-connect-screen", () => ({
+  GoogleConnectScreen: () => <div />,
+}));
+
+mock.module("@/domains/onboarding/screens/get-ios-app-screen", () => ({
+  GetIOSAppScreen: () => <div />,
+}));
+
+mock.module("@/domains/onboarding/screens/get-macos-app-screen", () => ({
+  GetMacOSAppScreen: () => <div />,
+}));
+
+const { HatchingScreen } = await import(
+  "@/domains/onboarding/pages/hatching-screen"
+);
+const { PreChatFlow } = await import(
+  "@/domains/onboarding/pages/pre-chat-flow"
+);
+
+beforeEach(() => {
+  searchParams = new URLSearchParams();
+  checkAssistantImpl = async () => {};
+  onboardingCompleted = false;
+  resolvedCohort = null;
+  sessionStorage.clear();
+  localStorage.clear();
+
+  navigateMock.mockClear();
+  checkAssistantMock.mockClear();
+  hatchAssistantMock.mockClear();
+  getAssistantMock.mockClear();
+  fetchCharacterTraitsMock.mockClear();
+  saveCharacterTraitsMock.mockClear();
+  setOnboardingCompletedMock.mockClear();
+  writeSelectedVersionMock.mockClear();
+  markPrivacyConsentMock.mockClear();
+  clearPrivacyConsentMock.mockClear();
+  persistContentAutomationPreChatHandoffMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("onboarding lifecycle sync", () => {
+  test("hatching refreshes the root assistant lifecycle before leaving onboarding", async () => {
+    let resolveLifecycle!: () => void;
+    checkAssistantImpl = () =>
+      new Promise<void>((resolve) => {
+        resolveLifecycle = resolve;
+      });
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(getAssistantMock).toHaveBeenCalled());
+    await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled(), {
+      timeout: 2_000,
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    resolveLifecycle();
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.prechat, {
+        replace: true,
+      }),
+    );
+  });
+
+  test("pre-chat completion refreshes the root assistant lifecycle before entering chat", async () => {
+    let resolveLifecycle!: () => void;
+    checkAssistantImpl = () =>
+      new Promise<void>((resolve) => {
+        resolveLifecycle = resolve;
+      });
+
+    render(<PreChatFlow />);
+
+    fireEvent.click(screen.getByTestId("name-continue"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tool-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
+
+    await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    resolveLifecycle();
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        `${routes.assistant}?onboarding=1`,
+        { replace: true },
+      ),
+    );
+  });
+});

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,6 +18,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
+import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
   readOnboardingCompleted,
@@ -98,6 +99,9 @@ export function HatchingScreen() {
   const userId = useAuthStore.use.user()?.id ?? null;
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const isAuthLoading = useAuthStore.use.isLoading();
+  const {
+    lifecycle: { checkAssistant },
+  } = useRootOutletContext();
   const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [hatchTraits] = useState<CharacterTraits>(() =>
     randomCharacterTraits(BUNDLED_COMPONENTS),
@@ -251,19 +255,25 @@ export function HatchingScreen() {
           phaseRef.current = "ready";
           navigateTimer = setTimeout(() => {
             if (cancelled) return;
-            if (isNativePlatform()) {
-              try {
-                setOnboardingCompleted(true);
-              } catch (err) {
-                Sentry.captureException(err, {
-                  tags: { context: "hatching_mark_onboarding_completed_native" },
+            void (async () => {
+              await checkAssistant();
+              if (cancelled) return;
+              if (isNativePlatform()) {
+                try {
+                  setOnboardingCompleted(true);
+                } catch (err) {
+                  Sentry.captureException(err, {
+                    tags: { context: "hatching_mark_onboarding_completed_native" },
+                  });
+                }
+                clearPrivacyConsent();
+                void navigate(`${routes.assistant}?onboarding=1`, {
+                  replace: true,
                 });
+                return;
               }
-              clearPrivacyConsent();
-              void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
-              return;
-            }
-            void navigate(routes.onboarding.prechat, { replace: true });
+              void navigate(routes.onboarding.prechat, { replace: true });
+            })();
           }, COMPLETION_NAVIGATE_DELAY_MS);
           return;
         }
@@ -297,6 +307,7 @@ export function HatchingScreen() {
     isAuthLoading,
     isLoggedIn,
     isReplay,
+    checkAssistant,
     navigate,
     setOnboardingCompleted,
     transitionPhase,

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { useIsIOSWeb, useIsMacOSWeb } from "@/utils/platform-detection";
@@ -43,6 +43,7 @@ import {
 import { resolveUserCohort } from "@/domains/onboarding/utm-cohort";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
+import { useRootOutletContext } from "@/root-layout";
 import { routes } from "@/utils/routes";
 
 /**
@@ -67,6 +68,9 @@ export function PreChatFlow() {
   const firstName = user?.firstName ?? "";
   const lastName = user?.lastName ?? "";
   const isNative = useIsNativePlatform();
+  const {
+    lifecycle: { checkAssistant },
+  } = useRootOutletContext();
   const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [cohort, setCohort] = useState<string | null>(null);
 
@@ -121,6 +125,11 @@ export function PreChatFlow() {
     enabled: !isAuthLoading && isLoggedIn,
   });
 
+  const navigateToChatAfterLifecycleRefresh = useCallback(async () => {
+    await checkAssistant();
+    void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+  }, [checkAssistant, navigate]);
+
   type ConsentSnapshot = {
     userId: string | null;
     decision: "pending" | "ok" | "missing";
@@ -162,7 +171,7 @@ export function PreChatFlow() {
       return;
     }
     if (readOnboardingCompleted()) {
-      void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+      void navigateToChatAfterLifecycleRefresh();
       return;
     }
     if (consentDecision === "missing" && !isNative) {
@@ -176,6 +185,7 @@ export function PreChatFlow() {
     isLoggedIn,
     isNative,
     navigate,
+    navigateToChatAfterLifecycleRefresh,
     setOnboardingCompleted,
     userId,
   ]);
@@ -198,10 +208,18 @@ export function PreChatFlow() {
       });
     }
     clearPrivacyConsent();
-    void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
-  }, [cohort, isNative, isAuthLoading, isLoggedIn, consentDecision, navigate, setOnboardingCompleted]);
+    void navigateToChatAfterLifecycleRefresh();
+  }, [
+    cohort,
+    isNative,
+    isAuthLoading,
+    isLoggedIn,
+    consentDecision,
+    navigateToChatAfterLifecycleRefresh,
+    setOnboardingCompleted,
+  ]);
 
-  function finish(connectedScopes?: string[]): void {
+  async function finish(connectedScopes?: string[]): Promise<void> {
     const context: PreChatOnboardingContext = {
       tools: stripOtherPrefix([...selectedTools]),
       tasks: [...selectedTasks].sort(),
@@ -235,7 +253,7 @@ export function PreChatFlow() {
       });
     }
     clearPrivacyConsent();
-    void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+    await navigateToChatAfterLifecycleRefresh();
   }
 
   const consentReady = isNative || consentDecision === "ok";
@@ -375,7 +393,7 @@ export function PreChatFlow() {
     } else if (showAppStep) {
       setScreen(5);
     } else {
-      finish();
+      void finish();
     }
   };
 
@@ -421,18 +439,38 @@ export function PreChatFlow() {
           if (showAppStep) {
             setScreen(5);
           } else {
-            finish(scopes);
+            void finish(scopes);
           }
         }}
-        onSkip={showAppStep ? () => setScreen(5) : () => finish()}
+        onSkip={
+          showAppStep
+            ? () => setScreen(5)
+            : () => {
+                void finish();
+              }
+        }
         onBack={() => setScreen(3)}
       />
     );
   }
 
   if (screen === 5) {
-    if (isIOSWeb) return <GetIOSAppScreen onComplete={() => finish()} />;
-    return <GetMacOSAppScreen onComplete={() => finish()} />;
+    if (isIOSWeb) {
+      return (
+        <GetIOSAppScreen
+          onComplete={() => {
+            void finish();
+          }}
+        />
+      );
+    }
+    return (
+      <GetMacOSAppScreen
+        onComplete={() => {
+          void finish();
+        }}
+      />
+    );
   }
 
   return null;

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -225,7 +225,10 @@ export async function startAuthFlow(
   if (isNativePlatform()) {
     try {
       await startNativeLogin({
-        returnTo: options.returnTo ?? null,
+        returnTo:
+          options.intent === "signup"
+            ? routes.onboarding.privacy
+            : options.returnTo ?? null,
         loginHint: options.loginHint,
         providerHint: options.providerHint,
       });


### PR DESCRIPTION
Related to LUM-1948.

## Summary

Fixes the post-signup and post-onboarding paths that could leave new users stuck on a `Connecting…` / `Connecting to your assistant…` screen until refresh.

## Root Cause

PR #31550 moved the authoritative assistant lifecycle from `ChatLayout` to `RootLayout`. That was correct for keeping the event bus alive across authenticated routes, but it created an onboarding gap: onboarding could create or poll the assistant independently while the root lifecycle still had `assistantState.kind === "loading"`.

There were two affected windows:

- Immediately after signup, the callback navigated to `/assistant`, allowing `ChatPage` to render its loading guard while the lifecycle decided to redirect into onboarding.
- After hatching or pre-chat completion, onboarding navigated back to chat before refreshing the root lifecycle state.

## Changes

- Route signup callbacks directly to `/assistant/onboarding/privacy` instead of entering `/assistant` first.
- Preserve normal login `returnTo` behavior for existing users.
- Refresh the root assistant lifecycle before leaving hatching or pre-chat onboarding.
- Add a small `Connecting…` reason helper and Sentry breadcrumb so future reports identify whether the screen came from auth loading, assistant lifecycle loading, or auto-greet pending.
- Add regression coverage for signup routing and onboarding lifecycle handoffs.

## Validation

- `bun test src/domains/account/login-flow.test.ts`
- `bun test src/domains/onboarding/onboarding-lifecycle-sync.test.tsx`
- `bun test src/domains/chat/utils/connecting-reason.test.ts`
- `bunx tsc --noEmit`
- targeted `bun run lint ...`
- Manual incognito signup flow completed without `Connecting…` screens or refreshes.