### PR TITLE
feat(web): support path-prefix ingress URLs in self-hosted rewrite

### DIFF
--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -151,6 +151,20 @@ describe("api-interceptors / self-hosted rewriting", () => {
     expect(outUrl.search).toBe("?limit=50");
   });
 
+  test("prepends the ingress path prefix when the ingress URL has a path", async () => {
+    const prefixedIngress = "http://localhost:3000/__gateway/20100";
+    setSelfHostedConnection({ url: prefixedIngress, token: ACTOR_TOKEN });
+    const input = new Request(
+      `https://platform.test/v1/assistants/self/conversations`,
+    );
+    const output = await requestInterceptor(input);
+    const outUrl = new URL(output.url);
+    expect(outUrl.origin).toBe("http://localhost:3000");
+    expect(outUrl.pathname).toBe(
+      "/__gateway/20100/v1/assistants/self/conversations",
+    );
+  });
+
   test("strips platform-only headers from the rewritten request", async () => {
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
     const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`, {

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -92,7 +92,8 @@ export async function rewriteForSelfHostedIngress(
   // `/v1/assistants/{id}/...` routes the platform's RuntimeProxyView
   // would otherwise forward to.
   const rewrittenUrl = new URL(ingressUrl);
-  rewrittenUrl.pathname = url.pathname;
+  const prefix = rewrittenUrl.pathname.replace(/\/$/, "");
+  rewrittenUrl.pathname = prefix + url.pathname;
   rewrittenUrl.search = url.search;
 
   // Build a fresh header set. Drop platform-only headers; keep client +


### PR DESCRIPTION
## Summary
- Change rewriteForSelfHostedIngress to prepend ingress path prefix instead of replacing pathname
- Backward-compatible: origin-only URLs behave identically
- Add test case for path-prefix ingress URL scenario

Part of plan: web-lockfile-driven-auth.md (PR 4 of 8)