### PR TITLE
fix(macos): explicit self in os.Logger interpolation in MainWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -427,7 +427,7 @@ public final class MainWindow {
         // content; the user just won't see it surface in the editor until they
         // reopen the doc.)
         guard documentManager.surfaceId == msg.surfaceId else {
-            log.info("Ignoring document_editor_update for surface \(msg.surfaceId) (active surface is \(documentManager.surfaceId ?? "nil"))")
+            log.info("Ignoring document_editor_update for surface \(msg.surfaceId) (active surface is \(self.documentManager.surfaceId ?? "nil"))")
             return
         }
         documentManager.updateDocument(markdown: msg.markdown, mode: msg.mode)


### PR DESCRIPTION
## Summary
- Fix CI build/test failure on main by adding explicit `self.` to `documentManager.surfaceId` inside the `os.Logger` autoclosure interpolation in `handleDocumentEditorUpdate`.
- The log line added in JARVIS-968 (#32397) references an instance property from within an `@autoclosure` `OSLogMessage`, which Swift requires to be qualified with `self.`.

## Original prompt
A CI job (https://github.com/vellum-ai/vellum-assistant/actions/runs/26585479130) started failing on `main` after merging #32397 (JARVIS-968). Both macOS Tests and macOS Build jobs failed on `MainWindow.swift:430` with: "reference to property 'documentManager' in closure requires explicit use of 'self' to make capture semantics explicit". Fix is to qualify the reference with `self.` so the new safety guard added in that PR compiles cleanly.