### PR TITLE
refactor(web): replace parseConversation(unknown) with typed toConversation transform (LUM-1956)

### DIFF
--- a/apps/web/src/domains/chat/api/conversations.test.ts
+++ b/apps/web/src/domains/chat/api/conversations.test.ts
@@ -1,125 +1,224 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
-import { listConversations, parseConversation } from "@/lib/conversations-api";
+import {
+  listConversations,
+  toConversation,
+  type RawConversationSummary,
+} from "@/lib/conversations-api";
 
-describe("parseConversation — originChannel plumbing", () => {
-  test("returns null for non-object input", () => {
-    expect(parseConversation(null)).toBeNull();
-    expect(parseConversation(undefined)).toBeNull();
-    expect(parseConversation("string")).toBeNull();
+/**
+ * Build a minimal valid `RawConversationSummary`. Callers override only the
+ * fields relevant to the test; everything else gets sensible defaults.
+ */
+function makeRaw(
+  overrides: Partial<RawConversationSummary> & { id: string },
+): RawConversationSummary {
+  return {
+    title: "",
+    createdAt: 0,
+    updatedAt: 0,
+    lastMessageAt: 0,
+    conversationType: "standard",
+    source: "vellum",
+    groupId: "",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// toConversation — field mapping
+// ---------------------------------------------------------------------------
+
+describe("toConversation — field mapping", () => {
+  test("maps id to conversationId", () => {
+    const result = toConversation(makeRaw({ id: "conv-123" }));
+    expect(result.conversationId).toBe("conv-123");
   });
 
-  test("returns null when neither conversationId nor id is present", () => {
-    expect(parseConversation({})).toBeNull();
+  test("converts epoch timestamps to ISO strings", () => {
+    const result = toConversation(
+      makeRaw({ id: "c", createdAt: 1710000000000, updatedAt: 1710000060000 }),
+    );
+    expect(result.createdAt).toBe(new Date(1710000000000).toISOString());
   });
 
-  test("prefers conversationId over id", () => {
-    const parsed = parseConversation({
-      conversationId: "from-conversation-id",
-      id: "from-id",
-    });
-    expect(parsed?.conversationId).toBe("from-conversation-id");
+  test("uses lastMessageAt falling back to updatedAt", () => {
+    const result = toConversation(
+      makeRaw({ id: "c", lastMessageAt: 1710000000000, updatedAt: 1 }),
+    );
+    expect(result.lastMessageAt).toBe(new Date(1710000000000).toISOString());
+
+    const fallback = toConversation(
+      makeRaw({ id: "c", lastMessageAt: null, updatedAt: 1710000060000 }),
+    );
+    expect(fallback.lastMessageAt).toBe(new Date(1710000060000).toISOString());
   });
 
-  test("falls back to id when conversationId is absent", () => {
-    const parsed = parseConversation({
-      id: "from-id",
-    });
-    expect(parsed?.conversationId).toBe("from-id");
+  test("flattens assistantAttention fields", () => {
+    const result = toConversation(
+      makeRaw({
+        id: "c",
+        assistantAttention: {
+          hasUnseenLatestAssistantMessage: true,
+          latestAssistantMessageAt: 1710000000000,
+          lastSeenAssistantMessageAt: 1709999000000,
+        },
+      }),
+    );
+    expect(result.hasUnseenLatestAssistantMessage).toBe(true);
+    expect(result.latestAssistantMessageAt).toBe(
+      new Date(1710000000000).toISOString(),
+    );
+    expect(result.lastSeenAssistantMessageAt).toBe(
+      new Date(1709999000000).toISOString(),
+    );
   });
 
-  test("ignores unrecognized identifier fields", () => {
-    // Defensive: a record carrying only an unknown identifier field (e.g.
-    // a hypothetical legacy `conversationKey`) should fail parsing rather
-    // than silently mapping it onto `conversationId`.
-    const parsed = parseConversation({
-      conversationKey: "ignored",
-    });
-    expect(parsed).toBeNull();
+  test("passes through scalar fields", () => {
+    const result = toConversation(
+      makeRaw({
+        id: "c",
+        archivedAt: 1710000000000,
+        groupId: "group-1",
+        source: "telegram",
+        isPinned: true,
+        conversationType: "background",
+        scheduleJobId: "job-1",
+        displayOrder: 3,
+      }),
+    );
+    expect(result.archivedAt).toBe(1710000000000);
+    expect(result.groupId).toBe("group-1");
+    expect(result.source).toBe("telegram");
+    expect(result.isPinned).toBe(true);
+    expect(result.conversationType).toBe("background");
+    expect(result.scheduleJobId).toBe("job-1");
+    expect(result.displayOrder).toBe(3);
   });
+});
 
+// ---------------------------------------------------------------------------
+// toConversation — originChannel coalescing
+// ---------------------------------------------------------------------------
+
+describe("toConversation — originChannel plumbing", () => {
   test("leaves originChannel undefined when neither field is present", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      title: "Hello",
-    });
-    expect(parsed?.originChannel).toBeUndefined();
+    const result = toConversation(makeRaw({ id: "c" }));
+    expect(result.originChannel).toBeUndefined();
   });
 
   test("reads originChannel from conversationOriginChannel as a fallback", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      conversationOriginChannel: "slack",
-    });
-    expect(parsed?.originChannel).toBe("slack");
+    const result = toConversation(
+      makeRaw({ id: "c", conversationOriginChannel: "slack" }),
+    );
+    expect(result.originChannel).toBe("slack");
   });
 
   test("prefers channelBinding.sourceChannel over conversationOriginChannel", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      channelBinding: { sourceChannel: "telegram" },
-      conversationOriginChannel: "slack",
-    });
-    expect(parsed?.originChannel).toBe("telegram");
-  });
-
-  test("treats non-string channelBinding.sourceChannel as missing", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      channelBinding: { sourceChannel: 42 },
-      conversationOriginChannel: "slack",
-    });
-    expect(parsed?.originChannel).toBe("slack");
+    const result = toConversation(
+      makeRaw({
+        id: "c",
+        channelBinding: {
+          sourceChannel: "telegram",
+          externalChatId: "ext-1",
+          externalUserId: "",
+          displayName: "",
+          username: "",
+        },
+        conversationOriginChannel: "slack",
+      }),
+    );
+    expect(result.originChannel).toBe("telegram");
   });
 
   test("treats notification:* origin channel as a literal pass-through", () => {
-    // `isChannelConversation` is the layer that excludes notification:*;
-    // the parser must preserve the raw value as-is so the predicate can
-    // make the decision.
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      conversationOriginChannel: "notification:reminder",
-    });
-    expect(parsed?.originChannel).toBe("notification:reminder");
+    const result = toConversation(
+      makeRaw({ id: "c", conversationOriginChannel: "notification:reminder" }),
+    );
+    expect(result.originChannel).toBe("notification:reminder");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toConversation — displayOrder
+// ---------------------------------------------------------------------------
+
+describe("toConversation — displayOrder", () => {
+  test("captures numeric displayOrder for drag-reordered conversations", () => {
+    const result = toConversation(
+      makeRaw({ id: "c", isPinned: true, displayOrder: 3 }),
+    );
+    expect(result.displayOrder).toBe(3);
   });
 
-  test("preserves Slack channel binding with id, name, and link", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      channelBinding: {
-        sourceChannel: "slack",
-        externalChatId: "C0123ABCDEF",
-        externalThreadId: "1710000000.000100",
-        externalChatName: "product",
-        slackChannel: {
-          id: "C0123ABCDEF",
-          name: "product",
-          link: "slack://channel?team=T0123&id=C0123ABCDEF",
-        },
-        slackThread: {
-          channelId: "C0123ABCDEF",
-          threadTs: "1710000000.000100",
-          link: {
-            appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
-            webUrl:
-              "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+  test("leaves displayOrder undefined when the field is absent", () => {
+    const result = toConversation(makeRaw({ id: "c" }));
+    expect(result.displayOrder).toBeUndefined();
+  });
+
+  test("treats non-finite displayOrder as missing", () => {
+    expect(
+      toConversation(makeRaw({ id: "c", displayOrder: Number.NaN }))
+        .displayOrder,
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toConversation — channel binding mapping
+// ---------------------------------------------------------------------------
+
+describe("toConversation — Slack channel binding", () => {
+  test("preserves Slack channel binding with name and link", () => {
+    const result = toConversation(
+      makeRaw({
+        id: "conv-123",
+        channelBinding: {
+          sourceChannel: "slack",
+          externalChatId: "C0123ABCDEF",
+          externalThreadId: "1710000000.000100",
+          externalChatName: "product",
+          externalUserId: "",
+          displayName: "",
+          username: "",
+          slackChannel: {
+            channelId: "C0123ABCDEF",
+            name: "product",
+            link: {
+              webUrl:
+                "https://example.slack.com/archives/C0123ABCDEF",
+            },
+          },
+          slackThread: {
+            channelId: "C0123ABCDEF",
+            threadTs: "1710000000.000100",
+            link: {
+              appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
+              webUrl:
+                "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+            },
           },
         },
-      },
-      conversationOriginChannel: "vellum",
-    });
+        conversationOriginChannel: "vellum",
+      }),
+    );
 
-    expect(parsed?.originChannel).toBe("slack");
-    expect(parsed?.channelBinding).toEqual({
+    expect(result.originChannel).toBe("slack");
+    expect(result.channelBinding).toEqual({
       sourceChannel: "slack",
       externalChatId: "C0123ABCDEF",
       externalThreadId: "1710000000.000100",
       externalChatName: "product",
+      externalUserId: "",
+      displayName: "",
+      username: "",
       slackChannel: {
-        id: "C0123ABCDEF",
+        channelId: "C0123ABCDEF",
         name: "product",
-        link: "slack://channel?team=T0123&id=C0123ABCDEF",
+        link: {
+          webUrl: "https://example.slack.com/archives/C0123ABCDEF",
+        },
       },
       slackThread: {
         channelId: "C0123ABCDEF",
@@ -133,62 +232,42 @@ describe("parseConversation — originChannel plumbing", () => {
     });
   });
 
-  test("does not throw for malformed or absent channelBinding", () => {
-    expect(
-      parseConversation({
-        conversationId: "conv-123",
-        channelBinding: "slack",
-      })?.channelBinding,
-    ).toBeUndefined();
+  test("falls back to conversationOriginChannel when channelBinding is absent", () => {
+    const result = toConversation(
+      makeRaw({ id: "conv-123", conversationOriginChannel: "slack" }),
+    );
 
-    const parsed = parseConversation({
-      conversationId: "conv-456",
-      channelBinding: {
-        sourceChannel: "slack",
-        externalChatId: 123,
-        slackChannel: {
-          id: 123,
-          name: "product",
+    expect(result.originChannel).toBe("slack");
+    expect(result.channelBinding).toBeUndefined();
+  });
+
+  test("preserves Slack actor identity fields on channel bindings", () => {
+    const result = toConversation(
+      makeRaw({
+        id: "conv-dm",
+        channelBinding: {
+          sourceChannel: "slack",
+          externalChatId: "D0123ABCDEF",
+          externalUserId: "U0123ABCDEF",
+          displayName: "Example User",
+          username: "example_user",
         },
-      },
-      conversationOriginChannel: "telegram",
-    });
+      }),
+    );
 
-    expect(parsed?.originChannel).toBe("slack");
-    expect(parsed?.channelBinding).toBeUndefined();
+    expect(result.channelBinding).toMatchObject({
+      sourceChannel: "slack",
+      externalChatId: "D0123ABCDEF",
+      externalUserId: "U0123ABCDEF",
+      displayName: "Example User",
+      username: "example_user",
+    });
   });
 });
 
-describe("parseConversation — displayOrder", () => {
-  test("captures numeric displayOrder for drag-reordered conversations", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-pinned",
-      isPinned: true,
-      displayOrder: 3,
-    });
-    expect(parsed?.displayOrder).toBe(3);
-  });
-
-  test("leaves displayOrder undefined when the field is absent", () => {
-    const parsed = parseConversation({ conversationId: "conv-fresh" });
-    expect(parsed?.displayOrder).toBeUndefined();
-  });
-
-  test("treats non-finite displayOrder as missing", () => {
-    expect(
-      parseConversation({
-        conversationId: "c1",
-        displayOrder: Number.NaN,
-      })?.displayOrder,
-    ).toBeUndefined();
-    expect(
-      parseConversation({
-        conversationId: "c2",
-        displayOrder: "0",
-      })?.displayOrder,
-    ).toBeUndefined();
-  });
-});
+// ---------------------------------------------------------------------------
+// listConversations — pagination
+// ---------------------------------------------------------------------------
 
 describe("listConversations — pagination", () => {
   const originalGet = daemonClient.get;
@@ -197,17 +276,46 @@ describe("listConversations — pagination", () => {
   };
 
   type Page = {
-    conversations: Array<{ conversationId: string }>;
+    conversations: Array<{
+      id: string;
+      title: string;
+      createdAt: number;
+      updatedAt: number;
+      lastMessageAt: number;
+      conversationType: "standard" | "background" | "scheduled";
+      source: string;
+      groupId: string;
+    }>;
     hasMore?: boolean;
   };
+
+  function makeConversationRow(id: string): Page["conversations"][number] {
+    return {
+      id,
+      title: "",
+      createdAt: 0,
+      updatedAt: 0,
+      lastMessageAt: 0,
+      conversationType: "standard",
+      source: "vellum",
+      groupId: "",
+    };
+  }
 
   function setupPagedResponses(pages: {
     foreground: Page[];
     background?: Page[];
-  }): { calls: Array<{ url: unknown; query: Record<string, unknown> | undefined }> } {
-    const calls: Array<{ url: unknown; query: Record<string, unknown> | undefined }> = [];
+  }): {
+    calls: Array<{ url: unknown; query: Record<string, unknown> | undefined }>;
+  } {
+    const calls: Array<{
+      url: unknown;
+      query: Record<string, unknown> | undefined;
+    }> = [];
     const foregroundQueue = [...pages.foreground];
-    const backgroundQueue = [...(pages.background ?? [{ conversations: [] }])];
+    const backgroundQueue = [
+      ...(pages.background ?? [{ conversations: [] }]),
+    ];
     daemonClient.get = mock(
       async (options: GetOptions & { url?: unknown }) => {
         calls.push({ url: options.url, query: options.query });
@@ -229,12 +337,12 @@ describe("listConversations — pagination", () => {
   });
 
   test("loops over pages until hasMore is false (>50 conversations preserved)", async () => {
-    const page1Items = Array.from({ length: 50 }, (_, i) => ({
-      conversationId: `foreground-${i}`,
-    }));
-    const page2Items = Array.from({ length: 30 }, (_, i) => ({
-      conversationId: `foreground-${50 + i}`,
-    }));
+    const page1Items = Array.from({ length: 50 }, (_, i) =>
+      makeConversationRow(`foreground-${i}`),
+    );
+    const page2Items = Array.from({ length: 30 }, (_, i) =>
+      makeConversationRow(`foreground-${50 + i}`),
+    );
     const { calls } = setupPagedResponses({
       foreground: [
         { conversations: page1Items, hasMore: true },
@@ -247,9 +355,6 @@ describe("listConversations — pagination", () => {
     expect(result).toHaveLength(80);
     expect(result.at(0)?.conversationId).toBe("foreground-0");
     expect(result.at(-1)?.conversationId).toBe("foreground-79");
-    // 2 foreground pages + 1 background page (empty by default). Foreground
-    // and background fetch in parallel via Promise.allSettled, so filter
-    // before asserting page offsets.
     expect(calls).toHaveLength(3);
     const foregroundCalls = calls.filter(
       (c) => c.query?.conversationType === undefined,
@@ -262,7 +367,7 @@ describe("listConversations — pagination", () => {
   test("stops on the first page when hasMore is false or absent", async () => {
     const { calls } = setupPagedResponses({
       foreground: [
-        { conversations: [{ conversationId: "only-one" }] },
+        { conversations: [makeConversationRow("only-one")] },
       ],
     });
 
@@ -276,7 +381,7 @@ describe("listConversations — pagination", () => {
   test("does not loop forever on hasMore=true with empty page", async () => {
     const { calls } = setupPagedResponses({
       foreground: [
-        { conversations: [{ conversationId: "a" }], hasMore: true },
+        { conversations: [makeConversationRow("a")], hasMore: true },
         { conversations: [], hasMore: true },
       ],
     });
@@ -285,110 +390,5 @@ describe("listConversations — pagination", () => {
 
     expect(result).toHaveLength(1);
     expect(calls).toHaveLength(3); // 2 foreground + 1 background
-  });
-});
-
-describe("parseConversation — Slack channel binding", () => {
-  test("preserves Slack channel binding with id, name, and link", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      channelBinding: {
-        sourceChannel: "slack",
-        externalChatId: "C0123ABCDEF",
-        externalThreadId: "1710000000.000100",
-        externalChatName: "product",
-        slackChannel: {
-          id: "C0123ABCDEF",
-          name: "product",
-          link: "slack://channel?team=T0123&id=C0123ABCDEF",
-        },
-        slackThread: {
-          channelId: "C0123ABCDEF",
-          threadTs: "1710000000.000100",
-          link: {
-            appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
-            webUrl: "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
-          },
-        },
-      },
-      conversationOriginChannel: "vellum",
-    });
-
-    expect(parsed?.originChannel).toBe("slack");
-    expect(parsed?.channelBinding).toEqual({
-      sourceChannel: "slack",
-      externalChatId: "C0123ABCDEF",
-      externalThreadId: "1710000000.000100",
-      externalChatName: "product",
-      slackChannel: {
-        id: "C0123ABCDEF",
-        name: "product",
-        link: "slack://channel?team=T0123&id=C0123ABCDEF",
-      },
-      slackThread: {
-        channelId: "C0123ABCDEF",
-        threadTs: "1710000000.000100",
-        link: {
-          appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
-          webUrl: "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
-        },
-      },
-    });
-  });
-
-  test("falls back to conversationOriginChannel when channelBinding is absent", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-123",
-      conversationOriginChannel: "slack",
-    });
-
-    expect(parsed?.originChannel).toBe("slack");
-    expect(parsed?.channelBinding).toBeUndefined();
-  });
-
-  test("preserves Slack actor identity fields on channel bindings", () => {
-    const parsed = parseConversation({
-      conversationId: "conv-dm",
-      channelBinding: {
-        sourceChannel: "slack",
-        externalChatId: "D0123ABCDEF",
-        externalUserId: "U0123ABCDEF",
-        displayName: "Alice",
-        username: "alice",
-      },
-    });
-
-    expect(parsed?.channelBinding).toMatchObject({
-      sourceChannel: "slack",
-      externalChatId: "D0123ABCDEF",
-      externalUserId: "U0123ABCDEF",
-      displayName: "Alice",
-      username: "alice",
-    });
-  });
-
-  test("does not throw for malformed or absent channelBinding", () => {
-    expect(
-      parseConversation({
-        conversationId: "conv-123",
-        channelBinding: "slack",
-      })?.channelBinding,
-    ).toBeUndefined();
-
-    const parsed = parseConversation({
-      conversationId: "conv-456",
-      channelBinding: {
-        sourceChannel: "slack",
-        externalChatId: 123,
-        slackChannel: {
-          id: 123,
-          name: "product",
-        },
-      },
-      conversationOriginChannel: "telegram",
-    });
-
-    expect(parsed?.originChannel).toBe("slack");
-    expect(parsed?.channelBinding).toBeUndefined();
   });
 });

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -34,7 +34,6 @@ function getSlackChannelLink(
   channelId?: string,
 ): string | undefined {
   if (slackChannel?.link) {
-    if (typeof slackChannel.link === "string") return slackChannel.link;
     return getSlackLinkUrl(slackChannel.link);
   }
   return getSlackChannelLinkFromMessageLink(messageLink, channelId);
@@ -101,8 +100,7 @@ function isChannelIdFallback(
   return (
     value === undefined ||
     value === channelBinding.externalChatId ||
-    value === channelBinding.slackChannel?.channelId ||
-    value === channelBinding.slackChannel?.id
+    value === channelBinding.slackChannel?.channelId
   );
 }
 
@@ -124,9 +122,7 @@ function getSlackChannelDisplayText(
   }
 
   return (
-    slackChannel?.channelId ??
-    slackChannel?.id ??
-    channelBinding.externalChatId
+    slackChannel?.channelId ?? channelBinding.externalChatId
   );
 }
 
@@ -186,9 +182,7 @@ export function SlackChannelFooter({
       : undefined;
   const slackChannel = channelBinding?.slackChannel;
   const channelId =
-    slackChannel?.channelId ??
-    slackChannel?.id ??
-    channelBinding?.externalChatId;
+    slackChannel?.channelId ?? channelBinding?.externalChatId;
   const messageChannel = getSlackMessageChannel(messages, channelId);
   const isDmChannel = isSlackDmChannelId(channelId);
   const channelDisplayText = channelBinding

--- a/apps/web/src/lib/conversations-api.ts
+++ b/apps/web/src/lib/conversations-api.ts
@@ -1,10 +1,10 @@
 /**
- * Conversation data layer: listing, detail, predicates, and parsing.
+ * Conversation data layer: listing, detail, predicates, and transforms.
  *
  * All daemon calls use the generated SDK (`@/generated/daemon/sdk.gen`).
  * The `Conversation` interface is a normalized client-side representation
  * (timestamps as ISO strings, attention fields flattened, `id` renamed to
- * `conversationId`). `parseConversation` transforms the raw daemon response
+ * `conversationId`). `toConversation` transforms the typed daemon response
  * into this shape. `ConversationGroup` is re-exported from the generated SDK.
  */
 
@@ -16,15 +16,13 @@ import {
   subagentsByIdGet,
 } from "@/generated/daemon/sdk.gen";
 import type {
+  ConversationsByIdGetResponse,
   ConversationsGetResponse,
   GroupsGetResponse,
 } from "@/generated/daemon/types.gen";
 
 import { ApiError, assertHasResponse, extractErrorMessage } from "@/lib/api-errors";
-import {
-  parseSlackMessageLink,
-  type SlackMessageLink,
-} from "@/utils/slack-message-link";
+import type { SlackMessageLink } from "@/utils/slack-message-link";
 
 // ---------------------------------------------------------------------------
 // Conversations
@@ -78,10 +76,9 @@ export interface ConversationChannelBinding {
 }
 
 export interface ConversationSlackChannel {
-  id?: string;
   channelId?: string;
   name?: string;
-  link?: string | SlackMessageLink;
+  link?: SlackMessageLink;
 }
 
 export interface ConversationSlackThread {
@@ -94,192 +91,124 @@ export interface ConversationSlackThread {
 export type ConversationGroup = GroupsGetResponse["groups"][number];
 
 // ---------------------------------------------------------------------------
-// Parsing helpers — transform raw daemon payloads into Conversation shape
+// Raw daemon conversation type + typed transform
 // ---------------------------------------------------------------------------
 
-function normalizeTimestamp(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
+/** Single conversation row from the generated daemon SDK response. */
+export type RawConversationSummary =
+  ConversationsGetResponse["conversations"][number];
+
+/** Single conversation detail from the generated daemon SDK response. */
+type RawConversationDetail =
+  ConversationsByIdGetResponse["conversation"];
+
+function epochToIso(value: number | unknown): string | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
     return new Date(value).toISOString();
   }
   return undefined;
 }
 
-function parseSlackChannel(raw: unknown): ConversationSlackChannel | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-
-  const record = raw as Record<string, unknown>;
-  const id = typeof record.id === "string" ? record.id : undefined;
-  const channelId =
-    typeof record.channelId === "string" ? record.channelId : undefined;
-  if (!id && !channelId) return undefined;
-
-  const link =
-    typeof record.link === "string"
-      ? record.link
-      : parseSlackMessageLink(record.link);
-  const hasLink =
-    typeof link === "string" ||
-    (typeof link === "object" && (Boolean(link.appUrl) || Boolean(link.webUrl)));
-
-  return {
-    ...(id ? { id } : {}),
-    ...(channelId ? { channelId } : {}),
-    name: typeof record.name === "string" ? record.name : undefined,
-    ...(hasLink ? { link } : {}),
-  };
+function asString(value: string | unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
-function parseSlackThread(raw: unknown): ConversationSlackThread | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-
-  const record = raw as Record<string, unknown>;
-  if (
-    typeof record.channelId !== "string" ||
-    typeof record.threadTs !== "string"
-  ) {
-    return undefined;
-  }
-
-  const link = parseSlackMessageLink(record.link);
-
-  return {
-    channelId: record.channelId,
-    threadTs: record.threadTs,
-    ...(link?.appUrl || link?.webUrl ? { link } : {}),
-  };
+function asNumber(value: number | unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
-function parseChannelBinding(
-  raw: unknown,
+function mapChannelBinding(
+  raw: RawConversationSummary["channelBinding"],
 ): ConversationChannelBinding | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-
-  const record = raw as Record<string, unknown>;
-  if (
-    typeof record.sourceChannel !== "string" ||
-    typeof record.externalChatId !== "string"
-  ) {
-    return undefined;
-  }
-
-  const slackChannel = parseSlackChannel(record.slackChannel);
-  const slackThread = parseSlackThread(record.slackThread);
-
+  if (!raw) return undefined;
   return {
-    sourceChannel: record.sourceChannel,
-    externalChatId: record.externalChatId,
-    externalThreadId:
-      typeof record.externalThreadId === "string"
-        ? record.externalThreadId
-        : undefined,
-    externalChatName:
-      typeof record.externalChatName === "string"
-        ? record.externalChatName
-        : undefined,
-    externalUserId:
-      typeof record.externalUserId === "string"
-        ? record.externalUserId
-        : undefined,
-    displayName:
-      typeof record.displayName === "string"
-        ? record.displayName
-        : undefined,
-    username:
-      typeof record.username === "string" ? record.username : undefined,
-    ...(slackChannel ? { slackChannel } : {}),
-    ...(slackThread ? { slackThread } : {}),
+    sourceChannel: raw.sourceChannel,
+    externalChatId: raw.externalChatId,
+    externalThreadId: raw.externalThreadId,
+    externalChatName: raw.externalChatName,
+    externalUserId: asString(raw.externalUserId),
+    displayName: asString(raw.displayName),
+    username: asString(raw.username),
+    slackChannel: raw.slackChannel
+      ? {
+          channelId: raw.slackChannel.channelId,
+          name: raw.slackChannel.name,
+          link: raw.slackChannel.link?.webUrl
+            ? { webUrl: raw.slackChannel.link.webUrl }
+            : undefined,
+        }
+      : undefined,
+    slackThread: raw.slackThread
+      ? {
+          channelId: raw.slackThread.channelId,
+          threadTs: raw.slackThread.threadTs,
+          link:
+            raw.slackThread.link?.appUrl || raw.slackThread.link?.webUrl
+              ? {
+                  appUrl: raw.slackThread.link.appUrl,
+                  webUrl: raw.slackThread.link.webUrl,
+                }
+              : undefined,
+        }
+      : undefined,
   };
 }
 
-export function parseConversation(raw: unknown): Conversation | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const record = raw as Record<string, unknown>;
-  // Read `conversationId` (the canonical entity field name) with `id` as a
-  // synonym. The daemon's `serializeConversationSummary` emits `id` only
-  // today; `conversationId` exists for forward compatibility (LUM-1890).
-  const conversationId =
-    typeof record.conversationId === "string"
-      ? record.conversationId
-      : typeof record.id === "string"
-        ? record.id
-        : null;
-
-  if (!conversationId) return null;
-
-  const attention =
-    record.assistantAttention &&
-    typeof record.assistantAttention === "object"
-      ? (record.assistantAttention as ConversationAttentionPayload)
-      : undefined;
-
-  const channelBinding =
-    record.channelBinding && typeof record.channelBinding === "object"
-      ? (record.channelBinding as Record<string, unknown>)
-      : null;
-  const parsedChannelBinding = parseChannelBinding(channelBinding);
-  // Read sourceChannel from the raw binding (before strict parsing) so
-  // originChannel is populated even when externalChatId is absent.
-  const bindingSourceChannel =
-    channelBinding && typeof channelBinding.sourceChannel === "string"
-      ? channelBinding.sourceChannel
-      : undefined;
-  const conversationOriginChannel =
-    typeof record.conversationOriginChannel === "string"
-      ? record.conversationOriginChannel
-      : undefined;
+/**
+ * Transform a typed daemon conversation summary into the client-side
+ * `Conversation` shape. Handles `id` → `conversationId` rename,
+ * epoch → ISO timestamp conversion, and attention field flattening.
+ */
+export function toConversation(raw: RawConversationSummary): Conversation {
+  const attention = raw.assistantAttention;
   // Match the macOS coalescing order in ConversationRestorer.swift:
   //   channelBinding?.sourceChannel ?? conversationOriginChannel
-  const originChannel = bindingSourceChannel ?? conversationOriginChannel;
+  const originChannel =
+    raw.channelBinding?.sourceChannel ??
+    asString(raw.conversationOriginChannel);
 
   return {
-    conversationId,
-    title: typeof record.title === "string" ? record.title : undefined,
-    createdAt: normalizeTimestamp(record.createdAt),
-    lastMessageAt: normalizeTimestamp(
-      record.lastMessageAt ?? record.updatedAt,
-    ),
+    conversationId: raw.id,
+    title: raw.title,
+    createdAt: epochToIso(raw.createdAt),
+    lastMessageAt: epochToIso(raw.lastMessageAt ?? raw.updatedAt),
     hasUnseenLatestAssistantMessage:
-      typeof attention?.hasUnseenLatestAssistantMessage === "boolean"
-        ? attention.hasUnseenLatestAssistantMessage
-        : undefined,
-    latestAssistantMessageAt: normalizeTimestamp(
-      attention?.latestAssistantMessageAt,
-    ),
-    lastSeenAssistantMessageAt: normalizeTimestamp(
+      attention?.hasUnseenLatestAssistantMessage,
+    latestAssistantMessageAt: epochToIso(attention?.latestAssistantMessageAt),
+    lastSeenAssistantMessageAt: epochToIso(
       attention?.lastSeenAssistantMessageAt,
     ),
-    archivedAt:
-      typeof record.archivedAt === "number" ? record.archivedAt : undefined,
-    groupId:
-      typeof record.groupId === "string" ? record.groupId : undefined,
-    source:
-      typeof record.source === "string" ? record.source : undefined,
-    isPinned:
-      typeof record.isPinned === "boolean" ? record.isPinned : undefined,
-    conversationType:
-      typeof record.conversationType === "string" ? record.conversationType : undefined,
-    scheduleJobId:
-      typeof record.scheduleJobId === "string" ? record.scheduleJobId : undefined,
-    displayOrder:
-      typeof record.displayOrder === "number" && Number.isFinite(record.displayOrder)
-        ? record.displayOrder
-        : undefined,
-    channelBinding: parsedChannelBinding,
+    archivedAt: raw.archivedAt,
+    groupId: asString(raw.groupId),
+    source: raw.source,
+    isPinned: raw.isPinned,
+    conversationType: raw.conversationType,
+    scheduleJobId: raw.scheduleJobId,
+    displayOrder: asNumber(raw.displayOrder),
+    channelBinding: mapChannelBinding(raw.channelBinding),
     originChannel,
   };
+}
+
+/**
+ * Transform a typed daemon conversation detail into the client-side
+ * `Conversation` shape. The detail response shares the same structure
+ * as summary rows.
+ */
+function detailToConversation(
+  raw: RawConversationDetail,
+): Conversation {
+  // The detail and summary types share the same shape from the daemon
+  // serializer. Cast is safe because both are produced by
+  // `serializeConversationSummary` in the daemon.
+  return toConversation(raw as RawConversationSummary);
 }
 
 // ---------------------------------------------------------------------------
 // Conversation list fetching with pagination
 // ---------------------------------------------------------------------------
-
-interface ConversationAttentionPayload {
-  hasUnseenLatestAssistantMessage?: unknown;
-  latestAssistantMessageAt?: unknown;
-  lastSeenAssistantMessageAt?: unknown;
-}
 
 const CONVERSATION_LIST_PAGE_SIZE = 50;
 const CONVERSATION_LIST_MAX_PAGES = 200;
@@ -307,18 +236,13 @@ async function fetchConversationList(
       throw new ApiError(response.status, msg);
     }
 
-    const payload = data as ConversationsGetResponse | undefined;
-    const rawItems = payload?.conversations ?? [];
-    const pageItems = rawItems
-      .map((conversation) => parseConversation(conversation))
-      .filter((conversation): conversation is Conversation => conversation !== null);
+    const conversations = data?.conversations ?? [];
+    all.push(...conversations.map(toConversation));
 
-    all.push(...pageItems);
-
-    const hasMore = payload?.hasMore ?? false;
+    const hasMore = data?.hasMore ?? false;
     if (!hasMore) break;
 
-    if (pageItems.length === 0) break;
+    if (conversations.length === 0) break;
   }
 
   return all;
@@ -364,18 +288,13 @@ export async function fetchConversationDetail(
     );
     throw new ApiError(response.status, msg);
   }
-  const payload =
-    data && typeof data === "object" && !Array.isArray(data)
-      ? (data as { conversation?: unknown })
-      : null;
-  const parsed = parseConversation(payload?.conversation ?? null);
-  if (!parsed) {
+  if (!data?.conversation) {
     throw new ApiError(
       response.status,
       "Conversation detail payload was malformed.",
     );
   }
-  return parsed;
+  return detailToConversation(data.conversation);
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Replace ~170 lines of manual `typeof` guards in `parseConversation(raw: unknown)` with a typed `toConversation(raw: RawConversationSummary)` transform that takes the generated daemon SDK type directly.

**Problem:** The generated SDK returns `ConversationsGetResponse` with fully typed conversation objects, but `parseConversation` accepts `unknown` and manually checks `typeof` on every single field (~170 lines of runtime type guards). This is redundant — the SDK already guarantees the shape at compile time.

**Solution:**
- Extract `RawConversationSummary` from `ConversationsGetResponse["conversations"][number]`
- New `toConversation(raw: RawConversationSummary): Conversation` — typed, ~30 lines
- New `mapChannelBinding()` — typed helper for channel binding fields
- Small utility helpers: `epochToIso()`, `asString()`, `asNumber()` for fields with `| unknown` unions in the generated type
- `detailToConversation()` for single-conversation fetches using `ConversationsByIdGetResponse`

**What was deleted:**
- `parseConversation(raw: unknown)` — the main ~80-line function with typeof guards
- `parseSlackChannel(raw: unknown)` — channel parsing from unknown
- `parseSlackThread(raw: unknown)` — thread parsing from unknown  
- `parseChannelBinding(raw: unknown)` — binding parsing from unknown
- `normalizeTimestamp(value: unknown)` — replaced by typed `epochToIso()`
- `ConversationAttentionPayload` interface — no longer needed with typed input

**Bugs fixed (discovered during audit):**
- `ConversationSlackChannel.id` field was dead — the daemon returns `channelId`, never `id`. Removed from interface.
- `ConversationSlackChannel.link` was typed `string | SlackMessageLink` but the daemon always returns an object, never a plain string. Removed the `string` case.
- `slack-channel-footer.tsx` had a dead `typeof slackChannel.link === "string"` branch. Removed.
- Three fallback references to `slackChannel?.id` in `slack-channel-footer.tsx` were always `undefined`. Removed.

**Alternatives considered:**
- Keep `parseConversation` but narrow the input type — rejected because the function's entire structure (typeof guards on every field) exists to handle `unknown` input. With typed input, the guards are dead code.
- Inline the transform into each call site — rejected because the `id → conversationId` rename and attention flattening logic should be centralized.

PR 1 of 3 in the conversation queries architectural rework (LUM-1956 → LUM-1957 → LUM-1958).

Closes LUM-1956

## Test plan

- `bunx tsc --noEmit` — passes (0 errors)
- `bun run lint` — passes
- `bun test src/domains/chat/api/conversations.test.ts` — 18/18 tests pass
- Tests rewritten to use typed `makeRaw()` helper instead of passing arbitrary `unknown` objects
- Test coverage: field mapping, originChannel coalescing, displayOrder, Slack channel binding, pagination

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka