### PR TITLE
[LUM-1691] fix(ios): prevent zoom getting stuck after device rotation

### DIFF
--- a/apps/ios/App/App/MyViewController.swift
+++ b/apps/ios/App/App/MyViewController.swift
@@ -9,17 +9,20 @@ import WebKit
 ///    App target (no SPM module) so the bridge won't discover them
 ///    automatically.
 ///
-/// 2. Injects a `WKUserScript` at `.atDocumentStart` that pins focusable
-///    fields to a minimum 16px font-size, preventing the iOS auto-zoom
-///    behaviour that otherwise gets stuck after the input loses focus.
+/// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
+///    a) Pin focusable fields to a minimum 16px font-size, preventing the
+///       iOS auto-zoom behaviour that gets stuck after the input loses focus.
+///    b) Append `maximum-scale=1.0, user-scalable=no` to the viewport meta
+///       tag. This is injected natively (rather than baked into `index.html`)
+///       so regular mobile-browser users keep their default zoom/accessibility
+///       behaviour. Only the Capacitor WKWebView shell receives the lock.
 ///
 /// 3. Resets the WKWebView scroll view zoom scale to 1.0 after device
 ///    rotation completes. Capacitor's built-in zoom prevention only
 ///    disables the pinch gesture recognizer (via `scrollViewWillBeginZooming`),
 ///    which doesn't prevent programmatic zoom changes triggered by rotation.
-///    The viewport meta tag (`maximum-scale=1.0`) is the primary guard;
-///    this reset is a native safety net for any edge case the viewport
-///    constraint doesn't cover.
+///    The viewport `maximum-scale` constraint (item 2b) is the primary guard;
+///    this reset is a native safety net for any edge case it doesn't cover.
 ///
 /// Safe-area handling lives on the web side: `apps/web/index.html` ships
 /// `viewport-fit=cover` in its viewport meta tag, and `initSafeAreaBridge()`
@@ -34,6 +37,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
         installInputZoomPreventionUserScript()
+        installViewportZoomLockUserScript()
     }
 
     // MARK: - Rotation zoom reset
@@ -50,18 +54,8 @@ class MyViewController: CAPBridgeViewController {
         }
     }
 
-    /// Inject a `WKUserScript` at `.atDocumentStart` that forces all
-    /// `<input>`, `<textarea>`, and `<select>` elements to a minimum
-    /// `font-size` of 16px. iOS Safari / WKWebView automatically zooms
-    /// into any focusable field whose computed `font-size` is below 16px
-    /// — and critically, once it zooms in it never resets the viewport
-    /// scale, leaving the entire app view stuck at a zoomed-in level even
-    /// after the user navigates away from the input.
-    ///
-    /// Pinning to 16px prevents the zoom from triggering in the first
-    /// place. The visual difference between 14px and 16px is negligible
-    /// at standard iOS display densities, and this only affects the
-    /// WKWebView shell — it has no impact on regular browser sessions.
+    /// Pin focusable fields to a minimum 16px font-size so iOS WKWebView
+    /// doesn't auto-zoom into inputs with small text.
     private func installInputZoomPreventionUserScript() {
         guard let contentController = webView?.configuration.userContentController else { return }
         let source = """
@@ -80,6 +74,31 @@ class MyViewController: CAPBridgeViewController {
         let script = WKUserScript(
             source: source,
             injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        contentController.addUserScript(script)
+    }
+
+    /// Append `maximum-scale=1.0, user-scalable=no` to the existing viewport
+    /// meta tag so WKWebView cannot zoom beyond 1x. Injected natively rather
+    /// than baked into `index.html` so regular mobile-browser users retain
+    /// their default zoom/accessibility behaviour.
+    private func installViewportZoomLockUserScript() {
+        guard let contentController = webView?.configuration.userContentController else { return }
+        let source = """
+        (function() {
+          var viewport = document.querySelector('meta[name="viewport"]');
+          if (viewport) {
+            var content = viewport.getAttribute('content') || '';
+            if (content.indexOf('maximum-scale') === -1) {
+              viewport.setAttribute('content', content + ', maximum-scale=1.0, user-scalable=no');
+            }
+          }
+        })();
+        """
+        let script = WKUserScript(
+            source: source,
+            injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         )
         contentController.addUserScript(script)

--- a/apps/ios/App/App/MyViewController.swift
+++ b/apps/ios/App/App/MyViewController.swift
@@ -2,26 +2,30 @@ import Capacitor
 import UIKit
 import WebKit
 
-/// Custom `CAPBridgeViewController` subclass used for two things:
+/// Custom `CAPBridgeViewController` subclass that:
 ///
-/// 1. Register `NativeAuthPlugin` and `NativeBiometricPlugin` as local
-///    plugin instances at bridge init time. Capacitor auto-registers
-///    plugins that live in external packages via their `Package.swift`
-///    manifest; these plugins live inside the App target (no SPM module
-///    for ~100 lines of Swift each) so the bridge won't discover them
-///    automatically — we hand them over here.
+/// 1. Registers `NativeAuthPlugin` and `NativeBiometricPlugin` as local
+///    plugin instances at bridge init time. These plugins live inside the
+///    App target (no SPM module) so the bridge won't discover them
+///    automatically.
 ///
-/// 2. Inject a `WKUserScript` at `.atDocumentStart` that pins focusable
+/// 2. Injects a `WKUserScript` at `.atDocumentStart` that pins focusable
 ///    fields to a minimum 16px font-size, preventing the iOS auto-zoom
 ///    behaviour that otherwise gets stuck after the input loses focus.
+///
+/// 3. Resets the WKWebView scroll view zoom scale to 1.0 after device
+///    rotation completes. Capacitor's built-in zoom prevention only
+///    disables the pinch gesture recognizer (via `scrollViewWillBeginZooming`),
+///    which doesn't prevent programmatic zoom changes triggered by rotation.
+///    The viewport meta tag (`maximum-scale=1.0`) is the primary guard;
+///    this reset is a native safety net for any edge case the viewport
+///    constraint doesn't cover.
 ///
 /// Safe-area handling lives on the web side: `apps/web/index.html` ships
 /// `viewport-fit=cover` in its viewport meta tag, and `initSafeAreaBridge()`
 /// in `runtime/native-safe-area.ts` reads native insets via
 /// `capacitor-plugin-safe-area` and writes them to `--safe-area-inset-*`
-/// CSS custom properties. `env(safe-area-inset-*)` alone returns 0 in
-/// Capacitor's WKWebView (WebKit bug #191872 + Capacitor #2149), so the
-/// bridge is what actually compensates for the notch and home indicator.
+/// CSS custom properties.
 ///
 /// `Main.storyboard`'s single scene uses this class instead of the stock
 /// `CAPBridgeViewController`.
@@ -30,6 +34,20 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
         installInputZoomPreventionUserScript()
+    }
+
+    // MARK: - Rotation zoom reset
+
+    override open func viewWillTransition(
+        to size: CGSize,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            guard let scrollView = self?.webView?.scrollView,
+                  scrollView.zoomScale != 1.0 else { return }
+            scrollView.setZoomScale(1.0, animated: false)
+        }
     }
 
     /// Inject a `WKUserScript` at `.atDocumentStart` that forces all

--- a/apps/web/capacitor-shell/index.html
+++ b/apps/web/capacitor-shell/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Vellum</title>
   </head>
   <body>

--- a/apps/web/docs/CAPACITOR.md
+++ b/apps/web/docs/CAPACITOR.md
@@ -174,6 +174,20 @@ References:
 
 ---
 
+## iOS-only viewport constraints belong in native injection
+
+`apps/web/index.html` serves both the Capacitor WKWebView shell and regular mobile browsers. **Do not add iOS-specific viewport properties** (e.g. `maximum-scale=1.0`, `user-scalable=no`) directly in the HTML — this disables pinch-zoom for all mobile-browser users, which is an accessibility regression.
+
+Instead, inject iOS-only viewport constraints via a `WKUserScript` in [`MyViewController.swift`](../../../apps/ios/App/App/MyViewController.swift). The native injection runs only inside the Capacitor shell and doesn't affect other platforms.
+
+When modifying the viewport meta tag, check whether the change affects zoom behaviour in the WKWebView shell — the [default `maximum-scale` is 5.0](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html), and Capacitor's built-in zoom prevention does not cover programmatic zoom changes (e.g. during device rotation).
+
+References:
+- Apple — [Configuring the Viewport](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html)
+- Apple — [Supported Meta Tags (`viewport`)](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html)
+
+---
+
 ## See also
 
 - [`CONVENTIONS.md`](./CONVENTIONS.md) — architecture, code organization, component patterns.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <!-- viewport-fit=cover is required for iOS WKWebView to expose env(safe-area-inset-*);
        without it the Capacitor shell renders under the notch / home indicator. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   <link rel="icon" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <!-- viewport-fit=cover is required for iOS WKWebView to expose env(safe-area-inset-*);
        without it the Capacitor shell renders under the notch / home indicator. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <link rel="icon" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>


### PR DESCRIPTION
Prevents the iOS WKWebView from getting stuck in a zoomed state after rotating between portrait and landscape. Without `maximum-scale=1.0` on the viewport, WKWebView freely scales content during orientation changes, and Capacitor's zoom prevention then traps the user at the zoomed level.

## Why this is needed

WKWebView [adjusts zoom during device rotation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html) to maintain content proportions. The viewport meta tag's [default `maximum-scale` is 5.0](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html), so without an explicit cap the web view can zoom up to 5x. Once zoomed, Capacitor's built-in `scrollViewWillBeginZooming` [disables the pinch gesture recognizer](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift#L308-L310), preventing the user from zooming back out. The result: the screen is stuck zoomed after rotation.

## Benefits

- Eliminates the stuck-zoom state on all supported iOS devices and orientations
- No impact on desktop browsers or regular mobile-browser users (constraints are injected natively, not in shared HTML)
- Minimal code footprint — a user script injection + a guarded rotation reset

## Safety

- The viewport zoom lock is injected via `WKUserScript` only in `MyViewController` (the Capacitor bridge controller). Regular mobile-browser sessions serving the same `index.html` are unaffected.
- The rotation reset is guarded (`zoomScale != 1.0`) so it's a no-op in normal operation.
- Capacitor already intends to disable zoom (`zoomingEnabled` defaults to `false`); these changes reinforce that intent at two additional layers.
- The existing `installInputZoomPreventionUserScript()` (16px font-size clamp) is preserved as defense-in-depth — it addresses the separate trigger of input-focus zoom.

## Changes

1. **Native viewport zoom lock** (`apps/ios/App/App/MyViewController.swift`): New `installViewportZoomLockUserScript()` injects `maximum-scale=1.0, user-scalable=no` into the viewport meta tag at `.atDocumentEnd`. Injected natively so only the Capacitor WKWebView shell receives the lock.

2. **Native rotation safety net** (`apps/ios/App/App/MyViewController.swift`): Override `viewWillTransition(to:with:)` to reset `scrollView.zoomScale` to 1.0 after the rotation animation completes.

3. **Capacitor shell loading page** (`apps/web/capacitor-shell/index.html`): Added `maximum-scale=1.0, user-scalable=no` to the loading page viewport. This file is only served locally by Capacitor during the initial load before navigating to the remote URL.

4. **Documentation** (`apps/web/docs/CAPACITOR.md`): Added "iOS-only viewport constraints belong in native injection" guideline to prevent recurrence.

## Alternatives not taken

| Approach | Why rejected |
|---|---|
| **Baking `maximum-scale=1` into `apps/web/index.html`** | Disables zoom for all mobile-browser users — accessibility regression. `index.html` serves both Capacitor and regular browsers. |
| **`viewForZooming(in:)` returning `nil`** | [Apple-recommended](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/viewforzooming(in:)) for disabling UIScrollView zoom, but Capacitor's internal `WebViewDelegationHandler` already owns the scrollView delegate. Replacing it would break Capacitor's navigation and event delegation. |
| **`scrollView.minimumZoomScale = 1.0` / `maximumZoomScale = 1.0`** | WKWebView [overrides these values](https://developer.apple.com/documentation/uikit/uiscrollview/minimumzoomscale) when loading new content, making them unreliable as a persistent constraint. |
| **`WKWebViewConfiguration.ignoresViewportScaleLimits`** | Goes the [wrong direction](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/ignoresviewportscalelimits) — allows zoom *despite* viewport restrictions, not the other way around. |
| **Removing `installInputZoomPreventionUserScript()`** | `maximum-scale=1` makes it redundant for zoom prevention, but it addresses a different trigger (input-focus zoom via CSS font-size clamp) and is harmless as defense-in-depth. |

## Root cause analysis

**How the code got into this state:** The viewport meta tag was added with `viewport-fit=cover` to fix safe-area insets, but `maximum-scale=1.0` was omitted. Capacitor's `zoomingEnabled` (which defaults to `false`) set up the `scrollViewWillBeginZooming` delegate — but this only prevents user-initiated pinch zoom, not programmatic zoom changes from rotation.

**What led to it:** The viewport change was focused on safe-area behaviour and didn't consider zoom implications. Capacitor's zoom prevention API gives a false sense of completeness — it suggests zoom is "disabled" but only covers one of several zoom vectors (pinch gesture, not programmatic layout changes during rotation).

**Warning signs missed:** The viewport meta tag shipped without `maximum-scale`, and no review caught that the default maximum-scale of 5.0 was implicitly in effect. The interaction between viewport scale limits and Capacitor's gesture-only zoom prevention isn't obvious without reading both Apple's viewport docs and Capacitor's source.

**Prevention:** Added a guideline to `CAPACITOR.md` documenting that iOS-only viewport constraints must be injected natively (not in shared HTML) and that viewport meta tag changes should be reviewed for zoom behaviour in the WKWebView shell. The `MyViewController` class docstring also documents the layered zoom prevention strategy so future changes understand the interaction.

## References

- Apple — [Configuring the Viewport](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html)
- Apple — [Supported Meta Tags (`viewport`)](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html)
- Apple — [`viewForZooming(in:)`](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/viewforzooming(in:))
- Apple — [`ignoresViewportScaleLimits`](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/ignoresviewportscalelimits)
- Capacitor — [`WebViewDelegationHandler` zoom prevention](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ef577d791df641838a041a9d642f1ef5
