### PR TITLE
fix(web): emit Sentry event for legacy conversation redirect (LUM-1900)

### DIFF
--- a/apps/web/src/domains/chat/conversation-redirect.tsx
+++ b/apps/web/src/domains/chat/conversation-redirect.tsx
@@ -3,6 +3,7 @@
  * / `?conversationKey=` search params to canonical path-based URLs.
  * Otherwise renders `ChatPage` (new/default conversation).
  */
+import * as Sentry from "@sentry/react";
 import { Navigate, useSearchParams } from "react-router";
 
 import { ChatPage } from "@/domains/chat/chat-page";
@@ -18,8 +19,9 @@ export function ConversationRedirect() {
     const param = searchParams.has("conversationId")
       ? "conversationId"
       : "conversationKey";
-    console.warn(
+    Sentry.captureMessage(
       `[ConversationRedirect] Legacy search param redirect: ?${param}=${target}`,
+      "warning",
     );
 
     const remaining = new URLSearchParams(searchParams);

--- a/apps/web/src/domains/chat/conversation-redirect.tsx
+++ b/apps/web/src/domains/chat/conversation-redirect.tsx
@@ -4,6 +4,7 @@
  * Otherwise renders `ChatPage` (new/default conversation).
  */
 import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
 import { Navigate, useSearchParams } from "react-router";
 
 import { ChatPage } from "@/domains/chat/chat-page";
@@ -15,10 +16,14 @@ export function ConversationRedirect() {
   // `conversationId` cutover. Ancient saved/shared URLs only have `conversationKey`.
   const target =
     searchParams.get("conversationId") ?? searchParams.get("conversationKey");
-  if (target) {
-    const param = searchParams.has("conversationId")
+  const param = target
+    ? searchParams.has("conversationId")
       ? "conversationId"
-      : "conversationKey";
+      : "conversationKey"
+    : null;
+
+  useEffect(() => {
+    if (!param) return;
     Sentry.withScope((scope) => {
       scope.setTag("legacy_param", param);
       Sentry.captureMessage(
@@ -26,7 +31,9 @@ export function ConversationRedirect() {
         "warning",
       );
     });
+  }, [param]);
 
+  if (target) {
     const remaining = new URLSearchParams(searchParams);
     remaining.delete("conversationId");
     remaining.delete("conversationKey");

--- a/apps/web/src/domains/chat/conversation-redirect.tsx
+++ b/apps/web/src/domains/chat/conversation-redirect.tsx
@@ -19,10 +19,13 @@ export function ConversationRedirect() {
     const param = searchParams.has("conversationId")
       ? "conversationId"
       : "conversationKey";
-    Sentry.captureMessage(
-      `[ConversationRedirect] Legacy search param redirect: ?${param}=${target}`,
-      "warning",
-    );
+    Sentry.withScope((scope) => {
+      scope.setTag("legacy_param", param);
+      Sentry.captureMessage(
+        "[ConversationRedirect] Legacy search param redirect",
+        "warning",
+      );
+    });
 
     const remaining = new URLSearchParams(searchParams);
     remaining.delete("conversationId");


### PR DESCRIPTION
## Prompt / plan

Replace the plain `console.warn` in `ConversationRedirect` with a properly instrumented `Sentry.captureMessage` so the legacy `?conversationKey=` / `?conversationId=` redirect produces a real warning-level Sentry event, observable in the dashboard.

**Why:** PR #32075 added a `console.warn` to track legacy redirect usage, but plain `console.warn` calls are only captured by Sentry as breadcrumbs on unrelated error events — they never create standalone Sentry issues/events. The Sentry SDK config does not include `captureConsoleIntegration`. An early signal check at ~24h found zero hits in Sentry, confirming the instrumentation gap. The 1-week deprecation check (June 2) needs real Sentry events to be meaningful.

**What changed** (`apps/web/src/domains/chat/conversation-redirect.tsx`):
- Replaced `console.warn(...)` with `Sentry.captureMessage(..., "warning")` inside a `useEffect` to avoid render-phase side effects.
- Uses a **static message string** so all redirect events group into a single Sentry issue (avoids high-cardinality from unique conversation IDs).
- The param name (`conversationId` vs `conversationKey`) is passed as a Sentry tag (`legacy_param`) for low-cardinality filtering.
- The conversation identifier itself is **not** included in the Sentry payload.

**Why it's safe:**
- `@sentry/react` is already a dependency used throughout the app.
- `Sentry.captureMessage` is a no-op when the Sentry client is disabled (user hasn't opted in to Share Diagnostics). Reference: [Sentry docs — captureMessage](https://docs.sentry.io/platforms/javascript/usage/#capturing-messages).
- The `useEffect` fires once per committed render, avoiding double-fire in StrictMode and speculative render issues in React concurrent mode. This follows the pattern used by every other `captureMessage` call in the codebase (event handlers / callbacks, never render body).
- The Sentry init config already has `attachStacktrace: true`, so the warning event will include a synthetic stack trace pointing to the source location.

**Alternatives not taken:**
- Adding `captureConsoleIntegration` to the Sentry config: would capture *all* `console.warn` calls app-wide, which is too noisy. A targeted `captureMessage` at the single call site is more precise.
- Including the conversation ID in the message: creates high-cardinality messages (one Sentry issue per redirect) and leaks user-associated identifiers. A static message with a tag is sufficient for the deprecation decision.
- Calling `captureMessage` in the render body (as the original `console.warn` was): violates React render purity, double-fires in StrictMode, and could fire on speculative renders.

Linear: [LUM-1900](https://linear.app/vellum/issue/LUM-1900)

## Test plan

- Typecheck (`bunx tsc --noEmit`): passes
- Lint (`bun run lint`): passes
- Verified `@sentry/react` is already in `apps/web/package.json` dependencies
- No behavioral change to the redirect logic itself — only the telemetry mechanism changed

Link to Devin session: https://app.devin.ai/sessions/c545b49ecc9b427eb7f49d0b2cc91141
Requested by: @ashleeradka