### PR TITLE
fix(cli): health-aware process liveness checks for wake and startLocalDaemon

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -63,6 +63,12 @@ The CLI must **never** read from or write to the `.vellum/` directory (e.g. `~/.
 
 For example, the signing key used for JWT auth between the daemon and gateway is persisted in the lockfile (`resources.signingKey`) so that client actor tokens survive daemon/gateway restarts. On first start (or when the key is missing), the CLI generates a new key via `generateLocalSigningKey()` in `lib/local.ts`, saves it to the lockfile entry, and passes it to both `startLocalDaemon` and `startGateway` as the `ACTOR_TOKEN_SIGNING_KEY` env var. The CLI does **not** read or write to the `.vellum/` directory for signing keys — it uses the lockfile instead.
 
+## Process liveness
+
+Use `resolveProcessState()` from `lib/process.ts` when checking whether a daemon or gateway should be (re)started. It combines PID existence with an HTTP `/healthz` probe, a readiness grace period, and a [`isVellumProcess()`](https://man7.org/linux/man-pages/man1/ps.1.html) guard against PID reuse — see the function's JSDoc for the full flow.
+
+Reserve `isProcessAlive()` for teardown paths (`sleep`, `retire`) where you need to kill a process regardless of its health.
+
 ## Docker Volume Management
 
 The CLI creates and manages six per-instance Docker volumes with strict per-service access boundaries (least-privilege at the container level).

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -103,8 +103,24 @@ export async function wake(): Promise<void> {
         10_000,
       );
       if (becameHealthy) {
-        daemonRunning = true;
-        console.log(`Assistant running (pid ${daemonStatus.pid}).`);
+        if (watch) {
+          // Process recovered — but caller wants watch mode, so fall through
+          // to the watch-mode restart path below.
+          if (!isAssistantWatchModeAvailable()) {
+            daemonRunning = true;
+            console.log(
+              `Assistant running (pid ${daemonStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
+            );
+          } else {
+            console.log(
+              `Assistant running (pid ${daemonStatus.pid}) — restarting in watch mode...`,
+            );
+            await stopProcessByPidFile(pidFile, "assistant");
+          }
+        } else {
+          daemonRunning = true;
+          console.log(`Assistant running (pid ${daemonStatus.pid}).`);
+        }
       } else if (!isVellumProcess(daemonStatus.pid!)) {
         console.log(
           `Stale PID file (pid ${daemonStatus.pid} is not a Vellum process) — cleaning up...`,

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -10,9 +10,11 @@ import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { seedGuardianTokenFromSiblingEnv } from "../lib/guardian-token.js";
 import {
   isProcessHealthy,
+  isVellumProcess,
   stopProcess,
   stopProcessByPidFile,
 } from "../lib/process";
+import { waitForDaemonReady } from "../lib/http-client";
 import {
   generateLocalSigningKey,
   isAssistantWatchModeAvailable,
@@ -94,10 +96,25 @@ export async function wake(): Promise<void> {
   const daemonStatus = await isProcessHealthy(pidFile, resources.daemonPort);
   if (daemonStatus.alive) {
     if (!daemonStatus.healthy) {
-      console.log(
-        `Assistant process alive (pid ${daemonStatus.pid}) but not responding — killing and restarting...`,
+      // The process may still be starting up (fresh installs can take up to
+      // 60s). Wait briefly before concluding it is hung.
+      const becameHealthy = await waitForDaemonReady(
+        resources.daemonPort,
+        10_000,
       );
-      await stopProcess(daemonStatus.pid!, "assistant");
+      if (becameHealthy) {
+        daemonRunning = true;
+        console.log(`Assistant running (pid ${daemonStatus.pid}).`);
+      } else if (!isVellumProcess(daemonStatus.pid!)) {
+        console.log(
+          `Stale PID file (pid ${daemonStatus.pid} is not a Vellum process) — cleaning up...`,
+        );
+      } else {
+        console.log(
+          `Assistant process alive (pid ${daemonStatus.pid}) but not responding — killing and restarting...`,
+        );
+        await stopProcess(daemonStatus.pid!, "assistant");
+      }
     } else if (watch) {
       // Restart in watch mode — but only if source files are available.
       // Watch mode requires bun --watch with .ts sources; packaged desktop
@@ -184,13 +201,23 @@ export async function wake(): Promise<void> {
         console.log(`Gateway already running (pid ${gatewayStatus.pid}).`);
       }
     } else {
+      let gatewayStartNeeded = true;
       if (gatewayStatus.alive && !gatewayStatus.healthy) {
-        console.log(
-          `Gateway process alive (pid ${gatewayStatus.pid}) but not responding — killing and restarting...`,
-        );
-        await stopProcessByPidFile(gatewayPidFile, "gateway");
+        // Brief wait — gateway may still be initializing.
+        const gwReady = await waitForDaemonReady(resources.gatewayPort, 10_000);
+        if (gwReady) {
+          console.log(`Gateway already running (pid ${gatewayStatus.pid}).`);
+          gatewayStartNeeded = false;
+        } else {
+          console.log(
+            `Gateway process alive (pid ${gatewayStatus.pid}) but not responding — killing and restarting...`,
+          );
+          await stopProcessByPidFile(gatewayPidFile, "gateway");
+        }
       }
-      await startGateway(watch, resources, { signingKey });
+      if (gatewayStartNeeded) {
+        await startGateway(watch, resources, { signingKey });
+      }
     }
   }
 

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -8,7 +8,11 @@ import {
 } from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { seedGuardianTokenFromSiblingEnv } from "../lib/guardian-token.js";
-import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
+import {
+  isProcessHealthy,
+  stopProcess,
+  stopProcessByPidFile,
+} from "../lib/process";
 import {
   generateLocalSigningKey,
   isAssistantWatchModeAvailable,
@@ -85,37 +89,34 @@ export async function wake(): Promise<void> {
 
   const pidFile = getDaemonPidPath(resources);
 
-  // Check if daemon is already running
+  // Check if daemon is already running and healthy
   let daemonRunning = false;
-  if (existsSync(pidFile)) {
-    const pidStr = readFileSync(pidFile, "utf-8").trim();
-    const pid = parseInt(pidStr, 10);
-    if (!isNaN(pid)) {
-      try {
-        process.kill(pid, 0);
+  const daemonStatus = await isProcessHealthy(pidFile, resources.daemonPort);
+  if (daemonStatus.alive) {
+    if (!daemonStatus.healthy) {
+      console.log(
+        `Assistant process alive (pid ${daemonStatus.pid}) but not responding — killing and restarting...`,
+      );
+      await stopProcess(daemonStatus.pid!, "assistant");
+    } else if (watch) {
+      // Restart in watch mode — but only if source files are available.
+      // Watch mode requires bun --watch with .ts sources; packaged desktop
+      // builds only have a compiled binary. Stopping the daemon without a
+      // viable watch-mode path would leave the user with no running assistant.
+      if (!isAssistantWatchModeAvailable()) {
         daemonRunning = true;
-        if (watch) {
-          // Restart in watch mode — but only if source files are available.
-          // Watch mode requires bun --watch with .ts sources; packaged desktop
-          // builds only have a compiled binary. Stopping the daemon without a
-          // viable watch-mode path would leave the user with no running assistant.
-          if (!isAssistantWatchModeAvailable()) {
-            console.log(
-              `Assistant running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
-            );
-          } else {
-            console.log(
-              `Assistant running (pid ${pid}) — restarting in watch mode...`,
-            );
-            await stopProcessByPidFile(pidFile, "assistant");
-            daemonRunning = false;
-          }
-        } else {
-          console.log(`Assistant already running (pid ${pid}).`);
-        }
-      } catch {
-        // Process not alive, will start below
+        console.log(
+          `Assistant running (pid ${daemonStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
+        );
+      } else {
+        console.log(
+          `Assistant running (pid ${daemonStatus.pid}) — restarting in watch mode...`,
+        );
+        await stopProcessByPidFile(pidFile, "assistant");
       }
+    } else {
+      daemonRunning = true;
+      console.log(`Assistant already running (pid ${daemonStatus.pid}).`);
     }
   }
 
@@ -161,25 +162,34 @@ export async function wake(): Promise<void> {
   {
     const vellumDir = join(resources.instanceDir, ".vellum");
     const gatewayPidFile = join(vellumDir, "gateway.pid");
-    const { alive, pid } = isProcessAlive(gatewayPidFile);
-    if (alive) {
+    const gatewayStatus = await isProcessHealthy(
+      gatewayPidFile,
+      resources.gatewayPort,
+    );
+    if (gatewayStatus.alive && gatewayStatus.healthy) {
       if (watch) {
         // Guard gateway restart separately: check gateway source availability.
         if (!isGatewayWatchModeAvailable()) {
           console.log(
-            `Gateway running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
+            `Gateway running (pid ${gatewayStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
           );
         } else {
           console.log(
-            `Gateway running (pid ${pid}) — restarting in watch mode...`,
+            `Gateway running (pid ${gatewayStatus.pid}) — restarting in watch mode...`,
           );
           await stopProcessByPidFile(gatewayPidFile, "gateway");
           await startGateway(watch, resources, { signingKey });
         }
       } else {
-        console.log(`Gateway already running (pid ${pid}).`);
+        console.log(`Gateway already running (pid ${gatewayStatus.pid}).`);
       }
     } else {
+      if (gatewayStatus.alive && !gatewayStatus.healthy) {
+        console.log(
+          `Gateway process alive (pid ${gatewayStatus.pid}) but not responding — killing and restarting...`,
+        );
+        await stopProcessByPidFile(gatewayPidFile, "gateway");
+      }
       await startGateway(watch, resources, { signingKey });
     }
   }
@@ -196,7 +206,10 @@ export async function wake(): Promise<void> {
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
   const workspaceDir = join(resources.instanceDir, ".vellum", "workspace");
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort, workspaceDir);
+  const ngrokChild = await maybeStartNgrokTunnel(
+    resources.gatewayPort,
+    workspaceDir,
+  );
   if (ngrokChild?.pid) {
     const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
     writeFileSync(ngrokPidFile, String(ngrokChild.pid));

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -8,13 +8,7 @@ import {
 } from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { seedGuardianTokenFromSiblingEnv } from "../lib/guardian-token.js";
-import {
-  isProcessHealthy,
-  isVellumProcess,
-  stopProcess,
-  stopProcessByPidFile,
-} from "../lib/process";
-import { waitForDaemonReady } from "../lib/http-client";
+import { resolveProcessState, stopProcessByPidFile } from "../lib/process";
 import {
   generateLocalSigningKey,
   isAssistantWatchModeAvailable,
@@ -91,65 +85,27 @@ export async function wake(): Promise<void> {
 
   const pidFile = getDaemonPidPath(resources);
 
-  // Check if daemon is already running and healthy
   let daemonRunning = false;
-  const daemonStatus = await isProcessHealthy(pidFile, resources.daemonPort);
-  if (daemonStatus.alive) {
-    if (!daemonStatus.healthy) {
-      // The process may still be starting up (fresh installs can take up to
-      // 60s). Wait briefly before concluding it is hung.
-      const becameHealthy = await waitForDaemonReady(
-        resources.daemonPort,
-        10_000,
+  const daemonState = await resolveProcessState(
+    pidFile,
+    resources.daemonPort,
+    "Assistant",
+  );
+  if (daemonState.status === "healthy") {
+    if (watch && isAssistantWatchModeAvailable()) {
+      console.log(
+        `Assistant running (pid ${daemonState.pid}) — restarting in watch mode...`,
       );
-      if (becameHealthy) {
-        if (watch) {
-          // Process recovered — but caller wants watch mode, so fall through
-          // to the watch-mode restart path below.
-          if (!isAssistantWatchModeAvailable()) {
-            daemonRunning = true;
-            console.log(
-              `Assistant running (pid ${daemonStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
-            );
-          } else {
-            console.log(
-              `Assistant running (pid ${daemonStatus.pid}) — restarting in watch mode...`,
-            );
-            await stopProcessByPidFile(pidFile, "assistant");
-          }
-        } else {
-          daemonRunning = true;
-          console.log(`Assistant running (pid ${daemonStatus.pid}).`);
-        }
-      } else if (!isVellumProcess(daemonStatus.pid!)) {
-        console.log(
-          `Stale PID file (pid ${daemonStatus.pid} is not a Vellum process) — cleaning up...`,
-        );
-      } else {
-        console.log(
-          `Assistant process alive (pid ${daemonStatus.pid}) but not responding — killing and restarting...`,
-        );
-        await stopProcess(daemonStatus.pid!, "assistant");
-      }
-    } else if (watch) {
-      // Restart in watch mode — but only if source files are available.
-      // Watch mode requires bun --watch with .ts sources; packaged desktop
-      // builds only have a compiled binary. Stopping the daemon without a
-      // viable watch-mode path would leave the user with no running assistant.
-      if (!isAssistantWatchModeAvailable()) {
-        daemonRunning = true;
-        console.log(
-          `Assistant running (pid ${daemonStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
-        );
-      } else {
-        console.log(
-          `Assistant running (pid ${daemonStatus.pid}) — restarting in watch mode...`,
-        );
-        await stopProcessByPidFile(pidFile, "assistant");
-      }
+      await stopProcessByPidFile(pidFile, "assistant");
     } else {
       daemonRunning = true;
-      console.log(`Assistant already running (pid ${daemonStatus.pid}).`);
+      if (watch) {
+        console.log(
+          `Assistant running (pid ${daemonState.pid}) — watch mode not available (no source files). Keeping existing process.`,
+        );
+      } else {
+        console.log(`Assistant already running (pid ${daemonState.pid}).`);
+      }
     }
   }
 
@@ -195,45 +151,29 @@ export async function wake(): Promise<void> {
   {
     const vellumDir = join(resources.instanceDir, ".vellum");
     const gatewayPidFile = join(vellumDir, "gateway.pid");
-    const gatewayStatus = await isProcessHealthy(
+    const gatewayState = await resolveProcessState(
       gatewayPidFile,
       resources.gatewayPort,
+      "Gateway",
     );
-    if (gatewayStatus.alive && gatewayStatus.healthy) {
-      if (watch) {
-        // Guard gateway restart separately: check gateway source availability.
-        if (!isGatewayWatchModeAvailable()) {
+    if (gatewayState.status === "healthy") {
+      if (watch && isGatewayWatchModeAvailable()) {
+        console.log(
+          `Gateway running (pid ${gatewayState.pid}) — restarting in watch mode...`,
+        );
+        await stopProcessByPidFile(gatewayPidFile, "gateway");
+        await startGateway(watch, resources, { signingKey });
+      } else {
+        if (watch) {
           console.log(
-            `Gateway running (pid ${gatewayStatus.pid}) — watch mode not available (no source files). Keeping existing process.`,
+            `Gateway running (pid ${gatewayState.pid}) — watch mode not available (no source files). Keeping existing process.`,
           );
         } else {
-          console.log(
-            `Gateway running (pid ${gatewayStatus.pid}) — restarting in watch mode...`,
-          );
-          await stopProcessByPidFile(gatewayPidFile, "gateway");
-          await startGateway(watch, resources, { signingKey });
+          console.log(`Gateway already running (pid ${gatewayState.pid}).`);
         }
-      } else {
-        console.log(`Gateway already running (pid ${gatewayStatus.pid}).`);
       }
     } else {
-      let gatewayStartNeeded = true;
-      if (gatewayStatus.alive && !gatewayStatus.healthy) {
-        // Brief wait — gateway may still be initializing.
-        const gwReady = await waitForDaemonReady(resources.gatewayPort, 10_000);
-        if (gwReady) {
-          console.log(`Gateway already running (pid ${gatewayStatus.pid}).`);
-          gatewayStartNeeded = false;
-        } else {
-          console.log(
-            `Gateway process alive (pid ${gatewayStatus.pid}) but not responding — killing and restarting...`,
-          );
-          await stopProcessByPidFile(gatewayPidFile, "gateway");
-        }
-      }
-      if (gatewayStartNeeded) {
-        await startGateway(watch, resources, { signingKey });
-      }
+      await startGateway(watch, resources, { signingKey });
     }
   }
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -17,7 +17,11 @@ import {
 } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
-import { stopProcessByPidFile } from "./process.js";
+import {
+  isProcessHealthy,
+  stopProcess,
+  stopProcessByPidFile,
+} from "./process.js";
 import { openLogFile, pipeToLogFile } from "./xdg-log.js";
 
 const _require = createRequire(import.meta.url);
@@ -355,11 +359,22 @@ async function startDaemonFromSource(
 
       const pid = parseInt(content, 10);
       if (!isNaN(pid)) {
-        try {
-          process.kill(pid, 0);
+        const { alive, healthy } = await isProcessHealthy(
+          pidFile,
+          resources.daemonPort,
+        );
+        if (alive && healthy) {
           console.log(`   Assistant already running (pid ${pid})\n`);
           return;
-        } catch {
+        } else if (alive) {
+          console.log(
+            `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+          );
+          await stopProcess(pid, "assistant");
+          try {
+            unlinkSync(pidFile);
+          } catch {}
+        } else {
           try {
             unlinkSync(pidFile);
           } catch {}
@@ -492,11 +507,22 @@ async function startDaemonWatchFromSource(
 
       const pid = parseInt(content, 10);
       if (!isNaN(pid)) {
-        try {
-          process.kill(pid, 0); // Check if alive
+        const { alive, healthy } = await isProcessHealthy(
+          pidFile,
+          resources.daemonPort,
+        );
+        if (alive && healthy) {
           console.log(`   Assistant already running (pid ${pid})\n`);
           return;
-        } catch {
+        } else if (alive) {
+          console.log(
+            `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+          );
+          await stopProcess(pid, "assistant");
+          try {
+            unlinkSync(pidFile);
+          } catch {}
+        } else {
           // Process doesn't exist, clean up stale PID file
           try {
             unlinkSync(pidFile);
@@ -927,11 +953,22 @@ export async function startLocalDaemon(
 
         const pid = parseInt(content, 10);
         if (!isNaN(pid)) {
-          try {
-            process.kill(pid, 0); // Check if alive
+          const { alive, healthy } = await isProcessHealthy(
+            pidFile,
+            resources.daemonPort,
+          );
+          if (alive && healthy) {
             daemonAlive = true;
             console.log(`   Assistant already running (pid ${pid})\n`);
-          } catch {
+          } else if (alive) {
+            console.log(
+              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+            );
+            await stopProcess(pid, "assistant");
+            try {
+              unlinkSync(pidFile);
+            } catch {}
+          } else {
             // Process doesn't exist, clean up stale PID file
             try {
               unlinkSync(pidFile);

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -19,6 +19,7 @@ import { GATEWAY_PORT } from "./constants.js";
 import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
 import {
   isProcessHealthy,
+  isVellumProcess,
   stopProcess,
   stopProcessByPidFile,
 } from "./process.js";
@@ -367,10 +368,21 @@ async function startDaemonFromSource(
           console.log(`   Assistant already running (pid ${pid})\n`);
           return;
         } else if (alive) {
-          console.log(
-            `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+          // The process may still be starting up — wait briefly before killing.
+          const becameHealthy = await waitForDaemonReady(
+            resources.daemonPort,
+            10_000,
           );
-          await stopProcess(pid, "assistant");
+          if (becameHealthy) {
+            console.log(`   Assistant already running (pid ${pid})\n`);
+            return;
+          }
+          if (isVellumProcess(pid)) {
+            console.log(
+              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+            );
+            await stopProcess(pid, "assistant");
+          }
           try {
             unlinkSync(pidFile);
           } catch {}
@@ -515,10 +527,21 @@ async function startDaemonWatchFromSource(
           console.log(`   Assistant already running (pid ${pid})\n`);
           return;
         } else if (alive) {
-          console.log(
-            `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+          // The process may still be starting up — wait briefly before killing.
+          const becameHealthy = await waitForDaemonReady(
+            resources.daemonPort,
+            10_000,
           );
-          await stopProcess(pid, "assistant");
+          if (becameHealthy) {
+            console.log(`   Assistant already running (pid ${pid})\n`);
+            return;
+          }
+          if (isVellumProcess(pid)) {
+            console.log(
+              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+            );
+            await stopProcess(pid, "assistant");
+          }
           try {
             unlinkSync(pidFile);
           } catch {}
@@ -961,13 +984,27 @@ export async function startLocalDaemon(
             daemonAlive = true;
             console.log(`   Assistant already running (pid ${pid})\n`);
           } else if (alive) {
-            console.log(
-              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+            // The process may still be starting up — wait briefly before killing.
+            const becameHealthy = await waitForDaemonReady(
+              resources.daemonPort,
+              10_000,
             );
-            await stopProcess(pid, "assistant");
-            try {
-              unlinkSync(pidFile);
-            } catch {}
+            if (becameHealthy) {
+              daemonAlive = true;
+              console.log(`   Assistant already running (pid ${pid})\n`);
+            } else if (isVellumProcess(pid)) {
+              console.log(
+                `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
+              );
+              await stopProcess(pid, "assistant");
+              try {
+                unlinkSync(pidFile);
+              } catch {}
+            } else {
+              try {
+                unlinkSync(pidFile);
+              } catch {}
+            }
           } else {
             // Process doesn't exist, clean up stale PID file
             try {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -17,12 +17,7 @@ import {
 } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
-import {
-  isProcessHealthy,
-  isVellumProcess,
-  stopProcess,
-  stopProcessByPidFile,
-} from "./process.js";
+import { resolveProcessState, stopProcessByPidFile } from "./process.js";
 import { openLogFile, pipeToLogFile } from "./xdg-log.js";
 
 const _require = createRequire(import.meta.url);
@@ -338,77 +333,19 @@ async function startDaemonFromSource(
   mkdirSync(dirname(pidFile), { recursive: true });
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
-  if (existsSync(pidFile)) {
-    try {
-      const content = readFileSync(pidFile, "utf-8").trim();
+  if (await awaitStartingSentinel(pidFile, resources.daemonPort)) return;
 
-      // Another caller is already spawning the daemon — wait for it
-      // instead of racing to spawn a duplicate.
-      if (content === "starting") {
-        console.log(
-          "   Assistant is starting — waiting for it to become ready...",
-        );
-        if (await waitForDaemonReady(resources.daemonPort, 60000)) {
-          console.log("   Assistant is ready\n");
-          return;
-        }
-        // The other spawn may have failed; clean up and proceed to spawn.
-        try {
-          unlinkSync(pidFile);
-        } catch {}
-      }
-
-      const pid = parseInt(content, 10);
-      if (!isNaN(pid)) {
-        const { alive, healthy } = await isProcessHealthy(
-          pidFile,
-          resources.daemonPort,
-        );
-        if (alive && healthy) {
-          console.log(`   Assistant already running (pid ${pid})\n`);
-          return;
-        } else if (alive) {
-          // The process may still be starting up — wait briefly before killing.
-          const becameHealthy = await waitForDaemonReady(
-            resources.daemonPort,
-            10_000,
-          );
-          if (becameHealthy) {
-            console.log(`   Assistant already running (pid ${pid})\n`);
-            return;
-          }
-          if (isVellumProcess(pid)) {
-            console.log(
-              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
-            );
-            await stopProcess(pid, "assistant");
-          }
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        } else {
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        }
-      }
-    } catch {}
-  }
-
-  // PID file was stale or missing — check if daemon is responding via HTTP
-  if (await isDaemonResponsive(resources.daemonPort)) {
-    // Recover PID tracking so lifecycle commands (sleep, retire,
-    // stopLocalProcesses) can manage this daemon process.
-    const recoveredPid = recoverPidFile(pidFile, resources.daemonPort);
-    if (recoveredPid) {
-      console.log(
-        `   Assistant is responsive (pid ${recoveredPid}) — skipping restart\n`,
-      );
-    } else {
-      console.log("   Assistant is responsive — skipping restart\n");
-    }
+  const daemonState = await resolveProcessState(
+    pidFile,
+    resources.daemonPort,
+    "Assistant",
+  );
+  if (daemonState.status === "healthy") {
+    console.log(`   Assistant already running (pid ${daemonState.pid})\n`);
     return;
   }
+
+  if (await checkOrphanedDaemon(pidFile, resources.daemonPort)) return;
 
   const env: Record<string, string | undefined> = {
     ...process.env,
@@ -496,79 +433,19 @@ async function startDaemonWatchFromSource(
   mkdirSync(dirname(pidFile), { recursive: true });
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
-  // If a daemon is already running, skip spawning a new one.
-  if (existsSync(pidFile)) {
-    try {
-      const content = readFileSync(pidFile, "utf-8").trim();
+  if (await awaitStartingSentinel(pidFile, resources.daemonPort)) return;
 
-      // Another caller is already spawning the daemon — wait for it
-      // instead of racing to spawn a duplicate.
-      if (content === "starting") {
-        console.log(
-          "   Assistant is starting — waiting for it to become ready...",
-        );
-        if (await waitForDaemonReady(resources.daemonPort, 60000)) {
-          console.log("   Assistant is ready\n");
-          return;
-        }
-        // The other spawn may have failed; clean up and proceed to spawn.
-        try {
-          unlinkSync(pidFile);
-        } catch {}
-      }
-
-      const pid = parseInt(content, 10);
-      if (!isNaN(pid)) {
-        const { alive, healthy } = await isProcessHealthy(
-          pidFile,
-          resources.daemonPort,
-        );
-        if (alive && healthy) {
-          console.log(`   Assistant already running (pid ${pid})\n`);
-          return;
-        } else if (alive) {
-          // The process may still be starting up — wait briefly before killing.
-          const becameHealthy = await waitForDaemonReady(
-            resources.daemonPort,
-            10_000,
-          );
-          if (becameHealthy) {
-            console.log(`   Assistant already running (pid ${pid})\n`);
-            return;
-          }
-          if (isVellumProcess(pid)) {
-            console.log(
-              `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
-            );
-            await stopProcess(pid, "assistant");
-          }
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        } else {
-          // Process doesn't exist, clean up stale PID file
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        }
-      }
-    } catch {}
-  }
-
-  // PID file was stale or missing — check if daemon is responding via HTTP
-  if (await isDaemonResponsive(resources.daemonPort)) {
-    // Recover PID tracking so lifecycle commands (sleep, retire,
-    // stopLocalProcesses) can manage this daemon process.
-    const recoveredPid = recoverPidFile(pidFile, resources.daemonPort);
-    if (recoveredPid) {
-      console.log(
-        `   Assistant is responsive (pid ${recoveredPid}) — skipping restart\n`,
-      );
-    } else {
-      console.log("   Assistant is responsive — skipping restart\n");
-    }
+  const daemonState = await resolveProcessState(
+    pidFile,
+    resources.daemonPort,
+    "Assistant",
+  );
+  if (daemonState.status === "healthy") {
+    console.log(`   Assistant already running (pid ${daemonState.pid})\n`);
     return;
   }
+
+  if (await checkOrphanedDaemon(pidFile, resources.daemonPort)) return;
 
   const env: Record<string, string | undefined> = {
     ...process.env,
@@ -707,6 +584,63 @@ function recoverPidFile(
     writeFileSync(pidFile, String(pid), "utf-8");
   }
   return pid;
+}
+
+/**
+ * Handle the "starting" sentinel in a PID file. When another caller is
+ * already spawning the daemon, wait for it to become ready instead of
+ * racing to spawn a duplicate.
+ *
+ * Returns `true` if the daemon became ready (caller should return early),
+ * `false` if the spawn failed or the sentinel wasn't present (caller
+ * should proceed). Cleans up the PID file on failure.
+ */
+async function awaitStartingSentinel(
+  pidFile: string,
+  daemonPort: number,
+): Promise<boolean> {
+  if (!existsSync(pidFile)) return false;
+  try {
+    const content = readFileSync(pidFile, "utf-8").trim();
+    if (content !== "starting") return false;
+  } catch {
+    return false;
+  }
+
+  console.log("   Assistant is starting — waiting for it to become ready...");
+  if (await waitForDaemonReady(daemonPort, 60000)) {
+    console.log("   Assistant is ready\n");
+    return true;
+  }
+  try {
+    unlinkSync(pidFile);
+  } catch {}
+  return false;
+}
+
+/**
+ * Check if a daemon without a valid PID file is still reachable on its
+ * HTTP port (orphaned process). If so, recover its PID file so lifecycle
+ * commands can manage it.
+ *
+ * Returns `true` if an orphaned daemon was found (caller should skip
+ * starting a new one), `false` otherwise.
+ */
+async function checkOrphanedDaemon(
+  pidFile: string,
+  daemonPort: number,
+): Promise<boolean> {
+  if (!(await isDaemonResponsive(daemonPort))) return false;
+
+  const recoveredPid = recoverPidFile(pidFile, daemonPort);
+  if (recoveredPid) {
+    console.log(
+      `   Assistant is responsive (pid ${recoveredPid}) — skipping restart\n`,
+    );
+  } else {
+    console.log("   Assistant is responsive — skipping restart\n");
+  }
+  return true;
 }
 
 export async function discoverPublicUrl(
@@ -949,89 +883,24 @@ export async function startLocalDaemon(
 
     const pidFile = getDaemonPidPath(resources);
 
-    // If a daemon is already running, skip spawning a new one.
-    // This prevents cascading kill→restart cycles when multiple callers
-    // invoke hatch() concurrently (setupDaemonClient + ensureDaemonConnected).
-    let daemonAlive = false;
-    if (existsSync(pidFile)) {
-      try {
-        const content = readFileSync(pidFile, "utf-8").trim();
+    // --- Lifecycle guard: prevent split-brain daemon state ---
+    if (await awaitStartingSentinel(pidFile, resources.daemonPort)) {
+      ensureBunInstalled();
+      return;
+    }
 
-        // Another caller is already spawning the daemon — wait for it
-        // instead of racing to spawn a duplicate.
-        if (content === "starting") {
-          console.log(
-            "   Assistant is starting — waiting for it to become ready...",
-          );
-          if (await waitForDaemonReady(resources.daemonPort, 60000)) {
-            console.log("   Assistant is ready\n");
-            ensureBunInstalled();
-            return;
-          }
-          // The other spawn may have failed; clean up and proceed to spawn.
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        }
-
-        const pid = parseInt(content, 10);
-        if (!isNaN(pid)) {
-          const { alive, healthy } = await isProcessHealthy(
-            pidFile,
-            resources.daemonPort,
-          );
-          if (alive && healthy) {
-            daemonAlive = true;
-            console.log(`   Assistant already running (pid ${pid})\n`);
-          } else if (alive) {
-            // The process may still be starting up — wait briefly before killing.
-            const becameHealthy = await waitForDaemonReady(
-              resources.daemonPort,
-              10_000,
-            );
-            if (becameHealthy) {
-              daemonAlive = true;
-              console.log(`   Assistant already running (pid ${pid})\n`);
-            } else if (isVellumProcess(pid)) {
-              console.log(
-                `   Assistant process alive (pid ${pid}) but not responding — killing and restarting...`,
-              );
-              await stopProcess(pid, "assistant");
-              try {
-                unlinkSync(pidFile);
-              } catch {}
-            } else {
-              try {
-                unlinkSync(pidFile);
-              } catch {}
-            }
-          } else {
-            // Process doesn't exist, clean up stale PID file
-            try {
-              unlinkSync(pidFile);
-            } catch {}
-          }
-        }
-      } catch {}
+    const daemonState = await resolveProcessState(
+      pidFile,
+      resources.daemonPort,
+      "Assistant",
+    );
+    const daemonAlive = daemonState.status === "healthy";
+    if (daemonAlive) {
+      console.log(`   Assistant already running (pid ${daemonState.pid})\n`);
     }
 
     if (!daemonAlive) {
-      // The PID file was stale or missing, but a daemon with a different PID
-      // may still be listening on the HTTP port (e.g. if the PID file was
-      // overwritten by a crashed restart attempt). Check before starting a new one.
-      if (await isDaemonResponsive(resources.daemonPort)) {
-        // Restore PID tracking so lifecycle commands (sleep, retire,
-        // stopLocalProcesses) can manage this daemon process.
-        const recoveredPid = recoverPidFile(pidFile, resources.daemonPort);
-        if (recoveredPid) {
-          console.log(
-            `   Assistant is responsive (pid ${recoveredPid}) — skipping restart\n`,
-          );
-        } else {
-          console.log("   Assistant is responsive — skipping restart\n");
-        }
-        // Ensure bun is available for runtime features (browser, skills install)
-        // even when reusing an existing daemon.
+      if (await checkOrphanedDaemon(pidFile, resources.daemonPort)) {
         ensureBunInstalled();
         return;
       }

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -102,7 +102,6 @@ export async function resolveProcessState(
   const result = await isProcessHealthy(pidFile, healthPort);
 
   if (!result.alive) {
-    cleanupPidFile(pidFile);
     return { status: "needs_start", pid: null };
   }
 

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 import { existsSync, readFileSync, unlinkSync } from "fs";
 
-import { httpHealthCheck } from "./http-client.js";
+import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
 
 /**
  * Verify that a PID belongs to a vellum-related process by inspecting its
@@ -48,6 +48,11 @@ export function isProcessAlive(pidFile: string): {
   }
 }
 
+/** Discriminated union: when `alive` is true, `pid` is guaranteed non-null. */
+export type ProcessHealthResult =
+  | { alive: true; healthy: boolean; pid: number }
+  | { alive: false; healthy: false; pid: null };
+
 /**
  * Check if a PID file's process is alive AND responding to HTTP health checks.
  *
@@ -59,14 +64,80 @@ export async function isProcessHealthy(
   pidFile: string,
   healthPort: number,
   timeoutMs: number = 3000,
-): Promise<{ alive: boolean; healthy: boolean; pid: number | null }> {
+): Promise<ProcessHealthResult> {
   const { alive, pid } = isProcessAlive(pidFile);
   if (!alive || pid === null) {
-    return { alive: false, healthy: false, pid };
+    return { alive: false, healthy: false, pid: null };
   }
 
   const healthy = await httpHealthCheck(healthPort, timeoutMs);
   return { alive: true, healthy, pid };
+}
+
+/**
+ * Outcome of {@link resolveProcessState}. Callers switch on `status`:
+ * - `"healthy"` — process is alive and responding; `pid` is the live PID.
+ * - `"needs_start"` — process was dead, hung (and killed), or a stale PID
+ *   was cleaned up. Caller should start a fresh process.
+ */
+export type ProcessState =
+  | { status: "healthy"; pid: number }
+  | { status: "needs_start"; pid: number | null };
+
+/**
+ * Determine whether a PID-tracked process is alive and healthy. If the
+ * process exists but is unresponsive, waits up to `readinessWaitMs` for it
+ * to finish initializing. If it remains unresponsive, verifies it belongs
+ * to Vellum before killing it, then cleans up the PID file.
+ *
+ * Encapsulates the full health → readiness-wait → guard → kill → cleanup
+ * flow so callers don't need to reimplement it.
+ */
+export async function resolveProcessState(
+  pidFile: string,
+  healthPort: number,
+  label: string,
+  readinessWaitMs: number = 10_000,
+): Promise<ProcessState> {
+  const result = await isProcessHealthy(pidFile, healthPort);
+
+  if (!result.alive) {
+    cleanupPidFile(pidFile);
+    return { status: "needs_start", pid: null };
+  }
+
+  if (result.healthy) {
+    return { status: "healthy", pid: result.pid };
+  }
+
+  // Alive but not healthy — may still be starting up.
+  const becameHealthy = await waitForDaemonReady(healthPort, readinessWaitMs);
+  if (becameHealthy) {
+    return { status: "healthy", pid: result.pid };
+  }
+
+  // Genuinely hung — kill if it belongs to Vellum, otherwise just clean up.
+  if (isVellumProcess(result.pid)) {
+    console.log(
+      `${label} process alive (pid ${result.pid}) but not responding — killing and restarting...`,
+    );
+    await stopProcess(result.pid, label);
+  } else {
+    console.log(
+      `Stale PID file (pid ${result.pid} is not a Vellum process) — cleaning up...`,
+    );
+  }
+  cleanupPidFile(pidFile);
+  return { status: "needs_start", pid: result.pid };
+}
+
+/** Remove a PID file if it exists. */
+function cleanupPidFile(pidFile: string): void {
+  if (existsSync(pidFile)) {
+    try {
+      unlinkSync(pidFile);
+    } catch {}
+  }
 }
 
 /**

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from "child_process";
 import { existsSync, readFileSync, unlinkSync } from "fs";
 
+import { httpHealthCheck } from "./http-client.js";
+
 /**
  * Verify that a PID belongs to a vellum-related process by inspecting its
  * command line via `ps`. Prevents killing unrelated processes when a PID file
@@ -44,6 +46,27 @@ export function isProcessAlive(pidFile: string): {
   } catch {
     return { alive: false, pid: null };
   }
+}
+
+/**
+ * Check if a PID file's process is alive AND responding to HTTP health checks.
+ *
+ * Combines PID existence check with an HTTP `/healthz` probe. A process that
+ * exists but does not respond (hung, deadlocked, at 100% CPU) returns
+ * `alive: true, healthy: false` — callers should kill and restart it.
+ */
+export async function isProcessHealthy(
+  pidFile: string,
+  healthPort: number,
+  timeoutMs: number = 3000,
+): Promise<{ alive: boolean; healthy: boolean; pid: number | null }> {
+  const { alive, pid } = isProcessAlive(pidFile);
+  if (!alive || pid === null) {
+    return { alive: false, healthy: false, pid };
+  }
+
+  const healthy = await httpHealthCheck(healthPort, timeoutMs);
+  return { alive: true, healthy, pid };
 }
 
 /**

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -86,9 +86,10 @@ export type ProcessState =
 
 /**
  * Determine whether a PID-tracked process is alive and healthy. If the
- * process exists but is unresponsive, waits up to `readinessWaitMs` for it
- * to finish initializing. If it remains unresponsive, verifies it belongs
- * to Vellum before killing it, then cleans up the PID file.
+ * process exists but is unresponsive, waits up to `readinessWaitMs`
+ * (default 30s — covers first-boot scenarios like Qdrant download) for
+ * it to finish initializing. If it remains unresponsive, verifies it
+ * belongs to Vellum before killing it, then cleans up the PID file.
  *
  * Encapsulates the full health → readiness-wait → guard → kill → cleanup
  * flow so callers don't need to reimplement it.
@@ -97,7 +98,7 @@ export async function resolveProcessState(
   pidFile: string,
   healthPort: number,
   label: string,
-  readinessWaitMs: number = 10_000,
+  readinessWaitMs: number = 30_000,
 ): Promise<ProcessState> {
   const result = await isProcessHealthy(pidFile, healthPort);
 

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -87,9 +87,11 @@ export type ProcessState =
 /**
  * Determine whether a PID-tracked process is alive and healthy. If the
  * process exists but is unresponsive, waits up to `readinessWaitMs`
- * (default 30s — covers first-boot scenarios like Qdrant download) for
- * it to finish initializing. If it remains unresponsive, verifies it
- * belongs to Vellum before killing it, then cleans up the PID file.
+ * (default 60s — matches the spawner's own `waitForDaemonReady` timeout
+ * so a concurrent caller never kills a daemon the spawner is still
+ * waiting on) for it to finish initializing. If it remains unresponsive,
+ * verifies it belongs to Vellum before killing it, then cleans up the
+ * PID file.
  *
  * Encapsulates the full health → readiness-wait → guard → kill → cleanup
  * flow so callers don't need to reimplement it.
@@ -98,7 +100,7 @@ export async function resolveProcessState(
   pidFile: string,
   healthPort: number,
   label: string,
-  readinessWaitMs: number = 30_000,
+  readinessWaitMs: number = 60_000,
 ): Promise<ProcessState> {
   const result = await isProcessHealthy(pidFile, healthPort);
 


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1996

## Why this change is needed

The `wake` command and all three `startLocalDaemon` code paths checked process **existence** (`process.kill(pid, 0)`) but not **health** (HTTP `/healthz` probe). A daemon that was alive but unresponsive — hung, deadlocked, at 100% CPU — passed the PID check, and `wake` would report "already running" instead of restarting it. The macOS app's `autoWakeIfAssistantDied()` would then loop indefinitely, never recovering.

The same ~30-line lifecycle guard pattern was copy-pasted across 4 call sites with subtle inconsistencies (some cleaned up PID files, some didn't; some checked `isVellumProcess`, some didn't). Two additional patterns — the "starting" sentinel check and the orphaned-daemon recovery — were each duplicated 3 times.

## Changes

**`cli/src/lib/process.ts`** — New centralized lifecycle functions:
- `isProcessHealthy()` — combines PID existence + HTTP `/healthz` probe. Returns a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) (`ProcessHealthResult`) where `alive: true` guarantees `pid: number`, eliminating non-null assertions.
- `resolveProcessState()` — encapsulates the full lifecycle check: health probe → 60s readiness wait (matches the spawner's own `waitForDaemonReady` timeout) → [`isVellumProcess()`](https://man7.org/linux/man-pages/man1/ps.1.html) guard (prevents killing unrelated processes on PID reuse) → kill/cleanup. Returns `ProcessState`: `"healthy"` or `"needs_start"`. Intentionally does NOT clean up PID files when the process isn't alive — the file may contain a `"starting"` sentinel from a concurrent spawner.

**`cli/src/lib/local.ts`** — Extracted two helpers:
- `awaitStartingSentinel()` — detects concurrent spawn via the "starting" PID file sentinel; waits for readiness instead of racing.
- `checkOrphanedDaemon()` — recovers orphaned daemons reachable on HTTP but missing a PID file, using [`lsof`](https://man7.org/linux/man-pages/man8/lsof.8.html) to recover the PID.

All three `startLocalDaemon` paths (dev, watch, bundled binary) now use the same 3-line guard. Previously each was 50-70 lines of inline logic.

**`cli/src/commands/wake.ts`** — Daemon and gateway checks both use `resolveProcessState()`. Watch-mode restart logic preserved.

## What this does NOT change

- `isProcessAlive()` — unchanged; `sleep`/`retire` intentionally use PID-only checks (they need to kill processes regardless of health)
- `stopProcessByPidFile()` — unchanged
- No Swift/macOS app changes, no wire format changes, no cross-repo impact
- Gateway's always-kill-and-restart behavior — preserved (gateway is stateless)

## Benefits

- **Self-healing**: hung daemons are detected and restarted automatically instead of requiring manual `pkill`
- **DRY**: 4 copies of the lifecycle guard consolidated into one function; 2 more patterns (3 copies each) extracted into helpers. Net -120 lines
- **Type safety**: discriminated unions eliminate `pid!` non-null assertions — the type system guarantees correctness at compile time
- **Consistency**: impossible for call sites to diverge on health-check behavior

## Why it's safe

- **Additive strictness**: health check is strictly more conservative than PID-only — processes that are truly running and healthy pass both checks
- **Readiness grace period**: `resolveProcessState()` waits 60s before declaring a process unhung — matching the spawner's own `waitForDaemonReady(port, 60000)` timeout so a concurrent caller never kills a daemon the spawner is still waiting on. The `awaitStartingSentinel()` check (also 60s) catches the initial spawn window before the PID file is written
- **PID reuse guard**: `isVellumProcess()` inspects the process command line via `ps` before sending any signal — a stale PID file pointing at an unrelated process results in cleanup, not a kill
- **Safe failure mode**: if `/healthz` is transiently unreachable, the worst case is an unnecessary daemon restart, which `waitForDaemonReady` handles gracefully

## Alternatives considered and rejected

| Alternative | Why rejected |
|---|---|
| Only patch `wake`, leave `startLocalDaemon` as-is | Leaves the same PID-only bug in 3 more call sites. Doesn't fix the root cause. |
| Always kill + restart (like gateway does) | Daemon has in-memory state (active conversations, tool executions). Unnecessary restarts disrupt running work. |
| Remove `wake`'s pre-checks, always delegate to `startLocalDaemon`/`startGateway` | `startLocalDaemon` had the same PID-only bug. Doesn't fix the root cause without also changing `startLocalDaemon`. |
| N-consecutive-failures threshold before killing | Adds complexity. `wake` is an explicit user/system action, not a background probe — a single health failure is sufficient signal. |
| Use IPC socket liveness instead of HTTP | The daemon's `/healthz` endpoint already exists and is unauthenticated. IPC socket checks would require additional protocol and wouldn't detect application-level hangs (e.g., event loop blocked). |

## Root cause analysis

1. **How did the code get into this state?** Process liveness was equated with PID existence from the initial implementation. `process.kill(pid, 0)` is the standard Node.js idiom for checking if a process exists ([Node.js docs](https://nodejs.org/api/process.html#processkillpid-signal)), and it worked until daemons started hanging without exiting.

2. **What decisions led to it?** The `httpHealthCheck()` and `isDaemonResponsive()` utilities already existed but were only used as fallbacks for missing PID files — the "happy path" (PID file exists, process alive) never reached them. The macOS app's own `autoWakeIfAssistantDied()` used HTTP health checks, but the CLI's `wake` command — which the app calls — did not.

3. **Were there warning signs?** Yes — the existence of two parallel liveness mechanisms (PID check in CLI, HTTP check in macOS app) was a sign that the CLI's check was incomplete. The 4x code duplication of the lifecycle guard was another signal: when the same complex logic is copy-pasted, it suggests a missing abstraction.

4. **What can we do to prevent this pattern from recurring?** The `resolveProcessState()` function is now the single source of truth for "is this process running and usable?" — adding a new `startLocalDaemon` path requires calling it, making it hard to accidentally skip health verification.

5. **AGENTS.md update**: Added a process liveness guideline to `cli/AGENTS.md` — use `resolveProcessState()` for health-aware checks; reserve `isProcessAlive()` for teardown paths.

## Test plan

- TypeScript compilation: `bunx tsc --noEmit` passes
- Lint: `bun run lint` passes (0 errors)
- Prettier: all modified files formatted
- 12 integration tests covering: alive-but-unhealthy detection, healthy process identification, dead/stale PID cleanup, isVellumProcess guard, readiness grace period, discriminated union narrowing
- 22 existing regression tests pass (pre-existing `recover.test.ts` failure confirmed on main, not introduced by this PR)
- CI: 3/3 checks passed

Link to Devin session: https://app.devin.ai/sessions/4370103ab5e547ae8696d39b423f7103
Requested by: @ashleeradka
