### PR TITLE
fix: address Codex review feedback — security, token keying, legacy paths

### DIFF
--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -6,9 +6,11 @@ import {
 
 const LS_TOKEN_KEY = "gw:token";
 const LS_EXPIRES_KEY = "gw:expiresAt";
+const LS_TOKEN_SOURCE_KEY = "gw:tokenSource";
 
 let cachedToken: string | null = null;
 let cachedExpiresAt: number = 0;
+let cachedTokenSource: string | null = null;
 
 export function isGatewayAuthEnabled(): boolean {
   if (isLocalMode()) {
@@ -60,15 +62,22 @@ async function acquireGatewayToken(tokenUrl?: string): Promise<string> {
   try {
     localStorage.setItem(LS_TOKEN_KEY, token);
     localStorage.setItem(LS_EXPIRES_KEY, String(expiresAt));
+    localStorage.setItem(LS_TOKEN_SOURCE_KEY, url);
   } catch {
     // localStorage unavailable
   }
   cachedToken = token;
   cachedExpiresAt = expiresAt;
+  cachedTokenSource = url;
   return token;
 }
 
 export async function ensureGatewayToken(tokenUrl?: string): Promise<string> {
+  const source = tokenUrl ?? "/auth/token";
+  const storedSource = cachedTokenSource ?? localStorage.getItem(LS_TOKEN_SOURCE_KEY);
+  if (storedSource && storedSource !== source) {
+    clearGatewayToken();
+  }
   const existing = getGatewayToken();
   if (existing) return existing;
   return acquireGatewayToken(tokenUrl);
@@ -83,9 +92,11 @@ export function getLocalTokenUrl(): string | undefined {
 export function clearGatewayToken(): void {
   cachedToken = null;
   cachedExpiresAt = 0;
+  cachedTokenSource = null;
   try {
     localStorage.removeItem(LS_TOKEN_KEY);
     localStorage.removeItem(LS_EXPIRES_KEY);
+    localStorage.removeItem(LS_TOKEN_SOURCE_KEY);
   } catch {
     // localStorage unavailable
   }

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -45,8 +45,12 @@ const SELECTED_ASSISTANT_STORAGE_KEY = "local:selectedAssistantId";
 // Core helpers
 // ---------------------------------------------------------------------------
 
+const LOCAL_MODE_FALSY = new Set(["", "0", "false", "no"]);
+
 export function isLocalMode(): boolean {
-  return !!import.meta.env.VITE_LOCAL_MODE;
+  const raw = import.meta.env.VITE_LOCAL_MODE;
+  if (!raw) return false;
+  return !LOCAL_MODE_FALSY.has(raw.toLowerCase());
 }
 
 export async function loadLockfile(): Promise<Lockfile> {
@@ -140,6 +144,6 @@ export function gatewayProxyUrl(port: number): string {
 export function getLocalGatewayUrl(): string | undefined {
   if (!isLocalMode()) return undefined;
   const assistant = getSelectedAssistant();
-  if (!assistant?.resources?.gatewayPort) return undefined;
-  return gatewayProxyUrl(assistant.resources.gatewayPort);
+  if (!assistant || !isLocalAssistant(assistant)) return undefined;
+  return gatewayProxyUrl(assistant.resources!.gatewayPort);
 }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -28,7 +28,6 @@ import {
 } from "@/lib/auth/gateway-session";
 import {
   isLocalMode,
-  getSelectedAssistant,
   getPlatformAssistants,
   clearSelectedAssistant,
 } from "@/lib/local-mode";
@@ -125,10 +124,6 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   initSession: async () => {
     if (isGatewayAuthEnabled()) {
-      if (isLocalMode() && !getSelectedAssistant()) {
-        set({ isLoggedIn: false, isLoading: false, user: null });
-        return;
-      }
       try {
         await ensureGatewayToken(getLocalTokenUrl());
         set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -23,19 +23,22 @@ const SENSITIVE_FIELDS = [
  * - Non-production: `$XDG_CONFIG_HOME/vellum-{env}/lockfile.json`
  * - `VELLUM_LOCKFILE_DIR` overrides the directory in both cases.
  */
-function resolveLockfilePath(env: Record<string, string>): string {
+function resolveLockfilePaths(env: Record<string, string>): string[] {
   const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
   const lockfileDir = env.VELLUM_LOCKFILE_DIR;
 
   if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
     const dir = lockfileDir ?? os.homedir();
-    return path.join(dir, ".vellum.lock.json");
+    return [
+      path.join(dir, ".vellum.lock.json"),
+      path.join(dir, ".vellum.lockfile.json"),
+    ];
   }
 
   const xdgConfigHome =
     env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   const dir = lockfileDir ?? path.join(xdgConfigHome, `vellum-${vellumEnv}`);
-  return path.join(dir, "lockfile.json");
+  return [path.join(dir, "lockfile.json")];
 }
 
 /**
@@ -46,8 +49,15 @@ function stripSensitiveFields(data: Record<string, unknown>): void {
   if (!Array.isArray(assistants)) return;
   for (const assistant of assistants) {
     if (assistant && typeof assistant === "object") {
+      const entry = assistant as Record<string, unknown>;
       for (const field of SENSITIVE_FIELDS) {
-        delete (assistant as Record<string, unknown>)[field];
+        delete entry[field];
+      }
+      const resources = entry.resources;
+      if (resources && typeof resources === "object") {
+        for (const field of SENSITIVE_FIELDS) {
+          delete (resources as Record<string, unknown>)[field];
+        }
       }
     }
   }
@@ -58,13 +68,12 @@ function stripSensitiveFields(data: Record<string, unknown>): void {
  * for local-mode development.
  */
 export function localModePlugin(env: Record<string, string>): Plugin {
-  const lockfilePath = resolveLockfilePath(env);
+  const lockfilePaths = resolveLockfilePaths(env);
 
   return {
     name: "vellum-local-mode",
     configureServer(server) {
-      // Runs before Vite's built-in middleware
-      server.middlewares.use(lockfileMiddleware(lockfilePath));
+      server.middlewares.use(lockfileMiddleware(lockfilePaths));
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -74,13 +83,13 @@ export function localModePlugin(env: Record<string, string>): Plugin {
  * Connect middleware for the lockfile read endpoint.
  */
 function lockfileMiddleware(
-  lockfilePath: string,
+  lockfilePaths: string[],
 ): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url !== "/__local/lockfile") return next();
 
     if (req.method === "GET") {
-      handleGetLockfile(lockfilePath, res);
+      handleGetLockfile(lockfilePaths, res);
     } else {
       res.statusCode = 405;
       res.end();
@@ -89,20 +98,26 @@ function lockfileMiddleware(
 }
 
 function handleGetLockfile(
-  lockfilePath: string,
+  lockfilePaths: string[],
   res: http.ServerResponse,
 ): void {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(lockfilePath, "utf-8");
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ assistants: [], activeAssistant: null }));
-      return;
+  let raw: string | undefined;
+  for (const candidate of lockfilePaths) {
+    try {
+      raw = fs.readFileSync(candidate, "utf-8");
+      break;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        res.statusCode = 500;
+        res.end();
+        return;
+      }
     }
-    res.statusCode = 500;
-    res.end();
+  }
+
+  if (!raw) {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ assistants: [], activeAssistant: null }));
     return;
   }
 


### PR DESCRIPTION
## Summary
Addresses Codex review comments across the feature branch:

- **P1: Strip nested signing keys** — `stripSensitiveFields` now also scrubs `resources.signingKey`
- **P2: Key gateway tokens by URL** — tokens are keyed by their source URL; switching assistants clears the stale token
- **P2: Legacy lockfile fallback** — production path resolution now tries `~/.vellum.lockfile.json` as fallback
- **P2: Parse VITE_LOCAL_MODE properly** — `"false"`, `"0"`, `"no"` are treated as falsy
- **P2: Dead no-selection guard** — removed unreachable `isLocalMode() && !getSelectedAssistant()` check
- **P2: Cloud type check** — `getLocalGatewayUrl()` now verifies `isLocalAssistant()` before returning

Part of plan: web-lockfile-driven-auth.md (Codex review fixes)