### PR TITLE
feat(web/voice): add LiveVoiceChannelClient WebSocket transport

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
@@ -1,0 +1,457 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import {
+  buildLiveVoiceWebSocketUrl,
+  LiveVoiceChannelClient,
+  type LiveVoiceChannelEvent,
+  type LiveVoiceChannelFailure,
+  type LiveVoiceWebSocketLike,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import {
+  base64ToPcm16,
+  pcm16ToBase64,
+} from "@/domains/voice/live-voice/protocol";
+
+// Mock the gateway-session module so we never touch localStorage from
+// tests. Lint rule `no-restricted-syntax` blocks writing tokens to
+// localStorage, and mocking lets us drive `getGatewayToken()` directly.
+let mockToken: string | null = "test-token";
+mock.module("@/lib/auth/gateway-session", () => ({
+  getGatewayToken: () => mockToken,
+  clearGatewayToken: () => {
+    mockToken = null;
+  },
+  isGatewayAuthEnabled: () => true,
+  isGatewayAuthMode: () => mockToken !== null,
+  ensureGatewayToken: async () => mockToken ?? "",
+  getLocalTokenUrl: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+interface SentRecord {
+  data: string | ArrayBufferLike | ArrayBufferView | Blob;
+}
+
+class MockWebSocket implements LiveVoiceWebSocketLike {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  binaryType: BinaryType = "blob";
+  readyState: number = MockWebSocket.CONNECTING;
+
+  onopen: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null = null;
+  onclose:
+    | ((this: LiveVoiceWebSocketLike, ev: CloseEvent) => unknown)
+    | null = null;
+  onerror: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null = null;
+  onmessage:
+    | ((this: LiveVoiceWebSocketLike, ev: MessageEvent) => unknown)
+    | null = null;
+
+  readonly sent: SentRecord[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void {
+    this.sent.push({ data });
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  // -------- Test helpers --------
+
+  emitOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.call(this, new Event("open"));
+  }
+
+  emitText(payload: string): void {
+    this.onmessage?.call(this, new MessageEvent("message", { data: payload }));
+  }
+
+  emitJson(frame: Record<string, unknown>): void {
+    this.emitText(JSON.stringify(frame));
+  }
+
+  emitClose(code = 1000, reason = ""): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.call(
+      this,
+      new CloseEvent("close", { code, reason, wasClean: code === 1000 }),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let originalWebSocket: unknown;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  originalWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
+  (globalThis as { WebSocket?: unknown }).WebSocket = MockWebSocket;
+  mockToken = "test-token";
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket?: unknown }).WebSocket = originalWebSocket;
+  mockToken = null;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildLiveVoiceWebSocketUrl", () => {
+  test("uses window.origin and ws scheme for http origin", () => {
+    const url = buildLiveVoiceWebSocketUrl("abc");
+    expect(url.startsWith("ws://localhost:3000/v1/live-voice?token=abc")).toBe(
+      true,
+    );
+  });
+
+  test("url-encodes the token", () => {
+    const url = buildLiveVoiceWebSocketUrl("a/b+c=");
+    expect(url).toContain(`token=${encodeURIComponent("a/b+c=")}`);
+  });
+});
+
+describe("LiveVoiceChannelClient", () => {
+  test("start sends the encoded start frame after the WS opens", async () => {
+    const client = new LiveVoiceChannelClient();
+    const onEvent = mock((_e: LiveVoiceChannelEvent) => {});
+    const onFailure = mock((_f: LiveVoiceChannelFailure) => {});
+
+    await client.start({
+      conversationId: "conv-1",
+      onEvent,
+      onFailure,
+    });
+
+    const ws = MockWebSocket.instances[0];
+    expect(ws).toBeDefined();
+    expect(ws!.binaryType).toBe("arraybuffer");
+    expect(client.getState()).toBe("connecting");
+
+    ws!.emitOpen();
+
+    expect(ws!.sent.length).toBe(1);
+    expect(typeof ws!.sent[0]!.data).toBe("string");
+    const decoded = JSON.parse(ws!.sent[0]!.data as string) as Record<
+      string,
+      unknown
+    >;
+    expect(decoded).toEqual({
+      type: "start",
+      conversationId: "conv-1",
+      audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+    });
+
+    client.close();
+  });
+
+  test("ready server frame transitions state to active and fires onEvent", async () => {
+    const client = new LiveVoiceChannelClient();
+    const onEvent = mock((_e: LiveVoiceChannelEvent) => {});
+    const onFailure = mock((_f: LiveVoiceChannelFailure) => {});
+
+    await client.start({ onEvent, onFailure });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    expect(client.getState()).toBe("active");
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0]![0]).toEqual({
+      type: "ready",
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    expect(onFailure).not.toHaveBeenCalled();
+
+    client.close();
+  });
+
+  test("sendAudio writes binary while active and drops otherwise", async () => {
+    const client = new LiveVoiceChannelClient();
+    await client.start({ onEvent: () => {}, onFailure: () => {} });
+    const ws = MockWebSocket.instances[0]!;
+
+    const samples = new Int16Array([1, -2, 3, -4]);
+
+    // While connecting, sendAudio is dropped.
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(0);
+
+    ws.emitOpen();
+    // The start frame is now the first sent item.
+    expect(ws.sent.length).toBe(1);
+
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    expect(client.getState()).toBe("active");
+
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(2);
+    const binary = ws.sent[1]!.data;
+    expect(ArrayBuffer.isView(binary)).toBe(true);
+    expect((binary as ArrayBufferView).byteLength).toBe(samples.byteLength);
+
+    // Also accepts ArrayBuffer directly.
+    const buf = new ArrayBuffer(8);
+    client.sendAudio(buf);
+    expect(ws.sent.length).toBe(3);
+    expect(ws.sent[2]!.data).toBe(buf);
+
+    client.close();
+
+    // After close, sendAudio is a no-op.
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(3);
+  });
+
+  test("connection timeout fires onFailure(timeout)", async () => {
+    // Capture timeout callbacks by intercepting setTimeout. We only
+    // trigger the *first* registered callback (the 10s connection
+    // timeout); other callbacks fall through to the real timer so
+    // `await client.start(...)` still resolves normally.
+    const realSetTimeout = globalThis.setTimeout;
+    const captured: Array<() => void> = [];
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && ms === 10_000) {
+        captured.push(handler as () => void);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      const failures: LiveVoiceChannelFailure[] = [];
+
+      await client.start({
+        onEvent: () => {},
+        onFailure: (f) => failures.push(f),
+      });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      // Do NOT emit `ready`; manually fire the captured 10s timeout.
+      expect(captured.length).toBe(1);
+      captured[0]!();
+
+      expect(failures.length).toBe(1);
+      expect(failures[0]).toEqual({
+        type: "timeout",
+        message: "ready frame not received",
+      });
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  test("protocol-error server frame fires onFailure(protocolError)", async () => {
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    ws.emitJson({
+      type: "error",
+      seq: 1,
+      code: "invalid_frame",
+      message: "oops",
+    });
+
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toEqual({
+      type: "protocolError",
+      code: "invalid_frame",
+      message: "oops",
+    });
+    expect(client.getState()).toBe("closed");
+  });
+
+  test("end then close are idempotent", async () => {
+    // Patch setTimeout so the 1s end-grace timer fires immediately and
+    // the connection-timeout (10s) registration becomes a no-op.
+    const realSetTimeout = globalThis.setTimeout;
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && (ms === 1_000 || ms === 10_000)) {
+        if (ms === 1_000) (handler as () => void)();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      await client.start({ onEvent: () => {}, onFailure: () => {} });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      ws.emitJson({
+        type: "ready",
+        seq: 0,
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+
+      const endPromise = client.end();
+      // The "end" control frame should have been sent.
+      const sentTypes = ws.sent.map((s) => {
+        try {
+          return JSON.parse(s.data as string).type as string;
+        } catch {
+          return null;
+        }
+      });
+      expect(sentTypes).toContain("end");
+
+      await endPromise;
+      expect(client.getState()).toBe("closed");
+      expect(ws.closeCalls.length).toBe(1);
+
+      // Subsequent end() and close() must be no-ops.
+      await client.end();
+      client.close();
+      expect(ws.closeCalls.length).toBe(1);
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  test("tts_audio frame decodes base64 and surfaces as ttsAudio with Uint8Array", async () => {
+    const client = new LiveVoiceChannelClient();
+    const events: LiveVoiceChannelEvent[] = [];
+
+    await client.start({
+      onEvent: (e) => events.push(e),
+      onFailure: () => {},
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    const pcm = new Int16Array([100, -200, 300, -400, 500, -600]);
+    const dataBase64 = pcm16ToBase64(pcm);
+
+    ws.emitJson({
+      type: "tts_audio",
+      seq: 1,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64,
+    });
+
+    const ttsEvent = events.find(
+      (e): e is Extract<LiveVoiceChannelEvent, { type: "ttsAudio" }> =>
+        e.type === "ttsAudio",
+    );
+    expect(ttsEvent).toBeDefined();
+    expect(ttsEvent!.mimeType).toBe("audio/pcm");
+    expect(ttsEvent!.sampleRate).toBe(24000);
+    expect(ttsEvent!.pcm).toBeInstanceOf(Uint8Array);
+    expect(ttsEvent!.pcm.byteLength).toBe(pcm.byteLength);
+
+    // Round-trip: decode the surfaced Uint8Array back into Int16 samples.
+    const roundTripped = new Int16Array(
+      ttsEvent!.pcm.buffer,
+      ttsEvent!.pcm.byteOffset,
+      ttsEvent!.pcm.byteLength / 2,
+    );
+    expect(Array.from(roundTripped)).toEqual(Array.from(pcm));
+    // Sanity-check the helper too.
+    expect(Array.from(base64ToPcm16(dataBase64))).toEqual(Array.from(pcm));
+
+    client.close();
+  });
+
+  test("missing gateway token fails fast", async () => {
+    mockToken = null;
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toEqual({
+      type: "connectionFailed",
+      message: "missing gateway token",
+    });
+    expect(client.getState()).toBe("closed");
+    expect(MockWebSocket.instances.length).toBe(0);
+  });
+
+  test("busy server frame fires onFailure(busy)", async () => {
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({ type: "busy", seq: 0, activeSessionId: "other-sess" });
+
+    expect(failures).toEqual([
+      { type: "busy", activeSessionId: "other-sess" },
+    ]);
+    expect(client.getState()).toBe("closed");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
@@ -437,6 +437,50 @@ describe("LiveVoiceChannelClient", () => {
     expect(MockWebSocket.instances.length).toBe(0);
   });
 
+  test("end() resolves even when teardown clears the grace timer first", async () => {
+    // Patch setTimeout so the 1 s end-grace timer never fires on its
+    // own (we want to drive teardown manually). The 10 s connection
+    // timeout is also a no-op so `start()` resolves cleanly.
+    const realSetTimeout = globalThis.setTimeout;
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && (ms === 1_000 || ms === 10_000)) {
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      await client.start({ onEvent: () => {}, onFailure: () => {} });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      ws.emitJson({
+        type: "ready",
+        seq: 0,
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      expect(client.getState()).toBe("active");
+
+      // Kick off end() but don't await it — the grace timer is
+      // stubbed to never fire, so end() is parked on the Promise.
+      const endPromise = client.end();
+      expect(client.getState()).toBe("ending");
+
+      // Force teardown via a WS abnormal close before the grace timer
+      // fires. handleClose -> teardown clears the grace timer; before
+      // the fix this orphans the resolver and end() would hang.
+      ws.emitClose(1006, "abnormal");
+
+      // The awaited end() must now resolve rather than hang.
+      await endPromise;
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
   test("busy server frame fires onFailure(busy)", async () => {
     const client = new LiveVoiceChannelClient();
     const failures: LiveVoiceChannelFailure[] = [];

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
@@ -1,0 +1,541 @@
+/**
+ * LiveVoiceChannelClient — WebSocket transport + frame dispatch for the
+ * live voice channel.
+ *
+ * TypeScript port of
+ * `clients/shared/Network/LiveVoiceChannelClient.swift`.
+ *
+ * Owns a single `WebSocket` to `/v1/live-voice`, authenticated via the
+ * gateway edge JWT (`getGatewayToken()` from
+ * `apps/web/src/lib/auth/gateway-session.ts`). Sends the JSON `start`
+ * frame after `open`, arms a 10 s ready-handshake timeout, normalizes
+ * incoming text/binary frames into a `LiveVoiceChannelEvent`
+ * discriminated union, and surfaces failures via
+ * `LiveVoiceChannelFailure`.
+ *
+ * Create a new instance for each session — `end()` and `close()` both
+ * transition state to `closed` and are idempotent.
+ */
+
+import {
+  base64ToPcm16,
+  encodeClientControlFrame,
+  encodeClientStartFrame,
+  LIVE_VOICE_AUDIO_PCM16K_MONO,
+  parseServerBinaryFrame,
+  parseServerTextFrame,
+  type LiveVoiceAudioConfig,
+  type LiveVoiceMetricsServerFrame,
+  type LiveVoiceServerFrame,
+} from "@/domains/voice/live-voice/protocol";
+import { getGatewayToken } from "@/lib/auth/gateway-session";
+import { getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Internal lifecycle state. Mirrors `LiveVoiceChannelSessionState`. */
+export type LiveVoiceChannelSessionState =
+  | "idle"
+  | "connecting"
+  | "active"
+  | "ending"
+  | "closed";
+
+/** Normalized server events. Mirrors the Swift `LiveVoiceChannelEvent` enum. */
+export type LiveVoiceChannelEvent =
+  | { type: "ready"; sessionId: string; conversationId: string }
+  | { type: "sttPartial"; text: string; seq: number }
+  | { type: "sttFinal"; text: string; seq: number }
+  | { type: "thinking"; turnId: string }
+  | { type: "assistantTextDelta"; text: string; seq: number }
+  | {
+      type: "ttsAudio";
+      pcm: Uint8Array;
+      mimeType: string;
+      sampleRate: number;
+      seq: number;
+    }
+  | { type: "ttsDone"; turnId: string }
+  | { type: "metrics"; metrics: LiveVoiceChannelMetrics }
+  | { type: "archived"; conversationId: string; sessionId: string };
+
+/** Turn-level latency metrics. Mirrors the Swift `LiveVoiceChannelMetrics`. */
+export interface LiveVoiceChannelMetrics {
+  readonly turnId: string;
+  readonly sttMs: number | null;
+  readonly llmFirstDeltaMs: number | null;
+  readonly ttsFirstAudioMs: number | null;
+  readonly totalMs: number | null;
+}
+
+/** Failure modes surfaced via `onFailure`. Mirrors `LiveVoiceChannelFailure`. */
+export type LiveVoiceChannelFailure =
+  | { type: "connectionFailed"; message: string }
+  | { type: "connectionRejected"; statusCode: number | null }
+  | { type: "protocolError"; code: string; message: string }
+  | { type: "busy"; activeSessionId: string }
+  | { type: "timeout"; message: string }
+  | { type: "abnormalClosure"; code: number; reason: string | null };
+
+export interface LiveVoiceChannelStartOptions {
+  conversationId?: string;
+  audioFormat?: LiveVoiceAudioConfig;
+  onEvent: (event: LiveVoiceChannelEvent) => void;
+  onFailure: (failure: LiveVoiceChannelFailure) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal WebSocket surface (for DI in tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of the DOM `WebSocket` interface the client depends on. Tests
+ * supply a mock via `globalThis.WebSocket = MockWebSocket`.
+ */
+export interface LiveVoiceWebSocketLike {
+  binaryType: BinaryType;
+  readonly readyState: number;
+  onopen: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null;
+  onclose:
+    | ((this: LiveVoiceWebSocketLike, ev: CloseEvent) => unknown)
+    | null;
+  onerror: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null;
+  onmessage:
+    | ((this: LiveVoiceWebSocketLike, ev: MessageEvent) => unknown)
+    | null;
+  send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void;
+  close(code?: number, reason?: string): void;
+}
+
+type WebSocketCtor = new (url: string) => LiveVoiceWebSocketLike;
+
+const CONNECTION_TIMEOUT_MS = 10_000;
+const END_GRACE_MS = 1_000;
+const NORMAL_CLOSURE = 1000;
+
+// ---------------------------------------------------------------------------
+// LiveVoiceChannelClient
+// ---------------------------------------------------------------------------
+
+export class LiveVoiceChannelClient {
+  private state: LiveVoiceChannelSessionState = "idle";
+  private ws: LiveVoiceWebSocketLike | null = null;
+  private connectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private endGraceTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private onEvent: ((event: LiveVoiceChannelEvent) => void) | null = null;
+  private onFailure:
+    | ((failure: LiveVoiceChannelFailure) => void)
+    | null = null;
+
+  /** Current state. Exposed for tests. */
+  getState(): LiveVoiceChannelSessionState {
+    return this.state;
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(options: LiveVoiceChannelStartOptions): Promise<void> {
+    if (this.state !== "idle") return;
+
+    const audio = options.audioFormat ?? LIVE_VOICE_AUDIO_PCM16K_MONO;
+    this.onEvent = options.onEvent;
+    this.onFailure = options.onFailure;
+    this.state = "connecting";
+
+    const token = getGatewayToken();
+    if (!token) {
+      this.fail({
+        type: "connectionFailed",
+        message: "missing gateway token",
+      });
+      return;
+    }
+
+    const url = buildLiveVoiceWebSocketUrl(token);
+    const Ctor = resolveWebSocketCtor();
+    if (!Ctor) {
+      this.fail({
+        type: "connectionFailed",
+        message: "WebSocket is not available in this environment",
+      });
+      return;
+    }
+
+    let ws: LiveVoiceWebSocketLike;
+    try {
+      ws = new Ctor(url);
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+    this.ws = ws;
+
+    ws.onopen = () => this.handleOpen(options.conversationId, audio);
+    ws.onmessage = (event: MessageEvent) => this.handleMessage(event);
+    ws.onerror = () => this.handleError();
+    ws.onclose = (event: CloseEvent) => this.handleClose(event);
+
+    this.connectionTimeoutId = setTimeout(() => {
+      this.connectionTimeoutId = null;
+      if (this.state === "connecting") {
+        this.fail({
+          type: "timeout",
+          message: "ready frame not received",
+        });
+      }
+    }, CONNECTION_TIMEOUT_MS);
+  }
+
+  sendAudio(data: ArrayBuffer | Int16Array): void {
+    if (this.state !== "active" || !this.ws) return;
+    const payload: ArrayBuffer | ArrayBufferView =
+      data instanceof Int16Array
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : data;
+    try {
+      this.ws.send(payload);
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  releasePushToTalk(): void {
+    this.sendControlFrame("ptt_release", ["active"]);
+  }
+
+  interrupt(): void {
+    this.sendControlFrame("interrupt", ["active"]);
+  }
+
+  async end(): Promise<void> {
+    if (this.state !== "connecting" && this.state !== "active") return;
+    this.state = "ending";
+    this.sendControlFrame("end", ["ending"]);
+
+    await new Promise<void>((resolve) => {
+      this.endGraceTimeoutId = setTimeout(() => {
+        this.endGraceTimeoutId = null;
+        resolve();
+      }, END_GRACE_MS);
+    });
+
+    this.teardown(null, NORMAL_CLOSURE);
+  }
+
+  close(): void {
+    if (this.state === "closed") return;
+    this.teardown(null, NORMAL_CLOSURE);
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket event handlers
+  // -------------------------------------------------------------------------
+
+  private handleOpen(
+    conversationId: string | undefined,
+    audioFormat: LiveVoiceAudioConfig,
+  ): void {
+    if (!this.ws || this.state !== "connecting") return;
+    try {
+      this.ws.send(encodeClientStartFrame({ conversationId, audio: audioFormat }));
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    if (this.state === "closed") return;
+    const data: unknown = event.data;
+
+    if (typeof data === "string") {
+      const result = parseServerTextFrame(data);
+      if (!result.ok) {
+        this.fail({
+          type: "protocolError",
+          code: result.error.code,
+          message: result.error.message,
+        });
+        return;
+      }
+      this.dispatchServerFrame(result.frame);
+      return;
+    }
+
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      const result = parseServerBinaryFrame(data);
+      if (!result.ok) {
+        this.fail({
+          type: "protocolError",
+          code: result.error.code,
+          message: result.error.message,
+        });
+        return;
+      }
+      // Binary frames are not part of the current server protocol surface;
+      // we accept them silently to stay forwards-compatible.
+      return;
+    }
+
+    // Blob fallback: browsers normally honor `binaryType = "arraybuffer"`,
+    // but treat any other payload shape as a protocol violation.
+    this.fail({
+      type: "protocolError",
+      code: "invalid_frame",
+      message: "Unsupported WebSocket frame payload",
+    });
+  }
+
+  private handleError(): void {
+    if (this.state === "closed" || this.state === "ending") return;
+    this.fail({
+      type: "connectionFailed",
+      message: "WebSocket error",
+    });
+  }
+
+  private handleClose(event: CloseEvent): void {
+    if (this.state === "closed") return;
+    if (event.code === NORMAL_CLOSURE || event.code === 0) {
+      this.teardown(null, NORMAL_CLOSURE);
+      return;
+    }
+    this.teardown(
+      {
+        type: "abnormalClosure",
+        code: event.code,
+        reason: event.reason ? event.reason : null,
+      },
+      NORMAL_CLOSURE,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Server frame dispatch
+  // -------------------------------------------------------------------------
+
+  private dispatchServerFrame(frame: LiveVoiceServerFrame): void {
+    switch (frame.type) {
+      case "ready":
+        if (this.state !== "connecting") return;
+        this.cancelConnectionTimeout();
+        this.state = "active";
+        this.onEvent?.({
+          type: "ready",
+          sessionId: frame.sessionId,
+          conversationId: frame.conversationId,
+        });
+        return;
+      case "busy":
+        this.fail({
+          type: "busy",
+          activeSessionId: frame.activeSessionId,
+        });
+        return;
+      case "stt_partial":
+        this.onEvent?.({ type: "sttPartial", text: frame.text, seq: frame.seq });
+        return;
+      case "stt_final":
+        this.onEvent?.({ type: "sttFinal", text: frame.text, seq: frame.seq });
+        return;
+      case "thinking":
+        this.onEvent?.({ type: "thinking", turnId: frame.turnId });
+        return;
+      case "assistant_text_delta":
+        this.onEvent?.({
+          type: "assistantTextDelta",
+          text: frame.text,
+          seq: frame.seq,
+        });
+        return;
+      case "tts_audio": {
+        let pcm: Uint8Array;
+        try {
+          const samples = base64ToPcm16(frame.dataBase64);
+          pcm = new Uint8Array(
+            samples.buffer,
+            samples.byteOffset,
+            samples.byteLength,
+          );
+        } catch (err) {
+          this.fail({
+            type: "protocolError",
+            code: "invalid_audio_payload",
+            message: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
+        this.onEvent?.({
+          type: "ttsAudio",
+          pcm,
+          mimeType: frame.mimeType,
+          sampleRate: frame.sampleRate,
+          seq: frame.seq,
+        });
+        return;
+      }
+      case "tts_done":
+        this.onEvent?.({ type: "ttsDone", turnId: frame.turnId });
+        return;
+      case "metrics":
+        this.onEvent?.({
+          type: "metrics",
+          metrics: toMetrics(frame),
+        });
+        return;
+      case "archived":
+        this.onEvent?.({
+          type: "archived",
+          conversationId: frame.conversationId,
+          sessionId: frame.sessionId,
+        });
+        return;
+      case "error":
+        this.fail({
+          type: "protocolError",
+          code: frame.code,
+          message: frame.message,
+        });
+        return;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private sendControlFrame(
+    type: "ptt_release" | "interrupt" | "end",
+    allowedStates: ReadonlyArray<LiveVoiceChannelSessionState>,
+  ): void {
+    if (!allowedStates.includes(this.state) || !this.ws) return;
+    try {
+      this.ws.send(encodeClientControlFrame(type));
+    } catch (err) {
+      if (this.state !== "closed") {
+        this.fail({
+          type: "connectionFailed",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  private fail(failure: LiveVoiceChannelFailure): void {
+    this.teardown(failure, NORMAL_CLOSURE);
+  }
+
+  private teardown(
+    failure: LiveVoiceChannelFailure | null,
+    closeCode: number,
+  ): void {
+    if (this.state === "closed") return;
+    this.state = "closed";
+
+    this.cancelConnectionTimeout();
+    if (this.endGraceTimeoutId !== null) {
+      clearTimeout(this.endGraceTimeoutId);
+      this.endGraceTimeoutId = null;
+    }
+
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      try {
+        ws.close(closeCode);
+      } catch {
+        // ignore — close is best-effort
+      }
+    }
+
+    const failureCallback = this.onFailure;
+    this.onEvent = null;
+    this.onFailure = null;
+    if (failure) failureCallback?.(failure);
+  }
+
+  private cancelConnectionTimeout(): void {
+    if (this.connectionTimeoutId !== null) {
+      clearTimeout(this.connectionTimeoutId);
+      this.connectionTimeoutId = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the live voice WebSocket URL with the gateway edge JWT
+ * embedded as a `token` query parameter. Mirrors
+ * `GatewayHTTPClient.buildWebSocketRequest` in the Swift client:
+ * converts `http(s)://` to `ws(s)://`.
+ *
+ * In local mode, the proxy URL from `getLocalGatewayUrl()` is a
+ * relative path (e.g. `/assistant/__gateway/7830`) — we resolve it
+ * against `window.location.origin` before swapping schemes. In
+ * platform mode, the SPA is served from the same origin as the
+ * gateway, so we use `window.location.origin` directly.
+ *
+ * Exported for tests.
+ */
+export function buildLiveVoiceWebSocketUrl(token: string): string {
+  const base = resolveGatewayBaseUrl();
+  const path = "/v1/live-voice";
+  const query = `?token=${encodeURIComponent(token)}`;
+  const url = new URL(`${base}${path}${query}`);
+  if (url.protocol === "https:") url.protocol = "wss:";
+  else if (url.protocol === "http:") url.protocol = "ws:";
+  return url.toString();
+}
+
+function resolveGatewayBaseUrl(): string {
+  if (isLocalMode()) {
+    const localGateway = getLocalGatewayUrl();
+    if (localGateway) {
+      // The local proxy URL is a relative path served by the Vite dev
+      // middleware on the same origin as the SPA. Resolve it against
+      // window.location.origin so the URL parser can swap http→ws.
+      if (localGateway.startsWith("http://") || localGateway.startsWith("https://")) {
+        return localGateway;
+      }
+      return `${window.location.origin}${localGateway}`;
+    }
+  }
+  return window.location.origin;
+}
+
+function resolveWebSocketCtor(): WebSocketCtor | null {
+  const ctor = (globalThis as { WebSocket?: WebSocketCtor }).WebSocket;
+  return typeof ctor === "function" ? ctor : null;
+}
+
+function toMetrics(
+  frame: LiveVoiceMetricsServerFrame,
+): LiveVoiceChannelMetrics {
+  return {
+    turnId: frame.turnId,
+    sttMs: frame.sttMs,
+    llmFirstDeltaMs: frame.llmFirstDeltaMs,
+    ttsFirstAudioMs: frame.ttsFirstAudioMs,
+    totalMs: frame.totalMs,
+  };
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
@@ -124,6 +124,14 @@ export class LiveVoiceChannelClient {
   private ws: LiveVoiceWebSocketLike | null = null;
   private connectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private endGraceTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Resolver for the Promise returned by `end()` while the 1 s grace
+   * timer is pending. Tracked separately from the timer so that
+   * `teardown()` (called by `close()`, `handleError()`, or a server
+   * failure) can resolve any awaited `end()` before clearing the
+   * timer — otherwise the caller hangs indefinitely.
+   */
+  private pendingEndResolver: (() => void) | null = null;
   private onEvent: ((event: LiveVoiceChannelEvent) => void) | null = null;
   private onFailure:
     | ((failure: LiveVoiceChannelFailure) => void)
@@ -224,8 +232,14 @@ export class LiveVoiceChannelClient {
     this.sendControlFrame("end", ["ending"]);
 
     await new Promise<void>((resolve) => {
+      // Track the resolver alongside the timer so `teardown()` can
+      // resolve this Promise even if it cancels the grace timer first
+      // (e.g. a concurrent `close()` or a WS error during the grace
+      // window). Without this, `await client.end()` would hang.
+      this.pendingEndResolver = resolve;
       this.endGraceTimeoutId = setTimeout(() => {
         this.endGraceTimeoutId = null;
+        this.pendingEndResolver = null;
         resolve();
       }, END_GRACE_MS);
     });
@@ -446,6 +460,15 @@ export class LiveVoiceChannelClient {
     this.state = "closed";
 
     this.cancelConnectionTimeout();
+    // If `end()` is currently awaiting the 1 s grace timer, resolve
+    // its Promise *before* clearing the timer. Otherwise the awaited
+    // `client.end()` would hang when a concurrent `close()` or error
+    // path tears the client down during the grace window.
+    if (this.pendingEndResolver !== null) {
+      const resolve = this.pendingEndResolver;
+      this.pendingEndResolver = null;
+      resolve();
+    }
     if (this.endGraceTimeoutId !== null) {
       clearTimeout(this.endGraceTimeoutId);
       this.endGraceTimeoutId = null;

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
+import type { Duplex } from "node:stream";
 import os from "node:os";
 import path from "node:path";
 import type { Plugin, Connect } from "vite";
@@ -78,6 +79,18 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(hatchMiddleware());
       server.middlewares.use(retireMiddleware());
       server.middlewares.use(gatewayProxyMiddleware());
+
+      // Connect middleware only handles HTTP requests; WebSocket
+      // upgrades bypass the middleware pipeline entirely and are
+      // dispatched via the underlying httpServer's `'upgrade'` event.
+      // Without this listener Vite would handle (and reject) browser
+      // WS upgrades to `/assistant/__gateway/:port/...`, so the live
+      // voice client could never connect to the local Bun gateway in
+      // local mode. `server.httpServer` is null when Vite runs in
+      // middleware mode (we don't use that), but be defensive.
+      if (server.httpServer) {
+        server.httpServer.on("upgrade", gatewayUpgradeHandler);
+      }
     },
   };
 }
@@ -486,4 +499,89 @@ function gatewayProxyMiddleware(): Connect.NextHandleFunction {
     // Pipe the incoming request body to the proxy request (supports POST, etc.)
     req.pipe(proxyReq);
   };
+}
+
+/**
+ * `'upgrade'` listener that tunnels WebSocket upgrades for paths
+ * matching `/assistant/__gateway/:port/*` (or `/__gateway/:port/*`)
+ * to the local Bun gateway at `http://127.0.0.1:{port}{rest}`.
+ *
+ * Why this exists: Connect/Vite middleware only handles HTTP requests
+ * that arrive through `httpServer.on('request', ...)`. WebSocket
+ * upgrades are dispatched separately via `httpServer.on('upgrade', ...)`
+ * and bypass the middleware stack entirely. Without an upgrade
+ * listener that mirrors the HTTP proxy in `gatewayProxyMiddleware`,
+ * browser WS upgrades to `/assistant/__gateway/:port/v1/live-voice`
+ * (and any future gateway WS endpoints) would terminate at Vite
+ * instead of being forwarded to the local Bun gateway, so live voice
+ * sessions could never connect in local mode.
+ *
+ * Implementation note: we issue a fresh `http.request` to 127.0.0.1
+ * with the original `Upgrade` / `Connection` / `Sec-WebSocket-*`
+ * headers, listen for the upstream `'upgrade'` event, replay the
+ * upstream HTTP 101 response line + headers onto the client socket,
+ * and then bidirectionally pipe the two sockets. This matches the
+ * minimal-dependency approach used by the HTTP proxy and avoids
+ * adding an external WS-proxy library to dev tooling.
+ */
+function gatewayUpgradeHandler(
+  req: http.IncomingMessage,
+  clientSocket: Duplex,
+  head: Buffer,
+): void {
+  const match = req.url?.match(GATEWAY_PATTERN);
+  if (!match) return;
+
+  const port = parseInt(match[1]!, 10);
+  if (port < 1024 || port > 65535) {
+    clientSocket.destroy();
+    return;
+  }
+  const restPath = match[2] || "/";
+
+  const proxyReq = http.request({
+    hostname: "127.0.0.1",
+    port,
+    path: restPath,
+    method: req.method ?? "GET",
+    headers: { ...req.headers, host: `127.0.0.1:${port}` },
+  });
+
+  proxyReq.on(
+    "upgrade",
+    (proxyRes: http.IncomingMessage, upstreamSocket: Duplex, upstreamHead: Buffer) => {
+      // Replay the upstream 101 Switching Protocols response onto the
+      // browser socket: status line, headers, blank line, then any
+      // body bytes that came along with the upgrade ack.
+      const statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 101} ${proxyRes.statusMessage ?? "Switching Protocols"}\r\n`;
+      const headerLines: string[] = [];
+      for (const [key, value] of Object.entries(proxyRes.headers)) {
+        if (value === undefined) continue;
+        if (Array.isArray(value)) {
+          for (const v of value) headerLines.push(`${key}: ${v}`);
+        } else {
+          headerLines.push(`${key}: ${value}`);
+        }
+      }
+      const responseHead = `${statusLine}${headerLines.join("\r\n")}\r\n\r\n`;
+      clientSocket.write(responseHead);
+      if (upstreamHead.length > 0) clientSocket.write(upstreamHead);
+
+      // Bidirectional pipe. Once either side closes the underlying
+      // socket, the other end will see EOF and tear down naturally.
+      upstreamSocket.on("error", () => clientSocket.destroy());
+      clientSocket.on("error", () => upstreamSocket.destroy());
+      upstreamSocket.pipe(clientSocket);
+      clientSocket.pipe(upstreamSocket);
+    },
+  );
+
+  proxyReq.on("error", () => {
+    clientSocket.destroy();
+  });
+
+  // Forward any pre-upgrade bytes the client already sent, then end
+  // the request side of the proxy connection (upgrades have no body).
+  if (head.length > 0) proxyReq.write(head);
+  proxyReq.end();
 }


### PR DESCRIPTION
## Summary
- TS port of clients/shared/Network/LiveVoiceChannelClient.swift
- Authenticated WebSocket to /v1/live-voice with gateway edge JWT
- Parses server frames into a normalized LiveVoiceChannelEvent union
- Connection timeout, idempotent end/close, base64 PCM decoding for tts_audio

Part of plan: realtime-voice-web.md (PR 5 of 9)