### PR TITLE
Local-Mode Onboarding Flow

### DIFF
--- a/apps/web/src/assistant/use-assistant-reachability.ts
+++ b/apps/web/src/assistant/use-assistant-reachability.ts
@@ -6,6 +6,7 @@ import {
   type AssistantsConnectionStatusResponse,
   type ConnectionStatus,
 } from "@/generated/api/index";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { subscribeAssistantUnreachable } from "@/assistant/unreachable-bus";
 
 /**
@@ -283,7 +284,7 @@ export function useAssistantReachability(
   }, [runProbe]);
 
   const probe = useCallback((options?: ReachabilityProbeOptions) => {
-    if (!assistantId) {
+    if (!assistantId || isGatewayAuthMode()) {
       return;
     }
     const mode = options?.mode ?? "visible";

--- a/apps/web/src/assistant/use-assistant-reachability.ts
+++ b/apps/web/src/assistant/use-assistant-reachability.ts
@@ -7,6 +7,7 @@ import {
   type ConnectionStatus,
 } from "@/generated/api/index";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import { subscribeAssistantUnreachable } from "@/assistant/unreachable-bus";
 
 /**
@@ -176,14 +177,29 @@ export function useAssistantReachability(
         return;
       }
       let response: AssistantsConnectionStatusResponse | null = null;
-      try {
-        const result = await assistantsConnectionStatus({
-          path: { id },
-          throwOnError: false,
-        });
-        response = result.data ?? null;
-      } catch {
-        response = null;
+
+      if (isGatewayAuthMode()) {
+        const ingressUrl = getSelfHostedIngressUrl();
+        if (ingressUrl) {
+          try {
+            const res = await fetch(`${ingressUrl}/healthz`);
+            response = res.ok
+              ? ({ state: "ready" } as AssistantsConnectionStatusResponse)
+              : null;
+          } catch {
+            response = null;
+          }
+        }
+      } else {
+        try {
+          const result = await assistantsConnectionStatus({
+            path: { id },
+            throwOnError: false,
+          });
+          response = result.data ?? null;
+        } catch {
+          response = null;
+        }
       }
 
       if (generation !== generationRef.current) {
@@ -284,7 +300,7 @@ export function useAssistantReachability(
   }, [runProbe]);
 
   const probe = useCallback((options?: ReachabilityProbeOptions) => {
-    if (!assistantId || isGatewayAuthMode()) {
+    if (!assistantId) {
       return;
     }
     const mode = options?.mode ?? "visible";

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -59,7 +59,6 @@ import { useChatAttachments } from "@/domains/chat/components/chat-attachments/u
 import { useVoiceInput } from "@/domains/chat/hooks/use-voice-input";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability";
-import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges";
@@ -689,7 +688,7 @@ export function ChatPage() {
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationId) return;
-    if (reachability.state.phase !== "ready" && !isGatewayAuthMode()) return;
+    if (reachability.state.phase !== "ready") return;
     const message = peekPendingPreChatContext()?.initialMessage;
     if (!message) return;
     initialMessageConsumedRef.current = true;

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -59,6 +59,7 @@ import { useChatAttachments } from "@/domains/chat/components/chat-attachments/u
 import { useVoiceInput } from "@/domains/chat/hooks/use-voice-input";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges";
@@ -688,7 +689,7 @@ export function ChatPage() {
   const initialMessageConsumedRef = useRef(false);
   useEffect(() => {
     if (initialMessageConsumedRef.current || !assistantId || !activeConversationId) return;
-    if (reachability.state.phase !== "ready") return;
+    if (reachability.state.phase !== "ready" && !isGatewayAuthMode()) return;
     const message = peekPendingPreChatContext()?.initialMessage;
     if (!message) return;
     initialMessageConsumedRef.current = true;

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from "@/assistant/lifecycle";
 import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
-import { getSelectedAssistant, getLocalGatewayUrl } from "@/lib/local-mode";
+import { getSelectedAssistant, getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { routes } from "@/utils/routes";
 
@@ -433,6 +433,16 @@ export function useAssistantLifecycle({
       setAssistantId(assistantId);
       setAssistantState({ kind: "active", isLocal: true });
       return;
+    }
+    // In local mode without a gateway token, the platform API (Django) is
+    // unreachable — calling checkAssistant() would produce a network error.
+    // Redirect to onboarding so the user can hatch a local assistant first.
+    if (isLocalMode() && !isGatewayAuthMode()) {
+      const redirect = resolveOnboardingRedirect({ intendedDestination: window.location.pathname });
+      if (redirect) {
+        onRedirectRef.current(redirect);
+        return;
+      }
     }
     if (hasPlatformSession) {
       setSelfHostedConnection(null);

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -395,20 +395,7 @@ export function useAssistantLifecycle({
     }
   }, [hatchAndCheck]);
 
-  // Initial check when auth is ready.
-  //
-  // Post-local-hatch flow: when a local assistant is hatched during
-  // onboarding, the hatching screen primes the gateway token and
-  // self-hosted connection (via loadLockfile + ensureGatewayToken +
-  // setSelfHostedConnection). After pre-chat completes and the user
-  // navigates back to /assistant, this effect re-runs with isLoggedIn
-  // true and isLoading false. Because the gateway token is now cached
-  // in localStorage, isGatewayAuthMode() returns true and the branch
-  // below activates — setting up the self-hosted connection, assistant
-  // ID, and active state so the chat page can communicate with the
-  // local assistant. This also handles page refreshes: the gateway
-  // token and lockfile are persisted in localStorage, so re-priming
-  // from cache is idempotent.
+  // Local-mode: gateway token and connection are primed during onboarding hatch.
   useEffect(() => {
     if (!isLoggedIn || isLoading) {
       return;

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -20,7 +20,7 @@ import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
 import { getSelectedAssistant, getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
-import { routes } from "@/utils/routes";
+
 
 const POLL_INTERVAL_MS = 3000;
 const MAX_HATCH_RETRIES = 3;

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -395,11 +395,26 @@ export function useAssistantLifecycle({
     }
   }, [hatchAndCheck]);
 
-  // Initial check when auth is ready
+  // Initial check when auth is ready.
+  //
+  // Post-local-hatch flow: when a local assistant is hatched during
+  // onboarding, the hatching screen primes the gateway token and
+  // self-hosted connection (via loadLockfile + ensureGatewayToken +
+  // setSelfHostedConnection). After pre-chat completes and the user
+  // navigates back to /assistant, this effect re-runs with isLoggedIn
+  // true and isLoading false. Because the gateway token is now cached
+  // in localStorage, isGatewayAuthMode() returns true and the branch
+  // below activates — setting up the self-hosted connection, assistant
+  // ID, and active state so the chat page can communicate with the
+  // local assistant. This also handles page refreshes: the gateway
+  // token and lockfile are persisted in localStorage, so re-priming
+  // from cache is idempotent.
   useEffect(() => {
     if (!isLoggedIn || isLoading) {
       return;
     }
+    // Gateway auth takes priority over the platform session path below.
+    // In local mode after hatch, this branch is the entry point.
     if (isGatewayAuthMode()) {
       let ingressUrl = window.location.origin;
       let assistantId = "self";

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -421,10 +421,11 @@ export function useAssistantLifecycle({
       setAssistantState({ kind: "active", isLocal: true });
       return;
     }
-    // In local mode without a gateway token, skip checkAssistant() — the
-    // platform API may not be available, and even if it is (user logged in),
-    // auto_hatch would redirect away from the onboarding flow the user is in.
-    if (isLocalMode() && !isGatewayAuthMode()) {
+    // In local mode without a gateway token AND no platform session,
+    // the platform API isn't available — redirect to onboarding.
+    // If the user logged in and chose Vellum Cloud, hasPlatformSession
+    // is true and we fall through to checkAssistant() below.
+    if (isLocalMode() && !isGatewayAuthMode() && !hasPlatformSession) {
       const redirect = resolveOnboardingRedirect({ intendedDestination: window.location.pathname });
       if (redirect) {
         onRedirectRef.current(redirect);

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -429,8 +429,11 @@ export function useAssistantLifecycle({
       const redirect = resolveOnboardingRedirect({ intendedDestination: window.location.pathname });
       if (redirect) {
         onRedirectRef.current(redirect);
+        return;
       }
-      return;
+      // No redirect needed (e.g., already on onboarding page, or has
+      // assistants) — fall through to checkAssistant() which will
+      // discover the assistant or surface an error state.
     }
     if (hasPlatformSession) {
       setSelfHostedConnection(null);

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -210,7 +210,7 @@ export function useAssistantLifecycle({
         // New signups without completed onboarding should land on
         // `/onboarding/privacy` before we hatch an assistant for them.
         const onboardingRedirect = resolveOnboardingRedirect({
-          intendedDestination: routes.assistant,
+          intendedDestination: window.location.pathname,
         });
         if (onboardingRedirect) {
           onRedirectRef.current(onboardingRedirect);

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -421,15 +421,15 @@ export function useAssistantLifecycle({
       setAssistantState({ kind: "active", isLocal: true });
       return;
     }
-    // In local mode without a gateway token, the platform API (Django) is
-    // unreachable — calling checkAssistant() would produce a network error.
-    // Redirect to onboarding so the user can hatch a local assistant first.
+    // In local mode without a gateway token, skip checkAssistant() — the
+    // platform API may not be available, and even if it is (user logged in),
+    // auto_hatch would redirect away from the onboarding flow the user is in.
     if (isLocalMode() && !isGatewayAuthMode()) {
       const redirect = resolveOnboardingRedirect({ intendedDestination: window.location.pathname });
       if (redirect) {
         onRedirectRef.current(redirect);
-        return;
       }
+      return;
     }
     if (hasPlatformSession) {
       setSelfHostedConnection(null);

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -13,7 +13,10 @@
 import { routes } from "@/utils/routes";
 
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
-import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
+import {
+  readOnboardingCompleted,
+  clearOnboardingCompleted,
+} from "@/domains/onboarding/prefs";
 
 /**
  * Returns the path to redirect to when onboarding should intercept, or
@@ -21,13 +24,14 @@ import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
  *
  * Rules (short-circuit, top to bottom):
  *   1. In local mode with hatched assistants, let the user through.
- *   2. If onboarding is already marked completed, let the user through
- *      — UNLESS local mode has no assistants (stale flag from a prior session).
- *   3. If the intended destination isn't the chat surface itself
+ *   2. In local mode with zero assistants, clear any stale completion flag
+ *      (lockfile was lost/emptied since last onboarding).
+ *   3. If onboarding is already marked completed, let the user through.
+ *   4. If the intended destination isn't the chat surface itself
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   4. Otherwise, route them to `routes.onboarding.privacy`.
+ *   5. Otherwise, route them to `routes.onboarding.privacy`.
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
@@ -35,7 +39,10 @@ export function resolveOnboardingRedirect({
   intendedDestination: string;
 }): string | null {
   if (isLocalMode() && hasAssistants()) return null;
-  if (readOnboardingCompleted() && !(isLocalMode() && !hasAssistants())) return null;
+  if (isLocalMode() && !hasAssistants() && readOnboardingCompleted()) {
+    clearOnboardingCompleted();
+  }
+  if (readOnboardingCompleted()) return null;
 
   // `intendedDestination` may be a bare path or a raw `returnTo` value that
   // survived the callback as an absolute URL (`https://assistant.host/assistant`,

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -31,7 +31,7 @@ import {
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   5. Otherwise, route them to `routes.onboarding.privacy`.
+ *   5. Otherwise, route them to hatching (local mode) or privacy (platform).
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
@@ -50,7 +50,7 @@ export function resolveOnboardingRedirect({
   // don't miss absolute URLs whose path is the assistant surface.
   const path = extractPathname(intendedDestination);
   if (path !== routes.assistant) return null;
-  return routes.onboarding.privacy;
+  return isLocalMode() ? routes.onboarding.hatching : routes.onboarding.privacy;
 }
 
 function extractPathname(destination: string): string {

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -12,7 +12,7 @@
  */
 import { routes } from "@/utils/routes";
 
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
 
 /**
@@ -20,19 +20,21 @@ import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
  * `null` if the intended destination is fine as-is.
  *
  * Rules (short-circuit, top to bottom):
- *   1. If onboarding is already marked completed, let the user through.
- *   2. If the intended destination isn't the chat surface itself
+ *   1. In local mode with hatched assistants, let the user through.
+ *   2. If onboarding is already marked completed, let the user through.
+ *   3. If the intended destination isn't the chat surface itself
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   3. Otherwise, route them to `routes.onboarding.privacy`.
+ *   4. Otherwise, route them to `routes.onboarding.privacy`.
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
 }: {
   intendedDestination: string;
 }): string | null {
-  if (isLocalMode() || readOnboardingCompleted()) return null;
+  if (isLocalMode() && hasAssistants()) return null;
+  if (readOnboardingCompleted()) return null;
 
   // `intendedDestination` may be a bare path or a raw `returnTo` value that
   // survived the callback as an absolute URL (`https://assistant.host/assistant`,

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -31,7 +31,7 @@ import {
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   5. Otherwise, route them to hosting selection (local mode) or privacy (platform).
+ *   5. Otherwise, route them to welcome (local mode) or privacy (platform).
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
@@ -50,7 +50,7 @@ export function resolveOnboardingRedirect({
   // don't miss absolute URLs whose path is the assistant surface.
   const path = extractPathname(intendedDestination);
   if (path !== routes.assistant) return null;
-  return isLocalMode() ? routes.onboarding.hosting : routes.onboarding.privacy;
+  return isLocalMode() ? routes.onboarding.welcome : routes.onboarding.privacy;
 }
 
 function extractPathname(destination: string): string {

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -50,6 +50,15 @@ export function resolveOnboardingRedirect({
   // don't miss absolute URLs whose path is the assistant surface.
   const path = extractPathname(intendedDestination);
   if (path !== routes.assistant) return null;
+  return getOnboardingEntrypoint();
+}
+
+/**
+ * The first screen a user should see when entering the onboarding flow.
+ * Local mode starts at the welcome/hosting selector; platform starts at
+ * privacy/consent.
+ */
+export function getOnboardingEntrypoint(): string {
   return isLocalMode() ? routes.onboarding.welcome : routes.onboarding.privacy;
 }
 

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -31,7 +31,7 @@ import {
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
  *      `/admin/...` etc. shouldn't be gated.
- *   5. Otherwise, route them to hatching (local mode) or privacy (platform).
+ *   5. Otherwise, route them to hosting selection (local mode) or privacy (platform).
  */
 export function resolveOnboardingRedirect({
   intendedDestination,
@@ -50,7 +50,7 @@ export function resolveOnboardingRedirect({
   // don't miss absolute URLs whose path is the assistant surface.
   const path = extractPathname(intendedDestination);
   if (path !== routes.assistant) return null;
-  return isLocalMode() ? routes.onboarding.hatching : routes.onboarding.privacy;
+  return isLocalMode() ? routes.onboarding.hosting : routes.onboarding.privacy;
 }
 
 function extractPathname(destination: string): string {

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -21,7 +21,8 @@ import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
  *
  * Rules (short-circuit, top to bottom):
  *   1. In local mode with hatched assistants, let the user through.
- *   2. If onboarding is already marked completed, let the user through.
+ *   2. If onboarding is already marked completed, let the user through
+ *      — UNLESS local mode has no assistants (stale flag from a prior session).
  *   3. If the intended destination isn't the chat surface itself
  *      (`/assistant`), let them through — sibling paths
  *      `/assistant/settings/...`, `/assistant/onboarding/...`,
@@ -34,7 +35,7 @@ export function resolveOnboardingRedirect({
   intendedDestination: string;
 }): string | null {
   if (isLocalMode() && hasAssistants()) return null;
-  if (readOnboardingCompleted()) return null;
+  if (readOnboardingCompleted() && !(isLocalMode() && !hasAssistants())) return null;
 
   // `intendedDestination` may be a bare path or a raw `returnTo` value that
   // survived the callback as an absolute URL (`https://assistant.host/assistant`,

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -150,6 +150,15 @@ mock.module("@/runtime/native-auth", () => ({
   useIsNativePlatform: () => false,
 }));
 
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => false,
+  hatchLocalAssistant: async () => ({ ok: true, assistantId: "local-1" }),
+  loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
+  setSelectedAssistantId: () => {},
+  saveLockfileAssistant: async () => {},
+  primeLocalGatewayConnection: async () => {},
+}));
+
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     use: {
@@ -160,6 +169,7 @@ mock.module("@/stores/auth-store", () => ({
       }),
       isLoggedIn: () => true,
       isLoading: () => false,
+      hasPlatformSession: () => false,
     },
   },
 }));

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -19,6 +19,7 @@ import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
 import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection } from "@/lib/local-mode";
+import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
 import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
@@ -94,7 +95,7 @@ export function decideHatchGate(input: {
   if (input.isLocalMode) return { kind: "proceed" };
   const persistedConsent = input.tosAccepted && input.aiDataConsentAccepted;
   if (!input.cameFromPrivacyScreen && !persistedConsent) {
-    return { kind: "redirect", to: routes.onboarding.privacy };
+    return { kind: "redirect", to: getOnboardingEntrypoint() };
   }
   return { kind: "proceed" };
 }

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -78,6 +78,7 @@ export type HatchGateDecision =
 export function decideHatchGate(input: {
   isAuthLoading: boolean;
   isLoggedIn: boolean;
+  isLocalMode: boolean;
   onboardingCompleted: boolean;
   tosAccepted: boolean;
   aiDataConsentAccepted: boolean;
@@ -86,6 +87,7 @@ export function decideHatchGate(input: {
   if (input.isAuthLoading) return { kind: "wait" };
   if (!input.isLoggedIn) return { kind: "redirect", to: routes.account.login };
   if (input.onboardingCompleted) return { kind: "redirect", to: routes.assistant };
+  if (input.isLocalMode) return { kind: "proceed" };
   const persistedConsent = input.tosAccepted && input.aiDataConsentAccepted;
   if (!input.cameFromPrivacyScreen && !persistedConsent) {
     return { kind: "redirect", to: routes.onboarding.privacy };
@@ -142,6 +144,7 @@ export function HatchingScreen() {
     const decision = decideHatchGate({
       isAuthLoading,
       isLoggedIn,
+      isLocalMode: isLocalMode(),
       onboardingCompleted: readOnboardingCompleted(),
       tosAccepted: readTosAccepted(),
       aiDataConsentAccepted: readAiDataConsent(),

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -226,7 +226,7 @@ export function HatchingScreen() {
       // 4. Navigate to pre-chat flow
       //
       // Transport: fetch to Vite dev middleware.
-      // In Electron: window.electronAPI.hatchAssistant() → direct IPC to main process.
+      // In Electron: window.electronAPI.hatchAssistant() → direct IPC to main process. (LUM-1997)
       if (useLocalHatch) {
         try {
           if (!localHatchPromise) {

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -464,9 +464,11 @@ export function HatchingScreen() {
               className="h-11 text-base"
               onClick={() =>
                 void navigate(
-                  isReplay
-                    ? `${routes.onboarding.privacy}?replay=1`
-                    : routes.onboarding.privacy,
+                  useLocalHatch
+                    ? routes.onboarding.hosting
+                    : isReplay
+                      ? `${routes.onboarding.privacy}?replay=1`
+                      : routes.onboarding.privacy,
                   { replace: true },
                 )
               }

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,7 +18,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
-import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, primeLocalGatewayConnection } from "@/lib/local-mode";
+import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection } from "@/lib/local-mode";
 import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
@@ -323,6 +323,14 @@ export function HatchingScreen() {
                 tags: { context: "onboarding_avatar_sync" },
               });
             });
+            if (isLocalMode()) {
+              void saveLockfileAssistant({
+                assistantId,
+                cloud: "vellum",
+                runtimeUrl: window.location.origin,
+                hatchedAt: new Date().toISOString(),
+              });
+            }
           }
 
           handleHatchReady();

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -103,6 +103,8 @@ export function HatchingScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isReplay = searchParams.get("replay") === "1";
+  const hostingParam = searchParams.get("hosting");
+  const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const userId = useAuthStore.use.user()?.id ?? null;
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const isAuthLoading = useAuthStore.use.isLoading();
@@ -187,7 +189,7 @@ export function HatchingScreen() {
       navigateTimer = setTimeout(() => {
         if (cancelled) return;
         void (async () => {
-          if (!isLocalMode()) {
+          if (!useLocalHatch) {
             await checkAssistant();
           }
           if (cancelled) return;
@@ -217,15 +219,15 @@ export function HatchingScreen() {
         return;
       }
 
-      // Local-mode hatch lifecycle:
-      // 1. POST /assistant/__local/hatch -> CLI spawns daemon + gateway
+      // Local/Docker hatch lifecycle:
+      // 1. POST /assistant/__local/hatch → CLI spawns daemon + gateway
       // 2. Reload lockfile to discover new assistant
       // 3. Acquire gateway token + set self-hosted connection
       // 4. Navigate to pre-chat flow
       //
       // Transport: fetch to Vite dev middleware.
-      // In Electron: window.electronAPI.hatchAssistant() -> direct IPC to main process.
-      if (isLocalMode()) {
+      // In Electron: window.electronAPI.hatchAssistant() → direct IPC to main process.
+      if (useLocalHatch) {
         try {
           if (!localHatchPromise) {
             localHatchPromise = hatchLocalAssistant();
@@ -360,6 +362,7 @@ export function HatchingScreen() {
     navigate,
     setOnboardingCompleted,
     transitionPhase,
+    useLocalHatch,
     userId,
   ]);
 

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,9 +18,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
-import { isLocalMode, hatchLocalAssistant, loadLockfile, getLocalGatewayUrl } from "@/lib/local-mode";
-import { ensureGatewayToken, getGatewayToken, getLocalTokenUrl } from "@/lib/auth/gateway-session";
-import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
+import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, primeLocalGatewayConnection } from "@/lib/local-mode";
 import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
@@ -173,8 +171,6 @@ export function HatchingScreen() {
         });
       }
       markPrivacyConsent(userId);
-      // Note: avatar sync only applies to platform-hatched assistants
-      // (local assistants don't have platform-side avatar storage yet)
       setDisplayProgress(1);
       displayProgressRef.current = 1;
       segmentStartRef.current = 1;
@@ -230,17 +226,10 @@ export function HatchingScreen() {
             return;
           }
           await loadLockfile();
-          const tokenUrl = getLocalTokenUrl();
-          if (tokenUrl) {
-            await ensureGatewayToken(tokenUrl);
-            const localGateway = getLocalGatewayUrl();
-            if (localGateway) {
-              setSelfHostedConnection({
-                url: `${window.location.origin}${localGateway}`,
-                token: getGatewayToken(),
-              });
-            }
+          if (result.assistantId) {
+            setSelectedAssistantId(result.assistantId);
           }
+          await primeLocalGatewayConnection();
           handleHatchReady();
         } catch {
           if (cancelled) return;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -41,6 +41,10 @@ const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 const MAX_HATCH_WAIT_MS = 300_000;
 
+// Module-level promise so HMR remounts and StrictMode double-mounts
+// can await the same in-flight hatch instead of spawning duplicates.
+let localHatchPromise: Promise<import("@/lib/local-mode").LocalHatchResult> | null = null;
+
 type HatchPhase = "initializing" | "provisioning" | "connecting" | "ready";
 
 const PHASE_TARGET: Record<HatchPhase, number> = {
@@ -139,6 +143,7 @@ export function HatchingScreen() {
     setAnimationEpoch((n) => n + 1);
   }, []);
 
+
   useEffect(() => {
     const cameFromPrivacyScreen = hasRecentPrivacyConsent(userId);
     const decision = decideHatchGate({
@@ -222,7 +227,11 @@ export function HatchingScreen() {
       // In Electron: window.electronAPI.hatchAssistant() -> direct IPC to main process.
       if (isLocalMode()) {
         try {
-          const result = await hatchLocalAssistant();
+          if (!localHatchPromise) {
+            localHatchPromise = hatchLocalAssistant();
+          }
+          const result = await localHatchPromise;
+          localHatchPromise = null;
           if (cancelled) return;
           if (!result.ok) {
             setError(result.error ?? "Failed to hatch local assistant.");
@@ -235,6 +244,7 @@ export function HatchingScreen() {
           await primeLocalGatewayConnection();
           handleHatchReady();
         } catch {
+          localHatchPromise = null;
           if (cancelled) return;
           setError("Failed to hatch local assistant. Check CLI logs for details.");
         }

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,6 +18,9 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
+import { isLocalMode, hatchLocalAssistant, loadLockfile, getLocalGatewayUrl } from "@/lib/local-mode";
+import { ensureGatewayToken, getGatewayToken, getLocalTokenUrl } from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useRootOutletContext } from "@/root-layout";
 import {
   readAiDataConsent,
@@ -161,12 +164,91 @@ export function HatchingScreen() {
 
     const pinnedVersion = readSelectedVersion();
 
+    const handleHatchReady = () => {
+      try {
+        writeSelectedVersion("");
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { context: "onboarding_mark_completed" },
+        });
+      }
+      markPrivacyConsent(userId);
+      // Note: avatar sync only applies to platform-hatched assistants
+      // (local assistants don't have platform-side avatar storage yet)
+      setDisplayProgress(1);
+      displayProgressRef.current = 1;
+      segmentStartRef.current = 1;
+      setPhase("ready");
+      phaseRef.current = "ready";
+      navigateTimer = setTimeout(() => {
+        if (cancelled) return;
+        void (async () => {
+          if (!isLocalMode()) {
+            await checkAssistant();
+          }
+          if (cancelled) return;
+          if (isNativePlatform()) {
+            try {
+              setOnboardingCompleted(true);
+            } catch (err) {
+              Sentry.captureException(err, {
+                tags: { context: "hatching_mark_onboarding_completed_native" },
+              });
+            }
+            clearPrivacyConsent();
+            void navigate(`${routes.assistant}?onboarding=1`, {
+              replace: true,
+            });
+            return;
+          }
+          void navigate(routes.onboarding.prechat, { replace: true });
+        })();
+      }, COMPLETION_NAVIGATE_DELAY_MS);
+    };
+
     const startHatch = async () => {
       transitionPhase("provisioning");
       if (isReplay) {
         scheduleNextPoll(0);
         return;
       }
+
+      // Local-mode hatch lifecycle:
+      // 1. POST /assistant/__local/hatch -> CLI spawns daemon + gateway
+      // 2. Reload lockfile to discover new assistant
+      // 3. Acquire gateway token + set self-hosted connection
+      // 4. Navigate to pre-chat flow
+      //
+      // Transport: fetch to Vite dev middleware.
+      // In Electron: window.electronAPI.hatchAssistant() -> direct IPC to main process.
+      if (isLocalMode()) {
+        try {
+          const result = await hatchLocalAssistant();
+          if (cancelled) return;
+          if (!result.ok) {
+            setError(result.error ?? "Failed to hatch local assistant.");
+            return;
+          }
+          await loadLockfile();
+          const tokenUrl = getLocalTokenUrl();
+          if (tokenUrl) {
+            await ensureGatewayToken(tokenUrl);
+            const localGateway = getLocalGatewayUrl();
+            if (localGateway) {
+              setSelfHostedConnection({
+                url: `${window.location.origin}${localGateway}`,
+                token: getGatewayToken(),
+              });
+            }
+          }
+          handleHatchReady();
+        } catch {
+          if (cancelled) return;
+          setError("Failed to hatch local assistant. Check CLI logs for details.");
+        }
+        return;
+      }
+
       try {
         const result = await hatchAssistant(
           pinnedVersion ? { version: pinnedVersion } : undefined,
@@ -227,15 +309,6 @@ export function HatchingScreen() {
         if (cancelled) return;
         const next = resolveAssistantLifecycleState(result);
         if (next.kind === "active") {
-          try {
-            writeSelectedVersion("");
-          } catch (err) {
-            Sentry.captureException(err, {
-              tags: { context: "onboarding_mark_completed" },
-            });
-          }
-          markPrivacyConsent(userId);
-
           if (result.ok) {
             const assistantId = result.data.id;
             fetchCharacterTraits(assistantId).then((existing) => {
@@ -248,33 +321,7 @@ export function HatchingScreen() {
             });
           }
 
-          setDisplayProgress(1);
-          displayProgressRef.current = 1;
-          segmentStartRef.current = 1;
-          setPhase("ready");
-          phaseRef.current = "ready";
-          navigateTimer = setTimeout(() => {
-            if (cancelled) return;
-            void (async () => {
-              await checkAssistant();
-              if (cancelled) return;
-              if (isNativePlatform()) {
-                try {
-                  setOnboardingCompleted(true);
-                } catch (err) {
-                  Sentry.captureException(err, {
-                    tags: { context: "hatching_mark_onboarding_completed_native" },
-                  });
-                }
-                clearPrivacyConsent();
-                void navigate(`${routes.assistant}?onboarding=1`, {
-                  replace: true,
-                });
-                return;
-              }
-              void navigate(routes.onboarding.prechat, { replace: true });
-            })();
-          }, COMPLETION_NAVIGATE_DELAY_MS);
+          handleHatchReady();
           return;
         }
         if (next.kind === "error") {

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
@@ -58,6 +60,8 @@ export function HostingScreen() {
 
   const onContinue = () => {
     if (selected === "vellum-cloud") {
+      clearGatewayToken();
+      setSelfHostedConnection(null);
       void navigate(routes.onboarding.privacy);
     } else {
       void navigate(`${routes.onboarding.hatching}?hosting=${selected}`);

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 type HostingMode = "vellum-cloud" | "local" | "docker";
@@ -20,8 +21,8 @@ interface HostingOption {
 const ICON_CLASS = "h-5 w-5 shrink-0 text-[var(--content-secondary)]";
 
 function useHostingOptions(): HostingOption[] {
-  // TODO: gate Docker behind a feature flag (local-docker-enabled) once
-  // the web feature flag store supports it. For now, always show it.
+  const hasPlatformSession = useAuthStore.use.hasPlatformSession();
+
   return [
     {
       mode: "vellum-cloud",
@@ -29,8 +30,9 @@ function useHostingOptions(): HostingOption[] {
       subtitle:
         "Always on, 24/7, even when your computer is off. Runs on Vellum's secure infrastructure.",
       icon: <Cloud className={ICON_CLASS} />,
-      disabled: true,
-      badge: "Requires Account",
+      ...(hasPlatformSession
+        ? {}
+        : { disabled: true, badge: "Requires Account" }),
     },
     {
       mode: "local",

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -1,0 +1,170 @@
+import { Cloud, Laptop, Package } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "react-router";
+
+import { Button } from "@vellum/design-library/components/button";
+import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { routes } from "@/utils/routes";
+
+type HostingMode = "vellum-cloud" | "local" | "docker";
+
+interface HostingOption {
+  mode: HostingMode;
+  label: string;
+  subtitle: string;
+  icon: ReactNode;
+  disabled?: boolean;
+  badge?: string;
+}
+
+const ICON_CLASS = "h-5 w-5 shrink-0 text-[var(--content-secondary)]";
+
+function useHostingOptions(): HostingOption[] {
+  // TODO: gate Docker behind a feature flag (local-docker-enabled) once
+  // the web feature flag store supports it. For now, always show it.
+  return [
+    {
+      mode: "vellum-cloud",
+      label: "Vellum Cloud",
+      subtitle:
+        "Always on, 24/7, even when your computer is off. Runs on Vellum's secure infrastructure.",
+      icon: <Cloud className={ICON_CLASS} />,
+      disabled: true,
+      badge: "Requires Account",
+    },
+    {
+      mode: "local",
+      label: "Local",
+      subtitle:
+        "Runs directly on your machine. Your data never leaves your computer.",
+      icon: <Laptop className={ICON_CLASS} />,
+    },
+    {
+      mode: "docker",
+      label: "Docker",
+      subtitle:
+        "Same privacy as local, but sandboxed using Docker for added isolation.",
+      icon: <Package className={ICON_CLASS} />,
+    },
+  ];
+}
+
+export function HostingScreen() {
+  const navigate = useNavigate();
+  const options = useHostingOptions();
+  const [selected, setSelected] = useState<HostingMode>("local");
+
+  const onContinue = () => {
+    // Both local and docker go to hatching; the hatching screen will
+    // pass the hosting mode to the CLI hatch command.
+    // Vellum Cloud would redirect to platform login (disabled for now).
+    void navigate(routes.onboarding.hatching);
+  };
+
+  return (
+    <OnboardingLayout>
+      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 pt-16 text-[var(--content-default)]">
+        <h1
+          className="text-3xl font-semibold tracking-tight"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
+        >
+          Hosting
+        </h1>
+        <p
+          className="mt-3 text-body-medium-lighter text-[var(--content-tertiary)]"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+        >
+          Where do you want your assistant to live?
+        </p>
+
+        <div
+          className="mt-10 flex w-full flex-col gap-3"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+        >
+          {options.map((opt) => (
+            <HostingCard
+              key={opt.mode}
+              option={opt}
+              selected={selected === opt.mode}
+              onSelect={() => {
+                if (!opt.disabled) setSelected(opt.mode);
+              }}
+            />
+          ))}
+        </div>
+
+        <div
+          className="mt-8 w-full max-w-sm"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+        >
+          <Button
+            variant="primary"
+            size="regular"
+            fullWidth
+            className="h-11 text-base"
+            onClick={onContinue}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </OnboardingLayout>
+  );
+}
+
+function HostingCard({
+  option,
+  selected,
+  onSelect,
+}: {
+  option: HostingOption;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={option.disabled}
+      className={`flex w-full items-center gap-4 rounded-xl border px-4 py-4 text-left transition-colors ${
+        option.disabled
+          ? "cursor-not-allowed opacity-60"
+          : "cursor-pointer"
+      } ${
+        selected && !option.disabled
+          ? "border-[var(--primary-base)] bg-[var(--primary-base)]/5"
+          : "border-[var(--border-default)] bg-transparent"
+      }`}
+    >
+      {option.icon}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-body-medium-default text-[var(--content-default)]">
+            {option.label}
+          </span>
+          {option.badge && (
+            <span className="rounded-full bg-[var(--surface-tertiary)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
+              {option.badge}
+            </span>
+          )}
+        </div>
+        <span className="mt-0.5 line-clamp-2 text-body-small-default text-[var(--content-tertiary)]">
+          {option.subtitle}
+        </span>
+      </div>
+      {!option.disabled && (
+        <div
+          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 ${
+            selected
+              ? "border-[var(--primary-base)]"
+              : "border-[var(--border-default)]"
+          }`}
+        >
+          {selected && (
+            <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary-base)]" />
+          )}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -57,10 +57,11 @@ export function HostingScreen() {
   const [selected, setSelected] = useState<HostingMode>("local");
 
   const onContinue = () => {
-    // Both local and docker go to hatching; the hatching screen will
-    // pass the hosting mode to the CLI hatch command.
-    // Vellum Cloud would redirect to platform login (disabled for now).
-    void navigate(routes.onboarding.hatching);
+    if (selected === "vellum-cloud") {
+      void navigate(routes.onboarding.privacy);
+    } else {
+      void navigate(`${routes.onboarding.hatching}?hosting=${selected}`);
+    }
   };
 
   return (

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -169,7 +169,7 @@ export function PreChatFlow() {
       setRecipeLoadState("loading");
       return;
     }
-    // In local mode, the gateway doesn't serve the recipe endpoint.
+    // In local mode, the gateway doesn't serve the recipe endpoint. (LUM-2000)
     if (isNative || localMode) {
       setRecipe(null);
       setRecipeLoadState("ready");
@@ -416,7 +416,7 @@ export function PreChatFlow() {
 
   // In local mode, platform-only screens (PriorAssistants, GoogleOAuth, GetApp) are
   // skipped. The recipe fetch is also disabled since the gateway doesn't serve it.
-  // In Electron, the recipe could be fetched from the daemon directly if needed.
+  // In Electron, the recipe could be fetched from the daemon directly if needed. (LUM-2000)
   const advancePastToolSelection = () => {
     if (localMode) {
       void finish();

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -117,8 +117,9 @@ export function PreChatFlow() {
   const [selectedPriorAssistants, setSelectedPriorAssistants] = useState<Set<string>>(
     () => new Set(),
   );
+  const hasPlatformSession = useAuthStore.use.hasPlatformSession();
   const { value: userName, onChange: handleUserNameChange } =
-    usePrefilledInput(localMode ? "" : (firstName || lastName));
+    usePrefilledInput(localMode && !hasPlatformSession ? "" : (firstName || lastName));
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [displayedAssistantNames] = useState<string[]>(
     () => sampleSuggestionNames(),

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -43,6 +43,7 @@ import {
   clearPrivacyConsent,
   hasRecentPrivacyConsent,
 } from "@/domains/onboarding/signals.js";
+import { isLocalMode } from "@/lib/local-mode";
 import { useIsNativePlatform } from "@/runtime/native-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { useRootOutletContext } from "@/root-layout";
@@ -79,6 +80,7 @@ export function PreChatFlow() {
     "loading",
   );
 
+  const localMode = isLocalMode();
   const isMacOSWeb = useIsMacOSWeb();
   const isIOSWeb = useIsIOSWeb();
   const showAppStep =
@@ -127,7 +129,7 @@ export function PreChatFlow() {
 
   const { data: activeAssistant } = useQuery({
     ...assistantsActiveRetrieveOptions(),
-    enabled: !isAuthLoading && isLoggedIn,
+    enabled: !isAuthLoading && isLoggedIn && !localMode,
   });
 
   const navigateToChatAfterLifecycleRefresh = useCallback(async () => {
@@ -166,7 +168,8 @@ export function PreChatFlow() {
       setRecipeLoadState("loading");
       return;
     }
-    if (isNative) {
+    // In local mode, the gateway doesn't serve the recipe endpoint.
+    if (isNative || localMode) {
       setRecipe(null);
       setRecipeLoadState("ready");
       return;
@@ -185,7 +188,7 @@ export function PreChatFlow() {
         if (!cancelled) setRecipeLoadState("ready");
       });
     return () => { cancelled = true; };
-  }, [isAuthLoading, isLoggedIn, isNative, userId]);
+  }, [isAuthLoading, isLoggedIn, isNative, localMode, userId]);
 
   useEffect(() => {
     if (isAuthLoading) return;
@@ -410,7 +413,14 @@ export function PreChatFlow() {
 
   const hasGoogleTool = [...selectedTools].some((id) => GOOGLE_TOOL_IDS.has(id));
 
+  // In local mode, platform-only screens (PriorAssistants, GoogleOAuth, GetApp) are
+  // skipped. The recipe fetch is also disabled since the gateway doesn't serve it.
+  // In Electron, the recipe could be fetched from the daemon directly if needed.
   const advancePastToolSelection = () => {
+    if (localMode) {
+      void finish();
+      return;
+    }
     setScreen(3);
   };
 

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -118,7 +118,7 @@ export function PreChatFlow() {
     () => new Set(),
   );
   const { value: userName, onChange: handleUserNameChange } =
-    usePrefilledInput(firstName || lastName);
+    usePrefilledInput(localMode ? "" : (firstName || lastName));
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [displayedAssistantNames] = useState<string[]>(
     () => sampleSuggestionNames(),

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 
@@ -16,10 +15,9 @@ export function WelcomeScreen() {
     setError(null);
     setLoading(true);
     try {
-      const callbackUrl = buildProviderCallbackUrl(routes.onboarding.hosting);
-      await startAuthFlow(PROVIDER_ID, callbackUrl, {
-        returnTo: routes.onboarding.hosting,
-      });
+      const returnTo = routes.onboarding.hosting;
+      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
+      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
     } catch {
       setError("Something went wrong. Please try again.");
       setLoading(false);

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import { Button } from "@vellum/design-library/components/button";
+import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow";
+import { startAuthFlow } from "@/runtime/native-auth";
+import { routes } from "@/utils/routes";
+
+export function WelcomeScreen() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const callbackUrl = buildProviderCallbackUrl(routes.onboarding.hosting);
+      await startAuthFlow(PROVIDER_ID, callbackUrl, {
+        returnTo: routes.onboarding.hosting,
+      });
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  const handleContinueWithoutAccount = () => {
+    void navigate(routes.onboarding.hosting);
+  };
+
+  return (
+    <OnboardingLayout>
+      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)]">
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <h1
+            className="text-3xl font-semibold tracking-tight"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
+          >
+            Welcome to Vellum
+          </h1>
+          <p
+            className="mt-3 text-body-medium-lighter text-[var(--content-tertiary)]"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+          >
+            Your own personal intelligence is just a step away.
+          </p>
+
+          {error && (
+            <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">
+              {error}
+            </p>
+          )}
+
+          <div
+            className="mt-10 flex w-full max-w-sm flex-col gap-3"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          >
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              className="h-11 text-base"
+              onClick={() => void handleLogin()}
+              disabled={loading}
+            >
+              {loading ? "Logging in…" : "Log In"}
+            </Button>
+            <Button
+              variant="ghost"
+              size="regular"
+              fullWidth
+              className="h-11 text-base"
+              onClick={handleContinueWithoutAccount}
+              disabled={loading}
+            >
+              Continue without account
+            </Button>
+          </div>
+        </div>
+      </div>
+    </OnboardingLayout>
+  );
+}

--- a/apps/web/src/domains/onboarding/prefs.ts
+++ b/apps/web/src/domains/onboarding/prefs.ts
@@ -108,6 +108,11 @@ export function readOnboardingCompleted(): boolean {
   return useOnboardingStore.getState().completed;
 }
 
+/** SSR-safe, non-hook clear of the completion flag. */
+export function clearOnboardingCompleted(): void {
+  useOnboardingStore.getState().setOnboardingCompleted(false);
+}
+
 /**
  * SSR-safe, non-hook read of the TOS-accepted flag. Used by
  * `/onboarding/hatching` to refuse to provision an assistant if the user

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -104,7 +104,7 @@ export interface LocalHatchResult {
  * Trigger a local assistant hatch via the dev server middleware.
  *
  * Transport: fetch to Vite dev middleware endpoint.
- * In Electron, replace with: window.electronAPI.hatchAssistant(species)
+ * In Electron, replace with: window.electronAPI.hatchAssistant(species) (LUM-1997)
  */
 export async function hatchLocalAssistant(
   species: string = "vellum",
@@ -121,7 +121,7 @@ export async function hatchLocalAssistant(
  * Write an assistant entry to the lockfile on disk and refresh the cache.
  *
  * Transport: fetch to Vite dev middleware endpoint.
- * In Electron, replace with: window.electronAPI.saveLockfileAssistant(entry)
+ * In Electron, replace with: window.electronAPI.saveLockfileAssistant(entry) (LUM-1998)
  */
 export async function saveLockfileAssistant(
   assistant: { assistantId: string; cloud: string; runtimeUrl: string; hatchedAt: string },
@@ -142,7 +142,7 @@ export async function saveLockfileAssistant(
 // Assistant queries
 // ---------------------------------------------------------------------------
 
-/** In Electron, replace with: window.electronAPI.hasAssistants() */
+/** In Electron, replace with: window.electronAPI.hasAssistants() (LUM-1998) */
 export function hasAssistants(): boolean {
   return getLockfile().assistants.length > 0;
 }
@@ -216,7 +216,7 @@ export function getLocalGatewayUrl(): string | undefined {
  * selected local assistant.
  *
  * Transport: fetch to Vite dev middleware gateway proxy.
- * In Electron, replace with direct IPC token acquisition.
+ * In Electron, replace with direct IPC token acquisition. (LUM-1999)
  */
 export async function primeLocalGatewayConnection(): Promise<void> {
   const tokenUrl = getLocalTokenUrl();

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -117,6 +117,27 @@ export async function hatchLocalAssistant(
   return res.json() as Promise<LocalHatchResult>;
 }
 
+/**
+ * Write an assistant entry to the lockfile on disk and refresh the cache.
+ *
+ * Transport: fetch to Vite dev middleware endpoint.
+ * In Electron, replace with: window.electronAPI.saveLockfileAssistant(entry)
+ */
+export async function saveLockfileAssistant(
+  assistant: { assistantId: string; cloud: string; runtimeUrl: string; hatchedAt: string },
+): Promise<void> {
+  const res = await fetch("/assistant/__local/lockfile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ assistant, activeAssistant: assistant.assistantId }),
+  });
+  if (res.ok) {
+    const { lockfile: updated } = (await res.json()) as { lockfile: Lockfile };
+    lockfile = updated;
+    setLocalSetting(LOCKFILE_STORAGE_KEY, JSON.stringify(updated));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Assistant queries
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -85,8 +85,40 @@ export function getLockfile(): Lockfile {
 }
 
 // ---------------------------------------------------------------------------
+// Hatch
+// ---------------------------------------------------------------------------
+
+export interface LocalHatchResult {
+  ok: boolean;
+  assistantId?: string;
+  error?: string;
+}
+
+/**
+ * Trigger a local assistant hatch via the dev server middleware.
+ *
+ * Transport: fetch to Vite dev middleware endpoint.
+ * In Electron, replace with: window.electronAPI.hatchAssistant(species)
+ */
+export async function hatchLocalAssistant(
+  species: string = "vellum",
+): Promise<LocalHatchResult> {
+  const res = await fetch("/assistant/__local/hatch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ species }),
+  });
+  return res.json() as Promise<LocalHatchResult>;
+}
+
+// ---------------------------------------------------------------------------
 // Assistant queries
 // ---------------------------------------------------------------------------
+
+/** In Electron, replace with: window.electronAPI.hasAssistants() */
+export function hasAssistants(): boolean {
+  return getLockfile().assistants.length > 0;
+}
 
 export function isLocalAssistant(a: LockfileAssistant): boolean {
   return a.cloud !== "vellum" && a.resources?.gatewayPort != null;

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -5,6 +5,12 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/lib/local-settings";
+import {
+  ensureGatewayToken,
+  getGatewayToken,
+  getLocalTokenUrl,
+} from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -178,4 +184,27 @@ export function getLocalGatewayUrl(): string | undefined {
   const assistant = getSelectedAssistant();
   if (!assistant || !isLocalAssistant(assistant)) return undefined;
   return gatewayProxyUrl(assistant.resources!.gatewayPort);
+}
+
+// ---------------------------------------------------------------------------
+// Gateway connection setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Acquire a gateway token and prime the self-hosted connection for the
+ * selected local assistant.
+ *
+ * Transport: fetch to Vite dev middleware gateway proxy.
+ * In Electron, replace with direct IPC token acquisition.
+ */
+export async function primeLocalGatewayConnection(): Promise<void> {
+  const tokenUrl = getLocalTokenUrl();
+  if (!tokenUrl) return;
+  await ensureGatewayToken(tokenUrl);
+  const localGateway = getLocalGatewayUrl();
+  if (!localGateway) return;
+  setSelfHostedConnection({
+    url: `${window.location.origin}${localGateway}`,
+    token: getGatewayToken(),
+  });
 }

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -84,6 +84,10 @@ export const router = createBrowserRouter(
         // Onboarding routes — full-screen (no ChatLayout sidebar).
         // Lazy-loaded: one-time flow, not revisited.
         {
+          path: "onboarding/hosting",
+          lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
+        },
+        {
           path: "onboarding/privacy",
           lazy: { Component: () => import("@/domains/onboarding/pages/privacy-screen").then((m) => m.PrivacyScreen) },
         },

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -84,6 +84,10 @@ export const router = createBrowserRouter(
         // Onboarding routes — full-screen (no ChatLayout sidebar).
         // Lazy-loaded: one-time flow, not revisited.
         {
+          path: "onboarding/welcome",
+          lazy: { Component: () => import("@/domains/onboarding/pages/welcome-screen").then((m) => m.WelcomeScreen) },
+        },
+        {
           path: "onboarding/hosting",
           lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
         },

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -152,6 +152,11 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       return;
     }
 
+    if (isLocalMode() && !isGatewayAuthEnabled()) {
+      set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
+      return;
+    }
+
     try {
       const result = await getSession();
       if (result.ok && result.data.user) {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -23,17 +23,15 @@ import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
   ensureGatewayToken,
-  getGatewayToken,
   clearGatewayToken,
   getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
 import {
   isLocalMode,
   getPlatformAssistants,
-  getLocalGatewayUrl,
   clearSelectedAssistant,
+  primeLocalGatewayConnection,
 } from "@/lib/local-mode";
-import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { syncOnboardingUser, clearOnboardingFlags } from "@/lib/onboarding-cleanup";
 import { clearOrganization } from "@/stores/organization-store";
@@ -128,14 +126,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   initSession: async () => {
     if (isGatewayAuthEnabled()) {
       try {
-        await ensureGatewayToken(getLocalTokenUrl());
-        const localGateway = getLocalGatewayUrl();
-        if (localGateway) {
-          setSelfHostedConnection({
-            url: `${window.location.origin}${localGateway}`,
-            token: getGatewayToken(),
-          });
-        }
+        await primeLocalGatewayConnection();
         set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
       } catch {
         set({ isLoggedIn: false, isLoading: false, user: null });

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -145,6 +145,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
     if (isLocalMode() && !isGatewayAuthEnabled()) {
       set({ isLoggedIn: true, isLoading: false, user: GATEWAY_LOCAL_USER });
+      getSession()
+        .then((result) => {
+          if (result.ok && result.data.user) {
+            const user = toAuthUser(result.data.user);
+            set({ hasPlatformSession: true, user });
+          }
+        })
+        .catch(() => {});
       return;
     }
 

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -45,6 +45,7 @@ export const routes = {
   },
 
   onboarding: {
+    hosting: r("/assistant/onboarding/hosting"),
     privacy: r("/assistant/onboarding/privacy"),
     prechat: r("/assistant/onboarding/prechat"),
     hatching: r("/assistant/onboarding/hatching"),

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -45,6 +45,7 @@ export const routes = {
   },
 
   onboarding: {
+    welcome: r("/assistant/onboarding/welcome"),
     hosting: r("/assistant/onboarding/hosting"),
     privacy: r("/assistant/onboarding/privacy"),
     prechat: r("/assistant/onboarding/prechat"),

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -92,6 +92,8 @@ function lockfileMiddleware(
 
     if (req.method === "GET") {
       handleGetLockfile(lockfilePaths, res);
+    } else if (req.method === "POST") {
+      handlePostLockfile(lockfilePaths, req, res);
     } else {
       res.statusCode = 405;
       res.end();
@@ -132,6 +134,87 @@ function handleGetLockfile(
     res.statusCode = 500;
     res.end();
   }
+}
+
+/**
+ * Merge an assistant entry into the lockfile on disk.
+ *
+ * Transport: Vite dev middleware (fs read/write).
+ * In Electron, replace with IPC call to main process: window.electronAPI.saveLockfileAssistant(entry).
+ */
+function handlePostLockfile(
+  lockfilePaths: string[],
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): void {
+  const chunks: Buffer[] = [];
+  req.on("data", (chunk: Buffer) => chunks.push(chunk));
+  req.on("end", () => {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+    } catch {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+      return;
+    }
+
+    const assistant = body.assistant as Record<string, unknown> | undefined;
+    const activeAssistant = body.activeAssistant as string | undefined;
+    if (!assistant || typeof assistant.assistantId !== "string") {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "Missing assistant.assistantId" }));
+      return;
+    }
+
+    // Read existing lockfile
+    let lockfile: Record<string, unknown> = { assistants: [], activeAssistant: null };
+    const writePath = lockfilePaths[0]!;
+    for (const candidate of lockfilePaths) {
+      try {
+        lockfile = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
+        break;
+      } catch {
+        // continue
+      }
+    }
+
+    // Upsert the assistant entry
+    const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+    const existingIdx = assistants.findIndex(
+      (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
+    );
+    if (existingIdx >= 0) {
+      assistants[existingIdx] = { ...assistants[existingIdx], ...assistant };
+    } else {
+      assistants.push(assistant);
+    }
+    lockfile.assistants = assistants;
+    if (activeAssistant !== undefined) {
+      lockfile.activeAssistant = activeAssistant;
+    }
+
+    // Atomic write
+    try {
+      const dir = path.dirname(writePath);
+      fs.mkdirSync(dir, { recursive: true });
+      const tmp = `${writePath}.tmp.${process.pid}`;
+      fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
+      fs.renameSync(tmp, writePath);
+    } catch (err) {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: `Failed to write lockfile: ${err}` }));
+      return;
+    }
+
+    const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<string, unknown>;
+    stripSensitiveFields(stripped);
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ ok: true, lockfile: stripped }));
+  });
 }
 
 const HATCH_TIMEOUT_MS = 120_000;

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -140,7 +140,7 @@ function handleGetLockfile(
  * Merge an assistant entry into the lockfile on disk.
  *
  * Transport: Vite dev middleware (fs read/write).
- * In Electron, replace with IPC call to main process: window.electronAPI.saveLockfileAssistant(entry).
+ * In Electron, replace with IPC call to main process: window.electronAPI.saveLockfileAssistant(entry). (LUM-1998)
  */
 function handlePostLockfile(
   lockfilePaths: string[],
@@ -223,7 +223,7 @@ const HATCH_TIMEOUT_MS = 120_000;
  * Connect middleware for the hatch endpoint.
  *
  * Transport: Vite dev middleware (child_process.spawn → CLI binary).
- * In Electron, replace with IPC call to main process: window.electronAPI.hatchAssistant(species).
+ * In Electron, replace with IPC call to main process: window.electronAPI.hatchAssistant(species). (LUM-1997)
  * The main process has direct access to the hatch-local module without spawning a subprocess.
  */
 function hatchMiddleware(): Connect.NextHandleFunction {

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
@@ -74,6 +75,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     name: "vellum-local-mode",
     configureServer(server) {
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
+      server.middlewares.use(hatchMiddleware());
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -130,6 +132,117 @@ function handleGetLockfile(
     res.statusCode = 500;
     res.end();
   }
+}
+
+const HATCH_TIMEOUT_MS = 120_000;
+
+/**
+ * Connect middleware for the hatch endpoint.
+ *
+ * Transport: Vite dev middleware (child_process.spawn → CLI binary).
+ * In Electron, replace with IPC call to main process: window.electronAPI.hatchAssistant(species).
+ * The main process has direct access to the hatch-local module without spawning a subprocess.
+ */
+function hatchMiddleware(): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/hatch" &&
+      req.url !== "/__local/hatch"
+    ) {
+      return next();
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let species = "vellum";
+      if (chunks.length > 0) {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            species?: string;
+          };
+          if (body.species) {
+            species = body.species;
+          }
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+          return;
+        }
+      }
+
+      handleHatch(species, res);
+    });
+  };
+}
+
+function handleHatch(species: string, res: http.ServerResponse): void {
+  // Resolve CLI entry point in dev mode (Vite runs in Node inside the repo).
+  const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+  const cliPath = path.join(repoRoot, "cli", "src", "index.ts");
+
+  if (!fs.existsSync(cliPath)) {
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        ok: false,
+        error: `CLI binary not found at ${cliPath}`,
+      }),
+    );
+    return;
+  }
+
+  const child = spawn("bun", ["run", cliPath, "hatch", species], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let responded = false;
+
+  const respond = (status: number, body: Record<string, unknown>) => {
+    if (responded) return;
+    responded = true;
+    clearTimeout(timeout);
+    res.statusCode = status;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(body));
+  };
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+    respond(500, { ok: false, error: "Hatch timed out after 120 seconds" });
+  }, HATCH_TIMEOUT_MS);
+
+  child.stdout.on("data", (data: Buffer) => {
+    stdout += data.toString();
+  });
+
+  child.stderr.on("data", (data: Buffer) => {
+    stderr += data.toString();
+  });
+
+  child.on("close", (code) => {
+    if (code === 0) {
+      const match = stdout.match(/Hatching local assistant:\s+(.+)/);
+      const assistantId = match?.[1]?.trim() ?? "";
+      respond(200, { ok: true, assistantId });
+    } else {
+      respond(500, { ok: false, error: stderr || stdout });
+    }
+  });
+
+  child.on("error", (err) => {
+    respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
+  });
 }
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;


### PR DESCRIPTION
## Summary
When `VITE_LOCAL_MODE` is set but no lockfile exists or it contains zero assistants, users now go through the standard onboarding flow (privacy → hatching → pre-chat) to hatch a local assistant from the browser. Previously they saw a broken empty chat page.

- **Vite plugin endpoint**: `POST /assistant/__local/hatch` spawns the CLI hatch command
- **Onboarding gate**: Routes local-mode users without assistants to onboarding (users with assistants skip as before)
- **Auth store**: Sets `GATEWAY_LOCAL_USER` in local mode even without assistants so onboarding screens render
- **Hatching screen**: Local-mode branch calls `hatchLocalAssistant()` instead of platform API, then reloads lockfile and establishes gateway connection
- **Pre-chat flow**: Skips platform-only screens (PriorAssistants, GoogleConnect, GetApp) and disables recipe fetch in local mode
- **Lifecycle integration**: Redirects to onboarding before platform API calls in local mode; documents post-hatch gateway auth flow

All changes are gated behind `isLocalMode()` / `VITE_LOCAL_MODE`. Zero impact on platform-hosted SPA.

## Self-review result
PASS after 1 fix round — 1 critical gap (lifecycle redirect before platform API) and 4 cleanup items fixed.

## PRs merged into feature branch
- #32344: feat(web): add POST /__local/hatch endpoint to Vite local-mode plugin
- #32343: feat(web): add hatchLocalAssistant() client function for local-mode hatch
- #32345: feat(web): route local-mode users without assistants through onboarding
- #32346: feat(web): skip platform-only screens in local-mode onboarding
- #32348: feat(web): local-mode hatch path in hatching screen
- #32347: feat(web): document post-local-hatch lifecycle integration path

### Fix PRs
- #32351: fix: redirect local-mode users to onboarding before platform API calls
- #32352: fix: cleanup slop from local-mode onboarding implementation

Part of plan: local-mode-onboarding.md