### PR TITLE
fix(cli): add timeout protections to vellum ps

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -165,19 +165,25 @@ function resolveCloud(entry: AssistantEntry): string {
   return "local";
 }
 
+const REMOTE_SSH_TIMEOUT_MS = 30_000;
+
 async function getRemoteProcessesGcp(entry: AssistantEntry): Promise<string> {
-  return execOutput("gcloud", [
-    "compute",
-    "ssh",
-    `${entry.sshUser ?? entry.assistantId}@${entry.assistantId}`,
-    `--zone=${entry.zone}`,
-    `--project=${entry.project}`,
-    `--command=${REMOTE_PS_CMD}`,
-    "--ssh-flag=-o StrictHostKeyChecking=no",
-    "--ssh-flag=-o UserKnownHostsFile=/dev/null",
-    "--ssh-flag=-o ConnectTimeout=10",
-    "--ssh-flag=-o LogLevel=ERROR",
-  ]);
+  return execOutput(
+    "gcloud",
+    [
+      "compute",
+      "ssh",
+      `${entry.sshUser ?? entry.assistantId}@${entry.assistantId}`,
+      `--zone=${entry.zone}`,
+      `--project=${entry.project}`,
+      `--command=${REMOTE_PS_CMD}`,
+      "--ssh-flag=-o StrictHostKeyChecking=no",
+      "--ssh-flag=-o UserKnownHostsFile=/dev/null",
+      "--ssh-flag=-o ConnectTimeout=10",
+      "--ssh-flag=-o LogLevel=ERROR",
+    ],
+    { timeoutMs: REMOTE_SSH_TIMEOUT_MS },
+  );
 }
 
 async function getRemoteProcessesCustom(
@@ -185,7 +191,9 @@ async function getRemoteProcessesCustom(
 ): Promise<string> {
   const host = extractHostFromUrl(entry.runtimeUrl);
   const sshUser = entry.sshUser ?? "root";
-  return execOutput("ssh", [...SSH_OPTS, `${sshUser}@${host}`, REMOTE_PS_CMD]);
+  return execOutput("ssh", [...SSH_OPTS, `${sshUser}@${host}`, REMOTE_PS_CMD], {
+    timeoutMs: REMOTE_SSH_TIMEOUT_MS,
+  });
 }
 
 interface ProcessSpec {
@@ -203,9 +211,13 @@ interface DetectedProcess {
   watch: boolean;
 }
 
+const LOCAL_CMD_TIMEOUT_MS = 5_000;
+
 async function isWatchMode(pid: string): Promise<boolean> {
   try {
-    const args = await execOutput("ps", ["-p", pid, "-o", "args="]);
+    const args = await execOutput("ps", ["-p", pid, "-o", "args="], {
+      timeoutMs: LOCAL_CMD_TIMEOUT_MS,
+    });
     return args.includes("--watch");
   } catch {
     return false;
@@ -320,12 +332,11 @@ async function getDockerContainerState(
   containerName: string,
 ): Promise<string | null> {
   try {
-    const output = await execOutput("docker", [
-      "inspect",
-      "--format",
-      "{{.State.Status}}",
-      containerName,
-    ]);
+    const output = await execOutput(
+      "docker",
+      ["inspect", "--format", "{{.State.Status}}", containerName],
+      { timeoutMs: LOCAL_CMD_TIMEOUT_MS },
+    );
     return output.trim() || "unknown";
   } catch {
     return null;
@@ -458,9 +469,12 @@ async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
-    console.error(
-      `Failed to list processes: ${error instanceof Error ? error.message : error}`,
-    );
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes("timed out")) {
+      console.warn(`Warning: remote process listing timed out — ${msg}`);
+      return;
+    }
+    console.error(`Failed to list processes: ${msg}`);
     process.exit(1);
   }
 

--- a/cli/src/lib/orphan-detection.ts
+++ b/cli/src/lib/orphan-detection.ts
@@ -138,10 +138,14 @@ export async function detectOrphanedProcesses(
   // Process table scan — discover orphaned processes by scanning the OS
   // process table rather than reading PID files from the workspace.
   try {
-    const output = await execOutput("sh", [
-      "-c",
-      "ps ax -o pid=,ppid=,args= | grep -E 'vellum|qdrant|openclaw' | grep -v grep",
-    ]);
+    const output = await execOutput(
+      "sh",
+      [
+        "-c",
+        "ps ax -o pid=,ppid=,args= | grep -E 'vellum|qdrant|openclaw' | grep -v grep",
+      ],
+      { timeoutMs: 5_000 },
+    );
     const procs = parseRemotePs(output);
     const ownPid = String(process.pid);
 

--- a/cli/src/lib/pgrep.ts
+++ b/cli/src/lib/pgrep.ts
@@ -1,8 +1,12 @@
 import { execOutput } from "./step-runner";
 
+const PGREP_TIMEOUT_MS = 5_000;
+
 export async function pgrepExact(name: string): Promise<string[]> {
   try {
-    const output = await execOutput("pgrep", ["-x", name]);
+    const output = await execOutput("pgrep", ["-x", name], {
+      timeoutMs: PGREP_TIMEOUT_MS,
+    });
     return output.trim().split("\n").filter(Boolean);
   } catch {
     return [];

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -521,6 +521,8 @@ export async function hatchAssistant(
   );
 }
 
+const PLATFORM_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Lightweight pre-check: returns the first active managed assistant for the
  * authenticated user, or `null` if none exists. Calls `GET /v1/assistants/`
@@ -536,9 +538,18 @@ export async function checkExistingPlatformAssistant(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/`;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    PLATFORM_FETCH_TIMEOUT_MS,
+  );
+
   const response = await fetch(url, {
+    signal: controller.signal,
     headers: await authHeaders(token, platformUrl),
   });
+
+  clearTimeout(timeoutId);
 
   if (!response.ok) {
     // Non-fatal: if the list call fails, fall through and let hatch handle it.
@@ -563,9 +574,18 @@ export async function fetchPlatformAssistants(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/`;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    PLATFORM_FETCH_TIMEOUT_MS,
+  );
+
   const response = await fetch(url, {
+    signal: controller.signal,
     headers: await authHeaders(token, platformUrl),
   });
+
+  clearTimeout(timeoutId);
 
   if (!response.ok) return [];
 
@@ -592,9 +612,19 @@ export async function fetchOrganizationId(
 ): Promise<string> {
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/organizations/`;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    PLATFORM_FETCH_TIMEOUT_MS,
+  );
+
   const response = await fetch(url, {
+    signal: controller.signal,
     headers: { ...tokenAuthHeader(token) },
   });
+
+  clearTimeout(timeoutId);
 
   if (!response.ok) {
     throw new Error(
@@ -627,9 +657,19 @@ export async function fetchCurrentUser(
 ): Promise<PlatformUser> {
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/_allauth/app/v1/auth/session`;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    PLATFORM_FETCH_TIMEOUT_MS,
+  );
+
   const response = await fetch(url, {
+    signal: controller.signal,
     headers: { "X-Session-Token": token },
   });
+
+  clearTimeout(timeoutId);
 
   if (!response.ok) {
     if (

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -544,23 +544,25 @@ export async function checkExistingPlatformAssistant(
     PLATFORM_FETCH_TIMEOUT_MS,
   );
 
-  const response = await fetch(url, {
-    signal: controller.signal,
-    headers: await authHeaders(token, platformUrl),
-  });
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: await authHeaders(token, platformUrl),
+    });
 
-  clearTimeout(timeoutId);
+    if (!response.ok) {
+      // Non-fatal: if the list call fails, fall through and let hatch handle it.
+      return null;
+    }
 
-  if (!response.ok) {
-    // Non-fatal: if the list call fails, fall through and let hatch handle it.
-    return null;
+    const body = (await response.json()) as {
+      results?: HatchedAssistant[];
+    };
+    const active = body.results?.find((a) => a.status === "active");
+    return active ?? null;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  const body = (await response.json()) as {
-    results?: HatchedAssistant[];
-  };
-  const active = body.results?.find((a) => a.status === "active");
-  return active ?? null;
 }
 
 /**
@@ -580,20 +582,22 @@ export async function fetchPlatformAssistants(
     PLATFORM_FETCH_TIMEOUT_MS,
   );
 
-  const response = await fetch(url, {
-    signal: controller.signal,
-    headers: await authHeaders(token, platformUrl),
-  });
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: await authHeaders(token, platformUrl),
+    });
 
-  clearTimeout(timeoutId);
+    if (!response.ok) return [];
 
-  if (!response.ok) return [];
+    const body = (await response.json()) as {
+      results?: HatchedAssistant[];
+    };
 
-  const body = (await response.json()) as {
-    results?: HatchedAssistant[];
-  };
-
-  return (body.results ?? []).filter((a) => a.status === "active");
+    return (body.results ?? []).filter((a) => a.status === "active");
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 export interface PlatformUser {
@@ -619,25 +623,27 @@ export async function fetchOrganizationId(
     PLATFORM_FETCH_TIMEOUT_MS,
   );
 
-  const response = await fetch(url, {
-    signal: controller.signal,
-    headers: { ...tokenAuthHeader(token) },
-  });
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { ...tokenAuthHeader(token) },
+    });
 
-  clearTimeout(timeoutId);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch organizations from ${resolvedUrl} (${response.status}). Try logging in again.`,
+      );
+    }
 
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch organizations from ${resolvedUrl} (${response.status}). Try logging in again.`,
-    );
+    const body = (await response.json()) as OrganizationListResponse;
+    const orgId = body.results?.[0]?.id;
+    if (!orgId) {
+      throw new Error("No organization found for this account.");
+    }
+    return orgId;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  const body = (await response.json()) as OrganizationListResponse;
-  const orgId = body.results?.[0]?.id;
-  if (!orgId) {
-    throw new Error("No organization found for this account.");
-  }
-  return orgId;
 }
 
 interface AllauthSessionResponse {
@@ -664,28 +670,30 @@ export async function fetchCurrentUser(
     PLATFORM_FETCH_TIMEOUT_MS,
   );
 
-  const response = await fetch(url, {
-    signal: controller.signal,
-    headers: { "X-Session-Token": token },
-  });
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { "X-Session-Token": token },
+    });
 
-  clearTimeout(timeoutId);
-
-  if (!response.ok) {
-    if (
-      response.status === 401 ||
-      response.status === 403 ||
-      response.status === 410
-    ) {
-      throw new Error("Invalid or expired token. Please login again.");
+    if (!response.ok) {
+      if (
+        response.status === 401 ||
+        response.status === 403 ||
+        response.status === 410
+      ) {
+        throw new Error("Invalid or expired token. Please login again.");
+      }
+      throw new Error(
+        `Platform API error: ${response.status} ${response.statusText}`,
+      );
     }
-    throw new Error(
-      `Platform API error: ${response.status} ${response.statusText}`,
-    );
-  }
 
-  const body = (await response.json()) as AllauthSessionResponse;
-  return body.data.user;
+    const body = (await response.json()) as AllauthSessionResponse;
+    return body.data.user;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/lib/step-runner.ts
+++ b/cli/src/lib/step-runner.ts
@@ -110,13 +110,28 @@ export function execWithStdin(
 export function execOutput(
   command: string,
   args: string[],
-  options: { cwd?: string } = {},
+  options: { cwd?: string; timeoutMs?: number } = {},
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
     });
+
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (options.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          child.kill("SIGTERM");
+          reject(
+            new Error(`${command} timed out after ${options.timeoutMs}ms`),
+          );
+        }
+      }, options.timeoutMs);
+    }
 
     let stdout = "";
     child.stdout.on("data", (data: Buffer) => {
@@ -129,17 +144,20 @@ export function execOutput(
     });
 
     child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
       if (code === 0) {
         resolve(stdout.trim());
       } else {
-        // execOutput intentionally drops stdout from the error message
-        // (callers that read stdout via the success path don't expect
-        // partial stdout to land in error.message). Stderr is enough
-        // for diagnostics, and the no-args-in-message guarantee from
-        // exec() still holds.
         reject(new Error(buildExecErrorMessage(command, code, stderr, "")));
       }
     });
-    child.on("error", reject);
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
   });
 }

--- a/cli/src/lib/sync-cloud-assistants.ts
+++ b/cli/src/lib/sync-cloud-assistants.ts
@@ -26,6 +26,13 @@ import {
 
 export type SyncLogger = (message: string) => void;
 
+function isTimeoutError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "AbortError" || err.message.includes("timed out"))
+  );
+}
+
 export interface SyncResult {
   added: number;
   removed: number;
@@ -68,6 +75,11 @@ export async function syncCloudAssistants(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log?.(`Failed to fetch current user: ${msg}`);
+    if (isTimeoutError(err)) {
+      console.warn(
+        "Warning: platform user lookup timed out — skipping cloud sync",
+      );
+    }
   }
 
   let platformAssistants: { id: string; name: string; status: string }[];
@@ -80,6 +92,11 @@ export async function syncCloudAssistants(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log?.(`fetchPlatformAssistants failed: ${msg}`);
+    if (isTimeoutError(err)) {
+      console.warn(
+        "Warning: platform assistant fetch timed out — using cached data",
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Add 10s timeout to all platform API fetch calls (`fetchCurrentUser`, `fetchPlatformAssistants`, `fetchOrganizationId`, `checkExistingPlatformAssistant`) using `AbortController`, matching the existing pattern in `health-check.ts`
- Add optional `timeoutMs` parameter to `execOutput()` in `step-runner.ts` that kills the child process after the deadline
- Apply timeouts to all subprocess calls in the `vellum ps` path: `pgrep` (5s), `ps` (5s), `docker inspect` (5s), remote SSH/gcloud (30s), and orphan detection (5s)
- Print user-visible warnings to stdout when timeouts are hit instead of silently hanging

## Original prompt
The `vellum ps` CLI command can hang indefinitely because several code paths — platform API fetches, subprocess calls (`pgrep`, `ps`), remote SSH commands, and orphan detection — have no timeout protection. The user asked to add timeout protections with stdout warnings when timeouts are hit, covering all the unprotected paths in the `ps` command flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)