### PR TITLE
feat(web): richer tool-call pills with risk badges + technical-details drawer

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -122,6 +122,7 @@ import { fetchSubagentDetail } from "@/lib/conversations-api";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
+import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
 import {
   type ChatConnectingReason,
   resolveChatConnectingReason,
@@ -239,6 +240,7 @@ export function ChatPage() {
     viewBeforeDocument: s.viewBeforeDocument,
     activeSubagentId: s.activeSubagentId,
     viewBeforeSubagentDetail: s.viewBeforeSubagentDetail,
+    activeToolDetail: s.activeToolDetail,
   })));
   const subagentState = useSubagentStore(useShallow((s) => ({ byId: s.byId, orderedIds: s.orderedIds })));
   const isSharing = useDeployStore.use.isSharing();
@@ -1766,6 +1768,16 @@ export function ChatPage() {
                 }
               }}
               onRequestDetail={handleRequestSubagentDetail}
+            />
+            <MobileToolDetailOverlay
+              detail={
+                viewerState.mainView === "tool-detail"
+                  ? viewerState.activeToolDetail
+                  : null
+              }
+              onClose={() => {
+                useViewerStore.getState().closeToolDetail();
+              }}
             />
           </>,
           overlayTarget,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -65,6 +65,13 @@ const SubagentDetailPanel = lazy(() =>
     default: m.SubagentDetailPanel,
   })),
 );
+// ToolDetailPanel is only rendered when the user opens a tool-call's detail
+// drawer; defer loading to keep its subtree out of the chat-critical bundle.
+const ToolDetailPanel = lazy(() =>
+  import("@/domains/chat/components/tool-detail-panel").then((m) => ({
+    default: m.ToolDetailPanel,
+  })),
+);
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -95,7 +102,7 @@ import {
 } from "@/domains/messaging/turn-selectors";
 import { isSurfaceInteractive } from "@/domains/chat/types/types";
 
-import type { MainView, OpenedAppState, OpenedDocumentState } from "@/stores/viewer-store";
+import { useViewerStore, type MainView, type OpenedAppState, type OpenedDocumentState } from "@/stores/viewer-store";
 import { useActiveProfileModel } from "@/domains/chat/hooks/use-active-profile-model";
 import { isPointerCoarse } from "@/utils/pointer";
 import { routes } from "@/utils/routes";
@@ -548,6 +555,13 @@ export function ChatRouteContent({
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
+
+  // -------------------------------------------------------------------------
+  // Tool-call detail drawer (from Zustand viewer store)
+  // -------------------------------------------------------------------------
+
+  const activeToolDetail = useViewerStore.use.activeToolDetail();
+  const closeToolDetail = useViewerStore.use.closeToolDetail();
 
   // -------------------------------------------------------------------------
   // Feature flags
@@ -1531,6 +1545,29 @@ export function ChatRouteContent({
         </>
       );
     }
+  }
+
+  if (mainView === "tool-detail" && activeToolDetail && !isMobile) {
+    return (
+      <>
+        <ResizablePanel
+          storageKey="toolDetailPanelWidth"
+          defaultLeftWidth={400}
+          minLeftWidth={300}
+          minRightWidth={400}
+          left={chatContent}
+          right={
+            <LazyBoundary>
+              <ToolDetailPanel
+                detail={activeToolDetail}
+                onClose={closeToolDetail}
+              />
+            </LazyBoundary>
+          }
+        />
+        {sendErrorModalNode}
+      </>
+    );
   }
 
   return (

--- a/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
@@ -1,0 +1,45 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+const ToolDetailPanel = lazy(() =>
+  import("@/domains/chat/components/tool-detail-panel").then((m) => ({
+    default: m.ToolDetailPanel,
+  })),
+);
+
+interface MobileToolDetailOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  detail: ToolDetailPayload | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the tool-call detail panel.
+ *
+ * **Mounting constraint**: must render outside `RootLayout`'s inner
+ * transformed wrapper (see `src/root-layout.tsx`) so
+ * `position: fixed` anchors to the viewport's initial containing block
+ * rather than the keyboard-following transform `RootLayout` applies when
+ * the soft keyboard opens.
+ *
+ * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ */
+export function MobileToolDetailOverlay({
+  detail,
+  onClose,
+}: MobileToolDetailOverlayProps) {
+  if (!detail) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+      <LazyBoundary>
+        <ToolDetailPanel detail={detail} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/risk-badge.stories.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RiskBadge } from "./risk-badge";
+
+const meta: Meta<typeof RiskBadge> = {
+  title: "Chat/RiskBadge",
+  component: RiskBadge,
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    level: {
+      control: "select",
+      options: ["low", "medium", "high", "workspace"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RiskBadge>;
+
+export const Low: Story = {
+  args: { level: "low" },
+};
+
+export const Medium: Story = {
+  args: { level: "medium" },
+};
+
+export const High: Story = {
+  args: { level: "high" },
+};
+
+export const Workspace: Story = {
+  args: { level: "workspace" },
+};
+
+export const AllLevels: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-row items-center gap-2">
+      <RiskBadge level="low" />
+      <RiskBadge level="medium" />
+      <RiskBadge level="high" />
+      <RiskBadge level="workspace" />
+    </div>
+  ),
+};

--- a/apps/web/src/domains/chat/components/risk-badge.test.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for `RiskBadge`.
+ *
+ * Uses `renderToStaticMarkup` since the workspace lacks jsdom.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+
+describe("RiskBadge", () => {
+  test("renders the Low label for low risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="low" />);
+    expect(html).toContain("Low");
+    expect(html).toContain('data-testid="risk-badge"');
+    expect(html).toContain('data-risk-level="low"');
+  });
+
+  test("renders the Medium label for medium risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="medium" />);
+    expect(html).toContain("Medium");
+  });
+
+  test("renders the High label for high risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="high" />);
+    expect(html).toContain("High");
+  });
+
+  test("renders the Workspace label for workspace risk", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="workspace" />);
+    expect(html).toContain("Workspace");
+  });
+
+  test("renders null for undefined level", () => {
+    const html = renderToStaticMarkup(<RiskBadge />);
+    expect(html).toBe("");
+  });
+
+  test("renders null for empty-string level", () => {
+    const html = renderToStaticMarkup(<RiskBadge level="" />);
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/components/risk-badge.tsx
+++ b/apps/web/src/domains/chat/components/risk-badge.tsx
@@ -1,0 +1,31 @@
+import { Typography } from "@vellum/design-library";
+
+import { cn } from "@/utils/misc";
+import { getRiskBadgeWeakStyle } from "@/domains/chat/utils/risk-utils";
+
+/**
+ * Weak-background / strong-text risk pill matching the macOS `RiskBadgeView`
+ * convention (Figma node 5010-103197). Renders `null` when no `level` is
+ * supplied so callers can pass optional risk without guarding the call site.
+ */
+export function RiskBadge({ level, className }: { level?: string; className?: string }) {
+  if (!level) return null;
+
+  const { bg, text, label } = getRiskBadgeWeakStyle(level);
+
+  return (
+    <span
+      data-testid="risk-badge"
+      data-risk-level={level}
+      className={cn(
+        "inline-flex items-center justify-center rounded-[100px] px-[6px] pt-[2px] pb-[3px]",
+        bg,
+        className,
+      )}
+    >
+      <Typography variant="label-medium-default" className={text}>
+        {label}
+      </Typography>
+    </span>
+  );
+}

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -16,15 +16,33 @@
  *    subagents).
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+// The viewer store (pulled in transitively for `openToolDetail`) imports the
+// generated daemon SDK, which isn't built in CI/worktree checkouts. Stub the
+// two endpoints it references so the module loads; the card never invokes
+// them. Mirrors the `mock.module` pattern used across the conversations
+// tests. The component + store are imported dynamically below so the mock is
+// registered first.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  appsByIdOpenPost: async () => ({ data: undefined }),
+  documentsByIdGet: async () => ({ data: undefined }),
+}));
+
+const { ToolCallProgressCard } = await import(
+  "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card"
+);
+const { useViewerStore } = await import("@/stores/viewer-store");
 
 afterEach(() => {
   cleanup();
+  // The pill click writes to the real viewer store — reset the drawer state
+  // between tests so assertions don't bleed across cases.
+  useViewerStore.setState({ activeToolDetail: null, mainView: "chat" });
 });
 
 function makeToolCall(
@@ -113,6 +131,65 @@ describe("ToolCallProgressCard — non-web tool group", () => {
     const indicator = getByTestId("tool-progress-card-status-indicator");
     expect(indicator.tagName.toLowerCase()).toBe("svg");
     expect(indicator.getAttribute("data-state")).toBe("complete");
+  });
+});
+
+describe("ToolCallProgressCard — tool step pill", () => {
+  test("non-web tool step renders a tool-step-pill with activity + risk badge", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "git status", activity: "Checking git status" },
+        riskLevel: "high",
+      }),
+    ];
+    const { getByTestId } = renderCard(toolCalls);
+    const pill = getByTestId("tool-step-pill");
+    expect(pill).toBeTruthy();
+    // Activity sentence wins over the terse command info (it also surfaces in
+    // the carousel header, hence the textContent check on the pill itself).
+    expect(pill.textContent).toContain("Checking git status");
+    // Risk badge rides along inside the pill.
+    expect(getByTestId("risk-badge").getAttribute("data-risk-level")).toBe(
+      "high",
+    );
+  });
+
+  test("clicking the pill calls openToolDetail with the matching tool-call snapshot", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "git status", activity: "Checking git status" },
+        result: "On branch main",
+        riskLevel: "high",
+        riskReason: "writes to disk",
+        startedAt: 0,
+        completedAt: 1000,
+        // Keep the card expanded so the pill is in the DOM post-completion.
+      }),
+    ];
+    const { getByTestId } = renderCard(toolCalls, {
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
+    fireEvent.click(getByTestId("tool-step-pill"));
+    const detail = useViewerStore.getState().activeToolDetail;
+    expect(detail).not.toBeNull();
+    expect(detail?.toolCallId).toBe("tc-1");
+    expect(detail?.toolName).toBe("bash");
+    expect(detail?.input).toEqual({
+      command: "git status",
+      activity: "Checking git status",
+    });
+    expect(detail?.result).toBe("On branch main");
+    expect(detail?.status).toBe("completed");
+    expect(detail?.riskLevel).toBe("high");
+    expect(detail?.riskReason).toBe("writes to disk");
+    // Opening the drawer flips the main view to the tool-detail surface.
+    expect(useViewerStore.getState().mainView).toBe("tool-detail");
   });
 });
 

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -14,10 +14,12 @@ import {
   DefaultStepPill,
   PhaseGroupedStepList,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
 import {
   ToolProgressCardShell,
   type ToolProgressCardState,
 } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { useViewerStore } from "@/stores/viewer-store";
 import {
   useToolCallCardData,
   WEB_TOOL_NAMES,
@@ -217,6 +219,7 @@ function UnifiedToolCallProgressCard({
   onDismissUnknownNudge,
   isStreaming,
 }: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
+  const openToolDetail = useViewerStore.use.openToolDetail();
   const cardId = toolCalls[0]?.id ?? null;
   const expanded = useCardExpanded(
     cardId,
@@ -228,7 +231,8 @@ function UnifiedToolCallProgressCard({
   const shellState: ToolProgressCardState = cardData.state;
 
   // Nudge rows need the raw call (riskLevel, allowlistOptions, …) which
-  // isn't carried on the step descriptor.
+  // isn't carried on the step descriptor. The pill's click handler also
+  // reads the raw call to build the tool-detail drawer payload.
   const toolCallById = new Map(toolCalls.map((tc) => [tc.id, tc]));
 
   return (
@@ -244,14 +248,43 @@ function UnifiedToolCallProgressCard({
         <PhaseGroupedStepList
           steps={cardData.steps}
           renderStep={(step) => {
-            const nudgeTarget =
-              step.kind === "tool" &&
-              unknownNudgeToolCallIds?.has(step.toolCallId)
-                ? toolCallById.get(step.toolCallId)
-                : undefined;
+            // Non-`tool` kinds (thinking, web_search, web_search_error,
+            // tool_error) keep their dedicated rows via `ExpandedStep`.
+            if (step.kind !== "tool") {
+              return <ExpandedStep step={step} />;
+            }
+
+            const nudgeTarget = unknownNudgeToolCallIds?.has(step.toolCallId)
+              ? toolCallById.get(step.toolCallId)
+              : undefined;
             return (
               <>
-                <ExpandedStep step={step} />
+                <ToolStepPill
+                  iconName={step.iconName}
+                  label={step.activity || step.info || step.title}
+                  riskLevel={step.riskLevel}
+                  tone={
+                    step.status === "error" || step.status === "denied"
+                      ? "error"
+                      : "default"
+                  }
+                  onClick={() => {
+                    const tc = toolCallById.get(step.toolCallId);
+                    if (!tc) return;
+                    openToolDetail({
+                      toolCallId: tc.id,
+                      toolName: tc.toolName,
+                      title: step.title,
+                      activity: step.activity,
+                      input: tc.input ?? {},
+                      result: tc.result,
+                      status: step.status,
+                      riskLevel: tc.riskLevel,
+                      riskReason: tc.riskReason,
+                      durationLabel: step.durationLabel,
+                    });
+                  }}
+                />
                 {nudgeTarget && onOpenRuleEditor && (
                   <UnknownCommandNudge
                     toolCall={nudgeTarget}

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -220,6 +220,10 @@ function UnifiedToolCallProgressCard({
   isStreaming,
 }: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
   const openToolDetail = useViewerStore.use.openToolDetail();
+  // Drives the pill's active state — the pill whose detail drawer is currently
+  // open renders selected. `null` when the drawer is closed or showing another
+  // view, so no pill reads as active.
+  const openToolDetailId = useViewerStore.use.activeToolDetail()?.toolCallId ?? null;
   const cardId = toolCalls[0]?.id ?? null;
   const expanded = useCardExpanded(
     cardId,
@@ -263,6 +267,7 @@ function UnifiedToolCallProgressCard({
                   iconName={step.iconName}
                   label={step.activity || step.info || step.title}
                   riskLevel={step.riskLevel}
+                  active={openToolDetailId === step.toolCallId}
                   tone={
                     step.status === "error" || step.status === "denied"
                       ? "error"

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -276,6 +276,11 @@ function UnifiedToolCallProgressCard({
                   onClick={() => {
                     const tc = toolCallById.get(step.toolCallId);
                     if (!tc) return;
+                    // Pin the card open: opening the drawer flips `mainView`,
+                    // which remounts the transcript and resets local expand
+                    // state. Persisting the user's intent in `expandedCardIds`
+                    // keeps the parent accordion open across that remount.
+                    expanded.onChange(true);
                     openToolDetail({
                       toolCallId: tc.id,
                       toolName: tc.toolName,

--- a/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+import { ToolDetailPanel } from "./tool-detail-panel";
+
+const meta: Meta<typeof ToolDetailPanel> = {
+  title: "Chat/ToolDetailPanel",
+  component: ToolDetailPanel,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[600px] w-[440px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ToolDetailPanel>;
+
+const subagentDetail: ToolDetailPayload = {
+  toolCallId: "tc-subagent-1",
+  toolName: "subagent_spawn",
+  title: "Spawning subagent",
+  activity: "Spawning subagent to research Toronto's location in Canada",
+  input: {
+    label: "toronto-location",
+    objective:
+      "Determine which province and country Toronto is located in, and summarise its geographic context.",
+    role: "researcher",
+  },
+  result: JSON.stringify(
+    {
+      summary:
+        "Toronto is the capital city of the province of Ontario, located in Canada on the northwestern shore of Lake Ontario.",
+      sources: ["wikipedia.org", "britannica.com"],
+    },
+    null,
+    2,
+  ),
+  status: "completed",
+  riskLevel: "low",
+};
+
+const bashDetail: ToolDetailPayload = {
+  toolCallId: "tc-bash-1",
+  toolName: "bash",
+  title: "Working (bash)",
+  activity: "",
+  input: { command: "ls -la" },
+  result:
+    "total 24\ndrwxr-xr-x  5 user  staff   160 May 27 10:00 .\ndrwxr-xr-x 12 user  staff   384 May 27 09:58 ..\n-rw-r--r--  1 user  staff  1024 May 27 10:00 README.md",
+  status: "completed",
+  riskLevel: "medium",
+};
+
+export const SubagentSpawn: Story = {
+  args: {
+    detail: subagentDetail,
+    onClose: () => {},
+  },
+};
+
+export const Bash: Story = {
+  args: {
+    detail: bashDetail,
+    onClose: () => {},
+  },
+};

--- a/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for `ToolDetailPanel` — the side-drawer body for a tool-call step.
+ *
+ * Runs under happy-dom (see apps/web/test-setup.ts) so we can render
+ * interactively and assert click / clipboard behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ToolDetailPanel } from "@/domains/chat/components/tool-detail-panel";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+const noop = () => {};
+
+function makeDetail(overrides: Partial<ToolDetailPayload> = {}): ToolDetailPayload {
+  return {
+    toolCallId: "tc-1",
+    toolName: "subagent_spawn",
+    title: "Spawning subagent",
+    activity: "Spawning subagent to research Toronto's location",
+    input: { label: "toronto-location", role: "researcher" },
+    result: '{"summary":"Toronto is in Ontario, Canada."}',
+    status: "completed",
+    riskLevel: "low",
+    ...overrides,
+  };
+}
+
+let writeText: ReturnType<typeof mock>;
+
+beforeEach(() => {
+  writeText = mock(() => Promise.resolve());
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolDetailPanel", () => {
+  test("renders the activity title, friendly tool name, input JSON and output", () => {
+    const { getByText, getAllByText, container } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
+    );
+
+    // Activity renders in both the header title and the technical-details body.
+    expect(
+      getAllByText("Spawning subagent to research Toronto's location").length,
+    ).toBeGreaterThan(0);
+    // Friendly tool name (title-cased from snake_case).
+    expect(getByText("Subagent Spawn")).toBeDefined();
+    // Input JSON + output appear inside <pre> blocks.
+    const text = container.textContent ?? "";
+    expect(text).toContain('"toronto-location"');
+    expect(text).toContain("Toronto is in Ontario, Canada.");
+  });
+
+  test("hides the Output section when result is empty", () => {
+    const { queryByText } = render(
+      <ToolDetailPanel detail={makeDetail({ result: "" })} onClose={noop} />,
+    );
+
+    expect(queryByText("Output")).toBeNull();
+  });
+
+  test("hides the Output section when result is undefined", () => {
+    const { queryByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "completed" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryByText("Output")).toBeNull();
+  });
+
+  test("shows a Running placeholder while running with no result", () => {
+    const { getByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "running" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("Output")).toBeDefined();
+    expect(getByText("Running…")).toBeDefined();
+  });
+
+  test("clicking close fires onClose", () => {
+    const onClose = mock(() => {});
+    const { getByLabelText } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={onClose} />,
+    );
+
+    fireEvent.click(getByLabelText("Close tool details"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("copy button writes the content to the clipboard", () => {
+    const { getAllByLabelText } = render(
+      <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
+    );
+
+    // Two copy buttons: one for input, one for output.
+    const copyButtons = getAllByLabelText("Copy");
+    expect(copyButtons.length).toBe(2);
+
+    fireEvent.click(copyButtons[0]!);
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -1,0 +1,211 @@
+/**
+ * Side-drawer body shown when a tool-call step pill is clicked. Mirrors the
+ * macOS "TECHNICAL DETAILS / OUTPUT" detail view and the web
+ * `SubagentDetailPanel` shell (outer container, header with leading icon /
+ * title / risk badge / close, scrollable body with sections).
+ *
+ * Driven by the `ToolDetailPayload` opened into `viewer-store`. Purely
+ * presentational: it reads the payload and reports `onClose`.
+ */
+
+import {
+  Bolt,
+  Check,
+  Code,
+  Copy,
+  FileText,
+  Monitor,
+  Pen,
+  Plug,
+  Sparkles,
+  UserPlus,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button, Typography } from "@vellum/design-library";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+import {
+  type IconName,
+  deriveStepLabelFromName,
+} from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/**
+ * Concrete lucide icon for each `IconName` produced by `deriveStepLabel`.
+ * Local copy of the map used by `phase-grouped-step-list` so this panel picks
+ * a matching header glyph without importing card internals.
+ */
+const ICON_MAP: Record<IconName, LucideIcon> = {
+  code: Code,
+  file: FileText,
+  pen: Pen,
+  monitor: Monitor,
+  plug: Plug,
+  sparkle: Sparkles,
+  "user-plus": UserPlus,
+  bolt: Bolt,
+};
+
+const COPIED_RESET_MS = 1500;
+
+/**
+ * Small ghost button that copies `text` to the clipboard and shows a transient
+ * "Copied" confirmation. Positioned by the caller (top-right of a `<pre>`).
+ */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy"}
+      className="absolute right-2 top-2 flex items-center gap-1 rounded p-1 text-label-small-default text-[var(--content-tertiary)] transition-colors hover:bg-[var(--ghost-hover)] hover:text-[var(--content-default)]"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? "Copied" : null}
+    </button>
+  );
+}
+
+/** A `<pre>` code block with a copy button positioned in the top-right. */
+function CodeBlock({ text }: { text: string }) {
+  return (
+    <div className="relative">
+      <pre className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
+        {text}
+      </pre>
+      <CopyButton text={text} />
+    </div>
+  );
+}
+
+/** Uppercase section label in `--content-tertiary`. */
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Typography
+      variant="label-small-default"
+      as="div"
+      className="mb-1.5 uppercase tracking-wider text-[var(--content-tertiary)]"
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export function ToolDetailPanel({
+  detail,
+  onClose,
+}: {
+  detail: ToolDetailPayload;
+  onClose: () => void;
+}) {
+  const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);
+  const Glyph = ICON_MAP[iconName] ?? Bolt;
+
+  const title = detail.activity || detail.title;
+  const hasResult = detail.result !== undefined && detail.result !== "";
+  const isRunning = detail.status === "running";
+  const inputJson = JSON.stringify(detail.input, null, 2);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] px-5 py-4">
+        <Glyph
+          className="h-5 w-5 shrink-0 text-[var(--content-secondary)]"
+          aria-hidden
+        />
+        <Typography
+          variant="title-medium"
+          className="min-w-0 shrink truncate text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        <RiskBadge level={detail.riskLevel} />
+        <span className="flex-1" />
+        <Button
+          variant="ghost"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close tool details"
+          tooltip="Close"
+          className="shrink-0"
+        />
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-5 py-5">
+        {detail.riskReason && (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="mb-4 text-[var(--content-tertiary)]"
+          >
+            {detail.riskReason}
+          </Typography>
+        )}
+
+        {/* Technical details section */}
+        <div>
+          <SectionLabel>Technical details</SectionLabel>
+          <Typography
+            variant="body-medium-default"
+            as="div"
+            className="text-[var(--content-default)]"
+          >
+            {titleCaseToolName(detail.toolName)}
+          </Typography>
+          {detail.activity && (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="mt-0.5 text-[var(--content-secondary)]"
+            >
+              {detail.activity}
+            </Typography>
+          )}
+          <div className="mt-2">
+            <CodeBlock text={inputJson} />
+          </div>
+        </div>
+
+        {/* Output section — omitted entirely when there's no result */}
+        {(hasResult || isRunning) && (
+          <div className="mt-5">
+            <SectionLabel>Output</SectionLabel>
+            {hasResult ? (
+              <CodeBlock text={detail.result as string} />
+            ) : (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-[var(--content-tertiary)]"
+              >
+                Running…
+              </Typography>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -32,6 +32,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Working (bash)",
       info: "echo hello world",
+      activity: "",
       iconName: "code",
     });
   });
@@ -60,6 +61,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Reading",
       info: "index.ts",
+      activity: "",
       iconName: "file",
     });
   });
@@ -74,6 +76,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Reading",
       info: "bar.md",
+      activity: "",
       iconName: "file",
     });
   });
@@ -88,6 +91,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Editing",
       info: "new-file.tsx",
+      activity: "",
       iconName: "pen",
     });
   });
@@ -102,6 +106,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Editing",
       info: "bar.ts",
+      activity: "",
       iconName: "pen",
     });
   });
@@ -116,6 +121,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using computer",
       info: "screenshot",
+      activity: "",
       iconName: "monitor",
     });
   });
@@ -130,6 +136,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using stripe",
       info: "create_payment_link",
+      activity: "",
       iconName: "plug",
     });
   });
@@ -144,6 +151,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using a skill",
       info: "code-review",
+      activity: "",
       iconName: "sparkle",
     });
   });
@@ -158,6 +166,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Using a skill",
       info: "deep-research",
+      activity: "",
       iconName: "sparkle",
     });
   });
@@ -172,6 +181,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Spawning subagent",
       info: "Investigate flaky test",
+      activity: "",
       iconName: "user-plus",
     });
   });
@@ -186,6 +196,7 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Spawning subagent",
       info: "Audit auth flow",
+      activity: "",
       iconName: "user-plus",
     });
   });
@@ -200,7 +211,62 @@ describe("deriveStepLabel", () => {
     expect(result).toEqual({
       title: "Running Some Unknown Tool",
       info: "",
+      activity: "",
       iconName: "bolt",
     });
+  });
+
+  test("subagent_spawn surfaces input.activity while title stays stable", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "subagent_spawn",
+        input: {
+          label: "research-toronto",
+          activity: "Spawning subagent to research Toronto's location in Canada",
+        },
+      }),
+    );
+    expect(result.title).toBe("Spawning subagent");
+    expect(result.activity).toBe(
+      "Spawning subagent to research Toronto's location in Canada",
+    );
+  });
+
+  test("skill_load falls back to input.reason when activity is absent", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill_load",
+        input: { name: "deep-research", reason: "Loading research playbook" },
+      }),
+    );
+    expect(result.activity).toBe("Loading research playbook");
+  });
+
+  test("no activity or reason → activity is the empty string", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "bash",
+        input: { command: "ls" },
+      }),
+    );
+    expect(result.activity).toBe("");
+  });
+
+  test("skill_execute wrapper preserves outer activity through inner-tool recursion", () => {
+    const result = deriveStepLabel(
+      buildToolCall({
+        toolName: "skill_execute",
+        input: {
+          tool: "bash",
+          input: { command: "echo hi", activity: "inner activity" },
+          activity: "outer activity wins",
+        },
+      }),
+    );
+    // Inner tool drives title/info/iconName; outer activity overrides inner.
+    expect(result.title).toBe("Working (bash)");
+    expect(result.info).toBe("echo hi");
+    expect(result.iconName).toBe("code");
+    expect(result.activity).toBe("outer activity wins");
   });
 });

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -37,6 +37,14 @@ export type IconName =
 export interface StepLabel {
   title: string;
   info: string;
+  /**
+   * Rich, human-readable activity sentence the daemon attaches to the tool
+   * input (`input.activity`, legacy `input.reason`), mirroring macOS
+   * `reasonDescription`. Empty string when absent. Drives pill/drawer text;
+   * `title` remains the stable phase-grouping key — do NOT fold activity into
+   * `title`.
+   */
+  activity: string;
   iconName: IconName;
 }
 
@@ -99,11 +107,17 @@ export function deriveStepLabelFromName(
     input && typeof input === "object" ? (input as Record<string, unknown>) : {};
   const name = toolName.toLowerCase();
 
+  // Rich activity sentence the daemon attaches to the input. Computed once and
+  // spread onto every branch so phase-grouping (`title`/`info`/`iconName`)
+  // stays untouched. `readString` trims and returns "" when neither key is set.
+  const activity = readString(inputBag, "activity", "reason");
+
   const mcp = parseMcpToolName(toolName);
   if (mcp) {
     return {
       title: `Using ${mcp.serverName}`,
       info: mcp.toolMethod,
+      activity,
       iconName: "plug",
     };
   }
@@ -116,6 +130,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Working (bash)",
         info: truncate(cleaned, INFO_MAX_LENGTH),
+        activity,
         iconName: "code",
       };
     }
@@ -127,11 +142,11 @@ export function deriveStepLabelFromName(
         readString(inputBag, "path", "file_path", "filePath"),
       );
       if (sub === "view") {
-        return { title: "Reading", info: file, iconName: "file" };
+        return { title: "Reading", info: file, activity, iconName: "file" };
       }
       // create / insert / str_replace (and any other write sub-command) all
       // map to "Editing" so any mutation surfaces as an edit.
-      return { title: "Editing", info: file, iconName: "pen" };
+      return { title: "Editing", info: file, activity, iconName: "pen" };
     }
 
     case "computer": {
@@ -139,6 +154,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Using computer",
         info: action,
+        activity,
         iconName: "monitor",
       };
     }
@@ -153,12 +169,16 @@ export function deriveStepLabelFromName(
       const innerTool = readString(inputBag, "tool");
       if (innerTool) {
         const innerInput = inputBag.input;
-        return deriveStepLabelFromName(innerTool, innerInput);
+        const inner = deriveStepLabelFromName(innerTool, innerInput);
+        // The daemon attaches `activity` to the OUTER `skill_execute` input;
+        // let it win over any activity on the inner tool's input.
+        return { ...inner, activity: activity || inner.activity };
       }
       const skillName = readString(inputBag, "skill", "name", "skillName");
       return {
         title: "Using a skill",
         info: skillName,
+        activity,
         iconName: "sparkle",
       };
     }
@@ -170,6 +190,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Using a skill",
         info: skillName,
+        activity,
         iconName: "sparkle",
       };
     }
@@ -179,6 +200,7 @@ export function deriveStepLabelFromName(
       return {
         title: "Spawning subagent",
         info: label,
+        activity,
         iconName: "user-plus",
       };
     }
@@ -187,6 +209,7 @@ export function deriveStepLabelFromName(
       return {
         title: toolName ? `Running ${titleCaseToolName(toolName)}` : "Running tool",
         info: "",
+        activity,
         iconName: "bolt",
       };
   }

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -32,6 +32,7 @@ function bash(
     kind: "tool",
     title: "Working (bash)",
     info: command,
+    activity: "",
     iconName: "code",
     durationLabel: duration,
     toolCallId,

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -38,7 +38,7 @@ import { formatMs } from "@/domains/chat/hooks/use-tool-call-card-data";
 import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 
 /** Concrete lucide icon for each `IconName` produced by `deriveStepLabel`. */
-const ICON_MAP: Record<IconName, LucideIcon> = {
+export const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
   file: FileText,
   pen: Pen,

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -31,6 +31,7 @@ const meta: Meta<typeof ToolStepPill> = {
       control: "inline-radio",
       options: ["default", "error"],
     },
+    active: { control: "boolean" },
   },
 };
 
@@ -90,6 +91,16 @@ export const ErrorTone: Story = {
   },
 };
 
+export const Active: Story = {
+  args: {
+    iconName: "sparkle",
+    label: "review-cycle",
+    riskLevel: "low",
+    active: true,
+    onClick: () => {},
+  },
+};
+
 export const AllVariants: Story = {
   parameters: {
     controls: { disable: true },
@@ -109,6 +120,13 @@ export const AllVariants: Story = {
         iconName="bolt"
         label="Command failed with exit code 1"
         tone="error"
+      />
+      <ToolStepPill
+        iconName="sparkle"
+        label="review-cycle (active)"
+        riskLevel="low"
+        active
+        onClick={() => {}}
       />
     </div>
   ),

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ToolStepPill } from "./tool-step-pill";
+
+const meta: Meta<typeof ToolStepPill> = {
+  title: "Chat/ToolStepPill",
+  component: ToolStepPill,
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    iconName: {
+      control: "select",
+      options: [
+        "code",
+        "file",
+        "pen",
+        "monitor",
+        "plug",
+        "sparkle",
+        "user-plus",
+        "bolt",
+      ],
+    },
+    label: { control: "text" },
+    riskLevel: {
+      control: "select",
+      options: [undefined, "low", "medium", "high", "workspace"],
+    },
+    tone: {
+      control: "inline-radio",
+      options: ["default", "error"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToolStepPill>;
+
+export const Default: Story = {
+  args: {
+    iconName: "sparkle",
+    label: "review-cycle",
+  },
+};
+
+export const WithRiskLow: Story = {
+  args: {
+    iconName: "code",
+    label: "bun test",
+    riskLevel: "low",
+  },
+};
+
+export const WithRiskHigh: Story = {
+  args: {
+    iconName: "code",
+    label: "rm -rf build",
+    riskLevel: "high",
+  },
+};
+
+export const LongActivity: Story = {
+  args: {
+    iconName: "pen",
+    label:
+      "Editing the phase-grouped step list to surface a button-based pill with a trailing risk badge",
+  },
+  render: (args) => (
+    <div className="w-[320px]">
+      <ToolStepPill {...args} />
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  args: {
+    iconName: "plug",
+    label: "linear.createIssue",
+    riskLevel: "medium",
+    onClick: () => {},
+  },
+};
+
+export const ErrorTone: Story = {
+  args: {
+    iconName: "bolt",
+    label: "Command failed with exit code 1",
+    tone: "error",
+  },
+};
+
+export const AllVariants: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-col items-start gap-2">
+      <ToolStepPill iconName="sparkle" label="review-cycle" />
+      <ToolStepPill iconName="code" label="bun test" riskLevel="low" />
+      <ToolStepPill iconName="code" label="rm -rf build" riskLevel="high" />
+      <ToolStepPill
+        iconName="plug"
+        label="linear.createIssue"
+        riskLevel="medium"
+        onClick={() => {}}
+      />
+      <ToolStepPill
+        iconName="bolt"
+        label="Command failed with exit code 1"
+        tone="error"
+      />
+    </div>
+  ),
+};

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
@@ -60,6 +60,20 @@ describe("ToolStepPill", () => {
     expect(html).toContain("<span");
   });
 
+  test("marks the pill active when `active` is set", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill
+        iconName="sparkle"
+        label="review-cycle"
+        active
+        onClick={() => {}}
+      />,
+    );
+    expect(html).toContain('data-active=""');
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain("border-[var(--primary-base)]");
+  });
+
   test("fires onClick when the button is clicked", () => {
     let clicks = 0;
     const { getByTestId } = render(

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
@@ -71,7 +71,7 @@ describe("ToolStepPill", () => {
     );
     expect(html).toContain('data-active=""');
     expect(html).toContain('aria-pressed="true"');
-    expect(html).toContain("border-[var(--primary-base)]");
+    expect(html).toContain("bg-[var(--surface-active)]");
   });
 
   test("fires onClick when the button is clicked", () => {

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for `ToolStepPill`.
+ *
+ * The non-interactive assertions use `renderToStaticMarkup` (the workspace
+ * may lack jsdom — matching the neighboring `risk-badge.test.tsx` /
+ * `phase-grouped-step-list.test.tsx` harness). The click test uses
+ * `@testing-library/react` + `fireEvent`, the harness existing interactive
+ * web tests (e.g. `favicon-chip.test.tsx`) rely on.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolStepPill", () => {
+  test("renders the label", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="sparkle" label="review-cycle" />,
+    );
+    expect(html).toContain("review-cycle");
+    expect(html).toContain('data-testid="tool-step-pill"');
+  });
+
+  test("renders the risk badge when a level is set", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="code" label="bun test" riskLevel="high" />,
+    );
+    expect(html).toContain('data-testid="risk-badge"');
+    expect(html).toContain('data-risk-level="high"');
+    expect(html).toContain("High");
+  });
+
+  test("omits the risk badge when no level is set", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="code" label="bun test" />,
+    );
+    expect(html).not.toContain('data-testid="risk-badge"');
+  });
+
+  test("renders a <button> with an aria-label when onClick is provided", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="plug" label="linear.createIssue" onClick={() => {}} />,
+    );
+    expect(html).toContain("<button");
+    expect(html).toContain('aria-label="View details: linear.createIssue"');
+  });
+
+  test("renders a non-button element when onClick is absent", () => {
+    const html = renderToStaticMarkup(
+      <ToolStepPill iconName="sparkle" label="review-cycle" />,
+    );
+    expect(html).not.toContain("<button");
+    expect(html).toContain("<span");
+  });
+
+  test("fires onClick when the button is clicked", () => {
+    let clicks = 0;
+    const { getByTestId } = render(
+      <ToolStepPill
+        iconName="plug"
+        label="linear.createIssue"
+        onClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    fireEvent.click(getByTestId("tool-step-pill"));
+    expect(clicks).toBe(1);
+  });
+
+  test("renders a <button> when onClick provided and a non-button when not (DOM)", () => {
+    const { getByTestId } = render(
+      <ToolStepPill iconName="plug" label="clickable" onClick={() => {}} />,
+    );
+    expect(getByTestId("tool-step-pill").tagName).toBe("BUTTON");
+
+    cleanup();
+
+    const { getByTestId: getStatic } = render(
+      <ToolStepPill iconName="sparkle" label="static" />,
+    );
+    expect(getStatic("tool-step-pill").tagName).not.toBe("BUTTON");
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -27,17 +27,29 @@ export interface ToolStepPillProps {
   riskLevel?: string;
   onClick?: () => void;
   tone?: "default" | "error";
+  /**
+   * Selected state — rendered when this pill's tool-detail drawer is open.
+   * Mirrors the design-library outlined+active button (primary border, lifted
+   * surface, primary-active text) so the open pill reads as the active source.
+   */
+  active?: boolean;
   /** Accessible label for the button. Defaults to `View details: ${label}`. */
   ariaLabel?: string;
 }
 
-/** Shared layout classes applied to both the button and span variants. */
+/**
+ * Shared layout classes applied to both the button and span variants.
+ *
+ * `leading-normal` is load-bearing: the label uses `truncate` (which sets
+ * `overflow: hidden`), and the `body-small-default` line-height is tight
+ * enough that descenders ("g", "p", "y") get clipped without extra leading.
+ */
 const BASE_CLASSES =
-  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] text-left";
+  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] text-left leading-normal";
 
-/** Interactive affordances added only when the pill renders as a button. */
-const INTERACTIVE_CLASSES =
-  "transition-colors hover:bg-[var(--surface-base)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)] cursor-pointer";
+/** Cursor / transition / focus-ring affordances when the pill is a button. */
+const INTERACTIVE_BASE =
+  "transition-colors cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)]";
 
 export function ToolStepPill({
   iconName,
@@ -45,10 +57,17 @@ export function ToolStepPill({
   riskLevel,
   onClick,
   tone = "default",
+  active = false,
   ariaLabel,
 }: ToolStepPillProps) {
-  const toneClasses =
-    tone === "error"
+  // Active overrides tone wholesale (border + bg + text) so we never emit
+  // conflicting arbitrary-value classes — Tailwind resolves equal-specificity
+  // collisions by stylesheet order, not class-attribute order.
+  const colorClasses = active
+    ? tone === "error"
+      ? "border-[var(--system-negative-strong)] bg-[var(--surface-lift)] text-[var(--system-negative-strong)]"
+      : "border-[var(--primary-base)] bg-[var(--surface-lift)] text-[var(--primary-active)]"
+    : tone === "error"
       ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
       : "border-[var(--border-base)] bg-transparent text-[var(--content-default)]";
 
@@ -56,7 +75,9 @@ export function ToolStepPill({
   const iconColor =
     tone === "error"
       ? "text-[var(--system-negative-strong)]"
-      : "text-[var(--content-tertiary)]";
+      : active
+        ? "text-[var(--primary-active)]"
+        : "text-[var(--content-tertiary)]";
 
   const content = (
     <>
@@ -66,7 +87,7 @@ export function ToolStepPill({
       />
       <Typography
         variant="body-small-default"
-        className="min-w-0 truncate text-inherit"
+        className="min-w-0 truncate text-inherit leading-normal"
       >
         {label}
       </Typography>
@@ -75,13 +96,21 @@ export function ToolStepPill({
   );
 
   if (onClick) {
+    // Active pills hover toward the stronger `surface-active`; idle pills lift
+    // to `surface-base`. Kept as distinct whole classes so the active hover
+    // doesn't fight the idle hover.
+    const hoverClass = active
+      ? "hover:bg-[var(--surface-active)]"
+      : "hover:bg-[var(--surface-base)]";
     return (
       <button
         type="button"
         data-testid="tool-step-pill"
+        data-active={active ? "" : undefined}
+        aria-pressed={active}
         aria-label={ariaLabel ?? `View details: ${label}`}
         onClick={onClick}
-        className={`${BASE_CLASSES} ${INTERACTIVE_CLASSES} ${toneClasses}`}
+        className={`${BASE_CLASSES} ${INTERACTIVE_BASE} ${hoverClass} ${colorClasses}`}
       >
         {content}
       </button>
@@ -91,7 +120,7 @@ export function ToolStepPill({
   return (
     <span
       data-testid="tool-step-pill"
-      className={`${BASE_CLASSES} ${toneClasses}`}
+      className={`${BASE_CLASSES} ${colorClasses}`}
     >
       {content}
     </span>

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -1,0 +1,99 @@
+/**
+ * Button-based tool-call step pill matching Figma node `5010-103193`.
+ *
+ * A leading glyph (from `ICON_MAP`) + a truncating label + an optional
+ * trailing `RiskBadge`. When an `onClick` is supplied the pill renders as a
+ * real `<button>` (with hover / focus affordances); otherwise it renders a
+ * non-interactive `<span>` with identical layout classes minus the
+ * interactive styling, so static / no-action contexts don't get a dead
+ * button.
+ *
+ * Props are intentionally PRIMITIVE (icon name + strings) rather than coupled
+ * to `ToolCallCardStep`, so the pill is independently testable and reusable
+ * outside the card pipeline.
+ */
+
+import { Bolt } from "lucide-react";
+
+import { Typography } from "@vellum/design-library";
+
+import { RiskBadge } from "@/domains/chat/components/risk-badge";
+import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+
+export interface ToolStepPillProps {
+  iconName: IconName;
+  label: string;
+  riskLevel?: string;
+  onClick?: () => void;
+  tone?: "default" | "error";
+  /** Accessible label for the button. Defaults to `View details: ${label}`. */
+  ariaLabel?: string;
+}
+
+/** Shared layout classes applied to both the button and span variants. */
+const BASE_CLASSES =
+  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-[10px] py-[6px] text-left";
+
+/** Interactive affordances added only when the pill renders as a button. */
+const INTERACTIVE_CLASSES =
+  "transition-colors hover:bg-[var(--surface-base)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)] cursor-pointer";
+
+export function ToolStepPill({
+  iconName,
+  label,
+  riskLevel,
+  onClick,
+  tone = "default",
+  ariaLabel,
+}: ToolStepPillProps) {
+  const toneClasses =
+    tone === "error"
+      ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
+      : "border-[var(--border-base)] bg-transparent text-[var(--content-default)]";
+
+  const Glyph = ICON_MAP[iconName] ?? Bolt;
+  const iconColor =
+    tone === "error"
+      ? "text-[var(--system-negative-strong)]"
+      : "text-[var(--content-tertiary)]";
+
+  const content = (
+    <>
+      <Glyph
+        aria-hidden="true"
+        className={`h-3.5 w-3.5 shrink-0 ${iconColor}`}
+      />
+      <Typography
+        variant="body-small-default"
+        className="min-w-0 truncate text-inherit"
+      >
+        {label}
+      </Typography>
+      <RiskBadge level={riskLevel} />
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-testid="tool-step-pill"
+        aria-label={ariaLabel ?? `View details: ${label}`}
+        onClick={onClick}
+        className={`${BASE_CLASSES} ${INTERACTIVE_CLASSES} ${toneClasses}`}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      data-testid="tool-step-pill"
+      className={`${BASE_CLASSES} ${toneClasses}`}
+    >
+      {content}
+    </span>
+  );
+}

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -60,13 +60,15 @@ export function ToolStepPill({
   active = false,
   ariaLabel,
 }: ToolStepPillProps) {
-  // Active overrides tone wholesale (border + bg + text) so we never emit
-  // conflicting arbitrary-value classes — Tailwind resolves equal-specificity
-  // collisions by stylesheet order, not class-attribute order.
+  // Active = a filled `--surface-active` background with the resting border /
+  // text kept neutral (the colored border read poorly against the card). Active
+  // overrides tone's background wholesale so we never emit conflicting
+  // arbitrary-value classes — Tailwind resolves equal-specificity collisions by
+  // stylesheet order, not class-attribute order.
   const colorClasses = active
     ? tone === "error"
-      ? "border-[var(--system-negative-strong)] bg-[var(--surface-lift)] text-[var(--system-negative-strong)]"
-      : "border-[var(--primary-base)] bg-[var(--surface-lift)] text-[var(--primary-active)]"
+      ? "border-[var(--border-base)] bg-[var(--surface-active)] text-[var(--system-negative-strong)]"
+      : "border-[var(--border-base)] bg-[var(--surface-active)] text-[var(--content-default)]"
     : tone === "error"
       ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
       : "border-[var(--border-base)] bg-transparent text-[var(--content-default)]";
@@ -75,9 +77,7 @@ export function ToolStepPill({
   const iconColor =
     tone === "error"
       ? "text-[var(--system-negative-strong)]"
-      : active
-        ? "text-[var(--primary-active)]"
-        : "text-[var(--content-tertiary)]";
+      : "text-[var(--content-tertiary)]";
 
   const content = (
     <>

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -137,6 +137,7 @@ export function mapToolEventToStep(
     iconName: label.iconName,
     title: label.title,
     info: label.info || content,
+    activity: label.activity,
     status: "running",
   };
 }

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -73,6 +73,8 @@ describe("computeToolCallCardData — step kinds", () => {
       durationLabel: "2s",
       title: "Working (bash)",
       info: "echo hello",
+      activity: "",
+      riskLevel: undefined,
       iconName: "code",
       toolCallId: "tc-1",
       status: "completed",
@@ -80,6 +82,45 @@ describe("computeToolCallCardData — step kinds", () => {
     expect(data.state).toBe("complete");
     // `currentStepTitle` / `currentStepInfo` mirror the tool step.
     expect(data.currentStepTitle).toBe("Working (bash)");
+    expect(data.currentStepInfo).toBe("echo hello");
+  });
+
+  test("carries activity + riskLevel on the `tool` step and prefers activity for currentStepInfo", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 2000,
+        riskLevel: "low",
+        input: {
+          command: "echo hello",
+          activity: "Greeting the user from the shell",
+        },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps[0]).toMatchObject({
+      kind: "tool",
+      activity: "Greeting the user from the shell",
+      riskLevel: "low",
+    });
+    // Collapsed-header subtext prefers the rich activity sentence.
+    expect(data.currentStepInfo).toBe("Greeting the user from the shell");
+  });
+
+  test("falls back to terse info for currentStepInfo when no activity is present", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "completed",
+        input: { command: "echo hello" },
+      }),
+    ];
+    const data = computeToolCallCardData(toolCalls, {}, null);
+    expect(data.steps[0]).toMatchObject({ kind: "tool", activity: "" });
     expect(data.currentStepInfo).toBe("echo hello");
   });
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -66,6 +66,14 @@ export type ToolCallCardStep =
       durationLabel: string;
       title: string;
       info: string;
+      /**
+       * Rich, human-readable activity sentence (from `StepLabel.activity`).
+       * Preferred display text for the pill/drawer; `info` is the terse
+       * fallback used when no activity sentence is present.
+       */
+      activity: string;
+      /** Daemon-assigned risk level for the call (e.g. `"low"`), when present. */
+      riskLevel?: string;
       iconName: IconName;
       toolCallId: string;
       status: "running" | "completed" | "error" | "denied";
@@ -291,12 +299,14 @@ function computeToolDurationLabel(tc: ChatMessageToolCall): string {
 }
 
 function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
-  const { title, info, iconName } = deriveStepLabel(tc);
+  const { title, info, activity, iconName } = deriveStepLabel(tc);
   return {
     kind: "tool",
     durationLabel: computeToolDurationLabel(tc),
     title,
     info,
+    activity,
+    riskLevel: tc.riskLevel,
     iconName,
     toolCallId: tc.id,
     status: deriveToolStepStatus(tc),
@@ -354,7 +364,8 @@ function deriveCurrentStepInfo(
   for (let i = toolCalls.length - 1; i >= 0; i--) {
     const tc = toolCalls[i]!;
     if (!isWebTool(tc)) {
-      return deriveStepLabel(tc).info;
+      const { info, activity } = deriveStepLabel(tc);
+      return activity || info;
     }
     const metadata = resolveMetadata(tc, liveWebActivity);
     const terminal = isTerminalStatus(tc);

--- a/apps/web/src/domains/chat/utils/risk-utils.ts
+++ b/apps/web/src/domains/chat/utils/risk-utils.ts
@@ -19,6 +19,31 @@ export function getRiskBadgeStyle(riskLevel?: string): { bg: string; text: strin
   }
 }
 
+/**
+ * Weak-background / strong-text variant of the risk badge styling, matching the
+ * macOS `RiskBadgeView` convention (Figma node 5010-103197). This is the style
+ * used by the inline pill + drawer header — distinct from the filled
+ * `getRiskBadgeStyle` that the confirmation chip depends on.
+ */
+export function getRiskBadgeWeakStyle(riskLevel?: string): { bg: string; text: string; label: string } {
+  switch (riskLevel?.toLowerCase()) {
+    case "low":
+      return { bg: "bg-[var(--system-positive-weak)]", text: "text-[var(--system-positive-strong)]", label: "Low" };
+    case "medium":
+      return { bg: "bg-[var(--system-mid-weak)]", text: "text-[var(--system-mid-strong)]", label: "Medium" };
+    case "high":
+      return { bg: "bg-[var(--system-negative-weak)]", text: "text-[var(--system-negative-strong)]", label: "High" };
+    case "workspace":
+      return { bg: "bg-[var(--surface-lift)]", text: "text-[var(--content-secondary)]", label: "Workspace" };
+    default:
+      return {
+        bg: "bg-[var(--surface-lift)]",
+        text: "text-[var(--content-secondary)]",
+        label: riskLevel ? riskLevel.charAt(0).toUpperCase() + riskLevel.slice(1) : "Unknown",
+      };
+  }
+}
+
 // "unknown" maps to 2 (treated as high risk), matching server/Swift semantics.
 // Unrecognized values fall through to the ?? -1 default (treated as no-risk / missing).
 const RISK_ORDINAL: Record<string, number> = { unknown: 2, low: 0, medium: 1, high: 2 };

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect } from "bun:test";
 
-import { useViewerStore } from "@/stores/viewer-store";
+import { useViewerStore, type ToolDetailPayload } from "@/stores/viewer-store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,6 +16,15 @@ beforeEach(() => {
 
 const SAMPLE_APP = { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" };
 const SAMPLE_DOC = { surfaceId: "surf-1", conversationId: "conv-1", documentName: "README.md", content: "# Hello" };
+const SAMPLE_TOOL: ToolDetailPayload = {
+  toolCallId: "tc-1",
+  toolName: "spawn_subagent",
+  title: "Spawning subagent",
+  activity: "Spawning a research subagent",
+  input: { task: "research" },
+  result: "done",
+  status: "completed",
+};
 
 // ---------------------------------------------------------------------------
 // View navigation
@@ -211,6 +220,66 @@ describe("closeSubagentDetail", () => {
     const state = getState();
     expect(state.mainView).toBe("app");
     expect(state.activeSubagentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool detail
+// ---------------------------------------------------------------------------
+
+describe("openToolDetail", () => {
+  it("sets the tool-detail view, payload, and records the prior view", () => {
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.mainView).toBe("tool-detail");
+    expect(state.activeToolDetail).toBe(SAMPLE_TOOL);
+    expect(state.viewBeforeToolDetail).toBe("chat");
+  });
+
+  it("records a non-chat prior view (app -> restores to app)", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.viewBeforeToolDetail).toBe("app");
+    getState().closeToolDetail();
+    expect(getState().mainView).toBe("app");
+  });
+
+  it("does not overwrite a real prior view with a transient one when already in subagent-detail", () => {
+    useViewerStore.setState({
+      mainView: "subagent-detail",
+      viewBeforeToolDetail: "app",
+    });
+    getState().openToolDetail(SAMPLE_TOOL);
+    const state = getState();
+    expect(state.mainView).toBe("tool-detail");
+    expect(state.viewBeforeToolDetail).toBe("app");
+  });
+
+  it("preserves existing viewBeforeToolDetail when already in tool-detail", () => {
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      viewBeforeToolDetail: "app",
+      activeToolDetail: SAMPLE_TOOL,
+    });
+    getState().openToolDetail({ ...SAMPLE_TOOL, toolCallId: "tc-2" });
+    const state = getState();
+    expect(state.viewBeforeToolDetail).toBe("app");
+    expect(state.activeToolDetail?.toolCallId).toBe("tc-2");
+  });
+});
+
+describe("closeToolDetail", () => {
+  it("restores the prior view and clears the payload", () => {
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      viewBeforeToolDetail: "chat",
+      activeToolDetail: SAMPLE_TOOL,
+    });
+    getState().closeToolDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeToolDetail).toBeNull();
   });
 });
 

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -11,8 +11,9 @@
  * - `isAppMinimized` — mobile-only: app viewer minimized
  * - `intelligenceTab` — sub-tab inside the intelligence panel
  * - `assetsRefreshKey` — counter bumped to force asset re-fetches
- * - `viewBeforeDocument` / `viewBeforeSubagentDetail` — previous view for restoration
+ * - `viewBeforeDocument` / `viewBeforeSubagentDetail` / `viewBeforeToolDetail` — previous view for restoration
  * - `activeSubagentId` — subagent detail panel
+ * - `activeToolDetail` — tool-call detail drawer payload
  *
  * App share/deploy lifecycle lives in `domains/chat/deploy-store.ts`.
  *
@@ -30,7 +31,13 @@ import { createSelectors } from "@/utils/create-selectors";
 // Types
 // ---------------------------------------------------------------------------
 
-export type MainView = "chat" | "app" | "app-editing" | "document" | "subagent-detail";
+export type MainView =
+  | "chat"
+  | "app"
+  | "app-editing"
+  | "document"
+  | "subagent-detail"
+  | "tool-detail";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
 
@@ -48,6 +55,19 @@ export interface OpenedDocumentState {
   content: string;
 }
 
+export interface ToolDetailPayload {
+  toolCallId: string;
+  toolName: string;
+  title: string; // phase title, e.g. "Spawning subagent"
+  activity: string; // rich sentence (may be "")
+  input: Record<string, unknown>;
+  result?: string;
+  status: "running" | "completed" | "error" | "denied";
+  riskLevel?: string;
+  riskReason?: string;
+  durationLabel?: string;
+}
+
 // ---------------------------------------------------------------------------
 // State & Actions
 // ---------------------------------------------------------------------------
@@ -61,9 +81,11 @@ export interface ViewerState {
   isAppMinimized: boolean;
   intelligenceTab: IntelligenceTab;
   assetsRefreshKey: number;
-  viewBeforeDocument: Exclude<MainView, "document" | "subagent-detail">;
+  viewBeforeDocument: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
   activeSubagentId: string | null;
-  viewBeforeSubagentDetail: Exclude<MainView, "document" | "subagent-detail">;
+  viewBeforeSubagentDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
+  activeToolDetail: ToolDetailPayload | null;
+  viewBeforeToolDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail">;
 }
 
 export interface ViewerActions {
@@ -85,6 +107,10 @@ export interface ViewerActions {
   // --- Subagent detail ---
   openSubagentDetail: (subagentId: string) => void;
   closeSubagentDetail: () => void;
+
+  // --- Tool detail ---
+  openToolDetail: (payload: ToolDetailPayload) => void;
+  closeToolDetail: () => void;
 
   // --- Document viewer ---
   openDocument: () => void;
@@ -119,6 +145,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeDocument: "chat",
   activeSubagentId: null,
   viewBeforeSubagentDetail: "chat",
+  activeToolDetail: null,
+  viewBeforeToolDetail: "chat",
 };
 
 // ---------------------------------------------------------------------------
@@ -226,9 +254,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   openSubagentDetail: (subagentId) => {
     const state = get();
     const viewBeforeSubagentDetail =
-      state.mainView === "subagent-detail" || state.mainView === "document"
+      state.mainView === "subagent-detail" ||
+      state.mainView === "document" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeSubagentDetail
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "subagent-detail",
       activeSubagentId: subagentId,
@@ -243,14 +273,40 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     });
   },
 
+  // --- Tool detail ---
+
+  openToolDetail: (payload) => {
+    const state = get();
+    const viewBeforeToolDetail =
+      state.mainView === "tool-detail" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "document"
+        ? state.viewBeforeToolDetail
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
+    set({
+      mainView: "tool-detail",
+      activeToolDetail: payload,
+      viewBeforeToolDetail,
+    });
+  },
+
+  closeToolDetail: () => {
+    set({
+      mainView: get().viewBeforeToolDetail,
+      activeToolDetail: null,
+    });
+  },
+
   // --- Document viewer ---
 
   openDocument: () => {
     const state = get();
     const viewBeforeDocument =
-      state.mainView === "document" || state.mainView === "subagent-detail"
+      state.mainView === "document" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "document",
       openedDocumentState: null,
@@ -261,9 +317,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   loadDocument: async (assistantId, documentSurfaceId) => {
     const state = get();
     const viewBeforeDocument =
-      state.mainView === "document" || state.mainView === "subagent-detail"
+      state.mainView === "document" ||
+      state.mainView === "subagent-detail" ||
+      state.mainView === "tool-detail"
         ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail">);
+        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "document",
       activeDocumentSurfaceId: documentSurfaceId,


### PR DESCRIPTION
## Summary
Brings the web client's tool-call step pills to macOS parity:
- Richer titles from the daemon's `input.activity` sentence (e.g. "Spawning subagent to research Toronto's location in Canada").
- A button-based `ToolStepPill` with a leading icon and an inline `RiskBadge` (weak style, matching Figma `5010-103197` / macOS).
- Clicking a pill opens a technical-details **side drawer** (`ToolDetailPanel`: tool name, input, output, copy buttons), modeled on the subagent detail drawer — resizable pane on desktop, full-screen overlay on mobile.
- Storybook stories for `ToolStepPill` (Chat/ToolStepPill — the QA target), `RiskBadge`, and `ToolDetailPanel`.

Web-only; the daemon already emits `input.activity` and `riskLevel`.

## PRs merged into this feature branch
- #32296 surface tool activity text in step-label derivation (PR 1)
- #32297 add RiskBadge weak-style pill (PR 3)
- #32298 add tool-detail view + actions to viewer store (PR 5)
- #32299 carry activity + risk on tool step descriptors (PR 2)
- #32300 add ToolStepPill with icon + risk badge (PR 4)
- #32302 add ToolDetailPanel with technical details + output (PR 6)
- #32303 mount ToolDetailPanel side drawer + mobile overlay (PR 7)
- #32304 render ToolStepPill in unified card + open drawer on click (PR 8)

Part of plan: web-tool-call-pills.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)