### PR TITLE
fix(web): center mobile detail header icon+title for single-line titles

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -98,7 +98,7 @@ export function HomeDetailPanel({
         </div>
 
         {/* Detail header */}
-        <div className="flex items-start gap-3 px-4 py-3">
+        <div className="flex items-start justify-center gap-3 px-4 py-3">
           <span
             className="mt-0.5 flex shrink-0 items-center justify-center rounded-full"
             style={{
@@ -116,7 +116,7 @@ export function HomeDetailPanel({
           </span>
           <Typography
             variant="title-small"
-            className="min-w-0 flex-1 text-[var(--content-default)]"
+            className="min-w-0 text-[var(--content-default)]"
           >
             {item.title ?? item.summary}
           </Typography>


### PR DESCRIPTION
Centers the notification detail header's icon+title pair horizontally on mobile when the title fits on a single line. Previously the pair was always left-aligned because the title Typography had `flex-1`, stretching it to fill remaining width regardless of content length.

## Prompt / plan

The mobile notification detail header (icon + title) was left-aligned even for short single-line titles. The fix adds `justify-center` to the flex container and removes `flex-1` from the Typography. For single-line titles, the content is narrower than its container so `justify-center` centers the group. For multi-line titles, the text naturally fills available width via `min-w-0` so centering has no visible effect.

## Test plan

- Typecheck (`bunx tsc --noEmit`): passes
- Lint (`bun run lint`): passes
- Pre-commit hooks: pass

## Root cause analysis

1. **How did the code get into this state?** PR #32261 restructured the mobile detail panel to match Figma mocks. The header used a standard `flex items-start` layout with `flex-1` on the title — a common pattern for headers where the text should fill remaining space. However, this prevents centering when the title is short.
2. **What decisions led to it?** The `flex-1` pattern is correct for headers with action buttons on the right (where the title should fill the gap), but the detail header only has icon + title with no trailing elements, so `flex-1` just pushes the content left.
3. **Were there warning signs?** The Figma mock may not have shown the difference clearly for short titles.
4. **Prevention:** When a flex row has no trailing elements, prefer `justify-center` over `flex-1` for content that should be visually centered.

## Alternatives not taken

- **JS-based line count detection** (ref + ResizeObserver): Overengineered — CSS handles this naturally since `justify-center` only visibly affects layout when content is narrower than its container.
- **`text-center` on Typography**: Doesn't center the icon+title as a group, and multi-line centered text reads poorly.
- **Flexbox column layout** (icon above title): Doesn't match the design (icon is beside the title).

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/64830935825c4401b868fdccc5567ce1