### PR TITLE
fix(web): explicitly set VITE_LOCAL_MODE=false in CI/CD web builds

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -175,6 +175,7 @@ jobs:
       # same-origin paths, so each bucket's origin reaches its own backend.
       - name: Build
         env:
+          VITE_LOCAL_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -128,6 +128,7 @@ jobs:
 
       - name: Build
         env:
+          VITE_LOCAL_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_APP_VERSION: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Add `VITE_LOCAL_MODE: "false"` to the build env in both `ci-main-web.yaml` (deploy) and `pr-web.yaml` (PR check)
- Ensures the production SPA bundle never activates local-mode features, rather than relying on the variable being undefined

## Original prompt
The user wanted to update the production build of the web SPA to explicitly pass `VITE_LOCAL_MODE=false` during CI/CD builds. While `isLocalMode()` already defaults to `false` when the env var is undefined, explicitly setting it guards against accidental activation if a `.env` file or CI config ever leaked a truthy value.