### PR TITLE
JARVIS-968: validate skill tool inputs and harden document-editor flow

### DIFF
--- a/assistant/src/__tests__/document-create-dedupe.test.ts
+++ b/assistant/src/__tests__/document-create-dedupe.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getDocumentById,
+  getDocumentsForConversation,
+} from "../documents/document-store.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { executeDocumentCreate } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    sendToClient: () => {},
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDbForTesting();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  createdAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.createdAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.createdAt,
+      params.createdAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.createdAt);
+}
+
+describe("executeDocumentCreate — dedupe empty same-title document", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+  });
+
+  test("reuses an empty same-title doc when incoming content is non-empty", () => {
+    const seededId = "doc-empty-seeded";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{
+      surface_id: string;
+      reused?: boolean;
+      message?: string;
+    }>(result);
+    expect(body.surface_id).toBe(seededId);
+    expect(body.reused).toBe(true);
+    expect(body.message).toBe("Document editor reopened (deduped empty draft)");
+
+    expect(getDocumentById(seededId)?.content).toBe("Hello");
+    expect(getDocumentsForConversation("conv-current").length).toBe(1);
+  });
+
+  test("creates a new doc when incoming initial_content is empty (no dedupe)", () => {
+    const seededId = "doc-empty-seeded";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+
+  test("does not dedupe when the seeded doc already has content", () => {
+    const seededId = "doc-has-content";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "already drafted",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentById(seededId)?.content).toBe("already drafted");
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+
+  test("does not dedupe when the seeded empty doc is outside the 5-minute window", () => {
+    const seededId = "doc-stale-empty";
+    seedDocument({
+      surfaceId: seededId,
+      conversationId: "conv-current",
+      title: "My Post",
+      content: "",
+      // 10 minutes ago — outside the 5-minute dedupe window.
+      createdAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const result = executeDocumentCreate(
+      { title: "My Post", initial_content: "Hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; reused?: boolean }>(result);
+    expect(body.reused).toBeUndefined();
+    expect(body.surface_id).not.toBe(seededId);
+    expect(getDocumentById(seededId)?.content).toBe("");
+    expect(getDocumentsForConversation("conv-current").length).toBe(2);
+  });
+});

--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -307,6 +307,20 @@ describe("executeDocumentUpdate — input validation", () => {
     );
   });
 
+  test("treats mode: null the same as undefined (factory validator accepts both)", () => {
+    // validateInputAgainstSchema treats null as "absent" for enum checks, so
+    // the executor must agree — { mode: null } should fall through to the
+    // access check, not return a confusing 'mode must be ...' error.
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "hi", mode: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).not.toContain("Invalid input: mode");
+    expect(body.error).toBe("Document not found");
+  });
+
   test("executeDocumentRead returns Invalid input when surface_id is missing", () => {
     const result = executeDocumentRead({}, makeContext());
     expect(result.isError).toBe(true);

--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -257,3 +257,67 @@ describe("document tool security", () => {
     expect(getDocumentById("doc-current")).toBeNull();
   });
 });
+
+describe("executeDocumentUpdate — input validation", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedFixtureDocuments();
+  });
+
+  test("returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentUpdate({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+    expect(body.error).not.toContain("Document not found");
+  });
+
+  test("returns Invalid input when content is missing", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe(
+      "Invalid input: content is required and must be a string",
+    );
+  });
+
+  test("allows empty string content (falls through to access check)", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    // Did NOT fail input validation; fell through to access/not-found path.
+    expect(body.error).toBe("Document not found");
+  });
+
+  test("returns Invalid input when mode is not replace or append", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-x", content: "hi", mode: "bogus" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe(
+      'Invalid input: mode must be "replace" or "append"',
+    );
+  });
+
+  test("executeDocumentRead returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentRead({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+  });
+
+  test("executeDocumentDelete returns Invalid input when surface_id is missing", () => {
+    const result = executeDocumentDelete({}, makeContext());
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toContain("Invalid input: surface_id is required");
+  });
+});

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -151,7 +151,9 @@ describe("createSkillTool", () => {
       hash,
     );
 
-    const result = await tool.execute({}, makeContext());
+    // Provide valid input so we reach the executor (the default schema
+    // declares `query` as required).
+    const result = await tool.execute({ query: "x" }, makeContext());
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Failed to load skill tool script");
@@ -215,8 +217,9 @@ describe("createSkillTool — unknown parameter validation", () => {
     );
 
     expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
     expect(result.content).toContain('Unknown parameter "unsubscribe"');
-    expect(result.content).toContain("Supported parameters");
+    expect(result.content).toContain("Supported:");
     expect(result.content).toContain('"query"');
   });
 
@@ -234,9 +237,9 @@ describe("createSkillTool — unknown parameter validation", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("Unknown parameters");
-    expect(result.content).toContain('"foo"');
-    expect(result.content).toContain('"bar"');
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
+    expect(result.content).toContain('Unknown parameter "foo"');
+    expect(result.content).toContain('Unknown parameter "bar"');
   });
 
   test("allows input with only known parameters", async () => {
@@ -285,6 +288,85 @@ describe("createSkillTool — unknown parameter validation", () => {
     const result = await tool.execute({ anything: "goes" }, makeContext());
 
     expect(result.isError).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSkillTool — required / type / enum validation
+// ---------------------------------------------------------------------------
+
+describe("createSkillTool — required/type/enum validation", () => {
+  test("rejects missing required field with self-correcting message", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
+    expect(result.content).toContain("query is required");
+  });
+
+  test("rejects wrong type with `must be a string` message", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({ query: 123 }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
+    expect(result.content).toContain("query must be a string");
+  });
+
+  test("rejects enum violation with `must be one of` message", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({
+        executor: "echo.ts",
+        input_schema: {
+          type: "object",
+          properties: { mode: { type: "string", enum: ["a", "b"] } },
+        },
+      }),
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({ mode: "c" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
+    expect(result.content).toContain('mode must be one of "a", "b"');
+  });
+
+  test("passes valid input through to the executor unchanged", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({
+        executor: "echo.ts",
+        input_schema: {
+          type: "object",
+          properties: { mode: { type: "string", enum: ["a", "b"] } },
+          required: ["mode"],
+        },
+      }),
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({ mode: "a" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.input).toEqual({ mode: "a" });
   });
 });
 

--- a/assistant/src/__tests__/validate-input.test.ts
+++ b/assistant/src/__tests__/validate-input.test.ts
@@ -108,7 +108,12 @@ describe("validateInputAgainstSchema — type checks", () => {
     ["array", { 0: 1 }, false],
     ["object", { a: 1 }, true],
     ["object", [1, 2], false],
-    ["object", null, true], // null is skipped (treated as absent)
+    ["object", null, false], // null is a present value and fails single-type check
+    ["string", null, false],
+    ["number", null, false],
+    ["integer", null, false],
+    ["boolean", null, false],
+    ["array", null, false],
   ] as const)("type=%s, value=%p, valid=%p", (type, value, valid) => {
     const result = validateInputAgainstSchema(
       "t",
@@ -154,8 +159,10 @@ describe("validateInputAgainstSchema — nullable / union types", () => {
     expect(stringResult).toEqual({ ok: true });
   });
 
-  test("still rejects null when the declared single `type` doesn't allow it", () => {
-    // `type: "string"` does NOT allow null — the type check should fire.
+  test("rejects null for single non-null type but presence-check still passes", () => {
+    // `type: "string"` does NOT allow null — the type check fires. Only
+    // union types (`["string","null"]`) bypass the single-type check. The
+    // `required` check is presence-only, so it does NOT fire for null.
     const schema = {
       type: "object",
       properties: {
@@ -164,11 +171,33 @@ describe("validateInputAgainstSchema — nullable / union types", () => {
       required: ["note"],
     };
     const result = validateInputAgainstSchema("t", { note: null }, schema);
-    // Per current step-2 behaviour, null is treated as absent so the type
-    // check is skipped. The presence-only `required` check sees the key, so
-    // there's no `required` error either. This matches the pre-PR lenient
-    // behaviour and avoids breaking nullable plugin schemas.
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("note must be a string");
+    expect(result.errors).not.toContain("note is required");
+  });
+
+  test("document_update({ content: null }) is rejected at the factory layer", () => {
+    // Codex's example: a tool call supplying `null` for a non-nullable string
+    // field should be rejected by the central validator, not passed through
+    // to the downstream tool/proxy.
+    const schema = {
+      type: "object",
+      properties: {
+        surface_id: { type: "string" },
+        content: { type: "string" },
+        mode: { type: "string" },
+      },
+      required: ["surface_id", "content"],
+    };
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: "x", content: null },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("content must be a string");
   });
 });
 

--- a/assistant/src/__tests__/validate-input.test.ts
+++ b/assistant/src/__tests__/validate-input.test.ts
@@ -34,12 +34,45 @@ describe("validateInputAgainstSchema — required", () => {
     expect(result.errors).toContain("content is required");
   });
 
-  test("treats explicit undefined / null as missing", () => {
+  test("treats present-but-undefined keys as present (JSON Schema spec)", () => {
+    // JSON Schema `required` is presence-only — `{ surface_id: undefined }`
+    // still has `"surface_id" in input` === true. The type/null skip in step
+    // 2 covers the actual value handling.
     const result = validateInputAgainstSchema(
       "document_update",
-      { surface_id: undefined, content: null },
+      { surface_id: undefined, content: undefined },
       schema,
     );
+    // No "required" errors since the keys are present.
+    if (!result.ok) {
+      expect(result.errors).not.toContain("surface_id is required");
+      expect(result.errors).not.toContain("content is required");
+    }
+  });
+
+  test("accepts explicit null for a required field (presence-only)", () => {
+    // JSON Schema `required` does NOT forbid null — that's a type concern.
+    // A custom/plugin schema with `type: ["string","null"]` would be valid;
+    // the type check (step 2) is what gates null values, not required (step 1).
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: "doc-1", content: null },
+      // Use a schema where `content` allows null via union, so type-check skips it.
+      {
+        type: "object",
+        properties: {
+          surface_id: { type: "string" },
+          content: { type: ["string", "null"] },
+          mode: { type: "string" },
+        },
+        required: ["surface_id", "content"],
+      },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("flags only truly absent keys, not explicit-undefined ones", () => {
+    const result = validateInputAgainstSchema("document_update", {}, schema);
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.errors).toContain("surface_id is required");
@@ -91,6 +124,51 @@ describe("validateInputAgainstSchema — type checks", () => {
         type,
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nullable / union-type handling (preserve plugin skills with nullable schemas)
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — nullable / union types", () => {
+  test("skips type check when `type` is an array union (e.g. ['string','null'])", () => {
+    // Plugin / custom skills may declare `required: ["note"]` with
+    // `type: ["string", "null"]`. Per the spec, `null` is a valid value.
+    // We don't model union types, so we skip — never reject.
+    const schema = {
+      type: "object",
+      properties: {
+        note: { type: ["string", "null"] },
+      },
+      required: ["note"],
+    };
+    const nullResult = validateInputAgainstSchema("t", { note: null }, schema);
+    expect(nullResult).toEqual({ ok: true });
+
+    const stringResult = validateInputAgainstSchema(
+      "t",
+      { note: "hello" },
+      schema,
+    );
+    expect(stringResult).toEqual({ ok: true });
+  });
+
+  test("still rejects null when the declared single `type` doesn't allow it", () => {
+    // `type: "string"` does NOT allow null — the type check should fire.
+    const schema = {
+      type: "object",
+      properties: {
+        note: { type: "string" },
+      },
+      required: ["note"],
+    };
+    const result = validateInputAgainstSchema("t", { note: null }, schema);
+    // Per current step-2 behaviour, null is treated as absent so the type
+    // check is skipped. The presence-only `required` check sees the key, so
+    // there's no `required` error either. This matches the pre-PR lenient
+    // behaviour and avoids breaking nullable plugin schemas.
+    expect(result).toEqual({ ok: true });
   });
 });
 

--- a/assistant/src/__tests__/validate-input.test.ts
+++ b/assistant/src/__tests__/validate-input.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateInputAgainstSchema } from "../skills/validate-input.js";
+
+// ---------------------------------------------------------------------------
+// required
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — required", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      surface_id: { type: "string" },
+      content: { type: "string" },
+      mode: { type: "string" },
+    },
+    required: ["surface_id", "content"],
+  };
+
+  test("succeeds when all required fields are present", () => {
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: "doc-1", content: "hi" },
+      schema,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("lists each missing required field individually", () => {
+    const result = validateInputAgainstSchema("document_update", {}, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("surface_id is required");
+    expect(result.errors).toContain("content is required");
+  });
+
+  test("treats explicit undefined / null as missing", () => {
+    const result = validateInputAgainstSchema(
+      "document_update",
+      { surface_id: undefined, content: null },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("surface_id is required");
+    expect(result.errors).toContain("content is required");
+  });
+
+  test("empty input is allowed when nothing is required", () => {
+    const schemaNoRequired = {
+      type: "object",
+      properties: { query: { type: "string" } },
+    };
+    const result = validateInputAgainstSchema("noop", {}, schemaNoRequired);
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// type checks
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — type checks", () => {
+  test.each([
+    ["string", "hello", true],
+    ["string", 5, false],
+    ["number", 3.14, true],
+    ["number", "3.14", false],
+    ["integer", 7, true],
+    ["integer", 7.5, false],
+    ["integer", "7", false],
+    ["boolean", true, true],
+    ["boolean", "true", false],
+    ["array", [1, 2], true],
+    ["array", { 0: 1 }, false],
+    ["object", { a: 1 }, true],
+    ["object", [1, 2], false],
+    ["object", null, true], // null is skipped (treated as absent)
+  ] as const)("type=%s, value=%p, valid=%p", (type, value, valid) => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { field: value },
+      { type: "object", properties: { field: { type } } },
+    );
+    expect(result.ok).toBe(valid);
+    if (!valid) {
+      expect((result as { ok: false; errors: string[] }).errors[0]).toContain(
+        `field must be `,
+      );
+      expect((result as { ok: false; errors: string[] }).errors[0]).toContain(
+        type,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enum
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — enum", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      mode: { type: "string", enum: ["replace", "append"] },
+    },
+  };
+
+  test("succeeds for a valid enum value", () => {
+    const result = validateInputAgainstSchema("t", { mode: "replace" }, schema);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("fails with the list of allowed values", () => {
+    const result = validateInputAgainstSchema("t", { mode: "bogus" }, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain('mode must be one of "replace", "append"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// array items
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — array items", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      tags: { type: "array", items: { type: "string" } },
+    },
+  };
+
+  test("succeeds when every element matches", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { tags: ["a", "b"] },
+      schema,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("flags each element that violates the item type", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { tags: ["a", 2, "c", false] },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain("tags[1] must be a string");
+    expect(result.errors).toContain("tags[3] must be a string");
+    expect(result.errors).not.toContain("tags[0] must be a string");
+    expect(result.errors).not.toContain("tags[2] must be a string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unknown keys
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — unknown keys", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      surface_id: { type: "string" },
+      content: { type: "string" },
+      mode: { type: "string" },
+    },
+  };
+
+  test("flags a single unknown key with the supported list", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { surface_id: "doc", content: "x", foo: 1 },
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContain(
+      'Unknown parameter "foo". Supported: "surface_id", "content", "mode"',
+    );
+  });
+
+  test("flags multiple unknown keys individually", () => {
+    const result = validateInputAgainstSchema("t", { foo: 1, bar: 2 }, schema);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const unknownErrors = result.errors.filter((e) =>
+      e.startsWith("Unknown parameter"),
+    );
+    expect(unknownErrors).toHaveLength(2);
+    expect(unknownErrors.some((e) => e.includes('"foo"'))).toBe(true);
+    expect(unknownErrors.some((e) => e.includes('"bar"'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// permissive paths
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — permissive paths", () => {
+  test("permits anything when schema is undefined", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { whatever: "goes" },
+      undefined,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("permits anything when schema has no properties", () => {
+    const result = validateInputAgainstSchema(
+      "t",
+      { anything: 1 },
+      { type: "object" },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("does not throw when schema contains oneOf / $ref keywords", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        field: {
+          $ref: "#/definitions/Thing",
+          oneOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    };
+    let result: ReturnType<typeof validateInputAgainstSchema>;
+    expect(() => {
+      result = validateInputAgainstSchema("t", { field: "x" }, schema);
+    }).not.toThrow();
+    expect(result!.ok).toBe(true);
+  });
+
+  test("does not throw when top-level schema contains anyOf / allOf", () => {
+    const schema = {
+      type: "object",
+      properties: { field: { type: "string" } },
+      anyOf: [{ required: ["field"] }],
+      allOf: [{ type: "object" }],
+    };
+    expect(() =>
+      validateInputAgainstSchema("t", { field: "x" }, schema),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// purity
+// ---------------------------------------------------------------------------
+
+describe("validateInputAgainstSchema — purity", () => {
+  test("does not mutate the input or the schema", () => {
+    const input = { surface_id: "doc", content: "hi", extra: 1 };
+    const schema = {
+      type: "object",
+      properties: {
+        surface_id: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["surface_id"],
+    };
+    const inputSnapshot = JSON.parse(JSON.stringify(input));
+    const schemaSnapshot = JSON.parse(JSON.stringify(schema));
+
+    validateInputAgainstSchema("t", input, schema);
+
+    expect(input).toEqual(inputSnapshot);
+    expect(schema).toEqual(schemaSnapshot);
+  });
+});

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -39,9 +39,13 @@ When the user asks to see, open, or pull up a document:
 
 ## Creating a new document
 
-1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
+1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble. Capture the `surface_id` from the response — every subsequent `document_update` call must reference it.
 2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, _italic_, code blocks, tables, lists, blockquotes as appropriate.
 3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. The user experiences real-time content appearing as you write.
+
+### Recovering from a failed update
+
+If a `document_update` call fails with an `Invalid input` error (for example because `surface_id` was missing), do NOT call `document_create` again. The `surface_id` you need is in the tool result of the most recent `document_create` call in this turn. Retry `document_update` with that `surface_id` and the same content. Creating a second document with the same title produces a duplicate for the user.
 
 ## Editing an existing document
 

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -218,6 +218,44 @@ export function searchDocumentsByTitle(
 }
 
 /**
+ * Return the most recent empty document in the given conversation with the
+ * supplied title, created within the last `withinMs` milliseconds.
+ *
+ * Used to dedupe a duplicate create-then-create flow after a failed update —
+ * when the model can't recover a malformed update and retries by creating a
+ * second same-title document, we reuse the first (still-empty) draft instead
+ * of producing a duplicate row. Returns `null` when no candidate exists.
+ */
+export function findRecentEmptyDocumentByTitle(
+  conversationId: string,
+  title: string,
+  withinMs: number,
+): { surfaceId: string } | null {
+  try {
+    const threshold = Date.now() - withinMs;
+    const row = rawGet<{ surface_id: string }>(
+      /*sql*/ `SELECT surface_id FROM documents
+       WHERE conversation_id = ?
+         AND title = ?
+         AND content = ''
+         AND created_at >= ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      conversationId,
+      title,
+      threshold,
+    );
+    return row ? { surfaceId: row.surface_id } : null;
+  } catch (error) {
+    log.error(
+      { err: error, conversationId, title },
+      "Find-recent-empty-document error",
+    );
+    return null;
+  }
+}
+
+/**
  * Delete a document and its conversation associations.
  * Returns `true` if the document existed and was deleted, `false` otherwise.
  */

--- a/assistant/src/skills/validate-input.ts
+++ b/assistant/src/skills/validate-input.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure JSON-schema input validator for skill tool calls.
+ *
+ * Deliberate strict subset of JSON Schema: it covers only the keywords
+ * actually used by `assistant/src/config/bundled-skills/**\/TOOLS.json`
+ * (required / type / enum / items.type) plus unknown-key detection. Anything
+ * else (`$ref`, `oneOf`, `anyOf`, `allOf`, `format`, `pattern`, `minimum`,
+ * `maximum`, object-shape `additionalProperties`, etc.) is silently skipped so
+ * a richer schema can never cause us to reject a legitimate call.
+ *
+ * Each error message is written to be agent-readable and self-correcting
+ * (e.g. `surface_id is required`, `mode must be one of "replace", "append"`).
+ */
+
+import { isPlainObject } from "../util/object.js";
+
+export interface InputValidationSuccess {
+  ok: true;
+}
+
+export interface InputValidationFailure {
+  ok: false;
+  /** Human-readable messages, one per problem. */
+  errors: string[];
+}
+
+export type InputValidationResult =
+  | InputValidationSuccess
+  | InputValidationFailure;
+
+type SupportedType =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "array"
+  | "object";
+
+const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "array",
+  "object",
+]);
+
+function matchesType(value: unknown, type: SupportedType): boolean {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return isPlainObject(value);
+  }
+}
+
+function quoteList(values: readonly string[]): string {
+  return values.map((v) => `"${v}"`).join(", ");
+}
+
+/**
+ * Validate a tool input object against the (optional) JSON-schema definition
+ * declared on the tool entry. Returns `{ ok: true }` if the input is valid (or
+ * if there is nothing actionable to validate); otherwise returns a list of
+ * human-readable error strings.
+ *
+ * Pure: never mutates `input` or `schema`, no I/O.
+ */
+export function validateInputAgainstSchema(
+  _toolName: string,
+  input: Record<string, unknown>,
+  schema: Record<string, unknown> | undefined,
+): InputValidationResult {
+  // Skip when there's no schema or no properties block — matches today's
+  // lenient behaviour for tools that declare only `{ type: "object" }`.
+  if (!schema) return { ok: true };
+  const properties = schema.properties;
+  if (!isPlainObject(properties)) return { ok: true };
+
+  const errors: string[] = [];
+  const knownKeys = Object.keys(properties);
+  const knownKeySet = new Set(knownKeys);
+
+  // 1. Required fields — `in` check, so explicit `undefined`/`null` count as missing.
+  const required = schema.required;
+  if (Array.isArray(required)) {
+    for (const key of required) {
+      if (typeof key !== "string") continue;
+      const present =
+        key in input && input[key] !== undefined && input[key] !== null;
+      if (!present) {
+        errors.push(`${key} is required`);
+      }
+    }
+  }
+
+  // 2. Per-property checks: type, enum, items.type.
+  for (const [key, rawSubSchema] of Object.entries(properties)) {
+    if (!(key in input)) continue;
+    const value = input[key];
+    if (value === undefined || value === null) continue;
+    if (!isPlainObject(rawSubSchema)) continue;
+
+    const declaredType = rawSubSchema.type;
+    if (typeof declaredType === "string" && SUPPORTED_TYPES.has(declaredType)) {
+      const type = declaredType as SupportedType;
+      if (!matchesType(value, type)) {
+        errors.push(`${key} must be ${typeArticle(type)} ${type}`);
+        // No point checking enum/items if the base type is wrong.
+        continue;
+      }
+
+      // 2a. Enum (string enums are the only shape used today).
+      const enumValues = rawSubSchema.enum;
+      if (Array.isArray(enumValues) && enumValues.length > 0) {
+        if (!enumValues.includes(value)) {
+          errors.push(
+            `${key} must be one of ${quoteList(enumValues.map(String))}`,
+          );
+        }
+      }
+
+      // 2b. Array items.type — per-element check.
+      if (type === "array" && isPlainObject(rawSubSchema.items)) {
+        const itemType = rawSubSchema.items.type;
+        if (
+          typeof itemType === "string" &&
+          SUPPORTED_TYPES.has(itemType) &&
+          Array.isArray(value)
+        ) {
+          const itemTypeName = itemType as SupportedType;
+          value.forEach((element, index) => {
+            if (!matchesType(element, itemTypeName)) {
+              errors.push(
+                `${key}[${index}] must be ${typeArticle(itemTypeName)} ${itemTypeName}`,
+              );
+            }
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Unknown keys — parity with the previous `validateNoUnknownParams`.
+  const unknownKeys = Object.keys(input).filter((k) => !knownKeySet.has(k));
+  for (const key of unknownKeys) {
+    errors.push(
+      `Unknown parameter "${key}". Supported: ${quoteList(knownKeys)}`,
+    );
+  }
+
+  if (errors.length === 0) return { ok: true };
+  return { ok: false, errors };
+}
+
+function typeArticle(type: SupportedType): "a" | "an" {
+  // `integer`, `array`, `object` start with a vowel sound.
+  return type === "integer" || type === "array" || type === "object"
+    ? "an"
+    : "a";
+}

--- a/assistant/src/skills/validate-input.ts
+++ b/assistant/src/skills/validate-input.ts
@@ -106,11 +106,12 @@ export function validateInputAgainstSchema(
   for (const [key, rawSubSchema] of Object.entries(properties)) {
     if (!(key in input)) continue;
     const value = input[key];
-    // `undefined` / `null` are treated as absent for type-checking purposes
-    // so we never reject a schema that legitimately permits null (e.g. a
-    // plugin schema with `type: ["string","null"]`). Combined with the
-    // presence-only `required` check above, this preserves nullable inputs.
-    if (value === undefined || value === null) continue;
+    // Skip type-checking for absent values; presence is enforced by the
+    // `required` check above. Note: `null` IS a present value and is
+    // type-checked below — only schemas that explicitly opt in to null via
+    // a union type (`type: ["string","null"]`) bypass the check, handled
+    // by the `Array.isArray(declaredType)` skip immediately below.
+    if (value === undefined) continue;
     if (!isPlainObject(rawSubSchema)) continue;
 
     const declaredType = rawSubSchema.type;

--- a/assistant/src/skills/validate-input.ts
+++ b/assistant/src/skills/validate-input.ts
@@ -89,14 +89,14 @@ export function validateInputAgainstSchema(
   const knownKeys = Object.keys(properties);
   const knownKeySet = new Set(knownKeys);
 
-  // 1. Required fields — `in` check, so explicit `undefined`/`null` count as missing.
+  // 1. Required fields — presence-only check per JSON Schema spec.
+  // `required` only requires the property to be present; `null` is a valid
+  // value when the schema allows it (e.g. `type: ["string", "null"]`).
   const required = schema.required;
   if (Array.isArray(required)) {
     for (const key of required) {
       if (typeof key !== "string") continue;
-      const present =
-        key in input && input[key] !== undefined && input[key] !== null;
-      if (!present) {
+      if (!(key in input)) {
         errors.push(`${key} is required`);
       }
     }
@@ -106,10 +106,17 @@ export function validateInputAgainstSchema(
   for (const [key, rawSubSchema] of Object.entries(properties)) {
     if (!(key in input)) continue;
     const value = input[key];
+    // `undefined` / `null` are treated as absent for type-checking purposes
+    // so we never reject a schema that legitimately permits null (e.g. a
+    // plugin schema with `type: ["string","null"]`). Combined with the
+    // presence-only `required` check above, this preserves nullable inputs.
     if (value === undefined || value === null) continue;
     if (!isPlainObject(rawSubSchema)) continue;
 
     const declaredType = rawSubSchema.type;
+    // Skip union types (e.g. `["string", "null"]`) — same lenient treatment
+    // we give `oneOf`/`anyOf`/`$ref`. We only validate single-type schemas.
+    if (Array.isArray(declaredType)) continue;
     if (typeof declaredType === "string" && SUPPORTED_TYPES.has(declaredType)) {
       const type = declaredType as SupportedType;
       if (!matchesType(value, type)) {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   deleteDocument,
   findInDocument,
+  findRecentEmptyDocumentByTitle,
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
@@ -124,12 +125,79 @@ export function executeDocumentOpen(
   };
 }
 
+const EMPTY_DOCUMENT_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * If the model just created an empty same-title document in this conversation
+ * and is now creating a second one with real content, reuse the first row
+ * instead of producing a duplicate. Returns `null` when no dedupe applies.
+ *
+ * Only triggers when `initialContent` is non-empty — an empty incoming create
+ * likely means the model intends a fresh blank doc.
+ */
+function maybeReuseEmptyDocument(
+  title: string,
+  initialContent: string,
+  context: ToolContext,
+): ToolExecutionResult | null {
+  if (initialContent.length === 0) return null;
+  const existing = findRecentEmptyDocumentByTitle(
+    context.conversationId,
+    title,
+    EMPTY_DOCUMENT_DEDUPE_WINDOW_MS,
+  );
+  if (!existing) return null;
+
+  const surfaceId = existing.surfaceId;
+  const update = updateDocumentContent(surfaceId, initialContent, "replace");
+  if (!update.success) return null;
+
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "document_editor_show",
+      conversationId: context.conversationId,
+      surfaceId,
+      title,
+      initialContent,
+    });
+
+    context.sendToClient({
+      type: "ui_surface_show",
+      conversationId: context.conversationId,
+      surfaceId: `preview-${surfaceId}`,
+      surfaceType: "document_preview",
+      display: "inline",
+      title,
+      data: {
+        title,
+        surfaceId,
+        subtitle: "Document",
+      },
+    });
+  }
+
+  return {
+    content: JSON.stringify({
+      surface_id: surfaceId,
+      title,
+      opened: context.sendToClient != null,
+      reused: true,
+      message: "Document editor reopened (deduped empty draft)",
+    }),
+    isError: false,
+  };
+}
+
 export function executeDocumentCreate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
   const title = (input.title as string | undefined) || "Untitled Document";
   const initialContent = (input.initial_content as string | undefined) || "";
+
+  const reused = maybeReuseEmptyDocument(title, initialContent, context);
+  if (reused) return reused;
+
   const surfaceId = `doc-${randomUUID()}`;
 
   // Persist the document so any client (web or macOS) can fetch it via

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -153,9 +153,8 @@ function maybeReuseEmptyDocument(
   const update = updateDocumentContent(surfaceId, initialContent, "replace");
   if (!update.success) return null;
 
-  // Mirror the create-new path's saveDocument → addDocumentConversation
-  // invariant so the deduped doc stays discoverable from this conversation
-  // even if the junction row was removed out of band.
+  // Defensive idempotent insert (saveDocument from the create-new path already
+  // ran addDocumentConversation; INSERT OR IGNORE makes this a safe no-op).
   addDocumentConversation(surfaceId, context.conversationId);
 
   if (context.sendToClient) {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  addDocumentConversation,
   deleteDocument,
   findInDocument,
   findRecentEmptyDocumentByTitle,
@@ -152,13 +153,22 @@ function maybeReuseEmptyDocument(
   const update = updateDocumentContent(surfaceId, initialContent, "replace");
   if (!update.success) return null;
 
+  // Mirror the create-new path's saveDocument → addDocumentConversation
+  // invariant so the deduped doc stays discoverable from this conversation
+  // even if the junction row was removed out of band.
+  addDocumentConversation(surfaceId, context.conversationId);
+
   if (context.sendToClient) {
+    // Use document_editor_update — not document_editor_show — because the
+    // empty draft is typically still OPEN on the macOS client. A *_show on an
+    // open doc triggers DocumentManager.closeDocument() → async save() of the
+    // OLD (empty) content, clobbering the initialContent we just persisted.
     context.sendToClient({
-      type: "document_editor_show",
+      type: "document_editor_update",
       conversationId: context.conversationId,
       surfaceId,
-      title,
-      initialContent,
+      markdown: initialContent,
+      mode: "replace",
     });
 
     context.sendToClient({
@@ -271,8 +281,11 @@ export function executeDocumentUpdate(
   if (typeof input.content !== "string") {
     return invalidInput("content is required and must be a string");
   }
+  // Loose `!= null` to match validateInputAgainstSchema, which treats null as
+  // "absent" for enum checks — without this, { mode: null } passes the
+  // factory validator but rejects here. The `?? "append"` below handles null.
   if (
-    input.mode !== undefined &&
+    input.mode != null &&
     input.mode !== "replace" &&
     input.mode !== "append"
   ) {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -40,13 +40,36 @@ export function canAccessDocument(
   );
 }
 
+function invalidInput(message: string): ToolExecutionResult {
+  return {
+    content: JSON.stringify({
+      success: false,
+      error: `Invalid input: ${message}`,
+    }),
+    isError: true,
+  };
+}
+
+function validateSurfaceId(
+  input: Record<string, unknown>,
+): ToolExecutionResult | string {
+  if (typeof input.surface_id !== "string" || input.surface_id.trim() === "") {
+    return invalidInput(
+      "surface_id is required and must be a non-empty string",
+    );
+  }
+  return input.surface_id;
+}
+
 // ── Exported execute functions ──────────────────────────────────────
 
 export function executeDocumentOpen(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -174,9 +197,21 @@ export function executeDocumentUpdate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
-  const content = input.content as string;
-  const mode = (input.mode as string | undefined) || "append";
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
+  if (typeof input.content !== "string") {
+    return invalidInput("content is required and must be a string");
+  }
+  if (
+    input.mode !== undefined &&
+    input.mode !== "replace" &&
+    input.mode !== "append"
+  ) {
+    return invalidInput('mode must be "replace" or "append"');
+  }
+  const content = input.content;
+  const mode = (input.mode as "replace" | "append" | undefined) ?? "append";
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -229,7 +264,9 @@ export function executeDocumentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -286,7 +323,9 @@ export function executeDocumentDelete(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
   }
@@ -309,7 +348,9 @@ export function executeDocumentFind(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   const query = input.query as string;
   const regex = (input.regex as boolean | undefined) ?? false;
   const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
@@ -360,7 +401,9 @@ export function executeDocumentReplaceText(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const surfaceIdOrError = validateSurfaceId(input);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   const find = input.find as string;
   const replace = (input.replace as string) ?? "";
   const regex = (input.regex as boolean | undefined) ?? false;

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -1,5 +1,6 @@
 import type { SkillToolEntry } from "../../config/skills.js";
 import { RiskLevel } from "../../permissions/types.js";
+import { validateInputAgainstSchema } from "../../skills/validate-input.js";
 import type {
   ExecutionTarget,
   Tool,
@@ -13,31 +14,6 @@ const riskMap: Record<SkillToolEntry["risk"], RiskLevel> = {
   medium: RiskLevel.Medium,
   high: RiskLevel.High,
 };
-
-/**
- * Validate that all keys in `input` are declared in the tool's input_schema
- * properties. Returns an error result listing unknown parameters, or undefined
- * if validation passes.
- */
-function validateNoUnknownParams(
-  toolName: string,
-  input: Record<string, unknown>,
-  schema: SkillToolEntry["input_schema"],
-): ToolExecutionResult | undefined {
-  const properties = schema?.properties;
-  if (!properties) return undefined;
-
-  const knownKeys = new Set(Object.keys(properties));
-  const unknownKeys = Object.keys(input).filter((k) => !knownKeys.has(k));
-  if (unknownKeys.length === 0) return undefined;
-
-  const listed = unknownKeys.map((k) => `"${k}"`).join(", ");
-  const supported = [...knownKeys].map((k) => `"${k}"`).join(", ");
-  return {
-    content: `Unknown parameter${unknownKeys.length > 1 ? "s" : ""} ${listed} for tool "${toolName}". Supported parameters: ${supported}. Remove unsupported parameters and retry.`,
-    isError: true,
-  };
-}
 
 /**
  * Create a runtime Tool object from a manifest entry.
@@ -66,12 +42,17 @@ export function createSkillTool(
       input: Record<string, unknown>,
       context: ToolContext,
     ): Promise<ToolExecutionResult> {
-      const validationError = validateNoUnknownParams(
+      const validation = validateInputAgainstSchema(
         entry.name,
         input,
-        entry.input_schema,
+        entry.input_schema as Record<string, unknown> | undefined,
       );
-      if (validationError) return validationError;
+      if (!validation.ok) {
+        return {
+          content: `Invalid input for tool "${entry.name}": ${validation.errors.join("; ")}. Fix the arguments and retry.`,
+          isError: true,
+        };
+      }
 
       return runSkillToolScript(skillDir, entry.executor, input, context, {
         target: entry.execution_target,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Combine
+import os
 import VellumAssistantShared
 import SwiftUI
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MainWindow")
 
 /// Delegate that intercepts the window close button to hide the window
 /// instead of closing it, keeping the app running in the dock + menu bar.
@@ -415,6 +418,18 @@ public final class MainWindow {
     }
 
     func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
+        // Safety: only apply when the message targets the currently-active document.
+        // Otherwise we'd mutate `currentContent` for an unrelated doc and the
+        // subsequent autoSave would persistently corrupt it on the daemon.
+        // (The active surface may not match the message — e.g. when the dedupe
+        // path in maybeReuseEmptyDocument fires for an empty draft the user has
+        // already navigated away from. In that case the daemon has the right
+        // content; the user just won't see it surface in the editor until they
+        // reopen the doc.)
+        guard documentManager.surfaceId == msg.surfaceId else {
+            log.info("Ignoring document_editor_update for surface \(msg.surfaceId) (active surface is \(documentManager.surfaceId ?? "nil"))")
+            return
+        }
         documentManager.updateDocument(markdown: msg.markdown, mode: msg.mode)
     }
 


### PR DESCRIPTION
## Summary

Closes JARVIS-968 (`document_editor` flow created duplicate docs after a malformed `document_update({})` call).

The feature branch implements end-to-end hardening of the document-editor flow:

- **Skill-tool factory layer:** new `validateInputAgainstSchema` utility rejects missing required fields, wrong types, and bad enum values for every skill tool's input BEFORE the executor runs, with self-correcting agent-readable error messages (`Invalid input for tool "..."`).
- **Executor layer:** `executeDocumentUpdate` (and sibling `executeDocument*` fns) defensively validate `surface_id`, `content`, and `mode` before any DB lookup, so a `document_update({})` call now surfaces as `Invalid input: surface_id is required …` instead of a misleading `Document not found`.
- **SKILL.md guidance:** new `Recovering from a failed update` subsection redirects the model from "create another doc" to "retry with the surface_id from the prior create call".
- **Server-side dedupe:** `executeDocumentCreate` now reuses an empty same-title document in the same conversation (within a 5-minute window) instead of creating a duplicate row.
- **macOS client safety:** `handleDocumentEditorUpdate` now gates on `documentManager.surfaceId == msg.surfaceId`, bringing macOS to parity with the web client and preventing the dedupe path from corrupting an unrelated active document.

## Self-review result

**PASS** after 3 rounds. Two remediation cycles addressed:
- **R1:** Codex P1 client/server race (closeDocument→save clobbering server content), document_conversations junction-row parity, mode=null inconsistency between factory validator and executor.
- **R2:** Wrong-doc data corruption regression introduced by R1's `_show → _update` swap — the macOS `_update` handler didn't gate on `surfaceId`, so the dedupe path could overwrite an unrelated active document and persist it via autoSave.

## PRs merged into feature branch
- #32375: docs(document-editor): clarify update-failure recovery in SKILL.md
- #32376: feat(assistant): add JSON schema input validator for skill tools
- #32377: fix(document-editor): validate update input before lookup
- #32382: fix(document-editor): reuse empty same-title doc in same conversation
- #32385: feat(assistant): enforce required/type/enum on skill tool inputs

### Fix PRs
- #32390: fix(document-editor): harden dedupe path and align mode null handling
- #32394: fix(macos): gate document_editor_update on surface_id match

## Deferred follow-ups (not blocking)

- **Recurse `validateInputAgainstSchema` into array `items`** for `enum`/`required` checks. Codex P2 on PR #32376 flagged that bundled skills like `messaging_list_conversations.types.items.enum` and `sequence_create.steps.items.required` aren't enforced by the new validator. Plan explicitly scoped this out ("strict subset of JSON Schema so we never reject a legitimate call"); existing executor-side checks still catch the bad data. Worth a follow-up enhancement if we want defense-in-depth at the validator layer.

Part of plan: doc-editor-validate.md