### PR TITLE
feat(web): lockfile-driven login page with self-hosted support

### DIFF
--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { Mail } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
@@ -8,11 +8,22 @@ import { GoogleLogo } from "@/components/icons/google-logo";
 import { NativeSplash } from "@/components/native-splash";
 import { LoginBackground } from "@/domains/account/components/login-background";
 import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow";
+import { ensureGatewayToken } from "@/lib/auth/gateway-session";
+import {
+  type LockfileAssistant,
+  isLocalMode,
+  loadLockfile,
+  getLocalAssistants,
+  getPlatformAssistants,
+  setSelectedAssistantId,
+  gatewayProxyUrl,
+} from "@/lib/local-mode";
 import {
   startAuthFlow,
   startNativeLogin,
   useIsNativePlatform,
 } from "@/runtime/native-auth";
+import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 const CARD_CLASS =
@@ -36,6 +47,20 @@ function SignUpFooter({ signUpHref }: { signUpHref: string }) {
 
 function LoginCard({ children }: { children: ReactNode }) {
   return <div className={CARD_CLASS}>{children}</div>;
+}
+
+/** Forced-dark full-screen shell with the branded gradient background. */
+function DarkLoginShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="dark">
+      <div className="relative min-h-screen overflow-x-hidden bg-[var(--surface-base)] text-[var(--content-default)]">
+        <LoginBackground />
+        <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-4">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
@@ -104,12 +129,77 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Shared platform sign-in buttons (Apple / Google / Email via WorkOS)
+// ---------------------------------------------------------------------------
+
+function PlatformLoginButtons({
+  returnTo,
+  loading,
+  errorMessage,
+  onProviderClick,
+}: {
+  returnTo: string | null;
+  loading: boolean;
+  errorMessage: string | null;
+  onProviderClick: (providerHint?: string) => void;
+}) {
+  const signUpHref = returnTo
+    ? `${routes.account.signup}?returnTo=${encodeURIComponent(returnTo)}`
+    : routes.account.signup;
+
+  return (
+    <>
+      <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
+        Sign in to Vellum
+      </h1>
+      {errorMessage && (
+        <p className="text-body-small-default text-center text-[var(--system-negative-strong)]">
+          {errorMessage}
+        </p>
+      )}
+      <div className="flex flex-col items-center gap-3">
+        <Button
+          type="button"
+          variant="outlined"
+          fullWidth
+          onClick={() => onProviderClick("AppleOAuth")}
+          disabled={loading}
+          leftIcon={<AppleLogo />}
+          className="max-w-[300px] gap-3"
+        >
+          Continue with Apple
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          fullWidth
+          onClick={() => onProviderClick("GoogleOAuth")}
+          disabled={loading}
+          leftIcon={<GoogleLogo />}
+          className="max-w-[300px] gap-3"
+        >
+          Continue with Google
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          fullWidth
+          onClick={() => onProviderClick()}
+          disabled={loading}
+          leftIcon={<Mail />}
+          className="max-w-[300px] gap-3"
+        >
+          Continue with Email
+        </Button>
+      </div>
+      <SignUpFooter signUpHref={signUpHref} />
+    </>
+  );
+}
+
 /**
  * Web login form: three equal sign-in buttons routing through WorkOS.
- * 1. Continue with Apple → `provider_hint=AppleOAuth` (top, per Apple HIG).
- * 2. Continue with Google → `provider_hint=GoogleOAuth`.
- * 3. Continue with Email → no hint, opens WorkOS AuthKit email/password UI.
- *
  * Wraps itself in a forced-dark theme context with the branded
  * `LoginBackground` — the web login screen is always dark per Figma.
  */
@@ -118,9 +208,6 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
   const [loading, setLoading] = useState(false);
 
   const callbackUrl = buildProviderCallbackUrl(returnTo);
-  const signUpHref = returnTo
-    ? `${routes.account.signup}?returnTo=${encodeURIComponent(returnTo)}`
-    : routes.account.signup;
 
   const handleProvider = async (providerHint?: string) => {
     setErrorMessage(null);
@@ -137,78 +224,231 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
     }
   };
 
-  const handleApple = () => void handleProvider("AppleOAuth");
-  const handleGoogle = () => void handleProvider("GoogleOAuth");
-  const handleEmail = () => void handleProvider();
-
   return (
-    <div className="dark">
-      <div className="relative min-h-screen overflow-x-hidden bg-[var(--surface-base)] text-[var(--content-default)]">
-        <LoginBackground />
-        <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-4">
-          <LoginCard>
-            <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
-              Sign in to Vellum
-            </h1>
-            {errorMessage && (
+    <DarkLoginShell>
+      <LoginCard>
+        <PlatformLoginButtons
+          returnTo={returnTo}
+          loading={loading}
+          errorMessage={errorMessage}
+          onProviderClick={(hint) => {
+            void handleProvider(hint);
+          }}
+        />
+      </LoginCard>
+    </DarkLoginShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Local-mode login — lockfile-driven conditional rendering
+// ---------------------------------------------------------------------------
+
+function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
+  const navigate = useNavigate();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [platformError, setPlatformError] = useState<string | null>(null);
+  const [platformLoading, setPlatformLoading] = useState(false);
+
+  // Force re-read of lockfile state when refreshKey changes
+  void refreshKey;
+  const localAssistants = getLocalAssistants();
+  const platformAssistants = getPlatformAssistants();
+  const hasLocal = localAssistants.length > 0;
+  const hasPlatform = platformAssistants.length > 0;
+
+  const handleRefresh = useCallback(() => {
+    void loadLockfile().then(() => setRefreshKey((k) => k + 1));
+  }, []);
+
+  const connectToLocal = useCallback(
+    async (assistant: LockfileAssistant) => {
+      setConnectError(null);
+      setConnectingId(assistant.assistantId);
+      try {
+        const tokenUrl = `${gatewayProxyUrl(assistant.resources!.gatewayPort)}/auth/token`;
+        setSelectedAssistantId(assistant.assistantId);
+        await ensureGatewayToken(tokenUrl);
+        await useAuthStore.getState().initSession();
+        navigate(returnTo || "/assistant");
+      } catch {
+        setConnectError(
+          "Couldn't connect to your assistant. Make sure it's running.",
+        );
+        setConnectingId(null);
+      }
+    },
+    [navigate, returnTo],
+  );
+
+  const handlePlatformProvider = useCallback(
+    async (providerHint?: string) => {
+      setPlatformError(null);
+      setPlatformLoading(true);
+      try {
+        const callbackUrl = buildProviderCallbackUrl(returnTo);
+        await startAuthFlow(PROVIDER_ID, callbackUrl, {
+          ...(providerHint ? { providerHint } : {}),
+          returnTo,
+        });
+      } catch (err) {
+        console.error("[local-login] platform auth flow failed:", err);
+        setPlatformError("Something went wrong. Please try again.");
+        setPlatformLoading(false);
+      }
+    },
+    [returnTo],
+  );
+
+  // Auto-connect when only local assistants are present
+  useEffect(() => {
+    if (hasLocal && !hasPlatform && !connectingId && !connectError) {
+      void connectToLocal(localAssistants[0]!);
+    }
+    // localAssistants excluded: new array ref each render, guarded by hasLocal
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasLocal, hasPlatform, connectingId, connectError, connectToLocal]);
+
+  // No assistants at all
+  if (!hasLocal && !hasPlatform) {
+    return (
+      <DarkLoginShell>
+        <LoginCard>
+          <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
+            Vellum
+          </h1>
+          <p className="text-body-small-default text-center text-[var(--content-secondary)]">
+            No assistants found. Hatch one via CLI (
+            <code className="rounded bg-[var(--surface-sunken)] px-1 py-0.5 text-[var(--content-default)]">
+              vellum hatch
+            </code>
+            ) or the Mac app to get started.
+          </p>
+          <div className="flex justify-center">
+            <Button type="button" variant="outlined" onClick={handleRefresh}>
+              Refresh
+            </Button>
+          </div>
+        </LoginCard>
+      </DarkLoginShell>
+    );
+  }
+
+  // Only platform assistants — render normal login
+  if (hasPlatform && !hasLocal) {
+    return <WebLoginForm returnTo={returnTo} />;
+  }
+
+  // Only local assistants — auto-connecting state
+  if (hasLocal && !hasPlatform) {
+    return (
+      <DarkLoginShell>
+        <LoginCard>
+          <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
+            Vellum
+          </h1>
+          {connectError ? (
+            <>
               <p className="text-body-small-default text-center text-[var(--system-negative-strong)]">
-                {errorMessage}
+                {connectError}
               </p>
-            )}
-            <div className="flex flex-col items-center gap-3">
-              <Button
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant="outlined"
+                  onClick={() => {
+                    void connectToLocal(localAssistants[0]!);
+                  }}
+                >
+                  Retry
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="text-body-small-default text-center text-[var(--content-secondary)]">
+              {connectingId
+                ? "Connecting to your assistant..."
+                : "Preparing connection..."}
+            </p>
+          )}
+        </LoginCard>
+      </DarkLoginShell>
+    );
+  }
+
+  // Mixed: platform + local assistants — two-card layout
+  return (
+    <DarkLoginShell>
+      <div className="flex w-full max-w-[960px] flex-col items-start justify-center gap-6 md:flex-row">
+        <LoginCard>
+          <PlatformLoginButtons
+            returnTo={returnTo}
+            loading={platformLoading}
+            errorMessage={platformError}
+            onProviderClick={(hint) => {
+              void handlePlatformProvider(hint);
+            }}
+          />
+        </LoginCard>
+        <LoginCard>
+          <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
+            Local Assistant
+          </h1>
+          {connectError && (
+            <p className="text-body-small-default text-center text-[var(--system-negative-strong)]">
+              {connectError}
+            </p>
+          )}
+          <div className="flex flex-col gap-2">
+            {localAssistants.map((assistant) => (
+              <button
+                key={assistant.assistantId}
                 type="button"
-                variant="outlined"
-                fullWidth
-                onClick={handleApple}
-                disabled={loading}
-                leftIcon={<AppleLogo />}
-                className="max-w-[300px] gap-3"
+                className="flex w-full items-center justify-between rounded-lg border border-[var(--border-disabled)] bg-[var(--surface-sunken)] px-4 py-3 text-left transition-colors hover:bg-[var(--surface-lift)] disabled:opacity-50"
+                disabled={connectingId === assistant.assistantId}
+                onClick={() => {
+                  void connectToLocal(assistant);
+                }}
               >
-                Continue with Apple
-              </Button>
-              <Button
-                type="button"
-                variant="outlined"
-                fullWidth
-                onClick={handleGoogle}
-                disabled={loading}
-                leftIcon={<GoogleLogo />}
-                className="max-w-[300px] gap-3"
-              >
-                Continue with Google
-              </Button>
-              <Button
-                type="button"
-                variant="outlined"
-                fullWidth
-                onClick={handleEmail}
-                disabled={loading}
-                leftIcon={<Mail />}
-                className="max-w-[300px] gap-3"
-              >
-                Continue with Email
-              </Button>
-            </div>
-            <SignUpFooter signUpHref={signUpHref} />
-          </LoginCard>
-        </div>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-body-small-default text-[var(--content-emphasised)]">
+                    {assistant.name || assistant.assistantId}
+                  </span>
+                  {assistant.species && (
+                    <span className="text-body-small-default text-[var(--content-secondary)]">
+                      {assistant.species}
+                    </span>
+                  )}
+                </div>
+                {connectingId === assistant.assistantId && (
+                  <span className="text-body-small-default text-[var(--content-secondary)]">
+                    Connecting...
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </LoginCard>
       </div>
-    </div>
+    </DarkLoginShell>
   );
 }
 
 /**
  * Branded sign-in screen for `/account/login`.
  *
- * Delegates to `NativeLoginForm` (Capacitor iOS) or `WebLoginForm`
- * (standard browser) based on platform detection.
+ * Delegates to `LocalModeLoginPage` (lockfile-driven self-hosted),
+ * `NativeLoginForm` (Capacitor iOS), or `WebLoginForm` (standard browser)
+ * based on platform detection.
  */
 export function LoginPage() {
   const [searchParams] = useSearchParams();
   const isNative = useIsNativePlatform();
   const returnTo = searchParams.get("returnTo");
 
+  if (isLocalMode()) return <LocalModeLoginPage returnTo={returnTo} />;
   if (isNative) return <NativeLoginForm returnTo={returnTo} />;
   return <WebLoginForm returnTo={returnTo} />;
 }


### PR DESCRIPTION
## Summary
- Add LocalModeLoginPage component with lockfile-driven conditional rendering
- Show error page when no assistants, normal login for platform-only, two-card layout for mixed
- Auto-connect to local assistants via gateway proxy token endpoint
- Gate all behavior behind VITE_LOCAL_MODE env var

Part of plan: web-lockfile-driven-auth.md (PR 8 of 8)