### PR TITLE
feat(web): add route guards for onboarding pages

### DIFF
--- a/apps/web/src/lib/onboarding-middleware.ts
+++ b/apps/web/src/lib/onboarding-middleware.ts
@@ -1,0 +1,31 @@
+import { redirect, type MiddlewareFunction } from "react-router";
+
+import { isLocalMode, hasAssistants } from "@/lib/local-mode";
+import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
+import { routes } from "@/utils/routes";
+
+export const localModeOnlyMiddleware: MiddlewareFunction = async (
+  _args,
+  next,
+) => {
+  if (!isLocalMode()) {
+    throw redirect(routes.assistant);
+  }
+  return next();
+};
+
+export const onboardingCompletedMiddleware: MiddlewareFunction = async (
+  { request },
+  next,
+) => {
+  const url = new URL(request.url);
+  if (url.searchParams.has("replay")) {
+    return next();
+  }
+
+  if (readOnboardingCompleted() || (isLocalMode() && hasAssistants())) {
+    throw redirect(routes.assistant);
+  }
+
+  return next();
+};

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,6 +1,10 @@
 import { createBrowserRouter, Navigate, useSearchParams } from "react-router";
 
 import { authMiddleware } from "@/lib/auth/auth-middleware";
+import {
+  localModeOnlyMiddleware,
+  onboardingCompletedMiddleware,
+} from "@/lib/onboarding-middleware";
 import { RootLayout } from "@/root-layout";
 import { ChatLayout } from "@/domains/chat/chat-layout";
 import { ChatPage } from "@/domains/chat/chat-page";
@@ -99,27 +103,38 @@ export const router = createBrowserRouter(
         {
           ErrorBoundary: RouteErrorBoundary,
           children: [
-        // Onboarding routes — full-screen (no ChatLayout sidebar).
-        // Lazy-loaded: one-time flow, not revisited.
+        // Onboarding routes — redirect to /assistant when onboarding is
+        // already completed (unless ?replay is present).
         {
-          path: "onboarding/welcome",
-          lazy: { Component: () => import("@/domains/onboarding/pages/welcome-screen").then((m) => m.WelcomeScreen) },
-        },
-        {
-          path: "onboarding/hosting",
-          lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
-        },
-        {
-          path: "onboarding/privacy",
-          lazy: { Component: () => import("@/domains/onboarding/pages/privacy-screen").then((m) => m.PrivacyScreen) },
-        },
-        {
-          path: "onboarding/prechat",
-          lazy: { Component: () => import("@/domains/onboarding/pages/pre-chat-flow").then((m) => m.PreChatFlow) },
-        },
-        {
-          path: "onboarding/hatching",
-          lazy: { Component: () => import("@/domains/onboarding/pages/hatching-screen").then((m) => m.HatchingScreen) },
+          middleware: [onboardingCompletedMiddleware],
+          children: [
+            // Local-mode-only: redirect to /assistant when not in local mode.
+            {
+              middleware: [localModeOnlyMiddleware],
+              children: [
+                {
+                  path: "onboarding/welcome",
+                  lazy: { Component: () => import("@/domains/onboarding/pages/welcome-screen").then((m) => m.WelcomeScreen) },
+                },
+                {
+                  path: "onboarding/hosting",
+                  lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
+                },
+              ],
+            },
+            {
+              path: "onboarding/privacy",
+              lazy: { Component: () => import("@/domains/onboarding/pages/privacy-screen").then((m) => m.PrivacyScreen) },
+            },
+            {
+              path: "onboarding/prechat",
+              lazy: { Component: () => import("@/domains/onboarding/pages/pre-chat-flow").then((m) => m.PreChatFlow) },
+            },
+            {
+              path: "onboarding/hatching",
+              lazy: { Component: () => import("@/domains/onboarding/pages/hatching-screen").then((m) => m.HatchingScreen) },
+            },
+          ],
         },
 
         // Settings routes — full-screen overlay panel (no ChatLayout sidebar).


### PR DESCRIPTION
## Summary
- Add `onboardingCompletedMiddleware` that redirects users who have already completed onboarding (or have assistants in local mode) away from onboarding routes back to `/assistant`, unless `?replay` is present
- Add `localModeOnlyMiddleware` that redirects non-local-mode users away from local-only onboarding routes (`welcome`, `hosting`)
- Wrap all onboarding routes with the completed guard, and nest `welcome`/`hosting` under the additional local-mode guard

## Original prompt
Prevent users from navigating to local-mode-specific onboarding routes when not in local mode, and prevent all users from reaching onboarding routes after they've already completed onboarding and have an assistant — unless they're intentionally replaying onboarding via the existing `?replay` convention from debug controls.