### PR TITLE
feat(web): add ToolStepPill with icon + risk badge (Figma 5010-103193)

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -38,7 +38,7 @@ import { formatMs } from "@/domains/chat/hooks/use-tool-call-card-data";
 import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 
 /** Concrete lucide icon for each `IconName` produced by `deriveStepLabel`. */
-const ICON_MAP: Record<IconName, LucideIcon> = {
+export const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
   file: FileText,
   pen: Pen,

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ToolStepPill } from "./tool-step-pill";
+
+const meta: Meta<typeof ToolStepPill> = {
+  title: "Chat/ToolStepPill",
+  component: ToolStepPill,
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    iconName: {
+      control: "select",
+      options: [
+        "code",
+        "file",
+        "pen",
+        "monitor",
+        "plug",
+        "sparkle",
+        "user-plus",
+        "bolt",
+      ],
+    },
+    label: { control: "text" },
+    riskLevel: {
+      control: "select",
+      options: [undefined, "low", "medium", "high", "workspace"],
+    },
+    tone: {
+      control: "inline-radio",
+      options: ["default", "error"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToolStepPill>;
+
+export const Default: Story = {
+  args: {
+    iconName: "sparkle",
+    label: "review-cycle",
+  },
+};
+
+export const WithRiskLow: Story = {
+  args: {
+    iconName: "code",
+    label: "bun test",
+    riskLevel: "low",
+  },
+};
+
+export const WithRiskHigh: Story = {
+  args: {
+    iconName: "code",
+    label: "rm -rf build",
+    riskLevel: "high",
+  },
+};
+
+export const LongActivity: Story = {
+  args: {
+    iconName: "pen",
+    label:
+      "Editing the phase-grouped step list to surface a button-based pill with a trailing risk badge",
+  },
+  render: (args) => (
+    <div className="w-[320px]">
+      <ToolStepPill {...args} />
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  args: {
+    iconName: "plug",
+    label: "linear.createIssue",
+    riskLevel: "medium",
+    onClick: () => {},
+  },
+};
+
+export const ErrorTone: Story = {
+  args: {
+    iconName: "bolt",
+    label: "Command failed with exit code 1",
+    tone: "error",
+  },
+};
+
+export const AllVariants: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-col items-start gap-2">
+      <ToolStepPill iconName="sparkle" label="review-cycle" />
+      <ToolStepPill iconName="code" label="bun test" riskLevel="low" />
+      <ToolStepPill iconName="code" label="rm -rf build" riskLevel="high" />
+      <ToolStepPill
+        iconName="plug"
+        label="linear.createIssue"
+        riskLevel="medium"
+        onClick={() => {}}
+      />
+      <ToolStepPill
+        iconName="bolt"
+        label="Command failed with exit code 1"
+        tone="error"
+      />
+    </div>
+  ),
+};

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for `ToolStepPill`.
+ *
+ * The non-interactive assertions use `renderToStaticMarkup` (the workspace
+ * may lack jsdom — matching the neighboring `risk-badge.test.tsx` /
+ * `phase-grouped-step-list.test.tsx` harness). The click test uses
+ * `@testing-library/react` + `fireEvent`, the harness existing interactive
+ * web tests (e.g. `favicon-chip.test.tsx`) rely on.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolStepPill", () => {
+  test("renders the label", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="sparkle" label="review-cycle" />,
+    );
+    expect(html).toContain("review-cycle");
+    expect(html).toContain('data-testid="tool-step-pill"');
+  });
+
+  test("renders the risk badge when a level is set", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="code" label="bun test" riskLevel="high" />,
+    );
+    expect(html).toContain('data-testid="risk-badge"');
+    expect(html).toContain('data-risk-level="high"');
+    expect(html).toContain("High");
+  });
+
+  test("omits the risk badge when no level is set", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="code" label="bun test" />,
+    );
+    expect(html).not.toContain('data-testid="risk-badge"');
+  });
+
+  test("renders a <button> with an aria-label when onClick is provided", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="plug" label="linear.createIssue" onClick={() => {}} />,
+    );
+    expect(html).toContain("<button");
+    expect(html).toContain('aria-label="View details: linear.createIssue"');
+  });
+
+  test("renders a non-button element when onClick is absent", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="sparkle" label="review-cycle" />,
+    );
+    expect(html).not.toContain("<button");
+    expect(html).toContain("<span");
+  });
+
+  test("fires onClick when the button is clicked", () => {
+    let clicks = 0;
+    const { getByTestId } = render(
+      <ToolStepPill
+        iconName="plug"
+        label="linear.createIssue"
+        onClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    fireEvent.click(getByTestId("tool-step-pill"));
+    expect(clicks).toBe(1);
+  });
+
+  test("renders a <button> when onClick provided and a non-button when not (DOM)", () => {
+    const { getByTestId } = render(
+      <ToolStepPill iconName="plug" label="clickable" onClick={() => {}} />,
+    );
+    expect(getByTestId("tool-step-pill").tagName).toBe("BUTTON");
+
+    cleanup();
+
+    const { getByTestId: getStatic } = render(
+      <ToolStepPill iconName="sparkle" label="static" />,
+    );
+    expect(getStatic("tool-step-pill").tagName).not.toBe("BUTTON");
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -1,0 +1,99 @@
+/**
+ * Button-based tool-call step pill matching Figma node `5010-103193`.
+ *
+ * A leading glyph (from `ICON_MAP`) + a truncating label + an optional
+ * trailing `RiskBadge`. When an `onClick` is supplied the pill renders as a
+ * real `<button>` (with hover / focus affordances); otherwise it renders a
+ * non-interactive `<span>` with identical layout classes minus the
+ * interactive styling, so static / no-action contexts don't get a dead
+ * button.
+ *
+ * Props are intentionally PRIMITIVE (icon name + strings) rather than coupled
+ * to `ToolCallCardStep`, so the pill is independently testable and reusable
+ * outside the card pipeline.
+ */
+
+import { Bolt } from "lucide-react";
+
+import { Typography } from "@vellum/design-library";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+
+export interface ToolStepPillProps {
+  iconName: IconName;
+  label: string;
+  riskLevel?: string;
+  onClick?: () => void;
+  tone?: "default" | "error";
+  /** Accessible label for the button. Defaults to `View details: ${label}`. */
+  ariaLabel?: string;
+}
+
+/** Shared layout classes applied to both the button and span variants. */
+const BASE_CLASSES =
+  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] text-left";
+
+/** Interactive affordances added only when the pill renders as a button. */
+const INTERACTIVE_CLASSES =
+  "transition-colors hover:bg-[var(--surface-base)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)] cursor-pointer";
+
+export function ToolStepPill({
+  iconName,
+  label,
+  riskLevel,
+  onClick,
+  tone = "default",
+  ariaLabel,
+}: ToolStepPillProps) {
+  const toneClasses =
+    tone === "error"
+      ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
+      : "border-[var(--border-base)] bg-transparent text-[var(--content-default)]";
+
+  const Glyph = ICON_MAP[iconName] ?? Bolt;
+  const iconColor =
+    tone === "error"
+      ? "text-[var(--system-negative-strong)]"
+      : "text-[var(--content-tertiary)]";
+
+  const content = (
+    <>
+      <Glyph
+        aria-hidden="true"
+        className={`h-3.5 w-3.5 shrink-0 ${iconColor}`}
+      />
+      <Typography
+        variant="body-small-default"
+        className="min-w-0 truncate text-inherit"
+      >
+        {label}
+      </Typography>
+      <RiskBadge level={riskLevel} />
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-testid="tool-step-pill"
+        aria-label={ariaLabel ?? `View details: ${label}`}
+        onClick={onClick}
+        className={`${BASE_CLASSES} ${INTERACTIVE_CLASSES} ${toneClasses}`}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      data-testid="tool-step-pill"
+      className={`${BASE_CLASSES} ${toneClasses}`}
+    >
+      {content}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ToolStepPill` button pill (icon + label + trailing RiskBadge) per Figma.
- Storybook story under Chat/ToolStepPill for QA. Export `ICON_MAP` for reuse.

Part of plan: web-tool-call-pills.md (PR 4 of 8)