### PR TITLE
Round-trip assistant reasoning for OpenAI-compatible providers

### DIFF
--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -35,20 +35,36 @@ function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
 function stubProvider(chunks: MockChunk[]): {
   provider: OpenAIChatCompletionsProvider;
   events: Array<{ type: string; thinking?: string; text?: string }>;
+  requests: unknown[];
 } {
   const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  return stubExistingProvider(provider, chunks);
+}
+
+function stubExistingProvider(
+  provider: OpenAIChatCompletionsProvider,
+  chunks: MockChunk[],
+): {
+  provider: OpenAIChatCompletionsProvider;
+  events: Array<{ type: string; thinking?: string; text?: string }>;
+  requests: unknown[];
+} {
+  const requests: unknown[] = [];
   // Swap the SDK client for a stub whose chat.completions.create returns our
   // canned async iterable.
   (provider as unknown as { client: unknown }).client = {
     chat: {
       completions: {
-        create: async () => makeStream(chunks),
+        create: async (params: unknown) => {
+          requests.push(params);
+          return makeStream(chunks);
+        },
       },
     },
   };
   const events: Array<{ type: string; thinking?: string; text?: string }> = [];
   (provider as unknown as { __events: typeof events }).__events = events;
-  return { provider, events };
+  return { provider, events, requests };
 }
 
 async function runStream(
@@ -231,5 +247,78 @@ describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
     const deltas = events.filter((e) => e.type === "thinking_delta");
     expect(deltas.map((d) => d.thinking)).toEqual(["it ", "worked", "!"]);
     expect(thinking).toBe("it worked!");
+  });
+
+  test("round-trips prior assistant thinking as reasoning_content for DeepSeek multi-turn", async () => {
+    const { provider, requests } = stubProvider([
+      {
+        choices: [{ delta: { content: "continued" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 4, completion_tokens: 2 },
+      },
+    ]);
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "first question" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hidden chain state", signature: "" },
+          { type: "text", text: "first answer" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "follow up" }] },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        content: string | null;
+        reasoning_content?: string;
+      }>;
+    };
+    const assistantMessage = params.messages.find(
+      (message) => message.role === "assistant",
+    );
+
+    expect(assistantMessage).toEqual({
+      role: "assistant",
+      content: "first answer",
+      reasoning_content: "hidden chain state",
+    });
+  });
+
+  test("can round-trip prior assistant thinking with OpenRouter's reasoning field", async () => {
+    const baseProvider = new OpenAIChatCompletionsProvider(
+      "test-key",
+      "test-model",
+      { assistantReasoningField: "reasoning" },
+    );
+    const { provider, requests } = stubExistingProvider(baseProvider, [
+      {
+        choices: [{ delta: { content: "continued" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 4, completion_tokens: 2 },
+      },
+    ]);
+
+    await provider.sendMessage([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "visible summary", signature: "" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        reasoning?: string;
+        reasoning_content?: string;
+      }>;
+    };
+
+    expect(params.messages[0].reasoning).toBe("visible summary");
+    expect(params.messages[0].reasoning_content).toBeUndefined();
   });
 });

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -75,6 +75,8 @@ export interface OpenAIChatCompletionsProviderOptions {
    *  blocks. MiniMax and similar providers embed reasoning inside XML-style
    *  tags in the regular content field rather than using `reasoning_content`. */
   parseThinkTags?: boolean;
+  /** Wire field used to replay prior assistant thinking on multi-turn requests. */
+  assistantReasoningField?: "reasoning" | "reasoning_content";
 }
 
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
@@ -146,6 +148,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private maxReasoningEffort: "high" | "xhigh" | "max";
   private requestHeaders: Record<string, string>;
   private parseThinkTags: boolean;
+  private assistantReasoningField: "reasoning" | "reasoning_content";
 
   constructor(
     apiKey: string,
@@ -168,6 +171,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.maxReasoningEffort = options.maxReasoningEffort ?? "xhigh";
     this.requestHeaders = options.requestHeaders ?? {};
     this.parseThinkTags = options.parseThinkTags ?? false;
+    this.assistantReasoningField =
+      options.assistantReasoningField ?? "reasoning_content";
   }
 
   async sendMessage(
@@ -661,6 +666,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     msg: Message,
   ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
     const textParts: string[] = [];
+    const reasoningParts: string[] = [];
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] =
       [];
 
@@ -668,6 +674,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
       switch (block.type) {
         case "text":
           textParts.push(block.text);
+          break;
+        case "thinking":
+          reasoningParts.push(block.thinking);
           break;
         case "tool_use":
           toolCalls.push({
@@ -685,7 +694,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         case "web_search_tool_result":
           textParts.push("[Web search results]");
           break;
-        // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
+        // redacted_thinking, image — not applicable for OpenAI assistant messages
       }
     }
 
@@ -694,6 +703,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
         role: "assistant",
         content: textParts.length > 0 ? textParts.join("") : null,
       };
+    if (reasoningParts.length > 0) {
+      (
+        result as OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam & {
+          reasoning?: string;
+          reasoning_content?: string;
+        }
+      )[this.assistantReasoningField] = reasoningParts.join("");
+    }
 
     if (toolCalls.length > 0) {
       result.tool_calls = toolCalls;

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -122,6 +122,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
       requestHeaders: OPENROUTER_APP_ATTRIBUTION_HEADERS,
+      assistantReasoningField: "reasoning",
     });
     this.openRouterApiKey = apiKey;
     this.defaultModel = model;


### PR DESCRIPTION
## Summary
- Preserve prior assistant `thinking` blocks when converting history back into OpenAI-compatible Chat Completions messages
- Default the replay field to `reasoning_content` for DeepSeek/Fireworks-style providers and use OpenRouter's `reasoning` field for OpenRouter
- Add regression coverage for DeepSeek multi-turn reasoning replay and OpenRouter field selection

Fixes #30878

## Testing
- `git diff --check`
- Not run: `bun test assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts` because `bun` is not installed on this machine/PATH