### PR TITLE
Invert VITE_LOCAL_MODE to VITE_PLATFORM_MODE

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -186,7 +186,7 @@ jobs:
       # same-origin paths, so each bucket's origin reaches its own backend.
       - name: Build
         env:
-          VITE_LOCAL_MODE: "false"
+          VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build
         env:
-          VITE_LOCAL_MODE: "false"
+          VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_APP_VERSION: ${{ github.sha }}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -8,6 +8,6 @@
 # Dev server port. Default: 3000
 # PORT=3000
 
-# Enable local-mode to read assistant lockfile from the CLI daemon.
-# When set, the web app reads /__local/lockfile to discover locally-hatched assistants.
-# VITE_LOCAL_MODE=true
+# Set to enable platform (cloud-hosted) mode. When unset, the app defaults to local mode,
+# reading the assistant lockfile from the CLI daemon via /__local/lockfile.
+# VITE_PLATFORM_MODE=true

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -18,8 +18,8 @@ interface ImportMetaEnv {
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */
   readonly VITE_APP_VERSION?: string;
-  /** Enable local-mode: read assistant lockfile from the CLI daemon. */
-  readonly VITE_LOCAL_MODE?: string;
+  /** When set, the app runs in platform (cloud-hosted) mode. Unset = local mode. */
+  readonly VITE_PLATFORM_MODE?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -52,12 +52,12 @@ const SELECTED_ASSISTANT_STORAGE_KEY = "local:selectedAssistantId";
 // Core helpers
 // ---------------------------------------------------------------------------
 
-const LOCAL_MODE_FALSY = new Set(["", "0", "false", "no"]);
+const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 
 export function isLocalMode(): boolean {
-  const raw = import.meta.env.VITE_LOCAL_MODE;
-  if (!raw) return false;
-  return !LOCAL_MODE_FALSY.has(raw.toLowerCase());
+  const raw = import.meta.env.VITE_PLATFORM_MODE;
+  if (!raw) return true;
+  return !PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
 }
 
 export async function loadLockfile(): Promise<Lockfile> {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(({ mode }) => {
           filesToDeleteAfterUpload: ["./dist/**/*.map"],
         },
       }),
-      env.VITE_LOCAL_MODE ? localModePlugin(env) : null,
+      !env.VITE_PLATFORM_MODE ? localModePlugin(env) : null,
     ].filter(Boolean),
     resolve: {
       alias: [


### PR DESCRIPTION
## Summary
- Replaces `VITE_LOCAL_MODE` with `VITE_PLATFORM_MODE` across the web SPA, inverting the default: local mode is now on when the env var is unset
- `isLocalMode()` returns `true` by default; CI/CD and production builds set `VITE_PLATFORM_MODE=true` to opt into platform mode
- Updates CI workflows, env types, vite config, and `.env.example`

## Test plan
- [ ] `bun run dev` without any env var → `isLocalMode()` returns `true`, `localModePlugin` loads
- [ ] `VITE_PLATFORM_MODE=true bun run dev` → `isLocalMode()` returns `false`, `localModePlugin` skipped
- [ ] CI build passes with `VITE_PLATFORM_MODE: "true"` set in workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)