### PR TITLE
fix(web/chat): prevent indicator dot clipping on collapsed sidebar group icons

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -106,7 +106,7 @@ export function CollapsedGroupIcon({
           {indicatorState != null ? (
             <span
               aria-hidden
-              className={`absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] ${INDICATOR_CLASS[indicatorState]}`}
+              className={`absolute right-0 top-0 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] ${INDICATOR_CLASS[indicatorState]}`}
             />
           ) : null}
         </button>


### PR DESCRIPTION
## Summary
- Moved the indicator dot from `absolute -right-0.5 -top-0.5` to `absolute right-0 top-0` so it stays within the 32px button bounds
- The dot was being clipped by `overflow-hidden` on `SideMenu.Root` and `overflow-x-hidden` on `SideMenu.Body`
- Introduced in #32078

## Test plan
- [ ] Open the web app with collapsed sidebar
- [ ] Verify yellow/pulsing indicator dots on system group icons are fully visible (not clipped)
- [ ] Verify dots still appear at the top-right corner of the icon button
- [ ] Verify popover still opens correctly when clicking icons with dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)