### PR TITLE
feat(evals): export sessions as JSONL

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -31,6 +31,7 @@ as a single grouped run.
 | Command                                    | Description                                                     |
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `evals run --profiles <ids> --tests <ids>` | Cartesian profile × test runner. `--label <text>` tags the run. |
+| `evals export --session <id> --out <path>` | Export a report session as JSONL for diffing and notebooks.     |
 | `evals server`                             | Local report-card server for `.runs` at `localhost:3005`.       |
 
 The report server is organized as a hierarchy:
@@ -41,6 +42,11 @@ The report server is organized as a hierarchy:
 - `/sessions/<id>/tests/<testId>/profiles/<profileId>` – execution detail
   with the metric card, transcript, container event log, and test-runner
   progress log for that specific run.
+
+Use `evals export --session <id> --out runs/<label>.jsonl` when you want a
+portable artifact for comparing eval runs outside the report server. The JSONL
+contains the session summary, per-test aggregate rows, and per-profile execution
+metric summaries without embedding full transcripts or raw event logs.
 
 ## Layout
 

--- a/evals/src/cli.ts
+++ b/evals/src/cli.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 
 import pkg from "../package.json";
 import { registerListCommands } from "./commands/list";
+import { registerExportCommand } from "./commands/export";
 import { registerRunCommand } from "./commands/run";
 import { registerServerCommand } from "./commands/server";
 
@@ -14,6 +15,7 @@ program
   .version(pkg.version);
 
 registerListCommands(program);
+registerExportCommand(program);
 registerRunCommand(program);
 registerServerCommand(program);
 

--- a/evals/src/commands/export.ts
+++ b/evals/src/commands/export.ts
@@ -1,0 +1,106 @@
+/** `evals export` — JSONL export for report-card artifacts. */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { Command } from "commander";
+
+import {
+  findExecutionRunId,
+  readReportRun,
+  readReportSession,
+  readTestInSession,
+} from "../lib/report-data";
+
+type ExportRecord =
+  | { type: "metadata"; schemaVersion: 1; exportedAt: string; sessionId: string }
+  | { type: "session"; session: Awaited<ReturnType<typeof readReportSession>> }
+  | {
+      type: "test";
+      test: NonNullable<Awaited<ReturnType<typeof readTestInSession>>>;
+    }
+  | {
+      type: "execution";
+      sessionId: string;
+      testId: string;
+      profileId: string;
+      run: {
+        runId: string;
+        status: string;
+        scoreTotal: number;
+        metricCount: number;
+        metrics: unknown[];
+        transcriptTurns: number;
+        assistantEventCount: number;
+        simulatorMessageCount: number;
+        totalInputTokens?: number;
+        totalOutputTokens?: number;
+        totalCostUsd?: number;
+      };
+    };
+
+function encodeJsonl(records: ExportRecord[]): string {
+  return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+}
+
+export function registerExportCommand(program: Command): void {
+  program
+    .command("export")
+    .description("Export a report session as JSONL for eval comparison")
+    .requiredOption("--session <id>", "Session id to export")
+    .requiredOption("--out <path>", "Output JSONL path")
+    .action(async (opts: { session: string; out: string }) => {
+      const session = await readReportSession(opts.session);
+      if (!session) {
+        throw new Error(`No session found for ${opts.session}`);
+      }
+
+      const records: ExportRecord[] = [
+        {
+          type: "metadata",
+          schemaVersion: 1,
+          exportedAt: new Date().toISOString(),
+          sessionId: opts.session,
+        },
+        { type: "session", session },
+      ];
+
+      for (const testEntry of session.tests) {
+        const test = await readTestInSession(opts.session, testEntry.testId);
+        if (!test) continue;
+        records.push({ type: "test", test });
+
+        for (const profile of test.profiles) {
+          const runId = await findExecutionRunId(
+            opts.session,
+            test.testId,
+            profile.profileId,
+          );
+          if (!runId) continue;
+          const run = await readReportRun(runId);
+          records.push({
+            type: "execution",
+            sessionId: opts.session,
+            testId: test.testId,
+            profileId: profile.profileId,
+            run: {
+              runId: run.runId,
+              status: run.status,
+              scoreTotal: run.scoreTotal,
+              metricCount: run.metricCount,
+              metrics: run.metrics,
+              transcriptTurns: run.transcriptTurns,
+              assistantEventCount: run.assistantEventCount,
+              simulatorMessageCount: run.simulatorMessageCount,
+              totalInputTokens: run.totalInputTokens,
+              totalOutputTokens: run.totalOutputTokens,
+              totalCostUsd: run.totalCostUsd,
+            },
+          });
+        }
+      }
+
+      await mkdir(dirname(opts.out), { recursive: true });
+      await writeFile(opts.out, encodeJsonl(records), "utf8");
+      console.log(`Exported ${records.length} records to ${opts.out}`);
+    });
+}


### PR DESCRIPTION
## Summary

Adds a portable JSONL export path for eval report sessions:

- new `evals export --session <id> --out <path>` command
- exports session summary, per-test aggregate rows, and per-profile execution metric summaries
- keeps full transcripts/raw event logs out of the export so the artifact is compact enough for diffs, notebooks, and CI-style comparison
- documents the command in `evals/README.md`

## Why

The eval report server is useful for inspection, but comparing personal-intelligence benchmark runs across model/profile changes still requires clicking through the browser. A compact JSONL export gives the team a stable artifact for offline analysis: trend dashboards, notebooks, regression diffs, or sharing a run summary in review without bundling the entire `.runs` directory.

This fits the eval harness direction: make qualitative agent behavior more measurable without turning the benchmark into a CI gate.

## Verification

- `git diff --check`

I could not run `bun run format:check` / `bun run typecheck` in this checkout because Bun and the evals package dependencies are not installed in the current environment.

## AI disclosure

I used an AI coding assistant to help draft this contribution. I reviewed the implementation before opening the PR.
