### PR TITLE
refactor(web): migrate conversation groups to generated TanStack Query hooks (LUM-1946)

### DIFF
--- a/apps/web/src/domains/conversations/conversation-queries.test.ts
+++ b/apps/web/src/domains/conversations/conversation-queries.test.ts
@@ -21,6 +21,7 @@ import type {
   ConversationGroup,
 } from "@/lib/conversations-api";
 import type { ChatContext } from "@/domains/chat/api/assistant";
+import type { GroupsGetResponse } from "@/generated/daemon/types.gen";
 
 const ASSISTANT_ID = "ast-1";
 
@@ -65,9 +66,16 @@ function getConversations(qc: QueryClient): Conversation[] {
 
 function getGroups(qc: QueryClient): ConversationGroup[] {
   return (
-    qc.getQueryData<ConversationGroup[]>(
+    qc.getQueryData<GroupsGetResponse>(
       conversationGroupsQueryKey(ASSISTANT_ID),
-    ) ?? []
+    )?.groups ?? []
+  );
+}
+
+function seedGroups(qc: QueryClient, groups: ConversationGroup[]): void {
+  qc.setQueryData<GroupsGetResponse>(
+    conversationGroupsQueryKey(ASSISTANT_ID),
+    { groups },
   );
 }
 
@@ -163,10 +171,7 @@ describe("resolveDraftKey", () => {
 describe("appendGroup", () => {
   it("auto-computes sortPosition from the current group count", () => {
     const qc = new QueryClient();
-    qc.setQueryData<ConversationGroup[]>(
-      conversationGroupsQueryKey(ASSISTANT_ID),
-      [makeGroup("g1", "First", { sortPosition: 0 })],
-    );
+    seedGroups(qc, [makeGroup("g1", "First", { sortPosition: 0 })]);
     appendGroup(
       qc,
       ASSISTANT_ID,
@@ -181,10 +186,7 @@ describe("appendGroup", () => {
 describe("patchGroup", () => {
   it("patches the matching group", () => {
     const qc = new QueryClient();
-    qc.setQueryData<ConversationGroup[]>(
-      conversationGroupsQueryKey(ASSISTANT_ID),
-      [makeGroup("g1", "Old")],
-    );
+    seedGroups(qc, [makeGroup("g1", "Old")]);
     patchGroup(qc, ASSISTANT_ID, "g1", { name: "New" });
     expect(getGroups(qc)[0]!.name).toBe("New");
   });
@@ -193,10 +195,7 @@ describe("patchGroup", () => {
 describe("replaceOptimisticGroup", () => {
   it("swaps the optimistic group with the real one", () => {
     const qc = new QueryClient();
-    qc.setQueryData<ConversationGroup[]>(
-      conversationGroupsQueryKey(ASSISTANT_ID),
-      [makeGroup("opt-1", "Temp")],
-    );
+    seedGroups(qc, [makeGroup("opt-1", "Temp")]);
     const real = makeGroup("real-1", "Real");
     replaceOptimisticGroup(qc, ASSISTANT_ID, "opt-1", real);
     expect(getGroups(qc)[0]).toEqual(real);
@@ -206,10 +205,7 @@ describe("replaceOptimisticGroup", () => {
 describe("removeGroup", () => {
   it("removes the matching group", () => {
     const qc = new QueryClient();
-    qc.setQueryData<ConversationGroup[]>(
-      conversationGroupsQueryKey(ASSISTANT_ID),
-      [makeGroup("g1", "A"), makeGroup("g2", "B")],
-    );
+    seedGroups(qc, [makeGroup("g1", "A"), makeGroup("g2", "B")]);
     removeGroup(qc, ASSISTANT_ID, "g1");
     expect(getGroups(qc).map((g) => g.id)).toEqual(["g2"]);
   });
@@ -222,10 +218,7 @@ describe("deleteGroupAndResetConversations", () => {
       makeConversation("a", { groupId: "g1" }),
       makeConversation("b", { groupId: "g2" }),
     ]);
-    qc.setQueryData<ConversationGroup[]>(
-      conversationGroupsQueryKey(ASSISTANT_ID),
-      [makeGroup("g1", "G1"), makeGroup("g2", "G2")],
-    );
+    seedGroups(qc, [makeGroup("g1", "G1"), makeGroup("g2", "G2")]);
     deleteGroupAndResetConversations(qc, ASSISTANT_ID, "g1");
     expect(getGroups(qc).map((g) => g.id)).toEqual(["g2"]);
     expect(getConversations(qc)[0]!.groupId).toBeUndefined();

--- a/apps/web/src/domains/conversations/conversation-queries.ts
+++ b/apps/web/src/domains/conversations/conversation-queries.ts
@@ -35,30 +35,43 @@ import {
   getChatContext,
 } from "@/domains/chat/api/assistant";
 import {
+  groupsGetOptions,
+  groupsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { Options } from "@/generated/daemon/sdk.gen";
+import type {
+  GroupsGetData,
+  GroupsGetResponse,
+} from "@/generated/daemon/types.gen";
+import {
   CONVERSATION_NOT_FOUND,
   type Conversation,
   type ConversationGroup,
   fetchConversationDetail,
-  fetchGroups,
 } from "@/lib/conversations-api";
+import {
+  CHAT_CONTEXT_QUERY_KEY,
+  chatContextQueryKey,
+} from "@/lib/sync/query-tags";
 
 // ---------------------------------------------------------------------------
 // Query keys
 // ---------------------------------------------------------------------------
 
-import {
-  CHAT_CONTEXT_QUERY_KEY,
-  CONVERSATION_GROUPS_QUERY_KEY,
-  chatContextQueryKey,
-  conversationGroupsQueryKey,
-} from "@/lib/sync/query-tags";
+export { CHAT_CONTEXT_QUERY_KEY, chatContextQueryKey };
 
-export {
-  CHAT_CONTEXT_QUERY_KEY,
-  CONVERSATION_GROUPS_QUERY_KEY,
-  chatContextQueryKey,
-  conversationGroupsQueryKey,
-};
+/**
+ * Build the generated query key for conversation groups. Exported so that
+ * invalidation call sites (sync stream, loader, group actions) can target
+ * the same cache entry that `useConversationGroupsQuery` populates.
+ */
+export function conversationGroupsQueryKey(
+  assistantId: string | null,
+): ReturnType<typeof groupsGetQueryKey> {
+  return groupsGetQueryKey({
+    path: { assistant_id: assistantId ?? "" },
+  } as Options<GroupsGetData>);
+}
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -131,9 +144,10 @@ export function useConversationGroupsQuery(
   enabled: boolean = true,
 ): { conversationGroups: ConversationGroup[]; isLoading: boolean } {
   const query = useQuery({
-    queryKey: conversationGroupsQueryKey(assistantId),
-    queryFn: () =>
-      assistantId ? fetchGroups(assistantId) : Promise.resolve([]),
+    ...groupsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    } as Options<GroupsGetData>),
+    select: (data) => data.groups,
     enabled: enabled && Boolean(assistantId),
     staleTime: QUERY_STALE_TIME_MS,
   });
@@ -348,12 +362,13 @@ function updateGroupsCache(
   assistantId: string | null,
   updater: (groups: ConversationGroup[]) => ConversationGroup[],
 ): void {
-  queryClient.setQueryData<ConversationGroup[]>(
+  queryClient.setQueryData<GroupsGetResponse>(
     conversationGroupsQueryKey(assistantId),
     (prev) => {
-      const list = prev ?? [];
+      const list = prev?.groups ?? [];
       const next = updater(list);
-      return next === list ? prev : next;
+      if (next === list) return prev;
+      return { ...prev, groups: next };
     },
   );
 }

--- a/apps/web/src/domains/conversations/use-conversation-group-actions.ts
+++ b/apps/web/src/domains/conversations/use-conversation-group-actions.ts
@@ -1,12 +1,24 @@
 
 import * as Sentry from "@sentry/react";
 import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  groupsByGroupIdDeleteMutation,
+  groupsByGroupIdPatchMutation,
+  groupsPostMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { Options } from "@/generated/daemon/sdk.gen";
+import type {
+  GroupsByGroupIdDeleteData,
+  GroupsByGroupIdPatchData,
+  GroupsPostData,
+} from "@/generated/daemon/types.gen";
 
 import {
   appendGroup,
-  chatContextQueryKey,
   conversationGroupsQueryKey,
+  chatContextQueryKey,
   deleteGroupAndResetConversations,
   patchGroup,
   removeGroup,
@@ -14,7 +26,7 @@ import {
 } from "@/domains/conversations/conversation-queries";
 
 import { haptic } from "@/utils/haptics";
-import { type ConversationGroup, createGroup, deleteGroup, updateGroup } from "@/lib/conversations-api";
+import type { ConversationGroup } from "@/lib/conversations-api";
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -42,6 +54,33 @@ export function useConversationGroupActions({
 }: UseConversationGroupActionsParams) {
   const queryClient = useQueryClient();
 
+  const createMutation = useMutation({
+    ...groupsPostMutation(),
+    onError: (err) => {
+      Sentry.captureException(err, {
+        tags: { context: "createGroup" },
+      });
+    },
+  });
+
+  const patchMutation = useMutation({
+    ...groupsByGroupIdPatchMutation(),
+    onError: (err) => {
+      Sentry.captureException(err, {
+        tags: { context: "renameGroup" },
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    ...groupsByGroupIdDeleteMutation(),
+    onError: (err) => {
+      Sentry.captureException(err, {
+        tags: { context: "deleteGroup" },
+      });
+    },
+  });
+
   const handleCreateGroup = useCallback(async () => {
     if (!assistantId) return;
     haptic.light();
@@ -57,15 +96,15 @@ export function useConversationGroupActions({
     appendGroup(queryClient, assistantId, { id: optimisticId, name: trimmed, sortPosition: 0, isSystemGroup: false });
 
     try {
-      const created = await createGroup(assistantId, trimmed);
+      const created = await createMutation.mutateAsync({
+        path: { assistant_id: assistantId },
+        body: { name: trimmed },
+      } as Options<GroupsPostData>);
       replaceOptimisticGroup(queryClient, assistantId, optimisticId, created);
-    } catch (err) {
+    } catch {
       removeGroup(queryClient, assistantId, optimisticId);
-      Sentry.captureException(err, {
-        tags: { context: "createGroup" },
-      });
     }
-  }, [assistantId, queryClient]);
+  }, [assistantId, queryClient, createMutation]);
 
   const handleRenameGroup = useCallback(
     async (groupId: string) => {
@@ -82,15 +121,15 @@ export function useConversationGroupActions({
       patchGroup(queryClient, assistantId, groupId, { name: trimmed });
 
       try {
-        await updateGroup(assistantId, groupId, { name: trimmed });
-      } catch (err) {
+        await patchMutation.mutateAsync({
+          path: { assistant_id: assistantId, groupId },
+          body: { name: trimmed },
+        } as Options<GroupsByGroupIdPatchData>);
+      } catch {
         patchGroup(queryClient, assistantId, groupId, { name: current });
-        Sentry.captureException(err, {
-          tags: { context: "renameGroup" },
-        });
       }
     },
-    [assistantId, conversationGroups, queryClient],
+    [assistantId, conversationGroups, queryClient, patchMutation],
   );
 
   const handleDeleteGroup = useCallback(
@@ -101,23 +140,19 @@ export function useConversationGroupActions({
       deleteGroupAndResetConversations(queryClient, assistantId, groupId);
 
       try {
-        await deleteGroup(assistantId, groupId);
-      } catch (err) {
-        // Rollback is imprecise — we can't distinguish conversations that
-        // already had no groupId from those we just cleared — so invalidate
-        // both caches and let subscribers refetch for accuracy.
+        await deleteMutation.mutateAsync({
+          path: { assistant_id: assistantId, groupId },
+        } as Options<GroupsByGroupIdDeleteData>);
+      } catch {
         void queryClient.invalidateQueries({
           queryKey: chatContextQueryKey(assistantId),
         });
         void queryClient.invalidateQueries({
           queryKey: conversationGroupsQueryKey(assistantId),
         });
-        Sentry.captureException(err, {
-          tags: { context: "deleteGroup" },
-        });
       }
     },
-    [assistantId, queryClient],
+    [assistantId, queryClient, deleteMutation],
   );
 
   return {

--- a/apps/web/src/domains/conversations/use-conversation-group-actions.ts
+++ b/apps/web/src/domains/conversations/use-conversation-group-actions.ts
@@ -54,7 +54,7 @@ export function useConversationGroupActions({
 }: UseConversationGroupActionsParams) {
   const queryClient = useQueryClient();
 
-  const createMutation = useMutation({
+  const { mutateAsync: createGroupAsync } = useMutation({
     ...groupsPostMutation(),
     onError: (err) => {
       Sentry.captureException(err, {
@@ -63,7 +63,7 @@ export function useConversationGroupActions({
     },
   });
 
-  const patchMutation = useMutation({
+  const { mutateAsync: patchGroupAsync } = useMutation({
     ...groupsByGroupIdPatchMutation(),
     onError: (err) => {
       Sentry.captureException(err, {
@@ -72,7 +72,7 @@ export function useConversationGroupActions({
     },
   });
 
-  const deleteMutation = useMutation({
+  const { mutateAsync: deleteGroupAsync } = useMutation({
     ...groupsByGroupIdDeleteMutation(),
     onError: (err) => {
       Sentry.captureException(err, {
@@ -96,7 +96,7 @@ export function useConversationGroupActions({
     appendGroup(queryClient, assistantId, { id: optimisticId, name: trimmed, sortPosition: 0, isSystemGroup: false });
 
     try {
-      const created = await createMutation.mutateAsync({
+      const created = await createGroupAsync({
         path: { assistant_id: assistantId },
         body: { name: trimmed },
       } as Options<GroupsPostData>);
@@ -104,7 +104,7 @@ export function useConversationGroupActions({
     } catch {
       removeGroup(queryClient, assistantId, optimisticId);
     }
-  }, [assistantId, queryClient, createMutation]);
+  }, [assistantId, queryClient, createGroupAsync]);
 
   const handleRenameGroup = useCallback(
     async (groupId: string) => {
@@ -121,7 +121,7 @@ export function useConversationGroupActions({
       patchGroup(queryClient, assistantId, groupId, { name: trimmed });
 
       try {
-        await patchMutation.mutateAsync({
+        await patchGroupAsync({
           path: { assistant_id: assistantId, groupId },
           body: { name: trimmed },
         } as Options<GroupsByGroupIdPatchData>);
@@ -129,7 +129,7 @@ export function useConversationGroupActions({
         patchGroup(queryClient, assistantId, groupId, { name: current });
       }
     },
-    [assistantId, conversationGroups, queryClient, patchMutation],
+    [assistantId, conversationGroups, queryClient, patchGroupAsync],
   );
 
   const handleDeleteGroup = useCallback(
@@ -140,7 +140,7 @@ export function useConversationGroupActions({
       deleteGroupAndResetConversations(queryClient, assistantId, groupId);
 
       try {
-        await deleteMutation.mutateAsync({
+        await deleteGroupAsync({
           path: { assistant_id: assistantId, groupId },
         } as Options<GroupsByGroupIdDeleteData>);
       } catch {
@@ -152,7 +152,7 @@ export function useConversationGroupActions({
         });
       }
     },
-    [assistantId, queryClient, deleteMutation],
+    [assistantId, queryClient, deleteGroupAsync],
   );
 
   return {

--- a/apps/web/src/hooks/use-assistant-sync-stream.test.tsx
+++ b/apps/web/src/hooks/use-assistant-sync-stream.test.tsx
@@ -13,8 +13,8 @@ import {
   assistantSoundsConfigQueryKey,
   avatarQueryKey,
   chatContextQueryKey,
-  conversationGroupsQueryKey,
 } from "@/lib/sync/query-tags";
+import { conversationGroupsQueryKey } from "@/domains/conversations/conversation-queries";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types";
 import {
   __resetEventBusForTesting,
@@ -482,10 +482,12 @@ describe("useAssistantSyncStream", () => {
         return arg?.queryKey?.[0] === chatContextQueryKey("asst-1")[0];
       },
     );
+    const expectedGroupsKey = conversationGroupsQueryKey("asst-1")[0];
     const groupsCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
       (call) => {
         const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-        return arg?.queryKey?.[0] === conversationGroupsQueryKey("asst-1")[0];
+        const key = arg?.queryKey?.[0] as Record<string, unknown> | undefined;
+        return key?._id === (expectedGroupsKey as Record<string, unknown>)._id;
       },
     );
     expect(chatCtxCalls.length).toBe(1);

--- a/apps/web/src/hooks/use-assistant-sync-stream.ts
+++ b/apps/web/src/hooks/use-assistant-sync-stream.ts
@@ -36,8 +36,8 @@ import {
   assistantSoundsConfigQueryKey,
   avatarQueryKey,
   chatContextQueryKey,
-  conversationGroupsQueryKey,
 } from "@/lib/sync/query-tags";
+import { conversationGroupsQueryKey } from "@/domains/conversations/conversation-queries";
 import {
   parseConversationSyncTag,
   SYNC_TAGS,

--- a/apps/web/src/lib/conversations-api.ts
+++ b/apps/web/src/lib/conversations-api.ts
@@ -1,8 +1,8 @@
 /**
- * Conversation CRUD operations and group management via the generated daemon SDK.
+ * Conversation CRUD operations via the generated daemon SDK.
  *
  * Handles listing, archiving, unarchiving, forking, renaming, reordering,
- * and analyzing conversations, as well as conversation group CRUD.
+ * and analyzing conversations.
  *
  * The `Conversation` interface is a normalized client-side representation
  * (timestamps as ISO strings, attention fields flattened, `id` renamed to
@@ -24,11 +24,6 @@ import {
   conversationsReorderPost,
   conversationsSeenPost,
   conversationsUnreadPost,
-  groupsByGroupIdDelete,
-  groupsByGroupIdPatch,
-  groupsGet,
-  groupsPost,
-  groupsReorderPost,
   subagentsByIdAbortPost,
   subagentsByIdGet,
 } from "@/generated/daemon/sdk.gen";
@@ -37,6 +32,7 @@ import type {
   ConversationsGetResponses,
   GroupsGetResponse,
 } from "@/generated/daemon/types.gen";
+
 import { ApiError, assertHasResponse, extractErrorMessage } from "@/lib/api-errors";
 import {
   parseSlackMessageLink,
@@ -690,93 +686,6 @@ export async function reorderConversations(
   assertHasResponse(response, error, "Failed to reorder conversations.");
   if (!response.ok) {
     const msg = extractErrorMessage(error, response, "Failed to reorder conversations.");
-    throw new ApiError(response.status, msg);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Conversation Groups
-// ---------------------------------------------------------------------------
-
-export async function fetchGroups(
-  assistantId: string,
-): Promise<ConversationGroup[]> {
-  const { data, error, response } = await groupsGet({
-    path: { assistant_id: assistantId },
-    throwOnError: false,
-  });
-  assertHasResponse(response, error, "Failed to list groups.");
-  if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to list groups.");
-    throw new ApiError(response.status, msg);
-  }
-  return data?.groups ?? [];
-}
-
-export async function createGroup(
-  assistantId: string,
-  name: string,
-): Promise<ConversationGroup> {
-  const { data, error, response } = await groupsPost({
-    path: { assistant_id: assistantId },
-    body: { name },
-    throwOnError: false,
-  });
-  assertHasResponse(response, error, "Failed to create group.");
-  if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to create group.");
-    throw new ApiError(response.status, msg);
-  }
-  if (!data || typeof data !== "object" || typeof (data as Record<string, unknown>).id !== "string") {
-    throw new ApiError(response.status, "Create group response did not include a valid group.");
-  }
-  return data as unknown as ConversationGroup;
-}
-
-export async function updateGroup(
-  assistantId: string,
-  groupId: string,
-  opts: { name?: string; sortPosition?: number },
-): Promise<void> {
-  const { error, response } = await groupsByGroupIdPatch({
-    path: { assistant_id: assistantId, groupId },
-    body: opts,
-    throwOnError: false,
-  });
-  assertHasResponse(response, error, "Failed to update group.");
-  if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to update group.");
-    throw new ApiError(response.status, msg);
-  }
-}
-
-export async function deleteGroup(
-  assistantId: string,
-  groupId: string,
-): Promise<void> {
-  const { error, response } = await groupsByGroupIdDelete({
-    path: { assistant_id: assistantId, groupId },
-    throwOnError: false,
-  });
-  assertHasResponse(response, error, "Failed to delete group.");
-  if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to delete group.");
-    throw new ApiError(response.status, msg);
-  }
-}
-
-export async function reorderGroups(
-  assistantId: string,
-  updates: { groupId: string; sortPosition: number }[],
-): Promise<void> {
-  const { error, response } = await groupsReorderPost({
-    path: { assistant_id: assistantId },
-    body: { updates },
-    throwOnError: false,
-  });
-  assertHasResponse(response, error, "Failed to reorder groups.");
-  if (!response.ok) {
-    const msg = extractErrorMessage(error, response, "Failed to reorder groups.");
     throw new ApiError(response.status, msg);
   }
 }

--- a/apps/web/src/lib/sync/query-tags.ts
+++ b/apps/web/src/lib/sync/query-tags.ts
@@ -7,14 +7,9 @@ export function avatarQueryKey(assistantId: string) {
 }
 
 export const CHAT_CONTEXT_QUERY_KEY = "chat-context" as const;
-export const CONVERSATION_GROUPS_QUERY_KEY = "conversation-groups" as const;
 
 export function chatContextQueryKey(assistantId: string | null) {
   return [CHAT_CONTEXT_QUERY_KEY, assistantId ?? ""] as const;
-}
-
-export function conversationGroupsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_GROUPS_QUERY_KEY, assistantId ?? ""] as const;
 }
 
 export function assistantDaemonConfigQueryKey(


### PR DESCRIPTION
## Prompt / plan

First PR in the consumer migration sequence (LUM-1946). Replaces hand-written group CRUD wrapper functions with generated TanStack Query hooks from the daemon codegen pipeline, following the patterns established in `docs/STATE_MANAGEMENT.md`.

**Why needed:** The hand-written wrappers in `conversations-api.ts` duplicate logic the HeyAPI codegen already generates (typed SDK functions + TanStack Query hooks). This is tech debt from the platform port — the original code predated the daemon codegen pipeline (LUM-1942).

**What changed:**
- `useConversationGroupsQuery` now spreads `groupsGetOptions()` with a `select: (data) => data.groups` transform instead of wrapping `fetchGroups()`
- `useConversationGroupActions` rewritten to use `useMutation()` with generated mutation options (`groupsPostMutation`, `groupsByGroupIdPatchMutation`, `groupsByGroupIdDeleteMutation`)
- `conversationGroupsQueryKey()` now delegates to `groupsGetQueryKey()` for proper cache key alignment with the generated hooks
- Cache helpers (`appendGroup`, `patchGroup`, `removeGroup`, etc.) updated to work with `GroupsGetResponse` shape (`{ groups: [...] }`)
- Deleted 5 group wrapper functions from `conversations-api.ts` (−94 lines)
- Removed `CONVERSATION_GROUPS_QUERY_KEY` from `query-tags.ts`
- Updated test files to use new cache shape and import paths

**Why safe:**
- Typecheck + lint pass
- All 30 relevant tests pass (18 in `use-assistant-sync-stream.test.tsx`, 12 in `conversation-queries.test.ts`)
- Optimistic updates preserved: create/rename roll back on failure, delete invalidates both caches
- No behavioral change for consumers — `useConversationGroupsQuery` still returns `{ conversationGroups, isLoading }`

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- `bun test src/hooks/use-assistant-sync-stream.test.tsx` — 18/18 pass
- `bun test src/domains/conversations/conversation-queries.test.ts` — 12/12 pass
- CI verification pending

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka