### PR TITLE
fix(document-editor): reuse empty same-title doc in same conversation

### DIFF
--- a/assistant/src/__tests__/document-create-dedupe.test.ts
+++ b/assistant/src/__tests__/document-create-dedupe.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getDocumentById,
+  getDocumentsForConversation,
+} from "../documents/document-store.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { executeDocumentCreate } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    sendToClient: () => {},
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDbForTesting();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  createdAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.createdAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.createdAt,
+      params.createdAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.createdAt);
+}
+
+describe("executeDocumentCreate — dedupe empty same-title document", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+  });
+
+  test("reuses an empty same-title doc when incoming content is non-empty", () => {
+    const seededId = "doc-empty-seeded";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{
+      surface_id: string;
+      reused?: boolean;
+      message?: string;
+    }>(result);
+    expect(body.surface_id).toBe(seededId);
+    expect(body.reused).toBe(true);
+    expect(body.message).toBe("Document editor reopened (deduped empty draft)");
+
+    expect(getDocumentById(seededId)?.content).toBe("Hello");
+    expect(getDocumentsForConversation("conv-current").length).toBe(1);
+  });
+
+  test("creates a new doc when incoming initial_content is empty (no dedupe)", () => {
+    const seededId = "doc-empty-seeded";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+
+  test("does not dedupe when the seeded doc already has content", () => {
+    const seededId = "doc-has-content";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "already drafted",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentById(seededId)?.content).toBe("already drafted");
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+
+  test("does not dedupe when the seeded empty doc is outside the 5-minute window", () => {
+    const seededId = "doc-stale-empty";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      // 10 minutes ago — outside the 5-minute dedupe window.
+      createdAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentById(seededId)?.content).toBe("");
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+});

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -218,6 +218,44 @@ export function searchDocumentsByTitle(
 }
 
 /**
+ * Return the most recent empty document in the given conversation with the
+ * supplied title, created within the last `withinMs` milliseconds.
+ *
+ * Used to dedupe a duplicate create-then-create flow after a failed update —
+ * when the model can't recover a malformed update and retries by creating a
+ * second same-title document, we reuse the first (still-empty) draft instead
+ * of producing a duplicate row. Returns `null` when no candidate exists.
+ */
+export function findRecentEmptyDocumentByTitle(
+  conversationId: string,
+  title: string,
+  withinMs: number,
+): { surfaceId: string } | null {
+  try {
+    const threshold = Date.now() - withinMs;
+    const row = rawGet<{ surface_id: string }>(
+      /*sql*/ `SELECT surface_id FROM documents
+       WHERE conversation_id = ?
+         AND title = ?
+         AND content = ''
+         AND created_at >= ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      conversationId,
+      title,
+      threshold,
+    );
+    return row ? { surfaceId: row.surface_id } : null;
+  } catch (error) {
+    log.error(
+      { err: error, conversationId, title },
+      "Find-recent-empty-document error",
+    );
+    return null;
+  }
+}
+
+/**
  * Delete a document and its conversation associations.
  * Returns `true` if the document existed and was deleted, `false` otherwise.
  */

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   deleteDocument,
   findInDocument,
+  findRecentEmptyDocumentByTitle,
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
@@ -124,12 +125,79 @@ export function executeDocumentOpen(
   };
 }
 
+const EMPTY_DOCUMENT_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * If the model just created an empty same-title document in this conversation
+ * and is now creating a second one with real content, reuse the first row
+ * instead of producing a duplicate. Returns `null` when no dedupe applies.
+ *
+ * Only triggers when `initialContent` is non-empty — an empty incoming create
+ * likely means the model intends a fresh blank doc.
+ */
+function maybeReuseEmptyDocument(
+  title: string,
+  initialContent: string,
+  context: ToolContext,
+): ToolExecutionResult | null {
+  if (initialContent.length === 0) return null;
+  const existing = findRecentEmptyDocumentByTitle(
+    context.conversationId,
+    title,
+    EMPTY_DOCUMENT_DEDUPE_WINDOW_MS,
+  );
+  if (!existing) return null;
+
+  const surfaceId = existing.surfaceId;
+  const update = updateDocumentContent(surfaceId, initialContent, "replace");
+  if (!update.success) return null;
+
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "document_editor_show",
+      conversationId: context.conversationId,
+      surfaceId,
+      title,
+      initialContent,
+    });
+
+    context.sendToClient({
+      type: "ui_surface_show",
+      conversationId: context.conversationId,
+      surfaceId: `preview-${surfaceId}`,
+      surfaceType: "document_preview",
+      display: "inline",
+      title,
+      data: {
+        title,
+        surfaceId,
+        subtitle: "Document",
+      },
+    });
+  }
+
+  return {
+    content: JSON.stringify({
+      surface_id: surfaceId,
+      title,
+      opened: context.sendToClient != null,
+      reused: true,
+      message: "Document editor reopened (deduped empty draft)",
+    }),
+    isError: false,
+  };
+}
+
 export function executeDocumentCreate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
   const title = (input.title as string | undefined) || "Untitled Document";
   const initialContent = (input.initial_content as string | undefined) || "";
+
+  const reused = maybeReuseEmptyDocument(title, initialContent, context);
+  if (reused) return reused;
+
   const surfaceId = `doc-${randomUUID()}`;
 
   // Persist the document so any client (web or macOS) can fetch it via


### PR DESCRIPTION
## Summary
- New `findRecentEmptyDocumentByTitle` helper in `document-store`.
- `executeDocumentCreate` now reuses an empty same-title doc (in the same conversation, within 5 min) instead of creating a duplicate — closes the JARVIS-968 duplicate path even when the model can't recover via SKILL.md guidance alone.

Part of plan: doc-editor-validate.md (PR 5 of 5)