### PR TITLE
fix(providers): round-trip reasoning_content for multi-turn DeepSeek conversations

### DIFF
--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -34,6 +34,7 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
       // overrides (e.g. DeepSeek V4 → "max") come from
       // {@link resolveMaxReasoningEffort}.
       maxReasoningEffort: "high",
+      assistantReasoningField: "reasoning_content",
     });
   }
 

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+import {
+  OpenAIChatCompletionsProvider,
+  type OpenAIChatCompletionsProviderOptions,
+} from "../chat-completions-provider.js";
 
 type ReasoningDetail = {
   type?: string;
@@ -32,23 +35,35 @@ function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
   };
 }
 
-function stubProvider(chunks: MockChunk[]): {
+function stubProvider(
+  chunks: MockChunk[],
+  options?: OpenAIChatCompletionsProviderOptions,
+): {
   provider: OpenAIChatCompletionsProvider;
   events: Array<{ type: string; thinking?: string; text?: string }>;
+  requests: unknown[];
 } {
-  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  const provider = new OpenAIChatCompletionsProvider(
+    "test-key",
+    "test-model",
+    options,
+  );
+  const requests: unknown[] = [];
   // Swap the SDK client for a stub whose chat.completions.create returns our
   // canned async iterable.
   (provider as unknown as { client: unknown }).client = {
     chat: {
       completions: {
-        create: async () => makeStream(chunks),
+        create: async (params: unknown) => {
+          requests.push(params);
+          return makeStream(chunks);
+        },
       },
     },
   };
   const events: Array<{ type: string; thinking?: string; text?: string }> = [];
   (provider as unknown as { __events: typeof events }).__events = events;
-  return { provider, events };
+  return { provider, events, requests };
 }
 
 async function runStream(
@@ -231,5 +246,142 @@ describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
     const deltas = events.filter((e) => e.type === "thinking_delta");
     expect(deltas.map((d) => d.thinking)).toEqual(["it ", "worked", "!"]);
     expect(thinking).toBe("it worked!");
+  });
+
+  test("round-trips prior assistant thinking as reasoning_content when field is set", async () => {
+    const { provider, requests } = stubProvider(
+      [
+        {
+          choices: [{ delta: { content: "continued" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 4, completion_tokens: 2 },
+        },
+      ],
+      { assistantReasoningField: "reasoning_content" },
+    );
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "first question" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hidden chain state", signature: "" },
+          { type: "text", text: "first answer" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "follow up" }] },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        content: string | null;
+        reasoning_content?: string;
+      }>;
+    };
+    const assistantMsg = params.messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toEqual({
+      role: "assistant",
+      content: "first answer",
+      reasoning_content: "hidden chain state",
+    });
+  });
+
+  test("uses reasoning field for OpenRouter-style round-trip", async () => {
+    const { provider, requests } = stubProvider(
+      [
+        {
+          choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        },
+      ],
+      { assistantReasoningField: "reasoning" },
+    );
+
+    await provider.sendMessage([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "visible summary", signature: "" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        reasoning?: string;
+        reasoning_content?: string;
+      }>;
+    };
+    expect(params.messages[0].reasoning).toBe("visible summary");
+    expect(params.messages[0].reasoning_content).toBeUndefined();
+  });
+
+  test("drops thinking blocks when assistantReasoningField is unset", async () => {
+    const { provider, requests } = stubProvider([
+      {
+        choices: [{ delta: { content: "reply" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 1 },
+      },
+    ]);
+
+    await provider.sendMessage([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "should be dropped", signature: "" },
+          { type: "text", text: "visible" },
+        ],
+      },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        content: string | null;
+        reasoning?: string;
+        reasoning_content?: string;
+      }>;
+    };
+    const assistantMsg = params.messages[0];
+    expect(assistantMsg.content).toBe("visible");
+    expect(assistantMsg.reasoning).toBeUndefined();
+    expect(assistantMsg.reasoning_content).toBeUndefined();
+  });
+
+  test("skips Anthropic-originated thinking blocks (with signatures)", async () => {
+    const { provider, requests } = stubProvider(
+      [
+        {
+          choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        },
+      ],
+      { assistantReasoningField: "reasoning_content" },
+    );
+
+    await provider.sendMessage([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "anthropic thinking",
+            signature: "sig-abc",
+          },
+          { type: "thinking", thinking: "deepseek thinking", signature: "" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        reasoning_content?: string;
+      }>;
+    };
+    expect(params.messages[0].reasoning_content).toBe("deepseek thinking");
   });
 });

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -75,6 +75,10 @@ export interface OpenAIChatCompletionsProviderOptions {
    *  blocks. MiniMax and similar providers embed reasoning inside XML-style
    *  tags in the regular content field rather than using `reasoning_content`. */
   parseThinkTags?: boolean;
+  /** Wire field used to replay prior assistant thinking on multi-turn requests.
+   *  DeepSeek/Fireworks use `"reasoning_content"`; OpenRouter uses `"reasoning"`.
+   *  When unset, thinking blocks are dropped from outbound assistant messages. */
+  assistantReasoningField?: "reasoning" | "reasoning_content";
 }
 
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
@@ -146,6 +150,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private maxReasoningEffort: "high" | "xhigh" | "max";
   private requestHeaders: Record<string, string>;
   private parseThinkTags: boolean;
+  private assistantReasoningField:
+    | "reasoning"
+    | "reasoning_content"
+    | undefined;
 
   constructor(
     apiKey: string,
@@ -168,6 +176,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.maxReasoningEffort = options.maxReasoningEffort ?? "xhigh";
     this.requestHeaders = options.requestHeaders ?? {};
     this.parseThinkTags = options.parseThinkTags ?? false;
+    this.assistantReasoningField = options.assistantReasoningField;
   }
 
   async sendMessage(
@@ -661,6 +670,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     msg: Message,
   ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
     const textParts: string[] = [];
+    const reasoningParts: string[] = [];
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] =
       [];
 
@@ -668,6 +678,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
       switch (block.type) {
         case "text":
           textParts.push(block.text);
+          break;
+        case "thinking":
+          // Anthropic thinking blocks carry signatures — skip those.
+          if (!block.signature) reasoningParts.push(block.thinking);
           break;
         case "tool_use":
           toolCalls.push({
@@ -685,7 +699,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         case "web_search_tool_result":
           textParts.push("[Web search results]");
           break;
-        // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
+        // redacted_thinking, image — not applicable for OpenAI assistant messages
       }
     }
 
@@ -694,6 +708,15 @@ export class OpenAIChatCompletionsProvider implements Provider {
         role: "assistant",
         content: textParts.length > 0 ? textParts.join("") : null,
       };
+
+    if (reasoningParts.length > 0 && this.assistantReasoningField) {
+      (
+        result as OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam & {
+          reasoning?: string;
+          reasoning_content?: string;
+        }
+      )[this.assistantReasoningField] = reasoningParts.join("");
+    }
 
     if (toolCalls.length > 0) {
       result.tool_calls = toolCalls;

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -122,6 +122,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
       requestHeaders: OPENROUTER_APP_ATTRIBUTION_HEADERS,
+      assistantReasoningField: "reasoning",
     });
     this.openRouterApiKey = apiKey;
     this.defaultModel = model;


### PR DESCRIPTION
## Summary
- Add opt-in `assistantReasoningField` option to `OpenAIChatCompletionsProvider` for replaying prior assistant thinking on multi-turn requests
- Set `reasoning_content` on Fireworks, `reasoning` on OpenRouter; base class defaults to undefined (no round-trip) per review feedback on #32253
- Skip Anthropic-originated thinking blocks (with signatures) to avoid leaking cryptographic tokens to non-Anthropic providers
- Add regression tests for DeepSeek multi-turn replay, OpenRouter field selection, no-op when unset, and Anthropic signature filtering

Closes #30878

Based on the approach from #32253 by @RitwijParmar and #30879 by @awlevin.

## Original prompt
A Discord user reported that DeepSeek multi-turn conversations fail with a 400 error because `reasoning_content` is not round-tripped. The `toOpenAIAssistantMessage` method was dropping thinking blocks entirely. An external contributor's PR (#32253) had the right fix direction but defaulted `reasoning_content` for all providers — review feedback (Codex + Vargas) flagged that this should be opt-in per provider to avoid breaking generic OpenAI-compatible endpoints.

## Test plan
- [x] Existing reasoning parsing tests still pass (6 tests)
- [x] New test: round-trips `reasoning_content` when field is set (DeepSeek/Fireworks path)
- [x] New test: uses `reasoning` field for OpenRouter-style round-trip
- [x] New test: drops thinking blocks when `assistantReasoningField` is unset (base class)
- [x] New test: skips Anthropic-originated thinking blocks with signatures
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)