### PR TITLE
feat(macOS): add Workspace case to RiskBadgeView for sandbox auto-approved tools

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -27,6 +27,10 @@ struct RiskBadgeView: View {
         }
     }
 
+    private var isWorkspaceChip: Bool {
+        riskLevel.lowercased() == "workspace"
+    }
+
     private var badgeContent: some View {
         Text(displayLabel)
             .font(VFont.labelDefault)
@@ -34,11 +38,19 @@ struct RiskBadgeView: View {
             .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
             .background(backgroundColor)
             .clipShape(Capsule())
+            .overlay {
+                if isWorkspaceChip {
+                    Capsule().stroke(VColor.borderElement, lineWidth: 1)
+                }
+            }
     }
 
     // MARK: - Display
 
     private var displayLabel: String {
+        if isWorkspaceChip {
+            return "Workspace"
+        }
         let base = riskLevel.isEmpty ? "Unknown" : riskLevel.prefix(1).uppercased() + riskLevel.dropFirst()
         if let provenance = provenanceText {
             return "\(base) \(provenance)"
@@ -56,6 +68,8 @@ struct RiskBadgeView: View {
             VColor.systemMidWeak
         case "high":
             VColor.systemNegativeWeak
+        case "workspace":
+            VColor.surfaceLift
         default:
             VColor.surfaceBase
         }
@@ -69,6 +83,8 @@ struct RiskBadgeView: View {
             VColor.systemMidStrong
         case "high":
             VColor.systemNegativeStrong
+        case "workspace":
+            VColor.contentSecondary
         default:
             VColor.contentSecondary
         }


### PR DESCRIPTION
## Summary
- Add 'workspace' case to RiskBadgeView with muted slate background and outlined border
- Visually distinct from low/medium/high risk badges (no traffic-light colors)
- Badge label shows 'Workspace' and ignores provenance text suffix

Part of plan: workspace-chip-sandbox-risk.md (PR 3 of 7)