### PR TITLE
[codex] Remove sidebar conversation counts

### DIFF
--- a/apps/web/src/components/collapsible-nav-section.tsx
+++ b/apps/web/src/components/collapsible-nav-section.tsx
@@ -15,19 +15,19 @@ import { cn } from "@vellum/design-library/utils/cn";
  *   - Leading icon that swaps to a disclosure chevron on hover
  *     (matching macOS SidebarSectionHeader). The original icon is
  *     always visible when not hovered, regardless of expanded state.
- *   - Optional `trailing` slot for an ellipsis menu, count badge, or
- *     other per-row affordance. Pointer events are isolated so clicking
- *     trailing content doesn't toggle the section.
+ *   - Optional `trailing` slot for an ellipsis menu or other per-row
+ *     affordance. Pointer events are isolated so clicking trailing
+ *     content doesn't toggle the section.
  *   - No hover background — the chevron swap is the affordance.
  *
  * Usage:
  *
- *   <CollapsibleNavSection.Root type="multiple" defaultValue={["recents"]}>
+ *   <CollapsibleNavSection.Root type="multiple" defaultValue={["scheduled"]}>
  *     <CollapsibleNavSection.Section
- *       value="recents"
+ *       value="scheduled"
  *       icon={Clock}
- *       label="Recents"
- *       trailing={<Badge>12</Badge>}
+ *       label="Scheduled"
+ *       trailing={<MenuButton />}
  *     >
  *       {childRows}
  *     </CollapsibleNavSection.Section>

--- a/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -7,7 +7,6 @@
  * rules unique to `AssistantSideMenu`.
  */
 
-import { readFileSync } from "node:fs";
 import { describe, expect, mock, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -35,6 +34,7 @@ function makeConversation(overrides: Partial<Conversation>): Conversation {
 function renderMenu(props: {
   conversations: Conversation[];
   activeConversationId?: string;
+  collapsed?: boolean;
   variant?: "rail" | "overlay";
   includeFooterAction?: boolean;
 }): string {
@@ -42,7 +42,7 @@ function renderMenu(props: {
   return renderToStaticMarkup(
     createElement(AssistantSideMenu, {
       assistantId: "asst-1",
-      collapsed: false,
+      collapsed: props.collapsed ?? false,
       variant: props.variant ?? "rail",
       conversations: props.conversations,
       activeConversationId: props.activeConversationId,
@@ -55,9 +55,14 @@ function renderMenu(props: {
 }
 
 describe("AssistantSideMenu · Conversations category rows", () => {
-  test("renders a Conversations section header with all four category rows", () => {
+  test("renders Pinned above Conversations with bucket rows after recents", () => {
     const conversations = [
       makeConversation({ conversationId: "p1", isPinned: true }),
+      makeConversation({
+        conversationId: "p2",
+        title: "Pinned thread",
+        isPinned: true,
+      }),
       makeConversation({
         conversationId: "s1",
         conversationType: "scheduled",
@@ -79,10 +84,16 @@ describe("AssistantSideMenu · Conversations category rows", () => {
 
     expect(html).toContain(">Conversations<");
     expect(html).toContain(">Pinned<");
+    expect(html).toContain(">Pinned thread<");
     expect(html).toContain(">Scheduled<");
     expect(html).toContain(">Background<");
-    expect(html).toContain(">Recents<");
+    expect(html).toContain(">Recent thread<");
+    expect(html).not.toContain(">Recents<");
     expect(html).not.toContain(">Slack<");
+
+    expect(html.indexOf(">Pinned<")).toBeLessThan(
+      html.indexOf(">Conversations<"),
+    );
   });
 
   test("renders Slack as a conditional peer section after Background", () => {
@@ -98,38 +109,73 @@ describe("AssistantSideMenu · Conversations category rows", () => {
 
     const html = renderMenu({ conversations });
     expect(html).toContain(">Slack<");
+    expect(html).not.toContain(">Pinned<");
 
-    const pinnedIndex = html.indexOf(">Pinned<");
-    const recentsIndex = html.indexOf(">Recents<");
+    const recentThreadIndex = html.indexOf(">Regular thread<");
     const scheduledIndex = html.indexOf(">Scheduled<");
     const backgroundIndex = html.indexOf(">Background<");
     const slackIndex = html.indexOf(">Slack<");
-    expect(pinnedIndex).toBeGreaterThanOrEqual(0);
-    expect(recentsIndex).toBeGreaterThan(pinnedIndex);
-    expect(scheduledIndex).toBeGreaterThan(recentsIndex);
+    expect(recentThreadIndex).toBeGreaterThanOrEqual(0);
+    expect(scheduledIndex).toBeGreaterThan(recentThreadIndex);
     expect(backgroundIndex).toBeGreaterThan(scheduledIndex);
     expect(slackIndex).toBeGreaterThan(backgroundIndex);
   });
 
-  test("renders a count badge only for non-empty category buckets", () => {
+  test("renders Pinned as a top-level section when non-empty", () => {
+    const conversations = [
+      makeConversation({ conversationId: "regular", title: "Regular thread" }),
+      makeConversation({
+        conversationId: "pinned",
+        title: "Pinned thread",
+        isPinned: true,
+      }),
+    ];
+
+    const expandedHtml = renderMenu({ conversations });
+
+    expect(expandedHtml).toContain(">Pinned<");
+    expect(expandedHtml).toContain(">Pinned thread<");
+    expect(expandedHtml.indexOf(">Pinned<")).toBeLessThan(
+      expandedHtml.indexOf(">Conversations<"),
+    );
+  });
+
+  test("hides Pinned when there are no pinned conversations", () => {
+    const conversations = [
+      makeConversation({ conversationId: "regular", title: "Regular thread" }),
+    ];
+
+    const expandedHtml = renderMenu({ conversations });
+    const collapsedHtml = renderMenu({ conversations, collapsed: true });
+
+    expect(expandedHtml).not.toContain(">Pinned<");
+    expect(collapsedHtml).not.toContain('aria-label="Pinned"');
+  });
+
+  test("omits chat count badges from category buckets and subgroups", () => {
     const conversations = [
       makeConversation({
-        conversationId: "b1",
+        conversationId: "background-alpha",
+        title: "Background Alpha",
         conversationType: "background",
         source: "heartbeat",
       }),
       makeConversation({
-        conversationId: "b2",
+        conversationId: "background-beta",
+        title: "Background Beta",
         conversationType: "background",
         source: "heartbeat",
       }),
-      makeConversation({ conversationId: "r1" }),
+      makeConversation({
+        conversationId: "recent-alpha",
+        title: "Recent Alpha",
+      }),
     ];
 
     const html = renderMenu({ conversations });
 
-    expect(html).toContain(">2<");
-    expect(html).toContain(">1<");
+    expect(html).not.toContain(">2<");
+    expect(html).not.toContain(">1<");
   });
 });
 
@@ -164,21 +210,10 @@ describe("AssistantSideMenu · Show more affordance", () => {
     expect(html).toContain("Show more");
   });
 
-  test("wires the same 'Show more' affordance for Slack conversations", () => {
-    const src = readFileSync(
-      new URL("../use-sidebar-state.ts", import.meta.url).pathname,
-      "utf8",
+  test("shares the sidebar conversation page size constant", () => {
+    expect(SIDEBAR_CONVERSATION_LIMIT).toBe(
+      ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT,
     );
-
-    expect(src).toContain(
-      "slack.slice(0, SIDEBAR_CONVERSATION_LIMIT)",
-    );
-    expect(src).toContain(
-      "slack.length > SIDEBAR_CONVERSATION_LIMIT",
-    );
-    expect(src).toContain("showAllSlack");
-    expect(src).toContain("setShowAllSlack");
-    expect(SIDEBAR_CONVERSATION_LIMIT).toBe(ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT);
   });
 });
 
@@ -250,4 +285,3 @@ describe("AssistantSideMenu · overlay close affordance", () => {
     expect(railHtml).not.toContain('aria-label="Close navigation"');
   });
 });
-

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -24,7 +24,6 @@ import { CollapsedGroupIcon, getGroupIndicatorState } from "@/domains/chat/compo
 import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle";
 import { GroupActionsMenu } from "@/domains/chat/components/group-actions-menu";
 import { BackgroundSubGroups, ScheduledSubGroups } from "@/domains/chat/components/sub-group-accordion";
-import { countBadge } from "@/domains/chat/components/sidebar-count-badge";
 import {
   formatBackgroundSubGroupLabel,
   groupBackgroundConversationsBySource,
@@ -90,15 +89,15 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
  *   Header
  *     • Your Assistant → Intelligence view
  *     • ───────────────
+ *   Body · Pinned section (when non-empty)
+ *     • pinned thread
  *   Body · Conversations section
- *     • Pinned (count)         — category summary
- *     • Scheduled (count)      — category summary
- *     • Background (count)     — category summary (includes Reflections sub-group)
- *     • Slack (count) ▾        — expanded inline when Slack conversations exist
- *     • Recents (count) ▾      — expanded inline
- *         ◦ thread … (pin icon if pinned, hover reveals …)
- *         ◦ …
- *         ◦ Show more (if > limit)
+ *     • thread …       — recent conversations inline
+ *     • …
+ *     • Show more/less — page through recent conversations
+ *     • Scheduled      — collapsible category
+ *     • Background     — collapsible category (includes Reflections sub-group)
+ *     • Slack ▾        — collapsible category when Slack conversations exist
  *   Footer
  *     • ───────────────
  *     • caller-provided action (PreferencesMenu)
@@ -287,9 +286,12 @@ export function AssistantSideMenu({
   const renderFlatList = (
     items: Conversation[],
     showMore: boolean,
-    onShowMore: () => void,
+    onShowMore?: () => void,
+    showLess = false,
+    onShowLess?: () => void,
+    className?: string,
   ): ReactNode => (
-    <SideMenu.SubList>
+    <SideMenu.SubList className={className}>
       {items.map((c) =>
         renderThreadRow(
           c,
@@ -303,13 +305,22 @@ export function AssistantSideMenu({
           />,
         ),
       )}
-      {showMore ? (
+      {showMore && onShowMore ? (
         <SideMenu.Item
           label="Show more"
           size="compact"
           indent
           emphasized
           onSelect={onShowMore}
+        />
+      ) : null}
+      {showLess && onShowLess ? (
+        <SideMenu.Item
+          label="Show less"
+          size="compact"
+          indent
+          emphasized
+          onSelect={onShowLess}
         />
       ) : null}
     </SideMenu.SubList>
@@ -404,14 +415,15 @@ export function AssistantSideMenu({
         {collapsed && variant === "rail" ? (
           <div className="flex flex-col items-center gap-1">
             {headerActions}
-            <CollapsedGroupIcon
-              icon={Pin}
-              label="Pinned"
-              disabled={sidebar.pinned.length === 0}
-              indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
-            >
-              {(close) => renderCollapsedGroupContent("Pinned", sidebar.pinned, close)}
-            </CollapsedGroupIcon>
+            {sidebar.pinned.length > 0 ? (
+              <CollapsedGroupIcon
+                icon={Pin}
+                label="Pinned"
+                indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
+              >
+                {(close) => renderCollapsedGroupContent("Pinned", sidebar.pinned, close)}
+              </CollapsedGroupIcon>
+            ) : null}
             <CollapsedGroupIcon
               icon={Clock}
               label="Recents"
@@ -456,118 +468,124 @@ export function AssistantSideMenu({
             </CollapsedGroupIcon>
           </div>
         ) : (
-          <SideMenu.Section
-            title="Conversations"
-            actions={variant === "overlay" ? undefined : headerActions}
-          >
-            <CollapsibleNavSection.Root
-              type="multiple"
-              value={sidebar.effectiveOpenCategories}
-              onValueChange={sidebar.onOpenCategoriesChange}
+          <>
+            {sidebar.pinned.length > 0 ? (
+              <SideMenu.Section title="Pinned">
+                {renderFlatList(
+                  sidebar.pinned,
+                  false,
+                  undefined,
+                  false,
+                  undefined,
+                  "-ml-[10px] w-[calc(100%+10px)]",
+                )}
+              </SideMenu.Section>
+            ) : null}
+
+            <SideMenu.Section
+              title="Conversations"
+              actions={variant === "overlay" ? undefined : headerActions}
             >
-              <CollapsibleNavSection.Section
-                value="pinned"
-                icon={Pin}
-                label="Pinned"
-                trailing={countBadge(sidebar.pinned.length)}
-              >
-                {renderFlatList(sidebar.pinned, false, () => {})}
-              </CollapsibleNavSection.Section>
+              {renderFlatList(
+                sidebar.recents.items,
+                sidebar.recents.showMore,
+                sidebar.recents.onShowMore,
+                sidebar.recents.showLess,
+                sidebar.recents.onShowLess,
+                "-ml-[10px] w-[calc(100%+10px)]",
+              )}
 
-              <CollapsibleNavSection.Section
-                value="recents"
-                icon={Clock}
-                label="Recents"
-                trailing={countBadge(sidebar.recents.totalCount)}
+              <CollapsibleNavSection.Root
+                type="multiple"
+                value={sidebar.effectiveOpenCategories}
+                onValueChange={sidebar.onOpenCategoriesChange}
               >
-                {renderFlatList(sidebar.recents.items, sidebar.recents.showMore, sidebar.recents.onShowMore)}
-              </CollapsibleNavSection.Section>
-
-              <CollapsibleNavSection.Section
-                value="scheduled"
-                icon={Calendar}
-                label="Scheduled"
-                trailing={countBadge(sidebar.scheduled.length)}
-              >
-                <ScheduledSubGroups
-                  subGroups={sidebar.scheduledSubGroups}
-                  {...subGroupProps}
-                />
-              </CollapsibleNavSection.Section>
-
-              <CollapsibleNavSection.Section
-                value="background"
-                icon={Layers}
-                label="Background"
-                trailing={countBadge(sidebar.background.length)}
-              >
-                <BackgroundSubGroups
-                  subGroups={sidebar.backgroundSubGroups}
-                  {...subGroupProps}
-                />
-              </CollapsibleNavSection.Section>
-
-              {sidebar.slack.totalCount > 0 ? (
                 <CollapsibleNavSection.Section
-                  value="slack"
-                  icon={Hash}
-                  label="Slack"
-                  trailing={countBadge(sidebar.slack.totalCount)}
+                  value="scheduled"
+                  icon={Calendar}
+                  label="Scheduled"
                 >
-                  {renderFlatList(sidebar.slack.items, sidebar.slack.showMore, sidebar.slack.onShowMore)}
+                  <ScheduledSubGroups
+                    subGroups={sidebar.scheduledSubGroups}
+                    {...subGroupProps}
+                  />
                 </CollapsibleNavSection.Section>
-              ) : null}
-            </CollapsibleNavSection.Root>
 
-            {sidebar.conversationGroupsEnabled && sidebar.customGroups.length > 0 ? (
-              <>
-                <SideMenu.Separator />
-                <SideMenu.Section title="Your Groups">
-                  <CollapsibleNavSection.Root
-                    type="multiple"
-                    value={sidebar.effectiveOpenCustomGroups}
-                    onValueChange={sidebar.onOpenCustomGroupsChange}
+                <CollapsibleNavSection.Section
+                  value="background"
+                  icon={Layers}
+                  label="Background"
+                >
+                  <BackgroundSubGroups
+                    subGroups={sidebar.backgroundSubGroups}
+                    {...subGroupProps}
+                  />
+                </CollapsibleNavSection.Section>
+
+                {sidebar.slack.totalCount > 0 ? (
+                  <CollapsibleNavSection.Section
+                    value="slack"
+                    icon={Hash}
+                    label="Slack"
                   >
-                    {sidebar.customGroups.map((group) => (
-                      <CollapsibleNavSection.Section
-                        key={group.id}
-                        value={group.id}
-                        label={group.name}
-                        trailing={
-                          <span className="flex items-center gap-1">
-                            {countBadge(group.conversations.length)}
-                            {onRenameGroup || onDeleteGroup ? (
+                    {renderFlatList(
+                      sidebar.slack.items,
+                      sidebar.slack.showMore,
+                      sidebar.slack.onShowMore,
+                      sidebar.slack.showLess,
+                      sidebar.slack.onShowLess,
+                    )}
+                  </CollapsibleNavSection.Section>
+                ) : null}
+              </CollapsibleNavSection.Root>
+
+              {sidebar.conversationGroupsEnabled && sidebar.customGroups.length > 0 ? (
+                <>
+                  <SideMenu.Separator />
+                  <SideMenu.Section title="Your Groups">
+                    <CollapsibleNavSection.Root
+                      type="multiple"
+                      value={sidebar.effectiveOpenCustomGroups}
+                      onValueChange={sidebar.onOpenCustomGroupsChange}
+                    >
+                      {sidebar.customGroups.map((group) => (
+                        <CollapsibleNavSection.Section
+                          key={group.id}
+                          value={group.id}
+                          label={group.name}
+                          trailing={
+                            onRenameGroup || onDeleteGroup ? (
                               <GroupActionsMenu
                                 groupId={group.id}
                                 onRename={onRenameGroup}
                                 onDelete={onDeleteGroup}
                               />
-                            ) : null}
-                          </span>
-                        }
-                      >
-                        <SideMenu.SubList>
-                          {group.conversations.map((c) =>
-                            renderThreadRow(
-                              c,
-                              <PanelItem
-                                leadingSlot={renderThreadPinToggle(c)}
-                                label={c.title ?? "Untitled"}
-                                marqueeOnHover
-                                active={c.conversationId === activeConversationId}
-                                onSelect={() => selectAndClose(c.conversationId)}
-                                trailingAction={renderThreadActions(c)}
-                              />,
-                            ),
-                          )}
-                        </SideMenu.SubList>
-                      </CollapsibleNavSection.Section>
-                    ))}
-                  </CollapsibleNavSection.Root>
-                </SideMenu.Section>
-              </>
-            ) : null}
-          </SideMenu.Section>
+                            ) : null
+                          }
+                        >
+                          <SideMenu.SubList>
+                            {group.conversations.map((c) =>
+                              renderThreadRow(
+                                c,
+                                <PanelItem
+                                  leadingSlot={renderThreadPinToggle(c)}
+                                  label={c.title ?? "Untitled"}
+                                  marqueeOnHover
+                                  active={c.conversationId === activeConversationId}
+                                  onSelect={() => selectAndClose(c.conversationId)}
+                                  trailingAction={renderThreadActions(c)}
+                                />,
+                              ),
+                            )}
+                          </SideMenu.SubList>
+                        </CollapsibleNavSection.Section>
+                      ))}
+                    </CollapsibleNavSection.Root>
+                  </SideMenu.Section>
+                </>
+              ) : null}
+            </SideMenu.Section>
+          </>
         )}
       </SideMenu.Body>
 
@@ -673,7 +691,6 @@ function CollapsedBackgroundGroup({
                   <PanelItem
                     icon={isExpanded ? ChevronDown : ChevronRight}
                     label={formatBackgroundSubGroupLabel(group.key)}
-                    badge={group.conversations.length}
                     onSelect={() => toggleGroup(group.key)}
                   />
                   {isExpanded

--- a/apps/web/src/domains/chat/components/sidebar-count-badge.tsx
+++ b/apps/web/src/domains/chat/components/sidebar-count-badge.tsx
@@ -1,9 +1,0 @@
-import type { ReactNode } from "react";
-
-export function countBadge(n: number): ReactNode {
-  return n > 0 ? (
-    <span className="text-label-small-default inline-flex items-center justify-center rounded-[4px] bg-[var(--surface-base)] px-[4px] py-[2px] text-[var(--content-tertiary)]">
-      {n}
-    </span>
-  ) : null;
-}

--- a/apps/web/src/domains/chat/components/sub-group-accordion.tsx
+++ b/apps/web/src/domains/chat/components/sub-group-accordion.tsx
@@ -4,7 +4,6 @@ import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
 import { PanelItem, SideMenu } from "@vellum/design-library";
 import type { Conversation } from "@/types/conversation-types";
 import type { SubGroup } from "@/domains/chat/utils/sub-group-utils";
-import { countBadge } from "@/domains/chat/components/sidebar-count-badge";
 
 // ---------------------------------------------------------------------------
 // SubGroupAccordion — shared sub-accordion for Background + Scheduled
@@ -62,7 +61,6 @@ export function SubGroupAccordion({
             <CollapsibleNavSection.Section
               value={group.key}
               label={group.label}
-              trailing={countBadge(group.conversations.length)}
             >
               <SideMenu.SubList>
                 {group.conversations.map((c) =>

--- a/apps/web/src/domains/chat/components/thread-pin-toggle.tsx
+++ b/apps/web/src/domains/chat/components/thread-pin-toggle.tsx
@@ -59,7 +59,7 @@ function IdleAndHoverGlyphs({
  *   Needs attention   → Exclamation circle (warning color, no pulse).
  *   Processing + idle → Pulsing dot (animate-pulse, primary-base).
  *   Unread + idle     → Static dot (system-mid-strong).
- *   Pinned + idle     → Hidden (no glyph; PinOff appears on hover).
+ *   Pinned + idle     → Pin glyph (PinOff appears on hover).
  *   Unpinned + idle   → Pin glyph at 0 opacity (hidden; label aligns).
  *   Any + hover       → Pin/PinOff toggle (overrides dot).
  *
@@ -116,7 +116,18 @@ export function ThreadPinToggle({ conversation, onPinToggle, isProcessing, needs
       />
     );
   } else if (isPinned) {
-    glyphs = <PinOff size={14} aria-hidden className={HOVER_REVEAL} />;
+    glyphs = (
+      <IdleAndHoverGlyphs
+        isPinned
+        idle={
+          <Pin
+            size={14}
+            aria-hidden
+            className={IDLE_FADE}
+          />
+        }
+      />
+    );
   } else {
     glyphs = (
       <Pin

--- a/apps/web/src/domains/chat/sidebar-collapse-store.test.ts
+++ b/apps/web/src/domains/chat/sidebar-collapse-store.test.ts
@@ -5,7 +5,7 @@ import { useSidebarCollapseStore } from "@/domains/chat/sidebar-collapse-store";
 function resetStore() {
   useSidebarCollapseStore.setState({
     assistantId: null,
-    openCategories: ["recents"],
+    openCategories: [],
     openCustomGroups: [],
   });
 }
@@ -16,9 +16,9 @@ afterEach(() => {
 });
 
 describe("SidebarCollapseStore", () => {
-  test("defaults to recents open and no custom groups", () => {
+  test("defaults to no open categories or custom groups", () => {
     const state = useSidebarCollapseStore.getState();
-    expect(state.openCategories).toEqual(["recents"]);
+    expect(state.openCategories).toEqual([]);
     expect(state.openCustomGroups).toEqual([]);
     expect(state.assistantId).toBeNull();
   });
@@ -26,7 +26,7 @@ describe("SidebarCollapseStore", () => {
   test("setAssistantId hydrates from localStorage", () => {
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-1",
-      JSON.stringify(["pinned", "background"]),
+      JSON.stringify(["scheduled", "background"]),
     );
     localStorage.setItem(
       "vellum:sidebar-open-custom-groups:asst-1",
@@ -37,7 +37,7 @@ describe("SidebarCollapseStore", () => {
 
     const state = useSidebarCollapseStore.getState();
     expect(state.assistantId).toBe("asst-1");
-    expect(state.openCategories).toEqual(["pinned", "background"]);
+    expect(state.openCategories).toEqual(["scheduled", "background"]);
     expect(state.openCustomGroups).toEqual(["grp-abc"]);
   });
 
@@ -54,15 +54,17 @@ describe("SidebarCollapseStore", () => {
 
   test("setOpenCategories persists to localStorage", () => {
     useSidebarCollapseStore.getState().setAssistantId("asst-1");
-    useSidebarCollapseStore.getState().setOpenCategories(["pinned", "recents"]);
+    useSidebarCollapseStore
+      .getState()
+      .setOpenCategories(["scheduled", "background"]);
 
     const raw = localStorage.getItem(
       "vellum:sidebar-open-categories:asst-1",
     );
-    expect(JSON.parse(raw!)).toEqual(["pinned", "recents"]);
+    expect(JSON.parse(raw!)).toEqual(["scheduled", "background"]);
     expect(useSidebarCollapseStore.getState().openCategories).toEqual([
-      "pinned",
-      "recents",
+      "scheduled",
+      "background",
     ]);
   });
 
@@ -81,7 +83,7 @@ describe("SidebarCollapseStore", () => {
   test("switching assistant re-hydrates from new assistant's storage", () => {
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-1",
-      JSON.stringify(["pinned"]),
+      JSON.stringify(["scheduled"]),
     );
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-2",
@@ -90,7 +92,7 @@ describe("SidebarCollapseStore", () => {
 
     useSidebarCollapseStore.getState().setAssistantId("asst-1");
     expect(useSidebarCollapseStore.getState().openCategories).toEqual([
-      "pinned",
+      "scheduled",
     ]);
 
     useSidebarCollapseStore.getState().setAssistantId("asst-2");
@@ -108,16 +110,14 @@ describe("SidebarCollapseStore", () => {
 
     useSidebarCollapseStore.getState().setAssistantId("asst-1");
 
-    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
-      "recents",
-    ]);
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([]);
   });
 
   test("setOpenCategories does not persist when no assistantId is set", () => {
-    useSidebarCollapseStore.getState().setOpenCategories(["pinned"]);
+    useSidebarCollapseStore.getState().setOpenCategories(["scheduled"]);
 
     expect(useSidebarCollapseStore.getState().openCategories).toEqual([
-      "pinned",
+      "scheduled",
     ]);
     expect(localStorage.length).toBe(0);
   });

--- a/apps/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/apps/web/src/domains/chat/sidebar-collapse-store.ts
@@ -6,13 +6,13 @@
  *
  * **Storage model:**
  *
- * - Built-in categories (pinned, scheduled, background, slack, recents)
+ * - Built-in collapsible categories (scheduled, background, slack)
  *   and custom groups are stored as two separate `string[]` values,
  *   keyed per assistant. This mirrors the Radix Accordion `value` prop
  *   for `type="multiple"`.
  * - Reads happen synchronously from localStorage on `setAssistantId`;
  *   writes happen on every toggle via `persist` helpers.
- * - Defaults to `["recents"]` for categories and `[]` for custom groups
+ * - Defaults to no open built-in categories and no open custom groups
  *   when no stored state exists.
  *
  * @see {@link https://zustand.docs.pmnd.rs/}
@@ -53,7 +53,7 @@ export type SidebarCollapseStore = SidebarCollapseState &
 
 const INITIAL_STATE: SidebarCollapseState = {
   assistantId: null,
-  openCategories: ["recents"],
+  openCategories: [],
   openCustomGroups: [],
 };
 

--- a/apps/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/apps/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -1,0 +1,98 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { Conversation } from "@/types/conversation-types";
+import { useSidebarCollapseStore } from "@/domains/chat/sidebar-collapse-store";
+import {
+  SIDEBAR_CONVERSATION_LIMIT,
+  useSidebarState,
+} from "@/domains/chat/use-sidebar-state";
+
+function makeConversation(
+  index: number,
+  overrides: Partial<Conversation> = {},
+): Conversation {
+  return {
+    conversationId: `conversation-${index}`,
+    title: `Thread ${index}`,
+    groupId: "system:all",
+    hasUnseenLatestAssistantMessage: false,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  useSidebarCollapseStore.setState({
+    assistantId: null,
+    openCategories: [],
+    openCustomGroups: [],
+  });
+});
+
+describe("useSidebarState pagination", () => {
+  test("reveals recents in page-size increments and can reset", () => {
+    const conversations = Array.from({ length: 12 }, (_, index) =>
+      makeConversation(index),
+    );
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations }),
+    );
+
+    expect(result.current.recents.items).toHaveLength(
+      SIDEBAR_CONVERSATION_LIMIT,
+    );
+    expect(result.current.recents.showMore).toBe(true);
+    expect(result.current.recents.showLess).toBe(false);
+
+    act(() => result.current.recents.onShowMore());
+
+    expect(result.current.recents.items).toHaveLength(
+      SIDEBAR_CONVERSATION_LIMIT * 2,
+    );
+    expect(result.current.recents.showMore).toBe(true);
+    expect(result.current.recents.showLess).toBe(true);
+
+    act(() => result.current.recents.onShowMore());
+
+    expect(result.current.recents.items).toHaveLength(conversations.length);
+    expect(result.current.recents.showMore).toBe(false);
+    expect(result.current.recents.showLess).toBe(true);
+
+    act(() => result.current.recents.onShowLess());
+
+    expect(result.current.recents.items).toHaveLength(
+      SIDEBAR_CONVERSATION_LIMIT,
+    );
+    expect(result.current.recents.showMore).toBe(true);
+    expect(result.current.recents.showLess).toBe(false);
+  });
+
+  test("uses the same incremental reveal behavior for Slack conversations", () => {
+    const conversations = Array.from({ length: 12 }, (_, index) =>
+      makeConversation(index, {
+        originChannel: "slack",
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations }),
+    );
+
+    expect(result.current.slack.items).toHaveLength(
+      SIDEBAR_CONVERSATION_LIMIT,
+    );
+    expect(result.current.slack.showMore).toBe(true);
+    expect(result.current.slack.showLess).toBe(false);
+
+    act(() => result.current.slack.onShowMore());
+
+    expect(result.current.slack.items).toHaveLength(
+      SIDEBAR_CONVERSATION_LIMIT * 2,
+    );
+    expect(result.current.slack.showMore).toBe(true);
+    expect(result.current.slack.showLess).toBe(true);
+  });
+});

--- a/apps/web/src/domains/chat/use-sidebar-state.ts
+++ b/apps/web/src/domains/chat/use-sidebar-state.ts
@@ -38,7 +38,9 @@ export interface PaginatedSection {
   items: Conversation[];
   totalCount: number;
   showMore: boolean;
+  showLess: boolean;
   onShowMore: () => void;
+  onShowLess: () => void;
 }
 
 export interface SidebarState {
@@ -120,52 +122,70 @@ export function useSidebarState({
 
   // --- Pagination ("show more") ---
 
-  const [showAllRecents, setShowAllRecents] = useState(false);
-  const [showAllSlack, setShowAllSlack] = useState(false);
+  const [visibleRecentsCount, setVisibleRecentsCount] = useState(
+    SIDEBAR_CONVERSATION_LIMIT,
+  );
+  const [visibleSlackCount, setVisibleSlackCount] = useState(
+    SIDEBAR_CONVERSATION_LIMIT,
+  );
 
   const recentsSection = useMemo((): PaginatedSection => {
-    const hasAttentionBeyondLimit =
-      !showAllRecents &&
-      grouped.recents.length > SIDEBAR_CONVERSATION_LIMIT &&
-      attentionConversationIds != null &&
-      grouped.recents
-        .slice(SIDEBAR_CONVERSATION_LIMIT)
-        .some((c) => attentionConversationIds.has(c.conversationId));
-    const effectiveShowAll = showAllRecents || !!hasAttentionBeyondLimit;
+    const attentionIndex = attentionConversationIds
+      ? grouped.recents.findIndex((c) =>
+          attentionConversationIds.has(c.conversationId),
+        )
+      : -1;
+    const effectiveVisibleCount =
+      attentionIndex >= visibleRecentsCount
+        ? attentionIndex + 1
+        : visibleRecentsCount;
     return {
       all: grouped.recents,
-      items: effectiveShowAll
-        ? grouped.recents
-        : grouped.recents.slice(0, SIDEBAR_CONVERSATION_LIMIT),
+      items: grouped.recents.slice(0, effectiveVisibleCount),
       totalCount: grouped.recents.length,
-      showMore:
-        !effectiveShowAll &&
+      showMore: effectiveVisibleCount < grouped.recents.length,
+      showLess:
+        visibleRecentsCount > SIDEBAR_CONVERSATION_LIMIT &&
         grouped.recents.length > SIDEBAR_CONVERSATION_LIMIT,
-      onShowMore: () => setShowAllRecents(true),
+      onShowMore: () =>
+        setVisibleRecentsCount((prev) =>
+          Math.min(
+            grouped.recents.length,
+            Math.max(prev, effectiveVisibleCount) + SIDEBAR_CONVERSATION_LIMIT,
+          ),
+        ),
+      onShowLess: () => setVisibleRecentsCount(SIDEBAR_CONVERSATION_LIMIT),
     };
-  }, [grouped.recents, showAllRecents, attentionConversationIds]);
+  }, [grouped.recents, visibleRecentsCount, attentionConversationIds]);
 
   const slackSection = useMemo((): PaginatedSection => {
-    const hasAttentionBeyondLimit =
-      !showAllSlack &&
-      grouped.slack.length > SIDEBAR_CONVERSATION_LIMIT &&
-      attentionConversationIds != null &&
-      grouped.slack
-        .slice(SIDEBAR_CONVERSATION_LIMIT)
-        .some((c) => attentionConversationIds.has(c.conversationId));
-    const effectiveShowAll = showAllSlack || !!hasAttentionBeyondLimit;
+    const attentionIndex = attentionConversationIds
+      ? grouped.slack.findIndex((c) =>
+          attentionConversationIds.has(c.conversationId),
+        )
+      : -1;
+    const effectiveVisibleCount =
+      attentionIndex >= visibleSlackCount
+        ? attentionIndex + 1
+        : visibleSlackCount;
     return {
       all: grouped.slack,
-      items: effectiveShowAll
-        ? grouped.slack
-        : grouped.slack.slice(0, SIDEBAR_CONVERSATION_LIMIT),
+      items: grouped.slack.slice(0, effectiveVisibleCount),
       totalCount: grouped.slack.length,
-      showMore:
-        !effectiveShowAll &&
+      showMore: effectiveVisibleCount < grouped.slack.length,
+      showLess:
+        visibleSlackCount > SIDEBAR_CONVERSATION_LIMIT &&
         grouped.slack.length > SIDEBAR_CONVERSATION_LIMIT,
-      onShowMore: () => setShowAllSlack(true),
+      onShowMore: () =>
+        setVisibleSlackCount((prev) =>
+          Math.min(
+            grouped.slack.length,
+            Math.max(prev, effectiveVisibleCount) + SIDEBAR_CONVERSATION_LIMIT,
+          ),
+        ),
+      onShowLess: () => setVisibleSlackCount(SIDEBAR_CONVERSATION_LIMIT),
     };
-  }, [grouped.slack, showAllSlack, attentionConversationIds]);
+  }, [grouped.slack, visibleSlackCount, attentionConversationIds]);
 
   // --- Attention-forced expansion ---
 
@@ -183,27 +203,21 @@ export function useSidebarState({
     if (!attentionConversationIds || attentionConversationIds.size === 0)
       return openCategories;
     const extra: string[] = [];
-    if (grouped.pinned.length > 0 && hasAttentionIn(grouped.pinned))
-      extra.push("pinned");
     if (grouped.scheduled.length > 0 && hasAttentionIn(grouped.scheduled))
       extra.push("scheduled");
     if (grouped.background.length > 0 && hasAttentionIn(grouped.background))
       extra.push("background");
     if (grouped.slack.length > 0 && hasAttentionIn(grouped.slack))
       extra.push("slack");
-    if (grouped.recents.length > 0 && hasAttentionIn(grouped.recents))
-      extra.push("recents");
     if (extra.length === 0) return openCategories;
     if (extra.every((c) => openCategories.includes(c))) return openCategories;
     return [...new Set([...openCategories, ...extra])];
   }, [
     openCategories,
     attentionConversationIds,
-    grouped.pinned,
     grouped.scheduled,
     grouped.background,
     grouped.slack,
-    grouped.recents,
     hasAttentionIn,
   ]);
 

--- a/apps/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
+++ b/apps/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
@@ -71,13 +71,24 @@ afterEach(() => {
 });
 
 describe("loadOpenCategories", () => {
-  test("returns default [recents] when no value is stored", () => {
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["recents"]);
+  test("returns default [] when no value is stored", () => {
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([]);
   });
 
   test("returns the stored categories when present", () => {
-    memoryStorage.setItem(STORAGE_KEY, JSON.stringify(["pinned", "recents"]));
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["pinned", "recents"]);
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(["scheduled", "background"]),
+    );
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["scheduled", "background"]);
+  });
+
+  test("filters stale flattened category values", () => {
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(["pinned", "recents", "background"]),
+    );
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
   });
 
   test("returns empty array when stored value is an empty array", () => {
@@ -85,32 +96,32 @@ describe("loadOpenCategories", () => {
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual([]);
   });
 
-  test("returns default [recents] when stored value is not a string array", () => {
+  test("returns default [] when stored value is not a string array", () => {
     memoryStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: "bar" }));
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["recents"]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([]);
   });
 
-  test("returns default [recents] when stored value is invalid JSON", () => {
+  test("returns default [] when stored value is invalid JSON", () => {
     memoryStorage.setItem(STORAGE_KEY, "not-json{{{");
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["recents"]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([]);
   });
 
   test("scopes lookups by assistant id", () => {
-    memoryStorage.setItem(STORAGE_KEY, JSON.stringify(["pinned"]));
-    expect(loadOpenCategories("other_assistant")).toEqual(["recents"]);
+    memoryStorage.setItem(STORAGE_KEY, JSON.stringify(["scheduled"]));
+    expect(loadOpenCategories("other_assistant")).toEqual([]);
   });
 });
 
 describe("saveOpenCategories", () => {
   test("writes the categories under the assistant-scoped storage key", () => {
-    saveOpenCategories(ASSISTANT_ID, ["pinned", "recents"]);
+    saveOpenCategories(ASSISTANT_ID, ["scheduled", "background"]);
     expect(memoryStorage.getItem(STORAGE_KEY)).toBe(
-      JSON.stringify(["pinned", "recents"]),
+      JSON.stringify(["scheduled", "background"]),
     );
   });
 
   test("overwrites any previously stored value", () => {
-    saveOpenCategories(ASSISTANT_ID, ["pinned", "recents"]);
+    saveOpenCategories(ASSISTANT_ID, ["scheduled", "background"]);
     saveOpenCategories(ASSISTANT_ID, ["background"]);
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
   });
@@ -121,9 +132,9 @@ describe("saveOpenCategories", () => {
   });
 
   test("keeps values for different assistants isolated", () => {
-    saveOpenCategories(ASSISTANT_ID, ["pinned"]);
+    saveOpenCategories(ASSISTANT_ID, ["background"]);
     saveOpenCategories("other_assistant", ["scheduled"]);
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["pinned"]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
     expect(loadOpenCategories("other_assistant")).toEqual(["scheduled"]);
   });
 });

--- a/apps/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
+++ b/apps/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
@@ -1,21 +1,25 @@
 // Persist the sidebar conversation group expand/collapse state to localStorage
-// so that the user's last-known toggle state for each group (Pinned, Scheduled,
-// Background, Recents, and custom groups) survives page reloads.
+// so that the user's last-known toggle state for each collapsible group
+// (Scheduled, Background, Slack, and custom groups) survives page reloads.
 //
 // Shape on disk: string[] — the list of currently-open category keys, one entry
 // per expanded group. The format mirrors the Radix Accordion `value` prop for
-// `type="multiple"`. Defaults to ["recents"] when no stored state exists so the
-// common case needs zero clicks after a fresh install.
+// `type="multiple"`. Defaults to [] when no stored state exists.
 //
-// Built-in sections (pinned / scheduled / background / recents) and custom
-// groups are stored under SEPARATE keys so each CollapsibleNavSection.Root
-// manages only its own items — sharing a single array across two Radix roots
-// would cause one root's onValueChange to clobber the other.
+// Built-in sections (scheduled / background / slack) and custom groups
+// are stored under SEPARATE keys so each CollapsibleNavSection.Root manages only
+// its own items — sharing a single array across two Radix roots would cause one
+// root's onValueChange to clobber the other.
 
 const STORAGE_KEY_PREFIX = "vellum:sidebar-open-categories:";
 const STORAGE_KEY_PREFIX_CUSTOM = "vellum:sidebar-open-custom-groups:";
-const DEFAULT_OPEN_CATEGORIES: string[] = ["recents"];
+const DEFAULT_OPEN_CATEGORIES: string[] = [];
 const DEFAULT_OPEN_CUSTOM_GROUPS: string[] = [];
+const OPEN_CATEGORY_KEYS = new Set([
+  "scheduled",
+  "background",
+  "slack",
+]);
 
 function storageKey(assistantId: string): string {
   return `${STORAGE_KEY_PREFIX}${assistantId}`;
@@ -62,10 +66,12 @@ function writeToStorage(key: string, value: string[]): void {
 
 /**
  * Load the list of open built-in sidebar category keys for a given assistant.
- * Returns `["recents"]` when no stored state exists or on any parse error.
+ * Returns `[]` when no stored state exists or on any parse error.
  */
 export function loadOpenCategories(assistantId: string): string[] {
-  return readFromStorage(storageKey(assistantId), DEFAULT_OPEN_CATEGORIES);
+  return readFromStorage(storageKey(assistantId), DEFAULT_OPEN_CATEGORIES).filter(
+    (category) => OPEN_CATEGORY_KEYS.has(category),
+  );
 }
 
 /**


### PR DESCRIPTION
Closes JARVIS-969

## Summary
- Remove sidebar count badges from conversation buckets, subgroups, and custom groups, including the now-unused badge helper.
- Move non-empty pinned conversations into a top-level `Pinned` section above `Conversations`.
- Flatten recent conversations under `Conversations`, keep `Scheduled`, `Background`, and `Slack` as collapsible buckets, and page long recent/Slack lists by 5 with `Show more` / `Show less`.
- Filter stale persisted `pinned` / `recents` collapse keys and show the pin glyph on pinned rows at rest.

## Validation
- `cd apps/web && bun test src/domains/chat/components/assistant-side-menu.test.tsx src/domains/chat/components/collapsed-group-icon.test.tsx src/domains/chat/use-sidebar-state.test.tsx src/domains/chat/sidebar-collapse-store.test.ts src/domains/chat/utils/sidebar-group-collapse-storage.test.ts`
- `cd apps/web && bunx eslint src/domains/chat/components/assistant-side-menu.tsx src/domains/chat/components/assistant-side-menu.test.tsx src/domains/chat/components/thread-pin-toggle.tsx src/domains/chat/use-sidebar-state.ts src/domains/chat/use-sidebar-state.test.tsx src/domains/chat/sidebar-collapse-store.ts src/domains/chat/sidebar-collapse-store.test.ts src/domains/chat/utils/sidebar-group-collapse-storage.ts src/domains/chat/utils/sidebar-group-collapse-storage.test.ts src/components/collapsible-nav-section.tsx src/domains/chat/components/sub-group-accordion.tsx`
- `cd apps/web && bunx tsc --noEmit`