### PR TITLE
fix(web): cast through unknown for SubagentInnerEvent conversion

### DIFF
--- a/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -41,7 +41,7 @@ export function handleSubagentEvent(
 
   const inner = event.event;
   if (inner.type === "usage_progress") {
-    const data = inner as Record<string, unknown>;
+    const data = inner as unknown as Record<string, unknown>;
     const inputTokens =
       typeof data.inputTokens === "number" ? data.inputTokens : 0;
     const outputTokens =


### PR DESCRIPTION
## Summary
Fixes CI type-check failure: `TS2352` when casting `SubagentInnerEvent` directly to `Record<string, unknown>`. Cast through `unknown` first as TypeScript requires.