### PR TITLE
fix(web): remove gatewayWebAuth feature flag

### DIFF
--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -1,4 +1,3 @@
-import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store";
 import {
   isLocalMode,
   getLocalGatewayUrl,
@@ -13,10 +12,7 @@ let cachedExpiresAt: number = 0;
 let cachedTokenSource: string | null = null;
 
 export function isGatewayAuthEnabled(): boolean {
-  if (isLocalMode()) {
-    return getLocalGatewayUrl() != null;
-  }
-  return useClientFeatureFlagStore.getState().gatewayWebAuth === true;
+  return isLocalMode() && getLocalGatewayUrl() != null;
 }
 
 export function isGatewayAuthMode(): boolean {

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -432,14 +432,6 @@
       "label": "Memory Router Playground",
       "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "gateway-web-auth",
-      "scope": "client",
-      "key": "gateway-web-auth",
-      "label": "Gateway Web Auth",
-      "description": "Enable web SPA authentication via gateway session cookies.",
-      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -432,14 +432,6 @@
       "label": "Memory Router Playground",
       "description": "Expose the developer-only Memory Router Playground tab in macOS Settings and the /assistant/memory-router-playground web page for dry-running v4 router config overrides against the live page index. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "gateway-web-auth",
-      "scope": "client",
-      "key": "gateway-web-auth",
-      "label": "Gateway Web Auth",
-      "description": "Enable web SPA authentication via gateway session cookies.",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Simplified `isGatewayAuthEnabled()` to only check `isLocalMode() && getLocalGatewayUrl() != null`, removing the `gatewayWebAuth` feature flag branch
- Removed `gateway-web-auth` entry from all four feature flag registries (apps/web, assistant, meta, gateway)
- Removed unused `useClientFeatureFlagStore` import from `gateway-session.ts`

## Original prompt
Gateway auth should only be available in local mode — the `gatewayWebAuth` client feature flag was an unnecessary killswitch for platform mode where gateway auth doesn't apply. The user asked to simplify `isGatewayAuthEnabled()` to only check `isLocalMode()` and `getLocalGatewayUrl()`, and remove all references to the flag.