### PR TITLE
fix(gateway): require guardian JWT on /auth/token

### DIFF
--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -17,6 +17,7 @@ import {
   getPlatformAssistants,
   setSelectedAssistantId,
   gatewayProxyUrl,
+  fetchGuardianToken,
 } from "@/lib/local-mode";
 import {
   startAuthFlow,
@@ -268,9 +269,10 @@ function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
       setConnectError(null);
       setConnectingId(assistant.assistantId);
       try {
+        const guardianToken = await fetchGuardianToken(assistant.assistantId);
         const tokenUrl = `${gatewayProxyUrl(assistant.resources!.gatewayPort)}/auth/token`;
         setSelectedAssistantId(assistant.assistantId);
-        await ensureGatewayToken(tokenUrl);
+        await ensureGatewayToken(tokenUrl, guardianToken);
         await useAuthStore.getState().initSession();
         navigate(returnTo || "/assistant");
       } catch {

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -49,9 +49,13 @@ export function getGatewayToken(): string | null {
   return null;
 }
 
-async function acquireGatewayToken(tokenUrl?: string): Promise<string> {
+async function acquireGatewayToken(tokenUrl?: string, guardianToken?: string): Promise<string> {
   const url = tokenUrl ?? "/auth/token";
-  const res = await fetch(url, { method: "POST" });
+  const headers: Record<string, string> = {};
+  if (guardianToken) {
+    headers["Authorization"] = `Bearer ${guardianToken}`;
+  }
+  const res = await fetch(url, { method: "POST", headers });
   if (!res.ok) {
     throw new Error(`Gateway token request failed: ${res.status}`);
   }
@@ -72,7 +76,7 @@ async function acquireGatewayToken(tokenUrl?: string): Promise<string> {
   return token;
 }
 
-export async function ensureGatewayToken(tokenUrl?: string): Promise<string> {
+export async function ensureGatewayToken(tokenUrl?: string, guardianToken?: string): Promise<string> {
   const source = tokenUrl ?? "/auth/token";
   const storedSource = cachedTokenSource ?? localStorage.getItem(LS_TOKEN_SOURCE_KEY);
   if (storedSource && storedSource !== source) {
@@ -80,7 +84,7 @@ export async function ensureGatewayToken(tokenUrl?: string): Promise<string> {
   }
   const existing = getGatewayToken();
   if (existing) return existing;
-  return acquireGatewayToken(tokenUrl);
+  return acquireGatewayToken(tokenUrl, guardianToken);
 }
 
 export function getLocalTokenUrl(): string | undefined {

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -242,6 +242,28 @@ export function getLocalGatewayUrl(): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Guardian token
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the guardian access token for a local assistant from the Vite dev
+ * middleware. The middleware reads the token from disk and handles refresh
+ * via the CLI if the access token is expired.
+ *
+ * Transport: fetch to Vite dev middleware endpoint.
+ * In Electron, replace with IPC call to main process.
+ */
+export async function fetchGuardianToken(assistantId: string): Promise<string> {
+  const res = await fetch(`/assistant/__local/guardian-token/${encodeURIComponent(assistantId)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `Guardian token request failed: ${res.status}`);
+  }
+  const { accessToken } = (await res.json()) as { accessToken: string };
+  return accessToken;
+}
+
+// ---------------------------------------------------------------------------
 // Gateway connection setup
 // ---------------------------------------------------------------------------
 
@@ -255,7 +277,9 @@ export function getLocalGatewayUrl(): string | undefined {
 export async function primeLocalGatewayConnection(): Promise<void> {
   const tokenUrl = getLocalTokenUrl();
   if (!tokenUrl) return;
-  await ensureGatewayToken(tokenUrl);
+  const assistant = getSelectedAssistant();
+  const guardianToken = assistant ? await fetchGuardianToken(assistant.assistantId) : undefined;
+  await ensureGatewayToken(tokenUrl, guardianToken);
   const localGateway = getLocalGatewayUrl();
   if (!localGateway) return;
   setSelfHostedConnection({

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -446,6 +446,15 @@ function handleRetire(assistantId: string, res: http.ServerResponse): void {
 // Guardian token middleware
 // ---------------------------------------------------------------------------
 
+function isLoopbackAddr(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1]! : addr;
+  if (normalized.includes(".")) {
+    return normalized.startsWith("127.");
+  }
+  return normalized === "::1";
+}
+
 const GUARDIAN_TOKEN_PATTERN =
   /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
 
@@ -508,6 +517,14 @@ function guardianTokenMiddleware(
     if (req.method !== "GET") {
       res.statusCode = 405;
       res.end();
+      return;
+    }
+
+    const peer = req.socket.remoteAddress ?? "";
+    if (!isLoopbackAddr(peer)) {
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Forbidden" }));
       return;
     }
 

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -77,6 +77,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
       server.middlewares.use(hatchMiddleware());
       server.middlewares.use(retireMiddleware());
+      server.middlewares.use(guardianTokenMiddleware(env));
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -440,6 +441,172 @@ function handleRetire(assistantId: string, res: http.ServerResponse): void {
     respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
   });
 }
+
+// ---------------------------------------------------------------------------
+// Guardian token middleware
+// ---------------------------------------------------------------------------
+
+const GUARDIAN_TOKEN_PATTERN =
+  /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
+
+const GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolve the config directory matching `cli/src/lib/environments/paths.ts:getConfigDir`.
+ */
+function resolveConfigDir(env: Record<string, string>): string {
+  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
+  const xdgConfigHome =
+    env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
+    return path.join(xdgConfigHome, "vellum");
+  }
+  return path.join(xdgConfigHome, `vellum-${vellumEnv}`);
+}
+
+function resolveGuardianTokenPath(
+  env: Record<string, string>,
+  assistantId: string,
+): string {
+  return path.join(resolveConfigDir(env), "assistants", assistantId, "guardian-token.json");
+}
+
+interface GuardianTokenData {
+  accessToken: string;
+  accessTokenExpiresAt: string | number;
+  refreshToken: string;
+  refreshTokenExpiresAt: string | number;
+}
+
+function isAccessTokenExpired(data: GuardianTokenData): boolean {
+  const expiresAt = new Date(data.accessTokenExpiresAt).getTime();
+  if (!Number.isFinite(expiresAt)) return true;
+  return Date.now() >= expiresAt - 60_000;
+}
+
+function isRefreshTokenExpired(data: GuardianTokenData): boolean {
+  const expiresAt = new Date(data.refreshTokenExpiresAt).getTime();
+  if (!Number.isFinite(expiresAt)) return true;
+  return Date.now() >= expiresAt;
+}
+
+/**
+ * Connect middleware that serves guardian access tokens for local assistants.
+ *
+ * GET /assistant/__local/guardian-token/:assistantId
+ *
+ * Reads the guardian token from disk. If the access token is expired,
+ * shells out to the CLI to refresh it, then re-reads from disk.
+ */
+function guardianTokenMiddleware(
+  env: Record<string, string>,
+): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const match = req.url?.match(GUARDIAN_TOKEN_PATTERN);
+    if (!match) return next();
+
+    if (req.method !== "GET") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const assistantId = decodeURIComponent(match[1]!);
+    const tokenPath = resolveGuardianTokenPath(env, assistantId);
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(tokenPath, "utf-8");
+    } catch {
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Guardian token not found" }));
+      return;
+    }
+
+    let data: GuardianTokenData;
+    try {
+      data = JSON.parse(raw) as GuardianTokenData;
+    } catch {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Malformed guardian token file" }));
+      return;
+    }
+
+    if (!isAccessTokenExpired(data)) {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ accessToken: data.accessToken }));
+      return;
+    }
+
+    if (isRefreshTokenExpired(data)) {
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Guardian token expired — re-run `vellum hatch` or `vellum wake`" }));
+      return;
+    }
+
+    // Refresh via CLI in a child process
+    const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+    const cliPath = path.join(repoRoot, "cli", "src", "index.ts");
+
+    if (!fs.existsSync(cliPath)) {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "CLI not found" }));
+      return;
+    }
+
+    const child = spawn(
+      "bun",
+      ["run", cliPath, "gateway", "token", "refresh", assistantId],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    let stdout = "";
+    let responded = false;
+
+    const respond = (status: number, body: Record<string, unknown>) => {
+      if (responded) return;
+      responded = true;
+      clearTimeout(timeout);
+      res.statusCode = status;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(body));
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      respond(500, { error: "Guardian token refresh timed out" });
+    }, GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        const accessToken = stdout.trim();
+        if (accessToken) {
+          respond(200, { accessToken });
+        } else {
+          respond(500, { error: "CLI returned empty token" });
+        }
+      } else {
+        respond(401, { error: "Failed to refresh guardian token" });
+      }
+    });
+
+    child.on("error", (err) => {
+      respond(500, { error: `Failed to spawn CLI: ${err.message}` });
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gateway proxy middleware
+// ---------------------------------------------------------------------------
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
 

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -561,7 +561,7 @@ function guardianTokenMiddleware(
     const child = spawn(
       "bun",
       ["run", cliPath, "gateway", "token", "refresh", assistantId],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, ...env } },
     );
 
     let stdout = "";

--- a/cli/src/commands/gateway.ts
+++ b/cli/src/commands/gateway.ts
@@ -1,0 +1,29 @@
+import { gatewayToken } from "./gateway/token.js";
+
+function printUsage(): void {
+  console.log("Usage: vellum gateway <subcommand>");
+  console.log("");
+  console.log("Gateway management commands.");
+  console.log("");
+  console.log("Subcommands:");
+  console.log("  token    Manage gateway authentication tokens");
+}
+
+export async function gateway(): Promise<void> {
+  const args = process.argv.slice(3);
+  const subcommand = args[0];
+
+  if (subcommand === "--help" || subcommand === "-h" || !subcommand) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (subcommand === "token") {
+    await gatewayToken();
+    return;
+  }
+
+  console.error(`Unknown subcommand: ${subcommand}`);
+  printUsage();
+  process.exit(1);
+}

--- a/cli/src/commands/gateway/token.ts
+++ b/cli/src/commands/gateway/token.ts
@@ -1,0 +1,73 @@
+import {
+  lookupAssistantByIdentifier,
+  formatAssistantLookupError,
+} from "../../lib/assistant-config.js";
+import {
+  loadGuardianToken,
+  refreshGuardianToken,
+} from "../../lib/guardian-token.js";
+
+function printUsage(): void {
+  console.log("Usage: vellum gateway token <subcommand> <assistantId>");
+  console.log("");
+  console.log("Manage gateway authentication tokens.");
+  console.log("");
+  console.log("Subcommands:");
+  console.log("  get       Print the current guardian access token");
+  console.log("  refresh   Refresh an expired access token and print it");
+}
+
+export async function gatewayToken(): Promise<void> {
+  const args = process.argv.slice(4);
+  const subcommand = args[0];
+
+  if (subcommand === "--help" || subcommand === "-h" || !subcommand) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (subcommand !== "get" && subcommand !== "refresh") {
+    console.error(`Unknown subcommand: ${subcommand}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  const assistantId = args[1];
+  if (!assistantId) {
+    console.error("Missing required argument: <assistantId>");
+    printUsage();
+    process.exit(1);
+  }
+
+  const result = lookupAssistantByIdentifier(assistantId);
+  if (result.status !== "found") {
+    console.error(formatAssistantLookupError(assistantId, result));
+    process.exit(1);
+  }
+  const entry = result.entry;
+
+  const tokenData = loadGuardianToken(entry.assistantId);
+  if (!tokenData) {
+    console.error("No guardian token found for this assistant.");
+    process.exit(1);
+  }
+
+  if (subcommand === "get") {
+    console.log(tokenData.accessToken);
+    return;
+  }
+
+  const gatewayUrl = entry.localUrl || entry.runtimeUrl;
+  if (!gatewayUrl) {
+    console.error("No gateway URL found for this assistant.");
+    process.exit(1);
+  }
+
+  const refreshed = await refreshGuardianToken(gatewayUrl, entry.assistantId);
+  if (!refreshed) {
+    console.error("Failed to refresh guardian token.");
+    process.exit(1);
+  }
+
+  console.log(refreshed.accessToken);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,6 +8,7 @@ import { env } from "./commands/env";
 import { events } from "./commands/events";
 import { exec } from "./commands/exec";
 import { flags } from "./commands/flags";
+import { gateway } from "./commands/gateway";
 import { hatch } from "./commands/hatch";
 import { login, logout, whoami } from "./commands/login";
 import { logs } from "./commands/logs";
@@ -39,6 +40,7 @@ const commands = {
   events,
   exec,
   flags,
+  gateway,
   hatch,
   login,
   logout,
@@ -75,6 +77,7 @@ function printHelp(): void {
   console.log("  events   Stream events from a running assistant");
   console.log("  exec     Execute a command inside an assistant's container");
   console.log("  flags    Show and toggle feature flags");
+  console.log("  gateway  Gateway management commands");
   console.log("  hatch    Create a new assistant instance");
   console.log("  logs     View logs from an assistant instance");
   console.log("  login    Log in to the Vellum platform");

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -38,6 +38,10 @@ export async function handleCreateToken(
     log.warn({ reason: verifyResult.reason }, "Token create rejected: invalid guardian token");
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (verifyResult.claims.scope_profile !== "actor_client_v1") {
+    log.warn({ scope: verifyResult.claims.scope_profile }, "Token create rejected: insufficient scope");
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const guardianPrincipalId = await ensureVellumGuardianBinding();
 

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -2,7 +2,7 @@ import type { Server } from "bun";
 
 import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
-import { mintToken } from "../../auth/token-service.js";
+import { mintToken, verifyToken } from "../../auth/token-service.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackPeer } from "../../util/is-loopback-address.js";
 
@@ -25,6 +25,18 @@ export async function handleCreateToken(
   if (!origin || !WEB_ORIGIN_RE.test(origin)) {
     log.warn({ origin }, "Token create rejected: missing or invalid Origin");
     return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    log.warn("Token create rejected: missing or malformed Authorization header");
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const bearerToken = authHeader.slice(7);
+  const verifyResult = verifyToken(bearerToken, "vellum-gateway");
+  if (!verifyResult.ok) {
+    log.warn({ reason: verifyResult.reason }, "Token create rejected: invalid guardian token");
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const guardianPrincipalId = await ensureVellumGuardianBinding();


### PR DESCRIPTION
## Summary
- The gateway's `POST /auth/token` endpoint now requires a valid guardian access token as `Authorization: Bearer` auth, closing a localhost CSRF vector where any local web page could mint actor tokens
- Adds `vellum gateway token get|refresh <assistantId>` CLI command for managing guardian tokens
- Adds Vite dev middleware endpoint (`GET /__local/guardian-token/:assistantId`) that reads the guardian token from disk and handles automatic refresh via the CLI when the access token is expired

## Test plan
- [ ] Run `bun test` in `gateway/` — existing tests pass (no dedicated auth-token tests existed previously)
- [ ] Run web app in local mode, confirm login flow works end-to-end (web UI fetches guardian token → passes to `/auth/token` → gets session JWT)
- [ ] Verify `curl -X POST http://localhost:{port}/auth/token -H "Origin: http://localhost:5173"` without a bearer token returns 401
- [ ] Verify `vellum gateway token get <assistantId>` prints the access token
- [ ] Verify `vellum gateway token refresh <assistantId>` refreshes and prints a new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)