### PR TITLE
feat(web/voice): add gapless PCM streaming playback for live voice TTS

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
@@ -328,6 +328,70 @@ describe("LiveVoicePcmPlayback", () => {
         expect(fresh?.startedAt).toBe(0);
     });
 
+    it("handleInterrupt() resolves a pending waitUntilPlaybackFinishes() promise without waiting for the original cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // 0.5s @ 24kHz = 12000 samples — long enough that a real setTimeout
+        // would visibly stall the test if the waiter weren't resolved early.
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // Synchronously, the waiter hasn't fired.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Interrupt before the cursor (0.5s) is reached. The waiter should
+        // resolve promptly rather than waiting for the original duration.
+        playback.handleInterrupt();
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleEnd() resolves a pending waitUntilPlaybackFinishes() promise without waiting for the original cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0))); // 0.5s
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        playback.handleEnd();
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleSessionError() resolves a pending waitUntilPlaybackFinishes() promise", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0))); // 0.5s
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        playback.handleSessionError();
+        await wait;
+        expect(resolved).toBe(true);
+    });
+
     it("resetForNextResponse() re-enables enqueue after handleEnd", () => {
         const ctx = new MockAudioContext();
         const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
@@ -404,4 +404,156 @@ describe("LiveVoicePcmPlayback", () => {
         playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
         expect(ctx.scheduled).toHaveLength(beforeEnqueue + 1);
     });
+
+    it("accepts audio/pcm with no parameters", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("accepts audio/pcm with parameters", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcm;rate=16000",
+            sampleRate: 16000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("accepts audio/PCM case-insensitively", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/PCM",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("rejects audio/pcma (G.711 A-law)", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcma",
+            sampleRate: 8000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("rejects audio/pcmu (G.711 mu-law)", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcmu",
+            sampleRate: 8000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("rejects audio/wav", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/wav",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("waitUntilPlaybackFinishes() keeps waiting when a new chunk extends the cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // First chunk: 0.05s
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // The waiter is pending against the 0.05s cursor.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Enqueue a second chunk before the first finishes — extends the
+        // cursor from 0.05s to 0.15s.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0))); // 0.1s
+
+        // Advance past where the FIRST chunk ended. The waiter must NOT
+        // resolve here — buffered audio still extends to 0.15s.
+        ctx.advanceTo(0.05);
+        // Give the rescheduled timer enough wall time to fire if it were
+        // pointed at the old cursor (~50ms is what the original waiter delay
+        // was). After this, the still-pending timer should be a ~100ms one
+        // counting toward the extended cursor.
+        await new Promise((r) => setTimeout(r, 60));
+        expect(resolved).toBe(false);
+
+        // Advance past the extended cursor — the rescheduled timer fires
+        // shortly after, resolving the waiter.
+        ctx.advanceTo(0.2);
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
@@ -124,8 +124,9 @@ describe("LiveVoicePcmPlayback", () => {
         // Cursor reset — current time is still 0, so isPlaying is false.
         expect(playback.isPlaying).toBe(false);
 
-        // After interrupt, a fresh enqueue starts at currentTime (0), not
-        // accumulated on top of the prior cursor.
+        // After interrupt + reset, a fresh enqueue starts at currentTime (0),
+        // not accumulated on top of the prior cursor.
+        playback.resetForNextResponse();
         playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
         const fresh = ctx.scheduled[ctx.scheduled.length - 1];
         expect(fresh?.startedAt).toBe(0);
@@ -225,7 +226,7 @@ describe("LiveVoicePcmPlayback", () => {
         expect(data[2]).toBeCloseTo(32767 / 32768, 5);
     });
 
-    it("resetForNextResponse() is a no-op for scheduling (cursor preserved)", () => {
+    it("resetForNextResponse() preserves the cursor between back-to-back responses", () => {
         const ctx = new MockAudioContext();
         const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
 
@@ -253,7 +254,20 @@ describe("LiveVoicePcmPlayback", () => {
         expect(playback.isPlaying).toBe(false);
     });
 
-    it("handleEnd() lets the scheduled tail drain without stopping nodes", () => {
+    it("handleSessionError() drops late TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleSessionError();
+
+        const scheduledCount = ctx.scheduled.length;
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        // No new node was scheduled — `acceptsAudio` gate dropped the chunk.
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("handleEnd() stops scheduled nodes and resets the cursor", () => {
         const ctx = new MockAudioContext();
         const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
 
@@ -261,8 +275,69 @@ describe("LiveVoicePcmPlayback", () => {
         playback.handleEnd();
 
         for (const entry of ctx.scheduled) {
-            expect(entry.stoppedAt).toBeUndefined();
+            expect(entry.stoppedAt).toBe(0);
         }
-        expect(playback.isPlaying).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleInterrupt() drops late TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleInterrupt();
+
+        const scheduledCount = ctx.scheduled.length;
+        // A delayed TTS chunk arriving after the interrupt must be dropped —
+        // mirrors `LiveVoiceAudioPlayer.stop(reason: .interrupt)` behaviour.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("handleEnd() drops subsequent TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+
+        const scheduledCount = ctx.scheduled.length;
+        // Once the user ends the live voice session, TTS must not resume —
+        // any chunks that race the session-end must be dropped.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("resetForNextResponse() re-enables enqueue after an interrupt", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleInterrupt();
+
+        const beforeReset = ctx.scheduled.length;
+        // Sanity: gate is closed after the interrupt.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(beforeReset);
+
+        playback.resetForNextResponse();
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        // After reset, the next assistant turn can play again.
+        expect(ctx.scheduled).toHaveLength(beforeReset + 1);
+        const fresh = ctx.scheduled[ctx.scheduled.length - 1];
+        expect(fresh?.startedAt).toBe(0);
+    });
+
+    it("resetForNextResponse() re-enables enqueue after handleEnd", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+        playback.resetForNextResponse();
+
+        const beforeEnqueue = ctx.scheduled.length;
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(beforeEnqueue + 1);
     });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import {
+    LiveVoicePcmPlayback,
+    type AudioBufferLike,
+    type AudioBufferSourceNodeLike,
+    type AudioDestinationNodeLike,
+    type PcmAudioContextLike,
+} from "@/domains/voice/live-voice/pcm-playback";
+
+interface ScheduledNode {
+    node: AudioBufferSourceNodeLike;
+    startedAt: number | undefined;
+    stoppedAt: number | undefined;
+    buffer: AudioBufferLike | null;
+}
+
+class MockAudioBuffer implements AudioBufferLike {
+    readonly duration: number;
+    private readonly channels: Float32Array[];
+
+    constructor(channelCount: number, frameCount: number, sampleRate: number) {
+        this.duration = frameCount / sampleRate;
+        this.channels = Array.from({ length: channelCount }, () => new Float32Array(frameCount));
+    }
+
+    getChannelData(channel: number): Float32Array {
+        const data = this.channels[channel];
+        if (!data) throw new Error(`channel ${channel} out of range`);
+        return data;
+    }
+
+    copyToChannel(source: Float32Array, channel: number): void {
+        this.getChannelData(channel).set(source);
+    }
+}
+
+class MockAudioContext implements PcmAudioContextLike {
+    currentTime = 0;
+    readonly destination: AudioDestinationNodeLike = {};
+    readonly scheduled: ScheduledNode[] = [];
+
+    createBuffer(channels: number, frameCount: number, sampleRate: number): AudioBufferLike {
+        return new MockAudioBuffer(channels, frameCount, sampleRate);
+    }
+
+    createBufferSource(): AudioBufferSourceNodeLike {
+        const tracked: ScheduledNode = {
+            node: undefined as unknown as AudioBufferSourceNodeLike,
+            startedAt: undefined,
+            stoppedAt: undefined,
+            buffer: null,
+        };
+        const node: AudioBufferSourceNodeLike = {
+            buffer: null,
+            onended: null,
+            connect: () => {},
+            start: (when?: number) => {
+                tracked.startedAt = when;
+                tracked.buffer = node.buffer;
+            },
+            stop: (when?: number) => {
+                tracked.stoppedAt = when;
+            },
+        };
+        tracked.node = node;
+        this.scheduled.push(tracked);
+        return node;
+    }
+
+    advanceTo(seconds: number): void {
+        this.currentTime = seconds;
+    }
+}
+
+function pcmChunk(samples: number[], sampleRate = 24000, channels = 1) {
+    const bytes = new Uint8Array(samples.length * 2);
+    const view = new DataView(bytes.buffer);
+    for (let i = 0; i < samples.length; i += 1) {
+        view.setInt16(i * 2, samples[i] ?? 0, true);
+    }
+    return {
+        pcm: bytes,
+        mimeType: "audio/pcm",
+        sampleRate,
+        channels,
+    };
+}
+
+describe("LiveVoicePcmPlayback", () => {
+    it("schedules consecutive PCM chunks back-to-back without gaps", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        const samplesA = new Array(2400).fill(100); // 0.1s @ 24kHz
+        const samplesB = new Array(4800).fill(200); // 0.2s @ 24kHz
+        playback.enqueueTtsAudio(pcmChunk(samplesA));
+        playback.enqueueTtsAudio(pcmChunk(samplesB));
+
+        expect(ctx.scheduled).toHaveLength(2);
+        const first = ctx.scheduled[0];
+        const second = ctx.scheduled[1];
+        expect(first?.startedAt).toBe(0);
+        expect(first?.buffer?.duration).toBeCloseTo(0.1, 5);
+        // Second start time must equal the first's end time — gapless.
+        expect(second?.startedAt).toBeCloseTo(0.1, 5);
+        expect(second?.buffer?.duration).toBeCloseTo(0.2, 5);
+    });
+
+    it("handleInterrupt() stops all scheduled nodes and resets the cursor", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(playback.isPlaying).toBe(true);
+
+        playback.handleInterrupt();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBe(0);
+        }
+
+        // Cursor reset — current time is still 0, so isPlaying is false.
+        expect(playback.isPlaying).toBe(false);
+
+        // After interrupt, a fresh enqueue starts at currentTime (0), not
+        // accumulated on top of the prior cursor.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        const fresh = ctx.scheduled[ctx.scheduled.length - 1];
+        expect(fresh?.startedAt).toBe(0);
+    });
+
+    it("waitUntilPlaybackFinishes() resolves only after the cursor is reached", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // 0.05s @ 24kHz = 1200 samples
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // Synchronously, the promise hasn't resolved yet.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Advance the mock clock past the cursor; the scheduled setTimeout
+        // (50ms) will fire after that real-time delay.
+        ctx.advanceTo(0.05);
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("waitUntilPlaybackFinishes() resolves immediately when no audio is queued", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // Never called the factory — should resolve without scheduling work.
+        await playback.waitUntilPlaybackFinishes();
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+        ctx.advanceTo(1);
+        // After advancing past the cursor, the promise resolves synchronously.
+        await playback.waitUntilPlaybackFinishes();
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("drops non-PCM chunks with a warning and does not throw", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        expect(() => {
+            playback.enqueueTtsAudio({
+                pcm: new Uint8Array([0xff, 0xfb, 0x00, 0x00]),
+                mimeType: "audio/mpeg",
+                sampleRate: 24000,
+                channels: 1,
+            });
+        }).not.toThrow();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("drops PCM chunks whose byte length isn't aligned to Int16", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x01, 0x02, 0x03]), // odd length
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("decodes PCM16 LE samples to normalized Float32 values", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // -32768, 0, 32767 — covers min, mid, near-max
+        const chunk = pcmChunk([-32768, 0, 32767]);
+        playback.enqueueTtsAudio(chunk);
+
+        const buffer = ctx.scheduled[0]?.buffer;
+        expect(buffer).not.toBeNull();
+        const data = buffer!.getChannelData(0);
+        expect(data[0]).toBeCloseTo(-1, 5);
+        expect(data[1]).toBe(0);
+        expect(data[2]).toBeCloseTo(32767 / 32768, 5);
+    });
+
+    it("resetForNextResponse() is a no-op for scheduling (cursor preserved)", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0))); // 0.1s
+        playback.resetForNextResponse();
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+
+        const first = ctx.scheduled[0];
+        const second = ctx.scheduled[1];
+        expect(first?.startedAt).toBe(0);
+        // Cursor still in effect — second chunk schedules after the first.
+        expect(second?.startedAt).toBeCloseTo(0.1, 5);
+    });
+
+    it("handleSessionError() stops scheduled nodes like an interrupt", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleSessionError();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBe(0);
+        }
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleEnd() lets the scheduled tail drain without stopping nodes", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBeUndefined();
+        }
+        expect(playback.isPlaying).toBe(true);
+    });
+});

--- a/apps/web/src/domains/voice/live-voice/pcm-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-playback.ts
@@ -86,6 +86,7 @@ export class LiveVoicePcmPlayback {
     private readonly logger: Pick<Console, "warn">;
     private audioContext: PcmAudioContextLike | null = null;
     private nextStartTime = 0;
+    private acceptsAudio = true;
     private readonly scheduledNodes = new Set<AudioBufferSourceNodeLike>();
 
     constructor(options: LiveVoicePcmPlaybackOptions = {}) {
@@ -106,6 +107,12 @@ export class LiveVoicePcmPlayback {
      * scheduled chunks. Non-PCM payloads are dropped with a warning.
      */
     enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+        if (!this.acceptsAudio) {
+            // Mirrors `LiveVoiceAudioPlayer.stop(reason:)`'s `acceptsAudio = false`
+            // gate: once the session has been interrupted or ended, drop any
+            // late TTS chunks that race the cancel until `resetForNextResponse()`.
+            return;
+        }
         if (!chunk.mimeType.toLowerCase().startsWith(PCM_MIME_PREFIX)) {
             this.logger.warn(
                 `[LiveVoicePcmPlayback] dropping non-PCM chunk (mimeType=${chunk.mimeType})`,
@@ -158,20 +165,26 @@ export class LiveVoicePcmPlayback {
 
     /**
      * Stop all scheduled playback immediately and clear the queue. Matches
-     * `LiveVoiceAudioPlayer.handleInterrupt()`.
+     * `LiveVoiceAudioPlayer.handleInterrupt()` → `stop(reason: .interrupt)`:
+     * any late chunks from the interrupted response are dropped via the
+     * `acceptsAudio` gate until the next `resetForNextResponse()`.
      */
     handleInterrupt(): void {
         this.stopAllScheduledNodes();
         this.nextStartTime = 0;
+        this.acceptsAudio = false;
     }
 
     /**
-     * Let the currently-scheduled tail drain naturally. The cursor isn't
-     * reset; new chunks would queue after the existing tail.
+     * Stop all scheduled playback and refuse further TTS chunks. Matches
+     * `LiveVoiceAudioPlayer.handleEnd()` → `stop(reason: .end)`: once the user
+     * has ended the session, TTS must not continue playing — late chunks are
+     * dropped via the `acceptsAudio` gate.
      */
     handleEnd(): void {
-        // Scheduled nodes drain on their own; `nextStartTime` stays put so
-        // `waitUntilPlaybackFinishes()` still observes the residual tail.
+        this.stopAllScheduledNodes();
+        this.nextStartTime = 0;
+        this.acceptsAudio = false;
     }
 
     handleSessionError(): void {
@@ -181,8 +194,9 @@ export class LiveVoicePcmPlayback {
     }
 
     resetForNextResponse(): void {
-        // No-op in v1: the scheduling cursor already handles back-to-back
-        // responses. Kept on the surface for parity with the macOS protocol.
+        // Re-enable the `acceptsAudio` gate so the next assistant turn can
+        // play. Matches `LiveVoiceAudioPlayer.resetForNextResponse()`.
+        this.acceptsAudio = true;
     }
 
     /**

--- a/apps/web/src/domains/voice/live-voice/pcm-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-playback.ts
@@ -1,0 +1,248 @@
+/**
+ * LiveVoicePcmPlayback — gapless streaming playback for live voice TTS.
+ *
+ * Mirrors `clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift`
+ * (pipelined PCM chunk fix in commit 39cdb36bae) and conforms to the
+ * `LiveVoiceAudioPlaying` protocol in `LiveVoiceChannelManager.swift`.
+ *
+ * Gapless scheduling: each chunk is scheduled at
+ * `Math.max(currentTime, nextStartTime)` and the cursor advances by the
+ * buffer's duration. Awaiting `onended` between chunks would introduce
+ * audible gaps from event-loop latency.
+ *
+ * Non-PCM payloads are dropped: the web live-voice path is PCM only, so we
+ * keep the protocol surface but skip `<audio>`-element fallbacks.
+ */
+
+const PCM_MIME_PREFIX = "audio/pcm";
+const BYTES_PER_SAMPLE = 2; // 16-bit signed little-endian PCM
+const INT16_MAX = 32768;
+
+export interface LiveVoiceTtsChunk {
+    pcm: Uint8Array;
+    mimeType: string;
+    sampleRate: number;
+    channels: number;
+}
+
+/**
+ * Minimal slice of the Web Audio surface this module depends on. Tests use a
+ * stand-in implementation; production code receives a real `AudioContext`.
+ */
+export interface PcmAudioContextLike {
+    readonly currentTime: number;
+    readonly destination: AudioDestinationNodeLike;
+    createBuffer(channels: number, frameCount: number, sampleRate: number): AudioBufferLike;
+    createBufferSource(): AudioBufferSourceNodeLike;
+}
+
+export type AudioDestinationNodeLike = Record<never, never>;
+
+export interface AudioBufferLike {
+    readonly duration: number;
+    getChannelData(channel: number): Float32Array;
+    copyToChannel?(source: Float32Array, channel: number): void;
+}
+
+export interface AudioBufferSourceNodeLike {
+    buffer: AudioBufferLike | null;
+    onended: ((this: AudioBufferSourceNodeLike, ev: Event) => unknown) | null;
+    connect(destination: AudioDestinationNodeLike): void;
+    start(when?: number): void;
+    stop(when?: number): void;
+}
+
+export type AudioContextFactory = () => PcmAudioContextLike;
+
+export interface LiveVoicePcmPlaybackOptions {
+    /**
+     * Override for the `AudioContext` constructor. Defaults to
+     * `globalThis.AudioContext || globalThis.webkitAudioContext`. The factory
+     * is invoked lazily on the first `enqueueTtsAudio` call.
+     */
+    audioContextFactory?: AudioContextFactory;
+    /**
+     * Optional logger for diagnostics. Defaults to `console`.
+     */
+    logger?: Pick<Console, "warn">;
+}
+
+interface WindowWithWebkitAudio {
+    AudioContext?: new () => PcmAudioContextLike;
+    webkitAudioContext?: new () => PcmAudioContextLike;
+}
+
+function defaultAudioContextFactory(): PcmAudioContextLike {
+    const w = globalThis as unknown as WindowWithWebkitAudio;
+    const Ctor = w.AudioContext ?? w.webkitAudioContext;
+    if (!Ctor) {
+        throw new Error("AudioContext is not available in this environment");
+    }
+    return new Ctor();
+}
+
+export class LiveVoicePcmPlayback {
+    private readonly factory: AudioContextFactory;
+    private readonly logger: Pick<Console, "warn">;
+    private audioContext: PcmAudioContextLike | null = null;
+    private nextStartTime = 0;
+    private readonly scheduledNodes = new Set<AudioBufferSourceNodeLike>();
+
+    constructor(options: LiveVoicePcmPlaybackOptions = {}) {
+        this.factory = options.audioContextFactory ?? defaultAudioContextFactory;
+        this.logger = options.logger ?? console;
+    }
+
+    /**
+     * `true` while at least one scheduled node hasn't drained yet.
+     */
+    get isPlaying(): boolean {
+        if (!this.audioContext) return false;
+        return this.audioContext.currentTime < this.nextStartTime;
+    }
+
+    /**
+     * Schedule a PCM16 LE chunk to play gaplessly after any previously
+     * scheduled chunks. Non-PCM payloads are dropped with a warning.
+     */
+    enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+        if (!chunk.mimeType.toLowerCase().startsWith(PCM_MIME_PREFIX)) {
+            this.logger.warn(
+                `[LiveVoicePcmPlayback] dropping non-PCM chunk (mimeType=${chunk.mimeType})`,
+            );
+            return;
+        }
+        if (chunk.pcm.byteLength === 0) return;
+        if (chunk.pcm.byteLength % BYTES_PER_SAMPLE !== 0) {
+            this.logger.warn(
+                "[LiveVoicePcmPlayback] dropping malformed PCM chunk (byteLength not aligned to Int16)",
+            );
+            return;
+        }
+        if (chunk.channels < 1 || chunk.sampleRate <= 0) {
+            this.logger.warn(
+                `[LiveVoicePcmPlayback] dropping PCM chunk with invalid format (channels=${chunk.channels}, sampleRate=${chunk.sampleRate})`,
+            );
+            return;
+        }
+
+        const samples = decodePcm16LeToFloat32(chunk.pcm);
+        if (samples.length === 0) return;
+
+        const ctx = this.ensureAudioContext();
+        const frameCount = Math.floor(samples.length / chunk.channels);
+        if (frameCount === 0) return;
+
+        const buffer = ctx.createBuffer(chunk.channels, frameCount, chunk.sampleRate);
+        for (let channel = 0; channel < chunk.channels; channel += 1) {
+            const channelData = extractChannel(samples, chunk.channels, channel, frameCount);
+            if (buffer.copyToChannel) {
+                buffer.copyToChannel(channelData, channel);
+            } else {
+                const target = buffer.getChannelData(channel);
+                target.set(channelData);
+            }
+        }
+
+        const node = ctx.createBufferSource();
+        node.buffer = buffer;
+        node.connect(ctx.destination);
+        const scheduledAt = Math.max(ctx.currentTime, this.nextStartTime);
+        this.scheduledNodes.add(node);
+        node.onended = () => {
+            this.scheduledNodes.delete(node);
+        };
+        node.start(scheduledAt);
+        this.nextStartTime = scheduledAt + buffer.duration;
+    }
+
+    /**
+     * Stop all scheduled playback immediately and clear the queue. Matches
+     * `LiveVoiceAudioPlayer.handleInterrupt()`.
+     */
+    handleInterrupt(): void {
+        this.stopAllScheduledNodes();
+        this.nextStartTime = 0;
+    }
+
+    /**
+     * Let the currently-scheduled tail drain naturally. The cursor isn't
+     * reset; new chunks would queue after the existing tail.
+     */
+    handleEnd(): void {
+        // Scheduled nodes drain on their own; `nextStartTime` stays put so
+        // `waitUntilPlaybackFinishes()` still observes the residual tail.
+    }
+
+    handleSessionError(): void {
+        // Same playback effect as an interrupt; observers distinguish the
+        // two via the session state, not the player.
+        this.handleInterrupt();
+    }
+
+    resetForNextResponse(): void {
+        // No-op in v1: the scheduling cursor already handles back-to-back
+        // responses. Kept on the surface for parity with the macOS protocol.
+    }
+
+    /**
+     * Resolve once `audioContext.currentTime` catches up to `nextStartTime`.
+     * Uses a single `setTimeout` rounded to the residual gap rather than a
+     * polling loop, matching `LiveVoiceAudioPlayer.waitUntilPlaybackFinishes()`.
+     */
+    waitUntilPlaybackFinishes(): Promise<void> {
+        const ctx = this.audioContext;
+        if (!ctx) return Promise.resolve();
+        const remaining = this.nextStartTime - ctx.currentTime;
+        if (remaining <= 0) return Promise.resolve();
+        return new Promise((resolve) => {
+            const delayMs = Math.ceil(remaining * 1000);
+            setTimeout(resolve, delayMs);
+        });
+    }
+
+    private ensureAudioContext(): PcmAudioContextLike {
+        if (!this.audioContext) {
+            this.audioContext = this.factory();
+            this.nextStartTime = 0;
+        }
+        return this.audioContext;
+    }
+
+    private stopAllScheduledNodes(): void {
+        for (const node of this.scheduledNodes) {
+            try {
+                node.stop(0);
+            } catch {
+                // Stopping an already-finished node throws InvalidStateError
+                // per the Web Audio spec.
+            }
+        }
+        this.scheduledNodes.clear();
+    }
+}
+
+function decodePcm16LeToFloat32(pcm: Uint8Array): Float32Array {
+    const sampleCount = Math.floor(pcm.byteLength / BYTES_PER_SAMPLE);
+    const out = new Float32Array(sampleCount);
+    // DataView (not Int16Array) so reads stay little-endian on big-endian hosts.
+    const view = new DataView(pcm.buffer, pcm.byteOffset, sampleCount * BYTES_PER_SAMPLE);
+    for (let i = 0; i < sampleCount; i += 1) {
+        out[i] = view.getInt16(i * BYTES_PER_SAMPLE, true) / INT16_MAX;
+    }
+    return out;
+}
+
+function extractChannel(
+    interleaved: Float32Array,
+    channelCount: number,
+    channel: number,
+    frameCount: number,
+): Float32Array {
+    if (channelCount === 1) return interleaved.subarray(0, frameCount);
+    const out = new Float32Array(frameCount);
+    for (let i = 0; i < frameCount; i += 1) {
+        out[i] = interleaved[i * channelCount + channel] ?? 0;
+    }
+    return out;
+}

--- a/apps/web/src/domains/voice/live-voice/pcm-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-playback.ts
@@ -81,6 +81,11 @@ function defaultAudioContextFactory(): PcmAudioContextLike {
     return new Ctor();
 }
 
+interface PendingWaiter {
+    timer: ReturnType<typeof setTimeout>;
+    resolve: () => void;
+}
+
 export class LiveVoicePcmPlayback {
     private readonly factory: AudioContextFactory;
     private readonly logger: Pick<Console, "warn">;
@@ -88,6 +93,7 @@ export class LiveVoicePcmPlayback {
     private nextStartTime = 0;
     private acceptsAudio = true;
     private readonly scheduledNodes = new Set<AudioBufferSourceNodeLike>();
+    private readonly pendingWaiters = new Set<PendingWaiter>();
 
     constructor(options: LiveVoicePcmPlaybackOptions = {}) {
         this.factory = options.audioContextFactory ?? defaultAudioContextFactory;
@@ -173,6 +179,7 @@ export class LiveVoicePcmPlayback {
         this.stopAllScheduledNodes();
         this.nextStartTime = 0;
         this.acceptsAudio = false;
+        this.resolvePendingWaiters();
     }
 
     /**
@@ -185,6 +192,7 @@ export class LiveVoicePcmPlayback {
         this.stopAllScheduledNodes();
         this.nextStartTime = 0;
         this.acceptsAudio = false;
+        this.resolvePendingWaiters();
     }
 
     handleSessionError(): void {
@@ -203,6 +211,11 @@ export class LiveVoicePcmPlayback {
      * Resolve once `audioContext.currentTime` catches up to `nextStartTime`.
      * Uses a single `setTimeout` rounded to the residual gap rather than a
      * polling loop, matching `LiveVoiceAudioPlayer.waitUntilPlaybackFinishes()`.
+     *
+     * If `handleInterrupt()` or `handleEnd()` runs while a waiter is pending,
+     * the waiter is resolved immediately so close/cleanup paths don't block on
+     * a stale cursor — mirrors `LiveVoiceAudioPlayer.stop(reason:)` resolving
+     * its own waiters on stop.
      */
     waitUntilPlaybackFinishes(): Promise<void> {
         const ctx = this.audioContext;
@@ -211,7 +224,14 @@ export class LiveVoicePcmPlayback {
         if (remaining <= 0) return Promise.resolve();
         return new Promise((resolve) => {
             const delayMs = Math.ceil(remaining * 1000);
-            setTimeout(resolve, delayMs);
+            const waiter: PendingWaiter = {
+                timer: setTimeout(() => {
+                    this.pendingWaiters.delete(waiter);
+                    resolve();
+                }, delayMs),
+                resolve,
+            };
+            this.pendingWaiters.add(waiter);
         });
     }
 
@@ -233,6 +253,14 @@ export class LiveVoicePcmPlayback {
             }
         }
         this.scheduledNodes.clear();
+    }
+
+    private resolvePendingWaiters(): void {
+        for (const waiter of this.pendingWaiters) {
+            clearTimeout(waiter.timer);
+            waiter.resolve();
+        }
+        this.pendingWaiters.clear();
     }
 }
 

--- a/apps/web/src/domains/voice/live-voice/pcm-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-playback.ts
@@ -14,7 +14,10 @@
  * keep the protocol surface but skip `<audio>`-element fallbacks.
  */
 
-const PCM_MIME_PREFIX = "audio/pcm";
+// Match only `audio/pcm` exactly (case-insensitive) or `audio/pcm;<parameters>`.
+// A raw prefix check would incorrectly accept G.711 codecs like `audio/pcma`
+// (A-law) and `audio/pcmu` (mu-law) — those bytes are NOT 16-bit LE PCM.
+const PCM_MIME_PATTERN = /^audio\/pcm(?:;|$)/i;
 const BYTES_PER_SAMPLE = 2; // 16-bit signed little-endian PCM
 const INT16_MAX = 32768;
 
@@ -119,7 +122,7 @@ export class LiveVoicePcmPlayback {
             // late TTS chunks that race the cancel until `resetForNextResponse()`.
             return;
         }
-        if (!chunk.mimeType.toLowerCase().startsWith(PCM_MIME_PREFIX)) {
+        if (!PCM_MIME_PATTERN.test(chunk.mimeType.trim())) {
             this.logger.warn(
                 `[LiveVoicePcmPlayback] dropping non-PCM chunk (mimeType=${chunk.mimeType})`,
             );
@@ -167,6 +170,7 @@ export class LiveVoicePcmPlayback {
         };
         node.start(scheduledAt);
         this.nextStartTime = scheduledAt + buffer.duration;
+        this.rescheduleWaitersForExtendedCursor();
     }
 
     /**
@@ -261,6 +265,28 @@ export class LiveVoicePcmPlayback {
             waiter.resolve();
         }
         this.pendingWaiters.clear();
+    }
+
+    /**
+     * When `enqueueTtsAudio()` extends `nextStartTime`, any pending
+     * `waitUntilPlaybackFinishes()` timer was rounded to the old cursor and
+     * would resolve too early. Reschedule each pending waiter against the new
+     * cursor so callers wait for the actual end of buffered audio. The waiter
+     * itself stays pending — only its timer handle is replaced.
+     */
+    private rescheduleWaitersForExtendedCursor(): void {
+        const ctx = this.audioContext;
+        if (!ctx) return;
+        if (this.pendingWaiters.size === 0) return;
+        for (const waiter of this.pendingWaiters) {
+            clearTimeout(waiter.timer);
+            const remaining = this.nextStartTime - ctx.currentTime;
+            const delayMs = remaining > 0 ? Math.ceil(remaining * 1000) : 0;
+            waiter.timer = setTimeout(() => {
+                this.pendingWaiters.delete(waiter);
+                waiter.resolve();
+            }, delayMs);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add LiveVoicePcmPlayback mirroring macOS LiveVoiceAudioPlayer
- Schedule PCM TTS chunks gaplessly via AudioBufferSourceNode + nextStartTime cursor
- Interrupt stops all scheduled nodes; waitUntilPlaybackFinishes uses single scheduled resolve

Part of plan: realtime-voice-web.md (PR 3 of 9)