### PR TITLE
use GitHub environment GCP vars for web deploy

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -138,19 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - environment: dev
-            gcp_project_id: vellum-nonprod
-            gcp_workload_identity_provider: projects/304030683664/locations/global/workloadIdentityPools/github-pool-dev/providers/github-actions-provider-0
-            gcp_service_account: gha-assistant-deploy@vellum-nonprod.iam.gserviceaccount.com
-          - environment: staging
-            gcp_project_id: vellum-staging
-            gcp_workload_identity_provider: projects/363794608366/locations/global/workloadIdentityPools/github-actions/providers/github-provider
-            gcp_service_account: gha-assistant-deploy@vellum-staging.iam.gserviceaccount.com
-          - environment: production
-            gcp_project_id: vellum-ai-prod
-            gcp_workload_identity_provider: projects/620844561845/locations/global/workloadIdentityPools/github-actions/providers/github-provider
-            gcp_service_account: gha-assistant-deploy@vellum-ai-prod.iam.gserviceaccount.com
+        environment: [dev, staging, production]
     environment: ${{ matrix.environment }}
     permissions:
       contents: read
@@ -202,12 +190,12 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
-          workload_identity_provider: ${{ matrix.gcp_workload_identity_provider }}
-          service_account: ${{ matrix.gcp_service_account }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Publish SPA to GCS
         env:
-          PROJECT_ID: ${{ matrix.gcp_project_id }}
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           TARGET_ENV: ${{ matrix.environment }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
ref ATL-607

Remove hardcoded `GCP_X` variables from matrix in workflow, and move them to github env vars

We're going to reuse these in the release workflows as well.