### PR TITLE
fix(macos): gate document_editor_update on surface_id match

### DIFF
--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -153,9 +153,8 @@ function maybeReuseEmptyDocument(
   const update = updateDocumentContent(surfaceId, initialContent, "replace");
   if (!update.success) return null;
 
-  // Mirror the create-new path's saveDocument → addDocumentConversation
-  // invariant so the deduped doc stays discoverable from this conversation
-  // even if the junction row was removed out of band.
+  // Defensive idempotent insert (saveDocument from the create-new path already
+  // ran addDocumentConversation; INSERT OR IGNORE makes this a safe no-op).
   addDocumentConversation(surfaceId, context.conversationId);
 
   if (context.sendToClient) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Combine
+import os
 import VellumAssistantShared
 import SwiftUI
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MainWindow")
 
 /// Delegate that intercepts the window close button to hide the window
 /// instead of closing it, keeping the app running in the dock + menu bar.
@@ -415,6 +418,18 @@ public final class MainWindow {
     }
 
     func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
+        // Safety: only apply when the message targets the currently-active document.
+        // Otherwise we'd mutate `currentContent` for an unrelated doc and the
+        // subsequent autoSave would persistently corrupt it on the daemon.
+        // (The active surface may not match the message — e.g. when the dedupe
+        // path in maybeReuseEmptyDocument fires for an empty draft the user has
+        // already navigated away from. In that case the daemon has the right
+        // content; the user just won't see it surface in the editor until they
+        // reopen the doc.)
+        guard documentManager.surfaceId == msg.surfaceId else {
+            log.info("Ignoring document_editor_update for surface \(msg.surfaceId) (active surface is \(documentManager.surfaceId ?? "nil"))")
+            return
+        }
         documentManager.updateDocument(markdown: msg.markdown, mode: msg.mode)
     }
 


### PR DESCRIPTION
## Summary
Fixes 2 gaps surfaced during round-2 self-review of plan `doc-editor-validate`:

1. `handleDocumentEditorUpdate` on macOS now ignores update messages whose `surfaceId` doesn't match the active doc. Without this, the dedupe path in `maybeReuseEmptyDocument` (which sends `document_editor_update` to avoid the closeDocument/save race for the same-doc case) could persistently corrupt an UNRELATED doc if the user had navigated away from the empty draft inside the 5-minute window — `DocumentManager.updateDocument` mutates `currentContent` and `scheduleAutoSave` would write the deduped content under the wrong `surfaceId`.
2. Replaced the overpromising `addDocumentConversation` comment in `maybeReuseEmptyDocument` with an honest defense-in-depth note.

Plan: doc-editor-validate.md (round-2 remediation)