### PR TITLE
fix(web): stop auto-marking notifications as read when opening detail panel

### DIFF
--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -62,17 +62,9 @@ export function HomePage({
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
 
-  const handleSelectItem = useCallback(
-    (item: FeedItem) => {
-      if (item.status === "new") {
-        setSelectedItem({ ...item, status: "seen" });
-        feedQuery.updateStatus.mutate({ itemId: item.id, status: "seen" });
-      } else {
-        setSelectedItem(item);
-      }
-    },
-    [feedQuery.updateStatus],
-  );
+  const handleSelectItem = useCallback((item: FeedItem) => {
+    setSelectedItem(item);
+  }, []);
 
   const handleCloseDetail = useCallback(() => {
     setSelectedItem(null);


### PR DESCRIPTION
On iOS, the notification detail panel always showed the closed envelope icon (`Mail`) regardless of the notification's actual read/unread state. This was because `handleSelectItem` overwrote the item's status to `"seen"` before passing it to `HomeDetailPanel`, making `isUnread` always `false`. Removing the auto-mark side effect lets the detail panel render the true status, so users see the correct icon and can explicitly toggle read/unread via the existing buttons.

## Root cause analysis

1. **How did the code get into this state?** — The auto-mark logic was ported verbatim from the platform repo in commit `9837e2f4cf` ("feat(web): port Home page from platform repo").
2. **What led to it?** — The original implementation conflated "opening the detail panel" with "marking as read," which is a reasonable pattern in some contexts (like email) but broke the detail panel's read/unread toggle by ensuring it was always in the "seen" state on render.
3. **Warning signs?** — The `MailOpen` icon import in `home-detail-panel.tsx` was effectively dead code — it could never be rendered because `isUnread` was always `false` by the time the panel mounted.
4. **Prevention?** — When porting code from the platform repo, each interaction side effect should be evaluated independently rather than copied verbatim.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/310e39be7e0f49058c1e38a680567eb3