### PR TITLE
feat(web): route local-mode users without assistants through onboarding

### DIFF
--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -12,7 +12,7 @@
  */
 import { routes } from "@/utils/routes";
 
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
 
 /**
@@ -20,19 +20,21 @@ import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
  * `null` if the intended destination is fine as-is.
  *
  * Rules (short-circuit, top to bottom):
- *   1. If onboarding is already marked completed, let the user through.
- *   2. If the intended destination isn't the chat surface itself
+ *   1. In local mode with hatched assistants, let the user through.
+ *   2. If onboarding is already marked completed, let the user through.
+ *   3. If the intended destination isn't the chat surface itself
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   3. Otherwise, route them to `routes.onboarding.privacy`.
+ *   4. Otherwise, route them to `routes.onboarding.privacy`.
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
 }: {
   intendedDestination: string;
 }): string | null {
-  if (isLocalMode() || readOnboardingCompleted()) return null;
+  if (isLocalMode() && hasAssistants()) return null;
+  if (readOnboardingCompleted()) return null;
 
   // `intendedDestination` may be a bare path or a raw `returnTo` value that
   // survived the callback as an absolute URL (`https://assistant.host/assistant`,

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -152,6 +152,11 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       return;
     }
 
+    if (isLocalMode() && !isGatewayAuthEnabled()) {
+      set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
+      return;
+    }
+
     try {
       const result = await getSession();
       if (result.ok && result.data.user) {


### PR DESCRIPTION
## Summary
- Update onboarding gate to redirect local-mode users to privacy screen when no assistants exist
- Add local-mode-without-assistants path in initSession that sets GATEWAY_LOCAL_USER
- Preserve existing behavior for local mode with hatched assistants and non-local mode

Part of plan: local-mode-onboarding.md (PR 3 of 6)