### PR TITLE
feat(daemon+web): personalized LLM greetings for web empty state (JARVIS-965)

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { SDK_BASE_OPTIONS } from "@/domains/chat/api/client";
-import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
+import { client } from "@/domains/chat/api/client";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
 import { useOrganizationStore } from "@/stores/organization-store";
 
@@ -27,36 +26,26 @@ function pickFallback(): string {
 
 async function streamGreeting(
   assistantId: string,
-  orgId: string,
   signal: AbortSignal,
   onDelta: (text: string) => void,
 ): Promise<string> {
-  const baseUrl =
-    (SDK_BASE_OPTIONS as Record<string, unknown>).baseUrl ?? "";
-  const url = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/btw`;
-
-  await ensureCsrfCookie();
-  const csrfToken = getCsrfToken();
-
-  const res = await fetch(url, {
+  const { response } = await client.request({
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
-      "Vellum-Organization-Id": orgId,
-    },
-    body: JSON.stringify({
+    url: "/v1/assistants/{assistantId}/btw",
+    path: { assistantId },
+    body: {
       conversationKey: "greeting",
       content: GREETING_PROMPT,
-    }),
+    },
+    parseAs: "stream",
     signal,
   });
 
-  if (!res.ok || !res.body) {
-    throw new Error(`BTW request failed: ${res.status}`);
+  if (!response || !response.ok || !response.body) {
+    throw new Error(`BTW request failed: ${response?.status}`);
   }
 
-  const reader = res.body.getReader();
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let accumulated = "";
   let buffer = "";
@@ -100,7 +89,7 @@ export function useEmptyStateGreeting(
 
     const controller = new AbortController();
 
-    streamGreeting(assistantId, orgId, controller.signal, (delta) => {
+    streamGreeting(assistantId, controller.signal, (delta) => {
       setGreeting((prev) => prev + delta);
     })
       .then((final) => {

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import {
-  client,
-  SDK_BASE_OPTIONS,
-} from "@/domains/chat/api/client";
+import { SDK_BASE_OPTIONS } from "@/domains/chat/api/client";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
 
 const GREETING_PROMPT =

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,76 +1,116 @@
-import { useRef } from "react";
-
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 
 import {
   client,
-  assertHasResponse,
   SDK_BASE_OPTIONS,
 } from "@/domains/chat/api/client";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
 
-const STALE_TIME_MS = 5 * 60 * 1000;
+const GREETING_PROMPT =
+  "Generate a short, casual greeting in your voice from you to your user. " +
+  "This will be displayed when the user opens a new conversation (under 8 words). " +
+  "Match your personality. Output ONLY the greeting text — no quotes, no formatting.";
 
-interface IdentityIntroResponse {
-  greetings?: string[];
-  /** @deprecated — kept for backwards compat with older daemons */
-  text?: string;
+const MAX_GREETING_LENGTH = 80;
+
+const FALLBACK_GREETINGS = [
+  "What are we working on?",
+  "I'm here whenever you need me.",
+  "What's on your mind?",
+  "Ready when you are.",
+];
+
+function pickFallback(): string {
+  return FALLBACK_GREETINGS[
+    Math.floor(Math.random() * FALLBACK_GREETINGS.length)
+  ]!;
 }
 
-async function fetchIdentityIntro(
+async function streamGreeting(
   assistantId: string,
-): Promise<string[] | null> {
-  try {
-    const { data, error, response } = await client.get<
-      IdentityIntroResponse,
-      unknown
-    >({
-      ...SDK_BASE_OPTIONS,
-      url: "/v1/assistants/{assistant_id}/identity/intro",
-      path: { assistant_id: assistantId },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch identity intro");
+  signal: AbortSignal,
+  onDelta: (text: string) => void,
+): Promise<string> {
+  const baseUrl =
+    (SDK_BASE_OPTIONS as Record<string, unknown>).baseUrl ?? "";
+  const url = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/btw`;
 
-    if (!response.ok || !data || typeof data !== "object") {
-      return null;
-    }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      conversationKey: "greeting",
+      content: GREETING_PROMPT,
+    }),
+    signal,
+  });
 
-    if (Array.isArray(data.greetings) && data.greetings.length > 0) {
-      return data.greetings;
-    }
-
-    if (typeof data.text === "string" && data.text.trim()) {
-      return [data.text.trim()];
-    }
-
-    return null;
-  } catch {
-    return null;
+  if (!res.ok || !res.body) {
+    throw new Error(`BTW request failed: ${res.status}`);
   }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = "";
+  let buffer = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        try {
+          const payload = JSON.parse(line.slice(6)) as Record<string, unknown>;
+          if (typeof payload.text === "string") {
+            accumulated += payload.text;
+            onDelta(payload.text);
+          }
+        } catch {
+          // skip malformed JSON
+        }
+      }
+    }
+  }
+
+  return accumulated;
 }
 
 export function useEmptyStateGreeting(
   assistantId: string | null | undefined,
 ): string {
-  const enabled = Boolean(assistantId);
-  const indexRef = useRef(-1);
+  const [greeting, setGreeting] = useState("");
+  const startedRef = useRef(false);
 
-  const query = useQuery<string[] | null>({
-    queryKey: ["identity-intro", assistantId],
-    queryFn: () => fetchIdentityIntro(assistantId!),
-    enabled,
-    staleTime: STALE_TIME_MS,
-  });
+  useEffect(() => {
+    if (!assistantId || startedRef.current) return;
+    startedRef.current = true;
 
-  const greetings = query.data;
-  if (!greetings || greetings.length === 0) {
-    return DEFAULT_EMPTY_STATE_GREETING;
-  }
+    const controller = new AbortController();
 
-  if (indexRef.current < 0) {
-    indexRef.current = Math.floor(Math.random() * greetings.length);
-  }
+    streamGreeting(assistantId, controller.signal, (delta) => {
+      setGreeting((prev) => prev + delta);
+    })
+      .then((final) => {
+        const trimmed = final.trim();
+        if (!trimmed || trimmed.length > MAX_GREETING_LENGTH) {
+          setGreeting(pickFallback());
+        } else {
+          setGreeting(trimmed);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setGreeting(pickFallback());
+        }
+      });
 
-  return greetings[indexRef.current % greetings.length]!;
+    return () => controller.abort();
+  }, [assistantId]);
+
+  return greeting || DEFAULT_EMPTY_STATE_GREETING;
 }

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,113 +1,68 @@
-import { useEffect, useRef, useState } from "react";
+/**
+ * React hook that fetches a personalized empty-state greeting from the daemon.
+ *
+ * Calls `GET /v1/assistants/{assistant_id}/identity/intro` which returns a
+ * deterministic greeting derived from the assistant's IDENTITY.md name (e.g.
+ * "Hi, I'm Pax!"). Falls back to {@link DEFAULT_EMPTY_STATE_GREETING} when the
+ * assistant ID is missing, the daemon is unreachable, or the response is empty.
+ *
+ * The query has a long `staleTime` (5 minutes) since the intro text only
+ * changes when the user renames the assistant — a rare operation.
+ */
 
-import { client } from "@/domains/chat/api/client";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  client,
+  assertHasResponse,
+  SDK_BASE_OPTIONS,
+} from "@/domains/chat/api/client";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
-import { useOrganizationStore } from "@/stores/organization-store";
 
-const GREETING_PROMPT =
-  "Generate a short, casual greeting in your voice from you to your user. " +
-  "This will be displayed when the user opens a new conversation (under 8 words). " +
-  "Match your personality. Output ONLY the greeting text — no quotes, no formatting.";
+const STALE_TIME_MS = 5 * 60 * 1000;
 
-const MAX_GREETING_LENGTH = 80;
-
-const FALLBACK_GREETINGS = [
-  "What are we working on?",
-  "I'm here whenever you need me.",
-  "What's on your mind?",
-  "Ready when you are.",
-];
-
-function pickFallback(): string {
-  return FALLBACK_GREETINGS[
-    Math.floor(Math.random() * FALLBACK_GREETINGS.length)
-  ]!;
+interface IdentityIntroResponse {
+  text: string;
 }
 
-async function streamGreeting(
+async function fetchIdentityIntro(
   assistantId: string,
-  signal: AbortSignal,
-  onDelta: (text: string) => void,
-): Promise<string> {
-  const { response } = await client.request({
-    method: "POST",
-    url: "/v1/assistants/{assistantId}/btw",
-    path: { assistantId },
-    body: {
-      conversationKey: "greeting",
-      content: GREETING_PROMPT,
-    },
-    parseAs: "stream",
-    signal,
-  });
+): Promise<string | null> {
+  try {
+    const { data, error, response } = await client.get<
+      IdentityIntroResponse,
+      unknown
+    >({
+      ...SDK_BASE_OPTIONS,
+      url: "/v1/assistants/{assistant_id}/identity/intro",
+      path: { assistant_id: assistantId },
+      throwOnError: false,
+    });
+    assertHasResponse(response, error, "Failed to fetch identity intro");
 
-  if (!response || !response.ok || !response.body) {
-    throw new Error(`BTW request failed: ${response?.status}`);
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let accumulated = "";
-  let buffer = "";
-
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop()!;
-
-    for (const line of lines) {
-      if (line.startsWith("data: ")) {
-        try {
-          const payload = JSON.parse(line.slice(6)) as Record<string, unknown>;
-          if (typeof payload.text === "string") {
-            accumulated += payload.text;
-            onDelta(payload.text);
-          }
-        } catch {
-          // skip malformed JSON
-        }
-      }
+    if (!response.ok || !data || typeof data !== "object") {
+      return null;
     }
-  }
 
-  return accumulated;
+    const text =
+      typeof data.text === "string" ? data.text.trim() : null;
+    return text || null;
+  } catch {
+    return null;
+  }
 }
 
 export function useEmptyStateGreeting(
   assistantId: string | null | undefined,
 ): string {
-  const [greeting, setGreeting] = useState("");
-  const startedRef = useRef(false);
-  const orgId = useOrganizationStore.use.currentOrganizationId();
+  const enabled = Boolean(assistantId);
 
-  useEffect(() => {
-    if (!assistantId || !orgId || startedRef.current) return;
-    startedRef.current = true;
+  const query = useQuery<string | null>({
+    queryKey: ["identity-intro", assistantId],
+    queryFn: () => fetchIdentityIntro(assistantId!),
+    enabled,
+    staleTime: STALE_TIME_MS,
+  });
 
-    const controller = new AbortController();
-
-    streamGreeting(assistantId, controller.signal, (delta) => {
-      setGreeting((prev) => prev + delta);
-    })
-      .then((final) => {
-        const trimmed = final.trim();
-        if (!trimmed || trimmed.length > MAX_GREETING_LENGTH) {
-          setGreeting(pickFallback());
-        } else {
-          setGreeting(trimmed);
-        }
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) {
-          setGreeting(pickFallback());
-        }
-      });
-
-    return () => controller.abort();
-  }, [assistantId, orgId]);
-
-  return greeting || DEFAULT_EMPTY_STATE_GREETING;
+  return query.data ?? DEFAULT_EMPTY_STATE_GREETING;
 }

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 
 import { SDK_BASE_OPTIONS } from "@/domains/chat/api/client";
+import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
+import { useOrganizationStore } from "@/stores/organization-store";
 
 const GREETING_PROMPT =
   "Generate a short, casual greeting in your voice from you to your user. " +
@@ -25,6 +27,7 @@ function pickFallback(): string {
 
 async function streamGreeting(
   assistantId: string,
+  orgId: string,
   signal: AbortSignal,
   onDelta: (text: string) => void,
 ): Promise<string> {
@@ -32,9 +35,16 @@ async function streamGreeting(
     (SDK_BASE_OPTIONS as Record<string, unknown>).baseUrl ?? "";
   const url = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/btw`;
 
+  await ensureCsrfCookie();
+  const csrfToken = getCsrfToken();
+
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
+      "Vellum-Organization-Id": orgId,
+    },
     body: JSON.stringify({
       conversationKey: "greeting",
       content: GREETING_PROMPT,
@@ -82,14 +92,15 @@ export function useEmptyStateGreeting(
 ): string {
   const [greeting, setGreeting] = useState("");
   const startedRef = useRef(false);
+  const orgId = useOrganizationStore.use.currentOrganizationId();
 
   useEffect(() => {
-    if (!assistantId || startedRef.current) return;
+    if (!assistantId || !orgId || startedRef.current) return;
     startedRef.current = true;
 
     const controller = new AbortController();
 
-    streamGreeting(assistantId, controller.signal, (delta) => {
+    streamGreeting(assistantId, orgId, controller.signal, (delta) => {
       setGreeting((prev) => prev + delta);
     })
       .then((final) => {
@@ -107,7 +118,7 @@ export function useEmptyStateGreeting(
       });
 
     return () => controller.abort();
-  }, [assistantId]);
+  }, [assistantId, orgId]);
 
   return greeting || DEFAULT_EMPTY_STATE_GREETING;
 }

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,14 +1,4 @@
-/**
- * React hook that fetches a personalized empty-state greeting from the daemon.
- *
- * Calls `GET /v1/assistants/{assistant_id}/identity/intro` which returns a
- * deterministic greeting derived from the assistant's IDENTITY.md name (e.g.
- * "Hi, I'm Pax!"). Falls back to {@link DEFAULT_EMPTY_STATE_GREETING} when the
- * assistant ID is missing, the daemon is unreachable, or the response is empty.
- *
- * The query has a long `staleTime` (5 minutes) since the intro text only
- * changes when the user renames the assistant — a rare operation.
- */
+import { useRef } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
@@ -22,12 +12,14 @@ import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-c
 const STALE_TIME_MS = 5 * 60 * 1000;
 
 interface IdentityIntroResponse {
-  text: string;
+  greetings?: string[];
+  /** @deprecated — kept for backwards compat with older daemons */
+  text?: string;
 }
 
 async function fetchIdentityIntro(
   assistantId: string,
-): Promise<string | null> {
+): Promise<string[] | null> {
   try {
     const { data, error, response } = await client.get<
       IdentityIntroResponse,
@@ -44,9 +36,15 @@ async function fetchIdentityIntro(
       return null;
     }
 
-    const text =
-      typeof data.text === "string" ? data.text.trim() : null;
-    return text || null;
+    if (Array.isArray(data.greetings) && data.greetings.length > 0) {
+      return data.greetings;
+    }
+
+    if (typeof data.text === "string" && data.text.trim()) {
+      return [data.text.trim()];
+    }
+
+    return null;
   } catch {
     return null;
   }
@@ -56,13 +54,23 @@ export function useEmptyStateGreeting(
   assistantId: string | null | undefined,
 ): string {
   const enabled = Boolean(assistantId);
+  const indexRef = useRef(-1);
 
-  const query = useQuery<string | null>({
+  const query = useQuery<string[] | null>({
     queryKey: ["identity-intro", assistantId],
     queryFn: () => fetchIdentityIntro(assistantId!),
     enabled,
     staleTime: STALE_TIME_MS,
   });
 
-  return query.data ?? DEFAULT_EMPTY_STATE_GREETING;
+  const greetings = query.data;
+  if (!greetings || greetings.length === 0) {
+    return DEFAULT_EMPTY_STATE_GREETING;
+  }
+
+  if (indexRef.current < 0) {
+    indexRef.current = Math.floor(Math.random() * greetings.length);
+  }
+
+  return greetings[indexRef.current % greetings.length]!;
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -10757,10 +10757,8 @@ paths:
   /v1/identity/intro:
     get:
       operationId: identity_intro_get
-      summary: Get identity intro text
-      description:
-        Returns a deterministic greeting derived from the assistant name in IDENTITY.md, falling back to
-        LLM-generated cache.
+      summary: Get identity greetings
+      description: Returns an array of greetings sourced from SOUL.md, LLM cache, or static fallbacks.
       tags:
         - identity
       responses:
@@ -10771,9 +10769,14 @@ paths:
               schema:
                 type: object
                 properties:
+                  greetings:
+                    type: array
+                    items:
+                      type: string
                   text:
                     type: string
                 required:
+                  - greetings
                   - text
                 additionalProperties: false
   /v1/image-generation/generate:

--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -60,6 +60,8 @@ mock.module("../prompts/persona-resolver.js", () => ({
 import {
   computeIdentityContentHash,
   getCachedIntro,
+  parseGreetingsSection,
+  readWorkspaceGreetings,
   readWorkspaceIdentityIntro,
   setCachedIntro,
 } from "../runtime/routes/identity-intro-cache.js";
@@ -113,21 +115,21 @@ describe("identity intro cache", () => {
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("round-trip: set then get returns cached text", () => {
+  test("round-trip: set then get returns cached greetings array", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
     workspaceFiles["SOUL.md"] = "Be playful.";
     guardianPersonaContent = "The user likes coffee.";
 
-    setCachedIntro("Hey, I'm Atlas.");
+    setCachedIntro(["Hey, I'm Atlas.", "What's up?"]);
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();
-    expect(cached!.text).toBe("Hey, I'm Atlas.");
+    expect(cached!.greetings).toEqual(["Hey, I'm Atlas.", "What's up?"]);
   });
 
   test("returns null when cache is expired (TTL exceeded)", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
 
-    setCachedIntro("Hello!");
+    setCachedIntro(["Hello!"]);
 
     // Manually set the timestamp to 5 hours ago
     const fiveHoursAgo = String(Date.now() - 5 * 60 * 60 * 1000);
@@ -136,10 +138,10 @@ describe("identity intro cache", () => {
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("returns cached text when within TTL (3 hours ago)", () => {
+  test("returns cached greetings when within TTL (3 hours ago)", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
 
-    setCachedIntro("Hello!");
+    setCachedIntro(["Hello!"]);
 
     // Set timestamp to 3 hours ago (within 4-hour TTL)
     const threeHoursAgo = String(Date.now() - 3 * 60 * 60 * 1000);
@@ -147,12 +149,12 @@ describe("identity intro cache", () => {
 
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();
-    expect(cached!.text).toBe("Hello!");
+    expect(cached!.greetings).toEqual(["Hello!"]);
   });
 
   test("busts cache when IDENTITY.md changes", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
-    setCachedIntro("I'm Atlas!");
+    setCachedIntro(["I'm Atlas!"]);
 
     // Change IDENTITY.md
     workspaceFiles["IDENTITY.md"] = "- **Name:** Nova";
@@ -162,7 +164,7 @@ describe("identity intro cache", () => {
 
   test("busts cache when SOUL.md changes", () => {
     workspaceFiles["SOUL.md"] = "Be playful.";
-    setCachedIntro("Hey there!");
+    setCachedIntro(["Hey there!"]);
 
     // Change SOUL.md
     workspaceFiles["SOUL.md"] = "Be serious and formal.";
@@ -172,7 +174,7 @@ describe("identity intro cache", () => {
 
   test("busts cache when guardian persona content changes", () => {
     guardianPersonaContent = "Likes coffee.";
-    setCachedIntro("Good morning!");
+    setCachedIntro(["Good morning!"]);
 
     // Change guardian persona (e.g. user edited users/<slug>.md)
     guardianPersonaContent = "Likes tea.";
@@ -185,11 +187,10 @@ describe("identity intro cache", () => {
     workspaceFiles["SOUL.md"] = "Be chill.";
     guardianPersonaContent = "Likes sunsets.";
 
-    setCachedIntro("Atlas here.");
+    setCachedIntro(["Atlas here.", "Hey friend."]);
 
-    // Read twice with the same guardian persona — both should return the cached value
-    expect(getCachedIntro()?.text).toBe("Atlas here.");
-    expect(getCachedIntro()?.text).toBe("Atlas here.");
+    expect(getCachedIntro()?.greetings).toEqual(["Atlas here.", "Hey friend."]);
+    expect(getCachedIntro()?.greetings).toEqual(["Atlas here.", "Hey friend."]);
   });
 
   test("computeIdentityContentHash is deterministic", () => {
@@ -235,30 +236,140 @@ describe("identity intro cache", () => {
 
   test("handles missing workspace files gracefully", () => {
     // No files exist — should still work (empty content hashed)
-    setCachedIntro("Hello!");
+    setCachedIntro(["Hello!"]);
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();
-    expect(cached!.text).toBe("Hello!");
+    expect(cached!.greetings).toEqual(["Hello!"]);
   });
 
-  test("returns null when text checkpoint is missing", () => {
+  test("handles legacy single-string cache value", () => {
+    // Simulate a cache entry written by an older daemon version
+    const hash = computeIdentityContentHash();
+    checkpointStore.set("identity:intro:greetings", "Legacy greeting");
+    checkpointStore.set("identity:intro:content_hash", hash);
+    checkpointStore.set("identity:intro:cached_at", String(Date.now()));
+
+    const cached = getCachedIntro();
+    expect(cached).not.toBeNull();
+    expect(cached!.greetings).toEqual(["Legacy greeting"]);
+  });
+
+  test("returns null when greetings checkpoint is missing", () => {
     checkpointStore.set("identity:intro:content_hash", "abc");
     checkpointStore.set("identity:intro:cached_at", String(Date.now()));
-    // Missing text — should return null
     expect(getCachedIntro()).toBeNull();
   });
 
   test("returns null when hash checkpoint is missing", () => {
-    checkpointStore.set("identity:intro:text", "Hello");
+    checkpointStore.set("identity:intro:greetings", '["Hello"]');
     checkpointStore.set("identity:intro:cached_at", String(Date.now()));
-    // Missing hash — should return null
     expect(getCachedIntro()).toBeNull();
   });
 
   test("returns null when timestamp checkpoint is missing", () => {
-    checkpointStore.set("identity:intro:text", "Hello");
+    checkpointStore.set("identity:intro:greetings", '["Hello"]');
     checkpointStore.set("identity:intro:content_hash", "abc");
-    // Missing timestamp — should return null
     expect(getCachedIntro()).toBeNull();
+  });
+});
+
+describe("parseGreetingsSection", () => {
+  test("parses bullet list from ## Greetings section", () => {
+    const content = [
+      "# Soul",
+      "",
+      "## Greetings",
+      "- Hey there, friend!",
+      "- What's on your mind?",
+      "- Ready to roll!",
+      "",
+      "## Other Section",
+      "Some other content.",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toEqual([
+      "Hey there, friend!",
+      "What's on your mind?",
+      "Ready to roll!",
+    ]);
+  });
+
+  test("handles asterisk bullets", () => {
+    const content = [
+      "## Greetings",
+      "* Hello!",
+      "* Hi there.",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toEqual(["Hello!", "Hi there."]);
+  });
+
+  test("returns null when section is missing", () => {
+    const content = [
+      "# Soul",
+      "## Personality",
+      "Be friendly.",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toBeNull();
+  });
+
+  test("returns null when section is empty", () => {
+    const content = [
+      "## Greetings",
+      "",
+      "## Next Section",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toBeNull();
+  });
+
+  test("ignores non-bullet lines in section", () => {
+    const content = [
+      "## Greetings",
+      "Some intro text that's not a bullet",
+      "- Actual greeting",
+      "Another non-bullet line",
+      "- Second greeting",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toEqual([
+      "Actual greeting",
+      "Second greeting",
+    ]);
+  });
+
+  test("stops at next heading", () => {
+    const content = [
+      "## Greetings",
+      "- First",
+      "- Second",
+      "### Sub-heading",
+      "- Should not appear",
+    ].join("\n");
+
+    expect(parseGreetingsSection(content)).toEqual(["First", "Second"]);
+  });
+});
+
+describe("readWorkspaceGreetings", () => {
+  test("reads greetings from SOUL.md", () => {
+    workspaceFiles["SOUL.md"] = [
+      "# Soul",
+      "## Greetings",
+      "- Hey!",
+      "- What's up?",
+    ].join("\n");
+
+    expect(readWorkspaceGreetings()).toEqual(["Hey!", "What's up?"]);
+  });
+
+  test("returns null when SOUL.md has no greetings section", () => {
+    workspaceFiles["SOUL.md"] = "# Soul\nBe friendly.";
+    expect(readWorkspaceGreetings()).toBeNull();
+  });
+
+  test("returns null when SOUL.md does not exist", () => {
+    expect(readWorkspaceGreetings()).toBeNull();
   });
 });

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -77,7 +77,7 @@ async function handleBtw({
         fastText = `Hi, I'm ${fields.name}!`;
       }
     }
-    fastText ??= getCachedIntro()?.text;
+    fastText ??= getCachedIntro()?.greetings[0];
     if (fastText) {
       log.debug("Returning identity intro fast-path");
       return new ReadableStream({
@@ -146,7 +146,7 @@ async function handleBtw({
 
           if (isIntroRequest && result.text) {
             try {
-              setCachedIntro(result.text);
+              setCachedIntro([result.text]);
               log.debug("Cached identity intro text");
             } catch {
               // Non-fatal — next request will regenerate.

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -1,11 +1,13 @@
 /**
- * Caching layer for the LLM-generated identity intro text.
+ * Caching layer for identity greetings.
  *
- * The intro (a short identity tagline) is generated via the
- * /v1/btw endpoint and displayed on the Identity panel. To avoid redundant LLM
- * calls, we cache the result for 4 hours with content-hash-based invalidation:
- * when IDENTITY.md, SOUL.md, or the guardian's per-user persona file change,
- * the cache is busted.
+ * Greetings are sourced from (in priority order):
+ * 1. A `## Greetings` section in SOUL.md (user-defined bullet list)
+ * 2. A cached greetings array (populated by the BTW side-chain LLM call)
+ * 3. Fallback: the assistant name from IDENTITY.md
+ *
+ * Cache uses TTL + content-hash invalidation: when IDENTITY.md, SOUL.md, or
+ * the guardian persona change, the cache is busted.
  *
  * Storage uses the existing `memory_checkpoints` table (simple key-value store).
  */
@@ -26,7 +28,7 @@ import { getWorkspacePromptPath } from "../../util/platform.js";
 
 const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
-const CHECKPOINT_KEY_TEXT = "identity:intro:text";
+const CHECKPOINT_KEY_GREETINGS = "identity:intro:greetings";
 const CHECKPOINT_KEY_HASH = "identity:intro:content_hash";
 const CHECKPOINT_KEY_TIMESTAMP = "identity:intro:cached_at";
 
@@ -78,6 +80,40 @@ export function readWorkspaceIdentityIntro(): string | null {
   );
 }
 
+/**
+ * Parse the `## Greetings` section from SOUL.md. Returns bullet items as an
+ * array of strings, or `null` if the section is missing or empty.
+ */
+export function parseGreetingsSection(content: string): string[] | null {
+  let inSection = false;
+  const greetings: string[] = [];
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (/^#+\s/.test(trimmed)) {
+      if (inSection) break;
+      inSection = /^#+\s+greetings\s*$/i.test(trimmed);
+      continue;
+    }
+    if (!inSection) continue;
+    const bullet = trimmed.replace(/^[-*]\s+/, "");
+    if (bullet.length > 0 && bullet !== trimmed) {
+      greetings.push(bullet);
+    }
+  }
+
+  return greetings.length > 0 ? greetings : null;
+}
+
+/**
+ * Read user-defined greetings from the `## Greetings` section of SOUL.md.
+ */
+export function readWorkspaceGreetings(): string[] | null {
+  const soulContent = readWorkspaceFile("SOUL.md");
+  if (!soulContent) return null;
+  return parseGreetingsSection(soulContent);
+}
+
 /** Compute a SHA-256 hex hash of the concatenated identity file contents. */
 export function computeIdentityContentHash(): string {
   const staticFiles = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
@@ -91,22 +127,22 @@ export function computeIdentityContentHash(): string {
 // ---------------------------------------------------------------------------
 
 export interface CachedIntro {
-  text: string;
+  greetings: string[];
 }
 
 /**
- * Retrieve the cached identity intro if it exists, is within the TTL window,
+ * Retrieve the cached greetings array if it exists, is within the TTL window,
  * and the identity files have not changed since it was generated.
  *
  * Returns `null` when the cache is missing, expired, or invalidated.
  */
 export function getCachedIntro(): CachedIntro | null {
   try {
-    const text = getMemoryCheckpoint(CHECKPOINT_KEY_TEXT);
+    const raw = getMemoryCheckpoint(CHECKPOINT_KEY_GREETINGS);
     const hash = getMemoryCheckpoint(CHECKPOINT_KEY_HASH);
     const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
 
-    if (!text || !hash || !timestampStr) return null;
+    if (!raw || !hash || !timestampStr) return null;
 
     // TTL check
     const cachedAt = Number(timestampStr);
@@ -116,21 +152,30 @@ export function getCachedIntro(): CachedIntro | null {
     const currentHash = computeIdentityContentHash();
     if (currentHash !== hash) return null;
 
-    return { text };
+    // Parse stored value — handles both JSON array and legacy single string
+    let greetings: string[];
+    try {
+      const parsed = JSON.parse(raw);
+      greetings = Array.isArray(parsed) ? parsed : [raw];
+    } catch {
+      greetings = [raw];
+    }
+
+    return { greetings };
   } catch {
     return null;
   }
 }
 
 /**
- * Store the generated identity intro text in the cache along with
- * the current content hash and timestamp.
+ * Store a greetings array in the cache along with the current content hash
+ * and timestamp.
  */
-export function setCachedIntro(text: string): void {
+export function setCachedIntro(greetings: string[]): void {
   try {
     const hash = computeIdentityContentHash();
     const now = String(Date.now());
-    setMemoryCheckpoint(CHECKPOINT_KEY_TEXT, text);
+    setMemoryCheckpoint(CHECKPOINT_KEY_GREETINGS, JSON.stringify(greetings));
     setMemoryCheckpoint(CHECKPOINT_KEY_HASH, hash);
     setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, now);
   } catch {

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -405,13 +405,13 @@ function getIdentityIntro() {
   // 1. User-defined greetings from SOUL.md `## Greetings`
   const workspaceGreetings = readWorkspaceGreetings();
   if (workspaceGreetings) {
-    return { greetings: workspaceGreetings };
+    return { greetings: workspaceGreetings, text: workspaceGreetings[0] };
   }
 
   // 2. Cached LLM-generated greetings
   const cached = getCachedIntro();
   if (cached) {
-    return { greetings: cached.greetings };
+    return { greetings: cached.greetings, text: cached.greetings[0] };
   }
 
   // 3. Fallback: name-based greeting + static defaults
@@ -420,11 +420,12 @@ function getIdentityIntro() {
     const content = readFileSync(identityPath, "utf-8");
     const fields = parseIdentityFields(content);
     if (fields.name) {
-      return { greetings: [`Hi, I'm ${fields.name}!`, ...FALLBACK_GREETINGS] };
+      const greetings = [`Hi, I'm ${fields.name}!`, ...FALLBACK_GREETINGS];
+      return { greetings, text: greetings[0] };
     }
   }
 
-  return { greetings: FALLBACK_GREETINGS };
+  return { greetings: FALLBACK_GREETINGS, text: FALLBACK_GREETINGS[0] };
 }
 
 // ---------------------------------------------------------------------------
@@ -537,6 +538,7 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["identity"],
     responseBody: z.object({
       greetings: z.array(z.string()),
+      text: z.string(),
     }),
   },
 ];

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -23,7 +23,10 @@ import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { NotFoundError } from "./errors.js";
-import { getCachedIntro } from "./identity-intro-cache.js";
+import {
+  getCachedIntro,
+  readWorkspaceGreetings,
+} from "./identity-intro-cache.js";
 import type { RouteDefinition } from "./types.js";
 
 interface MemoryInfo {
@@ -391,21 +394,37 @@ function resolveIdentityCreatedAt(identityPath: string): string | undefined {
   return resolveHatchedAtReadOnly(identityPath);
 }
 
+const FALLBACK_GREETINGS = [
+  "What are we working on?",
+  "I'm here whenever you need me.",
+  "What's on your mind?",
+  "Ready when you are.",
+];
+
 function getIdentityIntro() {
+  // 1. User-defined greetings from SOUL.md `## Greetings`
+  const workspaceGreetings = readWorkspaceGreetings();
+  if (workspaceGreetings) {
+    return { greetings: workspaceGreetings };
+  }
+
+  // 2. Cached LLM-generated greetings
+  const cached = getCachedIntro();
+  if (cached) {
+    return { greetings: cached.greetings };
+  }
+
+  // 3. Fallback: name-based greeting + static defaults
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   if (existsSync(identityPath)) {
     const content = readFileSync(identityPath, "utf-8");
     const fields = parseIdentityFields(content);
     if (fields.name) {
-      return { text: `Hi, I'm ${fields.name}!` };
+      return { greetings: [`Hi, I'm ${fields.name}!`, ...FALLBACK_GREETINGS] };
     }
   }
 
-  const cached = getCachedIntro();
-  if (!cached) {
-    throw new NotFoundError("No cached identity intro available");
-  }
-  return { text: cached.text };
+  return { greetings: FALLBACK_GREETINGS };
 }
 
 // ---------------------------------------------------------------------------
@@ -512,12 +531,12 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "identity/intro",
     method: "GET",
     handler: getIdentityIntro,
-    summary: "Get identity intro text",
+    summary: "Get identity greetings",
     description:
-      "Returns a deterministic greeting derived from the assistant name in IDENTITY.md, falling back to LLM-generated cache.",
+      "Returns an array of greetings sourced from SOUL.md, LLM cache, or static fallbacks.",
     tags: ["identity"],
     responseBody: z.object({
-      text: z.string(),
+      greetings: z.array(z.string()),
     }),
   },
 ];


### PR DESCRIPTION
## Summary
- Change `GET /v1/identity/intro` response from `{ text }` to `{ greetings[], text }` with a 3-tier priority: SOUL.md `## Greetings` section → cached LLM greetings → name-based + static fallbacks
- Web empty-state hook streams a personalized greeting via `POST /v1/btw` (conversationKey: `"greeting"`, `emptyStateGreeting` callsite) — matching the Mac app's `ChatGreetingState` pattern
- Falls back to a static greeting on error or if the LLM response exceeds 80 characters
- Preserves legacy `text` field in identity/intro for macOS client backward compatibility

## Test plan
- [ ] Open a new conversation on localhost:3000 — verify a personalized greeting streams in
- [ ] Kill the daemon mid-stream — verify fallback greeting appears
- [ ] Verify `GET /v1/identity/intro` returns both `greetings[]` and `text` fields
- [ ] Add `## Greetings` section to SOUL.md and verify those are returned from identity/intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)