### PR TITLE
fix(document-editor): harden dedupe path and align mode null handling

### DIFF
--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -307,6 +307,20 @@ describe("executeDocumentUpdate — input validation", () => {
     );
   });
 
+  test("treats mode: null the same as undefined (factory validator accepts both)", () => {
+    // validateInputAgainstSchema treats null as "absent" for enum checks, so
+    // the executor must agree — { mode: null } should fall through to the
+    // access check, not return a confusing 'mode must be ...' error.
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "hi", mode: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).not.toContain("Invalid input: mode");
+    expect(body.error).toBe("Document not found");
+  });
+
   test("executeDocumentRead returns Invalid input when surface_id is missing", () => {
     const result = executeDocumentRead({}, makeContext());
     expect(result.isError).toBe(true);

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  addDocumentConversation,
   deleteDocument,
   findInDocument,
   findRecentEmptyDocumentByTitle,
@@ -152,13 +153,22 @@ function maybeReuseEmptyDocument(
   const update = updateDocumentContent(surfaceId, initialContent, "replace");
   if (!update.success) return null;
 
+  // Mirror the create-new path's saveDocument → addDocumentConversation
+  // invariant so the deduped doc stays discoverable from this conversation
+  // even if the junction row was removed out of band.
+  addDocumentConversation(surfaceId, context.conversationId);
+
   if (context.sendToClient) {
+    // Use document_editor_update — not document_editor_show — because the
+    // empty draft is typically still OPEN on the macOS client. A *_show on an
+    // open doc triggers DocumentManager.closeDocument() → async save() of the
+    // OLD (empty) content, clobbering the initialContent we just persisted.
     context.sendToClient({
-      type: "document_editor_show",
+      type: "document_editor_update",
       conversationId: context.conversationId,
       surfaceId,
-      title,
-      initialContent,
+      markdown: initialContent,
+      mode: "replace",
     });
 
     context.sendToClient({
@@ -271,8 +281,11 @@ export function executeDocumentUpdate(
   if (typeof input.content !== "string") {
     return invalidInput("content is required and must be a string");
   }
+  // Loose `!= null` to match validateInputAgainstSchema, which treats null as
+  // "absent" for enum checks — without this, { mode: null } passes the
+  // factory validator but rejects here. The `?? "append"` below handles null.
   if (
-    input.mode !== undefined &&
+    input.mode != null &&
     input.mode !== "replace" &&
     input.mode !== "append"
   ) {


### PR DESCRIPTION
## Summary
Fixes 3 gaps surfaced during self-review of plan `doc-editor-validate`:

1. `maybeReuseEmptyDocument` now sends `document_editor_update` (not `document_editor_show`) to avoid the macOS client's `closeDocument()`→`save()` cycle clobbering the freshly-written server content (Codex P1).
2. `maybeReuseEmptyDocument` now calls `addDocumentConversation` after `updateDocumentContent` to keep the `document_conversations` junction row in sync with the create-new path.
3. `executeDocumentUpdate`'s `mode` guard accepts `null` (treats it as absent like `undefined`) so its behavior matches the factory-layer validator. New test covers this.

Plan: doc-editor-validate.md (post-merge remediation)