### PR TITLE
feat(web): add tool-detail view + open/close actions to viewer store

### DIFF
--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect } from "bun:test";
 
-import { useViewerStore } from "@/stores/viewer-store";
+import { useViewerStore, type ToolDetailPayload } from "@/stores/viewer-store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,6 +16,15 @@ beforeEach(() => {
 
 const SAMPLE_APP = { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" };
 const SAMPLE_DOC = { surfaceId: "surf-1", conversationId: "conv-1", documentName: "README.md", content: "# Hello" };
+const SAMPLE_TOOL: ToolDetailPayload = {
+  toolCallId: "tc-1",
+  toolName: "spawn_subagent",
+  title: "Spawning subagent",
+  activity: "Spawning a research subagent",
+  input: { task: "research" },
+  result: "done",
+  status: "completed",
+};
 
 // ---------------------------------------------------------------------------
 // View navigation
@@ -211,6 +220,66 @@ describe("closeSubagentDetail", () => {
     const state = getState();
     expect(state.mainView).toBe("app");
     expect(state.activeSubagentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool detail
+// ---------------------------------------------------------------------------
+
+describe("openToolDetail", () => {
+  it("sets the tool-detail view, payload, and records the prior view", () => {
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.mainView).toBe("tool-detail");
+    expect(state.activeToolDetail).toBe(SAMPLE_TOOL);
+    expect(state.viewBeforeToolDetail).toBe("chat");
+  });
+
+  it("records a non-chat prior view (app -> restores to app)", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.viewBeforeToolDetail).toBe("app");
+    getState().closeToolDetail();
+    expect(getState().mainView).toBe("app");
+  });
+
+  it("does not overwrite a real prior view with a transient one when already in subagent-detail", () => {
+    useViewerStore.setState({
+      mainView: "subagent-detail",
+      viewBeforeToolDetail: "app",
+    });
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.mainView).toBe("tool-detail");
+    expect(state.viewBeforeToolDetail).toBe("app");
+  });
+
+  it("preserves existing viewBeforeToolDetail when already in tool-detail", () => {
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      viewBeforeToolDetail: "app",
+      activeToolDetail: SAMPLE_TOOL,
+    });
+    getState().openToolDetail({ ...SAMPLE_TOOL, toolCallId: "tc-2" });
+    const state = getState();
+    expect(state.viewBeforeToolDetail).toBe("app");
+    expect(state.activeToolDetail?.toolCallId).toBe("tc-2");
+  });
+});
+
+describe("closeToolDetail", () => {
+  it("restores the prior view and clears the payload", () => {
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      viewBeforeToolDetail: "chat",
+      activeToolDetail: SAMPLE_TOOL,
+    });
+    getState().closeToolDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeToolDetail).toBeNull();
   });
 });
 

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -11,8 +11,9 @@
  * - `isAppMinimized` — mobile-only: app viewer minimized
  * - `intelligenceTab` — sub-tab inside the intelligence panel
  * - `assetsRefreshKey` — counter bumped to force asset re-fetches
- * - `viewBeforeDocument` / `viewBeforeSubagentDetail` — previous view for restoration
+ * - `viewBeforeDocument` / `viewBeforeSubagentDetail` / `viewBeforeToolDetail` — previous view for restoration
  * - `activeSubagentId` — subagent detail panel
+ * - `activeToolDetail` — tool-call detail drawer payload
  *
  * App share/deploy lifecycle lives in `domains/chat/deploy-store.ts`.
  *
@@ -30,7 +31,13 @@ import { createSelectors } from "@/utils/create-selectors";
 // Types
 // ---------------------------------------------------------------------------
 
-export type MainView = "chat" | "app" | "app-editing" | "document" | "subagent-detail";
+export type MainView =
+  | "chat"
+  | "app"
+  | "app-editing"
+  | "document"
+  | "subagent-detail"
+  | "tool-detail";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
 
@@ -48,6 +55,19 @@ export interface OpenedDocumentState {
   content: string;
 }
 
+export interface ToolDetailPayload {
+  toolCallId: string;
+  toolName: string;
+  title: string; // phase title, e.g. "Spawning subagent"
+  activity: string; // rich sentence (may be "")
+  input: Record<string, unknown>;
+  result?: string;
+  status: "running" | "completed" | "error" | "denied";
+  riskLevel?: string;
+  riskReason?: string;
+  durationLabel?: string;
+}
+
 // ---------------------------------------------------------------------------
 // State & Actions
 // ---------------------------------------------------------------------------
@@ -61,9 +81,11 @@ export interface ViewerState {
   isAppMinimized: boolean;
   intelligenceTab: IntelligenceTab;
   assetsRefreshKey: number;
-  viewBeforeDocument: Exclude<MainView, "document" | "subagent-detail">;
+  viewBeforeDocument: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
   activeSubagentId: string | null;
-  viewBeforeSubagentDetail: Exclude<MainView, "document" | "subagent-detail">;
+  viewBeforeSubagentDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
+  activeToolDetail: ToolDetailPayload | null;
+  viewBeforeToolDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
 }
 
 export interface ViewerActions {
@@ -85,6 +107,10 @@ export interface ViewerActions {
   // --- Subagent detail ---
   openSubagentDetail: (subagentId: string) => void;
   closeSubagentDetail: () => void;
+
+  // --- Tool detail ---
+  openToolDetail: (payload: ToolDetailPayload) => void;
+  closeToolDetail: () => void;
 
   // --- Document viewer ---
   openDocument: () => void;
@@ -119,6 +145,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeDocument: "chat",
   activeSubagentId: null,
   viewBeforeSubagentDetail: "chat",
+  activeToolDetail: null,
+  viewBeforeToolDetail: "chat",
 };
 
 // ---------------------------------------------------------------------------
@@ -226,9 +254,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   openSubagentDetail: (subagentId) => {
     const state = get();
     const viewBeforeSubagentDetail =
-      state.mainView === "subagent-detail" || state.mainView === "document"
+      state.mainView === "subagent-detail" ||
+      state.mainView === "document" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeSubagentDetail
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "subagent-detail",
       activeSubagentId: subagentId,
@@ -243,14 +273,40 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     });
   },
 
+  // --- Tool detail ---
+
+  openToolDetail: (payload) => {
+    const state = get();
+    const viewBeforeToolDetail =
+      state.mainView === "tool-detail" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "document"
+        ? state.viewBeforeToolDetail
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
+    set({
+      mainView: "tool-detail",
+      activeToolDetail: payload,
+      viewBeforeToolDetail,
+    });
+  },
+
+  closeToolDetail: () => {
+    set({
+      mainView: get().viewBeforeToolDetail,
+      activeToolDetail: null,
+    });
+  },
+
   // --- Document viewer ---
 
   openDocument: () => {
     const state = get();
     const viewBeforeDocument =
-      state.mainView === "document" || state.mainView === "subagent-detail"
+      state.mainView === "document" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "document",
       openedDocumentState: null,
@@ -261,9 +317,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   loadDocument: async (assistantId, documentSurfaceId) => {
     const state = get();
     const viewBeforeDocument =
-      state.mainView === "document" || state.mainView === "subagent-detail"
+      state.mainView === "document" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "document",
       activeDocumentSurfaceId: documentSurfaceId,


### PR DESCRIPTION
## Summary
- Add `tool-detail` MainView, `activeToolDetail` payload, and `openToolDetail`/`closeToolDetail` actions mirroring the subagent-detail pattern.
- Export `ToolDetailPayload`.

Part of plan: web-tool-call-pills.md (PR 5 of 8)