### PR TITLE
fix(web/ios): align iOS home page layout with Figma mocks

### DIFF
--- a/apps/web/docs/CAPACITOR.md
+++ b/apps/web/docs/CAPACITOR.md
@@ -115,6 +115,27 @@ References:
 
 ---
 
+## Full-screen overlays must respect safe-area insets
+
+Any element that takes over the full viewport (modals, detail panels, drawers) via `position: fixed; inset: 0` **must** apply safe-area padding so content does not render behind the iPhone status bar, Dynamic Island, or home indicator. The `ChatLayoutHeader` handles this for the persistent top bar, but overlays that cover the header lose its protection.
+
+Use the CSS custom properties set by `capacitor-plugin-safe-area`:
+
+```css
+padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+padding-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+```
+
+The double fallback (`var()` → `env()` → `0px`) covers Capacitor iOS (plugin sets `--safe-area-inset-*`), standard browsers (`env()` from `viewport-fit=cover`), and desktop/non-notch devices (`0px`).
+
+If the overlay includes its own nav bar, the nav bar itself should sit below the safe-area padding — don't push the inset down into child elements where it's easy to lose.
+
+References:
+- MDN — [`env()` safe area insets](https://developer.mozilla.org/en-US/docs/Web/CSS/env#safe_area_insets)
+- Apple HIG — [Layout: Safe area](https://developer.apple.com/design/human-interface-guidelines/layout#Safe-area)
+
+---
+
 ## See also
 
 - [`CONVENTIONS.md`](./CONVENTIONS.md) — architecture, code organization, component patterns.

--- a/apps/web/docs/CONVENTIONS.md
+++ b/apps/web/docs/CONVENTIONS.md
@@ -61,6 +61,26 @@ Push hooks down to the route component that needs them. Lift shared
 state to the nearest common ancestor — typically a layout route or a
 context provider mounted in `<App />`.
 
+### Layout header slots
+
+`ChatLayout` owns a shared `ChatLayoutHeader` that renders on every
+child route (home, chat, library, identity, etc.). Child routes
+populate the header's center and right sections via
+`setTopBarCenter` / `setTopBarRightSlot` from `useAssistantContext()`.
+Register content in a `useEffect` and clear it on unmount:
+
+```ts
+const { setTopBarCenter } = useAssistantContext();
+useEffect(() => {
+  setTopBarCenter(<span>Page Title</span>);
+  return () => { setTopBarCenter(null); };
+}, [setTopBarCenter]);
+```
+
+Every child route under `ChatLayout` should register its title this
+way. Without it the header center is empty, which is especially
+noticeable on mobile where the sidebar is hidden.
+
 References:
 - [React — Thinking in React](https://react.dev/learn/thinking-in-react)
 - [React Router — Layout Routes](https://reactrouter.com/start/framework/routing#layout-routes)

--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -1,9 +1,11 @@
 import {
+  ArrowLeft,
   CircleX,
   Mail,
   MailOpen,
   MoreVertical,
   RotateCcw,
+  Trash2,
   X,
 } from "lucide-react";
 
@@ -22,6 +24,7 @@ function resolveCategoryStyle(category?: FeedItemCategory) {
 
 export interface HomeDetailPanelProps {
   item: FeedItem | null;
+  isMobile?: boolean;
   validConversationIds: Set<string>;
   onClose: () => void;
   onGoToThread: (conversationId: string) => void;
@@ -31,6 +34,7 @@ export interface HomeDetailPanelProps {
 
 export function HomeDetailPanel({
   item,
+  isMobile,
   validConversationIds,
   onClose,
   onGoToThread,
@@ -46,6 +50,105 @@ export function HomeDetailPanel({
   const CategoryIcon = categoryStyle.icon;
   const isUnread = item.status === "new";
   const isDismissed = item.status === "dismissed";
+  const hasValidConversation =
+    !!item.conversationId && validConversationIds.has(item.conversationId);
+
+  if (isMobile) {
+    return (
+      <div className="flex h-full flex-col bg-[var(--surface-overlay)]">
+        {/* Nav bar */}
+        <div className="flex shrink-0 items-center gap-2 px-3 py-2">
+          <Button
+            variant="ghost"
+            iconOnly={<ArrowLeft />}
+            onClick={onClose}
+            aria-label="Back"
+          />
+
+          <Typography
+            variant="body-medium-default"
+            className="min-w-0 flex-1 text-center text-[var(--content-secondary)]"
+          >
+            Details
+          </Typography>
+
+          <Button
+            variant="ghost"
+            iconOnly={isUnread ? <MailOpen /> : <Mail />}
+            onClick={() =>
+              onUpdateStatus(item.id, isUnread ? "seen" : "new")
+            }
+            aria-label={isUnread ? "Mark as read" : "Mark as unread"}
+          />
+          {isDismissed ? (
+            <Button
+              variant="ghost"
+              iconOnly={<RotateCcw />}
+              onClick={() => onUpdateStatus(item.id, "seen")}
+              aria-label="Restore"
+            />
+          ) : (
+            <Button
+              variant="ghost"
+              iconOnly={<Trash2 />}
+              onClick={() => onDismiss(item.id)}
+              aria-label="Dismiss"
+            />
+          )}
+        </div>
+
+        {/* Detail header */}
+        <div className="flex items-start gap-3 px-4 py-3">
+          <span
+            className="mt-0.5 flex shrink-0 items-center justify-center rounded-full"
+            style={{
+              width: 40,
+              height: 40,
+              backgroundColor: categoryStyle.weak,
+            }}
+            aria-hidden="true"
+          >
+            <CategoryIcon
+              width={18}
+              height={18}
+              style={{ color: categoryStyle.strong }}
+            />
+          </span>
+          <Typography
+            variant="title-small"
+            className="min-w-0 flex-1 text-[var(--content-default)]"
+          >
+            {item.title ?? item.summary}
+          </Typography>
+        </div>
+
+        {/* Divider */}
+        <div className="mx-4 border-b border-[var(--border-disabled)]" />
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {panelKind === "toolPermission" ? (
+            <HomeToolPermissionCard item={item} />
+          ) : (
+            <HomeGenericDetail item={item} />
+          )}
+        </div>
+
+        {/* Bottom CTA */}
+        {hasValidConversation ? (
+          <div className="shrink-0 px-4 pb-4 pt-2">
+            <Button
+              variant="primary"
+              fullWidth
+              onClick={() => onGoToThread(item.conversationId!)}
+            >
+              Go to Conversation
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col rounded-[var(--radius-lg)] border border-[var(--border-base)] bg-[var(--surface-overlay)]">
@@ -74,8 +177,7 @@ export function HomeDetailPanel({
           {item.title ?? item.summary}
         </Typography>
 
-        {/* Go to Convo button — only when conversationId exists and is valid */}
-        {item.conversationId && validConversationIds.has(item.conversationId) ? (
+        {hasValidConversation ? (
           <Button
             variant="outlined"
             size="compact"

--- a/apps/web/src/domains/home/home-greeting-header.tsx
+++ b/apps/web/src/domains/home/home-greeting-header.tsx
@@ -10,6 +10,7 @@ interface HomeGreetingHeaderProps {
   avatarImageUrl: string | null;
   /** Optional daemon-supplied dynamic greeting. Falls back to a time-of-day greeting. */
   greeting?: string;
+  isMobile?: boolean;
   onStartNewChat: () => void;
 }
 
@@ -29,6 +30,7 @@ export function HomeGreetingHeader({
   avatarTraits,
   avatarImageUrl,
   greeting,
+  isMobile,
   onStartNewChat,
 }: HomeGreetingHeaderProps) {
   return (
@@ -45,13 +47,23 @@ export function HomeGreetingHeader({
         </Typography>
       </div>
 
-      <Button
-        variant="primary"
-        leftIcon={<SquarePen />}
-        onClick={onStartNewChat}
-      >
-        New Chat
-      </Button>
+      {isMobile ? (
+        <Button
+          variant="primary"
+          iconOnly={<SquarePen />}
+          onClick={onStartNewChat}
+          aria-label="New Chat"
+          className="!rounded-full"
+        />
+      ) : (
+        <Button
+          variant="primary"
+          leftIcon={<SquarePen />}
+          onClick={onStartNewChat}
+        >
+          New Chat
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -132,6 +132,7 @@ export function HomePage({
         avatarTraits={avatar.traits}
         avatarImageUrl={avatar.customImageUrl}
         greeting={feedQuery.data?.contextBanner?.greeting}
+        isMobile={isMobile}
         onStartNewChat={onStartNewChat}
       />
       {feedQuery.isError ? (
@@ -147,6 +148,7 @@ export function HomePage({
       ) : null}
       <HomeSuggestionPillBar
         suggestions={feedQuery.data?.suggestedPrompts ?? []}
+        maxVisible={isMobile ? 2 : 3}
         onSelect={handleSuggestionSelect}
       />
       <HomeFeedList
@@ -163,9 +165,18 @@ export function HomePage({
 
   if (selectedItem && isMobile) {
     return (
-      <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+      <div
+        className="fixed inset-0 z-30 bg-[var(--surface-overlay)]"
+        style={{
+          paddingTop:
+            "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+          paddingBottom:
+            "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        }}
+      >
         <HomeDetailPanel
           item={selectedItem}
+          isMobile
           validConversationIds={validConversationIds}
           onClose={handleCloseDetail}
           onGoToThread={handleGoToThread}

--- a/apps/web/src/domains/home/home-suggestion-pill-bar.tsx
+++ b/apps/web/src/domains/home/home-suggestion-pill-bar.tsx
@@ -140,18 +140,20 @@ function resolveIcon(iconName: string | undefined): LucideIcon {
 
 interface HomeSuggestionPillBarProps {
   suggestions: SuggestedPrompt[];
+  maxVisible?: number;
   onSelect: (prompt: SuggestedPrompt) => void;
 }
 
 export function HomeSuggestionPillBar({
   suggestions,
+  maxVisible = 3,
   onSelect,
 }: HomeSuggestionPillBarProps) {
   const [dismissed, setDismissed] = useState(false);
 
   if (dismissed || suggestions.length === 0) return null;
 
-  const visible = suggestions.slice(0, 3);
+  const visible = suggestions.slice(0, maxVisible);
 
   return (
     <div className="flex flex-col gap-[var(--app-spacing-sm)] rounded-2xl border border-[var(--border-disabled)] px-[var(--app-spacing-lg)] py-[var(--app-spacing-lg)]">

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router";
 
+import { Typography } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate";
+import { useAssistantContext } from "@/components/layout/assistant-context";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationListQuery } from "@/domains/conversations/conversation-queries";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
@@ -12,11 +14,25 @@ import { routes } from "@/utils/routes";
 export function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useActiveAssistantContext();
+  const { setTopBarCenter } = useAssistantContext();
   const { conversations } = useConversationListQuery(assistantId);
   const validConversationIds = useMemo(
     () => new Set(conversations.map((c) => c.conversationId)),
     [conversations],
   );
+
+  useEffect(() => {
+    setTopBarCenter(
+      <Typography
+        variant="body-medium-default"
+        className="text-[var(--content-secondary)]"
+      >
+        Home
+      </Typography>,
+    );
+    return () => { setTopBarCenter(null); };
+  }, [setTopBarCenter]);
+
   return (
     <HomePage
       assistantId={assistantId}


### PR DESCRIPTION
## Why

The iOS home page (Capacitor web-wrapper) diverged from the Figma designs in several ways, most critically the detail panel rendering content behind the iPhone's camera/Dynamic Island, making the title and action buttons inaccessible.

## Changes

**Nav bar title** — `HomePageRoute` now registers a centered "Home" label via `setTopBarCenter`, matching how `ChatPage` registers conversation titles. Previously the center slot was empty on the home route.

**New Chat button** — icon-only (rounded `SquarePen`) on mobile; full text button on desktop. Matches the Figma 40×40 circle spec.

**Suggestion pills** — capped at 2 on mobile (was 3 on all viewports). New `maxVisible` prop on `HomeSuggestionPillBar`.

**Detail panel safe-area** — the full-screen mobile overlay (`fixed inset-0`) now applies `--safe-area-inset-top` and `--safe-area-inset-bottom` padding, preventing content from clipping under the status bar and home indicator.

**Detail panel mobile layout** — complete restructure for mobile to match Figma:
- Own nav bar: back arrow, centered "Details" label, direct mark-read + trash/restore buttons (no overflow menu)
- Detail header: 40px category icon + wrapping title (was 28px + truncated)
- Divider between header and body
- Full-width "Go to Conversation" CTA pinned at bottom (was small "Go to Convo" button in header row)
- Desktop split-panel layout unchanged

**Documentation** — added two conventions:
- `CAPACITOR.md`: full-screen overlays must apply safe-area inset padding
- `CONVENTIONS.md`: child routes under `ChatLayout` must register their title via `setTopBarCenter`

## Why this is safe

- Desktop layout is completely untouched — all mobile changes are gated behind `isMobile` props/conditions
- No data flow changes — all existing callbacks (`onClose`, `onGoToThread`, `onUpdateStatus`, `onDismiss`) are reused as-is
- The `setTopBarCenter` pattern is battle-tested by `ChatPage` which has used it since the layout header was introduced
- Safe-area CSS vars are a progressive enhancement — `0px` fallback on non-notch devices

## Alternatives considered and rejected

1. **Separate `MobileHomeDetailPanel` component** — rejected because it would duplicate all prop wiring and state management. A conditional layout inside the existing component is maintainable and keeps the interface surface small.

2. **Using `ChatLayoutHeader` slots for the mobile detail panel nav** — rejected because the mobile detail panel is a `fixed inset-0 z-30` overlay that covers the layout header. Setting `topBarCenter` would update the hidden header underneath, not the visible panel. The panel needs its own inline nav bar.

3. **CSS-only approach for pill count** — rejected because `slice(0, N)` is logic, not layout. A `maxVisible` prop is explicit and testable; CSS `overflow: hidden` would still render and measure all 3 pills.

4. **CSS `env(safe-area-inset-top)` directly without `var()` wrapper** — rejected because the Capacitor iOS plugin sets `--safe-area-inset-*` CSS custom properties, and `env()` alone doesn't cover that path. The double fallback `var(--safe-area-inset-top, env(safe-area-inset-top, 0px))` covers both Capacitor (plugin vars) and standard browsers (`env()` from `viewport-fit=cover`). This pattern is already used by `ChatLayoutHeader`.

## Root cause analysis

### How the code got here
The home page was originally built for desktop (macOS has a native SwiftUI implementation; iOS uses the Capacitor web wrapper). The initial web implementation focused on the desktop split-panel layout and reused the same `HomeDetailPanel` component for mobile by wrapping it in a full-screen fixed overlay — but without adapting the panel layout or accounting for iOS safe-area insets.

### What was missed
1. **No safe-area padding on the mobile overlay** — `ChatLayoutHeader` correctly applies `paddingTop: calc(16px + var(--safe-area-inset-top, ...))`, but when the detail panel overlays it at `z-30`, that protection is hidden. The overlay itself had no inset padding.
2. **`HomePageRoute` never called `setTopBarCenter`** — the layout header slot mechanism existed and was documented in the `AssistantContextValue` interface, but wasn't used by the home route. `ChatPage` uses it; the home route was likely added later and the pattern wasn't carried over.
3. **Desktop-first detail panel reused on mobile without adaptation** — the single header row (icon + truncated title + "Go to Convo" + overflow menu + close) works in a 320px+ split panel but is cramped on a full-screen phone where users expect a native-feeling back nav + bottom CTA.

### Prevention
- Added `CAPACITOR.md` section: "Full-screen overlays must respect safe-area insets" — any future `fixed inset-0` element will trigger this convention during review.
- Added `CONVENTIONS.md` section: "Layout header slots" — documents that every `ChatLayout` child route must register its title via `setTopBarCenter`, with code example.
- These are durable guidelines (not task-specific) because the safe-area and layout-slot patterns apply to any new route or full-screen overlay, not just the home page.

## Test plan
- [ ] Open the app on an iOS device (or narrow browser to mobile width)
- [ ] Verify "Home" label appears centered in the top nav bar between the sidebar toggle and search icon
- [ ] Verify "New Chat" renders as a circular icon-only button on mobile
- [ ] Verify at most 2 suggestion pills appear on mobile (3 on desktop)
- [ ] Tap a feed item — detail panel should not clip under the camera/status bar
- [ ] Detail panel: back arrow, "Details" title, mark-read + trash buttons visible, wrapping title, divider, body content, full-width "Go to Conversation" at bottom
- [ ] Close detail panel via back arrow — returns to feed
- [ ] Verify desktop layout is unchanged (text "New Chat" button, 3 pills, split-panel detail view with existing header row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)