### PR TITLE
feat(assistant): add JSON schema input validator for skill tools

### DIFF
--- a/assistant/src/__tests__/validate-input.test.ts
+++ b/assistant/src/__tests__/validate-input.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateInputAgainstSchema } from "../skills/validate-input.js";
+
+// ---------------------------------------------------------------------------
+// required
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — required", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      surface_id: { type: "string" },
+      content: { type: "string" },
+      mode: { type: "string" },
+    },
+    required: ["surface_id", "content"],
+  };
+
+  test("succeeds when all required fields are present", () => {
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: "doc-1", content: "hi" },
+      schema,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("lists each missing required field individually", () => {
+    const result = validateInputAgainstSchema("document_update", {}, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("surface_id is required");
+    expect(result.errors).toContain("content is required");
+  });
+
+  test("treats explicit undefined / null as missing", () => {
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: undefined, content: null },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("surface_id is required");
+    expect(result.errors).toContain("content is required");
+  });
+
+  test("empty input is allowed when nothing is required", () => {
+    const schemaNoRequired = {
+      type: "object",
+      properties: { query: { type: "string" } },
+    };
+    const result = validateInputAgainstSchema("noop", {}, schemaNoRequired);
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// type checks
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — type checks", () => {
+  test.each([
+    ["string", "hello", true],
+    ["string", 5, false],
+    ["number", 3.14, true],
+    ["number", "3.14", false],
+    ["integer", 7, true],
+    ["integer", 7.5, false],
+    ["integer", "7", false],
+    ["boolean", true, true],
+    ["boolean", "true", false],
+    ["array", [1, 2], true],
+    ["array", { 0: 1 }, false],
+    ["object", { a: 1 }, true],
+    ["object", [1, 2], false],
+    ["object", null, true], // null is skipped (treated as absent)
+  ] as const)("type=%s, value=%p, valid=%p", (type, value, valid) => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { field: value },
+      { type: "object", properties: { field: { type } } },
+    );
+    expect(result.ok).toBe(valid);
+    if (!valid) {
+      expect((result as { ok: false; errors: string[] }).errors[0]).toContain(
+        `field must be `,
+      );
+      expect((result as { ok: false; errors: string[] }).errors[0]).toContain(
+        type,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enum
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — enum", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      mode: { type: "string", enum: ["replace", "append"] },
+    },
+  };
+
+  test("succeeds for a valid enum value", () => {
+    const result = validateInputAgainstSchema("t", { mode: "replace" }, schema);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("fails with the list of allowed values", () => {
+    const result = validateInputAgainstSchema("t", { mode: "bogus" }, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain('mode must be one of "replace", "append"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// array items
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — array items", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      tags: { type: "array", items: { type: "string" } },
+    },
+  };
+
+  test("succeeds when every element matches", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { tags: ["a", "b"] },
+      schema,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("flags each element that violates the item type", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { tags: ["a", 2, "c", false] },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("tags[1] must be a string");
+    expect(result.errors).toContain("tags[3] must be a string");
+    expect(result.errors).not.toContain("tags[0] must be a string");
+    expect(result.errors).not.toContain("tags[2] must be a string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unknown keys
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — unknown keys", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      surface_id: { type: "string" },
+      content: { type: "string" },
+      mode: { type: "string" },
+    },
+  };
+
+  test("flags a single unknown key with the supported list", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { surface_id: "doc", content: "x", foo: 1 },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain(
+      'Unknown parameter "foo". Supported: "surface_id", "content", "mode"',
+    );
+  });
+
+  test("flags multiple unknown keys individually", () => {
+    const result = validateInputAgainstSchema("t", { foo: 1, bar: 2 }, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const unknownErrors = result.errors.filter((e) =>
+      e.startsWith("Unknown parameter"),
+    );
+    expect(unknownErrors).toHaveLength(2);
+    expect(unknownErrors.some((e) => e.includes('"foo"'))).toBe(true);
+    expect(unknownErrors.some((e) => e.includes('"bar"'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// permissive paths
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — permissive paths", () => {
+  test("permits anything when schema is undefined", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { whatever: "goes" },
+      undefined,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("permits anything when schema has no properties", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { anything: 1 },
+      { type: "object" },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("does not throw when schema contains oneOf / $ref keywords", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        field: {
+          $ref: "#/definitions/Thing",
+          oneOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    };
+    let result: ReturnType<typeof validateInputAgainstSchema>;
+    expect(() => {
+      result = validateInputAgainstSchema("t", { field: "x" }, schema);
+    }).not.toThrow();
+    expect(result!.ok).toBe(true);
+  });
+
+  test("does not throw when top-level schema contains anyOf / allOf", () => {
+    const schema = {
+      type: "object",
+      properties: { field: { type: "string" } },
+      anyOf: [{ required: ["field"] }],
+      allOf: [{ type: "object" }],
+    };
+    expect(() =>
+      validateInputAgainstSchema("t", { field: "x" }, schema),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// purity
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — purity", () => {
+  test("does not mutate the input or the schema", () => {
+    const input = { surface_id: "doc", content: "hi", extra: 1 };
+    const schema = {
+      type: "object",
+      properties: {
+        surface_id: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["surface_id"],
+    };
+    const inputSnapshot = JSON.parse(JSON.stringify(input));
+    const schemaSnapshot = JSON.parse(JSON.stringify(schema));
+
+    validateInputAgainstSchema("t", input, schema);
+
+    expect(input).toEqual(inputSnapshot);
+    expect(schema).toEqual(schemaSnapshot);
+  });
+});

--- a/assistant/src/skills/validate-input.ts
+++ b/assistant/src/skills/validate-input.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure JSON-schema input validator for skill tool calls.
+ *
+ * Deliberate strict subset of JSON Schema: it covers only the keywords
+ * actually used by `assistant/src/config/bundled-skills/**\/TOOLS.json`
+ * (required / type / enum / items.type) plus unknown-key detection. Anything
+ * else (`$ref`, `oneOf`, `anyOf`, `allOf`, `format`, `pattern`, `minimum`,
+ * `maximum`, object-shape `additionalProperties`, etc.) is silently skipped so
+ * a richer schema can never cause us to reject a legitimate call.
+ *
+ * Each error message is written to be agent-readable and self-correcting
+ * (e.g. `surface_id is required`, `mode must be one of "replace", "append"`).
+ */
+
+import { isPlainObject } from "../util/object.js";
+
+export interface InputValidationSuccess {
+  ok: true;
+}
+
+export interface InputValidationFailure {
+  ok: false;
+  /** Human-readable messages, one per problem. */
+  errors: string[];
+}
+
+export type InputValidationResult =
+  | InputValidationSuccess
+  | InputValidationFailure;
+
+type SupportedType =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "array"
+  | "object";
+
+const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "array",
+  "object",
+]);
+
+function matchesType(value: unknown, type: SupportedType): boolean {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return isPlainObject(value);
+  }
+}
+
+function quoteList(values: readonly string[]): string {
+  return values.map((v) => `"${v}"`).join(", ");
+}
+
+/**
+ * Validate a tool input object against the (optional) JSON-schema definition
+ * declared on the tool entry. Returns `{ ok: true }` if the input is valid (or
+ * if there is nothing actionable to validate); otherwise returns a list of
+ * human-readable error strings.
+ *
+ * Pure: never mutates `input` or `schema`, no I/O.
+ */
+export function validateInputAgainstSchema(
+  _toolName: string,
+  input: Record<string, unknown>,
+  schema: Record<string, unknown> | undefined,
+): InputValidationResult {
+  // Skip when there's no schema or no properties block — matches today's
+  // lenient behaviour for tools that declare only `{ type: "object" }`.
+  if (!schema) return { ok: true };
+  const properties = schema.properties;
+  if (!isPlainObject(properties)) return { ok: true };
+
+  const errors: string[] = [];
+  const knownKeys = Object.keys(properties);
+  const knownKeySet = new Set(knownKeys);
+
+  // 1. Required fields — `in` check, so explicit `undefined`/`null` count as missing.
+  const required = schema.required;
+  if (Array.isArray(required)) {
+    for (const key of required) {
+      if (typeof key !== "string") continue;
+      const present =
+        key in input && input[key] !== undefined && input[key] !== null;
+      if (!present) {
+        errors.push(`${key} is required`);
+      }
+    }
+  }
+
+  // 2. Per-property checks: type, enum, items.type.
+  for (const [key, rawSubSchema] of Object.entries(properties)) {
+    if (!(key in input)) continue;
+    const value = input[key];
+    if (value === undefined || value === null) continue;
+    if (!isPlainObject(rawSubSchema)) continue;
+
+    const declaredType = rawSubSchema.type;
+    if (typeof declaredType === "string" && SUPPORTED_TYPES.has(declaredType)) {
+      const type = declaredType as SupportedType;
+      if (!matchesType(value, type)) {
+        errors.push(`${key} must be ${typeArticle(type)} ${type}`);
+        // No point checking enum/items if the base type is wrong.
+        continue;
+      }
+
+      // 2a. Enum (string enums are the only shape used today).
+      const enumValues = rawSubSchema.enum;
+      if (Array.isArray(enumValues) && enumValues.length > 0) {
+        if (!enumValues.includes(value)) {
+          errors.push(
+            `${key} must be one of ${quoteList(enumValues.map(String))}`,
+          );
+        }
+      }
+
+      // 2b. Array items.type — per-element check.
+      if (type === "array" && isPlainObject(rawSubSchema.items)) {
+        const itemType = rawSubSchema.items.type;
+        if (
+          typeof itemType === "string" &&
+          SUPPORTED_TYPES.has(itemType) &&
+          Array.isArray(value)
+        ) {
+          const itemTypeName = itemType as SupportedType;
+          value.forEach((element, index) => {
+            if (!matchesType(element, itemTypeName)) {
+              errors.push(
+                `${key}[${index}] must be ${typeArticle(itemTypeName)} ${itemTypeName}`,
+              );
+            }
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Unknown keys — parity with the previous `validateNoUnknownParams`.
+  const unknownKeys = Object.keys(input).filter((k) => !knownKeySet.has(k));
+  for (const key of unknownKeys) {
+    errors.push(
+      `Unknown parameter "${key}". Supported: ${quoteList(knownKeys)}`,
+    );
+  }
+
+  if (errors.length === 0) return { ok: true };
+  return { ok: false, errors };
+}
+
+function typeArticle(type: SupportedType): "a" | "an" {
+  // `integer`, `array`, `object` start with a vowel sound.
+  return type === "integer" || type === "array" || type === "object"
+    ? "an"
+    : "a";
+}


### PR DESCRIPTION
## Summary
- New `validateInputAgainstSchema` utility under `assistant/src/skills/validate-input.ts` supporting required/type/enum/items + unknown-key detection.
- Standalone, pure module with tests. No callers yet — PR 3 wires it into the skill-tool factory.

Part of plan: doc-editor-validate.md (PR 1 of 5)