### PR TITLE
[LUM-1692] fix(web): add safe-area insets to mobile full-screen overlays

### DIFF
--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -60,6 +60,10 @@ export function MobileAppOverlay({
     <div
       className="fixed inset-x-0 bottom-0 z-30 h-[100dvh] transition-transform duration-300 ease-out"
       style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
         transform: isAppMinimized
           ? "translateY(calc(100% - var(--app-strip-h, 56px)))"
           : "translateY(0)",

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -65,7 +65,7 @@ export function MobileAppOverlay({
         paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
         paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
         transform: isAppMinimized
-          ? "translateY(calc(100% - var(--app-strip-h, 56px)))"
+          ? "translateY(calc(100% - var(--app-strip-h, 56px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px))))"
           : "translateY(0)",
       }}
     >

--- a/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
@@ -33,7 +33,15 @@ export function MobileDocumentOverlay({
   if (!openedDocumentState || !assistantId) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+    >
       <DocumentViewerContainer
         documentName={openedDocumentState.documentName}
         content={openedDocumentState.content}

--- a/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
@@ -42,7 +42,15 @@ export function MobileSubagentDetailOverlay({
   }
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+    >
       <LazyBoundary>
         <SubagentDetailPanel
           entry={entry}


### PR DESCRIPTION
The three mobile full-screen overlays (`MobileDocumentOverlay`, `MobileAppOverlay`, `MobileSubagentDetailOverlay`) use `position: fixed` with `h-[100dvh]` and are portaled to `#viewport-overlays`. Because fixed positioning removes them from normal document flow, the parent `RootLayout`'s safe-area padding has no effect on them. On iOS, the overlay navbar and close button render behind the notch/status bar and are untappable.

Adds `paddingTop/Bottom/Left/Right` safe-area-inset CSS custom properties to each overlay's wrapper div, matching the existing pattern used by `attachment-preview-modal` and the home-page mobile detail panel. Also adjusts `MobileAppOverlay`'s minimized `translateY` calculation to include the safe-area-inset-top, so the 56px strip remains fully visible above the safe-area padding on notched devices.

Closes LUM-1692

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/70716e2c63e24f6a94e7021e18ed670f

## Prompt / plan
Investigate LUM-1692 (iOS document editor exit button unresponsive / icon bunched at top). Root cause: mobile overlays missing safe-area insets. Fix all three overlays.

## Test plan
- Typecheck passes (`bunx tsc --noEmit`)
- Lint passes (`bun run lint`)
- On non-iOS platforms, safe-area insets resolve to `0px` — no visual change
- On iOS, the overlay content will be inset from the notch/status bar area, making the navbar and close button tappable
- MobileAppOverlay minimized strip: the 56px AppNavBar strip remains fully visible below the safe-area padding on notched devices