### PR TITLE
fix(web): set VITE_PLATFORM_MODE=true in test preload

### DIFF
--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -12,6 +12,10 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 GlobalRegistrator.register();
 
+// Tests default to platform mode (matching CI/CD builds). Individual tests
+// that need local mode should mock isLocalMode() instead.
+process.env.VITE_PLATFORM_MODE = "true";
+
 // Set a base URL so relative fetch requests (e.g. "/v1/assistants/...")
 // resolve correctly instead of failing against "about:blank".
 window.location.href = "http://localhost:3000";


### PR DESCRIPTION
## Summary
- The `VITE_LOCAL_MODE` → `VITE_PLATFORM_MODE` inversion in #32370 changed the default when the env var is unset from platform mode to local mode
- Tests run without `VITE_PLATFORM_MODE` set, so `isLocalMode()` now returns `true` in tests, causing auth-store and api-interceptors tests to hit local-mode code paths instead of the platform-mode paths they're testing
- Set `VITE_PLATFORM_MODE=true` in `test-setup.ts` so the test environment defaults to platform mode, matching CI/CD builds

## Original prompt
Fix the CI test failures on main caused by the VITE_PLATFORM_MODE inversion commit. The `api-interceptors` and `auth-store` test suites were failing because tests now run in local mode by default (env var unset), but these tests exercise platform-mode behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)