### PR TITLE
fix(web): align vite.config platform mode check with isLocalMode()

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,12 @@ import tailwindcss from "@tailwindcss/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { localModePlugin } from "./vite-plugin-local-mode";
 
+// Keep in sync with PLATFORM_MODE_TRUTHY in src/lib/local-mode.ts
+const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
+function isPlatformMode(raw: string | undefined): boolean {
+  return !!raw && PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
+}
+
 // Reference: https://vite.dev/config/#using-environment-variables-in-config
 export default defineConfig(({ mode }) => {
   // loadEnv with empty prefix loads all .env variables, not just VITE_-prefixed ones.
@@ -45,7 +51,7 @@ export default defineConfig(({ mode }) => {
           filesToDeleteAfterUpload: ["./dist/**/*.map"],
         },
       }),
-      !env.VITE_PLATFORM_MODE ? localModePlugin(env) : null,
+      isPlatformMode(env.VITE_PLATFORM_MODE) ? null : localModePlugin(env),
     ].filter(Boolean),
     resolve: {
       alias: [


### PR DESCRIPTION
## Summary
- Replaced the simple `!env.VITE_PLATFORM_MODE` JS truthiness check in `vite.config.ts` with an explicit truthy-set check (`"1"`, `"true"`, `"yes"`) matching `isLocalMode()` in `local-mode.ts`
- Fixes a mismatch where values like `"0"`, `"false"`, or `"no"` would disable the Vite plugin (non-empty string is truthy in JS) but `isLocalMode()` would still return `true` (value not in the truthy set)

## Original prompt
While reviewing `isGatewayAuthEnabled()` and the `VITE_PLATFORM_MODE` env var usage, we noticed `vite.config.ts` uses a simple JS truthiness check (`!env.VITE_PLATFORM_MODE`) while `isLocalMode()` uses an explicit truthy-set (`["1", "true", "yes"]`). These diverge for standard falsy env var values like `"0"` or `"false"`. The user asked to align them so both handle all standard truthy/falsy env var values correctly.