### PR TITLE
feat(web): lockfile-driven auth routing in initSession

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/react";
 
 import { migrateDeviceSettings } from "@/lib/device-settings";
 import { initSentry } from "@/lib/sentry/sentry-init";
+import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { useAuthStore, setupAuthListeners } from "@/stores/auth-store";
 import { setupOrganizationStore } from "@/stores/organization-store";
 import { AppProviders } from "@/components/providers";
@@ -22,6 +23,9 @@ async function boot() {
   initSentry();
 
   setupOrganizationStore();
+  if (isLocalMode()) {
+    await loadLockfile();
+  }
   useAuthStore.getState().initSession();
   setupAuthListeners();
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -24,7 +24,14 @@ import {
   isGatewayAuthMode,
   ensureGatewayToken,
   clearGatewayToken,
+  getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
+import {
+  isLocalMode,
+  getSelectedAssistant,
+  getPlatformAssistants,
+  clearSelectedAssistant,
+} from "@/lib/local-mode";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { syncOnboardingUser, clearOnboardingFlags } from "@/lib/onboarding-cleanup";
 import { clearOrganization } from "@/stores/organization-store";
@@ -118,19 +125,25 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   initSession: async () => {
     if (isGatewayAuthEnabled()) {
+      if (isLocalMode() && !getSelectedAssistant()) {
+        set({ isLoggedIn: false, isLoading: false, user: null });
+        return;
+      }
       try {
-        await ensureGatewayToken();
+        await ensureGatewayToken(getLocalTokenUrl());
         set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
       } catch {
         set({ isLoggedIn: false, isLoading: false, user: null });
       }
-      getSession()
-        .then((result) => {
-          if (result.ok && result.data.user) {
-            set({ hasPlatformSession: true });
-          }
-        })
-        .catch(() => {});
+      if (!isLocalMode() || getPlatformAssistants().length > 0) {
+        getSession()
+          .then((result) => {
+            if (result.ok && result.data.user) {
+              set({ hasPlatformSession: true });
+            }
+          })
+          .catch(() => {});
+      }
       return;
     }
 
@@ -206,6 +219,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   logout: async () => {
     if (isGatewayAuthMode()) {
+      clearSelectedAssistant();
       clearGatewayToken();
       clearOnboardingFlags();
       clearOrganization();


### PR DESCRIPTION
## Summary
- Load lockfile at boot in main.tsx before initSession runs
- Route auth based on lockfile contents: local assistant → gateway token, platform-only → allauth
- Guard against no-assistant-selected state in local mode
- Clear selected assistant on logout

Part of plan: web-lockfile-driven-auth.md (PR 6 of 8)