### PR TITLE
feat(daemon): emit `usage_progress` event per LLM call for live subagent metrics

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -49,6 +49,10 @@ import type { ContentBlock, ImageContent } from "../providers/types.js";
 import { isContextOverflowError } from "../providers/types.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
+import {
+  buildPricingUsage,
+  resolveStructuredPricing,
+} from "../usage/pricing.js";
 import { ProviderError } from "../util/errors.js";
 import { faviconUrlForDomain } from "../util/favicon.js";
 import { getLogger } from "../util/logger.js";
@@ -1236,6 +1240,36 @@ function handleUsage(
     },
   );
   state.llmCallStartedEmitted = false;
+
+  // Emit a lightweight per-call usage progress event so clients can show
+  // live-updating token/cost metrics. This is a UI hint only — no DB writes.
+  const pricingUsage = buildPricingUsage({
+    providerName,
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    cacheCreationInputTokens: event.cacheCreationInputTokens,
+    cacheReadInputTokens: event.cacheReadInputTokens,
+    rawResponse: event.rawResponse,
+  });
+  const pricing = resolveStructuredPricing(
+    providerName,
+    event.model,
+    pricingUsage,
+  );
+  const estimatedCost =
+    pricing.pricingStatus === "priced" && pricing.estimatedCostUsd != null
+      ? pricing.estimatedCostUsd
+      : 0;
+
+  deps.onEvent({
+    type: "usage_progress",
+    conversationId: deps.ctx.conversationId,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    estimatedCost,
+    model: event.model,
+  });
 }
 
 /**

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -456,6 +456,20 @@ export interface UsageUpdate {
   contextWindowMaxTokens?: number;
 }
 
+/**
+ * Emitted after each LLM call with per-call token deltas and estimated cost.
+ * Clients accumulate these additively for live-updating usage metrics.
+ * This is a UI-only hint — it does not persist to DB or affect billing.
+ */
+export interface UsageProgress {
+  type: "usage_progress";
+  conversationId: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  model: string;
+}
+
 export interface UsageResponse {
   type: "usage_response";
   totalInputTokens: number;
@@ -651,6 +665,7 @@ export type _ConversationsServerMessages =
   | HistoryResponse
   | UndoComplete
   | UsageUpdate
+  | UsageProgress
   | UsageResponse
   | ContextCompacted
   | CompactionCircuitOpen


### PR DESCRIPTION
## Summary
- Adds a new `UsageProgress` ServerMessage type emitted after each LLM call with per-call token deltas and estimated cost
- Emitted from `handleUsage` via `onEvent`, so subagent conversations automatically get it wrapped as `subagent_event`
- This is a UI-only hint for live-updating metrics — no DB writes, no billing changes

Part of plan: subagent-usage-progress.md (PR 1 of 3)