### PR TITLE
fix(skills/notion): drop credentials reveal antipattern, use managed OAuth + auto-inject

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -461,7 +461,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-01T10:51:04-04:00"
+      "updatedAt": "2026-05-27T19:43:19-04:00"
     },
     {
       "id": "oura",
@@ -870,7 +870,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T10:18:46-04:00"
+      "updatedAt": "2026-05-27T14:02:41-04:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -448,7 +448,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-21T18:28:55-04:00"
+      "updatedAt": "2026-05-28T04:20:55-04:00"
     },
     {
       "id": "notion",
@@ -461,7 +461,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T19:43:19-04:00"
+      "updatedAt": "2026-05-28T08:10:46-04:00"
     },
     {
       "id": "oura",

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,38 +8,72 @@ metadata:
     display-name: "Notion"
 ---
 
-You have access to the Notion API via stored credentials for `notion`. Both Internal integration secrets and OAuth access tokens are supported.
+You have access to the Notion API via the managed OAuth connection or an internal integration secret stored in the credential vault. Both paths inject the Authorization header automatically. Never reveal credential values or echo token values into the shell.
 
 ## Authentication
 
-**Step 1 - Check for credentials:**
+**Step 1 - Determine connection type:**
 
 ```
 credential_store action=list
 ```
 
-Look for an entry with `service: "notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
+Look at the results to decide which path to use:
 
-- `field: "internal_secret"` - Internal integration (new default setup)
-- `field: "access_token"` - OAuth/Public integration (legacy setup)
-
-If neither exists, tell the user: "Notion is not connected yet. Load the **vellum-oauth-integrations** skill to set it up first."
+- **Managed OAuth (preferred, post-May-27 default):** No `service: "notion"` entry is needed in the vault. The OAuth connection is managed by the platform. Use **Path A** below.
+- **Internal integration secret:** An entry with `service: "notion"` and `field: "internal_secret"` is present. Use **Path B** below, noting the credential ID.
+- **Neither configured:** Tell the user: "Notion is not connected yet. Load the **vellum-oauth-integrations** skill to set it up first."
 
 **Step 2 - Make authenticated API calls:**
 
-Use `bash` with `assistant credentials reveal` to inject the token into the Authorization header. Substitute the correct `--field` value based on what you found in Step 1:
+Choose the path that matches what you found in Step 1.
+
+---
+
+### Path A. Managed OAuth (preferred)
+
+Use `assistant oauth request --provider notion`. The Authorization header is injected automatically; do not supply it manually.
+
+```
+assistant oauth request --provider notion \
+  -X POST \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  https://api.notion.com/v1/search
+```
+
+General shape: `assistant oauth request --provider notion -X <METHOD> -H "Notion-Version: 2022-06-28" [-H "Content-Type: application/json"] [-d '<json-body>'] <url>`
+
+- URL can be absolute (`https://api.notion.com/v1/pages/...`) or relative (`/v1/pages/...`).
+- `-d` accepts inline JSON, `@filename`, or `@-` for stdin.
+- Token refresh is handled automatically.
+
+---
+
+### Path B. Proxied bash with credential auto-injection
+
+For internal integration secrets registered with `allowedTools: ["bash"]` and an `injection_templates` entry for `api.notion.com`. The proxy adds `Authorization: Bearer <token>` automatically. Do not include an Authorization header in the curl command.
 
 ```
 bash:
+  network_mode: proxied
+  credential_ids: ["<credential_id_from_step_1>"]
   command: |
     curl -s -X POST https://api.notion.com/v1/search \
-      -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       -H "Content-Type: application/json" \
       -d '{}'
 ```
 
-For OAuth credentials, use `--field access_token` instead.
+The credential MUST have:
+
+- `allowedTools` including `"bash"` (otherwise the proxy blocks the call).
+- `injection_templates` with host pattern `api.notion.com` and header injection type for `Authorization`.
+
+If not configured, you will get a `credential tool policy denied` error. See Error Handling.
+
+---
 
 All Notion API calls go to `https://api.notion.com/v1/`. Always include the `Notion-Version: 2022-06-28` header.
 
@@ -254,6 +288,7 @@ When a response includes `"has_more": true`, pass `"start_cursor": response.next
 - **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
 - **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.
 - **429 Too Many Requests**: Wait a few seconds and retry.
+- **`credential tool policy denied`**: The credential was registered without `bash` in `allowedTools`, or without an `injection_templates` entry for `api.notion.com`. The proxy cannot inject the Authorization header. Fix: re-run the Notion setup via the **vellum-oauth-integrations** skill, or switch to Path A (managed OAuth) which bypasses this requirement entirely.
 
 ## Tips
 

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -20,8 +20,8 @@ credential_store action=list
 
 Look at the results to decide which path to use:
 
-- **Managed OAuth (preferred, post-May-27 default):** No `service: "notion"` entry is needed in the vault. The OAuth connection is managed by the platform. Use **Path A** below.
-- **Internal integration secret:** An entry with `service: "notion"` and `field: "internal_secret"` is present. Use **Path B** below, noting the credential ID.
+- **Managed OAuth (preferred):** No `service: "notion"` entry is needed in the vault. The OAuth connection is managed by the platform. Use **Path A** below.
+- **Internal integration secret:** An entry with `service: "notion"` and `field: "internal_secret"` is present. Use **Path A** below (recommended) or **Path B** if the credential has the required metadata (see Path B for details).
 - **Neither configured:** Tell the user: "Notion is not connected yet. Load the **vellum-oauth-integrations** skill to set it up first."
 
 **Step 2 - Make authenticated API calls:**
@@ -53,6 +53,8 @@ General shape: `assistant oauth request --provider notion -X <METHOD> -H "Notion
 
 ### Path B. Proxied bash with credential auto-injection
 
+> **Note:** The standard Notion setup flow (`vellum-oauth-integrations`) does not currently produce credentials with the metadata required by this path. Most users should use **Path A** instead. Path B is documented for credentials that have been manually configured with the required metadata.
+
 For internal integration secrets registered with `allowedTools: ["bash"]` and an `injection_templates` entry for `api.notion.com`. The proxy adds `Authorization: Bearer <token>` automatically. Do not include an Authorization header in the curl command.
 
 ```
@@ -66,12 +68,14 @@ bash:
       -d '{}'
 ```
 
+Where `<credential_id_from_step_1>` is the `id` field from the matching entry in `credential_store action=list` output.
+
 The credential MUST have:
 
 - `allowedTools` including `"bash"` (otherwise the proxy blocks the call).
 - `injection_templates` with host pattern `api.notion.com` and header injection type for `Authorization`.
 
-If not configured, you will get a `credential tool policy denied` error. See Error Handling.
+If these are missing, you will get a `credential tool policy denied` error. Switch to **Path A** instead.
 
 ---
 
@@ -288,7 +292,7 @@ When a response includes `"has_more": true`, pass `"start_cursor": response.next
 - **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
 - **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.
 - **429 Too Many Requests**: Wait a few seconds and retry.
-- **`credential tool policy denied`**: The credential was registered without `bash` in `allowedTools`, or without an `injection_templates` entry for `api.notion.com`. The proxy cannot inject the Authorization header. Fix: re-run the Notion setup via the **vellum-oauth-integrations** skill, or switch to Path A (managed OAuth) which bypasses this requirement entirely.
+- **`credential tool policy denied`**: The credential is missing `bash` in `allowedTools` or an `injection_templates` entry for `api.notion.com`, so the proxy cannot inject the Authorization header. Switch to **Path A** (managed OAuth), which bypasses credential metadata requirements entirely.
 
 ## Tips
 


### PR DESCRIPTION
Refs JARVIS-974.

## Why

The Notion skill previously instructed callers to do:

```
curl ... -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)"
```

That shape:

1. Violates the credential-handling discipline (never reveal credentials into the shell).
2. Triggers the JARVIS-974 deny under CES shell lockdown / credential `allowedTools` policy. CES rejects proxied-bash use of a credential whose metadata does not include `bash` in `allowedTools`. New static credentials created via `credential_store action=store` without explicit `allowed_tools` are born with `allowedTools: []` (separate defaulting bug, see [JARVIS-974 comments](https://linear.app/vellum/issue/JARVIS-974) for the code-level root cause).

## What

Two documented paths replace the old single curl example:

- **Path A. Managed OAuth (preferred, post-May-27 default):** `assistant oauth request --provider notion -X <METHOD> -H "Notion-Version: 2022-06-28" [-d ...] <url>`. Authorization injected automatically, token refresh handled.
- **Path B. Proxied bash with credential auto-injection:** plain `curl` with `network_mode: proxied` and `credential_ids: [...]`. No explicit Authorization header. The proxy injects `Authorization: Bearer <token>` via the credential's `injection_templates`. Documents the credential metadata requirements (`allowedTools` including `bash`, `injection_templates` for `api.notion.com`).

Error Handling adds a `credential tool policy denied` bullet pointing users back to `vellum-oauth-integrations` or Path A.

## Out of scope

- Fixing the underlying credential-store defaulting bug (`vault.ts:352-358` and parallel paths). Filed as a follow-up in JARVIS-974.
- Cleanup of `vellum-oauth-integrations/references/provider-app-setups/notion*.md` and `guardian-verify-setup/SKILL.md` which contain the same antipattern. Will land in a sibling PR.

## Validation

- `grep "credentials reveal" skills/notion/SKILL.md` returns no output.
- Frontmatter intact.
- All existing sections (Reading, Searching, Databases, Creating/Updating, Pagination, Tips) preserved verbatim.
