### PR TITLE
Fix content automation pre-chat recipe race

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 
+import { STORAGE_KEY } from "@/domains/onboarding/prechat";
 import { routes } from "@/utils/routes";
 
 let searchParams = new URLSearchParams();
@@ -38,10 +39,21 @@ const setOnboardingCompletedMock = mock(() => {});
 const writeSelectedVersionMock = mock(() => {});
 const markPrivacyConsentMock = mock(() => {});
 const clearPrivacyConsentMock = mock(() => {});
-const persistContentAutomationPreChatHandoffMock = mock(() => {});
+
+type TestOnboardingRecipe = {
+  cohort: string;
+  tasks: string[];
+  tone: string;
+  bootstrapTemplate: string;
+  initialMessage: string;
+  skills: string[];
+  skipPrechat: boolean;
+};
 
 let onboardingCompleted = false;
-let resolvedCohort: string | null = null;
+let fetchOnboardingRecipeImpl: () => Promise<TestOnboardingRecipe | null> =
+  async () => null;
+const fetchOnboardingRecipeMock = mock(() => fetchOnboardingRecipeImpl());
 
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
@@ -129,6 +141,10 @@ mock.module("@/domains/onboarding/signals", () => ({
   markPrivacyConsent: markPrivacyConsentMock,
 }));
 
+mock.module("@/domains/onboarding/recipe-client.js", () => ({
+  fetchOnboardingRecipe: fetchOnboardingRecipeMock,
+}));
+
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => false,
   useIsNativePlatform: () => false,
@@ -178,15 +194,6 @@ mock.module("@/hooks/use-ios-app-nudge", () => ({
 
 mock.module("@/hooks/use-macos-app-nudge", () => ({
   readMacOsAppDownloaded: () => true,
-}));
-
-mock.module("@/domains/onboarding/content-automation", () => ({
-  persistContentAutomationPreChatHandoff:
-    persistContentAutomationPreChatHandoffMock,
-}));
-
-mock.module("@/domains/onboarding/utm-cohort", () => ({
-  resolveUserCohort: async () => resolvedCohort,
 }));
 
 mock.module("@/domains/onboarding/screens/name-exchange-screen", () => ({
@@ -248,7 +255,7 @@ beforeEach(() => {
   searchParams = new URLSearchParams();
   checkAssistantImpl = async () => {};
   onboardingCompleted = false;
-  resolvedCohort = null;
+  fetchOnboardingRecipeImpl = async () => null;
   sessionStorage.clear();
   localStorage.clear();
 
@@ -262,7 +269,7 @@ beforeEach(() => {
   writeSelectedVersionMock.mockClear();
   markPrivacyConsentMock.mockClear();
   clearPrivacyConsentMock.mockClear();
-  persistContentAutomationPreChatHandoffMock.mockClear();
+  fetchOnboardingRecipeMock.mockClear();
 });
 
 afterEach(() => {
@@ -303,7 +310,7 @@ describe("onboarding lifecycle sync", () => {
 
     render(<PreChatFlow />);
 
-    fireEvent.click(screen.getByTestId("name-continue"));
+    fireEvent.click(await screen.findByTestId("name-continue"));
     fireEvent.click(await screen.findByTestId("task-continue"));
     fireEvent.click(await screen.findByTestId("tool-continue"));
     fireEvent.click(await screen.findByTestId("prior-continue"));
@@ -319,5 +326,59 @@ describe("onboarding lifecycle sync", () => {
         { replace: true },
       ),
     );
+  });
+
+  test("pre-chat waits for the web recipe decision before showing standard screens", async () => {
+    let resolveRecipe!: (recipe: TestOnboardingRecipe | null) => void;
+    fetchOnboardingRecipeImpl = () =>
+      new Promise<TestOnboardingRecipe | null>((resolve) => {
+        resolveRecipe = resolve;
+      });
+
+    render(<PreChatFlow />);
+
+    await waitFor(() => expect(fetchOnboardingRecipeMock).toHaveBeenCalled());
+    expect(screen.queryByTestId("name-continue")).toBeNull();
+
+    resolveRecipe(null);
+
+    expect(await screen.findByTestId("name-continue")).toBeTruthy();
+  });
+
+  test("recipe skip stores the pre-chat handoff and enters chat without showing pre-chat screens", async () => {
+    const recipe: TestOnboardingRecipe = {
+      cohort: "content-automation",
+      tasks: ["writing", "research"],
+      tone: "grounded",
+      bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
+      initialMessage: "I want to write articles that rank better in GEO",
+      skills: ["content-automation"],
+      skipPrechat: true,
+    };
+    fetchOnboardingRecipeImpl = async () => recipe;
+
+    render(<PreChatFlow />);
+
+    expect(screen.queryByTestId("name-continue")).toBeNull();
+    await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        `${routes.assistant}?onboarding=1`,
+        { replace: true },
+      ),
+    );
+
+    expect(setOnboardingCompletedMock).toHaveBeenCalledWith(true);
+    expect(clearPrivacyConsentMock).toHaveBeenCalled();
+    expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
+      tools: [],
+      tasks: recipe.tasks,
+      tone: recipe.tone,
+      googleConnected: false,
+      cohort: recipe.cohort,
+      initialMessage: recipe.initialMessage,
+      bootstrapTemplate: recipe.bootstrapTemplate,
+      skills: recipe.skills,
+    });
   });
 });

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -75,6 +75,9 @@ export function PreChatFlow() {
   } = useRootOutletContext();
   const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [recipe, setRecipe] = useState<OnboardingRecipe | null>(null);
+  const [recipeLoadState, setRecipeLoadState] = useState<"loading" | "ready">(
+    "loading",
+  );
 
   const isMacOSWeb = useIsMacOSWeb();
   const isIOSWeb = useIsIOSWeb();
@@ -158,13 +161,31 @@ export function PreChatFlow() {
   }, [consent, isAuthLoading, isLoggedIn, userId]);
 
   useEffect(() => {
-    if (isAuthLoading || !isLoggedIn) return;
+    if (isAuthLoading || !isLoggedIn) {
+      setRecipe(null);
+      setRecipeLoadState("loading");
+      return;
+    }
+    if (isNative) {
+      setRecipe(null);
+      setRecipeLoadState("ready");
+      return;
+    }
     let cancelled = false;
-    void fetchOnboardingRecipe().then((fetched) => {
-      if (!cancelled && fetched) setRecipe(fetched);
-    });
+    setRecipe(null);
+    setRecipeLoadState("loading");
+    void fetchOnboardingRecipe()
+      .then((fetched) => {
+        if (!cancelled) setRecipe(fetched);
+      })
+      .catch(() => {
+        if (!cancelled) setRecipe(null);
+      })
+      .finally(() => {
+        if (!cancelled) setRecipeLoadState("ready");
+      });
     return () => { cancelled = true; };
-  }, [isAuthLoading, isLoggedIn]);
+  }, [isAuthLoading, isLoggedIn, isNative, userId]);
 
   useEffect(() => {
     if (isAuthLoading) return;
@@ -261,10 +282,12 @@ export function PreChatFlow() {
   }
 
   const consentReady = isNative || consentDecision === "ok";
+  const recipeReady = isNative || recipeLoadState === "ready";
   if (
     isAuthLoading ||
     !isLoggedIn ||
     !consentReady ||
+    !recipeReady ||
     readOnboardingCompleted()
   ) {
     return null;


### PR DESCRIPTION
## Summary
- Wait for the onboarding recipe request before rendering the standard web pre-chat screens.
- Keep native pre-chat behavior unchanged.
- Add lifecycle coverage for the recipe wait state and recipe-driven auto-skip handoff.

## Tests
- `bun test src/domains/onboarding/onboarding-lifecycle-sync.test.tsx`
- `bunx tsc --noEmit`