### PR TITLE
fix(document-editor): validate update input before lookup

### DIFF
--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -257,3 +257,67 @@ describe("document tool security", () => {
     expect(getDocumentById("doc-current")).toBeNull();
   });
 });
+
+describe("executeDocumentUpdate — input validation", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedFixtureDocuments();
+  });
+
+  test("returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentUpdate({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+    expect(body.error).not.toContain("Document not found");
+  });
+
+  test("returns Invalid input when content is missing", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe(
+      "Invalid input: content is required and must be a string",
+    );
+  });
+
+  test("allows empty string content (falls through to access check)", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    // Did NOT fail input validation; fell through to access/not-found path.
+    expect(body.error).toBe("Document not found");
+  });
+
+  test("returns Invalid input when mode is not replace or append", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "hi", mode: "bogus" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe(
+      'Invalid input: mode must be "replace" or "append"',
+    );
+  });
+
+  test("executeDocumentRead returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentRead({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+  });
+
+  test("executeDocumentDelete returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentDelete({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+  });
+});

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -40,13 +40,36 @@ export function canAccessDocument(
   );
 }
 
+function invalidInput(message: string): ToolExecutionResult {
+  return {
+    content: JSON.stringify({
+      success: false,
+      error: `Invalid input: ${message}`,
+    }),
+    isError: true,
+  };
+}
+
+function validateSurfaceId(
+  input: Record<string, unknown>,
+): ToolExecutionResult | string {
+  if (typeof input.surface_id !== "string" || input.surface_id.trim() === "") {
+    return invalidInput(
+      "surface_id is required and must be a non-empty string",
+    );
+  }
+  return input.surface_id;
+}
+
 // ── Exported execute functions ──────────────────────────────────────
 
 export function executeDocumentOpen(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -174,9 +197,21 @@ export function executeDocumentUpdate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
-  const content = input.content as string;
-  const mode = (input.mode as string | undefined) || "append";
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
+  if (typeof input.content !== "string") {
+    return invalidInput("content is required and must be a string");
+  }
+  if (
+    input.mode !== undefined &&
+    input.mode !== "replace" &&
+    input.mode !== "append"
+  ) {
+    return invalidInput('mode must be "replace" or "append"');
+  }
+  const content = input.content;
+  const mode = (input.mode as "replace" | "append" | undefined) ?? "append";
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -229,7 +264,9 @@ export function executeDocumentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -286,7 +323,9 @@ export function executeDocumentDelete(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -309,7 +348,9 @@ export function executeDocumentFind(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   const query = input.query as string;
   const regex = (input.regex as boolean | undefined) ?? false;
   const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
@@ -360,7 +401,9 @@ export function executeDocumentReplaceText(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   const find = input.find as string;
   const replace = (input.replace as string) ?? "";
   const regex = (input.regex as boolean | undefined) ?? false;


### PR DESCRIPTION
## Summary
- `executeDocumentUpdate` now returns `Invalid input: …` for missing `surface_id`, missing `content`, or invalid `mode` before any DB lookup — fixes the misleading 'Document not found' from JARVIS-968.
- Same defensive `surface_id` guard applied to `executeDocumentOpen/Read/Delete/Find/ReplaceText`.
- Adds an `executeDocumentUpdate — input validation` test block plus cross-tool spot checks.

Part of plan: doc-editor-validate.md (PR 2 of 5)