### PR TITLE
feat(web): add POST /__local/hatch endpoint to Vite local-mode plugin

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -206,10 +206,20 @@ function handleHatch(species: string, res: http.ServerResponse): void {
 
   let stdout = "";
   let stderr = "";
+  let responded = false;
+
+  const respond = (status: number, body: Record<string, unknown>) => {
+    if (responded) return;
+    responded = true;
+    clearTimeout(timeout);
+    res.statusCode = status;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(body));
+  };
 
   const timeout = setTimeout(() => {
     child.kill("SIGTERM");
-    stderr += "\nHatch timed out after 120 seconds";
+    respond(500, { ok: false, error: "Hatch timed out after 120 seconds" });
   }, HATCH_TIMEOUT_MS);
 
   child.stdout.on("data", (data: Buffer) => {
@@ -221,30 +231,17 @@ function handleHatch(species: string, res: http.ServerResponse): void {
   });
 
   child.on("close", (code) => {
-    clearTimeout(timeout);
-
-    res.setHeader("Content-Type", "application/json");
-
     if (code === 0) {
-      // Parse assistant name from stdout: "🥚 Hatching local assistant: <name>"
-      const match = stdout.match(
-        /Hatching local assistant:\s+(.+)/,
-      );
+      const match = stdout.match(/Hatching local assistant:\s+(.+)/);
       const assistantId = match?.[1]?.trim() ?? "";
-      res.end(JSON.stringify({ ok: true, assistantId }));
+      respond(200, { ok: true, assistantId });
     } else {
-      res.statusCode = 500;
-      res.end(JSON.stringify({ ok: false, error: stderr || stdout }));
+      respond(500, { ok: false, error: stderr || stdout });
     }
   });
 
   child.on("error", (err) => {
-    clearTimeout(timeout);
-    res.statusCode = 500;
-    res.setHeader("Content-Type", "application/json");
-    res.end(
-      JSON.stringify({ ok: false, error: `Failed to spawn CLI: ${err.message}` }),
-    );
+    respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
   });
 }
 

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
@@ -74,6 +75,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     name: "vellum-local-mode",
     configureServer(server) {
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
+      server.middlewares.use(hatchMiddleware());
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -130,6 +132,120 @@ function handleGetLockfile(
     res.statusCode = 500;
     res.end();
   }
+}
+
+const HATCH_TIMEOUT_MS = 120_000;
+
+/**
+ * Connect middleware for the hatch endpoint.
+ *
+ * Transport: Vite dev middleware (child_process.spawn → CLI binary).
+ * In Electron, replace with IPC call to main process: window.electronAPI.hatchAssistant(species).
+ * The main process has direct access to the hatch-local module without spawning a subprocess.
+ */
+function hatchMiddleware(): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/hatch" &&
+      req.url !== "/__local/hatch"
+    ) {
+      return next();
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let species = "vellum";
+      if (chunks.length > 0) {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            species?: string;
+          };
+          if (body.species) {
+            species = body.species;
+          }
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+          return;
+        }
+      }
+
+      handleHatch(species, res);
+    });
+  };
+}
+
+function handleHatch(species: string, res: http.ServerResponse): void {
+  // Resolve CLI entry point in dev mode (Vite runs in Node inside the repo).
+  const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+  const cliPath = path.join(repoRoot, "cli", "src", "index.ts");
+
+  if (!fs.existsSync(cliPath)) {
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        ok: false,
+        error: `CLI binary not found at ${cliPath}`,
+      }),
+    );
+    return;
+  }
+
+  const child = spawn("bun", ["run", cliPath, "hatch", species], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+    stderr += "\nHatch timed out after 120 seconds";
+  }, HATCH_TIMEOUT_MS);
+
+  child.stdout.on("data", (data: Buffer) => {
+    stdout += data.toString();
+  });
+
+  child.stderr.on("data", (data: Buffer) => {
+    stderr += data.toString();
+  });
+
+  child.on("close", (code) => {
+    clearTimeout(timeout);
+
+    res.setHeader("Content-Type", "application/json");
+
+    if (code === 0) {
+      // Parse assistant name from stdout: "🥚 Hatching local assistant: <name>"
+      const match = stdout.match(
+        /Hatching local assistant:\s+(.+)/,
+      );
+      const assistantId = match?.[1]?.trim() ?? "";
+      res.end(JSON.stringify({ ok: true, assistantId }));
+    } else {
+      res.statusCode = 500;
+      res.end(JSON.stringify({ ok: false, error: stderr || stdout }));
+    }
+  });
+
+  child.on("error", (err) => {
+    clearTimeout(timeout);
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({ ok: false, error: `Failed to spawn CLI: ${err.message}` }),
+    );
+  });
 }
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;


### PR DESCRIPTION
## Summary
- Add POST /assistant/__local/hatch endpoint to Vite local-mode plugin
- Spawns CLI hatch command with species parameter and returns JSON result
- Includes Electron transport comments for future IPC migration

Part of plan: local-mode-onboarding.md (PR 1 of 6)