### PR TITLE
chore: remove pro-plan-adjust feature flag

### DIFF
--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -16,7 +16,6 @@ import { PlanCard } from "@/domains/settings/components/plan-card";
 import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
 import { ReferralPanel } from "@/domains/settings/components/referral-panel";
 import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
-import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -54,7 +53,6 @@ function BillingStatusHandler() {
 
 export function BillingPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const proPlanAdjust = useClientFeatureFlagStore.use.proPlanAdjust();
   const [planModalOpen, setPlanModalOpen] = useState(false);
   const openPlanModal = useCallback(() => setPlanModalOpen(true), []);
   const closePlanModal = useCallback(() => setPlanModalOpen(false), []);
@@ -88,12 +86,8 @@ export function BillingPage() {
         <BillingPortalReturnHandler />
       </Suspense>
       <GracePeriodBanner />
-      {proPlanAdjust && (
-        <>
-          <PlanCard onManage={openPlanModal} />
-          <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
-        </>
-      )}
+      <PlanCard onManage={openPlanModal} />
+      <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
       <PaymentMethodsCard />
       <Suspense fallback={null}>
         <BillingPanel />

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -314,14 +314,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "pro-plan-adjust",
-      "scope": "client",
-      "key": "pro-plan-adjust",
-      "label": "Pro Plan Adjust",
-      "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings \u2192 Billing tab.",
-      "defaultEnabled": false
-    },
-    {
       "id": "external-plugins",
       "scope": "assistant",
       "key": "external-plugins",

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -490,8 +490,7 @@ struct SettingsPanel: View {
             permissionsAndPrivacyContent
         case .billing:
             SettingsBillingTab(
-                authManager: authManager,
-                assistantFeatureFlagStore: assistantFeatureFlagStore
+                authManager: authManager
             )
         case .community:
             SettingsCommunityTab()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -5,7 +5,6 @@ import VellumAssistantShared
 @MainActor
 struct SettingsBillingTab: View {
     var authManager: AuthManager
-    var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     @State private var summary: BillingSummaryResponse?
     @State private var subscription: SubscriptionResponse?
@@ -23,10 +22,6 @@ struct SettingsBillingTab: View {
         topUpAmounts.contains(selectedAmount) ? selectedAmount : topUpAmounts.first ?? ""
     }
 
-    var isProPlanAdjustEnabled: Bool {
-        assistantFeatureFlagStore.isEnabled("pro-plan-adjust")
-    }
-
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
@@ -34,9 +29,7 @@ struct SettingsBillingTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            if isProPlanAdjustEnabled {
-                planSection
-            }
+            planSection
             balanceCard
             if isLoading {
                 addFundsSkeleton
@@ -472,13 +465,11 @@ extension SettingsBillingTab {
     /// and `PlanCardTests` to exercise the rendered output against known fixtures.
     init(
         authManager: AuthManager,
-        assistantFeatureFlagStore: AssistantFeatureFlagStore,
         initialSummary: BillingSummaryResponse?,
         initialSubscription: SubscriptionResponse? = nil,
         initialPlans: [PlanCatalogEntry]? = nil
     ) {
         self.authManager = authManager
-        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self._summary = State(initialValue: initialSummary)
         self._subscription = State(initialValue: initialSubscription)
         self._plans = State(initialValue: initialPlans)

--- a/clients/macos/vellum-assistantTests/PlanCardTests.swift
+++ b/clients/macos/vellum-assistantTests/PlanCardTests.swift
@@ -165,7 +165,6 @@ final class PlanCardTests: XCTestCase {
         let cancelISO = "2026-09-15T00:00:00Z"
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: true,
@@ -190,7 +189,6 @@ final class PlanCardTests: XCTestCase {
     func testActiveProSubscriptionRendersRenewsLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(cancelAtPeriodEnd: false),
             initialPlans: makePlanCatalog()
@@ -209,7 +207,6 @@ final class PlanCardTests: XCTestCase {
     func testBaseSubscriptionRendersNoRenewalLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeBaseSubscription(),
             initialPlans: makePlanCatalog()
@@ -224,7 +221,6 @@ final class PlanCardTests: XCTestCase {
     func testCancellingSubscriptionWithoutExplicitCancelAtFallsBackToPeriodEnd() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: true,
@@ -249,7 +245,6 @@ final class PlanCardTests: XCTestCase {
     func testCanceledStatusHidesRenewalLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: false,

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
@@ -35,7 +35,6 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
     func testSubtitleNilWhenSummaryNotLoaded() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil
         )
         XCTAssertNil(view.addCreditsSubtitleAttributed)
@@ -45,7 +44,6 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         let summary = makeSummary(maximumBalance: "1000")
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: summary
         )
 
@@ -72,7 +70,6 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         let summary = makeSummary(maximumBalance: "1000")
         let view = SettingsBillingTab(
             authManager: AuthManager(),
-            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: summary
         )
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -314,14 +314,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "pro-plan-adjust",
-      "scope": "client",
-      "key": "pro-plan-adjust",
-      "label": "Pro Plan Adjust",
-      "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings \u2192 Billing tab.",
-      "defaultEnabled": false
-    },
-    {
       "id": "external-plugins",
       "scope": "assistant",
       "key": "external-plugins",


### PR DESCRIPTION
## Summary
- Remove the `pro-plan-adjust` flag from the canonical feature-flag registry (and the in-sync web copy); the client store derives flags from the registry, so `proPlanAdjust` disappears automatically.
- Web: render `PlanCard` + `AdjustPlanModal` unconditionally in the Billing page and drop the now-unused feature-flag-store import.
- macOS: render `planSection` unconditionally in `SettingsBillingTab`, remove the dead `assistantFeatureFlagStore` dependency, and update its call site and tests.

## Original prompt
Remove all references to the `pro-plan-adjust` feature flag. The flag is GA'd in LaunchDarkly, so it's safe to retire and the previously-gated Billing UI should become the permanent behavior rather than being deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)