### PR TITLE
feat(web): retire local assistants via CLI instead of platform API

### DIFF
--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -5,7 +5,6 @@ import { Button } from "@vellum/design-library/components/button";
 import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog";
 import { toast } from "@vellum/design-library/components/toast";
 import { retireAssistantById } from "@/assistant/api";
-import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
 import { clearOnboardingFlags } from "@/lib/onboarding-cleanup";
 import {
   isLocalMode,
@@ -18,7 +17,8 @@ import { routes } from "@/utils/routes";
 
 function getPostRetireRoute(): string {
   if (isNativePlatform()) return routes.onboarding.prechat;
-  return getOnboardingEntrypoint();
+  if (isLocalMode()) return routes.onboarding.welcome;
+  return routes.onboarding.privacy;
 }
 
 interface RetireAssistantProps {

--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -5,9 +5,21 @@ import { Button } from "@vellum/design-library/components/button";
 import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog";
 import { toast } from "@vellum/design-library/components/toast";
 import { retireAssistantById } from "@/assistant/api";
+import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
 import { clearOnboardingFlags } from "@/lib/onboarding-cleanup";
+import {
+  isLocalMode,
+  getSelectedAssistant,
+  isLocalAssistant,
+  retireLocalAssistant,
+} from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
+
+function getPostRetireRoute(): string {
+  if (isNativePlatform()) return routes.onboarding.prechat;
+  return getOnboardingEntrypoint();
+}
 
 interface RetireAssistantProps {
   assistantId: string;
@@ -20,25 +32,32 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
   const handleRetire = async () => {
     setConfirmOpen(false);
     try {
-      const result = await retireAssistantById(assistantId);
-      if (result.ok || result.status === 404) {
-        clearOnboardingFlags();
-        toast.success("Assistant retired.");
-        // Native (iOS) re-onboarding skips the privacy/TOS step — those
-        // are re-shown only when the user explicitly resets prefs.
-        // Web users still see the privacy step to satisfy first-load
-        // consent requirements on a fresh assistant.
-        navigate(
-          isNativePlatform()
-            ? routes.onboarding.prechat
-            : routes.onboarding.privacy,
-        );
+      const selected = getSelectedAssistant();
+      const useLocal =
+        isLocalMode() && selected && isLocalAssistant(selected);
+
+      if (useLocal) {
+        const result = await retireLocalAssistant(assistantId);
+        if (result.ok) {
+          clearOnboardingFlags();
+          toast.success("Assistant retired.");
+          navigate(getPostRetireRoute());
+        } else {
+          toast.error(result.error || "Failed to retire assistant.");
+        }
       } else {
-        const detail =
-          typeof result.error?.detail === "string"
-            ? result.error.detail
-            : "Failed to retire assistant.";
-        toast.error(detail);
+        const result = await retireAssistantById(assistantId);
+        if (result.ok || result.status === 404) {
+          clearOnboardingFlags();
+          toast.success("Assistant retired.");
+          navigate(getPostRetireRoute());
+        } else {
+          const detail =
+            typeof result.error?.detail === "string"
+              ? result.error.detail
+              : "Failed to retire assistant.";
+          toast.error(detail);
+        }
       }
     } catch {
       toast.error("Failed to retire assistant.");

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -139,6 +139,39 @@ export async function saveLockfileAssistant(
 }
 
 // ---------------------------------------------------------------------------
+// Retire
+// ---------------------------------------------------------------------------
+
+export interface LocalRetireResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Retire a local assistant via the dev server middleware (shells out to CLI).
+ *
+ * Transport: fetch to Vite dev middleware endpoint.
+ * In Electron, replace with: window.electronAPI.retireAssistant(assistantId) (LUM-2000)
+ */
+export async function retireLocalAssistant(
+  assistantId: string,
+): Promise<LocalRetireResult> {
+  const res = await fetch("/assistant/__local/retire", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ assistantId }),
+  });
+  const result = (await res.json()) as LocalRetireResult;
+  if (result.ok) {
+    clearSelectedAssistant();
+    clearGatewayToken();
+    setSelfHostedConnection(null);
+    await loadLockfile();
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Assistant queries
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -6,6 +6,7 @@ import {
   setLocalSetting,
 } from "@/lib/local-settings";
 import {
+  clearGatewayToken,
   ensureGatewayToken,
   getGatewayToken,
   getLocalTokenUrl,

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -76,6 +76,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     configureServer(server) {
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
       server.middlewares.use(hatchMiddleware());
+      server.middlewares.use(retireMiddleware());
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -318,6 +319,118 @@ function handleHatch(species: string, res: http.ServerResponse): void {
       const match = stdout.match(/Hatching local assistant:\s+(.+)/);
       const assistantId = match?.[1]?.trim() ?? "";
       respond(200, { ok: true, assistantId });
+    } else {
+      respond(500, { ok: false, error: stderr || stdout });
+    }
+  });
+
+  child.on("error", (err) => {
+    respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
+  });
+}
+
+/**
+ * Connect middleware for the retire endpoint.
+ *
+ * Transport: Vite dev middleware (child_process.spawn → CLI binary).
+ * In Electron, replace with IPC call to main process: window.electronAPI.retireAssistant(assistantId). (LUM-2000)
+ */
+function retireMiddleware(): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/retire" &&
+      req.url !== "/__local/retire"
+    ) {
+      return next();
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let assistantId: string | undefined;
+      if (chunks.length > 0) {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            assistantId?: string;
+          };
+          assistantId = body.assistantId;
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+          return;
+        }
+      }
+
+      if (!assistantId) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+        return;
+      }
+
+      handleRetire(assistantId, res);
+    });
+  };
+}
+
+const RETIRE_TIMEOUT_MS = 60_000;
+
+function handleRetire(assistantId: string, res: http.ServerResponse): void {
+  const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+  const cliPath = path.join(repoRoot, "cli", "src", "index.ts");
+
+  if (!fs.existsSync(cliPath)) {
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        ok: false,
+        error: `CLI binary not found at ${cliPath}`,
+      }),
+    );
+    return;
+  }
+
+  const child = spawn("bun", ["run", cliPath, "retire", assistantId, "--yes"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let responded = false;
+
+  const respond = (status: number, body: Record<string, unknown>) => {
+    if (responded) return;
+    responded = true;
+    clearTimeout(timeout);
+    res.statusCode = status;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(body));
+  };
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+    respond(500, { ok: false, error: "Retire timed out after 60 seconds" });
+  }, RETIRE_TIMEOUT_MS);
+
+  child.stdout.on("data", (data: Buffer) => {
+    stdout += data.toString();
+  });
+
+  child.stderr.on("data", (data: Buffer) => {
+    stderr += data.toString();
+  });
+
+  child.on("close", (code) => {
+    if (code === 0) {
+      respond(200, { ok: true });
     } else {
       respond(500, { ok: false, error: stderr || stdout });
     }


### PR DESCRIPTION
## Summary
- Add `POST /__local/retire` Vite plugin endpoint that spawns `vellum retire <id> --yes` via CLI
- Add `retireLocalAssistant()` to `local-mode.ts` that calls the endpoint and cleans up gateway/connection state
- Update Retire Assistant button to conditionally use local retire (for local assistants) vs platform API

## Test plan
- [ ] In local mode, hatch a local assistant, go to `/assistant/settings`, click Retire Assistant → should retire via CLI and redirect to welcome screen
- [ ] In local mode with a Vellum Cloud assistant, click Retire → should use platform API as before
- [ ] On platform (no `VITE_LOCAL_MODE`), retire behavior unchanged
- [ ] After local retire, gateway token and self-hosted connection are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)