### PR TITLE
feat(web): mount ToolDetailPanel side drawer + mobile overlay

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -122,6 +122,7 @@ import { fetchSubagentDetail } from "@/lib/conversations-api";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
+import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
 import {
   type ChatConnectingReason,
   resolveChatConnectingReason,
@@ -239,6 +240,7 @@ export function ChatPage() {
     viewBeforeDocument: s.viewBeforeDocument,
     activeSubagentId: s.activeSubagentId,
     viewBeforeSubagentDetail: s.viewBeforeSubagentDetail,
+    activeToolDetail: s.activeToolDetail,
   })));
   const subagentState = useSubagentStore(useShallow((s) => ({ byId: s.byId, orderedIds: s.orderedIds })));
   const isSharing = useDeployStore.use.isSharing();
@@ -1766,6 +1768,16 @@ export function ChatPage() {
                 }
               }}
               onRequestDetail={handleRequestSubagentDetail}
+            />
+            <MobileToolDetailOverlay
+              detail={
+                viewerState.mainView === "tool-detail"
+                  ? viewerState.activeToolDetail
+                  : null
+              }
+              onClose={() => {
+                useViewerStore.getState().closeToolDetail();
+              }}
             />
           </>,
           overlayTarget,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -65,6 +65,13 @@ const SubagentDetailPanel = lazy(() =>
     default: m.SubagentDetailPanel,
   })),
 );
+// ToolDetailPanel is only rendered when the user opens a tool-call's detail
+// drawer; defer loading to keep its subtree out of the chat-critical bundle.
+const ToolDetailPanel = lazy(() =>
+  import("@/domains/chat/components/tool-detail-panel").then((m) => ({
+    default: m.ToolDetailPanel,
+  })),
+);
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -95,7 +102,7 @@ import {
 } from "@/domains/messaging/turn-selectors";
 import { isSurfaceInteractive } from "@/domains/chat/types/types";
 
-import type { MainView, OpenedAppState, OpenedDocumentState } from "@/stores/viewer-store";
+import { useViewerStore, type MainView, type OpenedAppState, type OpenedDocumentState } from "@/stores/viewer-store";
 import { useActiveProfileModel } from "@/domains/chat/hooks/use-active-profile-model";
 import { isPointerCoarse } from "@/utils/pointer";
 import { routes } from "@/utils/routes";
@@ -548,6 +555,13 @@ export function ChatRouteContent({
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
+
+  // -------------------------------------------------------------------------
+  // Tool-call detail drawer (from Zustand viewer store)
+  // -------------------------------------------------------------------------
+
+  const activeToolDetail = useViewerStore.use.activeToolDetail();
+  const closeToolDetail = useViewerStore.use.closeToolDetail();
 
   // -------------------------------------------------------------------------
   // Feature flags
@@ -1531,6 +1545,29 @@ export function ChatRouteContent({
         </>
       );
     }
+  }
+
+  if (mainView === "tool-detail" && activeToolDetail && !isMobile) {
+    return (
+      <>
+        <ResizablePanel
+          storageKey="toolDetailPanelWidth"
+          defaultLeftWidth={400}
+          minLeftWidth={300}
+          minRightWidth={400}
+          left={chatContent}
+          right={
+            <LazyBoundary>
+              <ToolDetailPanel
+                detail={activeToolDetail}
+                onClose={closeToolDetail}
+              />
+            </LazyBoundary>
+          }
+        />
+        {sendErrorModalNode}
+      </>
+    );
   }
 
   return (

--- a/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
@@ -1,0 +1,45 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+const ToolDetailPanel = lazy(() =>
+  import("@/domains/chat/components/tool-detail-panel").then((m) => ({
+    default: m.ToolDetailPanel,
+  })),
+);
+
+interface MobileToolDetailOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  detail: ToolDetailPayload | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the tool-call detail panel.
+ *
+ * **Mounting constraint**: must render outside `RootLayout`'s inner
+ * transformed wrapper (see `src/root-layout.tsx`) so
+ * `position: fixed` anchors to the viewport's initial containing block
+ * rather than the keyboard-following transform `RootLayout` applies when
+ * the soft keyboard opens.
+ *
+ * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ */
+export function MobileToolDetailOverlay({
+  detail,
+  onClose,
+}: MobileToolDetailOverlayProps) {
+  if (!detail) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+      <LazyBoundary>
+        <ToolDetailPanel detail={detail} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Mount `ToolDetailPanel` as a resizable right pane on desktop and a full-screen overlay on mobile, mirroring the subagent detail drawer.
- Wire `closeToolDetail` for the close path.

Part of plan: web-tool-call-pills.md (PR 7 of 8)