### PR TITLE
feat: add 1-hour sleep time and dev-only 5/10-min options to sleep policy control

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-sleep-policy.tsx
+++ b/apps/web/src/domains/settings/components/assistant-sleep-policy.tsx
@@ -4,14 +4,22 @@ import { useMemo, useState } from "react";
 
 import { Button } from "@vellum/design-library/components/button";
 import { toast } from "@vellum/design-library/components/toast";
+import { useEnvironmentStore } from "@/lib/environment/environment-store";
 import {
   assistantsSleepPolicyDetailReadOptions,
   assistantsSleepPolicyDetailReadQueryKey,
   assistantsSleepPolicyDetailPartialUpdateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 
-const PRESET_OPTIONS: ReadonlyArray<{ label: string; seconds: number }> = [
+const PRESET_OPTIONS: ReadonlyArray<{
+  label: string;
+  seconds: number;
+  devOnly?: boolean;
+}> = [
   { label: "Never", seconds: 0 },
+  { label: "5 min", seconds: 300, devOnly: true },
+  { label: "10 min", seconds: 600, devOnly: true },
+  { label: "1 hour", seconds: 3600 },
   { label: "1 day", seconds: 86400 },
   { label: "3 days", seconds: 259200 },
   { label: "7 days", seconds: 604800 },
@@ -39,6 +47,11 @@ export function AssistantSleepPolicy({
   assistantId,
 }: AssistantSleepPolicyProps) {
   const queryClient = useQueryClient();
+  const isNonProduction = useEnvironmentStore.use.isNonProduction();
+  const visibleOptions = useMemo(
+    () => PRESET_OPTIONS.filter((opt) => !opt.devOnly || isNonProduction),
+    [isNonProduction],
+  );
 
   const {
     data: policy,
@@ -100,7 +113,7 @@ export function AssistantSleepPolicy({
           &quot;Never&quot; disables idle sleep entirely.
         </p>
         <div className="mt-2 flex flex-wrap gap-2">
-          {PRESET_OPTIONS.map((opt) => (
+          {visibleOptions.map((opt) => (
             <Button
               key={opt.seconds}
               variant="outlined"

--- a/apps/web/src/domains/settings/components/assistant-sleep-policy.tsx
+++ b/apps/web/src/domains/settings/components/assistant-sleep-policy.tsx
@@ -20,6 +20,7 @@ const PRESET_OPTIONS: ReadonlyArray<{
   { label: "5 min", seconds: 300, devOnly: true },
   { label: "10 min", seconds: 600, devOnly: true },
   { label: "1 hour", seconds: 3600 },
+  { label: "3 hours", seconds: 10800 },
   { label: "1 day", seconds: 86400 },
   { label: "3 days", seconds: 259200 },
   { label: "7 days", seconds: 604800 },


### PR DESCRIPTION
Adds a 1-hour idle timeout option to the sleep policy preset buttons, and introduces 5-minute and 10-minute presets gated behind `isNonProduction` from the environment store for internal testing.

## Prompt / plan
Add 1-hour option to sleep policy control, plus 5-min and 10-min dev-only options.

## Test plan
- Lint passes (`bun run lint`)
- Type-check passes (verified by pre-commit hook)
- 1-hour option visible in all environments; 5-min/10-min only when `isNonProduction` is true

Link to Devin session: https://app.devin.ai/sessions/c41a06bb84d346919f22fa683d9ae617
Requested by: @m-abboud