### PR TITLE
fix: cleanup slop from local-mode onboarding

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -395,20 +395,7 @@ export function useAssistantLifecycle({
     }
   }, [hatchAndCheck]);
 
-  // Initial check when auth is ready.
-  //
-  // Post-local-hatch flow: when a local assistant is hatched during
-  // onboarding, the hatching screen primes the gateway token and
-  // self-hosted connection (via loadLockfile + ensureGatewayToken +
-  // setSelfHostedConnection). After pre-chat completes and the user
-  // navigates back to /assistant, this effect re-runs with isLoggedIn
-  // true and isLoading false. Because the gateway token is now cached
-  // in localStorage, isGatewayAuthMode() returns true and the branch
-  // below activates — setting up the self-hosted connection, assistant
-  // ID, and active state so the chat page can communicate with the
-  // local assistant. This also handles page refreshes: the gateway
-  // token and lockfile are persisted in localStorage, so re-priming
-  // from cache is idempotent.
+  // Local-mode: gateway token and connection are primed during onboarding hatch.
   useEffect(() => {
     if (!isLoggedIn || isLoading) {
       return;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,9 +18,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
-import { isLocalMode, hatchLocalAssistant, loadLockfile, getLocalGatewayUrl } from "@/lib/local-mode";
-import { ensureGatewayToken, getGatewayToken, getLocalTokenUrl } from "@/lib/auth/gateway-session";
-import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
+import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, primeLocalGatewayConnection } from "@/lib/local-mode";
 import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
@@ -173,8 +171,6 @@ export function HatchingScreen() {
         });
       }
       markPrivacyConsent(userId);
-      // Note: avatar sync only applies to platform-hatched assistants
-      // (local assistants don't have platform-side avatar storage yet)
       setDisplayProgress(1);
       displayProgressRef.current = 1;
       segmentStartRef.current = 1;
@@ -230,17 +226,10 @@ export function HatchingScreen() {
             return;
           }
           await loadLockfile();
-          const tokenUrl = getLocalTokenUrl();
-          if (tokenUrl) {
-            await ensureGatewayToken(tokenUrl);
-            const localGateway = getLocalGatewayUrl();
-            if (localGateway) {
-              setSelfHostedConnection({
-                url: `${window.location.origin}${localGateway}`,
-                token: getGatewayToken(),
-              });
-            }
+          if (result.assistantId) {
+            setSelectedAssistantId(result.assistantId);
           }
+          await primeLocalGatewayConnection();
           handleHatchReady();
         } catch {
           if (cancelled) return;

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -5,6 +5,12 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/lib/local-settings";
+import {
+  ensureGatewayToken,
+  getGatewayToken,
+  getLocalTokenUrl,
+} from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -178,4 +184,27 @@ export function getLocalGatewayUrl(): string | undefined {
   const assistant = getSelectedAssistant();
   if (!assistant || !isLocalAssistant(assistant)) return undefined;
   return gatewayProxyUrl(assistant.resources!.gatewayPort);
+}
+
+// ---------------------------------------------------------------------------
+// Gateway connection setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Acquire a gateway token and prime the self-hosted connection for the
+ * selected local assistant.
+ *
+ * Transport: fetch to Vite dev middleware gateway proxy.
+ * In Electron, replace with direct IPC token acquisition.
+ */
+export async function primeLocalGatewayConnection(): Promise<void> {
+  const tokenUrl = getLocalTokenUrl();
+  if (!tokenUrl) return;
+  await ensureGatewayToken(tokenUrl);
+  const localGateway = getLocalGatewayUrl();
+  if (!localGateway) return;
+  setSelfHostedConnection({
+    url: `${window.location.origin}${localGateway}`,
+    token: getGatewayToken(),
+  });
 }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -23,17 +23,15 @@ import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
   ensureGatewayToken,
-  getGatewayToken,
   clearGatewayToken,
   getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
 import {
   isLocalMode,
   getPlatformAssistants,
-  getLocalGatewayUrl,
   clearSelectedAssistant,
+  primeLocalGatewayConnection,
 } from "@/lib/local-mode";
-import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { syncOnboardingUser, clearOnboardingFlags } from "@/lib/onboarding-cleanup";
 import { clearOrganization } from "@/stores/organization-store";
@@ -128,14 +126,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   initSession: async () => {
     if (isGatewayAuthEnabled()) {
       try {
-        await ensureGatewayToken(getLocalTokenUrl());
-        const localGateway = getLocalGatewayUrl();
-        if (localGateway) {
-          setSelfHostedConnection({
-            url: `${window.location.origin}${localGateway}`,
-            token: getGatewayToken(),
-          });
-        }
+        await primeLocalGatewayConnection();
         set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
       } catch {
         set({ isLoggedIn: false, isLoading: false, user: null });


### PR DESCRIPTION
## Summary
- Extract primeLocalGatewayConnection() helper to deduplicate gateway setup
- Use returned assistantId from local hatch response
- Shorten overly long lifecycle comment
- Remove orphaned avatar sync comment

Part of plan: local-mode-onboarding.md (fix round 1)