### PR TITLE
[codex] Focus chat input for new conversations

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -276,6 +276,7 @@ export function ChatLayout() {
     const draftConversationId = createDraftConversationId();
     useConversationStore.getState().setActiveConversationId(draftConversationId);
     void navigate(routes.conversation(draftConversationId));
+    requestComposerFocus();
   }, [navigate]);
 
   const handleOpenHome = useCallback(() => {
@@ -487,6 +488,7 @@ export function ChatLayout() {
       const draftConversationId = createDraftConversationId();
       useConversationStore.getState().setActiveConversationId(draftConversationId);
       void navigate(routes.conversation(draftConversationId));
+      requestComposerFocus();
     },
     [navigate],
   );

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -29,6 +29,9 @@ import { useConversationStore } from "@/domains/conversations/conversation-store
 import {
   COMPOSER_FOCUS_EVENT,
   consumePendingComposerFocus,
+  insertTextAtSelection,
+  requestComposerFocus,
+  shouldFocusComposerForTyping,
 } from "./composer-focus";
 import {
   useConversationGroupsQuery,
@@ -292,11 +295,16 @@ export function ChatPage() {
   // chat-layout navigated us here) — see `./composer-focus.ts`.
   useEffect(() => {
     const focusInput = () => inputRef.current?.focus();
-    window.addEventListener(COMPOSER_FOCUS_EVENT, focusInput);
+    const handleFocusRequest = () => {
+      consumePendingComposerFocus();
+      focusInput();
+    };
+    window.addEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
     if (consumePendingComposerFocus()) {
       queueMicrotask(focusInput);
     }
-    return () => window.removeEventListener(COMPOSER_FOCUS_EVENT, focusInput);
+    return () =>
+      window.removeEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
   }, []);
 
   const activeConversationIdRef = useRef<string | null>(activeConversationId);
@@ -383,6 +391,36 @@ export function ChatPage() {
     draftConversationIdResolutionRef,
     onDraftRestored: setRestoredDraftConversationId,
   });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const inputEl = inputRef.current;
+      if (!inputEl || inputEl.disabled || inputEl.readOnly) return;
+      if (document.activeElement === inputEl) return;
+      if (document.querySelector('[aria-modal="true"]')) return;
+      if (!shouldFocusComposerForTyping(event, document.activeElement)) return;
+
+      event.preventDefault();
+      inputEl.focus();
+      setInput((current) => {
+        const next = insertTextAtSelection({
+          value: current,
+          text: event.key,
+          selectionStart: inputEl.selectionStart,
+          selectionEnd: inputEl.selectionEnd,
+        });
+        requestAnimationFrame(() => {
+          inputEl.setSelectionRange(next.cursor, next.cursor);
+        });
+        return next.value;
+      });
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+    };
+  }, [setInput]);
 
   // -------------------------------------------------------------------------
   // Attachments
@@ -500,6 +538,7 @@ export function ChatPage() {
     (opts: { silent?: boolean; initialMessage?: string } = {}) => {
       useSubagentStore.getState().reset();
       rawStartNewConversation(opts);
+      requestComposerFocus();
     },
     [rawStartNewConversation],
   );

--- a/apps/web/src/domains/chat/composer-focus.test.ts
+++ b/apps/web/src/domains/chat/composer-focus.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  insertTextAtSelection,
+  shouldFocusComposerForTyping,
+} from "@/domains/chat/composer-focus";
+
+const BASE_EVENT = {
+  altKey: false,
+  ctrlKey: false,
+  defaultPrevented: false,
+  isComposing: false,
+  key: "a",
+  keyCode: 65,
+  metaKey: false,
+} satisfies Parameters<typeof shouldFocusComposerForTyping>[0];
+
+describe("shouldFocusComposerForTyping", () => {
+  test("allows ordinary printable typing outside text entry controls", () => {
+    const button = document.createElement("button");
+    expect(shouldFocusComposerForTyping(BASE_EVENT, button)).toBe(true);
+  });
+
+  test("does not steal typing from text entry controls", () => {
+    const input = document.createElement("input");
+    expect(shouldFocusComposerForTyping(BASE_EVENT, input)).toBe(false);
+  });
+
+  test("does not steal shortcut or non-printable keys", () => {
+    expect(
+      shouldFocusComposerForTyping({ ...BASE_EVENT, metaKey: true }, null),
+    ).toBe(false);
+    expect(
+      shouldFocusComposerForTyping({ ...BASE_EVENT, key: "Enter" }, null),
+    ).toBe(false);
+  });
+
+  test("does not steal Space activation from focused buttons", () => {
+    const button = document.createElement("button");
+    expect(
+      shouldFocusComposerForTyping({ ...BASE_EVENT, key: " " }, button),
+    ).toBe(false);
+  });
+});
+
+describe("insertTextAtSelection", () => {
+  test("inserts text at the cursor", () => {
+    expect(
+      insertTextAtSelection({
+        value: "helo",
+        text: "l",
+        selectionStart: 2,
+        selectionEnd: 2,
+      }),
+    ).toEqual({ value: "hello", cursor: 3 });
+  });
+
+  test("replaces selected text and clamps stale selection offsets", () => {
+    expect(
+      insertTextAtSelection({
+        value: "hello",
+        text: "!",
+        selectionStart: 4,
+        selectionEnd: 99,
+      }),
+    ).toEqual({ value: "hell!", cursor: 5 });
+  });
+});

--- a/apps/web/src/domains/chat/composer-focus.ts
+++ b/apps/web/src/domains/chat/composer-focus.ts
@@ -31,3 +31,69 @@ export function consumePendingComposerFocus(): boolean {
   pending = false;
   return wasPending;
 }
+
+type ComposerTypingKeyEvent = Pick<
+  KeyboardEvent,
+  | "altKey"
+  | "ctrlKey"
+  | "defaultPrevented"
+  | "isComposing"
+  | "key"
+  | "keyCode"
+  | "metaKey"
+>;
+
+const TEXT_ENTRY_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[role="textbox"]',
+].join(",");
+
+function isTextEntryElement(element: Element | null): boolean {
+  return Boolean(element?.closest(TEXT_ENTRY_SELECTOR));
+}
+
+function isKeyboardActivationElement(element: Element | null): boolean {
+  return Boolean(element?.closest("a[href], button, summary"));
+}
+
+export function shouldFocusComposerForTyping(
+  event: ComposerTypingKeyEvent,
+  activeElement: Element | null,
+): boolean {
+  if (event.defaultPrevented) return false;
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+  if (event.isComposing || event.keyCode === 229) return false;
+  if (event.key.length !== 1) return false;
+  if (isTextEntryElement(activeElement)) return false;
+  if (event.key === " " && isKeyboardActivationElement(activeElement)) {
+    return false;
+  }
+  return true;
+}
+
+export function insertTextAtSelection({
+  value,
+  text,
+  selectionStart,
+  selectionEnd,
+}: {
+  value: string;
+  text: string;
+  selectionStart: number | null | undefined;
+  selectionEnd: number | null | undefined;
+}): { value: string; cursor: number } {
+  const start = Math.max(
+    0,
+    Math.min(selectionStart ?? value.length, value.length),
+  );
+  const end = Math.max(
+    start,
+    Math.min(selectionEnd ?? start, value.length),
+  );
+  const nextValue = value.slice(0, start) + text + value.slice(end);
+  return { value: nextValue, cursor: start + text.length };
+}

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { Typography } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate";
 import { useAssistantContext } from "@/components/layout/assistant-context";
+import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationListQuery } from "@/domains/conversations/conversation-queries";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
@@ -37,7 +38,10 @@ export function HomePageRoute() {
     <HomePage
       assistantId={assistantId}
       validConversationIds={validConversationIds}
-      onStartNewChat={() => navigate(routes.assistant)}
+      onStartNewChat={() => {
+        navigate(routes.assistant);
+        requestComposerFocus();
+      }}
       onOpenConversation={(conversationId) =>
         navigate(routes.conversation(conversationId))
       }


### PR DESCRIPTION
## Summary

- Request composer focus whenever a new chat route is created from the sidebar, command flow, or Home entry point.
- Add a guarded global typing fallback so printable typing focuses the visible composer and preserves the first keystroke.
- Add unit coverage for the typing focus predicate and selection insertion helper.

## Impact

Users who create a new conversation can begin typing immediately. If focus is lost while the composer is available, ordinary typing routes into the composer without stealing shortcuts, text-entry controls, or modal interactions.

## Validation

- `cd apps/web && bun test src/domains/chat/composer-focus.test.ts src/domains/chat/components/chat-composer/chat-composer.test.tsx`
- `cd apps/web && bunx eslint src/domains/chat/composer-focus.ts src/domains/chat/composer-focus.test.ts src/domains/chat/chat-page.tsx src/domains/chat/chat-layout.tsx src/home-page-route.tsx`
- `cd apps/web && bunx tsc --noEmit` fails on existing generated `@vellumai/assistant-api` export mismatches in chat event/inspector files, outside this diff.