### PR TITLE
feat(web): stream live usage metrics in subagent detail panel

### DIFF
--- a/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -38,9 +38,28 @@ export function handleSubagentEvent(
   if (event.conversationId) {
     store.setConversationId(event.subagentId, event.conversationId);
   }
+
+  const inner = event.event;
+  if (inner.type === "usage_progress") {
+    const data = inner as Record<string, unknown>;
+    const inputTokens =
+      typeof data.inputTokens === "number" ? data.inputTokens : 0;
+    const outputTokens =
+      typeof data.outputTokens === "number" ? data.outputTokens : 0;
+    const estimatedCost =
+      typeof data.estimatedCost === "number" ? data.estimatedCost : 0;
+    store.updateUsage({
+      subagentId: event.subagentId,
+      inputTokens,
+      outputTokens,
+      estimatedCost,
+    });
+    return;
+  }
+
   store.receiveEvent({
     subagentId: event.subagentId,
-    event: event.event,
+    event: inner,
     timestamp: Date.now(),
   });
 }

--- a/apps/web/src/domains/subagents/subagent-store.test.ts
+++ b/apps/web/src/domains/subagents/subagent-store.test.ts
@@ -647,6 +647,89 @@ describe("reset", () => {
 });
 
 // ---------------------------------------------------------------------------
+// updateUsage
+// ---------------------------------------------------------------------------
+
+describe("updateUsage", () => {
+  it("accumulates token deltas additively", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 200,
+      outputTokens: 75,
+      estimatedCost: 0.002,
+    });
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.inputTokens).toBe(300);
+    expect(entry.outputTokens).toBe(125);
+    expect(entry.totalCost).toBeCloseTo(0.003);
+  });
+
+  it("skips updates after terminal status with usage", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+
+    // Terminal status with final usage data
+    getState().changeStatus({
+      subagentId: "sa-1",
+      status: "completed",
+      inputTokens: 500,
+      outputTokens: 200,
+      totalCost: 0.005,
+    });
+
+    // This should be ignored — terminal guard
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 9999,
+      outputTokens: 9999,
+      estimatedCost: 99.99,
+    });
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.inputTokens).toBe(500);
+    expect(entry.outputTokens).toBe(200);
+    expect(entry.totalCost).toBe(0.005);
+  });
+
+  it("no-ops for unknown subagentId", () => {
+    const before = { ...getState().byId };
+    getState().updateUsage({
+      subagentId: "sa-nonexistent",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+
+    expect(getState().byId).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -14,6 +14,7 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import type { SubagentStatus, SubagentInnerEvent } from "@/types/interaction-ui-types";
+import { isActiveStatus } from "@/domains/subagents/status-helpers";
 
 // ---------------------------------------------------------------------------
 // State
@@ -58,6 +59,10 @@ export interface SubagentEntry {
 export interface SubagentState {
   byId: Record<string, SubagentEntry>;
   orderedIds: string[];
+  /** Subagent IDs whose terminal status event carried final usage data.
+   *  Further `updateUsage` calls for these IDs are no-ops to prevent
+   *  double-counting. */
+  terminalUsageIds: Set<string>;
   /**
    * Indexed view of `byId` keyed by parent assistant message id. Each entry
    * is registered under up to two keys — `parentMessageStableId` (set during
@@ -124,6 +129,13 @@ export interface SubagentActions {
 
   setConversationId: (subagentId: string, conversationId: string) => void;
 
+  updateUsage: (params: {
+    subagentId: string;
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCost: number;
+  }) => void;
+
   reset: () => void;
 }
 
@@ -136,6 +148,7 @@ export type SubagentStore = SubagentState & SubagentActions;
 const INITIAL_STATE: SubagentState = {
   byId: {},
   orderedIds: [],
+  terminalUsageIds: new Set<string>(),
   byParent: new Map<string, SubagentEntry[]>(),
 };
 
@@ -283,6 +296,18 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         },
       },
     });
+
+    // Mark as terminal so subsequent updateUsage calls are ignored,
+    // preventing double-counting when the daemon ships final totals
+    // alongside the terminal status event.
+    if (
+      !isActiveStatus(params.status) &&
+      (params.inputTokens != null ||
+        params.outputTokens != null ||
+        params.totalCost != null)
+    ) {
+      get().terminalUsageIds.add(params.subagentId);
+    }
   },
 
   receiveEvent: (params) => {
@@ -386,10 +411,30 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     });
   },
 
+  updateUsage: (params) => {
+    const { byId, terminalUsageIds } = get();
+    if (terminalUsageIds.has(params.subagentId)) return;
+    const existing = byId[params.subagentId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.subagentId]: {
+          ...existing,
+          inputTokens: existing.inputTokens + params.inputTokens,
+          outputTokens: existing.outputTokens + params.outputTokens,
+          totalCost: existing.totalCost + params.estimatedCost,
+        },
+      },
+    });
+  },
+
   reset: () =>
     set({
       byId: {},
       orderedIds: [],
+      terminalUsageIds: new Set<string>(),
       byParent: new Map<string, SubagentEntry[]>(),
     }),
 }));


### PR DESCRIPTION
## Summary
- Adds `updateUsage` action to subagent Zustand store with additive delta accumulation
- Routes `usage_progress` inner events from SSE stream to the new store action
- Terminal guard prevents double-counting after `subagent_status_changed` writes final usage
- Tests cover accumulation, terminal guard, and unknown-id edge case

Part of plan: subagent-usage-progress.md (PR 3 of 3)