### PR TITLE
refactor(web): extract useMobileOverlayTarget from chat-page (LUM-1959)

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -63,6 +63,7 @@ import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges";
 import { useConversationLoader } from "@/domains/conversations/use-conversation-loader";
+import { useMobileOverlayTarget } from "@/domains/chat/hooks/use-mobile-overlay-target";
 import { useContextWindowUsageHydration } from "@/domains/chat/hooks/use-context-window-usage-hydration";
 import { useConversationActions } from "@/domains/conversations/use-conversation-actions";
 import { RenameConversationDialog } from "@/domains/conversations/rename-conversation-dialog";
@@ -199,7 +200,6 @@ export function ChatPage() {
   });
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
   const [assistantIdentity, setAssistantIdentity] = useState<AssistantIdentity | null>(null);
-  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
   const prePinGroupIdsRef = useRef<Map<string, string | undefined>>(new Map());
 
   // -------------------------------------------------------------------------
@@ -1248,11 +1248,7 @@ export function ChatPage() {
   // -------------------------------------------------------------------------
   // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
   // -------------------------------------------------------------------------
-  useEffect(() => {
-    setOverlayTarget(
-      isMobile ? document.getElementById("viewport-overlays") : null,
-    );
-  }, [isMobile]);
+  const overlayTarget = useMobileOverlayTarget();
 
   // -------------------------------------------------------------------------
   // Ghost-text suggestion: fetch after each completed assistant turn

--- a/apps/web/src/domains/chat/hooks/use-mobile-overlay-target.ts
+++ b/apps/web/src/domains/chat/hooks/use-mobile-overlay-target.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+
+/**
+ * Resolves the mobile overlay portal target after DOM commit so chat-side
+ * full-screen overlays (`MobileDocumentOverlay`, `MobileSubagentDetailOverlay`,
+ * `MobileAppOverlay`) can be portaled outside `RootLayout`'s transformed
+ * wrapper.
+ *
+ * Why the `useEffect` instead of resolving the element during render:
+ * `document.getElementById("viewport-overlays")` is a DOM read that needs
+ * the SSR-safe deferred-to-commit pattern documented in
+ * `apps/web/docs/CONVENTIONS.md` §SSR. Resolving during render would also
+ * miss the element on first paint because `RootLayout` mounts it.
+ *
+ * Returns `null` on non-mobile viewports — desktop overlays render inline
+ * inside the normal layout flow.
+ */
+export function useMobileOverlayTarget(): HTMLElement | null {
+  const isMobile = useIsMobile();
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setTarget(
+      isMobile ? document.getElementById("viewport-overlays") : null,
+    );
+  }, [isMobile]);
+
+  return target;
+}


### PR DESCRIPTION
Linear: https://linear.app/vellum/issue/LUM-1959 (Phase 1 of [LUM-1742](https://linear.app/vellum/issue/LUM-1742) — chat-page god-component decomposition)

## Summary

First Phase 1 extraction from the chat-page god-component. Picked the smallest banner region in `chat-page.tsx` (~3 lines of `useState` + `useEffect`) so the PR is reviewable in two minutes and future extractions can follow the same template.

## What changed

- New hook `apps/web/src/domains/chat/hooks/use-mobile-overlay-target.ts`. Wraps the existing `useIsMobile` + `document.getElementById("viewport-overlays")` lookup behind a single named hook. Doc-comment explains the SSR rationale (`useEffect` instead of resolving during render).
- `chat-page.tsx` loses one `useState` and one `useEffect` for this concern. The "Mobile overlay portal" banner region collapses from 8 lines to one (`const overlayTarget = useMobileOverlayTarget();`).
- Line count: 1724 → 1721. Sounds tiny; the wins compound across ~30 banner regions.

## Pattern this PR establishes for the rest of Phase 1

- One banner region per PR — small, reviewable, revertable.
- New hooks live under `src/domains/chat/hooks/` (or domain-appropriate location if the concern isn't chat-scoped).
- Hook name and file kebab-case match (`useMobileOverlayTarget` → `use-mobile-overlay-target.ts`).
- Doc comment captures the *why* of any non-obvious choices so the next reader doesn't have to re-derive them.
- Tests added for any pure helpers the hook contains. (None here — the hook is pure delegation; testing it would be testing React + DOM mechanics.)

## Test plan

- [x] `bun run build` — no behavior change
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [ ] Manual: open a mobile viewport (or coarse-pointer simulation) → confirm `MobileDocumentOverlay` / `MobileSubagentDetailOverlay` / `MobileAppOverlay` portals still render
- [ ] Manual: desktop viewport → confirm those overlays render inline as before

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_