### PR TITLE
Fix Telegram manual OAuth requests

### DIFF
--- a/assistant/src/__tests__/manual-token-reconciliation.test.ts
+++ b/assistant/src/__tests__/manual-token-reconciliation.test.ts
@@ -13,6 +13,8 @@ let connectionStore: Record<
 > = {};
 let deletedConnectionIds: string[] = [];
 let createdConnections: Array<{ provider: string; accountInfo?: string }> = [];
+let updatedConnections: Array<{ id: string; accountInfo?: string | null }> = [];
+let telegramBotUsername: string | undefined;
 const warnings: string[] = [];
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,10 @@ mock.module("../security/secure-keys.js", () => ({
     };
     return result.value;
   },
+}));
+
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => telegramBotUsername,
 }));
 
 mock.module("../oauth/oauth-store.js", () => ({
@@ -72,7 +78,16 @@ mock.module("../oauth/oauth-store.js", () => ({
     };
     return { id: `conn-${params.provider}` };
   },
-  updateConnection: () => {},
+  updateConnection: (id: string, updates: { accountInfo?: string | null }) => {
+    updatedConnections.push({ id, accountInfo: updates.accountInfo });
+    for (const conn of Object.values(connectionStore)) {
+      if (conn.id === id) {
+        conn.accountInfo = updates.accountInfo;
+        return true;
+      }
+    }
+    return false;
+  },
   upsertApp: async (_provider: string, _clientId: string) => ({
     id: "app-1",
   }),
@@ -119,6 +134,8 @@ describe("syncManualTokenConnection", () => {
     connectionStore = {};
     deletedConnectionIds = [];
     createdConnections = [];
+    updatedConnections = [];
+    telegramBotUsername = undefined;
     warnings.length = 0;
   });
 
@@ -291,6 +308,62 @@ describe("syncManualTokenConnection", () => {
       { provider: "telegram", accountInfo: undefined },
     ]);
   });
+
+  test("creates telegram connection with configured bot username when account is omitted", async () => {
+    telegramBotUsername = "example_bot";
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "webhook-secret",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(createdConnections).toEqual([
+      { provider: "telegram", accountInfo: "@example_bot" },
+    ]);
+  });
+
+  test("updates existing telegram connection with configured bot username when account is omitted", async () => {
+    telegramBotUsername = "@example_bot";
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "webhook-secret",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(updatedConnections).toEqual([
+      { id: "conn-telegram", accountInfo: "@example_bot" },
+    ]);
+    expect(connectionStore["telegram"]?.accountInfo).toBe("@example_bot");
+  });
+
+  test("preserves existing telegram account label when deriving bot username lazily", async () => {
+    telegramBotUsername = "@example_bot";
+    seedConnection("telegram", { accountInfo: "@existing_bot" });
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "webhook-secret",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(updatedConnections).toEqual([]);
+    expect(connectionStore["telegram"]?.accountInfo).toBe("@existing_bot");
+  });
 });
 
 describe("backfillManualTokenConnections", () => {
@@ -299,6 +372,8 @@ describe("backfillManualTokenConnections", () => {
     connectionStore = {};
     deletedConnectionIds = [];
     createdConnections = [];
+    updatedConnections = [];
+    telegramBotUsername = undefined;
     warnings.length = 0;
   });
 

--- a/assistant/src/__tests__/oauth-commands-routes.test.ts
+++ b/assistant/src/__tests__/oauth-commands-routes.test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 interface MockProviderRow {
   provider: string;
+  authorizeUrl: string;
   managedServiceConfigKey: string | null;
   baseUrl: string | null;
   injectionTemplates: string | null;
@@ -32,6 +33,7 @@ interface MockProviderRow {
 
 const baseProvider: MockProviderRow = {
   provider: "google",
+  authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   managedServiceConfigKey: "google-oauth",
   baseUrl: "https://api.google.com",
   injectionTemplates: null,
@@ -69,6 +71,7 @@ let mockResolveResponse: {
   body: unknown;
 } = { status: 200, headers: {}, body: { ok: true } };
 let mockResolveRequests: unknown[] = [];
+let mockSyncManualTokenCalls: string[] = [];
 
 const mockDisconnectOAuthProvider = mock(() => Promise.resolve());
 const mockSaveRawConfig = mock(() => undefined);
@@ -115,6 +118,12 @@ mock.module("../oauth/connection-resolver.js", () => ({
       return mockResolveResponse;
     },
   }),
+}));
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  syncManualTokenConnection: async (provider: string) => {
+    mockSyncManualTokenCalls.push(provider);
+  },
 }));
 
 mock.module("../platform/client.js", () => ({
@@ -212,6 +221,7 @@ beforeEach(() => {
   });
   mockResolveResponse = { status: 200, headers: {}, body: { ok: true } };
   mockResolveRequests = [];
+  mockSyncManualTokenCalls = [];
   mockDisconnectOAuthProvider.mockClear();
   mockSaveRawConfig.mockClear();
 });
@@ -473,6 +483,33 @@ describe("GET oauth/status", () => {
       makeArgs({ queryParams: { provider: "google" } }),
     )) as { connections: Array<{ grantedScopes: string[] }> };
     expect(result.connections[0]!.grantedScopes).toEqual([]);
+  });
+
+  test("BYO mode reconciles manual-token providers before listing status", async () => {
+    mockProviders.telegram = {
+      ...baseProvider,
+      provider: "telegram",
+      authorizeUrl: "urn:manual-token",
+      managedServiceConfigKey: null,
+      baseUrl: "https://api.telegram.org",
+    };
+    mockAllConnections.telegram = [
+      {
+        id: "conn-telegram",
+        accountInfo: "@example_bot",
+        grantedScopes: "[]",
+        status: "active",
+        hasRefreshToken: 0,
+        expiresAt: null,
+      },
+    ];
+
+    const result = (await getRoute("GET", "oauth/status").handler(
+      makeArgs({ queryParams: { provider: "telegram" } }),
+    )) as { connections: Array<{ account: string | null }> };
+
+    expect(mockSyncManualTokenCalls).toEqual(["telegram"]);
+    expect(result.connections[0]!.account).toBe("@example_bot");
   });
 
   test("managed mode surfaces platform connections", async () => {

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -130,6 +130,7 @@ mock.module("./oauth-store.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
+import { credentialKey } from "../security/credential-key.js";
 import { setSecureKeyAsync } from "../security/secure-keys.js";
 import {
   _resetInflightRefreshes,
@@ -251,9 +252,20 @@ function createConnection(service = "google"): BYOOAuthConnection {
   return new BYOOAuthConnection({
     id: `conn-${service}`,
     provider: service,
-    baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    baseUrl:
+      service === "telegram"
+        ? "https://api.telegram.org"
+        : "https://gmail.googleapis.com/gmail/v1/users/me",
     accountInfo: null,
   });
+}
+
+async function setupTelegramCredential() {
+  await setupCredential("telegram");
+  await setSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+    "telegram-test-token",
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -436,6 +448,58 @@ describe("BYOOAuthConnection", () => {
       const headers = (init as RequestInit).headers as Headers;
       expect(headers.get("X-Custom-Header")).toBe("custom-value");
       expect(headers.get("Authorization")).toBe("Bearer test-access-token");
+    });
+
+    test("uses Telegram Bot API token URL format without Bearer auth", async () => {
+      await setupTelegramCredential();
+      const conn = createConnection("telegram");
+
+      const result = await conn.request({
+        method: "GET",
+        path: "/getMe",
+      });
+
+      expect(result.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://api.telegram.org/bottelegram-test-token/getMe");
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.has("Authorization")).toBe(false);
+    });
+
+    test("does not double-prefix Telegram paths that already include bot token", async () => {
+      await setupTelegramCredential();
+      const conn = createConnection("telegram");
+
+      await conn.request({
+        method: "GET",
+        path: "/bottelegram-test-token/getMe",
+      });
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://api.telegram.org/bottelegram-test-token/getMe");
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.has("Authorization")).toBe(false);
+    });
+
+    test("returns Telegram 401 responses without OAuth refresh", async () => {
+      await setupTelegramCredential();
+      const conn = createConnection("telegram");
+      const refreshCallsBefore = mockRefreshOAuth2Token.mock.calls.length;
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response("Unauthorized", { status: 401 })),
+      ) as unknown as typeof fetch;
+
+      const result = await conn.request({
+        method: "GET",
+        path: "/getMe",
+      });
+
+      expect(result.status).toBe(401);
+      expect(result.body).toBe("Unauthorized");
+      expect(mockRefreshOAuth2Token.mock.calls.length).toBe(refreshCallsBefore);
     });
   });
 

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -46,7 +46,11 @@ export class BYOOAuthConnection implements OAuthConnection {
       this.provider,
       async (token) => {
         const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
-        let fullUrl = `${effectiveBaseUrl}${req.path}`;
+        const isTelegram = this.provider === "telegram";
+        const requestPath = isTelegram
+          ? buildTelegramBotApiPath(req.path, token)
+          : req.path;
+        let fullUrl = `${effectiveBaseUrl}${requestPath}`;
 
         if (req.query && Object.keys(req.query).length > 0) {
           const params = new URLSearchParams();
@@ -60,8 +64,12 @@ export class BYOOAuthConnection implements OAuthConnection {
           fullUrl += `?${params.toString()}`;
         }
 
+        const logUrl = isTelegram
+          ? redactTelegramBotTokenFromUrl(fullUrl, token)
+          : fullUrl;
+
         log.debug(
-          { method: req.method, url: fullUrl, provider: this.provider },
+          { method: req.method, url: logUrl, provider: this.provider },
           "Making authenticated request",
         );
 
@@ -76,18 +84,23 @@ export class BYOOAuthConnection implements OAuthConnection {
             headers.set(key, value);
           }
         }
-        headers.set("Authorization", `Bearer ${token}`);
+        if (!isTelegram) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
 
         const resp = await fetch(fullUrl, {
           method: req.method,
           headers,
           body: req.body ? JSON.stringify(req.body) : undefined,
           signal: req.signal
-            ? AbortSignal.any([req.signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+            ? AbortSignal.any([
+                req.signal,
+                AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+              ])
             : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         });
 
-        if (resp.status === 401) {
+        if (resp.status === 401 && !isTelegram) {
           // Throw with a status property so withValidToken detects the 401
           // and triggers its refresh-and-retry logic.
           const err = new Error(`HTTP 401 from ${this.provider}`);
@@ -106,6 +119,20 @@ export class BYOOAuthConnection implements OAuthConnection {
       connectionId: this.id,
     });
   }
+}
+
+function buildTelegramBotApiPath(path: string, token: string): string {
+  if (path.startsWith("/bot")) return path;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `/bot${token}${normalizedPath}`;
+}
+
+function redactTelegramBotTokenFromUrl(url: string, token: string): string {
+  const redactedStoredToken = url.split(token).join("[REDACTED]");
+  return redactedStoredToken.replace(
+    /\/bot[^/?#]+(?=\/|[?#]|$)/g,
+    "/bot[REDACTED]",
+  );
 }
 
 async function buildResponse(resp: Response): Promise<OAuthConnectionResponse> {

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -9,6 +9,7 @@ let mockConnection: Record<string, unknown> | undefined;
 let mockAccessToken: string | undefined;
 let mockConfig: Record<string, unknown> = {};
 let mockPlatformClient: Record<string, unknown> | null = null;
+let syncManualTokenCalls: string[] = [];
 
 // ---------------------------------------------------------------------------
 // Module mocks (must precede imports of the module under test)
@@ -45,6 +46,15 @@ mock.module("./credential-token-resolver.js", () => ({
     unreachable: false,
     key: "mock-key",
   }),
+}));
+
+mock.module("./manual-token-connection.js", () => ({
+  syncManualTokenConnection: async (provider: string) => {
+    syncManualTokenCalls.push(provider);
+    if (provider === "telegram" && mockConnection?.provider === "telegram") {
+      mockConnection.accountInfo = "@example_bot";
+    }
+  },
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -92,6 +102,7 @@ function setupDefaults(): void {
   mockProvider = {
     provider: "google",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     managedServiceConfigKey: null,
   };
   mockConnection = {
@@ -121,6 +132,7 @@ function setupDefaults(): void {
     },
   };
   mockPlatformClient = makeMockClient();
+  syncManualTokenCalls = [];
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +263,34 @@ describe("resolveOAuthConnection", () => {
         clientId: "wrong-client",
       }),
     ).rejects.toThrow(/No active OAuth connection found/);
+  });
+
+  test("BYO path reconciles manual-token providers before exact account lookup", async () => {
+    mockProvider = {
+      provider: "telegram",
+      baseUrl: "https://api.telegram.org",
+      authorizeUrl: "urn:manual-token",
+      managedServiceConfigKey: null,
+    };
+    mockConnection = {
+      id: "conn-telegram",
+      provider: "telegram",
+      oauthAppId: "app-telegram",
+      accountInfo: null,
+      grantedScopes: JSON.stringify([]),
+      status: "active",
+      clientId: "manual-config",
+    };
+    mockAccessToken = "telegram-test-token";
+
+    const result = await resolveOAuthConnection("telegram", {
+      account: "@example_bot",
+    });
+
+    expect(syncManualTokenCalls).toEqual(["telegram"]);
+    expect(mockConnection.accountInfo).toBe("@example_bot");
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("conn-telegram");
   });
 });
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -9,6 +9,7 @@ import { getLogger } from "../util/logger.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
 import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
+import { syncManualTokenConnection } from "./manual-token-connection.js";
 import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
@@ -82,6 +83,10 @@ export async function resolveOAuthConnection(
   }
 
   // BYO path — requires a local connection row, access token, and base URL.
+  if (providerRow?.authorizeUrl === "urn:manual-token") {
+    await syncManualTokenConnection(provider);
+  }
+
   const conn = getActiveConnection(provider, { clientId, account });
   if (!conn) {
     const filters = [

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -10,6 +10,7 @@
 
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyResultAsync } from "../security/secure-keys.js";
+import { getTelegramBotUsername } from "../telegram/bot-username.js";
 import { getLogger } from "../util/logger.js";
 import {
   createConnection,
@@ -23,6 +24,44 @@ const log = getLogger("manual-token-connection");
 
 /** Sentinel client_id used for non-OAuth providers that don't have a real app. */
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
+
+type ResolvedAccountInfoSource = "provided" | "derived" | "none";
+
+interface ResolvedAccountInfo {
+  value?: string;
+  source: ResolvedAccountInfoSource;
+}
+
+function resolveManualTokenAccountInfo(
+  provider: string,
+  accountInfo?: string,
+): ResolvedAccountInfo {
+  if (accountInfo !== undefined) {
+    return { value: accountInfo, source: "provided" };
+  }
+
+  if (provider === "telegram") {
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) return { source: "none" };
+    return {
+      value: botUsername.startsWith("@") ? botUsername : `@${botUsername}`,
+      source: "derived",
+    };
+  }
+
+  return { source: "none" };
+}
+
+function accountInfoForManualTokenSync(
+  provider: string,
+  resolved: ResolvedAccountInfo,
+): string | undefined {
+  if (resolved.source !== "derived") return resolved.value;
+
+  const existing = getConnectionByProvider(provider);
+  if (existing?.accountInfo) return undefined;
+  return resolved.value;
+}
 
 /**
  * Ensure an active oauth_connection row exists for the given manual-token
@@ -79,6 +118,15 @@ export async function syncManualTokenConnection(
   provider: string,
   accountInfo?: string,
 ): Promise<void> {
+  const resolvedAccountInfo = resolveManualTokenAccountInfo(
+    provider,
+    accountInfo,
+  );
+  const accountInfoToStore = accountInfoForManualTokenSync(
+    provider,
+    resolvedAccountInfo,
+  );
+
   switch (provider) {
     case "telegram": {
       const botTokenResult = await getSecureKeyResultAsync(
@@ -94,7 +142,7 @@ export async function syncManualTokenConnection(
         return;
       }
       if (botTokenResult.value && webhookSecretResult.value) {
-        await ensureManualTokenConnection(provider, accountInfo);
+        await ensureManualTokenConnection(provider, accountInfoToStore);
       } else {
         removeManualTokenConnection(provider);
       }
@@ -115,7 +163,7 @@ export async function syncManualTokenConnection(
         return;
       }
       if (botTokenResult.value && appTokenResult.value) {
-        await ensureManualTokenConnection(provider, accountInfo);
+        await ensureManualTokenConnection(provider, accountInfoToStore);
       } else {
         removeManualTokenConnection(provider);
       }
@@ -133,7 +181,7 @@ export async function syncManualTokenConnection(
         return;
       }
       if (tokenResult.value) {
-        await ensureManualTokenConnection(provider, accountInfo);
+        await ensureManualTokenConnection(provider, accountInfoToStore);
       } else {
         removeManualTokenConnection(provider);
       }

--- a/assistant/src/runtime/routes/oauth-commands-routes.ts
+++ b/assistant/src/runtime/routes/oauth-commands-routes.ts
@@ -23,6 +23,7 @@ import {
   resolveOAuthConnection,
   type ResolveOAuthConnectionOptions,
 } from "../../oauth/connection-resolver.js";
+import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import {
   disconnectOAuthProvider,
   getActiveConnection,
@@ -516,6 +517,10 @@ async function handleStatus({ queryParams = {} }: RouteHandlerArgs) {
   }
 
   // BYO path
+  if (providerRow.authorizeUrl === "urn:manual-token") {
+    await syncManualTokenConnection(provider);
+  }
+
   const allConnections = listConnections(provider);
   const activeRows = allConnections.filter((r) => r.status === "active");
 


### PR DESCRIPTION
## Summary
- Reconcile manual-token providers before `oauth status` listing and BYO resolver lookup, so stale Telegram rows with blank account labels are backfilled before exact `--account` matching.
- Derive Telegram account labels from the configured bot username only when the stored label is missing or blank; existing non-empty labels are preserved for backwards compatibility.
- Send Telegram Bot API requests as `/bot<TOKEN>/<method>` without a Bearer header, redact bot tokens from request logs, and return Telegram 401 responses without attempting OAuth refresh.

## RCA
- `assistant oauth status telegram` listed active local `oauth_connection` rows directly from the store.
- `assistant oauth request --provider telegram --account ...` went through `resolveOAuthConnection()`, which performed an exact `accountInfo` lookup before reconciling manual-token metadata.
- Generic credential setup paths could create the synthetic Telegram connection with `accountInfo = null`, while dedicated Telegram config paths knew the bot username. That made status look active but explicit-account request lookup miss the stored row.
- Telegram also diverges from Google/Outlook because it is a manual-token Bot API provider, not OAuth Bearer auth.

## Backwards compatibility
- No migration is required; reconciliation runs lazily on status/request reads and remains non-destructive when the credential backend is unreachable.
- Existing Telegram rows with non-empty account labels are not overwritten by lazy bot-username derivation.
- The no-account request fallback still uses the existing first-active-connection lookup.
- Non-Telegram BYO providers continue to use Bearer auth and OAuth 401 refresh behavior.

## Tests
- `cd assistant && bun test src/__tests__/manual-token-reconciliation.test.ts`
- `cd assistant && bun test src/oauth/connection-resolver.test.ts`
- `cd assistant && bun test src/oauth/byo-connection.test.ts`
- `cd assistant && bun test src/__tests__/oauth-commands-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun run lint`
