### PR TITLE
feat(web): add Workspace chip style to risk-utils for sandbox auto-approved tools

### DIFF
--- a/apps/web/src/domains/chat/utils/risk-utils.test.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getProvenanceText, wasExpected } from "@/domains/chat/utils/risk-utils";
+import { getEffectiveRiskDisplay, getProvenanceText, getRiskBadgeStyle, wasExpected } from "@/domains/chat/utils/risk-utils";
 
 describe("wasExpected", () => {
   test("prompted mode is always expected", () => {
@@ -64,8 +64,11 @@ describe("wasExpected", () => {
 describe("getProvenanceText", () => {
   test("maps known reasons to display text", () => {
     expect(getProvenanceText("trust_rule_allowed")).toBe("· Auto-approved · Trust rule matched");
-    expect(getProvenanceText("sandbox_auto_approve")).toBe("· Auto-approved · Sandboxed workspace");
     expect(getProvenanceText("platform_auto_approve")).toBe("· Auto-approved · Platform session");
+  });
+
+  test("sandbox_auto_approve returns null (chip replaces provenance text)", () => {
+    expect(getProvenanceText("sandbox_auto_approve")).toBeNull();
   });
 
   test("returns null for expected-outcome reasons", () => {
@@ -79,5 +82,55 @@ describe("getProvenanceText", () => {
 
   test("returns null for undefined (backward compat)", () => {
     expect(getProvenanceText(undefined)).toBeNull();
+  });
+});
+
+describe("getRiskBadgeStyle", () => {
+  test("workspace returns slate/outlined styling", () => {
+    const style = getRiskBadgeStyle("workspace");
+    expect(style.bg).toBe("bg-[var(--surface-lift)]");
+    expect(style.text).toBe("text-[var(--content-secondary)]");
+    expect(style.border).toBe("border border-[var(--border-element)]");
+    expect(style.label).toBe("Workspace");
+  });
+
+  test("existing risk levels do not have a border field", () => {
+    expect(getRiskBadgeStyle("low").border).toBeUndefined();
+    expect(getRiskBadgeStyle("medium").border).toBeUndefined();
+    expect(getRiskBadgeStyle("high").border).toBeUndefined();
+  });
+});
+
+describe("getEffectiveRiskDisplay", () => {
+  test("sandbox_auto_approve maps to workspace with inherent risk preserved", () => {
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "high")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "high",
+    });
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "low")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "low",
+    });
+  });
+
+  test("non-sandbox reasons pass through the risk level", () => {
+    expect(getEffectiveRiskDisplay("trust_rule_allowed", "medium")).toEqual({
+      displayLevel: "medium",
+    });
+    expect(getEffectiveRiskDisplay("platform_auto_approve", "high")).toEqual({
+      displayLevel: "high",
+    });
+  });
+
+  test("undefined approvalReason passes through the risk level", () => {
+    expect(getEffectiveRiskDisplay(undefined, "medium")).toEqual({
+      displayLevel: "medium",
+    });
+  });
+
+  test("undefined riskLevel defaults to unknown", () => {
+    expect(getEffectiveRiskDisplay(undefined, undefined)).toEqual({
+      displayLevel: "unknown",
+    });
   });
 });

--- a/apps/web/src/domains/chat/utils/risk-utils.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.ts
@@ -1,4 +1,4 @@
-export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: string; label: string } {
+export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: string; label: string; border?: string } {
   switch (riskLevel?.toLowerCase()) {
     case "low":
       return { bg: "bg-[var(--system-positive-strong)]", text: "text-white", label: "Low" };
@@ -7,6 +7,13 @@ export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: strin
       return { bg: "bg-[var(--system-mid-strong)]", text: "text-black", label: "Medium" };
     case "high":
       return { bg: "bg-[var(--system-negative-strong)]", text: "text-white", label: "High" };
+    case "workspace":
+      return {
+        bg: "bg-[var(--surface-lift)]",
+        text: "text-[var(--content-secondary)]",
+        border: "border border-[var(--border-element)]",
+        label: "Workspace",
+      };
     default:
       return { bg: "bg-[var(--content-secondary)]", text: "text-white", label: riskLevel ?? "Unknown" };
   }
@@ -40,8 +47,23 @@ export function wasExpected(
 export function getProvenanceText(approvalReason: string | undefined): string | null {
   switch (approvalReason) {
     case "trust_rule_allowed":    return "· Auto-approved · Trust rule matched";
-    case "sandbox_auto_approve":  return "· Auto-approved · Sandboxed workspace";
+    case "sandbox_auto_approve":  return null;
     case "platform_auto_approve": return "· Auto-approved · Platform session";
     default:                      return null;
   }
+}
+
+/**
+ * Maps an approvalReason to the effective chip display level.
+ * Sandbox-auto-approved tools render a neutral "Workspace" chip instead of
+ * the inherent risk color, while preserving the original risk for tooltips.
+ */
+export function getEffectiveRiskDisplay(
+  approvalReason?: string,
+  riskLevel?: string,
+): { displayLevel: string; inherentRisk?: string } {
+  if (approvalReason === "sandbox_auto_approve") {
+    return { displayLevel: "workspace", inherentRisk: riskLevel };
+  }
+  return { displayLevel: riskLevel ?? "unknown" };
 }


### PR DESCRIPTION
## Summary
- Add 'workspace' case to getRiskBadgeStyle() with muted slate/outlined styling
- Add getEffectiveRiskDisplay() mapping function (approvalReason → chipConfig)
- Update getProvenanceText() to return null for sandbox_auto_approve (chip replaces provenance text)

Part of plan: workspace-chip-sandbox-risk.md (PR 1 of 7)