### PR TITLE
[LUM-2001] fix(web): add safe-area insets and backdrop dismiss to mobile tool detail overlay

### DIFF
--- a/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, type MouseEvent } from "react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
@@ -35,8 +35,26 @@ export function MobileToolDetailOverlay({
     return null;
   }
 
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]">
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh] bg-black/40"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom:
+          "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft:
+          "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight:
+          "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+      onClick={handleBackdropClick}
+    >
       <LazyBoundary>
         <ToolDetailPanel detail={detail} onClose={onClose} />
       </LazyBoundary>


### PR DESCRIPTION
The `MobileToolDetailOverlay` (introduced in PR #32305) was missing safe-area inset padding that all other mobile overlays received in #32308 (LUM-1692). Without these insets, the panel header and close button render behind the iOS notch/Dynamic Island, making the overlay nearly impossible to dismiss. This also adds a semi-transparent backdrop with tap-to-dismiss, giving users two clear ways to close the panel.

## Root cause analysis

1. **How did the code get into this state?** PR #32308 (LUM-1692) added safe-area insets to the three existing mobile overlays (document, subagent, app) on 2026-05-27. PR #32305 created `MobileToolDetailOverlay` on the same day, branched from #32308. The author of #32305 didn't apply the same safe-area pattern to the new overlay — likely because the pattern wasn't yet established as a mandatory convention when the feature was being developed.

2. **What mistakes or decisions led to it?** No checklist or AGENTS.md guidance existed to remind developers that all mobile full-screen overlays portaled to `#viewport-overlays` require safe-area insets. The fix in #32308 was reactive (fixing three overlays after the bug was reported), not proactive (establishing a pattern for all future overlays).

3. **Were there warning signs?** The pattern was established just hours before #32305 merged. A review of #32305 could have caught the omission by comparing against the sibling overlay files.

4. **What can we do to prevent this?** The comment in `use-mobile-overlay-target.ts` now names only three overlays. Future overlay authors should see the pattern in sibling files and apply it. A more durable solution would be extracting a shared `MobileOverlayWrapper` component, but that adds abstraction for a pattern with only 4 instances.

5. **AGENTS.md update?** Not warranted — the pattern is visible in the sibling overlay files and the overhead of documenting every CSS convention would make AGENTS.md unwieldy.

## Alternatives not taken

- **Swipe-down-to-dismiss**: Requires touch/pointer event tracking, animation, and threshold logic. Risk of conflicting with scrollable code blocks inside the panel. Over-engineered for 4 instances of this overlay pattern.
- **Only add safe-area insets (no backdrop)**: Fixes the notch issue but still leaves a single small dismissal target. [NN/g research on overlay dismissal](https://www.nngroup.com/articles/accidental-overlay-dismissal/) recommends multiple dismissal methods for mobile overlays.
- **Convert to `BottomSheet` component**: `BottomSheet` is capped at `max-h-[50dvh]` and designed for short menu-style content. The tool detail panel needs full-screen height for code blocks and output.
- **Extract a shared `MobileOverlayWrapper`**: Would DRY up the safe-area + backdrop pattern across 4 overlays, but adds indirection for a simple CSS concern. The overlays have divergent props/behavior (app overlay has minimize animation, subagent has stop button, etc.), so a wrapper would immediately need escape hatches.

## References

- [CSS Transforms Level 1 §6 — The Transform Rendering Model](https://www.w3.org/TR/css-transforms-1/#transform-rendering): explains why `position: fixed` inside a transformed parent anchors to the transform's containing block, not the viewport
- [Apple HIG — Safe area](https://developer.apple.com/design/human-interface-guidelines/layout#Safe-area): iOS content must respect safe-area insets
- [NN/g — Accidental Dismissal of Overlays](https://www.nngroup.com/articles/accidental-overlay-dismissal/): mobile overlays should provide multiple dismissal mechanisms (dedicated button + backdrop tap)
- PR #32308 (LUM-1692): the identical safe-area fix for the other three mobile overlays

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/1ec61ef77ede4a0e850e42c6b2dbd51c