### PR TITLE
fix(web): emit sync invalidation when scheduled conversations are created

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -67,7 +67,6 @@ import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
-import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import {
   initAuthSigningKey,
   resolveSigningKey,
@@ -75,6 +74,7 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
+import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -67,6 +67,7 @@ import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import {
   initAuthSigningKey,
   resolveSigningKey,
@@ -1019,6 +1020,7 @@ export async function runDaemon(): Promise<void> {
           scheduleJobId: info.scheduleJobId,
           title: info.title,
         });
+        publishConversationListChanged("created");
       },
     );
 


### PR DESCRIPTION
## Summary

- The web app's "Scheduled" sidebar section never showed newly created scheduled conversations until a full page refresh
- Root cause: the `onScheduleConversationCreated` callback only broadcast a `schedule_conversation_created` message (handled by macOS native client), but never emitted a `sync_changed` event with the `conversations:list` tag
- Added `publishConversationListChanged("created")` after the existing broadcast so the web app's cached conversation list is invalidated and refetched

## Test plan

- [ ] Typecheck passes (`bunx tsc --noEmit` in `assistant/`)
- [ ] Create a scheduled conversation — verify it appears in the web app sidebar without a page refresh
- [ ] Verify macOS native client still receives `schedule_conversation_created` (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)