### PR TITLE
feat(macOS): render Workspace chip for sandbox auto-approved tool calls in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1130,10 +1130,22 @@ struct ToolCallStepDetailRow: View {
 
     /// Risk badge rendered immediately after the title.
     /// Chat-specific, so it stays at this caller level rather than in the shared row.
+    ///
+    /// For sandbox-auto-approved tool calls, passes `"workspace"` to `RiskBadgeView`
+    /// so it renders the muted Workspace chip. The tooltip shows the inherent risk
+    /// level; the rule editor still receives the original risk for correct rule creation.
     @ViewBuilder
     private var leadingAccessory: some View {
         if let risk = toolCall.riskLevel {
-            let unexpected = !wasExpected(
+            let effective = effectiveRiskDisplay(
+                approvalReason: toolCall.approvalReason,
+                riskLevel: toolCall.riskLevel
+            )
+            let isWorkspace = effective.displayLevel == "workspace"
+
+            // For workspace chips, skip wasExpected/provenance — the chip itself
+            // communicates the sandbox auto-approval provenance.
+            let unexpected = !isWorkspace && !wasExpected(
                 approvalMode: toolCall.approvalMode,
                 riskLevel: toolCall.riskLevel,
                 riskThreshold: toolCall.riskThreshold
@@ -1141,10 +1153,16 @@ struct ToolCallStepDetailRow: View {
             let provenance = unexpected
                 ? approvalProvenanceText(approvalReason: toolCall.approvalReason)
                 : nil
+
+            let tooltip: String? = isWorkspace
+                ? "Workspace · Inherent risk: \(effective.inherentRisk?.capitalized ?? "Unknown")"
+                : nil
+
             RiskBadgeView(
-                riskLevel: risk,
+                riskLevel: effective.displayLevel,
                 hasExistingRule: toolCall.matchedTrustRuleId != nil,
-                provenanceText: provenance
+                provenanceText: provenance,
+                helpText: tooltip
             ) {
                 ruleEditorTask?.cancel()
                 ruleEditorTask = Task { await openRuleEditorForCompletedCall(toolCall) }

--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -13,15 +13,19 @@ struct RiskBadgeView: View {
     let riskLevel: String
     var hasExistingRule: Bool = false
     var provenanceText: String? = nil
+    /// Optional override for the tooltip text. When nil, the default
+    /// "Risk level: …" help text is used.
+    var helpText: String? = nil
     var onTap: (() -> Void)? = nil
 
     var body: some View {
         if let onTap {
+            let tooltip = helpText ?? "Risk level: \(displayLabel). \(hasExistingRule ? "Click to edit the matching rule." : "Click to create a rule.")"
             Button(action: onTap) {
                 badgeContent
             }
             .buttonStyle(.plain)
-            .help("Risk level: \(displayLabel). \(hasExistingRule ? "Click to edit the matching rule." : "Click to create a rule.")")
+            .help(tooltip)
         } else {
             badgeContent
         }

--- a/clients/shared/Features/Chat/ApprovalProvenance.swift
+++ b/clients/shared/Features/Chat/ApprovalProvenance.swift
@@ -16,13 +16,29 @@ public func wasExpected(approvalMode: String?, riskLevel: String?, riskThreshold
 
 /// Returns the inline provenance suffix to append to the risk badge label, or nil
 /// when no provenance should be shown (expected outcome or missing fields).
+///
+/// For `sandbox_auto_approve`, returns nil — the Workspace chip now communicates
+/// this provenance visually, so inline text is redundant.
 public func approvalProvenanceText(approvalReason: String?) -> String? {
     switch approvalReason {
     case "trust_rule_allowed":    return "· Auto-approved · Trust rule matched"
-    case "sandbox_auto_approve":  return "· Auto-approved · Sandboxed workspace"
+    case "sandbox_auto_approve":  return nil
     case "platform_auto_approve": return "· Auto-approved · Platform session"
     // "no_interactive_client" has approvalMode "blocked", so wasExpected always
     // returns true for it — the call site never reaches here for that reason.
     default:                      return nil
     }
+}
+
+/// Determines the display risk level and inherent risk for rendering.
+///
+/// For sandbox-auto-approved tool calls, returns `"workspace"` as the display level
+/// so `RiskBadgeView` renders the muted Workspace chip, and preserves the original
+/// risk level as `inherentRisk` for tooltip display. For all other cases, passes
+/// through the original risk level unchanged.
+public func effectiveRiskDisplay(approvalReason: String?, riskLevel: String?) -> (displayLevel: String, inherentRisk: String?) {
+    if approvalReason == "sandbox_auto_approve" {
+        return (displayLevel: "workspace", inherentRisk: riskLevel)
+    }
+    return (displayLevel: riskLevel ?? "unknown", inherentRisk: nil)
 }


### PR DESCRIPTION
## Summary
- Add effectiveRiskDisplay() to shared ApprovalProvenance.swift
- Update approvalProvenanceText() to return nil for sandbox_auto_approve
- Wire Workspace chip into AssistantProgressView leadingAccessory
- Tooltip shows inherent risk, rule editor uses original risk level
- Add helpText parameter to RiskBadgeView for tooltip override

Part of plan: workspace-chip-sandbox-risk.md (PR 4 of 7)