### PR TITLE
fix(web): show live subagent metrics instead of skeletons

### DIFF
--- a/apps/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -1,8 +1,8 @@
 /**
- * The detail panel shows skeleton Input/Output/Cost cards while a subagent is
- * still active and the daemon has not yet reported usage (all zeros). Once any
- * usage arrives — or the subagent reaches a terminal status — real formatted
- * values render, including a legitimate `0` / `0.00` for a trivial run.
+ * The detail panel's Input/Output/Cost cards always render their real
+ * formatted values. The metrics stream in as the subagent makes LLM calls, so
+ * the cards start at `0` / `0.00` and tick up — there are no skeleton loading
+ * states, even while the subagent is still running with zeroed usage.
  *
  * Heavy children (avatar, status badge, timeline) are stubbed so we can assert
  * the metric-row behavior without depending on their internals.
@@ -46,7 +46,7 @@ function makeEntry(overrides: Partial<SubagentEntry> = {}): SubagentEntry {
   };
 }
 
-/** A skeleton metric value is a pulsing bar; real values are plain text. */
+/** Skeleton bars (if any) pulse; real values are plain text. */
 function skeletonCount(container: HTMLElement): number {
   return container.querySelectorAll(".animate-pulse").length;
 }
@@ -58,8 +58,8 @@ afterAll(() => {
   mock.restore();
 });
 
-describe("SubagentDetailPanel — metric skeletons", () => {
-  test("running with zero usage renders three skeleton metric cards", () => {
+describe("SubagentDetailPanel — metric cards", () => {
+  test("running with zero usage renders real zeros, not skeletons", () => {
     const { container } = render(
       <SubagentDetailPanel
         entry={makeEntry({ status: "running", inputTokens: 0, outputTokens: 0, totalCost: 0 })}
@@ -67,17 +67,16 @@ describe("SubagentDetailPanel — metric skeletons", () => {
       />,
     );
 
-    // One skeleton bar per metric card (Input / Output / Cost).
-    expect(skeletonCount(container)).toBe(3);
-    // Labels (card shape) stay visible so there's no reflow when values land.
+    expect(skeletonCount(container)).toBe(0);
     expect(screen.getByText("Input")).toBeDefined();
     expect(screen.getByText("Output")).toBeDefined();
     expect(screen.getByText("Cost")).toBeDefined();
-    // The literal zeros must NOT be shown while metrics are pending.
-    expect(screen.queryByText("0.00")).toBeNull();
+    // Live values render immediately: two "0" tokens and one "0.00" cost.
+    expect(screen.getAllByText("0").length).toBe(2);
+    expect(screen.getByText("0.00")).toBeDefined();
   });
 
-  test("running with usage renders real values, not skeletons", () => {
+  test("running with usage renders real values", () => {
     const { container } = render(
       <SubagentDetailPanel
         entry={makeEntry({ status: "running", inputTokens: 1200, outputTokens: 340, totalCost: 0.68 })}
@@ -99,7 +98,6 @@ describe("SubagentDetailPanel — metric skeletons", () => {
       />,
     );
 
-    // A completed run is never a skeleton, even with zeroed usage.
     expect(skeletonCount(container)).toBe(0);
     // Two "0" inputs/outputs and one "0.00" cost render as real text.
     expect(screen.getAllByText("0").length).toBe(2);

--- a/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -18,7 +18,6 @@ import type { SubagentEntry } from "@/domains/subagents/subagent-store";
 import { isActiveStatus } from "@/domains/subagents/status-helpers";
 
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
-import { SkeletonBar } from "@/domains/chat/components/chat-skeleton";
 
 /** Format a number compactly (e.g. 257400 -> "257.4K"). */
 function formatNumber(n: number): string {
@@ -80,12 +79,10 @@ function MetricCard({
   icon,
   value,
   label,
-  loading = false,
 }: {
   icon: ReactNode;
   value: string;
   label: string;
-  loading?: boolean;
 }) {
   return (
     <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
@@ -93,20 +90,12 @@ function MetricCard({
         {icon}
       </div>
       <div className="min-w-0">
-        {loading ? (
-          // Match the title-small line-box height so the card does not reflow
-          // when the real value lands.
-          <span className="flex h-5 items-center" aria-hidden="true">
-            <SkeletonBar className="h-3 w-10" />
-          </span>
-        ) : (
-          <Typography
-            variant="title-small"
-            className="block text-[var(--content-default)]"
-          >
-            {value}
-          </Typography>
-        )}
+        <Typography
+          variant="title-small"
+          className="block text-[var(--content-default)]"
+        >
+          {value}
+        </Typography>
         <Typography
           variant="body-small-default"
           className="block text-[var(--content-secondary)]"
@@ -118,8 +107,8 @@ function MetricCard({
   );
 }
 
-function AnimatedMetricCard({ icon, label, target, format, loading = false }: {
-  icon: ReactNode; label: string; target: number; format: (n: number) => string; loading?: boolean;
+function AnimatedMetricCard({ icon, label, target, format }: {
+  icon: ReactNode; label: string; target: number; format: (n: number) => string;
 }) {
   const animated = useAnimatedNumber(target);
   return (
@@ -127,7 +116,6 @@ function AnimatedMetricCard({ icon, label, target, format, loading = false }: {
       icon={icon}
       label={label}
       value={format(animated)}
-      loading={loading}
     />
   );
 }
@@ -154,15 +142,6 @@ export function SubagentDetailPanel({
   onRequestDetail,
 }: SubagentDetailPanelProps) {
   const isRunning = isActiveStatus(entry.status);
-  // The daemon ships zeroed usage until a subagent completes, so all-zero
-  // while still active is our "metrics not yet available" signal. Once any
-  // usage arrives or the status is terminal, render real numbers — including
-  // a legitimate 0 for a trivial run.
-  const metricsPending =
-    isRunning &&
-    entry.inputTokens === 0 &&
-    entry.outputTokens === 0 &&
-    entry.totalCost === 0;
   const requestedRef = useRef<string | null>(null);
   const components = useBundledAvatarComponents();
 
@@ -233,21 +212,18 @@ export function SubagentDetailPanel({
             target={entry.inputTokens}
             format={(n) => formatNumber(Math.round(n))}
             label="Input"
-            loading={metricsPending}
           />
           <AnimatedMetricCard
             icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             target={entry.outputTokens}
             format={(n) => formatNumber(Math.round(n))}
             label="Output"
-            loading={metricsPending}
           />
           <AnimatedMetricCard
             icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
             target={entry.totalCost}
             format={formatCost}
             label="Cost"
-            loading={metricsPending}
           />
         </div>
 


### PR DESCRIPTION
## Summary

The Input / Output / Cost cards in the subagent detail panel rendered skeleton loading bars while the subagent was running with all-zero usage. But these values stream in as the subagent makes LLM calls, so the skeletons hid metrics that are actually available and updating.

This removes the `metricsPending` skeleton gating so the cards always show their real values — starting at 0 and animating up as usage arrives.

## Changes
- Drop the `loading`/`metricsPending` logic and `SkeletonBar` usage from `subagent-detail-panel.tsx`
- `MetricCard` / `AnimatedMetricCard` always render the formatted value

## Test plan
- Spin up a subagent and open its detail panel
- Confirm Input / Output / Cost show numeric values immediately and tick up as the subagent makes calls (no skeleton placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)