### PR TITLE
feat: add queryParams to conversation list route + migrate fetchConversationList to generated SDK (LUM-1955)

### DIFF
--- a/apps/web/src/lib/conversations-api.ts
+++ b/apps/web/src/lib/conversations-api.ts
@@ -1,9 +1,7 @@
 /**
- * Conversation CRUD operations via the generated daemon SDK.
+ * Conversation data layer: listing, detail, predicates, and parsing.
  *
- * Handles listing, archiving, unarchiving, forking, renaming, reordering,
- * and analyzing conversations.
- *
+ * All daemon calls use the generated SDK (`@/generated/daemon/sdk.gen`).
  * The `Conversation` interface is a normalized client-side representation
  * (timestamps as ISO strings, attention fields flattened, `id` renamed to
  * `conversationId`). `parseConversation` transforms the raw daemon response
@@ -12,14 +10,13 @@
 
 import * as Sentry from "@sentry/browser";
 
-import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
   conversationsByIdGet,
+  conversationsGet,
   subagentsByIdGet,
 } from "@/generated/daemon/sdk.gen";
 import type {
   ConversationsGetResponse,
-  ConversationsGetResponses,
   GroupsGetResponse,
 } from "@/generated/daemon/types.gen";
 
@@ -295,18 +292,12 @@ async function fetchConversationList(
 
   for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
     const offset = page * CONVERSATION_LIST_PAGE_SIZE;
-    // The daemon route definition doesn't declare query parameters, so the
-    // generated SDK type has `query?: never`. Use the raw daemon client for
-    // the paginated list call.
-    const { data, error, response } = await daemonClient.get<
-      ConversationsGetResponses
-    >({
-      url: "/v1/assistants/{assistant_id}/conversations",
+    const { data, error, response } = await conversationsGet({
       path: { assistant_id: assistantId },
       query: {
-        ...(conversationType ? { conversationType } : {}),
         limit: CONVERSATION_LIST_PAGE_SIZE,
         offset,
+        ...(conversationType ? { conversationType } : {}),
       },
       throwOnError: false,
     });

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5156,6 +5156,27 @@ paths:
                   - nextOffset
                   - hasMore
                 additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Maximum number of conversations to return (default 50).
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Number of conversations to skip (default 0).
+        - name: conversationType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - background
+          description: Filter by conversation type. Pass "background" to list only background/scheduled conversations.
     post:
       operationId: conversations_post
       summary: Create a conversation

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -312,6 +312,28 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Paginated list of conversations with attention state and display metadata.",
     tags: ["conversations"],
+    queryParams: [
+      {
+        name: "limit",
+        type: "integer",
+        required: false,
+        description: "Maximum number of conversations to return (default 50).",
+      },
+      {
+        name: "offset",
+        type: "integer",
+        required: false,
+        description: "Number of conversations to skip (default 0).",
+      },
+      {
+        name: "conversationType",
+        type: "string",
+        required: false,
+        description:
+          'Filter by conversation type. Pass "background" to list only background/scheduled conversations.',
+        schema: { type: "string", enum: ["background"] },
+      },
+    ],
     responseBody: listConversationsResponseSchema,
     handler: handleListConversations,
   },


### PR DESCRIPTION
## Prompt / plan

The `GET /v1/conversations` daemon route handler reads `limit`, `offset`, and `conversationType` from query parameters, but the route definition didn't declare them in `queryParams`. This meant the generated OpenAPI spec had no query parameters for this endpoint, and the generated SDK typed `query` as `never` — forcing `fetchConversationList` to bypass the generated SDK and use the raw `daemonClient.get()` call.

This PR adds the missing `queryParams` declarations, regenerates the spec, and replaces the raw client call with the generated `conversationsGet()` SDK function. This eliminates the last raw daemon client usage in the conversations domain.

**What changed:**

| Layer | Change |
|-------|--------|
| Daemon route | Added `queryParams` array to `listConversations` route definition with `limit` (integer), `offset` (integer), `conversationType` (enum: `\"background\"`) |
| OpenAPI spec | Regenerated — `conversations_get` now has 3 query parameters |
| Web consumer | `fetchConversationList` now calls `conversationsGet()` instead of `daemonClient.get()`. Removed unused `client.gen` import |

**Why this is safe:**
- The daemon handler already reads these params from `queryParams` — adding the schema is purely declarative (no behavior change)
- The generated `conversationsGet()` calls the same URL with the same parameters as the raw client call
- Consumer code (`listConversations`, `getChatContext`, all sidebar/chat hooks) is unchanged
- All 22 conversation tests + 12 conversation query tests pass

**Alternatives not taken:**
- Could have migrated `fetchConversationList` to use `conversationsGetOptions()` (generated TanStack Query hook) directly, but the foreground+background parallel fetch + merge + sort composition makes a plain query hook impractical — that would need `useQueries` or a custom `queryFn`, which is a larger change

Closes LUM-1955

## Test plan

- `bunx tsc --noEmit` passes in both `assistant/` and `apps/web/`
- `bun run lint` passes in both packages
- `bun test src/domains/chat/api/conversations.test.ts` — 22/22 pass (listConversations pagination, parseConversation normalization)
- `bun test src/domains/conversations/conversation-queries.test.ts` — 12/12 pass
- Pre-push hook ran 32 related assistant tests — all pass

## CLI verb checklist

N/A — no new routes added. This only adds `queryParams` to an existing route definition.

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka