### PR TITLE
fix(web): prevent hatch screen from showing after retiring assistant in local mode

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -429,11 +429,8 @@ export function useAssistantLifecycle({
       const redirect = resolveOnboardingRedirect({ intendedDestination: window.location.pathname });
       if (redirect) {
         onRedirectRef.current(redirect);
-        return;
       }
-      // No redirect needed (e.g., already on onboarding page, or has
-      // assistants) — fall through to checkAssistant() which will
-      // discover the assistant or surface an error state.
+      return;
     }
     if (hasPlatformSession) {
       setSelfHostedConnection(null);


### PR DESCRIPTION
## Summary
- In `use-assistant-lifecycle.ts`, the local-mode-without-auth branch now always returns after handling the onboarding redirect, instead of falling through to `checkAssistant()`.
- This prevents the platform API from being called without auth after retire, which was producing `auto_hatch` / `awaiting_version_selection` state and showing the hatch screen instead of the onboarding welcome page.

## Original prompt
After clicking "Retire Assistant" in local mode, the user was being redirected to the hatch screen (`/assistant`) instead of `/assistant/onboarding/welcome`. The root cause was that `resolveOnboardingRedirect()` returning `null` (already navigating to onboarding) caused the lifecycle effect to fall through to `checkAssistant()`, which called the platform API without auth and produced `auto_hatch` state. The fix adds an early return so `checkAssistant()` is never reached without an auth context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)