### PR TITLE
feat(macos): stream live usage metrics in subagent detail panel

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -379,6 +379,19 @@ public final class SubagentDetailStore {
             trackMutation()
             #endif
 
+        case .usageProgress(let progress):
+            guard !terminalUsageReceivedIds.contains(subagentId) else { break }
+            let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
+            stagedUsage[subagentId] = SubagentUsageStats(
+                inputTokens: current.inputTokens + progress.inputTokens,
+                outputTokens: current.outputTokens + progress.outputTokens,
+                estimatedCost: current.estimatedCost + progress.estimatedCost
+            )
+            scheduleFlush()
+            #if DEBUG
+            trackMutation()
+            #endif
+
         default:
             break
         }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -5331,6 +5331,26 @@ public struct UsageStats: Codable, Sendable {
     }
 }
 
+public struct UsageProgress: Codable, Sendable {
+    public let type: String
+    public let conversationId: String?
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let estimatedCost: Double
+    public let model: String
+
+    public init(type: String, conversationId: String? = nil,
+                inputTokens: Int, outputTokens: Int,
+                estimatedCost: Double, model: String) {
+        self.type = type
+        self.conversationId = conversationId
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.estimatedCost = estimatedCost
+        self.model = model
+    }
+}
+
 public struct UsageUpdate: Codable, Sendable {
     public let type: String
     public let conversationId: String?

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -3081,6 +3081,7 @@ public enum ServerMessage: Decodable, Sendable {
     case bookmarkDeleted(BookmarkDeletedMessage)
     case contextCompacted(ContextCompacted)
     case usageUpdate(UsageUpdate)
+    case usageProgress(UsageProgress)
     case compactionCircuitOpen(CompactionCircuitOpen)
     case compactionCircuitClosed(CompactionCircuitClosed)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
@@ -3603,6 +3604,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
+        case "usage_progress":
+            let message = try UsageProgress(from: decoder)
+            self = .usageProgress(message)
         case "compaction_circuit_open":
             let message = try CompactionCircuitOpen(from: decoder)
             self = .compactionCircuitOpen(message)


### PR DESCRIPTION
## Summary
- Adds `UsageProgress` Swift struct and `ServerMessage` decoder case for the new `usage_progress` event
- Handles `usage_progress` in `SubagentDetailStore` with additive delta accumulation and terminal guard
- Uses existing 100ms coalescing flush for smooth UI updates

Part of plan: subagent-usage-progress.md (PR 2 of 3)