### PR TITLE
feat(notifications): list surfaced home-feed items with filters

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -437,74 +437,218 @@ describe("notifications send — minimal-surface ergonomics", () => {
 // ---------------------------------------------------------------------------
 
 describe("notifications list", () => {
-  test("list returns empty array when no events", async () => {
-    ipcResponse = { ok: true, result: [] };
+  const emptyPayload = {
+    items: [],
+    total: 0,
+    returned: 0,
+    hasMore: false,
+    updatedAt: "2026-05-28T00:00:00.000Z",
+  };
+
+  function feedItem(
+    overrides: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      id: "feed-1",
+      type: "notification",
+      priority: 50,
+      summary: "Background sync done",
+      timestamp: "2026-05-28T10:00:00.000Z",
+      status: "new",
+      createdAt: "2026-05-28T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  test("list calls list_home_feed and returns empty payload", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
 
     const { parsed, exitCode } = await runCommand(["list"]);
 
     expect(exitCode).toBe(0);
     expect(parsed.ok).toBe(true);
-    expect(parsed.events).toEqual([]);
+    expect(parsed.items).toEqual([]);
+    expect(parsed.total).toBe(0);
 
     expect(ipcCalls).toHaveLength(1);
-    expect(ipcCalls[0].method).toBe("list_notification_events");
+    expect(ipcCalls[0].method).toBe("list_home_feed");
   });
 
-  test("list returns events from IPC", async () => {
+  test("list returns items from IPC", async () => {
     ipcResponse = {
       ok: true,
-      result: [
-        {
-          id: "evt-1",
-          sourceEventName: "user.send_notification",
-          sourceChannel: "assistant_tool",
-          sourceContextId: "session-1",
-          urgency: "medium",
-          dedupeKey: null,
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      ],
+      result: {
+        ...emptyPayload,
+        items: [feedItem({ title: "Hello", urgency: "medium" })],
+        total: 1,
+        returned: 1,
+      },
     };
 
     const { parsed, exitCode } = await runCommand(["list"]);
 
     expect(exitCode).toBe(0);
     expect(parsed.ok).toBe(true);
-    const events = parsed.events as Array<Record<string, unknown>>;
-    expect(events).toHaveLength(1);
-    expect(events[0].sourceEventName).toBe("user.send_notification");
+    const items = parsed.items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Hello");
   });
 
-  test("list passes --limit to IPC", async () => {
-    ipcResponse = { ok: true, result: [] };
+  test("list defaults to excluding dismissed (no includeDismissed flag in body)", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
 
-    const { parsed, exitCode } = await runCommand(["list", "--limit", "5"]);
+    await runCommand(["list"]);
 
-    expect(exitCode).toBe(0);
-    expect(parsed.ok).toBe(true);
-
-    expect(ipcCalls).toHaveLength(1);
-    expect((ipcCalls[0].params?.body as Record<string, unknown>)?.limit).toBe(
-      5,
-    );
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.includeDismissed).toBeUndefined();
+    expect(body.statuses).toBeUndefined();
   });
 
-  test("list passes --source-event-name to IPC", async () => {
-    ipcResponse = { ok: true, result: [] };
+  test("--all sets includeDismissed=true", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
 
+    await runCommand(["list", "--all"]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.includeDismissed).toBe(true);
+  });
+
+  test("--status is repeatable and passed as statuses array", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand(["list", "--status", "new", "--status", "acted_on"]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.statuses).toEqual(["new", "acted_on"]);
+  });
+
+  test("--status rejects invalid value before IPC call", async () => {
     const { parsed, exitCode } = await runCommand([
       "list",
-      "--source-event-name",
-      "schedule.notify",
+      "--status",
+      "bogus",
     ]);
 
-    expect(exitCode).toBe(0);
-    expect(parsed.ok).toBe(true);
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("status");
+    expect(ipcCalls).toHaveLength(0);
+  });
 
-    expect(ipcCalls).toHaveLength(1);
-    expect(
-      (ipcCalls[0].params?.body as Record<string, unknown>)?.sourceEventName,
-    ).toBe("schedule.notify");
+  test("--before and --after are forwarded as ISO strings", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand([
+      "list",
+      "--after",
+      "2026-05-28T00:00:00Z",
+      "--before",
+      "2026-05-29T00:00:00Z",
+    ]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.after).toBe("2026-05-28T00:00:00Z");
+    expect(body.before).toBe("2026-05-29T00:00:00Z");
+  });
+
+  test("--urgency is repeatable and passed as urgencies array", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand(["list", "--urgency", "high", "--urgency", "critical"]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.urgencies).toEqual(["high", "critical"]);
+  });
+
+  test("--urgency rejects invalid value", async () => {
+    const { exitCode, parsed } = await runCommand([
+      "list",
+      "--urgency",
+      "extreme",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("urgency");
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("--category is repeatable and passed as categories array", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand([
+      "list",
+      "--category",
+      "email",
+      "--category",
+      "scheduling",
+    ]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.categories).toEqual(["email", "scheduling"]);
+  });
+
+  test("--conversation-id, --from-assistant, --noteworthy forwarded", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand([
+      "list",
+      "--conversation-id",
+      "conv-abc",
+      "--from-assistant",
+      "--noteworthy",
+    ]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.conversationId).toBe("conv-abc");
+    expect(body.fromAssistant).toBe(true);
+    expect(body.noteworthy).toBe(true);
+  });
+
+  test("--limit and --offset are forwarded as integers", async () => {
+    ipcResponse = { ok: true, result: emptyPayload };
+
+    await runCommand(["list", "--limit", "5", "--offset", "10"]);
+
+    const body = ipcCalls[0].params?.body as Record<string, unknown>;
+    expect(body.limit).toBe(5);
+    expect(body.offset).toBe(10);
+  });
+
+  test("--limit rejects non-positive integers", async () => {
+    const { exitCode, parsed } = await runCommand(["list", "--limit", "0"]);
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("limit");
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("--limit rejects values above 200", async () => {
+    const { exitCode, parsed } = await runCommand(["list", "--limit", "500"]);
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("200");
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("--offset rejects negative values", async () => {
+    const { exitCode, parsed } = await runCommand(["list", "--offset", "-1"]);
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("offset");
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("empty --conversation-id is rejected", async () => {
+    const { exitCode, parsed } = await runCommand([
+      "list",
+      "--conversation-id",
+      "   ",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Conversation ID");
+    expect(ipcCalls).toHaveLength(0);
   });
 
   test("list surfaces IPC error response", async () => {
@@ -524,7 +668,7 @@ describe("notifications list", () => {
   test("list maps daemon 4xx to exit 2", async () => {
     ipcResponse = {
       ok: false,
-      error: "Invalid limit",
+      error: "Invalid filter",
       statusCode: 400,
     };
 
@@ -532,7 +676,7 @@ describe("notifications list", () => {
 
     expect(exitCode).toBe(2);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toBe("Invalid limit");
+    expect(parsed.error).toBe("Invalid filter");
   });
 
   test("list maps daemon 5xx to exit 3", async () => {

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 
+import type { FeedItem } from "../../home/feed-types.js";
 import {
   cliIpcCall,
   exitCodeFromIpcResult,
@@ -9,6 +10,66 @@ import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 import { tryResolveConversationId } from "../utils/conversation-id.js";
+
+// ---------------------------------------------------------------------------
+// Local types & helpers
+// ---------------------------------------------------------------------------
+
+interface ListHomeFeedPayload {
+  items: FeedItem[];
+  total: number;
+  returned: number;
+  hasMore: boolean;
+  updatedAt: string;
+}
+
+function parseBoundedInt(
+  raw: string | undefined,
+  label: string,
+  bounds: { min: number; max?: number },
+): { value?: number; error?: string } {
+  if (raw === undefined) return {};
+  const n = Number(raw);
+  const upper = bounds.max ?? Infinity;
+  if (
+    !Number.isFinite(n) ||
+    !Number.isInteger(n) ||
+    n < bounds.min ||
+    n > upper
+  ) {
+    const range =
+      bounds.max !== undefined
+        ? `[${bounds.min}, ${bounds.max}]`
+        : `>= ${bounds.min}`;
+    return {
+      error: `Invalid ${label} "${raw}". Must be an integer ${range}`,
+    };
+  }
+  return { value: n };
+}
+
+function renderFeedItemsHuman(payload: ListHomeFeedPayload): void {
+  if (payload.items.length === 0) {
+    log.info("No notifications match the filters.");
+    return;
+  }
+  log.info(`${payload.returned} of ${payload.total} notifications:\n`);
+  for (const item of payload.items) {
+    const idShort = item.id.slice(0, 8);
+    const status = item.status.toUpperCase().padEnd(10);
+    const urgency = (item.urgency ?? "").padEnd(8);
+    const headline = item.title ?? item.summary;
+    const convoTag = item.conversationId
+      ? `  (conv: ${item.conversationId.slice(0, 8)})`
+      : "";
+    log.info(
+      `  ${idShort}  ${item.createdAt}  ${status} ${urgency} ${headline}${convoTag}`,
+    );
+  }
+  if (payload.hasMore) {
+    log.info("\n(more results available; bump --offset to paginate)");
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Command registration
@@ -353,84 +414,189 @@ Examples:
       // list
       // -------------------------------------------------------------------------
 
+      // Commander's `.exitOverride()` (used in tests) swallows thrown errors
+      // from collector functions, so we append values here and validate the
+      // accumulated array inside the action handler instead.
+      const collectFlag = (
+        value: string,
+        prev: string[] | undefined,
+      ): string[] => [...(prev ?? []), value];
+
+      function validateEnumFlag(
+        values: string[] | undefined,
+        label: string,
+        allowed: readonly string[],
+      ): { error?: string } {
+        if (!values) return {};
+        for (const v of values) {
+          if (!allowed.includes(v)) {
+            return {
+              error: `Invalid ${label} "${v}". Must be one of: ${allowed.join(", ")}`,
+            };
+          }
+        }
+        return {};
+      }
+
       notifications
         .command("list")
         .description(
-          "List recent notification events from the local event store",
+          "List notifications surfaced to the user via the home feed. Excludes dismissed items by default.",
         )
         .option(
-          "--limit <n>",
-          "Maximum number of events to return (default: 20)",
+          "--all",
+          "Include dismissed items (default: only new/seen/acted_on)",
+          false,
         )
-        .option("--source-event-name <name>", "Filter by source event name")
+        .option(
+          "--status <status>",
+          "Filter by status (new|seen|acted_on|dismissed); repeatable. Overrides --all default behavior.",
+          collectFlag,
+        )
+        .option(
+          "--before <iso>",
+          "Only items with createdAt strictly before this ISO-8601 timestamp",
+        )
+        .option(
+          "--after <iso>",
+          "Only items with createdAt strictly after this ISO-8601 timestamp",
+        )
+        .option(
+          "--urgency <urgency>",
+          "Filter by urgency (low|medium|high|critical); repeatable",
+          collectFlag,
+        )
+        .option(
+          "--category <category>",
+          "Filter by category (security|scheduling|background|email|system); repeatable",
+          collectFlag,
+        )
+        .option(
+          "--conversation-id <id>",
+          "Only items tied to this conversation id",
+        )
+        .option(
+          "--from-assistant",
+          "Only items emitted by the assistant",
+          false,
+        )
+        .option("--noteworthy", "Only items flagged as noteworthy", false)
+        .option(
+          "--limit <n>",
+          "Maximum number of items to return (default: 20, max: 200)",
+        )
+        .option("--offset <n>", "Pagination offset (default: 0)")
         .addHelpText(
           "after",
           `
-Reads from the local notification events store, ordered by creation time
-(newest first). Each event represents a signal that was emitted through the
-notification pipeline.
+Reads the home feed at ~/.vellum/workspace/data/home-feed.json — the
+user's notification inbox. Items are ordered by priority then recency,
+matching what the user sees in the macOS Home page. The home feed covers
+background/async notifications mirrored from the unified pipeline;
+real-time chat pushes that did not mirror to the feed will not appear.
 
 Examples:
   $ assistant notifications list
-  $ assistant notifications list --limit 5
-  $ assistant notifications list --source-event-name schedule.notify
-  $ assistant notifications list --source-event-name schedule.notify --limit 10 --json`,
+  $ assistant notifications list --all
+  $ assistant notifications list --status new --status seen
+  $ assistant notifications list --after 2026-05-28T00:00:00Z --urgency high
+  $ assistant notifications list --conversation-id 7fab234c --json
+  $ assistant notifications list --limit 5 --offset 5`,
         )
         .action(
           async (
             opts: {
+              all?: boolean;
+              status?: string[];
+              before?: string;
+              after?: string;
+              urgency?: string[];
+              category?: string[];
+              conversationId?: string;
+              fromAssistant?: boolean;
+              noteworthy?: boolean;
               limit?: string;
-              sourceEventName?: string;
+              offset?: string;
             },
             cmd: Command,
           ) => {
             try {
-              // Validate --source-event-name (accept any non-empty string; custom
-              // event names are valid since skills can emit arbitrary names)
-              if (
-                opts.sourceEventName != null &&
-                opts.sourceEventName.trim().length === 0
-              ) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: "Source event name must be a non-empty string",
-                });
+              const enumChecks: Array<{ error?: string }> = [
+                validateEnumFlag(opts.status, "status", [
+                  "new",
+                  "seen",
+                  "acted_on",
+                  "dismissed",
+                ]),
+                validateEnumFlag(opts.urgency, "urgency", [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical",
+                ]),
+                validateEnumFlag(opts.category, "category", [
+                  "security",
+                  "scheduling",
+                  "background",
+                  "email",
+                  "system",
+                ]),
+              ];
+              const enumError = enumChecks.find((c) => c.error);
+              if (enumError) {
+                writeOutput(cmd, { ok: false, error: enumError.error });
                 process.exitCode = 1;
                 return;
               }
 
-              // Parse and validate --limit
-              let limit = 20;
-              if (opts.limit != null) {
-                const parsed = Number(opts.limit);
-                if (
-                  !Number.isFinite(parsed) ||
-                  !Number.isInteger(parsed) ||
-                  parsed < 1
-                ) {
+              const limit = parseBoundedInt(opts.limit, "limit", {
+                min: 1,
+                max: 200,
+              });
+              if (limit.error) {
+                writeOutput(cmd, { ok: false, error: limit.error });
+                process.exitCode = 1;
+                return;
+              }
+              const offset = parseBoundedInt(opts.offset, "offset", {
+                min: 0,
+              });
+              if (offset.error) {
+                writeOutput(cmd, { ok: false, error: offset.error });
+                process.exitCode = 1;
+                return;
+              }
+
+              if (opts.conversationId != null) {
+                const trimmed = opts.conversationId.trim();
+                if (trimmed.length === 0) {
                   writeOutput(cmd, {
                     ok: false,
-                    error: `Invalid limit "${opts.limit}". Must be a positive integer`,
+                    error: "Conversation ID must be a non-empty string",
                   });
                   process.exitCode = 1;
                   return;
                 }
-                limit = parsed;
               }
 
-              const result = await cliIpcCall<
-                Array<{
-                  id: string;
-                  sourceEventName: string;
-                  sourceChannel: string;
-                  sourceContextId: string;
-                  urgency: string;
-                  dedupeKey: string | null;
-                  createdAt: string;
-                }>
-              >("list_notification_events", {
-                body: { limit, sourceEventName: opts.sourceEventName },
-              });
+              const body: Record<string, unknown> = {};
+              if (opts.all) body.includeDismissed = true;
+              if (opts.status?.length) body.statuses = opts.status;
+              if (opts.before) body.before = opts.before;
+              if (opts.after) body.after = opts.after;
+              if (opts.urgency?.length) body.urgencies = opts.urgency;
+              if (opts.category?.length) body.categories = opts.category;
+              if (opts.conversationId)
+                body.conversationId = opts.conversationId.trim();
+              if (opts.fromAssistant) body.fromAssistant = true;
+              if (opts.noteworthy) body.noteworthy = true;
+              if (limit.value !== undefined) body.limit = limit.value;
+              if (offset.value !== undefined) body.offset = offset.value;
+
+              const result = await cliIpcCall<ListHomeFeedPayload>(
+                "list_home_feed",
+                { body },
+              );
 
               if (!result.ok) {
                 writeOutput(cmd, { ok: false, error: result.error });
@@ -438,21 +604,11 @@ Examples:
                 return;
               }
 
-              const events = result.result!;
-
-              writeOutput(cmd, { ok: true, events });
+              const payload = result.result!;
+              writeOutput(cmd, { ok: true, ...payload });
 
               if (!shouldOutputJson(cmd)) {
-                if (events.length === 0) {
-                  log.info("No notification events found");
-                } else {
-                  log.info(`${events.length} event(s):\n`);
-                  for (const event of events) {
-                    log.info(
-                      `  ${event.createdAt}  ${event.sourceEventName}  ${event.urgency}  ${event.sourceChannel}`,
-                    );
-                  }
-                }
+                renderFeedItemsHuman(payload);
               }
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
@@ -70,6 +70,7 @@ const {
   computeGreeting,
   formatRelativeTime,
   handleGetHomeFeed: _handleGetHomeFeed,
+  handleListHomeFeed,
   handlePatchFeedItem: _handlePatchFeedItem,
   handlePostFeedAction: _handlePostFeedAction,
   ROUTES,
@@ -154,9 +155,14 @@ type FeedItemFixture = {
   title: string;
   summary: string;
   timestamp: string;
-  status: "new" | "seen" | "acted_on";
+  status: "new" | "seen" | "acted_on" | "dismissed";
   expiresAt?: string;
   actions?: Array<{ id: string; label: string; prompt: string }>;
+  urgency?: "low" | "medium" | "high" | "critical";
+  category?: "security" | "scheduling" | "background" | "email" | "system";
+  conversationId?: string;
+  fromAssistant?: boolean;
+  noteworthy?: boolean;
   createdAt: string;
 };
 
@@ -563,5 +569,205 @@ describe("handlePostFeedAction", () => {
       "reply",
     );
     expect(res.status).toBe(500);
+  });
+});
+
+// ─── handleListHomeFeed ────────────────────────────────────────────────────
+
+describe("handleListHomeFeed", () => {
+  type ListResult = {
+    items: Array<{ id: string; status: string }>;
+    total: number;
+    returned: number;
+    hasMore: boolean;
+  };
+
+  test("excludes dismissed items by default", () => {
+    writeFeedFile([
+      makeItem({ id: "a", status: "new" }),
+      makeItem({ id: "b", status: "seen" }),
+      makeItem({ id: "c", status: "acted_on" }),
+      makeItem({ id: "d", status: "dismissed" }),
+    ]);
+
+    const result = handleListHomeFeed({ body: {} }) as ListResult;
+    expect(result.items.map((i) => i.id).sort()).toEqual(["a", "b", "c"]);
+    expect(result.total).toBe(3);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("includeDismissed: true returns dismissed items too", () => {
+    writeFeedFile([
+      makeItem({ id: "a", status: "new" }),
+      makeItem({ id: "d", status: "dismissed" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { includeDismissed: true },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id).sort()).toEqual(["a", "d"]);
+  });
+
+  test("statuses filter overrides the dismissed-default exclusion", () => {
+    writeFeedFile([
+      makeItem({ id: "a", status: "new" }),
+      makeItem({ id: "b", status: "seen" }),
+      makeItem({ id: "d", status: "dismissed" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { statuses: ["dismissed"] },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["d"]);
+  });
+
+  test("urgencies filter narrows by urgency and excludes items missing urgency", () => {
+    writeFeedFile([
+      makeItem({ id: "a", urgency: "high" }),
+      makeItem({ id: "b", urgency: "low" }),
+      makeItem({ id: "c" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { urgencies: ["high"] },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  test("categories filter narrows by category", () => {
+    writeFeedFile([
+      makeItem({ id: "a", category: "email" }),
+      makeItem({ id: "b", category: "background" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { categories: ["email"] },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  test("conversationId filter narrows by conversation", () => {
+    writeFeedFile([
+      makeItem({ id: "a", conversationId: "conv-1" }),
+      makeItem({ id: "b", conversationId: "conv-2" }),
+      makeItem({ id: "c" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { conversationId: "conv-1" },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  test("fromAssistant: true returns only assistant-emitted items", () => {
+    writeFeedFile([
+      makeItem({ id: "a", fromAssistant: true }),
+      makeItem({ id: "b", fromAssistant: false }),
+      makeItem({ id: "c" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { fromAssistant: true },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  test("noteworthy: true returns only noteworthy items", () => {
+    writeFeedFile([
+      makeItem({ id: "a", noteworthy: true }),
+      makeItem({ id: "b" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { noteworthy: true },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  test("before filter is strict (createdAt < before)", () => {
+    writeFeedFile([
+      makeItem({ id: "old", createdAt: "2026-05-01T00:00:00.000Z" }),
+      makeItem({ id: "edge", createdAt: "2026-05-15T00:00:00.000Z" }),
+      makeItem({ id: "new", createdAt: "2026-05-20T00:00:00.000Z" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { before: "2026-05-15T00:00:00.000Z" },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["old"]);
+  });
+
+  test("after filter is strict (createdAt > after)", () => {
+    writeFeedFile([
+      makeItem({ id: "old", createdAt: "2026-05-01T00:00:00.000Z" }),
+      makeItem({ id: "edge", createdAt: "2026-05-15T00:00:00.000Z" }),
+      makeItem({ id: "new", createdAt: "2026-05-20T00:00:00.000Z" }),
+    ]);
+
+    const result = handleListHomeFeed({
+      body: { after: "2026-05-15T00:00:00.000Z" },
+    }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["new"]);
+  });
+
+  test("limit and offset paginate; hasMore reflects remaining items", () => {
+    writeFeedFile(
+      Array.from({ length: 25 }, (_, i) =>
+        makeItem({
+          id: `i${String(i).padStart(2, "0")}`,
+          // distinct priorities so the file's sort is stable + deterministic
+          priority: 100 - i,
+        }),
+      ),
+    );
+
+    const page1 = handleListHomeFeed({
+      body: { limit: 10, offset: 0 },
+    }) as ListResult;
+    expect(page1.items).toHaveLength(10);
+    expect(page1.total).toBe(25);
+    expect(page1.returned).toBe(10);
+    expect(page1.hasMore).toBe(true);
+
+    const page3 = handleListHomeFeed({
+      body: { limit: 10, offset: 20 },
+    }) as ListResult;
+    expect(page3.items).toHaveLength(5);
+    expect(page3.hasMore).toBe(false);
+  });
+
+  test("invalid before timestamp throws 400", () => {
+    writeFeedFile([]);
+    let caught: unknown;
+    try {
+      handleListHomeFeed({ body: { before: "not-a-date" } });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RouteError);
+    expect((caught as { statusCode: number }).statusCode).toBe(400);
+  });
+
+  test("invalid filter shape throws 400", () => {
+    writeFeedFile([]);
+    let caught: unknown;
+    try {
+      handleListHomeFeed({ body: { urgencies: ["extreme"] } });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RouteError);
+    expect((caught as { statusCode: number }).statusCode).toBe(400);
+  });
+
+  test("expired items are excluded (matches readHomeFeed TTL behavior)", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    writeFeedFile([
+      makeItem({ id: "alive" }),
+      makeItem({ id: "dead", expiresAt: past }),
+    ]);
+
+    const result = handleListHomeFeed({ body: {} }) as ListResult;
+    expect(result.items.map((i) => i.id)).toEqual(["alive"]);
   });
 });

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -62,6 +62,32 @@ const patchFeedItemRequestSchema = z.object({
   status: z.enum(["new", "seen", "acted_on", "dismissed"]),
 });
 
+const listHomeFeedRequestSchema = z.object({
+  includeDismissed: z.boolean().optional(),
+  statuses: z
+    .array(z.enum(["new", "seen", "acted_on", "dismissed"]))
+    .optional(),
+  before: z.string().optional(),
+  after: z.string().optional(),
+  urgencies: z.array(z.enum(["low", "medium", "high", "critical"])).optional(),
+  categories: z
+    .array(z.enum(["security", "scheduling", "background", "email", "system"]))
+    .optional(),
+  conversationId: z.string().optional(),
+  fromAssistant: z.boolean().optional(),
+  noteworthy: z.boolean().optional(),
+  limit: z.number().int().positive().max(200).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+const listHomeFeedResponseSchema = z.object({
+  items: z.array(feedItemSchema),
+  total: z.number().int().nonnegative(),
+  returned: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+  updatedAt: z.string(),
+});
+
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for direct testing)
 // ---------------------------------------------------------------------------
@@ -183,6 +209,97 @@ export async function handlePatchFeedItem({
   return updated as unknown as Record<string, unknown>;
 }
 
+export function handleListHomeFeed({
+  body = {},
+}: RouteHandlerArgs): Record<string, unknown> {
+  const parsed = listHomeFeedRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid list request: ${parsed.error.issues
+        .map((i) => `${i.path.join(".")} ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  const params = parsed.data;
+
+  const beforeMs =
+    params.before !== undefined ? Date.parse(params.before) : undefined;
+  if (beforeMs !== undefined && Number.isNaN(beforeMs)) {
+    throw new BadRequestError(
+      `Invalid 'before' timestamp; expected ISO-8601 (got "${params.before}")`,
+    );
+  }
+  const afterMs =
+    params.after !== undefined ? Date.parse(params.after) : undefined;
+  if (afterMs !== undefined && Number.isNaN(afterMs)) {
+    throw new BadRequestError(
+      `Invalid 'after' timestamp; expected ISO-8601 (got "${params.after}")`,
+    );
+  }
+
+  // `statuses` is the explicit override. Otherwise default to excluding
+  // dismissed unless includeDismissed=true — the assistant's primary use
+  // case is "what's still outstanding", so dismissed items are noise
+  // unless explicitly requested.
+  const statusFilter: Set<FeedItemStatus> | null = params.statuses
+    ? new Set(params.statuses)
+    : params.includeDismissed
+      ? null
+      : new Set<FeedItemStatus>(["new", "seen", "acted_on"]);
+
+  const urgencySet = params.urgencies ? new Set(params.urgencies) : null;
+  const categorySet = params.categories ? new Set(params.categories) : null;
+
+  const feed = readHomeFeed();
+
+  const filtered = feed.items.filter((item) => {
+    if (statusFilter && !statusFilter.has(item.status)) return false;
+    if (urgencySet) {
+      if (!item.urgency || !urgencySet.has(item.urgency)) return false;
+    }
+    if (categorySet) {
+      if (!item.category || !categorySet.has(item.category)) return false;
+    }
+    if (
+      params.conversationId !== undefined &&
+      item.conversationId !== params.conversationId
+    )
+      return false;
+    if (
+      params.fromAssistant !== undefined &&
+      (item.fromAssistant ?? false) !== params.fromAssistant
+    )
+      return false;
+    if (
+      params.noteworthy !== undefined &&
+      (item.noteworthy ?? false) !== params.noteworthy
+    )
+      return false;
+
+    if (beforeMs !== undefined || afterMs !== undefined) {
+      const createdMs = Date.parse(item.createdAt);
+      if (Number.isNaN(createdMs)) return false;
+      if (beforeMs !== undefined && createdMs >= beforeMs) return false;
+      if (afterMs !== undefined && createdMs <= afterMs) return false;
+    }
+
+    return true;
+  });
+
+  const total = filtered.length;
+  const offset = params.offset ?? 0;
+  const limit = params.limit ?? 20;
+  const items = filtered.slice(offset, offset + limit);
+
+  return {
+    items,
+    total,
+    returned: items.length,
+    hasMore: total > offset + items.length,
+    updatedAt: feed.updatedAt,
+  };
+}
+
 export async function handlePostFeedAction({
   pathParams = {},
 }: RouteHandlerArgs): Promise<Record<string, unknown>> {
@@ -260,6 +377,18 @@ export const ROUTES: RouteDefinition[] = [
       "404": { description: "Feed item not found" },
       "500": { description: "Failed to persist feed item status" },
     },
+  },
+  {
+    operationId: "list_home_feed",
+    endpoint: "home/feed/query",
+    method: "POST",
+    handler: handleListHomeFeed,
+    summary: "List home feed items with filters",
+    description:
+      "Return home feed items filtered by status, urgency, category, conversation, and date range. Defaults to excluding dismissed items. Used by the assistant CLI to inspect what notifications have been surfaced to the user.",
+    tags: ["home"],
+    requestBody: listHomeFeedRequestSchema,
+    responseBody: listHomeFeedResponseSchema,
   },
   {
     operationId: "trigger_home_feed_action",

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -62,10 +62,65 @@ assistant notifications send \
 { "ok": true, "signalId": "...", "dispatched": true }
 ```
 
-## Listing Notifications
+## Reading Surfaced Notifications
 
 ```bash
 assistant notifications list --json
+```
+
+Reads from the user's home feed (`~/.vellum/workspace/data/home-feed.json`) — the inbox that mirrors background and async notifications surfaced via the unified pipeline. Real-time chat pushes that did not mirror to the feed (direct Telegram/Slack/Vellum-chat sends without `--is-async-background`) will not appear here.
+
+### When to call
+
+- **Before sending**: check whether you already surfaced a similar item recently (filter by `--conversation-id` or `--after` to dedupe).
+- **Catch-up summaries**: when the user asks "what did I miss" or returns after a session break, list the items they haven't dismissed.
+- **Lookup**: when the user references a past notification ("the email thing you flagged earlier"), find it by `--conversation-id` or date range.
+
+### Filters
+
+| Flag | Purpose |
+| --- | --- |
+| `--all` | Include dismissed items (default: excluded — assistant cares about outstanding work) |
+| `--status <s>` | Filter by status (`new` / `seen` / `acted_on` / `dismissed`); repeatable. Overrides the `--all` default. |
+| `--before <iso>` / `--after <iso>` | ISO-8601 createdAt bounds (strict; `=` is excluded). |
+| `--urgency <u>` | Filter by urgency (`low` / `medium` / `high` / `critical`); repeatable. |
+| `--category <c>` | Filter by category (`security` / `scheduling` / `background` / `email` / `system`); repeatable. |
+| `--conversation-id <id>` | Only items tied to this conversation. |
+| `--from-assistant` | Only items the assistant herself emitted. |
+| `--noteworthy` | Only items flagged as noteworthy. |
+| `--limit <n>` | Default 20, max 200. |
+| `--offset <n>` | Pagination offset. Combine with `--limit` to walk older pages. |
+
+### Examples
+
+```bash
+# What's outstanding right now (defaults: skip dismissed, newest first)
+assistant notifications list --json
+
+# Everything you've shown the user today
+assistant notifications list --after 2026-05-28T00:00:00Z --all --json
+
+# Only high-stakes items
+assistant notifications list --urgency high --urgency critical --json
+
+# Pre-send dedupe: anything you already surfaced for this conversation
+assistant notifications list --conversation-id 7fab234c --after 2026-05-28T00:00:00Z --json
+
+# Walk older pages
+assistant notifications list --limit 20 --offset 20 --json
+```
+
+### Response shape
+
+```json
+{
+  "ok": true,
+  "items": [ /* FeedItem records: id, title?, summary, status, urgency?, category?, conversationId?, createdAt, ... */ ],
+  "total": 12,
+  "returned": 3,
+  "hasMore": true,
+  "updatedAt": "2026-05-28T10:30:00.000Z"
+}
 ```
 
 ## Important


### PR DESCRIPTION
## Summary

- Repurpose `assistant notifications list` from a useless raw-event dump (id + source + urgency + dedupeKey only) to the user-visible home-feed inbox, with rendered title/summary, status, urgency, category, conversation, and pagination filters.
- Add `list_home_feed` IPC/HTTP route (`POST /v1/home/feed/query`) on the daemon side, reading via the existing `readHomeFeed()` helper and applying filters in-memory.
- Default excludes `dismissed` items (assistant cares about what's outstanding); `--all` includes them. Filters: `--status`, `--before`/`--after` (ISO), `--urgency`, `--category`, `--conversation-id`, `--from-assistant`, `--noteworthy`, `--limit`/`--offset`.
- Update the `notifications` skill so the assistant knows when to call it (pre-send dedupe, catch-up summaries, lookup) and which filters to combine, with the scope caveat that home-feed only covers background/async notifications.

## Original prompt

The `assistant notifications` CLI and the `notifications` skill already let the assistant *send* notifications. The user asked to extend both so the assistant can also *read* notifications surfaced to the user, with filters for undismissed/all, pagination, before/after dates, and other useful filters. After exploring the data model, we picked the home-feed (`~/.vellum/workspace/data/home-feed.json`) as the source of truth because it already carries the user-visible status field (`new`/`seen`/`acted_on`/`dismissed`) that the macOS client maintains. The user explicitly confirmed the current `list` output is "completely worthless" and was fine with replacing it.

## Test plan

- [x] `bunx tsc --noEmit` in `assistant/`
- [x] `bun run lint` in `assistant/`
- [x] `bun test src/cli/commands/__tests__/notifications.test.ts` — 34 pass (rewrote list-subcommand tests for the new shape; added filter coverage for `--all`, `--status`, `--before`/`--after`, `--urgency`, `--category`, `--conversation-id`, `--from-assistant`, `--noteworthy`, `--limit`/`--offset` with bounds validation)
- [x] `bun test src/runtime/routes/__tests__/home-feed-routes.test.ts` — 40 pass (added 12 tests for `handleListHomeFeed`: status defaults + override, urgencies, categories, conversationId, fromAssistant, noteworthy, before/after, pagination, invalid timestamps, expired-item TTL)