### PR TITLE
feat(web): use lockfile gateway URL in assistant lifecycle

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 } from "@/assistant/lifecycle";
 import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
+import { isLocalMode, getSelectedAssistant, gatewayProxyUrl } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { routes } from "@/utils/routes";
 
@@ -404,11 +405,22 @@ export function useAssistantLifecycle({
       return;
     }
     if (isGatewayAuthMode()) {
+      let ingressUrl = window.location.origin;
+      let assistantId = "self";
+
+      if (isLocalMode()) {
+        const assistant = getSelectedAssistant();
+        if (assistant?.resources?.gatewayPort) {
+          ingressUrl = `${window.location.origin}${gatewayProxyUrl(assistant.resources.gatewayPort)}`;
+          assistantId = assistant.assistantId;
+        }
+      }
+
       setSelfHostedConnection({
-        url: window.location.origin,
+        url: ingressUrl,
         token: getGatewayToken(),
       });
-      setAssistantId("self");
+      setAssistantId(assistantId);
       setAssistantState({ kind: "active", isLocal: true });
       return;
     }


### PR DESCRIPTION
## Summary
- Use lockfile's gateway port to derive self-hosted connection URL via proxy path
- Use real assistant ID from lockfile instead of hardcoded 'self'
- Backward-compatible: non-local-mode uses window.location.origin as before

Part of plan: web-lockfile-driven-auth.md (PR 7 of 8)