### PR TITLE
feat(web): add VITE_LOCAL_MODE env var and local-mode lockfile module

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,3 +7,7 @@
 
 # Dev server port. Default: 3000
 # PORT=3000
+
+# Enable local-mode to read assistant lockfile from the CLI daemon.
+# When set, the web app reads /__local/lockfile to discover locally-hatched assistants.
+# VITE_LOCAL_MODE=true

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -18,6 +18,8 @@ interface ImportMetaEnv {
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */
   readonly VITE_APP_VERSION?: string;
+  /** Enable local-mode: read assistant lockfile from the CLI daemon. */
+  readonly VITE_LOCAL_MODE?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -1,0 +1,145 @@
+// Transport: Vite dev middleware for now. In Electron, swap to IPC (window.electronAPI.readLockfile).
+
+import {
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
+} from "@/lib/local-settings";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LocalAssistantResources {
+  gatewayPort: number;
+  daemonPort: number;
+}
+
+export interface LockfileAssistant {
+  assistantId: string;
+  name?: string;
+  cloud: string;
+  runtimeUrl: string;
+  species?: string;
+  hatchedAt?: string;
+  resources?: LocalAssistantResources;
+}
+
+export interface Lockfile {
+  assistants: LockfileAssistant[];
+  activeAssistant: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level cache
+// ---------------------------------------------------------------------------
+
+let lockfile: Lockfile | null = null;
+
+const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
+
+const LOCKFILE_STORAGE_KEY = "local:lockfile";
+const SELECTED_ASSISTANT_STORAGE_KEY = "local:selectedAssistantId";
+
+// ---------------------------------------------------------------------------
+// Core helpers
+// ---------------------------------------------------------------------------
+
+export function isLocalMode(): boolean {
+  return !!import.meta.env.VITE_LOCAL_MODE;
+}
+
+export async function loadLockfile(): Promise<Lockfile> {
+  try {
+    const res = await fetch("/__local/lockfile");
+    if (!res.ok) throw new Error(`lockfile fetch failed: ${res.status}`);
+    const data: Lockfile = await res.json();
+    lockfile = data;
+    setLocalSetting(LOCKFILE_STORAGE_KEY, JSON.stringify(data));
+    return data;
+  } catch {
+    lockfile = { ...EMPTY_LOCKFILE };
+    return lockfile;
+  }
+}
+
+export function getLockfile(): Lockfile {
+  if (lockfile) return lockfile;
+
+  const stored = getLocalSetting(LOCKFILE_STORAGE_KEY, "");
+  if (stored) {
+    try {
+      lockfile = JSON.parse(stored) as Lockfile;
+      return lockfile;
+    } catch {
+      // Corrupted storage -- fall through to empty lockfile.
+    }
+  }
+
+  lockfile = { ...EMPTY_LOCKFILE };
+  return lockfile;
+}
+
+// ---------------------------------------------------------------------------
+// Assistant queries
+// ---------------------------------------------------------------------------
+
+export function getLocalAssistants(): LockfileAssistant[] {
+  return getLockfile().assistants.filter(
+    (a) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  );
+}
+
+export function getPlatformAssistants(): LockfileAssistant[] {
+  return getLockfile().assistants.filter((a) => a.cloud === "vellum");
+}
+
+export function getActiveAssistant(): LockfileAssistant | undefined {
+  const lf = getLockfile();
+  const active = lf.assistants.find(
+    (a) => a.assistantId === lf.activeAssistant,
+  );
+  if (active) return active;
+  if (lf.assistants.length === 1) return lf.assistants[0];
+  return undefined;
+}
+
+export function getSelectedAssistant(): LockfileAssistant | undefined {
+  const selectedId = getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "");
+  if (selectedId) {
+    const found = getLockfile().assistants.find(
+      (a) => a.assistantId === selectedId,
+    );
+    if (found) return found;
+  }
+  return getActiveAssistant();
+}
+
+export function setSelectedAssistantId(id: string): void {
+  setLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, id);
+}
+
+export function clearSelectedAssistant(): void {
+  removeLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY);
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+export async function writeLockfile(patch: Partial<Lockfile>): Promise<void> {
+  await fetch("/__local/lockfile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  await loadLockfile();
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+export function gatewayProxyUrl(port: number): string {
+  return `/__gateway/${port}`;
+}


### PR DESCRIPTION
## Summary
- Add VITE_LOCAL_MODE build-time env var to gate local-mode behavior
- Create local-mode.ts module with lockfile types, caching, and helper functions
- Document the new env var in .env.example

Part of plan: web-lockfile-driven-auth.md (PR 1 of 8)