### PR TITLE
Stream subagent usage progress (live input/output/cost)

### DIFF
--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -7,7 +7,7 @@ import {
   X,
 } from "lucide-react";
 
-import { type ReactNode, useEffect, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import { Button, Typography } from "@vellum/design-library";
@@ -43,6 +43,39 @@ function formatCost(cost: number): string {
   return cost.toFixed(2);
 }
 
+const ANIMATION_DURATION_MS = 300;
+
+function useAnimatedNumber(target: number): number {
+  const [displayed, setDisplayed] = useState(target);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef({ value: target, time: 0 });
+
+  const animate = useCallback((from: number, to: number) => {
+    cancelAnimationFrame(rafRef.current);
+    const start = performance.now();
+    startRef.current = { value: from, time: start };
+
+    const step = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
+      const eased = 1 - (1 - progress) ** 3; // ease-out cubic
+      setDisplayed(from + (to - from) * eased);
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      }
+    };
+    rafRef.current = requestAnimationFrame(step);
+  }, []);
+
+  useEffect(() => {
+    animate(displayed, target);
+    return () => cancelAnimationFrame(rafRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- animate from current displayed value
+  }, [target, animate]);
+
+  return displayed;
+}
+
 function MetricCard({
   icon,
   value,
@@ -73,6 +106,16 @@ function MetricCard({
       </div>
     </div>
   );
+}
+
+function AnimatedTokenCard({ icon, label, target }: { icon: ReactNode; label: string; target: number }) {
+  const animated = useAnimatedNumber(target);
+  return <MetricCard icon={icon} label={label} value={formatNumber(Math.round(animated))} />;
+}
+
+function AnimatedCostCard({ icon, label, target }: { icon: ReactNode; label: string; target: number }) {
+  const animated = useAnimatedNumber(target);
+  return <MetricCard icon={icon} label={label} value={formatCost(animated)} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,19 +200,19 @@ export function SubagentDetailPanel({
       <div className="flex-1 overflow-y-auto px-5 py-5">
         {/* Metrics row */}
         <div className="mb-5 grid grid-cols-3 gap-3">
-          <MetricCard
+          <AnimatedTokenCard
             icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            value={formatNumber(entry.inputTokens)}
+            target={entry.inputTokens}
             label="Input"
           />
-          <MetricCard
+          <AnimatedTokenCard
             icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            value={formatNumber(entry.outputTokens)}
+            target={entry.outputTokens}
             label="Output"
           />
-          <MetricCard
+          <AnimatedCostCard
             icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            value={formatCost(entry.totalCost)}
+            target={entry.totalCost}
             label="Cost"
           />
         </div>

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -7,7 +7,7 @@ import {
   X,
 } from "lucide-react";
 
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import { Button, Typography } from "@vellum/design-library";
@@ -48,30 +48,29 @@ const ANIMATION_DURATION_MS = 300;
 function useAnimatedNumber(target: number): number {
   const [displayed, setDisplayed] = useState(target);
   const rafRef = useRef<number>(0);
-  const startRef = useRef({ value: target, time: 0 });
+  const displayedRef = useRef(target);
 
-  const animate = useCallback((from: number, to: number) => {
+  useEffect(() => {
+    const from = displayedRef.current;
+    if (from === target) return;
+
     cancelAnimationFrame(rafRef.current);
     const start = performance.now();
-    startRef.current = { value: from, time: start };
 
     const step = (now: number) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
-      const eased = 1 - (1 - progress) ** 3; // ease-out cubic
-      setDisplayed(from + (to - from) * eased);
+      const eased = 1 - (1 - progress) ** 3;
+      const value = from + (target - from) * eased;
+      displayedRef.current = value;
+      setDisplayed(value);
       if (progress < 1) {
         rafRef.current = requestAnimationFrame(step);
       }
     };
     rafRef.current = requestAnimationFrame(step);
-  }, []);
-
-  useEffect(() => {
-    animate(displayed, target);
     return () => cancelAnimationFrame(rafRef.current);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- animate from current displayed value
-  }, [target, animate]);
+  }, [target]);
 
   return displayed;
 }

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -107,14 +107,11 @@ function MetricCard({
   );
 }
 
-function AnimatedTokenCard({ icon, label, target }: { icon: ReactNode; label: string; target: number }) {
+function AnimatedMetricCard({ icon, label, target, format }: {
+  icon: ReactNode; label: string; target: number; format: (n: number) => string;
+}) {
   const animated = useAnimatedNumber(target);
-  return <MetricCard icon={icon} label={label} value={formatNumber(Math.round(animated))} />;
-}
-
-function AnimatedCostCard({ icon, label, target }: { icon: ReactNode; label: string; target: number }) {
-  const animated = useAnimatedNumber(target);
-  return <MetricCard icon={icon} label={label} value={formatCost(animated)} />;
+  return <MetricCard icon={icon} label={label} value={format(animated)} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -199,19 +196,22 @@ export function SubagentDetailPanel({
       <div className="flex-1 overflow-y-auto px-5 py-5">
         {/* Metrics row */}
         <div className="mb-5 grid grid-cols-3 gap-3">
-          <AnimatedTokenCard
+          <AnimatedMetricCard
             icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             target={entry.inputTokens}
+            format={(n) => formatNumber(Math.round(n))}
             label="Input"
           />
-          <AnimatedTokenCard
+          <AnimatedMetricCard
             icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             target={entry.outputTokens}
+            format={(n) => formatNumber(Math.round(n))}
             label="Output"
           />
-          <AnimatedCostCard
+          <AnimatedMetricCard
             icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             target={entry.totalCost}
+            format={formatCost}
             label="Cost"
           />
         </div>

--- a/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -38,9 +38,28 @@ export function handleSubagentEvent(
   if (event.conversationId) {
     store.setConversationId(event.subagentId, event.conversationId);
   }
+
+  const inner = event.event;
+  if (inner.type === "usage_progress") {
+    const data = inner as Record<string, unknown>;
+    const inputTokens =
+      typeof data.inputTokens === "number" ? data.inputTokens : 0;
+    const outputTokens =
+      typeof data.outputTokens === "number" ? data.outputTokens : 0;
+    const estimatedCost =
+      typeof data.estimatedCost === "number" ? data.estimatedCost : 0;
+    store.updateUsage({
+      subagentId: event.subagentId,
+      inputTokens,
+      outputTokens,
+      estimatedCost,
+    });
+    return;
+  }
+
   store.receiveEvent({
     subagentId: event.subagentId,
-    event: event.event,
+    event: inner,
     timestamp: Date.now(),
   });
 }

--- a/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -41,7 +41,7 @@ export function handleSubagentEvent(
 
   const inner = event.event;
   if (inner.type === "usage_progress") {
-    const data = inner as Record<string, unknown>;
+    const data = inner as unknown as Record<string, unknown>;
     const inputTokens =
       typeof data.inputTokens === "number" ? data.inputTokens : 0;
     const outputTokens =

--- a/apps/web/src/domains/subagents/subagent-store.test.ts
+++ b/apps/web/src/domains/subagents/subagent-store.test.ts
@@ -647,6 +647,89 @@ describe("reset", () => {
 });
 
 // ---------------------------------------------------------------------------
+// updateUsage
+// ---------------------------------------------------------------------------
+
+describe("updateUsage", () => {
+  it("accumulates token deltas additively", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 200,
+      outputTokens: 75,
+      estimatedCost: 0.002,
+    });
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.inputTokens).toBe(300);
+    expect(entry.outputTokens).toBe(125);
+    expect(entry.totalCost).toBeCloseTo(0.003);
+  });
+
+  it("skips updates after terminal status with usage", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+
+    // Terminal status with final usage data
+    getState().changeStatus({
+      subagentId: "sa-1",
+      status: "completed",
+      inputTokens: 500,
+      outputTokens: 200,
+      totalCost: 0.005,
+    });
+
+    // This should be ignored — terminal guard
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 9999,
+      outputTokens: 9999,
+      estimatedCost: 99.99,
+    });
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.inputTokens).toBe(500);
+    expect(entry.outputTokens).toBe(200);
+    expect(entry.totalCost).toBe(0.005);
+  });
+
+  it("no-ops for unknown subagentId", () => {
+    const before = { ...getState().byId };
+    getState().updateUsage({
+      subagentId: "sa-nonexistent",
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.001,
+    });
+
+    expect(getState().byId).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/domains/subagents/subagent-store.ts
+++ b/apps/web/src/domains/subagents/subagent-store.ts
@@ -14,6 +14,7 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import type { SubagentStatus, SubagentInnerEvent } from "@/types/interaction-ui-types";
+import { isActiveStatus } from "@/domains/subagents/status-helpers";
 
 // ---------------------------------------------------------------------------
 // State
@@ -58,6 +59,10 @@ export interface SubagentEntry {
 export interface SubagentState {
   byId: Record<string, SubagentEntry>;
   orderedIds: string[];
+  /** Subagent IDs whose terminal status event carried final usage data.
+   *  Further `updateUsage` calls for these IDs are no-ops to prevent
+   *  double-counting. */
+  terminalUsageIds: Set<string>;
   /**
    * Indexed view of `byId` keyed by parent assistant message id. Each entry
    * is registered under up to two keys — `parentMessageStableId` (set during
@@ -124,6 +129,13 @@ export interface SubagentActions {
 
   setConversationId: (subagentId: string, conversationId: string) => void;
 
+  updateUsage: (params: {
+    subagentId: string;
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCost: number;
+  }) => void;
+
   reset: () => void;
 }
 
@@ -136,6 +148,7 @@ export type SubagentStore = SubagentState & SubagentActions;
 const INITIAL_STATE: SubagentState = {
   byId: {},
   orderedIds: [],
+  terminalUsageIds: new Set<string>(),
   byParent: new Map<string, SubagentEntry[]>(),
 };
 
@@ -283,6 +296,18 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         },
       },
     });
+
+    // Mark as terminal so subsequent updateUsage calls are ignored,
+    // preventing double-counting when the daemon ships final totals
+    // alongside the terminal status event.
+    if (
+      !isActiveStatus(params.status) &&
+      (params.inputTokens != null ||
+        params.outputTokens != null ||
+        params.totalCost != null)
+    ) {
+      get().terminalUsageIds.add(params.subagentId);
+    }
   },
 
   receiveEvent: (params) => {
@@ -386,10 +411,30 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     });
   },
 
+  updateUsage: (params) => {
+    const { byId, terminalUsageIds } = get();
+    if (terminalUsageIds.has(params.subagentId)) return;
+    const existing = byId[params.subagentId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.subagentId]: {
+          ...existing,
+          inputTokens: existing.inputTokens + params.inputTokens,
+          outputTokens: existing.outputTokens + params.outputTokens,
+          totalCost: existing.totalCost + params.estimatedCost,
+        },
+      },
+    });
+  },
+
   reset: () =>
     set({
       byId: {},
       orderedIds: [],
+      terminalUsageIds: new Set<string>(),
       byParent: new Map<string, SubagentEntry[]>(),
     }),
 }));

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -49,6 +49,10 @@ import type { ContentBlock, ImageContent } from "../providers/types.js";
 import { isContextOverflowError } from "../providers/types.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
+import {
+  buildPricingUsage,
+  resolveStructuredPricing,
+} from "../usage/pricing.js";
 import { ProviderError } from "../util/errors.js";
 import { faviconUrlForDomain } from "../util/favicon.js";
 import { getLogger } from "../util/logger.js";
@@ -1236,6 +1240,36 @@ function handleUsage(
     },
   );
   state.llmCallStartedEmitted = false;
+
+  // Emit a lightweight per-call usage progress event so clients can show
+  // live-updating token/cost metrics. This is a UI hint only — no DB writes.
+  const pricingUsage = buildPricingUsage({
+    providerName,
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    cacheCreationInputTokens: event.cacheCreationInputTokens,
+    cacheReadInputTokens: event.cacheReadInputTokens,
+    rawResponse: event.rawResponse,
+  });
+  const pricing = resolveStructuredPricing(
+    providerName,
+    event.model,
+    pricingUsage,
+  );
+  const estimatedCost =
+    pricing.pricingStatus === "priced" && pricing.estimatedCostUsd != null
+      ? pricing.estimatedCostUsd
+      : 0;
+
+  deps.onEvent({
+    type: "usage_progress",
+    conversationId: deps.ctx.conversationId,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    estimatedCost,
+    model: event.model,
+  });
 }
 
 /**

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -456,6 +456,20 @@ export interface UsageUpdate {
   contextWindowMaxTokens?: number;
 }
 
+/**
+ * Emitted after each LLM call with per-call token deltas and estimated cost.
+ * Clients accumulate these additively for live-updating usage metrics.
+ * This is a UI-only hint — it does not persist to DB or affect billing.
+ */
+export interface UsageProgress {
+  type: "usage_progress";
+  conversationId: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  model: string;
+}
+
 export interface UsageResponse {
   type: "usage_response";
   totalInputTokens: number;
@@ -651,6 +665,7 @@ export type _ConversationsServerMessages =
   | HistoryResponse
   | UndoComplete
   | UsageUpdate
+  | UsageProgress
   | UsageResponse
   | ContextCompacted
   | CompactionCircuitOpen

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -436,6 +436,8 @@ struct SubagentDetailPanel: View {
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .contentTransition(.numericText())
+                    .animation(.easeInOut(duration: 0.3), value: value)
                 Text(label)
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -379,6 +379,19 @@ public final class SubagentDetailStore {
             trackMutation()
             #endif
 
+        case .usageProgress(let progress):
+            guard !terminalUsageReceivedIds.contains(subagentId) else { break }
+            let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
+            stagedUsage[subagentId] = SubagentUsageStats(
+                inputTokens: current.inputTokens + progress.inputTokens,
+                outputTokens: current.outputTokens + progress.outputTokens,
+                estimatedCost: current.estimatedCost + progress.estimatedCost
+            )
+            scheduleFlush()
+            #if DEBUG
+            trackMutation()
+            #endif
+
         default:
             break
         }

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -129,6 +129,11 @@ public final class SubagentDetailStore {
     /// (usageUpdate uses additive estimatedCost while recordStatusChanged writes cumulative).
     @ObservationIgnored
     private var terminalUsageReceivedIds: Set<String> = []
+    /// Subagent IDs that have received at least one `.usageProgress` event.
+    /// When set, `.usageUpdate` is skipped to avoid double-counting (progress
+    /// events already provide the same data more granularly).
+    @ObservationIgnored
+    private var progressReceivedIds: Set<String> = []
     /// The coalescing flush task; non-nil while a flush is scheduled.
     @ObservationIgnored
     private var flushTask: Task<Void, Never>?
@@ -368,6 +373,10 @@ public final class SubagentDetailStore {
             // Skip late deltas after recordStatusChanged has written cumulative stats
             // to avoid double-counting estimatedCost (which uses additive accumulation).
             guard !terminalUsageReceivedIds.contains(subagentId) else { break }
+            // Skip when usage_progress events already provided granular updates —
+            // applying both would double-count cost. The terminal subagent_status_changed
+            // will write the final authoritative numbers.
+            guard !progressReceivedIds.contains(subagentId) else { break }
             let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: update.totalInputTokens,
@@ -381,6 +390,7 @@ public final class SubagentDetailStore {
 
         case .usageProgress(let progress):
             guard !terminalUsageReceivedIds.contains(subagentId) else { break }
+            progressReceivedIds.insert(subagentId)
             let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: current.inputTokens + progress.inputTokens,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -5331,6 +5331,26 @@ public struct UsageStats: Codable, Sendable {
     }
 }
 
+public struct UsageProgress: Codable, Sendable {
+    public let type: String
+    public let conversationId: String?
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let estimatedCost: Double
+    public let model: String
+
+    public init(type: String, conversationId: String? = nil,
+                inputTokens: Int, outputTokens: Int,
+                estimatedCost: Double, model: String) {
+        self.type = type
+        self.conversationId = conversationId
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.estimatedCost = estimatedCost
+        self.model = model
+    }
+}
+
 public struct UsageUpdate: Codable, Sendable {
     public let type: String
     public let conversationId: String?

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -3081,6 +3081,7 @@ public enum ServerMessage: Decodable, Sendable {
     case bookmarkDeleted(BookmarkDeletedMessage)
     case contextCompacted(ContextCompacted)
     case usageUpdate(UsageUpdate)
+    case usageProgress(UsageProgress)
     case compactionCircuitOpen(CompactionCircuitOpen)
     case compactionCircuitClosed(CompactionCircuitClosed)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
@@ -3603,6 +3604,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
+        case "usage_progress":
+            let message = try UsageProgress(from: decoder)
+            self = .usageProgress(message)
         case "compaction_circuit_open":
             let message = try CompactionCircuitOpen(from: decoder)
             self = .compactionCircuitOpen(message)


### PR DESCRIPTION
## Summary
Adds a new `usage_progress` event that streams input tokens, output tokens, and estimated cost from the daemon to clients after every LLM call within a subagent. Previously these numbers only appeared after the subagent's entire turn completed. Both macOS and web clients now show live-updating usage metrics in the subagent detail panel.

The new event is a lightweight UI hint — it does not persist to DB or affect billing. The existing `usage_update` at turn boundaries is completely unchanged.

## PRs merged into feature branch
- #32255: feat(daemon): emit `usage_progress` event per LLM call for live subagent metrics
- #32256: feat(macos): stream live usage metrics in subagent detail panel
- #32257: feat(web): stream live usage metrics in subagent detail panel

## Architecture
- **Daemon**: `handleUsage` in `conversation-agent-loop-handlers.ts` now emits a `usage_progress` ServerMessage after each LLM call, carrying per-call token deltas and estimated cost (computed via `resolveStructuredPricing`). For subagent conversations, this automatically gets wrapped as a `subagent_event`.
- **macOS**: `SubagentDetailStore` handles `.usageProgress` with additive delta accumulation, guarded by `terminalUsageReceivedIds` to prevent double-counting after final `subagent_status_changed`. Uses existing 100ms coalescing flush.
- **Web**: New `updateUsage` Zustand action with `terminalUsageIds` guard. `handleSubagentEvent` intercepts `usage_progress` inner events before `receiveEvent`.

Part of plan: subagent-usage-progress.md