### PR TITLE
feat(macos): typed command bus + File menu wired end-to-end

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -91,6 +91,12 @@ The preload script exposes a typed `window.vellum` API to the renderer:
   backed by `electron-store` in the main process. Writes are validated against
   a JSON schema (`hotkeys`, `theme`, `featureFlags`); a schema violation
   surfaces as a rejected `Promise`.
+- `commands.on(callback)` — subscribe to main-process commands dispatched
+  by the application menu (and, eventually, global hotkeys). Returns an
+  unsubscribe function. The renderer-side wrapper is
+  [`apps/web/src/runtime/vellum-commands.ts`](../web/src/runtime/vellum-commands.ts);
+  feature code mounts the `useVellumCommands` hook with a partial handler
+  map at whichever component owns the relevant state.
 - `auth.*` and `helper.*` — typed stubs that reject with "not implemented yet"
   until the corresponding feature tickets land.
 

--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -1,0 +1,63 @@
+import { BrowserWindow } from "electron";
+
+import { readSetting } from "./settings";
+
+/**
+ * Discriminated union of every command the app supports. Main is the source
+ * of truth for the contract; the renderer-side mirror lives in
+ * `apps/web/src/runtime/vellum-commands.ts`. Adding a variant here requires
+ * a matching update there — both halves are tiny on purpose so divergence
+ * is easy to spot in review.
+ */
+export type VellumCommand =
+  | { kind: "newConversation" }
+  | { kind: "currentConversation" }
+  | { kind: "markCurrentUnread" };
+
+export type VellumCommandKind = VellumCommand["kind"];
+
+/**
+ * Default accelerators per command, matching the Swift app's
+ * `UserDefaults` defaults from
+ * `clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift`.
+ *
+ * Populated lazily at menu-build time by merging with `settings.hotkeys`
+ * (rather than via the electron-store schema `default` block, which would
+ * clobber user overrides on schema migration — see LUM-1962).
+ */
+export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
+  newConversation: "CmdOrCtrl+N",
+  currentConversation: "CmdOrCtrl+Shift+N",
+  markCurrentUnread: "CmdOrCtrl+Shift+U",
+};
+
+/**
+ * Resolve the accelerator for a command, preferring the user override from
+ * `settings.hotkeys.<kind>` and falling back to the default. Returns the
+ * default for empty/non-string overrides so a corrupted setting doesn't
+ * silently disable a menu item.
+ */
+export const resolveAccelerator = (kind: VellumCommandKind): string => {
+  const hotkeys = readSetting("hotkeys");
+  if (hotkeys && typeof hotkeys === "object") {
+    const override = (hotkeys as Record<string, unknown>)[kind];
+    if (typeof override === "string" && override.length > 0) {
+      return override;
+    }
+  }
+  return DEFAULT_ACCELERATORS[kind];
+};
+
+/**
+ * Send a command to whichever BrowserWindow currently has focus, falling
+ * back to the first window if none is focused (which happens when a menu
+ * item is clicked from the menu bar while the app is in the background but
+ * its window isn't the OS focus owner). Capturing a window reference at
+ * menu-construction time would break thread pop-outs (LUM-1870) where the
+ * user expects Cmd+N to operate on the popped-out window they're in.
+ */
+export const dispatchToFocused = (command: VellumCommand): void => {
+  const target =
+    BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+  target?.webContents.send("vellum:command", command);
+};

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -1,26 +1,31 @@
 import { Menu, type MenuItemConstructorOptions, app, shell } from "electron";
 
+import {
+  dispatchToFocused,
+  resolveAccelerator,
+  type VellumCommand,
+} from "./commands";
+
 /**
  * Builds and installs the macOS application menu. Without this, Electron
  * ships a default menu that includes developer-flavored items (Reload,
  * Toggle Developer Tools at the top level) and lacks the standard macOS
  * shape end users expect.
  *
- * Scope of this initial wiring:
- *
- * - `Vellum`, `Edit`, `View`, `Window`, `Help` — all entirely role-based,
- *   so the items work today without any renderer IPC.
- * - `File` items that need renderer-side actions (New Conversation, Mark
- *   Unread, etc.) are intentionally omitted here. They land in a future
- *   ticket alongside the renderer handlers that implement them. Adding
- *   menu items that do nothing when clicked is worse than omitting them
- *   from the menu entirely.
- *
  * The `View > Toggle Developer Tools` item is gated to dev only so the
  * packaged build doesn't expose devtools to end users.
  */
 export const installApplicationMenu = (): void => {
   const isDev = !app.isPackaged;
+
+  const fileItem = (
+    label: string,
+    command: VellumCommand,
+  ): MenuItemConstructorOptions => ({
+    label,
+    accelerator: resolveAccelerator(command.kind),
+    click: () => dispatchToFocused(command),
+  });
 
   const template: MenuItemConstructorOptions[] = [
     {
@@ -36,6 +41,15 @@ export const installApplicationMenu = (): void => {
         { role: "unhide" },
         { type: "separator" },
         { role: "quit" },
+      ],
+    },
+    {
+      label: "File",
+      submenu: [
+        fileItem("New Conversation", { kind: "newConversation" }),
+        fileItem("Current Conversation", { kind: "currentConversation" }),
+        { type: "separator" },
+        fileItem("Mark Current as Unread", { kind: "markCurrentUnread" }),
       ],
     },
     {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -1,10 +1,21 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
 
-// Surface exposed to the renderer as `window.vellum`. `platform` and the
-// `settings` accessors are wired through IPC; `auth` and `helper` are typed
-// stubs that reject with "not implemented yet" until their feature tickets
-// land. When adding new bridge methods, see the "When to extend the bridge
-// with new methods" section in `apps/macos/README.md` for the convention
+// Command surface mirrors the discriminated union in
+// `apps/macos/src/main/commands.ts`. Kept inline (rather than imported)
+// because preload + main + renderer each have their own TS project; the
+// type is tiny enough that maintaining three identical literal unions is
+// cheaper than wiring cross-package imports. Drift surfaces as a renderer
+// handler being missing for a command kind — graceful no-op, not a crash.
+export type VellumCommand =
+  | { kind: "newConversation" }
+  | { kind: "currentConversation" }
+  | { kind: "markCurrentUnread" };
+
+// Surface exposed to the renderer as `window.vellum`. `platform`, `settings`,
+// and `commands` are wired through IPC; `auth` and `helper` are typed stubs
+// that reject with "not implemented yet" until their feature tickets land.
+// When adding new bridge methods, see the "When to extend the bridge with
+// new methods" section in `apps/macos/README.md` for the convention
 // (generic KV for non-sensitive prefs; dedicated `<capability>.<verb>()`
 // methods for sensitive capabilities).
 export interface VellumBridge {
@@ -20,6 +31,15 @@ export interface VellumBridge {
   };
   helper: {
     ping(): Promise<"pong">;
+  };
+  commands: {
+    /**
+     * Subscribe to commands dispatched by the main-process menu / hotkey
+     * system. Returns an unsubscribe function; callers should invoke it on
+     * cleanup (e.g. React `useEffect` return) to avoid leaks on window
+     * close or hot-reload.
+     */
+    on(callback: (command: VellumCommand) => void): () => void;
   };
 }
 
@@ -41,6 +61,17 @@ const bridge: VellumBridge = {
   },
   helper: {
     ping: notImplemented("helper.ping"),
+  },
+  commands: {
+    on: (callback) => {
+      const handler = (_event: IpcRendererEvent, command: VellumCommand) => {
+        callback(command);
+      };
+      ipcRenderer.on("vellum:command", handler);
+      return () => {
+        ipcRenderer.off("vellum:command", handler);
+      };
+    },
   },
 };
 

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -22,6 +22,7 @@ import type { AssistantContextValue } from "@/components/layout/assistant-contex
 
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
+import { requestComposerFocus } from "./composer-focus";
 import {
   conversationsQueryKey,
   useConversationGroupsQuery,
@@ -515,15 +516,21 @@ export function ChatLayout() {
   // Electron host commands (File menu / future global hotkeys). The hook
   // is a no-op on the web host. Handlers close over the latest state via
   // an internal ref, so we don't need to memoize them. Composer focus is
-  // routed to ChatPage via a window event because the textarea ref lives
-  // there, not here — see the matching `vellum:focus-composer` listener
-  // in `chat-page.tsx`.
+  // routed via `requestComposerFocus` (see `./composer-focus.ts`) so it
+  // works whether ChatPage is already mounted (event listener) or the
+  // command comes from another `/assistant/*` route (pending flag drained
+  // on the next ChatPage mount).
   useVellumCommands({
     newConversation: () => {
       startNewConversation();
     },
     currentConversation: () => {
-      window.dispatchEvent(new Event("vellum:focus-composer"));
+      if (!activeConversationId) return;
+      const target = routes.conversation(activeConversationId);
+      if (location.pathname !== target) {
+        void navigate(target);
+      }
+      requestComposerFocus();
     },
     markCurrentUnread: () => {
       if (!activeConversationId) return;

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -20,6 +20,7 @@ import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useHomeUnreadBadge } from "@/hooks/use-home-unread-badge";
 import type { AssistantContextValue } from "@/components/layout/assistant-context";
 
+import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
 import {
   conversationsQueryKey,
@@ -509,6 +510,28 @@ export function ChatLayout() {
     switchConversation: handleSelectConversation,
     startNewConversation,
     prePinGroupIdsRef,
+  });
+
+  // Electron host commands (File menu / future global hotkeys). The hook
+  // is a no-op on the web host. Handlers close over the latest state via
+  // an internal ref, so we don't need to memoize them. Composer focus is
+  // routed to ChatPage via a window event because the textarea ref lives
+  // there, not here — see the matching `vellum:focus-composer` listener
+  // in `chat-page.tsx`.
+  useVellumCommands({
+    newConversation: () => {
+      startNewConversation();
+    },
+    currentConversation: () => {
+      window.dispatchEvent(new Event("vellum:focus-composer"));
+    },
+    markCurrentUnread: () => {
+      if (!activeConversationId) return;
+      const conversation = conversations.find(
+        (c) => c.conversationId === activeConversationId,
+      );
+      if (conversation) handleMarkConversationUnread(conversation);
+    },
   });
 
   const handleOpenLibrary = useCallback(() => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -27,6 +27,10 @@ import { useAssistantContext } from "@/components/layout/assistant-context";
 import { useShallow } from "zustand/shallow";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
 import {
+  COMPOSER_FOCUS_EVENT,
+  consumePendingComposerFocus,
+} from "./composer-focus";
+import {
   useConversationGroupsQuery,
   useConversationListQuery,
 } from "@/domains/conversations/conversation-queries";
@@ -282,11 +286,17 @@ export function ChatPage() {
   // command. The command is dispatched in `chat-layout.tsx` via the
   // `useVellumCommands` hook; the textarea ref lives here, so we listen
   // for a window event rather than threading the ref upward through
-  // props/context just for this one cross-cutting capability.
+  // props/context just for this one cross-cutting capability. On mount,
+  // also drain any pending focus request that fired before we mounted
+  // (e.g. when the command was invoked from `/assistant/home` and
+  // chat-layout navigated us here) — see `./composer-focus.ts`.
   useEffect(() => {
-    const handler = () => inputRef.current?.focus();
-    window.addEventListener("vellum:focus-composer", handler);
-    return () => window.removeEventListener("vellum:focus-composer", handler);
+    const focusInput = () => inputRef.current?.focus();
+    window.addEventListener(COMPOSER_FOCUS_EVENT, focusInput);
+    if (consumePendingComposerFocus()) {
+      queueMicrotask(focusInput);
+    }
+    return () => window.removeEventListener(COMPOSER_FOCUS_EVENT, focusInput);
   }, []);
 
   const activeConversationIdRef = useRef<string | null>(activeConversationId);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -278,6 +278,16 @@ export function ChatPage() {
   // the actual `<Transcript />` instance there.
   const transcriptRef = useRef<TranscriptHandle | null>(null);
 
+  // Composer focus from the Electron host's File > Current Conversation
+  // command. The command is dispatched in `chat-layout.tsx` via the
+  // `useVellumCommands` hook; the textarea ref lives here, so we listen
+  // for a window event rather than threading the ref upward through
+  // props/context just for this one cross-cutting capability.
+  useEffect(() => {
+    const handler = () => inputRef.current?.focus();
+    window.addEventListener("vellum:focus-composer", handler);
+    return () => window.removeEventListener("vellum:focus-composer", handler);
+  }, []);
 
   const activeConversationIdRef = useRef<string | null>(activeConversationId);
   useEffect(() => { activeConversationIdRef.current = activeConversationId; }, [activeConversationId]);

--- a/apps/web/src/domains/chat/composer-focus.ts
+++ b/apps/web/src/domains/chat/composer-focus.ts
@@ -1,0 +1,33 @@
+/**
+ * Coordinates focus requests for the chat composer textarea across route
+ * boundaries. The textarea ref lives in `chat-page.tsx`; callers in
+ * higher-level layouts (and the Electron command bus) request focus via
+ * `requestComposerFocus()`, which:
+ *
+ * - fires a window event consumed by `chat-page`'s mounted listener
+ *   (for the same-route case), AND
+ * - sets a one-shot pending flag that `chat-page` drains on its next
+ *   mount (for the case where the caller navigated to the conversation
+ *   route from elsewhere — `/assistant/home`, `/assistant/library`,
+ *   etc. — and the listener doesn't exist yet at dispatch time).
+ *
+ * Without the pending-flag drain, File > Current Conversation would no-op
+ * when invoked from non-chat routes.
+ */
+export const COMPOSER_FOCUS_EVENT = "vellum:focus-composer";
+
+let pending = false;
+
+export function requestComposerFocus(): void {
+  pending = true;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(COMPOSER_FOCUS_EVENT));
+  }
+}
+
+/** Returns and clears the pending flag in one step. */
+export function consumePendingComposerFocus(): boolean {
+  const wasPending = pending;
+  pending = false;
+  return wasPending;
+}

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -13,6 +13,18 @@
  * `window.vellum`, `isNativePlatform()` calls Capacitor, and the web branch
  * uses `localStorage` — so consumers stay platform-agnostic.
  */
+/**
+ * Renderer-side mirror of the discriminated union in
+ * `apps/macos/src/main/commands.ts`. Inline (rather than cross-package
+ * imported) because main, preload, and renderer each have their own TS
+ * project; the type is tiny enough that maintaining identical literal
+ * unions is cheaper than wiring cross-package imports.
+ */
+export type VellumCommand =
+  | { kind: "newConversation" }
+  | { kind: "currentConversation" }
+  | { kind: "markCurrentUnread" };
+
 declare global {
   interface Window {
     vellum?: {
@@ -20,6 +32,9 @@ declare global {
       settings: {
         get<T = unknown>(key: string): Promise<T | null>;
         set<T = unknown>(key: string, value: T): Promise<void>;
+      };
+      commands: {
+        on(callback: (command: VellumCommand) => void): () => void;
       };
     };
   }

--- a/apps/web/src/runtime/vellum-commands.ts
+++ b/apps/web/src/runtime/vellum-commands.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+import { isElectron, type VellumCommand } from "@/runtime/is-electron";
+
+/**
+ * Renderer-side dispatcher for commands sent by the Electron host's
+ * application menu (and, eventually, global hotkeys). The contract is
+ * defined in `apps/macos/src/main/commands.ts`; this file mirrors the
+ * union type via the ambient declaration in `is-electron.ts`.
+ *
+ * Consumers register a partial map of handlers. Missing entries no-op,
+ * which is intentional: the same command stream is consumed at multiple
+ * mount points (chat layout, settings, future thread pop-outs) and not
+ * every consumer cares about every command.
+ *
+ * Handlers are held in a ref so re-renders don't re-subscribe to the IPC
+ * channel, and the latest handler closure is always invoked when a
+ * command arrives (avoids stale-closure bugs without forcing callers to
+ * memoize).
+ */
+export type CommandHandlers = Partial<
+  Record<VellumCommand["kind"], () => void>
+>;
+
+export function useVellumCommands(handlers: CommandHandlers): void {
+  const handlersRef = useRef<CommandHandlers>(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (!isElectron()) return;
+    const bridge = window.vellum;
+    if (!bridge) return;
+    return bridge.commands.on((command) => {
+      handlersRef.current[command.kind]?.();
+    });
+  }, []);
+}


### PR DESCRIPTION
## Summary

Lands the typed command/hotkey system that connects Electron's main-process application menu to renderer-side handlers — main + preload + renderer in one PR so each command works end-to-end the moment it ships. No dormant menu items, no IPC channels without subscribers.

Three commands wired:

| Item | Default | Behavior |
|---|---|---|
| `File > New Conversation` | `Cmd+N` | `startNewConversation()` in chat-layout |
| `File > Current Conversation` | `Cmd+Shift+N` | Focus the composer textarea (chat-page listens for a `vellum:focus-composer` window event) |
| `File > Mark Current as Unread` | `Cmd+Shift+U` | `handleMarkConversationUnread()` against the active conversation |

## Architecture

Modeled on VS Code's `ICommandService` + `MenuRegistry`. Three layers:

1. **Main as source of truth** (`apps/macos/src/main/commands.ts`) — discriminated union `VellumCommand`, a `dispatchToFocused(command)` helper that resolves `BrowserWindow.getFocusedWindow()` at click-time (so future thread pop-outs inherit the right routing), and `resolveAccelerator(kind)` that reads from `settings.hotkeys.<kind>` with defaults merged at menu-build time.
2. **Preload bridge** (`apps/macos/src/preload/index.ts`) — adds `commands.on(callback)` returning an unsubscribe. Renderer never sees the channel name (`vellum:command`) — only the typed callback.
3. **Renderer hook** (`apps/web/src/runtime/vellum-commands.ts`) — `useVellumCommands(handlers)` with a ref-based handler latch so re-renders don't re-subscribe to the IPC channel and stale closures aren't a problem.

## Why the defaults aren't in the electron-store schema

The schema's `default` block populates on _every_ store-creation, which would clobber a user override on a future schema migration. Defaults live in `DEFAULT_ACCELERATORS` and are merged at read time. User overrides via `window.vellum.settings.set("hotkeys", ...)` win; corrupted/non-string overrides fall back to the default so a bad write doesn't silently disable a menu item.

## Why focus is routed via a window event

The composer textarea ref lives in `chat-page.tsx`, not `chat-layout.tsx`. Rather than threading the ref upward through props/context just for this one cross-cutting capability, chat-layout dispatches `window.dispatchEvent(new Event("vellum:focus-composer"))` and chat-page subscribes via `useEffect`. Loose coupling, easy to extend if other commands need composer access later.

## Test plan

- [x] `bun run typecheck` clean in `apps/macos/`
- [x] `bun run build` clean in `apps/macos/` (`out/preload/index.js` is 0.94 kB — tiny addition)
- [x] No new errors introduced in `apps/web/` typecheck (pre-existing errors are all missing `@/generated/daemon/*` codegen artifacts unrelated to this PR)

Pending on a real Mac (cloud environment can't launch Electron):

- [ ] `bun run dev` shows the new `File` submenu with three items and the documented accelerators
- [ ] `Cmd+N` from anywhere in the app navigates to a new draft conversation
- [ ] `Cmd+Shift+N` focuses the composer textarea
- [ ] `Cmd+Shift+U` with an active conversation marks it unread
- [ ] Setting `settings.hotkeys.newConversation = "Cmd+Shift+M"` and restarting the app updates the menu's displayed shortcut AND the new shortcut fires the command

## Out of scope

- Global hotkey listener (`globalShortcut`) for commands while the app is unfocused — different mechanism, follow-up if/when needed.
- Settings UI for configuring hotkeys — schema accepts overrides via `window.vellum.settings.set`; UI lands in its own ticket.
- Command palette (Cmd+K) — same bus consumes it eventually, but the palette UI itself is out of scope here.

[LUM-1962](https://linear.app/vellum/issue/LUM-1962)

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_