### PR TITLE
test: add test coverage for Workspace chip display logic across web and macOS

### DIFF
--- a/apps/web/src/domains/chat/utils/risk-utils.test.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.test.ts
@@ -107,6 +107,10 @@ describe("getEffectiveRiskDisplay", () => {
       displayLevel: "workspace",
       inherentRisk: "high",
     });
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "medium")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "medium",
+    });
     expect(getEffectiveRiskDisplay("sandbox_auto_approve", "low")).toEqual({
       displayLevel: "workspace",
       inherentRisk: "low",
@@ -114,6 +118,9 @@ describe("getEffectiveRiskDisplay", () => {
   });
 
   test("non-sandbox reasons pass through the risk level", () => {
+    expect(getEffectiveRiskDisplay("trust_rule_allowed", "high")).toEqual({
+      displayLevel: "high",
+    });
     expect(getEffectiveRiskDisplay("trust_rule_allowed", "medium")).toEqual({
       displayLevel: "medium",
     });
@@ -123,6 +130,9 @@ describe("getEffectiveRiskDisplay", () => {
   });
 
   test("undefined approvalReason passes through the risk level", () => {
+    expect(getEffectiveRiskDisplay(undefined, "low")).toEqual({
+      displayLevel: "low",
+    });
     expect(getEffectiveRiskDisplay(undefined, "medium")).toEqual({
       displayLevel: "medium",
     });

--- a/clients/shared/Tests/ApprovalProvenanceTests.swift
+++ b/clients/shared/Tests/ApprovalProvenanceTests.swift
@@ -53,8 +53,12 @@ final class ApprovalProvenanceTests: XCTestCase {
 
     func test_knownReasons() {
         XCTAssertEqual(approvalProvenanceText(approvalReason: "trust_rule_allowed"),    "· Auto-approved · Trust rule matched")
-        XCTAssertEqual(approvalProvenanceText(approvalReason: "sandbox_auto_approve"),  "· Auto-approved · Sandboxed workspace")
         XCTAssertEqual(approvalProvenanceText(approvalReason: "platform_auto_approve"), "· Auto-approved · Platform session")
+    }
+
+    func test_sandboxAutoApprove_returnsNil() {
+        // sandbox_auto_approve no longer shows inline text — the Workspace chip communicates provenance visually.
+        XCTAssertNil(approvalProvenanceText(approvalReason: "sandbox_auto_approve"))
     }
 
     func test_expectedReasons_returnNil() {
@@ -66,5 +70,47 @@ final class ApprovalProvenanceTests: XCTestCase {
         // true for it, so this path is never reached from the call site.
         XCTAssertNil(approvalProvenanceText(approvalReason: "no_interactive_client"))
         XCTAssertNil(approvalProvenanceText(approvalReason: nil))
+    }
+
+    // MARK: - effectiveRiskDisplay (tuple overload)
+
+    func test_effectiveRiskDisplay_sandboxAutoApprove_highRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "sandbox_auto_approve", riskLevel: "high"
+        )
+        XCTAssertEqual(result.displayLevel, "workspace")
+        XCTAssertEqual(result.inherentRisk, "high")
+    }
+
+    func test_effectiveRiskDisplay_sandboxAutoApprove_mediumRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "sandbox_auto_approve", riskLevel: "medium"
+        )
+        XCTAssertEqual(result.displayLevel, "workspace")
+        XCTAssertEqual(result.inherentRisk, "medium")
+    }
+
+    func test_effectiveRiskDisplay_nilApprovalReason_mediumRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: nil, riskLevel: "medium"
+        )
+        XCTAssertEqual(result.displayLevel, "medium")
+        XCTAssertNil(result.inherentRisk)
+    }
+
+    func test_effectiveRiskDisplay_trustRuleAllowed_lowRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "trust_rule_allowed", riskLevel: "low"
+        )
+        XCTAssertEqual(result.displayLevel, "low")
+        XCTAssertNil(result.inherentRisk)
+    }
+
+    func test_effectiveRiskDisplay_nilRiskLevel_defaultsToUnknown() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: nil, riskLevel: nil
+        )
+        XCTAssertEqual(result.displayLevel, "unknown")
+        XCTAssertNil(result.inherentRisk)
     }
 }


### PR DESCRIPTION
## Summary
- Add/verify web risk-utils tests for getEffectiveRiskDisplay() including sandbox_auto_approve with medium risk, trust_rule_allowed with high risk, and undefined approvalReason with low risk
- Fix stale Swift test assertion: sandbox_auto_approve now returns nil (Workspace chip replaced inline text)
- Add Swift effectiveRiskDisplay tuple-overload tests covering sandbox auto-approve, nil approval, trust rule, and nil risk level cases
- Verify existing tests still pass

Part of plan: workspace-chip-sandbox-risk.md (PR 7 of 7)