### PR TITLE
feat(web): surface tool `activity` text in step-label derivation

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -32,6 +32,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Working (bash)",
       info: "echo hello world",
+      activity: "",
       iconName: "code",
     });
   });
@@ -60,6 +61,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Reading",
       info: "index.ts",
+      activity: "",
       iconName: "file",
     });
   });
@@ -74,6 +76,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Reading",
       info: "bar.md",
+      activity: "",
       iconName: "file",
     });
   });
@@ -88,6 +91,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Editing",
       info: "new-file.tsx",
+      activity: "",
       iconName: "pen",
     });
   });
@@ -102,6 +106,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Editing",
       info: "bar.ts",
+      activity: "",
       iconName: "pen",
     });
   });
@@ -116,6 +121,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using computer",
       info: "screenshot",
+      activity: "",
       iconName: "monitor",
     });
   });
@@ -130,6 +136,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using stripe",
       info: "create_payment_link",
+      activity: "",
       iconName: "plug",
     });
   });
@@ -144,6 +151,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using a skill",
       info: "code-review",
+      activity: "",
       iconName: "sparkle",
     });
   });
@@ -158,6 +166,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using a skill",
       info: "deep-research",
+      activity: "",
       iconName: "sparkle",
     });
   });
@@ -172,6 +181,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Spawning subagent",
       info: "Investigate flaky test",
+      activity: "",
       iconName: "user-plus",
     });
   });
@@ -186,6 +196,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Spawning subagent",
       info: "Audit auth flow",
+      activity: "",
       iconName: "user-plus",
     });
   });
@@ -200,7 +211,62 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Running Some Unknown Tool",
       info: "",
+      activity: "",
       iconName: "bolt",
     });
+  });
+
+  test("subagent_spawn surfaces input.activity while title stays stable", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "subagent_spawn",
+        input: {
+          label: "research-toronto",
+          activity: "Spawning subagent to research Toronto's location in Canada",
+        },
+      }),
+    );
+    expect(result.title).toBe("Spawning subagent");
+    expect(result.activity).toBe(
+      "Spawning subagent to research Toronto's location in Canada",
+    );
+  });
+
+  test("skill_load falls back to input.reason when activity is absent", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill_load",
+        input: { name: "deep-research", reason: "Loading research playbook" },
+      }),
+    );
+    expect(result.activity).toBe("Loading research playbook");
+  });
+
+  test("no activity or reason → activity is the empty string", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "bash",
+        input: { command: "ls" },
+      }),
+    );
+    expect(result.activity).toBe("");
+  });
+
+  test("skill_execute wrapper preserves outer activity through inner-tool recursion", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill_execute",
+        input: {
+          tool: "bash",
+          input: { command: "echo hi", activity: "inner activity" },
+          activity: "outer activity wins",
+        },
+      }),
+    );
+    // Inner tool drives title/info/iconName; outer activity overrides inner.
+    expect(result.title).toBe("Working (bash)");
+    expect(result.info).toBe("echo hi");
+    expect(result.iconName).toBe("code");
+    expect(result.activity).toBe("outer activity wins");
   });
 });

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -37,6 +37,14 @@ export type IconName =
 export interface StepLabel {
   title: string;
   info: string;
+  /**
+   * Rich, human-readable activity sentence the daemon attaches to the tool
+   * input (`input.activity`, legacy `input.reason`), mirroring macOS
+   * `reasonDescription`. Empty string when absent. Drives pill/drawer text;
+   * `title` remains the stable phase-grouping key — do NOT fold activity into
+   * `title`.
+   */
+  activity: string;
   iconName: IconName;
 }
 
@@ -99,11 +107,17 @@ export function deriveStepLabelFromName(
     input && typeof input === "object" ? (input as Record<string, unknown>) : {};
   const name = toolName.toLowerCase();
 
+  // Rich activity sentence the daemon attaches to the input. Computed once and
+  // spread onto every branch so phase-grouping (`title`/`info`/`iconName`)
+  // stays untouched. `readString` trims and returns "" when neither key is set.
+  const activity = readString(inputBag, "activity", "reason");
+
   const mcp = parseMcpToolName(toolName);
   if (mcp) {
     return {
       title: `Using ${mcp.serverName}`,
       info: mcp.toolMethod,
+      activity,
       iconName: "plug",
     };
   }
@@ -116,6 +130,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Working (bash)",
         info: truncate(cleaned, INFO_MAX_LENGTH),
+        activity,
         iconName: "code",
       };
     }
@@ -127,11 +142,11 @@ export function deriveStepLabelFromName(
         readString(inputBag, "path", "file_path", "filePath"),
       );
       if (sub === "view") {
-        return { title: "Reading", info: file, iconName: "file" };
+        return { title: "Reading", info: file, activity, iconName: "file" };
       }
       // create / insert / str_replace (and any other write sub-command) all
       // map to "Editing" so any mutation surfaces as an edit.
-      return { title: "Editing", info: file, iconName: "pen" };
+      return { title: "Editing", info: file, activity, iconName: "pen" };
     }
 
     case "computer": {
@@ -139,6 +154,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Using computer",
         info: action,
+        activity,
         iconName: "monitor",
       };
     }
@@ -153,12 +169,16 @@ export function deriveStepLabelFromName(
       const innerTool = readString(inputBag, "tool");
       if (innerTool) {
         const innerInput = inputBag.input;
-        return deriveStepLabelFromName(innerTool, innerInput);
+        const inner = deriveStepLabelFromName(innerTool, innerInput);
+        // The daemon attaches `activity` to the OUTER `skill_execute` input;
+        // let it win over any activity on the inner tool's input.
+        return { ...inner, activity: activity || inner.activity };
       }
       const skillName = readString(inputBag, "skill", "name", "skillName");
       return {
         title: "Using a skill",
         info: skillName,
+        activity,
         iconName: "sparkle",
       };
     }
@@ -170,6 +190,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Using a skill",
         info: skillName,
+        activity,
         iconName: "sparkle",
       };
     }
@@ -179,6 +200,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Spawning subagent",
         info: label,
+        activity,
         iconName: "user-plus",
       };
     }
@@ -187,6 +209,7 @@ export function deriveStepLabelFromName(
       return {
         title: toolName ? `Running ${titleCaseToolName(toolName)}` : "Running tool",
         info: "",
+        activity,
         iconName: "bolt",
       };
   }


### PR DESCRIPTION
## Summary
- Add `activity` to `StepLabel`, read from `input.activity` (legacy `input.reason`), mirroring macOS `reasonDescription`.
- `title`/`info`/`iconName` unchanged so phase grouping stays stable.

Part of plan: web-tool-call-pills.md (PR 1 of 8)