### PR TITLE
feat: Workspace chip for sandbox auto-approved tool calls

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
-import { getRiskBadgeStyle, getProvenanceText, wasExpected } from "@/domains/chat/utils/risk-utils";
+import { getRiskBadgeStyle, getProvenanceText, wasExpected, getEffectiveRiskDisplay } from "@/domains/chat/utils/risk-utils";
 import { formatStartTime, useElapsedTime } from "@/domains/chat/hooks/use-elapsed-time";
 
 import type { AllowlistOption, ChatMessageToolCall, ConfirmationDecision, DirectoryScopeOption, ScopeOption } from "@/domains/chat/api/event-types";
@@ -302,10 +302,23 @@ export function ToolCallChip({
       {!embedded && getIcon(toolCall.toolName, inputSummary)}
       <span className="min-w-0 truncate text-[var(--content-secondary)]">{label}</span>
       {toolCall.riskLevel && toolCall.status !== "running" && !(hasPendingConfirmation && isActiveConfirmation) && (() => {
-        const badge = getRiskBadgeStyle(toolCall.riskLevel);
-        const unexpected = !wasExpected(toolCall.approvalMode, toolCall.riskLevel, toolCall.riskThreshold);
+        const { displayLevel, inherentRisk } = getEffectiveRiskDisplay(toolCall.approvalReason, toolCall.riskLevel);
+        const badge = getRiskBadgeStyle(displayLevel);
+        const isWorkspace = displayLevel === "workspace";
+
+        // For workspace chips, skip provenance — the chip itself is the provenance indicator.
+        // For normal badges, check wasExpected against the original riskLevel.
+        const unexpected = !isWorkspace && !wasExpected(toolCall.approvalMode, toolCall.riskLevel, toolCall.riskThreshold);
         const provenance = unexpected ? getProvenanceText(toolCall.approvalReason) : null;
-        const displayLabel = provenance ? `${badge.label} ${provenance}` : badge.label;
+
+        let displayLabel: string;
+        if (isWorkspace) {
+          const capitalizedRisk = inherentRisk ? inherentRisk.charAt(0).toUpperCase() + inherentRisk.slice(1) : "Unknown";
+          displayLabel = `Workspace · Inherent risk: ${capitalizedRisk}`;
+        } else {
+          displayLabel = provenance ? `${badge.label} ${provenance}` : badge.label;
+        }
+
         return (
           <button
             type="button"
@@ -322,12 +335,12 @@ export function ToolCallChip({
               });
             }}
             // typography: off-scale — compact risk badge pill
-             
-            className={`${embedded ? "" : "ml-auto "}max-w-[45%] shrink-0 truncate rounded-full px-2 py-0.5 text-[11px] font-medium leading-tight ${badge.bg} ${badge.text} ${onOpenRuleEditor ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
+
+            className={`${embedded ? "" : "ml-auto "}max-w-[45%] shrink-0 truncate rounded-full px-2 py-0.5 text-[11px] font-medium leading-tight ${badge.bg} ${badge.text} ${badge.border ?? ""} ${onOpenRuleEditor ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
             title={displayLabel}
           >
             <span className="sm:hidden">{badge.label}</span>
-            <span className="hidden sm:inline">{displayLabel}</span>
+            <span className="hidden sm:inline">{isWorkspace ? badge.label : displayLabel}</span>
           </button>
         );
       })()}

--- a/apps/web/src/domains/chat/utils/risk-utils.test.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getProvenanceText, wasExpected } from "@/domains/chat/utils/risk-utils";
+import { getEffectiveRiskDisplay, getProvenanceText, getRiskBadgeStyle, wasExpected } from "@/domains/chat/utils/risk-utils";
 
 describe("wasExpected", () => {
   test("prompted mode is always expected", () => {
@@ -64,8 +64,11 @@ describe("wasExpected", () => {
 describe("getProvenanceText", () => {
   test("maps known reasons to display text", () => {
     expect(getProvenanceText("trust_rule_allowed")).toBe("· Auto-approved · Trust rule matched");
-    expect(getProvenanceText("sandbox_auto_approve")).toBe("· Auto-approved · Sandboxed workspace");
     expect(getProvenanceText("platform_auto_approve")).toBe("· Auto-approved · Platform session");
+  });
+
+  test("sandbox_auto_approve returns null (chip replaces provenance text)", () => {
+    expect(getProvenanceText("sandbox_auto_approve")).toBeNull();
   });
 
   test("returns null for expected-outcome reasons", () => {
@@ -79,5 +82,55 @@ describe("getProvenanceText", () => {
 
   test("returns null for undefined (backward compat)", () => {
     expect(getProvenanceText(undefined)).toBeNull();
+  });
+});
+
+describe("getRiskBadgeStyle", () => {
+  test("workspace returns slate/outlined styling", () => {
+    const style = getRiskBadgeStyle("workspace");
+    expect(style.bg).toBe("bg-[var(--surface-lift)]");
+    expect(style.text).toBe("text-[var(--content-secondary)]");
+    expect(style.border).toBe("border border-[var(--border-element)]");
+    expect(style.label).toBe("Workspace");
+  });
+
+  test("existing risk levels do not have a border field", () => {
+    expect(getRiskBadgeStyle("low").border).toBeUndefined();
+    expect(getRiskBadgeStyle("medium").border).toBeUndefined();
+    expect(getRiskBadgeStyle("high").border).toBeUndefined();
+  });
+});
+
+describe("getEffectiveRiskDisplay", () => {
+  test("sandbox_auto_approve maps to workspace with inherent risk preserved", () => {
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "high")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "high",
+    });
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "low")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "low",
+    });
+  });
+
+  test("non-sandbox reasons pass through the risk level", () => {
+    expect(getEffectiveRiskDisplay("trust_rule_allowed", "medium")).toEqual({
+      displayLevel: "medium",
+    });
+    expect(getEffectiveRiskDisplay("platform_auto_approve", "high")).toEqual({
+      displayLevel: "high",
+    });
+  });
+
+  test("undefined approvalReason passes through the risk level", () => {
+    expect(getEffectiveRiskDisplay(undefined, "medium")).toEqual({
+      displayLevel: "medium",
+    });
+  });
+
+  test("undefined riskLevel defaults to unknown", () => {
+    expect(getEffectiveRiskDisplay(undefined, undefined)).toEqual({
+      displayLevel: "unknown",
+    });
   });
 });

--- a/apps/web/src/domains/chat/utils/risk-utils.test.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.test.ts
@@ -107,6 +107,10 @@ describe("getEffectiveRiskDisplay", () => {
       displayLevel: "workspace",
       inherentRisk: "high",
     });
+    expect(getEffectiveRiskDisplay("sandbox_auto_approve", "medium")).toEqual({
+      displayLevel: "workspace",
+      inherentRisk: "medium",
+    });
     expect(getEffectiveRiskDisplay("sandbox_auto_approve", "low")).toEqual({
       displayLevel: "workspace",
       inherentRisk: "low",
@@ -114,6 +118,9 @@ describe("getEffectiveRiskDisplay", () => {
   });
 
   test("non-sandbox reasons pass through the risk level", () => {
+    expect(getEffectiveRiskDisplay("trust_rule_allowed", "high")).toEqual({
+      displayLevel: "high",
+    });
     expect(getEffectiveRiskDisplay("trust_rule_allowed", "medium")).toEqual({
       displayLevel: "medium",
     });
@@ -123,6 +130,9 @@ describe("getEffectiveRiskDisplay", () => {
   });
 
   test("undefined approvalReason passes through the risk level", () => {
+    expect(getEffectiveRiskDisplay(undefined, "low")).toEqual({
+      displayLevel: "low",
+    });
     expect(getEffectiveRiskDisplay(undefined, "medium")).toEqual({
       displayLevel: "medium",
     });

--- a/apps/web/src/domains/chat/utils/risk-utils.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.ts
@@ -1,4 +1,4 @@
-export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: string; label: string } {
+export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: string; label: string; border?: string } {
   switch (riskLevel?.toLowerCase()) {
     case "low":
       return { bg: "bg-[var(--system-positive-strong)]", text: "text-white", label: "Low" };
@@ -7,6 +7,13 @@ export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: strin
       return { bg: "bg-[var(--system-mid-strong)]", text: "text-black", label: "Medium" };
     case "high":
       return { bg: "bg-[var(--system-negative-strong)]", text: "text-white", label: "High" };
+    case "workspace":
+      return {
+        bg: "bg-[var(--surface-lift)]",
+        text: "text-[var(--content-secondary)]",
+        border: "border border-[var(--border-element)]",
+        label: "Workspace",
+      };
     default:
       return { bg: "bg-[var(--content-secondary)]", text: "text-white", label: riskLevel ?? "Unknown" };
   }
@@ -40,8 +47,23 @@ export function wasExpected(
 export function getProvenanceText(approvalReason: string | undefined): string | null {
   switch (approvalReason) {
     case "trust_rule_allowed":    return "· Auto-approved · Trust rule matched";
-    case "sandbox_auto_approve":  return "· Auto-approved · Sandboxed workspace";
+    case "sandbox_auto_approve":  return null;
     case "platform_auto_approve": return "· Auto-approved · Platform session";
     default:                      return null;
   }
+}
+
+/**
+ * Maps an approvalReason to the effective chip display level.
+ * Sandbox-auto-approved tools render a neutral "Workspace" chip instead of
+ * the inherent risk color, while preserving the original risk for tooltips.
+ */
+export function getEffectiveRiskDisplay(
+  approvalReason?: string,
+  riskLevel?: string,
+): { displayLevel: string; inherentRisk?: string } {
+  if (approvalReason === "sandbox_auto_approve") {
+    return { displayLevel: "workspace", inherentRisk: riskLevel };
+  }
+  return { displayLevel: riskLevel ?? "unknown" };
 }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1130,10 +1130,22 @@ struct ToolCallStepDetailRow: View {
 
     /// Risk badge rendered immediately after the title.
     /// Chat-specific, so it stays at this caller level rather than in the shared row.
+    ///
+    /// For sandbox-auto-approved tool calls, passes `"workspace"` to `RiskBadgeView`
+    /// so it renders the muted Workspace chip. The tooltip shows the inherent risk
+    /// level; the rule editor still receives the original risk for correct rule creation.
     @ViewBuilder
     private var leadingAccessory: some View {
         if let risk = toolCall.riskLevel {
-            let unexpected = !wasExpected(
+            let effective = effectiveRiskDisplay(
+                approvalReason: toolCall.approvalReason,
+                riskLevel: toolCall.riskLevel
+            )
+            let isWorkspace = effective.displayLevel == "workspace"
+
+            // For workspace chips, skip wasExpected/provenance — the chip itself
+            // communicates the sandbox auto-approval provenance.
+            let unexpected = !isWorkspace && !wasExpected(
                 approvalMode: toolCall.approvalMode,
                 riskLevel: toolCall.riskLevel,
                 riskThreshold: toolCall.riskThreshold
@@ -1141,10 +1153,16 @@ struct ToolCallStepDetailRow: View {
             let provenance = unexpected
                 ? approvalProvenanceText(approvalReason: toolCall.approvalReason)
                 : nil
+
+            let tooltip: String? = isWorkspace
+                ? "Workspace · Inherent risk: \(effective.inherentRisk?.capitalized ?? "Unknown")"
+                : nil
+
             RiskBadgeView(
-                riskLevel: risk,
+                riskLevel: effective.displayLevel,
                 hasExistingRule: toolCall.matchedTrustRuleId != nil,
-                provenanceText: provenance
+                provenanceText: provenance,
+                helpText: tooltip
             ) {
                 ruleEditorTask?.cancel()
                 ruleEditorTask = Task { await openRuleEditorForCompletedCall(toolCall) }

--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -27,6 +27,10 @@ struct RiskBadgeView: View {
         }
     }
 
+    private var isWorkspaceChip: Bool {
+        riskLevel.lowercased() == "workspace"
+    }
+
     private var badgeContent: some View {
         Text(displayLabel)
             .font(VFont.labelDefault)
@@ -34,11 +38,19 @@ struct RiskBadgeView: View {
             .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
             .background(backgroundColor)
             .clipShape(Capsule())
+            .overlay {
+                if isWorkspaceChip {
+                    Capsule().stroke(VColor.borderElement, lineWidth: 1)
+                }
+            }
     }
 
     // MARK: - Display
 
     private var displayLabel: String {
+        if isWorkspaceChip {
+            return "Workspace"
+        }
         let base = riskLevel.isEmpty ? "Unknown" : riskLevel.prefix(1).uppercased() + riskLevel.dropFirst()
         if let provenance = provenanceText {
             return "\(base) \(provenance)"
@@ -56,6 +68,8 @@ struct RiskBadgeView: View {
             VColor.systemMidWeak
         case "high":
             VColor.systemNegativeWeak
+        case "workspace":
+            VColor.surfaceLift
         default:
             VColor.surfaceBase
         }
@@ -69,6 +83,8 @@ struct RiskBadgeView: View {
             VColor.systemMidStrong
         case "high":
             VColor.systemNegativeStrong
+        case "workspace":
+            VColor.contentSecondary
         default:
             VColor.contentSecondary
         }

--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -13,15 +13,19 @@ struct RiskBadgeView: View {
     let riskLevel: String
     var hasExistingRule: Bool = false
     var provenanceText: String? = nil
+    /// Optional override for the tooltip text. When nil, the default
+    /// "Risk level: …" help text is used.
+    var helpText: String? = nil
     var onTap: (() -> Void)? = nil
 
     var body: some View {
         if let onTap {
+            let tooltip = helpText ?? "Risk level: \(displayLabel). \(hasExistingRule ? "Click to edit the matching rule." : "Click to create a rule.")"
             Button(action: onTap) {
                 badgeContent
             }
             .buttonStyle(.plain)
-            .help("Risk level: \(displayLabel). \(hasExistingRule ? "Click to edit the matching rule." : "Click to create a rule.")")
+            .help(tooltip)
         } else {
             badgeContent
         }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -20,12 +20,22 @@ struct SimulationResult: Equatable {
     /// Execution target resolved by the daemon from the tool name.
     let snapshotExecutionTarget: String?
 
+    /// Inferred approval reason from the decision reason text.
+    let approvalReason: String?
+
+    /// The risk level to display in the badge, which may differ from the raw
+    /// `riskLevel` (e.g. "workspace" for sandbox auto-approved results).
+    var effectiveDisplayLevel: String {
+        effectiveRiskDisplay(approvalReason: approvalReason, riskLevel: riskLevel)
+    }
+
     static func == (lhs: SimulationResult, rhs: SimulationResult) -> Bool {
         lhs.decision == rhs.decision
         && lhs.riskLevel == rhs.riskLevel
         && lhs.reason == rhs.reason
         && lhs.matchedTrustRuleId == rhs.matchedTrustRuleId
         && lhs.localOverrideLabel == rhs.localOverrideLabel
+        && lhs.approvalReason == rhs.approvalReason
     }
 }
 
@@ -402,15 +412,23 @@ final class ToolPermissionTesterModel: ObservableObject {
             return
         }
 
+        // Infer approvalReason from the reason text since the simulate
+        // endpoint doesn't return it directly.
+        let reason = response.reason ?? ""
+        let inferredApprovalReason: String? = reason.contains("sandbox auto-approve")
+            ? "sandbox_auto_approve"
+            : nil
+
         lastResult = SimulationResult(
             decision: response.decision ?? "unknown",
             riskLevel: response.riskLevel ?? "unknown",
-            reason: response.reason ?? "",
+            reason: reason,
             matchedTrustRuleId: response.matchedTrustRuleId,
             promptPayload: response.promptPayload,
             snapshotToolName: pendingSnapshotToolName,
             snapshotInputJSON: pendingSnapshotInputJSON,
-            snapshotExecutionTarget: response.executionTarget
+            snapshotExecutionTarget: response.executionTarget,
+            approvalReason: inferredApprovalReason
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -26,7 +26,7 @@ struct SimulationResult: Equatable {
     /// The risk level to display in the badge, which may differ from the raw
     /// `riskLevel` (e.g. "workspace" for sandbox auto-approved results).
     var effectiveDisplayLevel: String {
-        effectiveRiskDisplay(approvalReason: approvalReason, riskLevel: riskLevel)
+        effectiveRiskDisplay(approvalReason: approvalReason, riskLevel: riskLevel).displayLevel
     }
 
     static func == (lhs: SimulationResult, rhs: SimulationResult) -> Bool {

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -214,7 +214,7 @@ struct ToolPermissionTesterView: View {
                 HStack(spacing: VSpacing.sm) {
                     decisionBadge(result.decision)
 
-                    VTag(result.riskLevel.capitalized, color: riskColor(result.riskLevel))
+                    RiskBadgeView(riskLevel: result.effectiveDisplayLevel)
 
                     if let ruleId = result.matchedTrustRuleId {
                         Text("Rule: \(ruleId)")
@@ -326,12 +326,4 @@ struct ToolPermissionTesterView: View {
         }
     }
 
-    private func riskColor(_ level: String) -> Color {
-        switch level.lowercased() {
-        case "low": return VColor.contentTertiary
-        case "medium": return VColor.systemMidStrong
-        case "high": return VColor.systemNegativeStrong
-        default: return VColor.contentTertiary
-        }
-    }
 }

--- a/clients/shared/Features/Chat/ApprovalProvenance.swift
+++ b/clients/shared/Features/Chat/ApprovalProvenance.swift
@@ -16,13 +16,29 @@ public func wasExpected(approvalMode: String?, riskLevel: String?, riskThreshold
 
 /// Returns the inline provenance suffix to append to the risk badge label, or nil
 /// when no provenance should be shown (expected outcome or missing fields).
+///
+/// For `sandbox_auto_approve`, returns nil — the Workspace chip now communicates
+/// this provenance visually, so inline text is redundant.
 public func approvalProvenanceText(approvalReason: String?) -> String? {
     switch approvalReason {
     case "trust_rule_allowed":    return "· Auto-approved · Trust rule matched"
-    case "sandbox_auto_approve":  return "· Auto-approved · Sandboxed workspace"
+    case "sandbox_auto_approve":  return nil
     case "platform_auto_approve": return "· Auto-approved · Platform session"
     // "no_interactive_client" has approvalMode "blocked", so wasExpected always
     // returns true for it — the call site never reaches here for that reason.
     default:                      return nil
     }
+}
+
+/// Determines the display risk level and inherent risk for rendering.
+///
+/// For sandbox-auto-approved tool calls, returns `"workspace"` as the display level
+/// so `RiskBadgeView` renders the muted Workspace chip, and preserves the original
+/// risk level as `inherentRisk` for tooltip display. For all other cases, passes
+/// through the original risk level unchanged.
+public func effectiveRiskDisplay(approvalReason: String?, riskLevel: String?) -> (displayLevel: String, inherentRisk: String?) {
+    if approvalReason == "sandbox_auto_approve" {
+        return (displayLevel: "workspace", inherentRisk: riskLevel)
+    }
+    return (displayLevel: riskLevel ?? "unknown", inherentRisk: nil)
 }

--- a/clients/shared/Features/Chat/ApprovalProvenance.swift
+++ b/clients/shared/Features/Chat/ApprovalProvenance.swift
@@ -14,17 +14,6 @@ public func wasExpected(approvalMode: String?, riskLevel: String?, riskThreshold
     return risk <= threshold
 }
 
-/// Returns the display-level string to use for the risk badge. When the tool call
-/// was sandbox auto-approved, the badge should show "workspace" instead of the raw
-/// risk level so the UI communicates that the operation ran inside the sandboxed
-/// workspace scope.
-public func effectiveRiskDisplay(approvalReason: String?, riskLevel: String?) -> String {
-    if approvalReason == "sandbox_auto_approve" {
-        return "workspace"
-    }
-    return riskLevel ?? "unknown"
-}
-
 /// Returns the inline provenance suffix to append to the risk badge label, or nil
 /// when no provenance should be shown (expected outcome or missing fields).
 ///

--- a/clients/shared/Features/Chat/ApprovalProvenance.swift
+++ b/clients/shared/Features/Chat/ApprovalProvenance.swift
@@ -14,6 +14,17 @@ public func wasExpected(approvalMode: String?, riskLevel: String?, riskThreshold
     return risk <= threshold
 }
 
+/// Returns the display-level string to use for the risk badge. When the tool call
+/// was sandbox auto-approved, the badge should show "workspace" instead of the raw
+/// risk level so the UI communicates that the operation ran inside the sandboxed
+/// workspace scope.
+public func effectiveRiskDisplay(approvalReason: String?, riskLevel: String?) -> String {
+    if approvalReason == "sandbox_auto_approve" {
+        return "workspace"
+    }
+    return riskLevel ?? "unknown"
+}
+
 /// Returns the inline provenance suffix to append to the risk badge label, or nil
 /// when no provenance should be shown (expected outcome or missing fields).
 ///

--- a/clients/shared/Tests/ApprovalProvenanceTests.swift
+++ b/clients/shared/Tests/ApprovalProvenanceTests.swift
@@ -53,8 +53,12 @@ final class ApprovalProvenanceTests: XCTestCase {
 
     func test_knownReasons() {
         XCTAssertEqual(approvalProvenanceText(approvalReason: "trust_rule_allowed"),    "· Auto-approved · Trust rule matched")
-        XCTAssertEqual(approvalProvenanceText(approvalReason: "sandbox_auto_approve"),  "· Auto-approved · Sandboxed workspace")
         XCTAssertEqual(approvalProvenanceText(approvalReason: "platform_auto_approve"), "· Auto-approved · Platform session")
+    }
+
+    func test_sandboxAutoApprove_returnsNil() {
+        // sandbox_auto_approve no longer shows inline text — the Workspace chip communicates provenance visually.
+        XCTAssertNil(approvalProvenanceText(approvalReason: "sandbox_auto_approve"))
     }
 
     func test_expectedReasons_returnNil() {
@@ -66,5 +70,47 @@ final class ApprovalProvenanceTests: XCTestCase {
         // true for it, so this path is never reached from the call site.
         XCTAssertNil(approvalProvenanceText(approvalReason: "no_interactive_client"))
         XCTAssertNil(approvalProvenanceText(approvalReason: nil))
+    }
+
+    // MARK: - effectiveRiskDisplay (tuple overload)
+
+    func test_effectiveRiskDisplay_sandboxAutoApprove_highRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "sandbox_auto_approve", riskLevel: "high"
+        )
+        XCTAssertEqual(result.displayLevel, "workspace")
+        XCTAssertEqual(result.inherentRisk, "high")
+    }
+
+    func test_effectiveRiskDisplay_sandboxAutoApprove_mediumRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "sandbox_auto_approve", riskLevel: "medium"
+        )
+        XCTAssertEqual(result.displayLevel, "workspace")
+        XCTAssertEqual(result.inherentRisk, "medium")
+    }
+
+    func test_effectiveRiskDisplay_nilApprovalReason_mediumRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: nil, riskLevel: "medium"
+        )
+        XCTAssertEqual(result.displayLevel, "medium")
+        XCTAssertNil(result.inherentRisk)
+    }
+
+    func test_effectiveRiskDisplay_trustRuleAllowed_lowRisk() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: "trust_rule_allowed", riskLevel: "low"
+        )
+        XCTAssertEqual(result.displayLevel, "low")
+        XCTAssertNil(result.inherentRisk)
+    }
+
+    func test_effectiveRiskDisplay_nilRiskLevel_defaultsToUnknown() {
+        let result: (displayLevel: String, inherentRisk: String?) = effectiveRiskDisplay(
+            approvalReason: nil, riskLevel: nil
+        )
+        XCTAssertEqual(result.displayLevel, "unknown")
+        XCTAssertNil(result.inherentRisk)
     }
 }


### PR DESCRIPTION
## Summary
High-risk tool calls that are auto-approved via sandbox auto-approve (e.g., `rm somefile.txt` in the workspace) currently show a misleading red "High risk" badge. This PR introduces a distinct "Workspace" chip — a muted slate/blue-gray outlined pill that replaces the risk badge when `approvalReason === "sandbox_auto_approve"`.

The chip communicates that the action was scoped to the workspace without implying a risk judgment. Inherent risk is preserved in tooltips and audit logs. No backend/policy changes — purely presentational.

### Changes
- **Web**: New `getEffectiveRiskDisplay()` mapping function + `getRiskBadgeStyle("workspace")` in risk-utils, wired into ToolCallChip
- **macOS**: New `effectiveRiskDisplay()` in shared ApprovalProvenance.swift, wired into AssistantProgressView and ToolPermissionTesterView
- **Both**: `getProvenanceText("sandbox_auto_approve")` / `approvalProvenanceText()` now return nil (the chip replaces the provenance text)

### Design
- Label: "Workspace"
- Color: muted slate/blue-gray (`--surface-lift` / `VColor.surfaceLift`)
- Style: outlined (border, not filled) — visually distinct from low/medium/high traffic-light badges
- Tooltip: "Workspace · Inherent risk: High" — preserves full transparency
- Rule editor: still uses original risk level for trust rule creation

## PRs merged into feature branch
- #32262: feat(web): add Workspace chip style to risk-utils
- #32263: feat(macOS): add Workspace case to RiskBadgeView
- #32264: feat(web): render Workspace chip in ToolCallChip
- #32266: feat(macOS): render Workspace chip in AssistantProgressView
- #32267: feat(macOS): show Workspace chip in permission tester
- #32268: test: add test coverage for Workspace chip logic
- PR 6 (notifications): verified as no-op — sandbox auto-approved calls never trigger notifications

Part of plan: workspace-chip-sandbox-risk.md