### PR TITLE
feat(macOS): show Workspace chip in permission tester for sandbox auto-approved results

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -20,12 +20,22 @@ struct SimulationResult: Equatable {
     /// Execution target resolved by the daemon from the tool name.
     let snapshotExecutionTarget: String?
 
+    /// Inferred approval reason from the decision reason text.
+    let approvalReason: String?
+
+    /// The risk level to display in the badge, which may differ from the raw
+    /// `riskLevel` (e.g. "workspace" for sandbox auto-approved results).
+    var effectiveDisplayLevel: String {
+        effectiveRiskDisplay(approvalReason: approvalReason, riskLevel: riskLevel)
+    }
+
     static func == (lhs: SimulationResult, rhs: SimulationResult) -> Bool {
         lhs.decision == rhs.decision
         && lhs.riskLevel == rhs.riskLevel
         && lhs.reason == rhs.reason
         && lhs.matchedTrustRuleId == rhs.matchedTrustRuleId
         && lhs.localOverrideLabel == rhs.localOverrideLabel
+        && lhs.approvalReason == rhs.approvalReason
     }
 }
 
@@ -402,15 +412,23 @@ final class ToolPermissionTesterModel: ObservableObject {
             return
         }
 
+        // Infer approvalReason from the reason text since the simulate
+        // endpoint doesn't return it directly.
+        let reason = response.reason ?? ""
+        let inferredApprovalReason: String? = reason.contains("sandbox auto-approve")
+            ? "sandbox_auto_approve"
+            : nil
+
         lastResult = SimulationResult(
             decision: response.decision ?? "unknown",
             riskLevel: response.riskLevel ?? "unknown",
-            reason: response.reason ?? "",
+            reason: reason,
             matchedTrustRuleId: response.matchedTrustRuleId,
             promptPayload: response.promptPayload,
             snapshotToolName: pendingSnapshotToolName,
             snapshotInputJSON: pendingSnapshotInputJSON,
-            snapshotExecutionTarget: response.executionTarget
+            snapshotExecutionTarget: response.executionTarget,
+            approvalReason: inferredApprovalReason
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -214,7 +214,7 @@ struct ToolPermissionTesterView: View {
                 HStack(spacing: VSpacing.sm) {
                     decisionBadge(result.decision)
 
-                    VTag(result.riskLevel.capitalized, color: riskColor(result.riskLevel))
+                    RiskBadgeView(riskLevel: result.effectiveDisplayLevel)
 
                     if let ruleId = result.matchedTrustRuleId {
                         Text("Rule: \(ruleId)")
@@ -326,12 +326,4 @@ struct ToolPermissionTesterView: View {
         }
     }
 
-    private func riskColor(_ level: String) -> Color {
-        switch level.lowercased() {
-        case "low": return VColor.contentTertiary
-        case "medium": return VColor.systemMidStrong
-        case "high": return VColor.systemNegativeStrong
-        default: return VColor.contentTertiary
-        }
-    }
 }

--- a/clients/shared/Features/Chat/ApprovalProvenance.swift
+++ b/clients/shared/Features/Chat/ApprovalProvenance.swift
@@ -14,6 +14,17 @@ public func wasExpected(approvalMode: String?, riskLevel: String?, riskThreshold
     return risk <= threshold
 }
 
+/// Returns the display-level string to use for the risk badge. When the tool call
+/// was sandbox auto-approved, the badge should show "workspace" instead of the raw
+/// risk level so the UI communicates that the operation ran inside the sandboxed
+/// workspace scope.
+public func effectiveRiskDisplay(approvalReason: String?, riskLevel: String?) -> String {
+    if approvalReason == "sandbox_auto_approve" {
+        return "workspace"
+    }
+    return riskLevel ?? "unknown"
+}
+
 /// Returns the inline provenance suffix to append to the risk badge label, or nil
 /// when no provenance should be shown (expected outcome or missing fields).
 public func approvalProvenanceText(approvalReason: String?) -> String? {


### PR DESCRIPTION
## Summary
- Show Workspace chip in permission tester when result is sandbox auto-approved
- Tester preview now matches actual chat display for sandbox-scoped commands

Part of plan: workspace-chip-sandbox-risk.md (PR 5 of 7)