### PR TITLE
feat(web/voice): add live voice mode Zustand store

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { LiveVoiceStoreState } from "@/domains/voice/live-voice/live-voice-store";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+
+function resetStore() {
+  useLiveVoiceStore.getState().reset();
+}
+
+afterEach(() => {
+  resetStore();
+});
+
+describe("LiveVoiceStore", () => {
+  test("defaults to the off state with empty session info", () => {
+    const state = useLiveVoiceStore.getState();
+    expect(state.state).toBe("off");
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+    expect(state.partialTranscript).toBe("");
+    expect(state.finalTranscript).toBe("");
+    expect(state.assistantTranscript).toBe("");
+    expect(state.inputAmplitude).toBe(0);
+    expect(state.errorMessage).toBe("");
+  });
+
+  test("setState transitions through each lifecycle phase", () => {
+    const phases = [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+      "failed",
+      "off",
+    ] as const;
+
+    for (const phase of phases) {
+      useLiveVoiceStore.getState().setState(phase);
+      expect(useLiveVoiceStore.getState().state).toBe(phase);
+    }
+  });
+
+  test("setSessionInfo updates both session and conversation ids", () => {
+    useLiveVoiceStore.getState().setSessionInfo({
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    let state = useLiveVoiceStore.getState();
+    expect(state.sessionId).toBe("sess-1");
+    expect(state.conversationId).toBe("conv-1");
+
+    useLiveVoiceStore.getState().setSessionInfo({
+      sessionId: null,
+      conversationId: null,
+    });
+
+    state = useLiveVoiceStore.getState();
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+  });
+
+  test("setPartialTranscript replaces the partial transcript", () => {
+    useLiveVoiceStore.getState().setPartialTranscript("hello");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello");
+
+    useLiveVoiceStore.getState().setPartialTranscript("hello world");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello world");
+
+    useLiveVoiceStore.getState().setPartialTranscript("");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("");
+  });
+
+  test("setFinalTranscript replaces the final transcript", () => {
+    useLiveVoiceStore.getState().setFinalTranscript("done");
+    expect(useLiveVoiceStore.getState().finalTranscript).toBe("done");
+
+    useLiveVoiceStore.getState().setFinalTranscript("done again");
+    expect(useLiveVoiceStore.getState().finalTranscript).toBe("done again");
+  });
+
+  test("appendAssistantTranscript concatenates streamed deltas", () => {
+    useLiveVoiceStore.getState().appendAssistantTranscript("hello");
+    useLiveVoiceStore.getState().appendAssistantTranscript(" ");
+    useLiveVoiceStore.getState().appendAssistantTranscript("world");
+
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe(
+      "hello world",
+    );
+  });
+
+  test("setInputAmplitude updates the amplitude", () => {
+    useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.42);
+
+    useLiveVoiceStore.getState().setInputAmplitude(0);
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0);
+  });
+
+  test("setError records the error message", () => {
+    useLiveVoiceStore.getState().setError("mic permission denied");
+    expect(useLiveVoiceStore.getState().errorMessage).toBe(
+      "mic permission denied",
+    );
+
+    useLiveVoiceStore.getState().setError("");
+    expect(useLiveVoiceStore.getState().errorMessage).toBe("");
+  });
+
+  test("reset returns the store to its initial state", () => {
+    const actions = useLiveVoiceStore.getState();
+    actions.setState("listening");
+    actions.setSessionInfo({
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    actions.setPartialTranscript("partial");
+    actions.setFinalTranscript("final");
+    actions.appendAssistantTranscript("assistant");
+    actions.setInputAmplitude(0.5);
+    actions.setError("boom");
+
+    actions.reset();
+
+    const state = useLiveVoiceStore.getState();
+    expect(state.state).toBe("off");
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+    expect(state.partialTranscript).toBe("");
+    expect(state.finalTranscript).toBe("");
+    expect(state.assistantTranscript).toBe("");
+    expect(state.inputAmplitude).toBe(0);
+    expect(state.errorMessage).toBe("");
+  });
+
+  test("createSelectors exposes a per-field hook for every state field", () => {
+    // The atomic-selector contract: every state field gets its own
+    // `use.<field>()` hook, so consumers can subscribe to one slice
+    // without re-rendering on unrelated mutations.
+    const expectedFields: ReadonlyArray<keyof typeof useLiveVoiceStore.use> = [
+      "state",
+      "sessionId",
+      "conversationId",
+      "partialTranscript",
+      "finalTranscript",
+      "assistantTranscript",
+      "inputAmplitude",
+      "errorMessage",
+    ];
+
+    for (const field of expectedFields) {
+      expect(typeof useLiveVoiceStore.use[field]).toBe("function");
+    }
+  });
+
+  test("state shape uses only primitive fields (no nested objects)", () => {
+    // createSelectors compares field references with ===; nested
+    // objects would break that contract by producing new references
+    // on every set(). This guard ensures we keep state flat.
+    const state = useLiveVoiceStore.getState();
+    const stateFields: ReadonlyArray<keyof LiveVoiceStoreState> = [
+      "state",
+      "sessionId",
+      "conversationId",
+      "partialTranscript",
+      "finalTranscript",
+      "assistantTranscript",
+      "inputAmplitude",
+      "errorMessage",
+    ];
+
+    for (const field of stateFields) {
+      const value = state[field];
+      const isPrimitive =
+        value === null ||
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean";
+      expect(isPrimitive).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/live-voice-store.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-store.ts
@@ -1,0 +1,125 @@
+/**
+ * Zustand store for the live voice mode state machine.
+ *
+ * Mirrors the macOS `LiveVoiceChannelManager.State` enum
+ * (see `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`)
+ * so the web client tracks the same lifecycle:
+ * off → connecting → listening → transcribing → thinking → speaking →
+ * ending, with a `failed` branch for error states.
+ *
+ * Holds the session id, conversation id, rolling transcripts, current
+ * input amplitude, and the most recent error message. All fields are
+ * primitives so per-field selectors via `createSelectors` give minimal
+ * re-renders.
+ *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
+ *
+ * **Primary API** — per-field selectors:
+ * ```ts
+ * const state = useLiveVoiceStore.use.state();
+ * ```
+ *
+ * **Non-React code** — use `.getState()` in callbacks, effects, handlers:
+ * ```ts
+ * const { state } = useLiveVoiceStore.getState();
+ * ```
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/guides/auto-generating-selectors}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LiveVoiceState =
+  | "off"
+  | "connecting"
+  | "listening"
+  | "transcribing"
+  | "thinking"
+  | "speaking"
+  | "ending"
+  | "failed";
+
+export interface LiveVoiceStoreState {
+  /** Current phase of the live voice lifecycle. */
+  state: LiveVoiceState;
+  /** Server-assigned session id for the active live voice channel. */
+  sessionId: string | null;
+  /** Conversation id the session is currently attached to. */
+  conversationId: string | null;
+  /** In-progress user transcript from the STT stream. */
+  partialTranscript: string;
+  /** Finalized user transcript for the current turn. */
+  finalTranscript: string;
+  /** Rolling assistant transcript accumulated from streamed deltas. */
+  assistantTranscript: string;
+  /** Most recent microphone input amplitude in [0, 1]. */
+  inputAmplitude: number;
+  /** Most recent error message; empty string when there is no error. */
+  errorMessage: string;
+}
+
+export interface LiveVoiceStoreActions {
+  setState: (s: LiveVoiceState) => void;
+  setSessionInfo: (info: {
+    sessionId: string | null;
+    conversationId: string | null;
+  }) => void;
+  setPartialTranscript: (text: string) => void;
+  setFinalTranscript: (text: string) => void;
+  appendAssistantTranscript: (delta: string) => void;
+  setInputAmplitude: (amp: number) => void;
+  setError: (msg: string) => void;
+  reset: () => void;
+}
+
+export type LiveVoiceStore = LiveVoiceStoreState & LiveVoiceStoreActions;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: LiveVoiceStoreState = {
+  state: "off",
+  sessionId: null,
+  conversationId: null,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  errorMessage: "",
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
+  ...INITIAL_STATE,
+
+  setState: (s) => set({ state: s }),
+
+  setSessionInfo: ({ sessionId, conversationId }) =>
+    set({ sessionId, conversationId }),
+
+  setPartialTranscript: (text) => set({ partialTranscript: text }),
+
+  setFinalTranscript: (text) => set({ finalTranscript: text }),
+
+  appendAssistantTranscript: (delta) =>
+    set((prev) => ({ assistantTranscript: prev.assistantTranscript + delta })),
+
+  setInputAmplitude: (amp) => set({ inputAmplitude: amp }),
+
+  setError: (msg) => set({ errorMessage: msg }),
+
+  reset: () => set(INITIAL_STATE),
+}));
+
+export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);


### PR DESCRIPTION
## Summary
- Add LiveVoiceState union (off → connecting → listening → transcribing → thinking → speaking → ending → failed) mirroring macOS LiveVoiceChannelManager.State
- Zustand store with atomic selectors via createSelectors
- Tracks session id, transcripts, amplitude, error message

Part of plan: realtime-voice-web.md (PR 4 of 9)