### PR TITLE
fix(macos): add missing approvalReason param to ToolPermissionTesterModelTests

### DIFF
--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -73,7 +73,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "allow", riskLevel: "low", reason: "test",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil,
+            approvalReason: nil
         )
 
         model.toolName = "host_bash"
@@ -204,7 +205,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil,
+            approvalReason: nil
         )
 
         model.allowOnce()
@@ -223,7 +225,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil,
+            approvalReason: nil
         )
 
         model.denyOnce()
@@ -249,7 +252,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "host_bash", snapshotInputJSON: "{}", snapshotExecutionTarget: "host"
+            snapshotToolName: "host_bash", snapshotInputJSON: "{}", snapshotExecutionTarget: "host",
+            approvalReason: nil
         )
 
         model.alwaysAllow(pattern: "echo *", scope: "project")
@@ -280,7 +284,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "high", reason: "dangerous",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil,
+            approvalReason: nil
         )
 
         model.alwaysAllow(pattern: "rm -rf *", scope: "global")
@@ -304,7 +309,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "low", reason: "test",
             matchedTrustRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil,
+            approvalReason: nil
         )
 
         model.alwaysAllow(pattern: "*", scope: "global")


### PR DESCRIPTION
## Summary
- PR #32269 added `approvalReason: String?` to `SimulationResult` but missed updating the 6 constructor call sites in `ToolPermissionTesterModelTests.swift`, causing the macOS test build to fail with `missing argument for parameter 'approvalReason' in call`
- Adds `approvalReason: nil` to all 6 call sites

## Test plan
- [ ] CI macOS Tests job passes (the sole failure in [run 26532255768](https://github.com/vellum-ai/vellum-assistant/actions/runs/26532255768/job/78151793180))

🤖 Generated with [Claude Code](https://claude.com/claude-code)