### PR TITLE
feat(web/voice): add 16 kHz mono PCM AudioWorklet capture for live voice

### DIFF
--- a/apps/web/public/worklets/pcm16k-capture-processor.js
+++ b/apps/web/public/worklets/pcm16k-capture-processor.js
@@ -1,0 +1,157 @@
+/**
+ * AudioWorklet processor that captures microphone audio at the input
+ * AudioContext sample rate (typically 48 kHz), downmixes to mono,
+ * decimates to 16 kHz, batches into ~20 ms PCM16 LE chunks (320 samples),
+ * and posts each chunk to the main thread.
+ *
+ * This is the web port of the macOS `LiveVoicePCM16kMonoConverter`
+ * (see clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift).
+ *
+ * Loaded at runtime by `LiveVoicePcmCapture` via
+ * `audioContext.audioWorklet.addModule("/worklets/pcm16k-capture-processor.js")`.
+ *
+ * Plain JS (no TypeScript compile) because it runs in the audio-rendering
+ * worklet global scope, which has its own module loader.
+ */
+
+/* global AudioWorkletProcessor, registerProcessor, sampleRate */
+
+const TARGET_SAMPLE_RATE = 16000;
+/** 20 ms at 16 kHz = 320 samples. */
+const CHUNK_SAMPLES = 320;
+/** Post amplitude updates at ~20 Hz (every 50 ms of input audio). */
+const AMPLITUDE_INTERVAL_SECONDS = 0.05;
+
+class Pcm16kCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Decimation ratio from the AudioContext sample rate (set by the host,
+    // usually 48000) down to 16 kHz. Fractional positions are accumulated
+    // across `process()` calls so we don't drift.
+    this.decimationRatio = sampleRate / TARGET_SAMPLE_RATE;
+    this.nextSourcePosition = 0;
+
+    // Ring/append buffer of decimated mono samples. We flush 320-sample
+    // chunks as PCM16 LE.
+    this.pendingSamples = new Float32Array(CHUNK_SAMPLES * 4);
+    this.pendingCount = 0;
+
+    // Amplitude meter: peak absolute value over a ~50 ms window.
+    this.amplitudePeak = 0;
+    this.amplitudeFramesAccumulated = 0;
+    this.amplitudeWindowFrames = Math.max(
+      1,
+      Math.round(sampleRate * AMPLITUDE_INTERVAL_SECONDS),
+    );
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) {
+      return true;
+    }
+
+    const channelCount = input.length;
+    const frameCount = input[0]?.length ?? 0;
+    if (frameCount === 0) {
+      return true;
+    }
+
+    // Track peak amplitude on the input (pre-decimation) signal so the
+    // meter responds to the raw mic loudness.
+    for (let i = 0; i < frameCount; i++) {
+      let monoSample = 0;
+      for (let c = 0; c < channelCount; c++) {
+        monoSample += input[c][i];
+      }
+      monoSample /= channelCount;
+
+      const abs = monoSample >= 0 ? monoSample : -monoSample;
+      if (abs > this.amplitudePeak) {
+        this.amplitudePeak = abs;
+      }
+    }
+
+    this.amplitudeFramesAccumulated += frameCount;
+    if (this.amplitudeFramesAccumulated >= this.amplitudeWindowFrames) {
+      const amplitude = this.amplitudePeak > 1 ? 1 : this.amplitudePeak;
+      this.port.postMessage({ type: "amplitude", amplitude });
+      this.amplitudePeak = 0;
+      this.amplitudeFramesAccumulated = 0;
+    }
+
+    // Decimate by linear interpolation between adjacent mono samples.
+    // `nextSourcePosition` is a fractional index into the current input
+    // buffer; after the loop we subtract `frameCount` so the remainder
+    // carries into the next callback.
+    while (this.nextSourcePosition < frameCount) {
+      const lowerFrame = Math.min(
+        Math.floor(this.nextSourcePosition),
+        frameCount - 1,
+      );
+      const upperFrame = Math.min(lowerFrame + 1, frameCount - 1);
+      const fraction = this.nextSourcePosition - lowerFrame;
+
+      const lowerSample = monoAt(input, lowerFrame, channelCount);
+      const upperSample = monoAt(input, upperFrame, channelCount);
+      const sample = lowerSample + (upperSample - lowerSample) * fraction;
+
+      this.appendSample(sample);
+      this.nextSourcePosition += this.decimationRatio;
+    }
+    this.nextSourcePosition -= frameCount;
+    if (this.nextSourcePosition < 0) {
+      this.nextSourcePosition = 0;
+    }
+
+    // Flush full 320-sample chunks. Multiple may be ready if the
+    // sample rate is low enough relative to the input quantum.
+    while (this.pendingCount >= CHUNK_SAMPLES) {
+      const pcm16 = new Int16Array(CHUNK_SAMPLES);
+      let peakAbs = 0;
+      for (let i = 0; i < CHUNK_SAMPLES; i++) {
+        const f = this.pendingSamples[i];
+        const clamped = f < -1 ? -1 : f > 1 ? 1 : f;
+        const abs = clamped >= 0 ? clamped : -clamped;
+        if (abs > peakAbs) peakAbs = abs;
+        const scale = clamped < 0 ? 32768 : 32767;
+        pcm16[i] = Math.trunc(clamped * scale);
+      }
+
+      this.port.postMessage(
+        { type: "chunk", pcm16, frameCount: CHUNK_SAMPLES, amplitude: peakAbs },
+        [pcm16.buffer],
+      );
+
+      // Shift remaining samples down.
+      const remaining = this.pendingCount - CHUNK_SAMPLES;
+      this.pendingSamples.copyWithin(0, CHUNK_SAMPLES, this.pendingCount);
+      this.pendingCount = remaining;
+    }
+
+    return true;
+  }
+
+  appendSample(sample) {
+    if (this.pendingCount >= this.pendingSamples.length) {
+      // Grow the buffer in chunks to avoid frequent reallocations. This
+      // shouldn't normally happen at the input rates we expect, but it
+      // keeps the worklet correct under bursty schedulers.
+      const grown = new Float32Array(this.pendingSamples.length * 2);
+      grown.set(this.pendingSamples);
+      this.pendingSamples = grown;
+    }
+    this.pendingSamples[this.pendingCount++] = sample;
+  }
+}
+
+function monoAt(input, frame, channelCount) {
+  let sum = 0;
+  for (let c = 0; c < channelCount; c++) {
+    sum += input[c][frame];
+  }
+  return sum / channelCount;
+}
+
+registerProcessor("pcm16k-capture-processor", Pcm16kCaptureProcessor);

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -53,8 +53,12 @@ class MockMessagePort {
 class MockAudioWorkletNode {
   port = new MockMessagePort();
   disconnectCount = 0;
+  connectedTo: unknown[] = [];
   constructor(public context: MockAudioContext, public name: string) {
     context.lastWorkletNode = this;
+  }
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
   }
   disconnect() {
     this.disconnectCount += 1;
@@ -63,8 +67,11 @@ class MockAudioWorkletNode {
 
 class MockMediaStreamAudioSourceNode {
   disconnectCount = 0;
+  connectedTo: unknown[] = [];
   constructor(public context: MockAudioContext, public stream: MockMediaStream) {}
-  connect(_destination: unknown): void {}
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
+  }
   disconnect() {
     this.disconnectCount += 1;
   }
@@ -78,14 +85,36 @@ class MockAudioWorklet {
   }
 }
 
+class MockAudioDestinationNode {}
+
+class MockGainNode {
+  gain = { value: 1 };
+  disconnectCount = 0;
+  connectedTo: unknown[] = [];
+  constructor(public context: MockAudioContext) {}
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
+  }
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
 class MockAudioContext {
   audioWorklet = new MockAudioWorklet();
+  destination = new MockAudioDestinationNode();
   closed = false;
   lastWorkletNode: MockAudioWorkletNode | null = null;
   lastSourceNode: MockMediaStreamAudioSourceNode | null = null;
+  lastGainNode: MockGainNode | null = null;
   createMediaStreamSource(stream: MockMediaStream): MockMediaStreamAudioSourceNode {
     const node = new MockMediaStreamAudioSourceNode(this, stream);
     this.lastSourceNode = node;
+    return node;
+  }
+  createGain(): MockGainNode {
+    const node = new MockGainNode(this);
+    this.lastGainNode = node;
     return node;
   }
   close(): Promise<void> {
@@ -241,6 +270,29 @@ describe("LiveVoicePcmCapture", () => {
     ]);
   });
 
+  it("connects the worklet through a muted GainNode to the destination", async () => {
+    // Regression: Web Audio only pulls render quanta along edges that
+    // terminate at `audioContext.destination`. Without the muted sink
+    // the AudioWorklet's `process()` never runs and live voice gets
+    // zero PCM chunks.
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+    expect(ok).toBe(true);
+
+    const lastContext = getInternalContext(capture);
+    const worklet = lastContext.lastWorkletNode!;
+    const gain = lastContext.lastGainNode!;
+    expect(gain).not.toBeNull();
+
+    // Worklet feeds into the GainNode, which feeds into destination.
+    expect(worklet.connectedTo).toContain(gain);
+    expect(gain.gain.value).toBe(0);
+    expect(gain.connectedTo).toContain(lastContext.destination);
+  });
+
   it("stop() is idempotent", async () => {
     mockStream = new MockMediaStream();
     getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
@@ -250,16 +302,19 @@ describe("LiveVoicePcmCapture", () => {
     const lastContext = getInternalContext(capture);
     const worklet = lastContext.lastWorkletNode!;
     const source = lastContext.lastSourceNode!;
+    const gain = lastContext.lastGainNode!;
 
     capture.stop();
     expect(worklet.disconnectCount).toBe(1);
     expect(source.disconnectCount).toBe(1);
+    expect(gain.disconnectCount).toBe(1);
     expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
 
     // Second stop is a no-op and does not throw.
     expect(() => capture.stop()).not.toThrow();
     expect(worklet.disconnectCount).toBe(1);
     expect(source.disconnectCount).toBe(1);
+    expect(gain.disconnectCount).toBe(1);
 
     // AudioContext stays warm after stop().
     expect(lastContext.closed).toBe(false);
@@ -295,14 +350,17 @@ describe("LiveVoicePcmCapture", () => {
     const capture = new LiveVoicePcmCapture();
     await capture.start({ onChunk: () => undefined });
     const lastContext = getInternalContext(capture);
+    const gain = lastContext.lastGainNode!;
 
     capture.shutdown();
     expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
     expect(lastContext.closed).toBe(true);
+    expect(gain.disconnectCount).toBe(1);
 
     // Second shutdown is a no-op.
     expect(() => capture.shutdown()).not.toThrow();
     expect(lastContext.closed).toBe(true);
+    expect(gain.disconnectCount).toBe(1);
 
     // start() after shutdown returns false.
     const ok = await capture.start({ onChunk: () => undefined });

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -10,6 +10,10 @@
  *  (c) `stop()` is idempotent
  *  (d) `shutdown()` releases MediaStream tracks and closes the
  *      AudioContext, and is idempotent
+ *  (e) `stop()` issued before `getUserMedia` resolves cancels the
+ *      pending start and releases the late-arriving stream
+ *  (f) Two overlapping `start()` calls cooperate — only the latest
+ *      wins; the earlier one releases its stream
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -303,5 +307,127 @@ describe("LiveVoicePcmCapture", () => {
     // start() after shutdown returns false.
     const ok = await capture.start({ onChunk: () => undefined });
     expect(ok).toBe(false);
+  });
+
+  it("stop() during a pending start() cancels it and releases the late stream", async () => {
+    // Regression: in a push-to-talk flow, the user can release the key
+    // before `getUserMedia()` resolves. The pending start must observe
+    // the cancellation, release the stream that does eventually arrive,
+    // and return false rather than wiring up a phantom mic.
+    let resolveGetUserMedia: ((stream: MockMediaStream) => void) | null = null;
+    const pendingStream = new MockMediaStream();
+    getUserMediaImpl = () =>
+      new Promise<MockMediaStream>((resolve) => {
+        resolveGetUserMedia = resolve;
+      });
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise = capture.start({ onChunk: () => undefined });
+
+    // User releases PTT key before `getUserMedia` resolves.
+    capture.stop();
+
+    // Now permission grant resolves, late — pending start should
+    // release the stream and bail.
+    expect(resolveGetUserMedia).not.toBeNull();
+    resolveGetUserMedia!(pendingStream);
+
+    const ok = await startPromise;
+    expect(ok).toBe(false);
+    expect(pendingStream.getTracks()[0]!.readyState).toBe("ended");
+
+    // No nodes should have been wired up.
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    const internalWorklet = (
+      capture as unknown as { workletNode: MockAudioWorkletNode | null }
+    ).workletNode;
+    expect(internalStream).toBeNull();
+    expect(internalWorklet).toBeNull();
+  });
+
+  it("two overlapping start() calls cancel the earlier one and only the latest wins", async () => {
+    // Regression: prior to the generation counter, both starts would
+    // race past the synchronous guard and the slower one would
+    // overwrite the stored nodes, leaving the earlier capture's
+    // MediaStream dangling.
+    const resolvers: ((stream: MockMediaStream) => void)[] = [];
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const stream = new MockMediaStream();
+      streams.push(stream);
+      return new Promise<MockMediaStream>((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise1 = capture.start({ onChunk: () => undefined });
+    const startPromise2 = capture.start({ onChunk: () => undefined });
+
+    // Both starts are pending on getUserMedia; the second one bumped
+    // the generation past the first.
+    expect(resolvers).toHaveLength(2);
+    expect(streams).toHaveLength(2);
+
+    // Resolve the FIRST start last to exercise the "earlier resolves
+    // last" ordering too. Actually we want the first to resolve first
+    // to mirror the bug scenario where the slower second overwrites
+    // the first's nodes. With the generation counter both orderings
+    // are correct — the first call always loses regardless of order.
+    resolvers[0]!(streams[0]!);
+    resolvers[1]!(streams[1]!);
+
+    const [ok1, ok2] = await Promise.all([startPromise1, startPromise2]);
+
+    expect(ok1).toBe(false);
+    expect(ok2).toBe(true);
+
+    // The first call's stream must be released; the second's must be
+    // live and wired up.
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    expect(internalStream).toBe(streams[1]!);
+  });
+
+  it("two overlapping start() calls — earlier resolves last, latest still wins", async () => {
+    // Same as above but with the resolution order swapped: the second
+    // (winning) start resolves first, then the stale first one
+    // resolves. The first must still release its stream and not
+    // clobber the second's nodes.
+    const resolvers: ((stream: MockMediaStream) => void)[] = [];
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const stream = new MockMediaStream();
+      streams.push(stream);
+      return new Promise<MockMediaStream>((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise1 = capture.start({ onChunk: () => undefined });
+    const startPromise2 = capture.start({ onChunk: () => undefined });
+
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[1]!(streams[1]!);
+    resolvers[0]!(streams[0]!);
+
+    const [ok1, ok2] = await Promise.all([startPromise1, startPromise2]);
+    expect(ok1).toBe(false);
+    expect(ok2).toBe(true);
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    expect(internalStream).toBe(streams[1]!);
   });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for `LiveVoicePcmCapture` — verifies the lifecycle and
+ * message routing without spinning up a real `AudioContext` or
+ * microphone.
+ *
+ * Covers:
+ *  (a) `start()` returns `false` when `getUserMedia` rejects
+ *  (b) `start()` returns `true` and forwards chunks/amplitude from the
+ *      mock worklet to the supplied callbacks
+ *  (c) `stop()` is idempotent
+ *  (d) `shutdown()` releases MediaStream tracks and closes the
+ *      AudioContext, and is idempotent
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { LiveVoicePcmCapture } from "../pcm-capture";
+
+// ---------------------------------------------------------------------------
+// Mock primitives
+// ---------------------------------------------------------------------------
+
+class MockMediaStreamTrack {
+  kind = "audio";
+  readyState: "live" | "ended" = "live";
+  stop() {
+    this.readyState = "ended";
+  }
+}
+
+class MockMediaStream {
+  private tracks: MockMediaStreamTrack[];
+  constructor() {
+    this.tracks = [new MockMediaStreamTrack()];
+  }
+  getTracks(): MockMediaStreamTrack[] {
+    return this.tracks;
+  }
+}
+
+class MockMessagePort {
+  onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  /** Test helper: simulate the worklet posting to the main thread. */
+  emit(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent<unknown>);
+  }
+}
+
+class MockAudioWorkletNode {
+  port = new MockMessagePort();
+  disconnectCount = 0;
+  constructor(public context: MockAudioContext, public name: string) {
+    context.lastWorkletNode = this;
+  }
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
+class MockMediaStreamAudioSourceNode {
+  disconnectCount = 0;
+  constructor(public context: MockAudioContext, public stream: MockMediaStream) {}
+  connect(_destination: unknown): void {}
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
+class MockAudioWorklet {
+  loadedModules: string[] = [];
+  addModule(url: string): Promise<void> {
+    this.loadedModules.push(url);
+    return Promise.resolve();
+  }
+}
+
+class MockAudioContext {
+  audioWorklet = new MockAudioWorklet();
+  closed = false;
+  lastWorkletNode: MockAudioWorkletNode | null = null;
+  lastSourceNode: MockMediaStreamAudioSourceNode | null = null;
+  createMediaStreamSource(stream: MockMediaStream): MockMediaStreamAudioSourceNode {
+    const node = new MockMediaStreamAudioSourceNode(this, stream);
+    this.lastSourceNode = node;
+    return node;
+  }
+  close(): Promise<void> {
+    this.closed = true;
+    return Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global wiring
+// ---------------------------------------------------------------------------
+
+interface TestGlobals {
+  AudioContext: typeof MockAudioContext;
+  AudioWorkletNode: typeof MockAudioWorkletNode;
+  navigator: {
+    mediaDevices: {
+      getUserMedia: (constraints: unknown) => Promise<MockMediaStream>;
+    };
+  };
+}
+
+const originals = {
+  AudioContext: (globalThis as unknown as { AudioContext?: unknown })
+    .AudioContext,
+  AudioWorkletNode: (globalThis as unknown as { AudioWorkletNode?: unknown })
+    .AudioWorkletNode,
+  mediaDevices: (
+    globalThis as unknown as { navigator?: { mediaDevices?: unknown } }
+  ).navigator?.mediaDevices,
+};
+
+let mockStream: MockMediaStream | null = null;
+let getUserMediaImpl: (constraints: unknown) => Promise<MockMediaStream> = () =>
+  Promise.reject(new Error("getUserMedia not configured"));
+
+function installMocks() {
+  const g = globalThis as unknown as TestGlobals;
+  g.AudioContext = MockAudioContext;
+  g.AudioWorkletNode = MockAudioWorkletNode;
+
+  // Bun's happy-dom registrator sets `navigator`, so we patch
+  // `mediaDevices` rather than replacing the whole navigator object.
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      getUserMedia: (constraints: unknown) => getUserMediaImpl(constraints),
+    },
+  });
+}
+
+function restoreMocks() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (originals.AudioContext === undefined) {
+    delete g.AudioContext;
+  } else {
+    g.AudioContext = originals.AudioContext;
+  }
+  if (originals.AudioWorkletNode === undefined) {
+    delete g.AudioWorkletNode;
+  } else {
+    g.AudioWorkletNode = originals.AudioWorkletNode;
+  }
+  if (originals.mediaDevices === undefined) {
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: undefined,
+    });
+  } else {
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: originals.mediaDevices,
+    });
+  }
+}
+
+beforeEach(() => {
+  mockStream = null;
+  getUserMediaImpl = () =>
+    Promise.reject(new Error("getUserMedia not configured"));
+  installMocks();
+});
+
+afterEach(() => {
+  restoreMocks();
+});
+
+/**
+ * Test-only escape hatch for reading the capture's internal AudioContext.
+ * Keeps the public API surface clean while still letting tests drive the
+ * worklet port directly.
+ */
+function getInternalContext(capture: LiveVoicePcmCapture): MockAudioContext {
+  const ctx = (capture as unknown as { audioContext: MockAudioContext })
+    .audioContext;
+  expect(ctx).toBeInstanceOf(MockAudioContext);
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoicePcmCapture", () => {
+  it("returns false when getUserMedia rejects", async () => {
+    getUserMediaImpl = () => Promise.reject(new Error("denied"));
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(false);
+  });
+
+  it("returns true and forwards chunks/amplitude when worklet posts", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const chunks: { pcm16: Int16Array; frameCount: number; amplitude: number }[] = [];
+    const amplitudes: number[] = [];
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({
+      onChunk: (chunk) => chunks.push(chunk),
+      onAmplitude: (a) => amplitudes.push(a),
+    });
+    expect(ok).toBe(true);
+
+    // The most recently constructed worklet node lives on the
+    // AudioContext the capture is using. Reach in and simulate the
+    // audio-thread posting messages.
+    const lastContext = getInternalContext(capture);
+    const lastWorklet = lastContext.lastWorkletNode;
+    expect(lastWorklet).not.toBeNull();
+
+    const pcm = new Int16Array([1, 2, 3]);
+    lastWorklet!.port.emit({
+      type: "chunk",
+      pcm16: pcm,
+      frameCount: 3,
+      amplitude: 0.42,
+    });
+    lastWorklet!.port.emit({ type: "amplitude", amplitude: 0.75 });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.frameCount).toBe(3);
+    expect(chunks[0]!.amplitude).toBe(0.42);
+    expect(Array.from(chunks[0]!.pcm16)).toEqual([1, 2, 3]);
+    expect(amplitudes).toEqual([0.75]);
+
+    // Verify worklet module was registered at the expected static path.
+    expect(lastContext.audioWorklet.loadedModules).toEqual([
+      "/worklets/pcm16k-capture-processor.js",
+    ]);
+  });
+
+  it("stop() is idempotent", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    await capture.start({ onChunk: () => undefined });
+    const lastContext = getInternalContext(capture);
+    const worklet = lastContext.lastWorkletNode!;
+    const source = lastContext.lastSourceNode!;
+
+    capture.stop();
+    expect(worklet.disconnectCount).toBe(1);
+    expect(source.disconnectCount).toBe(1);
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
+
+    // Second stop is a no-op and does not throw.
+    expect(() => capture.stop()).not.toThrow();
+    expect(worklet.disconnectCount).toBe(1);
+    expect(source.disconnectCount).toBe(1);
+
+    // AudioContext stays warm after stop().
+    expect(lastContext.closed).toBe(false);
+  });
+
+  it("shutdown() releases MediaStream tracks, closes AudioContext, and is idempotent", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    await capture.start({ onChunk: () => undefined });
+    const lastContext = getInternalContext(capture);
+
+    capture.shutdown();
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
+    expect(lastContext.closed).toBe(true);
+
+    // Second shutdown is a no-op.
+    expect(() => capture.shutdown()).not.toThrow();
+    expect(lastContext.closed).toBe(true);
+
+    // start() after shutdown returns false.
+    const ok = await capture.start({ onChunk: () => undefined });
+    expect(ok).toBe(false);
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -261,6 +261,29 @@ describe("LiveVoicePcmCapture", () => {
     expect(lastContext.closed).toBe(false);
   });
 
+  it("start() called while already active releases the previous MediaStream", async () => {
+    // Regression: previously `start()` only called `stopInternal()` when
+    // restarting, leaving the old MediaStream alive and leaking the mic.
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const s = new MockMediaStream();
+      streams.push(s);
+      return Promise.resolve(s);
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const ok1 = await capture.start({ onChunk: () => undefined });
+    expect(ok1).toBe(true);
+    const ok2 = await capture.start({ onChunk: () => undefined });
+    expect(ok2).toBe(true);
+
+    // Two distinct streams were opened; the first one must have been
+    // released so the OS-level mic indicator can clear.
+    expect(streams).toHaveLength(2);
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+  });
+
   it("shutdown() releases MediaStream tracks, closes AudioContext, and is idempotent", async () => {
     mockStream = new MockMediaStream();
     getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -1,0 +1,217 @@
+/**
+ * Main-thread driver for the 16 kHz mono PCM AudioWorklet capture.
+ *
+ * Mirrors the macOS `LiveVoiceAudioCapture` surface so the rest of the
+ * live-voice manager (built in later PRs) can call into a familiar
+ * `start` / `stop` / `shutdown` lifecycle.
+ *
+ * Pipeline:
+ *
+ *   getUserMedia → MediaStreamAudioSourceNode → AudioWorkletNode
+ *   ("pcm16k-capture-processor" — see public/worklets/) → onChunk callback
+ *
+ * The worklet posts two message types: `chunk` (PCM16 LE Int16Array, 320
+ * samples = 20 ms at 16 kHz) and `amplitude` (peak abs in [0, 1] at ~20 Hz).
+ *
+ * `stop()` tears down the active capture but keeps the `AudioContext` warm
+ * so the next `start()` can resume without paying for context creation
+ * again. `shutdown()` fully releases everything (tracks, context).
+ *
+ * Both methods are idempotent — duplicate calls are safe and cheap.
+ */
+
+const WORKLET_MODULE_URL = "/worklets/pcm16k-capture-processor.js";
+const WORKLET_PROCESSOR_NAME = "pcm16k-capture-processor";
+
+type AudioContextCtor = new (
+  contextOptions?: AudioContextOptions,
+) => AudioContext;
+
+interface PcmCaptureChunk {
+  pcm16: Int16Array;
+  frameCount: number;
+  amplitude: number;
+}
+
+export interface LiveVoicePcmCaptureStartOptions {
+  /** Called once per 320-sample PCM16 LE chunk (~20 ms at 16 kHz). */
+  onChunk: (chunk: PcmCaptureChunk) => void;
+  /** Called at ~20 Hz with peak amplitude in [0, 1]. Optional UI meter. */
+  onAmplitude?: (amplitude: number) => void;
+}
+
+interface WorkletChunkMessage {
+  type: "chunk";
+  pcm16: Int16Array;
+  frameCount: number;
+  amplitude: number;
+}
+
+interface WorkletAmplitudeMessage {
+  type: "amplitude";
+  amplitude: number;
+}
+
+type WorkletMessage = WorkletChunkMessage | WorkletAmplitudeMessage;
+
+function getAudioContextCtor(): AudioContextCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as typeof window & { webkitAudioContext?: AudioContextCtor };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+export class LiveVoicePcmCapture {
+  private audioContext: AudioContext | null = null;
+  private stream: MediaStream | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  private moduleLoaded = false;
+  private isShutdown = false;
+
+  async start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean> {
+    if (this.isShutdown) return false;
+    // If a previous capture is still wired up, tear it down before
+    // starting a fresh one — keeps `start` callable as a "make sure
+    // we're currently capturing" idempotent step.
+    if (this.workletNode) {
+      this.stopInternal();
+    }
+
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.getUserMedia) return false;
+
+    let stream: MediaStream;
+    try {
+      stream = await mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+    } catch {
+      return false;
+    }
+
+    // If `shutdown()` ran between awaiting permission and getting the
+    // stream, release the tracks we just opened and bail.
+    if (this.isShutdown) {
+      releaseStream(stream);
+      return false;
+    }
+
+    const AudioCtx = getAudioContextCtor();
+    if (!AudioCtx) {
+      releaseStream(stream);
+      return false;
+    }
+
+    try {
+      if (!this.audioContext) {
+        this.audioContext = new AudioCtx();
+      }
+      const audioContext = this.audioContext;
+
+      if (!this.moduleLoaded) {
+        await audioContext.audioWorklet.addModule(WORKLET_MODULE_URL);
+        this.moduleLoaded = true;
+      }
+
+      // Shutdown could have raced the worklet module load.
+      if (this.isShutdown) {
+        releaseStream(stream);
+        return false;
+      }
+
+      const sourceNode = audioContext.createMediaStreamSource(stream);
+      const workletNode = new AudioWorkletNode(
+        audioContext,
+        WORKLET_PROCESSOR_NAME,
+      );
+
+      workletNode.port.onmessage = (event: MessageEvent<WorkletMessage>) => {
+        const data = event.data;
+        if (data.type === "chunk") {
+          options.onChunk({
+            pcm16: data.pcm16,
+            frameCount: data.frameCount,
+            amplitude: data.amplitude,
+          });
+        } else if (data.type === "amplitude") {
+          options.onAmplitude?.(data.amplitude);
+        }
+      };
+
+      sourceNode.connect(workletNode);
+
+      this.stream = stream;
+      this.sourceNode = sourceNode;
+      this.workletNode = workletNode;
+      return true;
+    } catch {
+      releaseStream(stream);
+      return false;
+    }
+  }
+
+  /**
+   * Stop the current capture but keep the `AudioContext` warm — cheap
+   * to call again from `start()`. The MediaStream is also released so
+   * the OS-level mic indicator clears; `start()` opens a fresh stream.
+   */
+  stop(): void {
+    this.stopInternal();
+    if (this.stream) {
+      releaseStream(this.stream);
+      this.stream = null;
+    }
+  }
+
+  /**
+   * Release all resources. Idempotent. After `shutdown()`, `start()`
+   * returns `false`.
+   */
+  shutdown(): void {
+    if (this.isShutdown) return;
+    this.isShutdown = true;
+
+    this.stopInternal();
+
+    if (this.stream) {
+      releaseStream(this.stream);
+      this.stream = null;
+    }
+
+    if (this.audioContext) {
+      void this.audioContext.close();
+      this.audioContext = null;
+    }
+  }
+
+  private stopInternal(): void {
+    if (this.workletNode) {
+      this.workletNode.port.onmessage = null;
+      try {
+        this.workletNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.workletNode = null;
+    }
+    if (this.sourceNode) {
+      try {
+        this.sourceNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.sourceNode = null;
+    }
+  }
+}
+
+function releaseStream(stream: MediaStream): void {
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -67,18 +67,32 @@ export class LiveVoicePcmCapture {
   private workletNode: AudioWorkletNode | null = null;
   private moduleLoaded = false;
   private isShutdown = false;
+  /**
+   * Monotonic counter bumped on every `start()`, `stop()`, and
+   * `shutdown()`. The async `start()` work captures its generation at
+   * entry and re-verifies it after each `await` (and before each
+   * mutation). If the counter has moved, a concurrent `stop()`,
+   * `shutdown()`, or newer `start()` has superseded this attempt, and
+   * the continuation releases any opened stream and bails. Mirrors the
+   * macOS `LiveVoiceAudioCapture` generation counter.
+   */
+  private startGeneration = 0;
 
   async start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean> {
     if (this.isShutdown) return false;
-    // If a previous capture is still wired up, tear it down before
-    // starting a fresh one — keeps `start` callable as a "make sure
-    // we're currently capturing" idempotent step. Use `stop()` (not
-    // `stopInternal()`) so the previous `MediaStream` is released —
-    // otherwise the assignment to `this.stream` below would drop the
-    // only reference and leak the mic.
+
+    // If a previous capture is already wired up synchronously, tear it
+    // down so the new start observes a clean slate. Pending async
+    // starts are handled by the generation bump below — their
+    // continuations will bail without touching `this.stream` etc.
     if (this.workletNode || this.stream) {
       this.stop();
     }
+
+    // Bump the generation: this both cancels any in-flight `start()`
+    // continuation (it will observe a stale generation at its next
+    // checkpoint) AND captures the current generation for this call.
+    const myGen = ++this.startGeneration;
 
     const mediaDevices = navigator.mediaDevices;
     if (!mediaDevices?.getUserMedia) return false;
@@ -97,9 +111,10 @@ export class LiveVoicePcmCapture {
       return false;
     }
 
-    // If `shutdown()` ran between awaiting permission and getting the
-    // stream, release the tracks we just opened and bail.
-    if (this.isShutdown) {
+    // A concurrent `stop()`, `shutdown()`, or newer `start()` may have
+    // run while we awaited permission. Release the tracks we just
+    // opened and bail.
+    if (myGen !== this.startGeneration || this.isShutdown) {
       releaseStream(stream);
       return false;
     }
@@ -118,11 +133,18 @@ export class LiveVoicePcmCapture {
 
       if (!this.moduleLoaded) {
         await audioContext.audioWorklet.addModule(WORKLET_MODULE_URL);
+        // Re-check after the worklet module load — `stop()`,
+        // `shutdown()`, or a newer `start()` may have raced it.
+        if (myGen !== this.startGeneration || this.isShutdown) {
+          releaseStream(stream);
+          return false;
+        }
         this.moduleLoaded = true;
-      }
-
-      // Shutdown could have raced the worklet module load.
-      if (this.isShutdown) {
+      } else if (myGen !== this.startGeneration || this.isShutdown) {
+        // Even when the module is already loaded we re-check, because
+        // a concurrent caller may have invalidated us between the
+        // permission await and here (e.g. another `start()` chained
+        // synchronously).
         releaseStream(stream);
         return false;
       }
@@ -148,6 +170,25 @@ export class LiveVoicePcmCapture {
 
       sourceNode.connect(workletNode);
 
+      // Final guard before publishing the new nodes — even node
+      // construction is synchronous, so this is mostly belt-and-
+      // suspenders, but cheap.
+      if (myGen !== this.startGeneration || this.isShutdown) {
+        try {
+          workletNode.port.onmessage = null;
+          workletNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
+        try {
+          sourceNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
+        releaseStream(stream);
+        return false;
+      }
+
       this.stream = stream;
       this.sourceNode = sourceNode;
       this.workletNode = workletNode;
@@ -162,8 +203,13 @@ export class LiveVoicePcmCapture {
    * Stop the current capture but keep the `AudioContext` warm — cheap
    * to call again from `start()`. The MediaStream is also released so
    * the OS-level mic indicator clears; `start()` opens a fresh stream.
+   *
+   * Also bumps `startGeneration` so any pending `start()` continuation
+   * (e.g. still awaiting `getUserMedia` after PTT release) observes a
+   * stale generation and releases the stream it opens.
    */
   stop(): void {
+    this.startGeneration++;
     this.stopInternal();
     if (this.stream) {
       releaseStream(this.stream);
@@ -178,6 +224,10 @@ export class LiveVoicePcmCapture {
   shutdown(): void {
     if (this.isShutdown) return;
     this.isShutdown = true;
+    // Bump for consistency with `stop()` — `isShutdown` already gates
+    // the continuation, but the generation check is the primary
+    // cancellation signal so we keep them in sync.
+    this.startGeneration++;
 
     this.stopInternal();
 

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -13,6 +13,12 @@
  * The worklet posts two message types: `chunk` (PCM16 LE Int16Array, 320
  * samples = 20 ms at 16 kHz) and `amplitude` (peak abs in [0, 1] at ~20 Hz).
  *
+ * Web Audio only pulls render quanta along graph edges that terminate at
+ * `audioContext.destination`. With no downstream consumer the worklet's
+ * `process()` never runs, so we also connect the worklet through a muted
+ * `GainNode` (gain = 0) to the destination. This keeps the graph
+ * renderable without producing any audible output.
+ *
  * `stop()` tears down the active capture but keeps the `AudioContext` warm
  * so the next `start()` can resume without paying for context creation
  * again. `shutdown()` fully releases everything (tracks, context).
@@ -65,6 +71,12 @@ export class LiveVoicePcmCapture {
   private stream: MediaStream | null = null;
   private sourceNode: MediaStreamAudioSourceNode | null = null;
   private workletNode: AudioWorkletNode | null = null;
+  /**
+   * Muted sink that keeps the capture graph connected to
+   * `audioContext.destination` so the AudioWorklet's `process()` is
+   * actually scheduled. Gain is pinned to 0 — no audible output.
+   */
+  private muteNode: GainNode | null = null;
   private moduleLoaded = false;
   private isShutdown = false;
   /**
@@ -170,6 +182,17 @@ export class LiveVoicePcmCapture {
 
       sourceNode.connect(workletNode);
 
+      // Web Audio only pulls render quanta along graph edges that
+      // terminate at `audioContext.destination`. Without a sink the
+      // worklet's `process()` is never called, so live voice would
+      // receive zero PCM chunks. Route the worklet through a muted
+      // GainNode (gain = 0) to the destination — keeps the graph
+      // renderable without producing audible output.
+      const muteNode = audioContext.createGain();
+      muteNode.gain.value = 0;
+      workletNode.connect(muteNode);
+      muteNode.connect(audioContext.destination);
+
       // Final guard before publishing the new nodes — even node
       // construction is synchronous, so this is mostly belt-and-
       // suspenders, but cheap.
@@ -185,6 +208,11 @@ export class LiveVoicePcmCapture {
         } catch {
           // Best-effort cleanup.
         }
+        try {
+          muteNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
         releaseStream(stream);
         return false;
       }
@@ -192,6 +220,7 @@ export class LiveVoicePcmCapture {
       this.stream = stream;
       this.sourceNode = sourceNode;
       this.workletNode = workletNode;
+      this.muteNode = muteNode;
       return true;
     } catch {
       releaseStream(stream);
@@ -259,6 +288,14 @@ export class LiveVoicePcmCapture {
         // Already disconnected — safe to ignore.
       }
       this.sourceNode = null;
+    }
+    if (this.muteNode) {
+      try {
+        this.muteNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.muteNode = null;
     }
   }
 }

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -72,9 +72,12 @@ export class LiveVoicePcmCapture {
     if (this.isShutdown) return false;
     // If a previous capture is still wired up, tear it down before
     // starting a fresh one — keeps `start` callable as a "make sure
-    // we're currently capturing" idempotent step.
-    if (this.workletNode) {
-      this.stopInternal();
+    // we're currently capturing" idempotent step. Use `stop()` (not
+    // `stopInternal()`) so the previous `MediaStream` is released —
+    // otherwise the assignment to `this.stream` below would drop the
+    // only reference and leak the mic.
+    if (this.workletNode || this.stream) {
+      this.stop();
     }
 
     const mediaDevices = navigator.mediaDevices;


### PR DESCRIPTION
## Summary
- Add AudioWorklet processor that decimates to 16 kHz mono PCM16 LE chunks
- Add LiveVoicePcmCapture main-thread driver mirroring macOS LiveVoiceAudioCapture
- Expose start/stop/shutdown lifecycle with amplitude callback for UI meters

Part of plan: realtime-voice-web.md (PR 2 of 9)