### PR TITLE
feat(web): carry activity + risk on tool step descriptors and header

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -73,6 +73,8 @@ describe("computeToolCallCardData — step kinds", () => {
       durationLabel: "2s",
       title: "Working (bash)",
       info: "echo hello",
+      activity: "",
+      riskLevel: undefined,
       iconName: "code",
       toolCallId: "tc-1",
       status: "completed",
@@ -80,6 +82,45 @@ describe("computeToolCallCardData — step kinds", () => {
     expect(data.state).toBe("complete");
     // `currentStepTitle` / `currentStepInfo` mirror the tool step.
     expect(data.currentStepTitle).toBe("Working (bash)");
+    expect(data.currentStepInfo).toBe("echo hello");
+  });
+
+  test("carries activity + riskLevel on the `tool` step and prefers activity for currentStepInfo", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 2000,
+        riskLevel: "low",
+        input: {
+          command: "echo hello",
+          activity: "Greeting the user from the shell",
+        },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps[0]).toMatchObject({
+      kind: "tool",
+      activity: "Greeting the user from the shell",
+      riskLevel: "low",
+    });
+    // Collapsed-header subtext prefers the rich activity sentence.
+    expect(data.currentStepInfo).toBe("Greeting the user from the shell");
+  });
+
+  test("falls back to terse info for currentStepInfo when no activity is present", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "echo hello" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps[0]).toMatchObject({ kind: "tool", activity: "" });
     expect(data.currentStepInfo).toBe("echo hello");
   });
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -66,6 +66,14 @@ export type ToolCallCardStep =
       durationLabel: string;
       title: string;
       info: string;
+      /**
+       * Rich, human-readable activity sentence (from `StepLabel.activity`).
+       * Preferred display text for the pill/drawer; `info` is the terse
+       * fallback used when no activity sentence is present.
+       */
+      activity: string;
+      /** Daemon-assigned risk level for the call (e.g. `"low"`), when present. */
+      riskLevel?: string;
       iconName: IconName;
       toolCallId: string;
       status: "running" | "completed" | "error" | "denied";
@@ -291,12 +299,14 @@ function computeToolDurationLabel(tc: ChatMessageToolCall): string {
 }
 
 function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
-  const { title, info, iconName } = deriveStepLabel(tc);
+  const { title, info, activity, iconName } = deriveStepLabel(tc);
   return {
     kind: "tool",
     durationLabel: computeToolDurationLabel(tc),
     title,
     info,
+    activity,
+    riskLevel: tc.riskLevel,
     iconName,
     toolCallId: tc.id,
     status: deriveToolStepStatus(tc),
@@ -354,7 +364,8 @@ function deriveCurrentStepInfo(
   for (let i = toolCalls.length - 1; i >= 0; i--) {
     const tc = toolCalls[i]!;
     if (!isWebTool(tc)) {
-      return deriveStepLabel(tc).info;
+      const { info, activity } = deriveStepLabel(tc);
+      return activity || info;
     }
     const metadata = resolveMetadata(tc, liveWebActivity);
     const terminal = isTerminalStatus(tc);


### PR DESCRIPTION
## Summary
- Add `activity`/`riskLevel` to the `tool` step variant; populate in `buildToolStep`.
- Collapsed-header subtext prefers the rich activity sentence (matches macOS).

Part of plan: web-tool-call-pills.md (PR 2 of 8)