### PR TITLE
feat(web): add ToolDetailPanel with technical details + output

### DIFF
--- a/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+import { ToolDetailPanel } from "./tool-detail-panel";
+
+const meta: Meta<typeof ToolDetailPanel> = {
+  title: "Chat/ToolDetailPanel",
+  component: ToolDetailPanel,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[600px] w-[440px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ToolDetailPanel>;
+
+const subagentDetail: ToolDetailPayload = {
+  toolCallId: "tc-subagent-1",
+  toolName: "subagent_spawn",
+  title: "Spawning subagent",
+  activity: "Spawning subagent to research Toronto's location in Canada",
+  input: {
+    label: "toronto-location",
+    objective:
+      "Determine which province and country Toronto is located in, and summarise its geographic context.",
+    role: "researcher",
+  },
+  result: JSON.stringify(
+    {
+      summary:
+        "Toronto is the capital city of the province of Ontario, located in Canada on the northwestern shore of Lake Ontario.",
+      sources: ["wikipedia.org", "britannica.com"],
+    },
+    null,
+    2,
+  ),
+  status: "completed",
+  riskLevel: "low",
+};
+
+const bashDetail: ToolDetailPayload = {
+  toolCallId: "tc-bash-1",
+  toolName: "bash",
+  title: "Working (bash)",
+  activity: "",
+  input: { command: "ls -la" },
+  result:
+    "total 24\ndrwxr-xr-x  5 user  staff   160 May 27 10:00 .\ndrwxr-xr-x 12 user  staff   384 May 27 09:58 ..\n-rw-r--r--  1 user  staff  1024 May 27 10:00 README.md",
+  status: "completed",
+  riskLevel: "medium",
+};
+
+export const SubagentSpawn: Story = {
+  args: {
+    detail: subagentDetail,
+    onClose: () => {},
+  },
+};
+
+export const Bash: Story = {
+  args: {
+    detail: bashDetail,
+    onClose: () => {},
+  },
+};

--- a/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for `ToolDetailPanel` — the side-drawer body for a tool-call step.
+ *
+ * Runs under happy-dom (see apps/web/test-setup.ts) so we can render
+ * interactively and assert click / clipboard behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ToolDetailPanel } from "@/domains/chat/components/tool-detail-panel";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+const noop = () => {};
+
+function makeDetail(overrides: Partial<ToolDetailPayload> = {}): ToolDetailPayload {
+  return {
+    toolCallId: "tc-1",
+    toolName: "subagent_spawn",
+    title: "Spawning subagent",
+    activity: "Spawning subagent to research Toronto's location",
+    input: { label: "toronto-location", role: "researcher" },
+    result: '{"summary":"Toronto is in Ontario, Canada."}',
+    status: "completed",
+    riskLevel: "low",
+    ...overrides,
+  };
+}
+
+let writeText: ReturnType<typeof mock>;
+
+beforeEach(() => {
+  writeText = mock(() => Promise.resolve());
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolDetailPanel", () => {
+  test("renders the activity title, friendly tool name, input JSON and output", () => {
+    const { getByText, getAllByText, container } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
+    );
+
+    // Activity renders in both the header title and the technical-details body.
+    expect(
+      getAllByText("Spawning subagent to research Toronto's location").length,
+    ).toBeGreaterThan(0);
+    // Friendly tool name (title-cased from snake_case).
+    expect(getByText("Subagent Spawn")).toBeDefined();
+    // Input JSON + output appear inside <pre> blocks.
+    const text = container.textContent ?? "";
+    expect(text).toContain('"toronto-location"');
+    expect(text).toContain("Toronto is in Ontario, Canada.");
+  });
+
+  test("hides the Output section when result is empty", () => {
+    const { queryByText } = render(
+      <ToolDetailPanel detail={makeDetail({ result: "" })} onClose={noop} />,
+    );
+
+    expect(queryByText("Output")).toBeNull();
+  });
+
+  test("hides the Output section when result is undefined", () => {
+    const { queryByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "completed" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryByText("Output")).toBeNull();
+  });
+
+  test("shows a Running placeholder while running with no result", () => {
+    const { getByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "running" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("Output")).toBeDefined();
+    expect(getByText("Running…")).toBeDefined();
+  });
+
+  test("clicking close fires onClose", () => {
+    const onClose = mock(() => {});
+    const { getByLabelText } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={onClose} />,
+    );
+
+    fireEvent.click(getByLabelText("Close tool details"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("copy button writes the content to the clipboard", () => {
+    const { getAllByLabelText } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
+    );
+
+    // Two copy buttons: one for input, one for output.
+    const copyButtons = getAllByLabelText("Copy");
+    expect(copyButtons.length).toBe(2);
+
+    fireEvent.click(copyButtons[0]!);
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -1,0 +1,211 @@
+/**
+ * Side-drawer body shown when a tool-call step pill is clicked. Mirrors the
+ * macOS "TECHNICAL DETAILS / OUTPUT" detail view and the web
+ * `SubagentDetailPanel` shell (outer container, header with leading icon /
+ * title / risk badge / close, scrollable body with sections).
+ *
+ * Driven by the `ToolDetailPayload` opened into `viewer-store`. Purely
+ * presentational: it reads the payload and reports `onClose`.
+ */
+
+import {
+  Bolt,
+  Check,
+  Code,
+  Copy,
+  FileText,
+  Monitor,
+  Pen,
+  Plug,
+  Sparkles,
+  UserPlus,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button, Typography } from "@vellum/design-library";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+import {
+  type IconName,
+  deriveStepLabelFromName,
+} from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/**
+ * Concrete lucide icon for each `IconName` produced by `deriveStepLabel`.
+ * Local copy of the map used by `phase-grouped-step-list` so this panel picks
+ * a matching header glyph without importing card internals.
+ */
+const ICON_MAP: Record<IconName, LucideIcon> = {
+  code: Code,
+  file: FileText,
+  pen: Pen,
+  monitor: Monitor,
+  plug: Plug,
+  sparkle: Sparkles,
+  "user-plus": UserPlus,
+  bolt: Bolt,
+};
+
+const COPIED_RESET_MS = 1500;
+
+/**
+ * Small ghost button that copies `text` to the clipboard and shows a transient
+ * "Copied" confirmation. Positioned by the caller (top-right of a `<pre>`).
+ */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy"}
+      className="absolute right-2 top-2 flex items-center gap-1 rounded p-1 text-label-small-default text-[var(--content-tertiary)] transition-colors hover:bg-[var(--ghost-hover)] hover:text-[var(--content-default)]"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? "Copied" : null}
+    </button>
+  );
+}
+
+/** A `<pre>` code block with a copy button positioned in the top-right. */
+function CodeBlock({ text }: { text: string }) {
+  return (
+    <div className="relative">
+      <pre className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
+        {text}
+      </pre>
+      <CopyButton text={text} />
+    </div>
+  );
+}
+
+/** Uppercase section label in `--content-tertiary`. */
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Typography
+      variant="label-small-default"
+      as="div"
+      className="mb-1.5 uppercase tracking-wider text-[var(--content-tertiary)]"
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export function ToolDetailPanel({
+  detail,
+  onClose,
+}: {
+  detail: ToolDetailPayload;
+  onClose: () => void;
+}) {
+  const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);
+  const Glyph = ICON_MAP[iconName] ?? Bolt;
+
+  const title = detail.activity || detail.title;
+  const hasResult = detail.result !== undefined && detail.result !== "";
+  const isRunning = detail.status === "running";
+  const inputJson = JSON.stringify(detail.input, null, 2);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] px-5 py-4">
+        <Glyph
+          className="h-5 w-5 shrink-0 text-[var(--content-secondary)]"
+          aria-hidden
+        />
+        <Typography
+          variant="title-medium"
+          className="min-w-0 shrink truncate text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        <RiskBadge level={detail.riskLevel} />
+        <span className="flex-1" />
+        <Button
+          variant="ghost"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close tool details"
+          tooltip="Close"
+          className="shrink-0"
+        />
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-5 py-5">
+        {detail.riskReason && (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="mb-4 text-[var(--content-tertiary)]"
+          >
+            {detail.riskReason}
+          </Typography>
+        )}
+
+        {/* Technical details section */}
+        <div>
+          <SectionLabel>Technical details</SectionLabel>
+          <Typography
+            variant="body-medium-default"
+            as="div"
+            className="text-[var(--content-default)]"
+          >
+            {titleCaseToolName(detail.toolName)}
+          </Typography>
+          {detail.activity && (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="mt-0.5 text-[var(--content-secondary)]"
+            >
+              {detail.activity}
+            </Typography>
+          )}
+          <div className="mt-2">
+            <CodeBlock text={inputJson} />
+          </div>
+        </div>
+
+        {/* Output section — omitted entirely when there's no result */}
+        {(hasResult || isRunning) && (
+          <div className="mt-5">
+            <SectionLabel>Output</SectionLabel>
+            {hasResult ? (
+              <CodeBlock text={detail.result as string} />
+            ) : (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-[var(--content-tertiary)]"
+              >
+                Running…
+              </Typography>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ToolDetailPanel` drawer body (header + Technical details + Output, with copy buttons), mirroring SubagentDetailPanel.
- Storybook story under Chat/ToolDetailPanel.

Part of plan: web-tool-call-pills.md (PR 6 of 8)