### PR TITLE
fix(web): add missing mock exports in onboarding lifecycle test

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -130,6 +130,7 @@ mock.module("@/domains/onboarding/prefs", () => ({
   readOnboardingCompleted: () => onboardingCompleted,
   readSelectedVersion: () => null,
   readTosAccepted: () => true,
+  clearOnboardingCompleted: mock(() => {}),
   useOnboardingCompleted: () =>
     [onboardingCompleted, setOnboardingCompletedMock] as const,
   writeSelectedVersion: writeSelectedVersionMock,
@@ -152,6 +153,7 @@ mock.module("@/runtime/native-auth", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => false,
+  hasAssistants: () => false,
   hatchLocalAssistant: async () => ({ ok: true, assistantId: "local-1" }),
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setSelectedAssistantId: () => {},


### PR DESCRIPTION
## Summary
- Added `clearOnboardingCompleted` to the `@/domains/onboarding/prefs` mock — now required because `hatching-screen.tsx` imports `gate.ts` which uses this export
- Added `hasAssistants` to the `@/lib/local-mode` mock — also imported by `gate.ts` in its onboarding redirect logic

## Original prompt
Fix CI failure from the Local-Mode Onboarding Flow PR (#32353) where `onboarding-lifecycle-sync.test.tsx` crashes with `SyntaxError: Export named 'clearOnboardingCompleted' not found`. The `getOnboardingEntrypoint()` extraction added a transitive import of `gate.ts` to the test's module tree, but the test mocks were missing exports that `gate.ts` requires (`clearOnboardingCompleted` from prefs and `hasAssistants` from local-mode).