### PR TITLE
feat(web): add RiskBadge weak-style pill (Figma 5010-103197)

### DIFF
--- a/apps/web/src/domains/chat/components/risk-badge.stories.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RiskBadge } from "./risk-badge";
+
+const meta: Meta<typeof RiskBadge> = {
+  title: "Chat/RiskBadge",
+  component: RiskBadge,
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    level: {
+      control: "select",
+      options: ["low", "medium", "high", "workspace"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RiskBadge>;
+
+export const Low: Story = {
+  args: { level: "low" },
+};
+
+export const Medium: Story = {
+  args: { level: "medium" },
+};
+
+export const High: Story = {
+  args: { level: "high" },
+};
+
+export const Workspace: Story = {
+  args: { level: "workspace" },
+};
+
+export const AllLevels: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-row items-center gap-2">
+      <RiskBadge level="low" />
+      <RiskBadge level="medium" />
+      <RiskBadge level="high" />
+      <RiskBadge level="workspace" />
+    </div>
+  ),
+};

--- a/apps/web/src/domains/chat/components/risk-badge.test.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for `RiskBadge`.
+ *
+ * Uses `renderToStaticMarkup` since the workspace lacks jsdom.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+
+describe("RiskBadge", () => {
+  test("renders the Low label for low risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="low" />);
+    expect(html).toContain("Low");
+    expect(html).toContain('data-testid="risk-badge"');
+    expect(html).toContain('data-risk-level="low"');
+  });
+
+  test("renders the Medium label for medium risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="medium" />);
+    expect(html).toContain("Medium");
+  });
+
+  test("renders the High label for high risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="high" />);
+    expect(html).toContain("High");
+  });
+
+  test("renders the Workspace label for workspace risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="workspace" />);
+    expect(html).toContain("Workspace");
+  });
+
+  test("renders null for undefined level", () => {
+    const html = renderToStaticMarkup(<RiskBadge />);
+    expect(html).toBe("");
+  });
+
+  test("renders null for empty-string level", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="" />);
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/components/risk-badge.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.tsx
@@ -1,0 +1,31 @@
+import { Typography } from "@vellum/design-library";
+
+import { cn } from "@/utils/misc";
+import { getRiskBadgeWeakStyle } from "@/domains/chat/utils/risk-utils";
+
+/**
+ * Weak-background / strong-text risk pill matching the macOS `RiskBadgeView`
+ * convention (Figma node 5010-103197). Renders `null` when no `level` is
+ * supplied so callers can pass optional risk without guarding the call site.
+ */
+export function RiskBadge({ level, className }: { level?: string; className?: string }) {
+  if (!level) return null;
+
+  const { bg, text, label } = getRiskBadgeWeakStyle(level);
+
+  return (
+    <span
+      data-testid="risk-badge"
+      data-risk-level={level}
+      className={cn(
+        "inline-flex items-center justify-center rounded-[100px] px-[6px] pt-[2px] pb-[3px]",
+        bg,
+        className,
+      )}
+    >
+      <Typography variant="label-medium-default" className={text}>
+        {label}
+      </Typography>
+    </span>
+  );
+}

--- a/apps/web/src/domains/chat/utils/risk-utils.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.ts
@@ -19,6 +19,31 @@ export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: strin
   }
 }
 
+/**
+ * Weak-background / strong-text variant of the risk badge styling, matching the
+ * macOS `RiskBadgeView` convention (Figma node 5010-103197). This is the style
+ * used by the inline pill + drawer header — distinct from the filled
+ * `getRiskBadgeStyle` that the confirmation chip depends on.
+ */
+export function getRiskBadgeWeakStyle(riskLevel?: string): { bg: string; text: string; label: string } {
+  switch (riskLevel?.toLowerCase()) {
+    case "low":
+      return { bg: "bg-[var(--system-positive-weak)]", text: "text-[var(--system-positive-strong)]", label: "Low" };
+    case "medium":
+      return { bg: "bg-[var(--system-mid-weak)]", text: "text-[var(--system-mid-strong)]", label: "Medium" };
+    case "high":
+      return { bg: "bg-[var(--system-negative-weak)]", text: "text-[var(--system-negative-strong)]", label: "High" };
+    case "workspace":
+      return { bg: "bg-[var(--surface-lift)]", text: "text-[var(--content-secondary)]", label: "Workspace" };
+    default:
+      return {
+        bg: "bg-[var(--surface-lift)]",
+        text: "text-[var(--content-secondary)]",
+        label: riskLevel ? riskLevel.charAt(0).toUpperCase() + riskLevel.slice(1) : "Unknown",
+      };
+  }
+}
+
 // "unknown" maps to 2 (treated as high risk), matching server/Swift semantics.
 // Unrecognized values fall through to the ?? -1 default (treated as no-risk / missing).
 const RISK_ORDINAL: Record<string, number> = { unknown: 2, low: 0, medium: 1, high: 2 };


### PR DESCRIPTION
## Summary
- Add `RiskBadge` (weak bg + strong text, matches macOS) and `getRiskBadgeWeakStyle` helper.
- Storybook story under Chat/RiskBadge for QA. Existing filled `getRiskBadgeStyle` untouched.

Part of plan: web-tool-call-pills.md (PR 3 of 8)