### PR TITLE
fix(web): clear gateway and local-mode keys on logout

### DIFF
--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -30,6 +30,8 @@ const APP_KEY_PREFIXES = [
   "ff:client:",
   "voice:",
   "integrations.",
+  "gw:",
+  "local:",
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add gw: and local: to APP_KEY_PREFIXES so gateway tokens and local-mode state are cleared on logout

Part of plan: web-lockfile-driven-auth.md (PR 3 of 8)