### PR TITLE
fix(schedule): default recurring schedules to reuse conversations

### DIFF
--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -210,12 +210,57 @@ describe("scheduler conversation reuse", () => {
     expect(runs2[0].conversationId).toBe(firstConversationId);
   });
 
-  test("recurring schedule with reuseConversation=false creates new conversation each run", async () => {
+  test("recurring schedule defaults to reuseConversation=true", async () => {
     /**
-     * Default behavior: each run creates a brand-new conversation.
+     * When no explicit reuseConversation is provided, recurring schedules
+     * default to true — subsequent runs reuse the same conversation.
      */
 
-    // GIVEN a recurring schedule with reuseConversation disabled (default)
+    // GIVEN a recurring schedule with no explicit reuseConversation
+    const rruleExpr = buildEveryMinuteRrule();
+    const schedule = createSchedule({
+      name: "Default Reuse Test",
+      cronExpression: rruleExpr,
+      message: "Default reuse message",
+      syntax: "rrule",
+      expression: rruleExpr,
+      // no explicit reuseConversation — should default to true for recurring
+    });
+
+    // WHEN the schedule fires for the first time
+    forceScheduleDue(schedule.id);
+
+    const processMessage = async (conversationId: string, message: string) => {
+      processedMessages.push({ conversationId, message });
+    };
+
+    const scheduler1 = startScheduler(processMessage, () => {});
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler1.stop();
+
+    expect(processedMessages).toHaveLength(1);
+    const firstConversationId = processedMessages[0].conversationId;
+    expect(firstConversationId).toBeTruthy();
+
+    // WHEN the schedule fires for the second time
+    forceScheduleDue(schedule.id);
+    processedMessages.length = 0;
+
+    const scheduler2 = startScheduler(processMessage, () => {});
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler2.stop();
+
+    // THEN the same conversation is reused
+    expect(processedMessages).toHaveLength(1);
+    expect(processedMessages[0].conversationId).toBe(firstConversationId);
+  });
+
+  test("recurring schedule with reuseConversation=false creates new conversation each run", async () => {
+    /**
+     * When explicitly opted out, each run creates a brand-new conversation.
+     */
+
+    // GIVEN a recurring schedule with reuseConversation explicitly disabled
     const rruleExpr = buildEveryMinuteRrule();
     const schedule = createSchedule({
       name: "No Reuse Test",
@@ -223,7 +268,7 @@ describe("scheduler conversation reuse", () => {
       message: "New conv each run",
       syntax: "rrule",
       expression: rruleExpr,
-      // reuseConversation defaults to false
+      reuseConversation: false, // explicitly opt out of conversation reuse
     });
 
     // WHEN the schedule fires for the first time

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -100,7 +100,7 @@ Use `notify` for simple reminders ("remind me to take medicine at 9am"), `execut
 
 ## Conversation Reuse
 
-By default, each schedule run creates a new conversation. For recurring schedules that benefit from accumulating context across runs (e.g. polling-style jobs, daily digests that reference prior results), set `reuse_conversation: true`. When enabled, subsequent runs reuse the conversation from the last successful run instead of creating a new one.
+Recurring schedules reuse the same conversation across runs by default — subsequent runs continue the conversation from the last successful run, preserving context and channel thread continuity. Set `reuse_conversation: false` explicitly if each run should start with a fresh conversation (e.g. independent reports that shouldn't accumulate prior context). One-shot schedules always create a fresh conversation.
 
 - Only applies to **recurring** schedules; ignored for one-shot schedules.
 - If the prior conversation has been deleted, a new one is created automatically.

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -62,7 +62,7 @@
           },
           "reuse_conversation": {
             "type": "boolean",
-            "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules. Defaults to false."
+            "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Defaults to true for recurring schedules, false for one-shot. Set to false explicitly if each run should start fresh."
           },
           "max_retries": {
             "type": "integer",
@@ -161,7 +161,7 @@
           },
           "reuse_conversation": {
             "type": "boolean",
-            "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules."
+            "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Defaults to true for recurring schedules. Set to false explicitly if each run should start fresh."
           },
           "max_retries": {
             "type": "integer",

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -131,7 +131,7 @@ export function createSchedule(params: {
   const routingIntent = params.routingIntent ?? "all_channels";
   const routingHints = params.routingHints ?? {};
   const quiet = params.quiet ?? false;
-  const reuseConversation = params.reuseConversation ?? false;
+  const reuseConversation = params.reuseConversation ?? !isOneShot;
   const maxRetries = params.maxRetries ?? 3;
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
 

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -43,7 +43,7 @@ export async function executeScheduleCreate(
     | Record<string, unknown>
     | undefined;
   const quiet = (input.quiet as boolean) ?? false;
-  const reuseConversation = (input.reuse_conversation as boolean) ?? false;
+  const reuseConversation = input.reuse_conversation as boolean | undefined;
   const maxRetries = input.max_retries as number | undefined;
   const retryBackoffMs = input.retry_backoff_ms as number | undefined;
 


### PR DESCRIPTION
## Summary

- Recurring schedules now default to `reuseConversation=true` so daily/weekly schedules post in the same conversation thread instead of creating a new one each fire
- One-shot schedules are unaffected — they still default to `reuseConversation=false`
- The tool executor (`create.ts`) no longer eagerly resolves the default — it passes `undefined` through so the store can apply the correct default based on whether the schedule is one-shot or recurring

## Changes

1. **`schedule-store.ts`**: `reuseConversation` defaults to `!isOneShot` instead of `false`
2. **`tools/schedule/create.ts`**: Passes `undefined` instead of `false` so the store handles the default
3. **`TOOLS.json`**: Updated `reuse_conversation` descriptions for both `schedule_create` and `schedule_update`
4. **`SKILL.md`**: Updated conversation reuse documentation to reflect new default
5. **Test**: Added test for new default behavior; fixed existing test to explicitly opt out of reuse

## Test plan

- [x] `bunx tsc --noEmit` — no new typecheck errors in changed files
- [x] `bun test src/__tests__/scheduler-reuse-conversation.test.ts` — all 10 tests pass
- [ ] Verify on local dev: create a recurring schedule without specifying `reuse_conversation` and confirm it reuses the same conversation across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)