### PR TITLE
refactor(web): viewer-store.handleAppUnpinned owns cross-store cleanup (LUM-1959)

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -257,20 +257,10 @@ export function ChatPage() {
   // -------------------------------------------------------------------------
   // Pin-sync side-effect
   // -------------------------------------------------------------------------
-  const handleActiveAppUnpinned = useCallback(
-    (appId: string) => {
-      const { activeAppId, mainView } = useViewerStore.getState();
-      useViewerStore.getState().handleAppUnpinned(appId);
-      if (
-        activeAppId === appId &&
-        (mainView === "app" || mainView === "app-editing")
-      ) {
-        useConversationStore.getState().setEditingConversationId(null);
-      }
-    },
-    [],
-  );
-  useActiveAppPinSync(handleActiveAppUnpinned);
+  // Cross-store coordination (clearing the app + editing-conversation when
+  // the active app gets unpinned) lives inside `viewer-store.handleAppUnpinned`,
+  // so every consumer gets the same behavior without re-implementing it.
+  useActiveAppPinSync(useViewerStore.getState().handleAppUnpinned);
 
   // -------------------------------------------------------------------------
   // Shared refs — owned here, read/written by hooks

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -24,6 +24,7 @@ import { create } from "zustand";
 
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 import { createSelectors } from "@/utils/create-selectors";
 
 // ---------------------------------------------------------------------------
@@ -211,6 +212,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeAppId: null,
       openedAppState: null,
     });
+    // The viewer state and the conversation store's `editingConversationId`
+    // are coupled: leaving the app-editing view should drop the editing
+    // pointer too. Owning this here keeps the cross-store coordination in
+    // one place instead of pushing it onto every caller of `useActiveAppPinSync`.
+    useConversationStore.getState().setEditingConversationId(null);
   },
 
   enterAppEditing: () => {


### PR DESCRIPTION
Linear: https://linear.app/vellum/issue/LUM-1959 (Phase 1 of [LUM-1742](https://linear.app/vellum/issue/LUM-1742))

## Summary

Third Phase 1 extraction. Different shape than the first two: instead of moving code into a new hook, this one pushes a cross-store coordination concern *down* into the store action that already owns the gate condition. Net result: one fewer `useCallback` in chat-page, the viewer-store action is now self-contained, and any future caller of `handleAppUnpinned` gets the complete cleanup.

## The broken pattern

ChatPage owned a `handleActiveAppUnpinned` callback that:

1. Read viewer-store state to check the gate
2. Called `viewer-store.handleAppUnpinned()` (which checks the same gate internally)
3. If the gate matched, **also** called `conversation-store.setEditingConversationId(null)`

That's two stores being coordinated by a route component — exactly the kind of thing [STATE_MANAGEMENT.md](../apps/web/docs/STATE_MANAGEMENT.md) and the user's standing "make it right" directive call out. The viewer store already knows the condition under which an app gets disabled; it should also know to clear the editing pointer that goes with leaving app-editing.

## What changed

- `viewer-store.handleAppUnpinned` now also calls `useConversationStore.getState().setEditingConversationId(null)` after it resets the viewer state. The gate check is unchanged.
- `chat-page.tsx`'s pin-sync block collapses from 17 lines to one: `useActiveAppPinSync(useViewerStore.getState().handleAppUnpinned)`.

## Test plan

- [x] `bun run build` — no behavior change
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run audit:cross-domain:check` — passes (the audit only flags `domains/X → domains/Y` crossings, and a top-level store importing from a domain store is allowed under the existing rule set)
- [ ] Manual: open an app in edit-app mode, unpin it from the sidebar → expect the app pane to close AND the chat to no longer show the "editing app" state

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_