### PR TITLE
[LUM-1802] fix(web): defer text selection in rename dialog for iOS WKWebView

### DIFF
--- a/apps/web/docs/CAPACITOR.md
+++ b/apps/web/docs/CAPACITOR.md
@@ -84,6 +84,30 @@ References:
 
 ---
 
+## Programmatic text selection requires frame deferral on iOS
+
+iOS Safari/WKWebView ignores `HTMLInputElement.select()` and `setSelectionRange()` when called synchronously during `focus()` — the editing context (keyboard, selection system) isn't initialized until the next animation frame. This affects any code that programmatically focuses an input and immediately tries to select its content.
+
+**Always defer selection to the next frame after focus:**
+
+```ts
+input.focus();
+requestAnimationFrame(() => {
+  input.setSelectionRange(0, input.value.length);
+});
+```
+
+Prefer `setSelectionRange(start, end)` over `select()` — it's more explicit about the selection range and behaves consistently across browsers. The single-frame delay is imperceptible on all platforms.
+
+This commonly arises with Radix Dialog's `onOpenAutoFocus`, which fires synchronously when the dialog content mounts. Desktop browsers tolerate synchronous focus + select, so the issue only surfaces on iOS.
+
+References:
+- WebKit — [Bug 224425: `select()` does not work in programmatically focused input](https://bugs.webkit.org/show_bug.cgi?id=224425)
+- MDN — [`HTMLInputElement.setSelectionRange()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange)
+- MDN — [`requestAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)
+
+---
+
 ## Deep links (Capacitor `appUrlOpen`)
 
 Native OAuth completion auto-dismisses `SFSafariViewController` by redirecting to a registered custom URL scheme (`vellum-assistant://`, `-dev`, `-staging`) and routing the URL via the `@capacitor/app` plugin's `appUrlOpen` listener. The router is mounted globally for the app routes; pure utilities and the typed `WindowEventMap` augmentation live in [`src/runtime/native-deep-link.ts`](../src/runtime/native-deep-link.ts).

--- a/apps/web/src/domains/conversations/rename-conversation-dialog.tsx
+++ b/apps/web/src/domains/conversations/rename-conversation-dialog.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 
 import { Button, Input, Modal } from "@vellum/design-library";
 
@@ -38,6 +38,7 @@ function RenameConversationDialog({
   onSubmit,
   onCancel,
 }: RenameConversationDialogProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(currentTitle);
 
   // Reset the field each time a new rename request opens so the input
@@ -76,12 +77,16 @@ function RenameConversationDialog({
         // pre-filled title — select-all so typing replaces it in one
         // motion, the same UX as `window.prompt`.
         onOpenAutoFocus={(event) => {
-          const content = event.currentTarget as HTMLElement | null;
-          const input = content?.querySelector<HTMLInputElement>("input");
+          event.preventDefault();
+          const input = inputRef.current;
           if (input) {
-            event.preventDefault();
             input.focus();
-            input.select();
+            // iOS Safari/WKWebView ignores selection APIs called
+            // synchronously during focus — the editing context isn't
+            // ready until the next frame.
+            requestAnimationFrame(() => {
+              input.setSelectionRange(0, input.value.length);
+            });
           }
         }}
         // When stacked inside another modal, Escape should close only
@@ -100,6 +105,7 @@ function RenameConversationDialog({
           </Modal.Header>
           <Modal.Body>
             <Input
+              ref={inputRef}
               label="Name"
               value={value}
               onChange={(event) => setValue(event.target.value)}


### PR DESCRIPTION
iOS Safari/WKWebView silently ignores `HTMLInputElement.select()` when called synchronously during `focus()` — the editing context (keyboard, selection system) isn't initialized until the next animation frame. This causes the rename conversation dialog's pre-filled title to not be auto-selected on iOS, forcing users to manually clear the text before typing a new name.

The fix defers selection to the next frame via `requestAnimationFrame` + `setSelectionRange`, which is the [WebKit-recommended pattern](https://bugs.webkit.org/show_bug.cgi?id=224425) for programmatic text selection after focus. Also refactors from `querySelector` to a React ref for type-safe, DOM-structure-independent input access, and adds a permanent guideline to `docs/CAPACITOR.md` so future iOS input work follows this pattern.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/410f1c2479b6483290a560ff8df86166

## Why this is safe

- `requestAnimationFrame` adds ~16ms of delay before selection — imperceptible on all platforms.
- `setSelectionRange(0, value.length)` is functionally identical to `select()` but [more explicit about the range](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange). Desktop behavior is unchanged.
- The ref replaces a `querySelector("input")` call, which is fragile to DOM restructuring. The `Input` component already accepts a `ref` prop forwarded to the native `<input>`.
- All 12 existing tests pass unchanged.

## References

- WebKit — [Bug 224425: `select()` does not work in programmatically focused input](https://bugs.webkit.org/show_bug.cgi?id=224425)
- MDN — [`HTMLInputElement.setSelectionRange()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange)
- MDN — [`requestAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)
- Radix — [`Dialog` `onOpenAutoFocus`](https://www.radix-ui.com/primitives/docs/components/dialog#content)

## Alternatives considered and rejected

1. **`setTimeout(0)` instead of `requestAnimationFrame`** — Both defer execution past the current task, but `requestAnimationFrame` is semantically correct for visual/layout-dependent operations and aligns with the browser's rendering cycle. `setTimeout(0)` has unpredictable scheduling relative to paint.
2. **Selecting in an `onFocus` handler on the `<Input>`** — Would re-select text every time the input gains focus (e.g., user clicks away then back), which is surprising UX. Selection should only happen on initial dialog open.
3. **Keeping `querySelector` instead of a ref** — Works but is fragile (assumes exactly one `<input>` inside the dialog content DOM) and isn't idiomatic React. A ref is type-safe and survives DOM restructuring.
4. **Double `requestAnimationFrame` (two-frame deferral)** — Some older iOS versions needed two frames. Single-frame deferral is sufficient for iOS 18+ (the reporter's device runs iOS 26.4.2). If older devices surface issues, this can be added later with a targeted `setTimeout(50)` fallback.

## Root cause analysis

1. **How did the code get into this state?** PR [#32169](https://github.com/vellum-ai/vellum-assistant/pull/32169) (merged 2026-05-27) replaced `window.prompt` with an in-app Modal dialog. The `onOpenAutoFocus` handler called `input.focus()` then `input.select()` synchronously — standard DOM API usage that works on desktop browsers.

2. **What decisions led to it?** `input.select()` is the canonical DOM API for selecting all text. The iOS timing quirk where the editing context isn't ready during the same event loop tick as `focus()` is a non-obvious WebKit behavior that doesn't surface during desktop development or testing.

3. **Were there warning signs?** The PR didn't include iOS-specific testing, and `docs/CAPACITOR.md` had no guidance about programmatic text selection timing. The iOS overlay dismiss fix in [#32282](https://github.com/vellum-ai/vellum-assistant/pull/32282) (also merged today) shows a pattern of iOS-specific DOM behaviors not being caught before merge.

4. **What can we do to prevent this?** Added a "Programmatic text selection requires frame deferral on iOS" section to `docs/CAPACITOR.md` with the correct pattern and references. This ensures future developers and agents who read the mandatory iOS guidance doc will use `requestAnimationFrame` + `setSelectionRange` instead of synchronous `select()`.

5. **AGENTS.md update?** No change to `AGENTS.md` — the existing `apps/web/AGENTS.md` already points to `docs/CAPACITOR.md` as mandatory reading for iOS code paths. The new CAPACITOR.md section is the right home for this guidance since it's iOS-specific and sits alongside the other WebKit behavioral quirks documented there.

## Prompt / plan
Investigate and fix LUM-1802 — iOS TestFlight feedback requesting auto-highlighted text when renaming conversations.

## Test plan
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun test src/domains/conversations/rename-conversation-dialog.test.tsx` — 12/12 pass
- Desktop behavior unchanged: `setSelectionRange(0, value.length)` after `requestAnimationFrame` is functionally identical to synchronous `select()`
- iOS: the `requestAnimationFrame` deferral gives WebKit time to initialize the editing context after focus