### PR TITLE
fix: consolidate local gateway helpers and fix refreshSession token URL

### DIFF
--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -308,7 +308,6 @@ function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
       void connectToLocal(localAssistants[0]!);
     }
     // localAssistants excluded: new array ref each render, guarded by hasLocal
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasLocal, hasPlatform, connectingId, connectError, connectToLocal]);
 
   // No assistants at all

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from "@/assistant/lifecycle";
 import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
-import { isLocalMode, getSelectedAssistant, gatewayProxyUrl } from "@/lib/local-mode";
+import { getSelectedAssistant, getLocalGatewayUrl } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { routes } from "@/utils/routes";
 
@@ -408,12 +408,11 @@ export function useAssistantLifecycle({
       let ingressUrl = window.location.origin;
       let assistantId = "self";
 
-      if (isLocalMode()) {
+      const localGateway = getLocalGatewayUrl();
+      if (localGateway) {
         const assistant = getSelectedAssistant();
-        if (assistant?.resources?.gatewayPort) {
-          ingressUrl = `${window.location.origin}${gatewayProxyUrl(assistant.resources.gatewayPort)}`;
-          assistantId = assistant.assistantId;
-        }
+        ingressUrl = `${window.location.origin}${localGateway}`;
+        assistantId = assistant?.assistantId ?? assistantId;
       }
 
       setSelfHostedConnection({

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -1,8 +1,7 @@
 import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store";
 import {
   isLocalMode,
-  getSelectedAssistant,
-  gatewayProxyUrl,
+  getLocalGatewayUrl,
 } from "@/lib/local-mode";
 
 const LS_TOKEN_KEY = "gw:token";
@@ -13,12 +12,7 @@ let cachedExpiresAt: number = 0;
 
 export function isGatewayAuthEnabled(): boolean {
   if (isLocalMode()) {
-    const assistant = getSelectedAssistant();
-    return (
-      assistant !== undefined &&
-      assistant.cloud !== "vellum" &&
-      assistant.resources?.gatewayPort != null
-    );
+    return getLocalGatewayUrl() != null;
   }
   return useClientFeatureFlagStore.getState().gatewayWebAuth === true;
 }
@@ -81,10 +75,9 @@ export async function ensureGatewayToken(tokenUrl?: string): Promise<string> {
 }
 
 export function getLocalTokenUrl(): string | undefined {
-  if (!isLocalMode()) return undefined;
-  const assistant = getSelectedAssistant();
-  if (!assistant?.resources?.gatewayPort) return undefined;
-  return `${gatewayProxyUrl(assistant.resources.gatewayPort)}/auth/token`;
+  const gatewayUrl = getLocalGatewayUrl();
+  if (!gatewayUrl) return undefined;
+  return `${gatewayUrl}/auth/token`;
 }
 
 export function clearGatewayToken(): void {

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -84,17 +84,19 @@ export function getLockfile(): Lockfile {
 // Assistant queries
 // ---------------------------------------------------------------------------
 
+export function isLocalAssistant(a: LockfileAssistant): boolean {
+  return a.cloud !== "vellum" && a.resources?.gatewayPort != null;
+}
+
 export function getLocalAssistants(): LockfileAssistant[] {
-  return getLockfile().assistants.filter(
-    (a) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
-  );
+  return getLockfile().assistants.filter(isLocalAssistant);
 }
 
 export function getPlatformAssistants(): LockfileAssistant[] {
   return getLockfile().assistants.filter((a) => a.cloud === "vellum");
 }
 
-export function getActiveAssistant(): LockfileAssistant | undefined {
+function getActiveAssistant(): LockfileAssistant | undefined {
   const lf = getLockfile();
   const active = lf.assistants.find(
     (a) => a.assistantId === lf.activeAssistant,
@@ -142,4 +144,15 @@ export async function writeLockfile(patch: Partial<Lockfile>): Promise<void> {
 
 export function gatewayProxyUrl(port: number): string {
   return `/__gateway/${port}`;
+}
+
+/**
+ * Return the local gateway proxy URL for the selected assistant, or
+ * `undefined` when not in local mode / no local assistant is selected.
+ */
+export function getLocalGatewayUrl(): string | undefined {
+  if (!isLocalMode()) return undefined;
+  const assistant = getSelectedAssistant();
+  if (!assistant?.resources?.gatewayPort) return undefined;
+  return gatewayProxyUrl(assistant.resources.gatewayPort);
 }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -187,17 +187,19 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   refreshSession: async () => {
     if (isGatewayAuthMode()) {
       try {
-        await ensureGatewayToken();
+        await ensureGatewayToken(getLocalTokenUrl());
         set({ isLoggedIn: true });
       } catch {
         set({ isLoggedIn: false, user: null, hasPlatformSession: false });
         return false;
       }
-      getSession()
-        .then((result) => {
-          set({ hasPlatformSession: !!(result.ok && result.data.user) });
-        })
-        .catch(() => set({ hasPlatformSession: false }));
+      if (!isLocalMode() || getPlatformAssistants().length > 0) {
+        getSession()
+          .then((result) => {
+            set({ hasPlatformSession: !!(result.ok && result.data.user) });
+          })
+          .catch(() => set({ hasPlatformSession: false }));
+      }
       return true;
     }
 


### PR DESCRIPTION
## Summary
Fixes gaps from self-review:
- Fix refreshSession to use getLocalTokenUrl() for correct gateway port
- Skip allauth probe in refreshSession when in pure local mode
- Add getLocalGatewayUrl() and isLocalAssistant() helpers to local-mode.ts
- Consolidate repeated predicate/URL patterns across gateway-session, lifecycle, and local-mode
- Unexport getActiveAssistant (only used internally)

Part of plan: web-lockfile-driven-auth.md (review fix round 1)