### PR TITLE
fix(web): stop three-dot indicator overlapping the "Working" phase label

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -266,7 +266,13 @@ function PhaseHeaderRow({
         ) : (
           <ThreeDotIndicator
             data-testid="phase-header-status-icon"
-            className="h-[14px] w-[14px]"
+            // `shrink-0` with no fixed width: the dots keep their natural 8px
+            // footprint (matching the card header) and own their full width in
+            // the flex row, so the row's `gap-1` always separates them from the
+            // label. A fixed `w-[14px]` here let the wider dots overflow onto
+            // the label — flex overflow ignores the gap — which is the overlap
+            // this replaces.
+            className="shrink-0"
           />
         )}
         <Typography


### PR DESCRIPTION
## Problem

In the tool-progress card's expanded body, an in-progress phase header (e.g. **Working**) renders the animated three-dot indicator overlapping the phase label — the row reads as `●●Working` with no gap.

## Root cause

The phase-header status slot pinned its icon to a fixed **14px** box so the running indicator would line up with the completed (`Check`) and failed (`AlertTriangle`) icons. But `ThreeDotIndicator`'s natural width is ~30px (3 × 8px dots + 3px gaps) and each dot is `shrink-0`, so the dots couldn't compress to fit. Flexbox overflow ignores the row's `gap`, so the overflowing dots painted straight over where the label starts.

The same component renders fine in the card header (`●●● Running File Read`) because there it's given `shrink-0` with no width constraint, so it sizes to its natural width.

## Fix

Drop the fixed `w-[14px]` and give the phase-header indicator `shrink-0` instead. It keeps its natural **8px-dot** footprint — identical to the card header — and owns its full width as a flex item, so the row's `gap-1` always separates it from the label. Overlap is now structurally impossible regardless of dot size, rather than relying on a magic width.

One-line change:
```diff
-            className="h-[14px] w-[14px]"
+            className="shrink-0"
```

## Testing

- `three-dot-indicator`, `phase-grouped-step-list`, and `tool-progress-card-shell` tests all pass unchanged (39 tests).
- Visually verified in Storybook with a `Thinking` → running `Working` phase: the dots now sit cleanly left of the label with proper spacing, at the same size as the card-header dots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)