### PR TITLE
fix(web): default detail-panel pixel width to the right pane, not the left

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1382,7 +1382,7 @@ export function ChatRouteContent({
     return (
       <ResizablePanel
         storageKey="appEditPanelWidth"
-        defaultLeftWidth={400}
+        defaultRightWidth={400}
         minLeftWidth={300}
         minRightWidth={400}
         left={
@@ -1493,7 +1493,7 @@ export function ChatRouteContent({
       <>
         <ResizablePanel
           storageKey="documentPanelWidth"
-          defaultLeftWidth={400}
+          defaultRightWidth={400}
           minLeftWidth={300}
           minRightWidth={400}
           left={chatContent}
@@ -1526,7 +1526,7 @@ export function ChatRouteContent({
         <>
           <ResizablePanel
             storageKey="subagentDetailPanelWidth"
-            defaultLeftWidth={400}
+            defaultRightWidth={400}
             minLeftWidth={300}
             minRightWidth={400}
             left={chatContent}
@@ -1552,7 +1552,7 @@ export function ChatRouteContent({
       <>
         <ResizablePanel
           storageKey="toolDetailPanelWidth"
-          defaultLeftWidth={400}
+          defaultRightWidth={400}
           minLeftWidth={300}
           minRightWidth={400}
           left={chatContent}

--- a/packages/design-library/src/components/resizable-panel.tsx
+++ b/packages/design-library/src/components/resizable-panel.tsx
@@ -11,6 +11,14 @@ import {
 import { cn } from "../utils/cn";
 
 /**
+ * Width of the drag-handle column between the two panes. Must match the
+ * Tailwind `w-2` class on the separator element below (0.5rem = 8px under
+ * the default rem). Subtracted from container width when resolving a
+ * `defaultRightWidth` so the right pane ends up at exactly that size.
+ */
+const SEPARATOR_WIDTH_PX = 8;
+
+/**
  * Read a persisted pixel width from localStorage, validating both shape
  * and finiteness. Returns `null` for unset/malformed entries or when
  * storage access throws (strict-privacy contexts, quota errors, SSR).
@@ -40,6 +48,13 @@ export interface ResizablePanelProps extends Omit<ComponentProps<"div">, "childr
   defaultLeftWidth?: number;
   /** Initial width of the left pane as a percentage of the container (0–100). Resolved via useLayoutEffect on mount. */
   defaultLeftPercent?: number;
+  /**
+   * Initial width of the *right* pane in px. When set, the left pane is sized
+   * to fill the rest of the container on first open, so the right pane stays
+   * at a bounded size regardless of window width. Resolved via useLayoutEffect
+   * on mount. Ignored when `defaultLeftPercent` is also set (percent wins).
+   */
+  defaultRightWidth?: number;
   /** Minimum left pane width in px (default 300). */
   minLeftWidth?: number;
   /** Minimum right pane width in px (default 300). */
@@ -61,6 +76,7 @@ export function ResizablePanel({
   right,
   defaultLeftWidth = 400,
   defaultLeftPercent,
+  defaultRightWidth,
   minLeftWidth = 300,
   minRightWidth = 300,
   onWidthChange,
@@ -139,18 +155,35 @@ export function ResizablePanel({
     return () => window.removeEventListener("resize", onResize);
   }, [clamp]);
 
-  // Resolve percentage-based default on mount (before paint) when no valid
-  // persisted preference exists. Runs in useLayoutEffect so the resolved
-  // width is committed before the browser paints, preventing a single-frame
-  // flash of the `defaultLeftWidth` pixel fallback.
+  // Resolve the on-mount width before paint when no valid persisted
+  // preference exists. Runs in useLayoutEffect so the resolved width is
+  // committed before the browser paints, preventing a single-frame flash
+  // of the `defaultLeftWidth` pixel fallback.
+  //
+  // Precedence: `defaultLeftPercent` > `defaultRightWidth` > `defaultLeftWidth`
+  // (whose value already seeds the initial useState above, so the no-prop
+  // branch is a no-op here).
   useLayoutEffect(() => {
-    if (defaultLeftPercent == null) return;
     if (readStoredWidth(storageKey, minLeftWidth) !== null) return;
     const container = containerRef.current;
     if (!container) return;
-    const target = (container.offsetWidth * defaultLeftPercent) / 100;
+    const containerWidth = container.offsetWidth;
+    if (containerWidth <= 0) return;
+    let target: number | null = null;
+    if (defaultLeftPercent != null) {
+      target = (containerWidth * defaultLeftPercent) / 100;
+    } else if (defaultRightWidth != null) {
+      target = containerWidth - defaultRightWidth - SEPARATOR_WIDTH_PX;
+    }
+    if (target == null) return;
     setLeftWidth(clamp(target));
-  }, [defaultLeftPercent, storageKey, minLeftWidth, clamp]);
+  }, [
+    defaultLeftPercent,
+    defaultRightWidth,
+    storageKey,
+    minLeftWidth,
+    clamp,
+  ]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Add a `defaultRightWidth` prop to `ResizablePanel`, resolved before paint via `useLayoutEffect`, so callers can pin the *right* pane to a px width and let the left pane absorb the slack. Precedence: `defaultLeftPercent` > `defaultRightWidth` > `defaultLeftWidth`.
- Flip the four chat detail-panel call sites in `chat-route-content.tsx` (subagent detail, tool detail, document viewer, app editing) from `defaultLeftWidth={400}` to `defaultRightWidth={400}`. Previously the chat column was pinned at 400px and the detail pane absorbed the entire remaining container — on a wide window the detail pane ended up ~1300px while the conversation felt cramped. Now the detail pane stays a bounded 400px on first open regardless of window width, and the chat absorbs the slack.
- Dragged widths are still persisted to localStorage per panel (`subagentDetailPanelWidth`, `toolDetailPanelWidth`, `documentPanelWidth`, `appEditPanelWidth`), so anyone who's already adjusted their preferred split keeps it. Home page is untouched (still uses `defaultLeftPercent={50}`).

## Original prompt

Tirman noticed in the macOS app that the subagent / tool-call detail panel takes up too much horizontal space on first open and suspected the dragged width was being persisted. Investigation showed `ResizablePanel` does persist via localStorage on pointer-up, but the chat detail panels were being seeded with `defaultLeftWidth={400}` — which sized the *left* (chat) pane, not the right (detail) pane. On wide windows the right pane was absorbing all the slack. The fix is to size the right pane to a bounded 400px instead, by introducing a `defaultRightWidth` prop on `ResizablePanel` and switching the four chat call sites to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)