### PR TITLE
feat(cli): add clean tests + cloudflare tunnel provider

### DIFF
--- a/cli/src/__tests__/clean.test.ts
+++ b/cli/src/__tests__/clean.test.ts
@@ -1,0 +1,179 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+import type { OrphanedProcess } from "../lib/orphan-detection.js";
+
+// ── Module mocks (must be set up before importing the command) ───────────────
+
+const detectOrphansMock = mock(async (): Promise<OrphanedProcess[]> => []);
+const stopProcessMock = mock(
+  async (_pid: number, _label: string): Promise<boolean> => true,
+);
+
+beforeAll(() => {
+  mock.module("../lib/orphan-detection.js", () => ({
+    detectOrphanedProcesses: detectOrphansMock,
+  }));
+  mock.module("../lib/process.js", () => ({
+    stopProcess: stopProcessMock,
+  }));
+});
+
+import { clean } from "../commands/clean.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeOrphan(
+  name: string,
+  pid: string,
+  source = "process table",
+): OrphanedProcess {
+  return { name, pid, source };
+}
+
+const originalArgv = [...process.argv];
+
+let consoleLogSpy: ReturnType<typeof spyOn>;
+let consoleErrorSpy: ReturnType<typeof spyOn>;
+let exitSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = spyOn(process, "exit").mockImplementation((_code?: number) => {
+    throw new Error(`process.exit(${_code})`);
+  });
+  detectOrphansMock.mockClear();
+  stopProcessMock.mockClear();
+});
+
+afterEach(() => {
+  process.argv = [...originalArgv];
+  consoleLogSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+  exitSpy.mockRestore();
+});
+
+afterAll(() => {
+  process.argv = [...originalArgv];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("vellum clean --help", () => {
+  test("prints usage and exits 0", async () => {
+    process.argv = ["bun", "vellum", "clean", "--help"];
+    await expect(clean()).rejects.toThrow("process.exit(0)");
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Usage: vellum clean");
+    expect(output).toContain("orphaned");
+  });
+
+  test("-h is accepted as an alias for --help", async () => {
+    process.argv = ["bun", "vellum", "clean", "-h"];
+    await expect(clean()).rejects.toThrow("process.exit(0)");
+  });
+});
+
+describe("vellum clean — no orphans", () => {
+  test("prints nothing-to-do message when no orphans are found", async () => {
+    detectOrphansMock.mockResolvedValueOnce([]);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("No orphaned processes found.");
+    expect(stopProcessMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("vellum clean — single orphan", () => {
+  test("kills the orphan and prints singular 'process'", async () => {
+    detectOrphansMock.mockResolvedValueOnce([makeOrphan("assistant", "12345")]);
+    stopProcessMock.mockResolvedValueOnce(true);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+
+    expect(stopProcessMock).toHaveBeenCalledTimes(1);
+    expect(stopProcessMock).toHaveBeenCalledWith(
+      12345,
+      "assistant (PID 12345)",
+    );
+
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Found 1 orphaned process");
+    expect(output).not.toContain("processes");
+    expect(output).toContain("Cleaned up 1 process.");
+    expect(output).not.toContain("processes.");
+  });
+
+  test("reports 0 cleaned when stopProcess returns false", async () => {
+    detectOrphansMock.mockResolvedValueOnce([makeOrphan("gateway", "99999")]);
+    stopProcessMock.mockResolvedValueOnce(false);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Cleaned up 0 process");
+  });
+});
+
+describe("vellum clean — multiple orphans", () => {
+  test("uses plural 'processes' with multiple orphans", async () => {
+    detectOrphansMock.mockResolvedValueOnce([
+      makeOrphan("assistant", "1001"),
+      makeOrphan("gateway", "1002"),
+      makeOrphan("qdrant", "1003"),
+    ]);
+    stopProcessMock.mockResolvedValue(true);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+
+    expect(stopProcessMock).toHaveBeenCalledTimes(3);
+
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Found 3 orphaned processes");
+    expect(output).toContain("Cleaned up 3 processes.");
+  });
+
+  test("counts only successfully stopped processes in the total", async () => {
+    detectOrphansMock.mockResolvedValueOnce([
+      makeOrphan("assistant", "2001"),
+      makeOrphan("qdrant", "2002"),
+      makeOrphan("gateway", "2003"),
+    ]);
+    // Only the first and third succeed
+    stopProcessMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+
+    const output = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Found 3 orphaned processes");
+    expect(output).toContain("Cleaned up 2 processes.");
+  });
+
+  test("passes the correct PID and label to stopProcess for each orphan", async () => {
+    detectOrphansMock.mockResolvedValueOnce([
+      makeOrphan("assistant", "3001"),
+      makeOrphan("gateway", "3002"),
+    ]);
+    stopProcessMock.mockResolvedValue(true);
+    process.argv = ["bun", "vellum", "clean"];
+    await clean();
+
+    const calls = stopProcessMock.mock.calls as [number, string][];
+    expect(calls[0]).toEqual([3001, "assistant (PID 3001)"]);
+    expect(calls[1]).toEqual([3002, "gateway (PID 3002)"]);
+  });
+});

--- a/cli/src/__tests__/cloudflare-tunnel.test.ts
+++ b/cli/src/__tests__/cloudflare-tunnel.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+
+import { waitForCloudflareTunnelUrl } from "../lib/cloudflare-tunnel.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal fake ChildProcess whose stdout and stderr are plain
+ * EventEmitters. Tests control what data is emitted and when.
+ */
+function makeChild(): {
+  child: ChildProcess;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  emitExit: (code: number | null) => void;
+} {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const childEmitter = new EventEmitter();
+
+  const child = Object.assign(childEmitter, {
+    stdout,
+    stderr,
+    killed: false,
+    kill: () => false,
+    pid: 99999,
+  }) as unknown as ChildProcess;
+
+  const emitExit = (code: number | null) => childEmitter.emit("exit", code);
+
+  return { child, stdout, stderr, emitExit };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("waitForCloudflareTunnelUrl", () => {
+  test("resolves when the URL appears on stderr", async () => {
+    const { child, stderr } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    stderr.emit(
+      "data",
+      Buffer.from(
+        "2024-01-01T00:00:00Z INF |  https://quick-slug-test.trycloudflare.com  |\n",
+      ),
+    );
+
+    await expect(promise).resolves.toBe(
+      "https://quick-slug-test.trycloudflare.com",
+    );
+  });
+
+  test("resolves when the URL appears on stdout", async () => {
+    const { child, stdout } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    stdout.emit(
+      "data",
+      Buffer.from("https://another-slug.trycloudflare.com\n"),
+    );
+
+    await expect(promise).resolves.toBe(
+      "https://another-slug.trycloudflare.com",
+    );
+  });
+
+  test("resolves with the first URL when multiple lines contain one", async () => {
+    const { child, stderr } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    stderr.emit(
+      "data",
+      Buffer.from(
+        "INFO https://first-slug.trycloudflare.com\nINFO https://second-slug.trycloudflare.com\n",
+      ),
+    );
+
+    await expect(promise).resolves.toBe("https://first-slug.trycloudflare.com");
+  });
+
+  test("handles a URL split across two data chunks", async () => {
+    const { child, stderr } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    // First chunk ends mid-line before the URL
+    stderr.emit("data", Buffer.from("INFO Visit: "));
+    // Second chunk completes the line
+    stderr.emit(
+      "data",
+      Buffer.from("https://chunked-slug.trycloudflare.com\n"),
+    );
+
+    await expect(promise).resolves.toBe(
+      "https://chunked-slug.trycloudflare.com",
+    );
+  });
+
+  test("rejects when the process exits before a URL is found", async () => {
+    const { child, emitExit } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    emitExit(1);
+
+    await expect(promise).rejects.toThrow("exited with code 1");
+  });
+
+  test("rejects on null exit code (killed by signal)", async () => {
+    const { child, emitExit } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child);
+
+    emitExit(null);
+
+    await expect(promise).rejects.toThrow("exited with code unknown");
+  });
+
+  test("rejects after the timeout when no URL appears", async () => {
+    const { child } = makeChild();
+    // Use a very short timeout so the test runs fast
+    const promise = waitForCloudflareTunnelUrl(child, 50);
+
+    await expect(promise).rejects.toThrow("did not appear within");
+  });
+
+  test("does not resolve for non-trycloudflare.com hostnames", async () => {
+    const { child, stderr, emitExit } = makeChild();
+    const promise = waitForCloudflareTunnelUrl(child, 50);
+
+    // Emit a line with a URL that is not a Cloudflare quick-tunnel URL
+    stderr.emit("data", Buffer.from("Connecting to https://example.com/api\n"));
+
+    // Should still time out — the fake URL does not match the pattern
+    emitExit(null);
+    await expect(promise).rejects.toThrow();
+  });
+});

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,4 +1,5 @@
 import { resolveAssistant } from "../lib/assistant-config";
+import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { runNgrokTunnel } from "../lib/ngrok";
 
 const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
@@ -21,17 +22,45 @@ function parseArgs(): TunnelArgs {
     if (arg === "--help" || arg === "-h") {
       console.log("Usage: vellum tunnel [<name>] [options]");
       console.log("");
-      console.log("Create a tunnel for a locally hosted assistant.");
+      console.log(
+        "Expose a locally running assistant to the internet via a tunnel.",
+      );
+      console.log(
+        "The public URL is saved to the workspace config as the ingress base URL,",
+      );
+      console.log(
+        "enabling webhook integrations (Telegram, Twilio, etc.) to reach the assistant.",
+      );
       console.log("");
       console.log("Arguments:");
       console.log(
-        "  <name>                        Name of the assistant (defaults to latest)",
+        "  <name>                        Name of the assistant (defaults to active or only local)",
       );
       console.log("");
       console.log("Options:");
       console.log(
         `  --provider <provider>         Tunnel provider: ${VALID_PROVIDERS.join(", ")} (default: ${DEFAULT_PROVIDER})`,
       );
+      console.log("");
+      console.log("Providers:");
+      console.log(
+        "  vellum       Managed tunnel via Vellum Cloud (default; requires account)",
+      );
+      console.log(
+        "  ngrok        ngrok tunnel — install: brew install ngrok/ngrok/ngrok",
+      );
+      console.log(
+        "  cloudflare   Cloudflare quick tunnel — install: brew install cloudflare/cloudflare/cloudflared",
+      );
+      console.log(
+        "               No Cloudflare account required for quick tunnels.",
+      );
+      console.log("");
+      console.log("Examples:");
+      console.log("  $ vellum tunnel");
+      console.log("  $ vellum tunnel --provider ngrok");
+      console.log("  $ vellum tunnel --provider cloudflare");
+      console.log("  $ vellum tunnel my-assistant --provider cloudflare");
       process.exit(0);
     } else if (arg === "--provider") {
       const next = args[i + 1];
@@ -75,6 +104,11 @@ export async function tunnel(): Promise<void> {
 
   if (provider === "ngrok") {
     await runNgrokTunnel();
+    return;
+  }
+
+  if (provider === "cloudflare") {
+    await runCloudflareTunnel();
     return;
   }
 

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,3 +1,5 @@
+import { join } from "path";
+
 import { resolveAssistant } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { runNgrokTunnel } from "../lib/ngrok";
@@ -108,7 +110,15 @@ export async function tunnel(): Promise<void> {
   }
 
   if (provider === "cloudflare") {
-    await runCloudflareTunnel();
+    const resources = entry.resources;
+    await runCloudflareTunnel(
+      resources
+        ? {
+            port: resources.gatewayPort,
+            workspaceDir: join(resources.instanceDir, ".vellum", "workspace"),
+          }
+        : {},
+    );
     return;
   }
 

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -1,0 +1,262 @@
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { GATEWAY_PORT } from "./constants.js";
+
+// ── Workspace config helpers (mirrors the pattern in ngrok.ts) ───────────────
+
+function getDefaultWorkspaceDir(): string {
+  return (
+    process.env.VELLUM_WORKSPACE_DIR?.trim() ||
+    join(homedir(), ".vellum", "workspace")
+  );
+}
+
+function getConfigPath(workspaceDir: string): string {
+  return join(workspaceDir, "config.json");
+}
+
+function loadRawConfig(workspaceDir: string): Record<string, unknown> {
+  const configPath = getConfigPath(workspaceDir);
+  if (!existsSync(configPath)) return {};
+  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function saveRawConfig(
+  workspaceDir: string,
+  config: Record<string, unknown>,
+): void {
+  const configPath = getConfigPath(workspaceDir);
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+function saveIngressUrl(workspaceDir: string, publicUrl: string): void {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  ingress.publicBaseUrl = publicUrl;
+  ingress.enabled = true;
+  config.ingress = ingress;
+  saveRawConfig(workspaceDir, config);
+}
+
+function clearIngressUrl(workspaceDir: string): void {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  delete ingress.publicBaseUrl;
+  config.ingress = ingress;
+  saveRawConfig(workspaceDir, config);
+}
+
+// ── Cloudflare Tunnel ─────────────────────────────────────────────────────────
+
+const CLOUDFLARED_TIMEOUT_MS = 30_000;
+
+// Quick-tunnel hostnames follow the pattern <word>-<word>-<word>.trycloudflare.com
+const QUICK_TUNNEL_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+
+/**
+ * Check whether cloudflared is installed and on PATH.
+ * Returns the version string if found, null otherwise.
+ */
+export function getCloudflareTunnelVersion(): string | null {
+  try {
+    const output = execFileSync("cloudflared", ["version"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Spawn a cloudflared quick-tunnel process forwarding HTTP traffic to
+ * `targetPort`.  The child process writes its public URL to stderr during
+ * startup — use {@link waitForCloudflareTunnelUrl} to extract it.
+ */
+export function startCloudflareTunnelProcess(targetPort: number): ChildProcess {
+  return spawn(
+    "cloudflared",
+    ["tunnel", "--url", `http://localhost:${targetPort}`, "--no-autoupdate"],
+    // Keep stdio as pipes so we can parse the URL from output.
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+/**
+ * Listen to a running cloudflared process's stdout/stderr and resolve with
+ * the public quick-tunnel URL once cloudflared prints it.
+ *
+ * cloudflared emits a line containing the trycloudflare.com URL during
+ * startup — typically within 5–15 seconds on a normal internet connection.
+ *
+ * Rejects when:
+ * - The URL does not appear within `timeoutMs`.
+ * - The child process exits before the URL is found.
+ */
+export function waitForCloudflareTunnelUrl(
+  child: ChildProcess,
+  timeoutMs: number = CLOUDFLARED_TIMEOUT_MS,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `cloudflared tunnel URL did not appear within ${timeoutMs / 1000}s. ` +
+            `Ensure cloudflared is working: try running 'cloudflared tunnel --url http://localhost:8080' manually.`,
+        ),
+      );
+    }, timeoutMs);
+
+    let resolved = false;
+
+    function scanLine(line: string): void {
+      if (resolved) return;
+      const match = QUICK_TUNNEL_URL_RE.exec(line);
+      if (match) {
+        resolved = true;
+        clearTimeout(timer);
+        resolve(match[0]);
+      }
+    }
+
+    // Buffer incomplete lines across chunks
+    let stdoutBuf = "";
+    let stderrBuf = "";
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutBuf += chunk.toString();
+      const lines = stdoutBuf.split("\n");
+      stdoutBuf = lines.pop() ?? "";
+      for (const line of lines) scanLine(line);
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrBuf += chunk.toString();
+      const lines = stderrBuf.split("\n");
+      stderrBuf = lines.pop() ?? "";
+      for (const line of lines) scanLine(line);
+    });
+
+    child.on("exit", (code) => {
+      if (resolved) return;
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `cloudflared exited with code ${code ?? "unknown"} before the tunnel URL appeared.`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Run the cloudflared quick-tunnel workflow:
+ * 1. Verify cloudflared is installed.
+ * 2. Start a quick tunnel pointing at the gateway port.
+ * 3. Parse the public URL from cloudflared output.
+ * 4. Persist the URL to the workspace config as the ingress base URL.
+ * 5. Block until the process exits or the user presses Ctrl+C.
+ * 6. Clear the ingress URL from config on exit.
+ *
+ * No Cloudflare account is required — quick tunnels are free and ephemeral.
+ */
+export async function runCloudflareTunnel(): Promise<void> {
+  const version = getCloudflareTunnelVersion();
+  if (!version) {
+    console.error("Error: cloudflared is not installed.");
+    console.error("");
+    console.error("Install cloudflared:");
+    console.error("  macOS:   brew install cloudflare/cloudflare/cloudflared");
+    console.error("  Linux:   https://pkg.cloudflare.com/index.html");
+    console.error(
+      "  Windows: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
+    );
+    console.error("");
+    console.error("No Cloudflare account is required for quick tunnels.");
+    process.exit(1);
+  }
+
+  console.log(`Using ${version}`);
+
+  const port = GATEWAY_PORT;
+  const workspaceDir = getDefaultWorkspaceDir();
+
+  console.log(`Starting cloudflared quick tunnel to localhost:${port}...`);
+  console.log("No Cloudflare account required — quick tunnels are free.");
+  console.log("");
+
+  let publicUrl: string | undefined;
+  const child = startCloudflareTunnelProcess(port);
+
+  const cleanup = (): void => {
+    if (!child.killed) child.kill("SIGTERM");
+    if (publicUrl) {
+      console.log("\nClearing ingress URL from config...");
+      clearIngressUrl(workspaceDir);
+    }
+  };
+
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+
+  child.on("error", (err: Error) => {
+    console.error(`cloudflared process error: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code) => {
+    if (publicUrl !== undefined && code !== null && code !== 0) {
+      console.error(`\ncloudflared exited with code ${code}.`);
+      process.exit(1);
+    }
+  });
+
+  // Forward cloudflared output to the console so the user can see startup
+  // progress and any authentication errors.
+  child.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[cloudflared] ${line}`);
+  });
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[cloudflared] ${line}`);
+  });
+
+  try {
+    publicUrl = await waitForCloudflareTunnelUrl(child);
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+
+  console.log("");
+  console.log(`Tunnel established: ${publicUrl}`);
+  console.log(`Forwarding to:     localhost:${port}`);
+  console.log("");
+
+  saveIngressUrl(workspaceDir, publicUrl);
+  console.log("Ingress URL saved to config.");
+  console.log("");
+  console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");
+
+  // Keep running until cloudflared exits (e.g., network error or user Ctrl+C)
+  await new Promise<void>((resolve) => {
+    child.on("exit", () => resolve());
+  });
+}

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -170,7 +170,16 @@ export function waitForCloudflareTunnelUrl(
  *
  * No Cloudflare account is required — quick tunnels are free and ephemeral.
  */
-export async function runCloudflareTunnel(): Promise<void> {
+export interface RunCloudflareTunnelOptions {
+  /** Gateway port to forward. Defaults to the global GATEWAY_PORT. */
+  port?: number;
+  /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
+  workspaceDir?: string;
+}
+
+export async function runCloudflareTunnel(
+  opts: RunCloudflareTunnelOptions = {},
+): Promise<void> {
   const version = getCloudflareTunnelVersion();
   if (!version) {
     console.error("Error: cloudflared is not installed.");
@@ -188,8 +197,8 @@ export async function runCloudflareTunnel(): Promise<void> {
 
   console.log(`Using ${version}`);
 
-  const port = GATEWAY_PORT;
-  const workspaceDir = getDefaultWorkspaceDir();
+  const port = opts.port ?? GATEWAY_PORT;
+  const workspaceDir = opts.workspaceDir ?? getDefaultWorkspaceDir();
 
   console.log(`Starting cloudflared quick tunnel to localhost:${port}...`);
   console.log("No Cloudflare account required — quick tunnels are free.");
@@ -221,7 +230,12 @@ export async function runCloudflareTunnel(): Promise<void> {
   });
 
   child.on("exit", (code) => {
-    if (publicUrl !== undefined && code !== null && code !== 0) {
+    // Always clear the saved ingress URL when the tunnel process ends so
+    // webhook integrations don't keep hitting a dead endpoint.
+    if (publicUrl !== undefined) {
+      clearIngressUrl(workspaceDir);
+    }
+    if (code !== null && code !== 0) {
       console.error(`\ncloudflared exited with code ${code}.`);
       process.exit(1);
     }


### PR DESCRIPTION
## vellum clean — test coverage

Add clean.test.ts covering all branches of the clean command:
- --help / -h prints usage and exits 0
- no orphans found → "No orphaned processes found."
- single orphan stopped → singular grammar ("1 process")
- stopProcess returning false → counted as 0 cleaned
- multiple orphans → plural grammar, partial-success count
- correct PID (parsed as int) and label passed to stopProcess

Uses mock.module to stub detectOrphanedProcesses and stopProcess so tests run without touching the real OS process table.

## vellum tunnel --provider cloudflare

Add cli/src/lib/cloudflare-tunnel.ts implementing the Cloudflare quick-tunnel provider:

- getCloudflareTunnelVersion(): checks cloudflared is on PATH
- startCloudflareTunnelProcess(port): spawns cloudflared with piped stdio so the URL can be parsed from output
- waitForCloudflareTunnelUrl(child, timeoutMs): scans stdout/stderr for the trycloudflare.com URL pattern, buffers incomplete lines across chunks, rejects on process exit or timeout
- runCloudflareTunnel(): full workflow — check install, start tunnel, save URL to workspace config, block until Ctrl+C, clear on exit

No Cloudflare account required — quick tunnels are free and ephemeral.

Wire cloudflare into tunnel.ts alongside the existing ngrok path. Improve --help with provider descriptions, install instructions, and four concrete examples.

Add cloudflare-tunnel.test.ts with 8 tests covering: URL detected on stderr, URL detected on stdout, first-URL-wins when multiple match, chunked data across two events, process-exit rejection, null-exit rejection, timeout rejection, and non-matching hostnames ignored.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
