### PR TITLE
feat(web/voice): add LiveVoiceChannelManager orchestrating client + capture + playback

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -254,15 +254,30 @@ interface Harness {
   client(): FakeClient;
   /** Every client the factory has handed out, oldest-first. */
   clients: FakeClient[];
-  capture: FakeCapture;
-  playback: FakePlayback;
+  /**
+   * Returns the most-recently-built fake capture. Like the client,
+   * capture is built lazily inside `start()` via the factory, so tests
+   * must resolve it after `start()`. Snapshot the returned reference
+   * before driving another `start()` if you need to inspect the prior
+   * session's capture.
+   */
+  capture(): FakeCapture;
+  /** Every capture the factory has handed out, oldest-first. */
+  captures: FakeCapture[];
+  /**
+   * Returns the most-recently-built fake playback. Same lazy semantics
+   * as `capture()` — playback is built per `start()`.
+   */
+  playback(): FakePlayback;
+  /** Every playback the factory has handed out, oldest-first. */
+  playbacks: FakePlayback[];
   store: LiveVoiceStoreLike;
 }
 
 function makeHarness(): Harness {
   const clients: FakeClient[] = [];
-  const capture = new FakeCapture();
-  const playback = new FakePlayback();
+  const captures: FakeCapture[] = [];
+  const playbacks: FakePlayback[] = [];
   const store = createFakeStore();
   const manager = new LiveVoiceChannelManager({
     clientFactory: () => {
@@ -270,21 +285,47 @@ function makeHarness(): Harness {
       clients.push(next);
       return next;
     },
-    capture,
-    playback,
+    captureFactory: () => {
+      const next = new FakeCapture();
+      captures.push(next);
+      return next;
+    },
+    playbackFactory: () => {
+      const next = new FakePlayback();
+      playbacks.push(next);
+      return next;
+    },
     store,
   });
   return {
     manager,
     clients,
-    capture,
-    playback,
+    captures,
+    playbacks,
     store,
     client: () => {
       const latest = clients[clients.length - 1];
       if (!latest) {
         throw new Error(
           "FakeClient factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+    capture: () => {
+      const latest = captures[captures.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakeCapture factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+    playback: () => {
+      const latest = playbacks[playbacks.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakePlayback factory has not been invoked yet — call manager.start first",
         );
       }
       return latest;
@@ -311,10 +352,12 @@ describe("LiveVoiceChannelManager", () => {
   describe("happy path", () => {
     test("walks the macOS state machine through a full turn", async () => {
       const harness = makeHarness();
-      const { manager, capture, playback, store } = harness;
+      const { manager, store } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
       expect(store.getState().state).toBe("connecting");
       expect(client.startCalls.length).toBe(1);
       expect(client.startCalls[0]!.conversationId).toBe("conv-1");
@@ -404,9 +447,11 @@ describe("LiveVoiceChannelManager", () => {
   describe("interrupt path", () => {
     test("interruptSpeakingAndStartListening interrupts client + playback and restarts capture", async () => {
       const harness = makeHarness();
-      const { manager, capture, playback } = harness;
+      const { manager } = harness;
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -427,9 +472,11 @@ describe("LiveVoiceChannelManager", () => {
   describe("end path", () => {
     test("end shuts down capture, drains playback, ends client, resets store", async () => {
       const harness = makeHarness();
-      const { manager, capture, playback, store } = harness;
+      const { manager, store } = harness;
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -460,10 +507,12 @@ describe("LiveVoiceChannelManager", () => {
   describe("early failure path", () => {
     test("busy failure tears down capture+playback and surfaces error state", async () => {
       const harness = makeHarness();
-      const { manager, capture, playback, store } = harness;
+      const { manager, store } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
       expect(store.getState().state).toBe("connecting");
 
       // No `ready` yet — server reports another session is already active.
@@ -497,9 +546,10 @@ describe("LiveVoiceChannelManager", () => {
   describe("stopListening", () => {
     test("releases push-to-talk and stops capture, keeps channel open", async () => {
       const harness = makeHarness();
-      const { manager, capture } = harness;
+      const { manager } = harness;
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -519,10 +569,12 @@ describe("LiveVoiceChannelManager", () => {
   describe("barge-in playback gate", () => {
     test("re-opens playback gate before the first ttsAudio of a new turn after interrupt", async () => {
       const harness = makeHarness();
-      const { manager, capture, playback } = harness;
+      const { manager } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -591,10 +643,11 @@ describe("LiveVoiceChannelManager", () => {
 
     test("subsequent ttsAudio chunks in the same turn do not call resetForNextResponse again", async () => {
       const harness = makeHarness();
-      const { manager, playback } = harness;
+      const { manager } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -632,10 +685,11 @@ describe("LiveVoiceChannelManager", () => {
   describe("ttsDone teardown race", () => {
     test("ttsDone continuation bails after end() arrives during the playback drain", async () => {
       const harness = makeHarness();
-      const { manager, playback, store } = harness;
+      const { manager, store } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -688,10 +742,11 @@ describe("LiveVoiceChannelManager", () => {
 
     test("ttsDone continuation bails after a failure arrives during the playback drain", async () => {
       const harness = makeHarness();
-      const { manager, playback, store } = harness;
+      const { manager, store } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const playback = harness.playback();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -787,13 +842,85 @@ describe("LiveVoiceChannelManager", () => {
     });
   });
 
-  describe("user mute suppresses ttsDone listening transition", () => {
-    test("ttsDone after stopListening does NOT transition state to listening", async () => {
+  describe("capture + playback factories", () => {
+    test("start → end → start rebuilds capture and playback so the new session can listen", async () => {
+      const harness = makeHarness();
+      const { manager, captures, playbacks, store } = harness;
+
+      // ---- Session 1: start, ready, end. ----
+      await manager.start("conv-1");
+      expect(captures.length).toBe(1);
+      expect(playbacks.length).toBe(1);
+      const firstCapture = captures[0]!;
+      const firstPlayback = playbacks[0]!;
+
+      // `end()` calls shutdown — for the real `LiveVoicePcmCapture`,
+      // this would set `isShutdown = true` and any subsequent `start()`
+      // would return false, leaving the next session stuck in
+      // `connecting`. We must therefore build a fresh capture/playback.
+      await manager.end();
+      expect(firstCapture.shutdownCalls).toBe(1);
+      expect(firstPlayback.handleEndCalls).toBe(1);
+
+      // ---- Session 2: a brand-new capture and playback must be built. ----
+      await manager.start("conv-2");
+      expect(captures.length).toBe(2);
+      expect(playbacks.length).toBe(2);
+      const secondCapture = captures[1]!;
+      const secondPlayback = playbacks[1]!;
+      expect(secondCapture).not.toBe(firstCapture);
+      expect(secondPlayback).not.toBe(firstPlayback);
+      // The new capture has not been shut down — start() can transition
+      // the second session past `connecting`.
+      expect(secondCapture.shutdownCalls).toBe(0);
+      expect(secondPlayback.handleEndCalls).toBe(0);
+
+      // Drive the second session through `ready` to confirm the new
+      // capture actually starts (it would not on a recycled-and-shutdown
+      // instance — the second session would be stuck in `connecting`).
+      const secondClient = harness.client();
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+      expect(secondCapture.startCalls.length).toBe(1);
+      expect(store.getState().state).toBe("listening");
+    });
+
+    test("failure path discards capture and playback so the next start gets fresh ones", async () => {
+      const harness = makeHarness();
+      const { manager, captures, playbacks } = harness;
+
+      await manager.start("conv-1");
+      const firstCapture = captures[0]!;
+      const firstPlayback = playbacks[0]!;
+      const firstClient = harness.client();
+
+      // Failure tears down capture (shutdown) and playback (interrupt),
+      // and must drop both references so the next start builds fresh
+      // ones.
+      firstClient.fail({ type: "connectionFailed", message: "boom" });
+      expect(firstCapture.shutdownCalls).toBe(1);
+      expect(firstPlayback.handleInterruptCalls).toBe(1);
+
+      await manager.start("conv-2");
+      expect(captures.length).toBe(2);
+      expect(playbacks.length).toBe(2);
+      expect(captures[1]).not.toBe(firstCapture);
+      expect(playbacks[1]).not.toBe(firstPlayback);
+    });
+  });
+
+  describe("muted ttsDone ends the session", () => {
+    test("ttsDone after stopListening tears down the session instead of staying half-alive", async () => {
       const harness = makeHarness();
       const { manager, store } = harness;
 
       await manager.start("conv-1");
       const client = harness.client();
+      const capture = harness.capture();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -813,70 +940,71 @@ describe("LiveVoiceChannelManager", () => {
       });
       expect(store.getState().state).toBe("speaking");
 
-      // User releases PTT — manager flips `isUserMuted = true` and
-      // forwards the mute to the client/capture.
+      // User releases PTT — `ptt_release` is terminal on the server, so
+      // the session is logically done once `ttsDone` lands.
       await manager.stopListening();
       expect(client.releasePushToTalkCalls).toBe(1);
 
-      // ttsDone fires after the mute. The post-drain continuation must
-      // NOT clobber the state back to `listening` — that would
-      // silently re-arm the mic against the user's wish.
+      // ttsDone fires after the mute. The continuation must end the
+      // session instead of dangling in a half-alive state — otherwise
+      // the user's next utterance hits a server-side closed session.
       client.emit({ type: "ttsDone", turnId: "turn-1" });
       await flushMicrotasks();
+      await flushMicrotasks();
 
-      expect(store.getState().state).not.toBe("listening");
-      // The continuation still tears down the per-response transcript
-      // and resets the playback gate so the next response is heard.
+      // Full teardown ran: store reset, client.end + capture.shutdown
+      // both invoked exactly once.
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().sessionId).toBeNull();
       expect(store.getState().assistantTranscript).toBe("");
+      expect(client.endCalls).toBe(1);
+      expect(capture.shutdownCalls).toBe(1);
     });
 
-    test("interruptSpeakingAndStartListening re-arms the mic so subsequent ttsDone transitions to listening", async () => {
+    test("post-mute teardown lets the next start() build a fresh session", async () => {
       const harness = makeHarness();
-      const { manager, store } = harness;
+      const { manager, store, clients } = harness;
 
       await manager.start("conv-1");
-      const client = harness.client();
-      client.emit({
+      const firstClient = harness.client();
+      firstClient.emit({
         type: "ready",
         sessionId: "sess-1",
         conversationId: "conv-1",
       });
       await flushMicrotasks();
 
-      // Enter the muted state via stopListening, then verify ttsDone
-      // does not flip to listening.
-      await manager.stopListening();
-      client.emit({ type: "thinking", turnId: "turn-1" });
-      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
-      client.emit({
+      // Run a turn that ends with stopListening + ttsDone — the session
+      // is now fully torn down.
+      firstClient.emit({ type: "thinking", turnId: "turn-1" });
+      firstClient.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      firstClient.emit({
         type: "ttsAudio",
         pcm: new Uint8Array([1]),
         mimeType: "audio/pcm",
         sampleRate: 24000,
         seq: 2,
       });
-      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await manager.stopListening();
+      firstClient.emit({ type: "ttsDone", turnId: "turn-1" });
       await flushMicrotasks();
-      expect(store.getState().state).not.toBe("listening");
-
-      // User barges in — clears the mute flag and restarts capture.
-      await manager.interruptSpeakingAndStartListening("conv-1");
       await flushMicrotasks();
+      expect(store.getState().state).toBe("off");
 
-      // A subsequent ttsDone should now transition to listening since
-      // the user is no longer muted.
-      client.emit({ type: "thinking", turnId: "turn-2" });
-      client.emit({ type: "assistantTextDelta", text: "again", seq: 3 });
-      client.emit({
-        type: "ttsAudio",
-        pcm: new Uint8Array([2]),
-        mimeType: "audio/pcm",
-        sampleRate: 24000,
-        seq: 4,
+      // Next start() builds a brand-new client/capture/playback and
+      // walks the new session through `listening` as usual.
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
       });
-      client.emit({ type: "ttsDone", turnId: "turn-2" });
       await flushMicrotasks();
       expect(store.getState().state).toBe("listening");
+      expect(store.getState().sessionId).toBe("sess-2");
     });
 
     test("start() resets isUserMuted so a new session is not stuck muted", async () => {

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -243,24 +243,53 @@ class FakePlayback implements LiveVoicePcmPlaybackLike {
 
 interface Harness {
   manager: LiveVoiceChannelManager;
-  client: FakeClient;
+  /**
+   * Returns the most-recently-built fake client. The manager
+   * constructs a fresh client via the factory in every `start()` call,
+   * so tests resolve the client lazily (after calling `start`) rather
+   * than destructuring it up front. Tests that want to inspect a
+   * prior session's client should snapshot the returned reference
+   * before driving the next `start()`.
+   */
+  client(): FakeClient;
+  /** Every client the factory has handed out, oldest-first. */
+  clients: FakeClient[];
   capture: FakeCapture;
   playback: FakePlayback;
   store: LiveVoiceStoreLike;
 }
 
 function makeHarness(): Harness {
-  const client = new FakeClient();
+  const clients: FakeClient[] = [];
   const capture = new FakeCapture();
   const playback = new FakePlayback();
   const store = createFakeStore();
   const manager = new LiveVoiceChannelManager({
-    client,
+    clientFactory: () => {
+      const next = new FakeClient();
+      clients.push(next);
+      return next;
+    },
     capture,
     playback,
     store,
   });
-  return { manager, client, capture, playback, store };
+  return {
+    manager,
+    clients,
+    capture,
+    playback,
+    store,
+    client: () => {
+      const latest = clients[clients.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakeClient factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+  };
 }
 
 /**
@@ -281,9 +310,11 @@ async function flushMicrotasks(): Promise<void> {
 describe("LiveVoiceChannelManager", () => {
   describe("happy path", () => {
     test("walks the macOS state machine through a full turn", async () => {
-      const { manager, client, capture, playback, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture, playback, store } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       expect(store.getState().state).toBe("connecting");
       expect(client.startCalls.length).toBe(1);
       expect(client.startCalls[0]!.conversationId).toBe("conv-1");
@@ -372,8 +403,10 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("interrupt path", () => {
     test("interruptSpeakingAndStartListening interrupts client + playback and restarts capture", async () => {
-      const { manager, client, capture, playback } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture, playback } = harness;
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -393,8 +426,10 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("end path", () => {
     test("end shuts down capture, drains playback, ends client, resets store", async () => {
-      const { manager, client, capture, playback, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture, playback, store } = harness;
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -424,9 +459,11 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("early failure path", () => {
     test("busy failure tears down capture+playback and surfaces error state", async () => {
-      const { manager, client, capture, playback, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture, playback, store } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       expect(store.getState().state).toBe("connecting");
 
       // No `ready` yet — server reports another session is already active.
@@ -442,8 +479,10 @@ describe("LiveVoiceChannelManager", () => {
     });
 
     test("failure with explicit message stores that message verbatim", async () => {
-      const { manager, client, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, store } = harness;
       await manager.start("conv-1");
+      const client = harness.client();
 
       client.fail({
         type: "connectionFailed",
@@ -457,8 +496,10 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("stopListening", () => {
     test("releases push-to-talk and stops capture, keeps channel open", async () => {
-      const { manager, client, capture } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture } = harness;
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -477,9 +518,11 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("barge-in playback gate", () => {
     test("re-opens playback gate before the first ttsAudio of a new turn after interrupt", async () => {
-      const { manager, client, capture, playback } = makeHarness();
+      const harness = makeHarness();
+      const { manager, capture, playback } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -547,9 +590,11 @@ describe("LiveVoiceChannelManager", () => {
     });
 
     test("subsequent ttsAudio chunks in the same turn do not call resetForNextResponse again", async () => {
-      const { manager, client, playback } = makeHarness();
+      const harness = makeHarness();
+      const { manager, playback } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -586,9 +631,11 @@ describe("LiveVoiceChannelManager", () => {
 
   describe("ttsDone teardown race", () => {
     test("ttsDone continuation bails after end() arrives during the playback drain", async () => {
-      const { manager, client, playback, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, playback, store } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -640,9 +687,11 @@ describe("LiveVoiceChannelManager", () => {
     });
 
     test("ttsDone continuation bails after a failure arrives during the playback drain", async () => {
-      const { manager, client, playback, store } = makeHarness();
+      const harness = makeHarness();
+      const { manager, playback, store } = harness;
 
       await manager.start("conv-1");
+      const client = harness.client();
       client.emit({
         type: "ready",
         sessionId: "sess-1",
@@ -676,6 +725,196 @@ describe("LiveVoiceChannelManager", () => {
       // State stays `failed` — not clobbered back to `listening`.
       expect(store.getState().state).toBe("failed");
       expect(playback.resetCalls).toBe(resetCallsAtFailure);
+    });
+  });
+
+  describe("client factory", () => {
+    test("start → end → start uses a fresh client each time", async () => {
+      const { manager, clients, store } = makeHarness();
+
+      // ---- Session 1: start then end. ----
+      await manager.start("conv-1");
+      expect(clients.length).toBe(1);
+      const firstClient = clients[0]!;
+      expect(firstClient.startCalls.length).toBe(1);
+
+      firstClient.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.end();
+      expect(firstClient.endCalls).toBe(1);
+      expect(store.getState().state).toBe("off");
+
+      // ---- Session 2: a brand-new client must be built. ----
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      expect(secondClient.startCalls.length).toBe(1);
+      expect(secondClient.startCalls[0]!.conversationId).toBe("conv-2");
+      // The old (closed) client must not be touched again.
+      expect(firstClient.startCalls.length).toBe(1);
+
+      // The second client's `ready` event drives the second session
+      // through the same listening transition as the first.
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+      expect(store.getState().sessionId).toBe("sess-2");
+    });
+
+    test("failure path discards the client so the next start gets a fresh one", async () => {
+      const { manager, clients } = makeHarness();
+
+      await manager.start("conv-1");
+      const firstClient = clients[0]!;
+      firstClient.fail({ type: "connectionFailed", message: "boom" });
+      expect(firstClient.closeCalls).toBe(1);
+
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      expect(secondClient.startCalls.length).toBe(1);
+    });
+  });
+
+  describe("user mute suppresses ttsDone listening transition", () => {
+    test("ttsDone after stopListening does NOT transition state to listening", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Run a normal turn so we're in `speaking` when ttsDone arrives.
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      expect(store.getState().state).toBe("speaking");
+
+      // User releases PTT — manager flips `isUserMuted = true` and
+      // forwards the mute to the client/capture.
+      await manager.stopListening();
+      expect(client.releasePushToTalkCalls).toBe(1);
+
+      // ttsDone fires after the mute. The post-drain continuation must
+      // NOT clobber the state back to `listening` — that would
+      // silently re-arm the mic against the user's wish.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+
+      expect(store.getState().state).not.toBe("listening");
+      // The continuation still tears down the per-response transcript
+      // and resets the playback gate so the next response is heard.
+      expect(store.getState().assistantTranscript).toBe("");
+    });
+
+    test("interruptSpeakingAndStartListening re-arms the mic so subsequent ttsDone transitions to listening", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Enter the muted state via stopListening, then verify ttsDone
+      // does not flip to listening.
+      await manager.stopListening();
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(store.getState().state).not.toBe("listening");
+
+      // User barges in — clears the mute flag and restarts capture.
+      await manager.interruptSpeakingAndStartListening("conv-1");
+      await flushMicrotasks();
+
+      // A subsequent ttsDone should now transition to listening since
+      // the user is no longer muted.
+      client.emit({ type: "thinking", turnId: "turn-2" });
+      client.emit({ type: "assistantTextDelta", text: "again", seq: 3 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([2]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 4,
+      });
+      client.emit({ type: "ttsDone", turnId: "turn-2" });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+    });
+
+    test("start() resets isUserMuted so a new session is not stuck muted", async () => {
+      const { manager, clients, store } = makeHarness();
+
+      // Session 1: mute then end without un-muting.
+      await manager.start("conv-1");
+      clients[0]!.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      await manager.stopListening();
+      await manager.end();
+
+      // Session 2: start fresh — the mute flag must be cleared.
+      await manager.start("conv-2");
+      const secondClient = clients[1]!;
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+
+      secondClient.emit({ type: "thinking", turnId: "turn-1" });
+      secondClient.emit({ type: "assistantTextDelta", text: "hi", seq: 1 });
+      secondClient.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      secondClient.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
     });
   });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -164,6 +164,12 @@ class FakeCapture implements LiveVoicePcmCaptureLike {
 
 class FakePlayback implements LiveVoicePcmPlaybackLike {
   isPlaying = false;
+  /**
+   * Ordered call log used to assert call sequencing (e.g. that
+   * `resetForNextResponse` ran BEFORE the first `enqueueTtsAudio` for a
+   * new turn).
+   */
+  callLog: string[] = [];
   enqueueCalls: LiveVoiceTtsChunk[] = [];
   handleInterruptCalls = 0;
   handleEndCalls = 0;
@@ -171,28 +177,63 @@ class FakePlayback implements LiveVoicePcmPlaybackLike {
   resetCalls = 0;
   waitCalls = 0;
 
+  /**
+   * Controls whether `waitUntilPlaybackFinishes()` resolves synchronously
+   * (default) or returns a manually controlled promise. Tests that need
+   * to race teardown against the `ttsDone` continuation flip this to a
+   * deferred promise and resolve it after driving the teardown.
+   */
+  private pendingWait: { promise: Promise<void>; resolve: () => void } | null =
+    null;
+
   enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+    this.callLog.push("enqueueTtsAudio");
     this.enqueueCalls.push(chunk);
   }
 
   handleInterrupt(): void {
+    this.callLog.push("handleInterrupt");
     this.handleInterruptCalls += 1;
   }
 
   handleEnd(): void {
+    this.callLog.push("handleEnd");
     this.handleEndCalls += 1;
   }
 
   handleSessionError(): void {
+    this.callLog.push("handleSessionError");
     this.handleSessionErrorCalls += 1;
   }
 
   resetForNextResponse(): void {
+    this.callLog.push("resetForNextResponse");
     this.resetCalls += 1;
   }
 
   async waitUntilPlaybackFinishes(): Promise<void> {
+    this.callLog.push("waitUntilPlaybackFinishes");
     this.waitCalls += 1;
+    if (this.pendingWait) {
+      await this.pendingWait.promise;
+    }
+  }
+
+  /**
+   * Make the next `waitUntilPlaybackFinishes()` call hang until the
+   * returned `resolve` is invoked. Used to simulate the race where
+   * teardown happens between `ttsDone` and playback drain finishing.
+   */
+  deferNextWait(): () => void {
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    this.pendingWait = { promise, resolve: resolveFn };
+    return () => {
+      resolveFn();
+      this.pendingWait = null;
+    };
   }
 }
 
@@ -294,7 +335,7 @@ describe("LiveVoiceChannelManager", () => {
       // Second delta does not re-enter `speaking`.
       expect(store.getState().state).toBe("speaking");
 
-      // ttsAudio → playback enqueued with pcm chunk payload.
+      // ttsAudio → first chunk re-opens the playback gate, then enqueues.
       const ttsPcm = new Uint8Array([0, 1, 2, 3]);
       client.emit({
         type: "ttsAudio",
@@ -310,13 +351,20 @@ describe("LiveVoiceChannelManager", () => {
         sampleRate: 24000,
         channels: 1,
       });
+      // First chunk of the response: reset must come BEFORE enqueue so
+      // the playback gate is open.
+      expect(playback.callLog).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
 
       // ttsDone → waitUntilPlaybackFinishes runs, transcript reset,
-      // state back to listening.
+      // state back to listening. The reset count picks up a second call
+      // from the `completeAssistantTurn` continuation.
       client.emit({ type: "ttsDone", turnId: "turn-1" });
       await flushMicrotasks();
       expect(playback.waitCalls).toBe(1);
-      expect(playback.resetCalls).toBe(1);
+      expect(playback.resetCalls).toBe(2);
       expect(store.getState().assistantTranscript).toBe("");
       expect(store.getState().state).toBe("listening");
     });
@@ -424,6 +472,210 @@ describe("LiveVoiceChannelManager", () => {
       expect(capture.stopCalls).toBe(1);
       expect(client.endCalls).toBe(0);
       expect(client.closeCalls).toBe(0);
+    });
+  });
+
+  describe("barge-in playback gate", () => {
+    test("re-opens playback gate before the first ttsAudio of a new turn after interrupt", async () => {
+      const { manager, client, capture, playback } = makeHarness();
+
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // ---- Turn 1: assistant speaks. ----
+      client.emit({ type: "sttFinal", text: "first", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      const turn1Pcm = new Uint8Array([1, 2]);
+      client.emit({
+        type: "ttsAudio",
+        pcm: turn1Pcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+
+      // First chunk of turn 1 must reset BEFORE enqueueing.
+      const turn1Calls = playback.callLog.filter(
+        (call) =>
+          call === "resetForNextResponse" || call === "enqueueTtsAudio",
+      );
+      expect(turn1Calls).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
+      const turn1ResetCount = playback.resetCalls;
+
+      // ---- User barges in: interrupt slams the playback gate shut. ----
+      await manager.interruptSpeakingAndStartListening("conv-1");
+      await flushMicrotasks();
+      expect(playback.handleInterruptCalls).toBe(1);
+      // Capture restarts after the interrupt.
+      expect(capture.startCalls.length).toBeGreaterThan(1);
+
+      // ---- Turn 2: new utterance produces TTS. The first chunk of
+      //      turn 2 must re-open the gate before enqueueing, otherwise
+      //      `acceptsAudio === false` silently drops the audio. ----
+      client.emit({ type: "sttFinal", text: "second", seq: 4 });
+      client.emit({ type: "thinking", turnId: "turn-2" });
+      client.emit({ type: "assistantTextDelta", text: "again", seq: 5 });
+
+      const turn2Pcm = new Uint8Array([3, 4]);
+      const callsBeforeTurn2 = playback.callLog.length;
+      client.emit({
+        type: "ttsAudio",
+        pcm: turn2Pcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 6,
+      });
+
+      // The next two calls (after the snapshot) must be reset → enqueue,
+      // in that order — the new turn's first chunk re-opens the gate
+      // before it tries to enqueue.
+      expect(playback.callLog.slice(callsBeforeTurn2)).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
+      expect(playback.resetCalls).toBe(turn1ResetCount + 1);
+    });
+
+    test("subsequent ttsAudio chunks in the same turn do not call resetForNextResponse again", async () => {
+      const { manager, client, playback } = makeHarness();
+
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "sttFinal", text: "hi", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+      expect(playback.resetCalls).toBe(1);
+
+      // Second chunk in the same response should NOT call reset again —
+      // the gate is already open.
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([2]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 4,
+      });
+      expect(playback.resetCalls).toBe(1);
+      expect(playback.enqueueCalls.length).toBe(2);
+    });
+  });
+
+  describe("ttsDone teardown race", () => {
+    test("ttsDone continuation bails after end() arrives during the playback drain", async () => {
+      const { manager, client, playback, store } = makeHarness();
+
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "sttFinal", text: "hi", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      // First chunk enqueues and opens the gate (resetCalls = 1).
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+      expect(playback.resetCalls).toBe(1);
+
+      // Make the upcoming drain hang so we can teardown mid-await.
+      const resolveDrain = playback.deferNextWait();
+
+      // ttsDone kicks off completeAssistantTurn, which awaits
+      // waitUntilPlaybackFinishes — but we haven't resolved yet.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(playback.waitCalls).toBe(1);
+      // No post-await mutations yet — still in `speaking`.
+      expect(store.getState().state).toBe("speaking");
+
+      // User ends the session BEFORE the drain finishes. This bumps the
+      // session generation, so the in-flight continuation must bail.
+      await manager.end();
+      expect(store.getState().state).toBe("off");
+      const resetCallsAtTeardown = playback.resetCalls;
+
+      // Now resolve the drain — the continuation resumes but should
+      // detect the generation mismatch and return without touching the
+      // store or calling resetForNextResponse.
+      resolveDrain();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(store.getState().state).toBe("off");
+      // No extra reset call from the cancelled continuation.
+      expect(playback.resetCalls).toBe(resetCallsAtTeardown);
+    });
+
+    test("ttsDone continuation bails after a failure arrives during the playback drain", async () => {
+      const { manager, client, playback, store } = makeHarness();
+
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+
+      const resolveDrain = playback.deferNextWait();
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+
+      // Failure arrives mid-await — bumps the generation.
+      client.fail({ type: "abnormalClosure", code: 1006, reason: "boom" });
+      expect(store.getState().state).toBe("failed");
+      const resetCallsAtFailure = playback.resetCalls;
+
+      resolveDrain();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // State stays `failed` — not clobbered back to `listening`.
+      expect(store.getState().state).toBe("failed");
+      expect(playback.resetCalls).toBe(resetCallsAtFailure);
     });
   });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  LiveVoiceChannelClientLike,
+  LiveVoicePcmCaptureLike,
+  LiveVoicePcmPlaybackLike,
+  LiveVoiceStoreLike,
+} from "@/domains/voice/live-voice/live-voice-channel-manager";
+import { LiveVoiceChannelManager } from "@/domains/voice/live-voice/live-voice-channel-manager";
+import type {
+  LiveVoiceChannelEvent,
+  LiveVoiceChannelFailure,
+  LiveVoiceChannelStartOptions,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import type {
+  LiveVoiceStore,
+  LiveVoiceStoreState,
+} from "@/domains/voice/live-voice/live-voice-store";
+import type { LiveVoicePcmCaptureStartOptions } from "@/domains/voice/live-voice/pcm-capture";
+import type { LiveVoiceTtsChunk } from "@/domains/voice/live-voice/pcm-playback";
+
+// ---------------------------------------------------------------------------
+// Fake store
+//
+// The real `useLiveVoiceStore` is a Zustand singleton; touching it from
+// these tests would leak state across the test runner. We replicate the
+// store's mutating actions over a plain object so each test has its own
+// isolated snapshot.
+// ---------------------------------------------------------------------------
+
+const INITIAL_STORE_STATE: LiveVoiceStoreState = {
+  state: "off",
+  sessionId: null,
+  conversationId: null,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  errorMessage: "",
+};
+
+function createFakeStore(): LiveVoiceStoreLike {
+  const snapshot: LiveVoiceStoreState = { ...INITIAL_STORE_STATE };
+  const api: LiveVoiceStore = {
+    ...snapshot,
+    setState: (s) => {
+      api.state = s;
+    },
+    setSessionInfo: ({ sessionId, conversationId }) => {
+      api.sessionId = sessionId;
+      api.conversationId = conversationId;
+    },
+    setPartialTranscript: (text) => {
+      api.partialTranscript = text;
+    },
+    setFinalTranscript: (text) => {
+      api.finalTranscript = text;
+    },
+    appendAssistantTranscript: (delta) => {
+      api.assistantTranscript = api.assistantTranscript + delta;
+    },
+    clearAssistantTranscript: () => {
+      api.assistantTranscript = "";
+    },
+    setInputAmplitude: (amp) => {
+      api.inputAmplitude = amp;
+    },
+    setError: (msg) => {
+      api.errorMessage = msg;
+    },
+    reset: () => {
+      Object.assign(api, INITIAL_STORE_STATE);
+    },
+  };
+  return { getState: () => api };
+}
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures the `onEvent` / `onFailure` callbacks from `start()` so each
+ * test can drive event sequences synchronously. Records every method
+ * call so assertions can verify both the call ordering and the payloads
+ * the manager forwarded.
+ */
+class FakeClient implements LiveVoiceChannelClientLike {
+  startCalls: LiveVoiceChannelStartOptions[] = [];
+  sendAudioCalls: Array<ArrayBuffer | Int16Array> = [];
+  releasePushToTalkCalls = 0;
+  interruptCalls = 0;
+  endCalls = 0;
+  closeCalls = 0;
+
+  /** Most recent `onEvent` callback captured from `start()`. */
+  onEvent: ((event: LiveVoiceChannelEvent) => void) | null = null;
+  /** Most recent `onFailure` callback captured from `start()`. */
+  onFailure: ((failure: LiveVoiceChannelFailure) => void) | null = null;
+
+  async start(options: LiveVoiceChannelStartOptions): Promise<void> {
+    this.startCalls.push(options);
+    this.onEvent = options.onEvent;
+    this.onFailure = options.onFailure;
+  }
+
+  sendAudio(data: ArrayBuffer | Int16Array): void {
+    this.sendAudioCalls.push(data);
+  }
+
+  releasePushToTalk(): void {
+    this.releasePushToTalkCalls += 1;
+  }
+
+  interrupt(): void {
+    this.interruptCalls += 1;
+  }
+
+  async end(): Promise<void> {
+    this.endCalls += 1;
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+  }
+
+  /** Drive an event through the manager. */
+  emit(event: LiveVoiceChannelEvent): void {
+    if (!this.onEvent) {
+      throw new Error("FakeClient.start has not been called");
+    }
+    this.onEvent(event);
+  }
+
+  /** Drive a failure through the manager. */
+  fail(failure: LiveVoiceChannelFailure): void {
+    if (!this.onFailure) {
+      throw new Error("FakeClient.start has not been called");
+    }
+    this.onFailure(failure);
+  }
+}
+
+class FakeCapture implements LiveVoicePcmCaptureLike {
+  startCalls: LiveVoicePcmCaptureStartOptions[] = [];
+  stopCalls = 0;
+  shutdownCalls = 0;
+  /** Return value for the next `start()` call. Defaults to true. */
+  startResult = true;
+
+  async start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean> {
+    this.startCalls.push(options);
+    return this.startResult;
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+  }
+
+  shutdown(): void {
+    this.shutdownCalls += 1;
+  }
+}
+
+class FakePlayback implements LiveVoicePcmPlaybackLike {
+  isPlaying = false;
+  enqueueCalls: LiveVoiceTtsChunk[] = [];
+  handleInterruptCalls = 0;
+  handleEndCalls = 0;
+  handleSessionErrorCalls = 0;
+  resetCalls = 0;
+  waitCalls = 0;
+
+  enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+    this.enqueueCalls.push(chunk);
+  }
+
+  handleInterrupt(): void {
+    this.handleInterruptCalls += 1;
+  }
+
+  handleEnd(): void {
+    this.handleEndCalls += 1;
+  }
+
+  handleSessionError(): void {
+    this.handleSessionErrorCalls += 1;
+  }
+
+  resetForNextResponse(): void {
+    this.resetCalls += 1;
+  }
+
+  async waitUntilPlaybackFinishes(): Promise<void> {
+    this.waitCalls += 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  manager: LiveVoiceChannelManager;
+  client: FakeClient;
+  capture: FakeCapture;
+  playback: FakePlayback;
+  store: LiveVoiceStoreLike;
+}
+
+function makeHarness(): Harness {
+  const client = new FakeClient();
+  const capture = new FakeCapture();
+  const playback = new FakePlayback();
+  const store = createFakeStore();
+  const manager = new LiveVoiceChannelManager({
+    client,
+    capture,
+    playback,
+    store,
+  });
+  return { manager, client, capture, playback, store };
+}
+
+/**
+ * Yield to the microtask queue. `startCapture()` runs synchronously
+ * inside an `onEvent` handler but its `await capture.start(...)`
+ * resolves on a microtask, so tests await an already-resolved promise
+ * to let those continuations land before asserting.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoiceChannelManager", () => {
+  describe("happy path", () => {
+    test("walks the macOS state machine through a full turn", async () => {
+      const { manager, client, capture, playback, store } = makeHarness();
+
+      await manager.start("conv-1");
+      expect(store.getState().state).toBe("connecting");
+      expect(client.startCalls.length).toBe(1);
+      expect(client.startCalls[0]!.conversationId).toBe("conv-1");
+
+      // ready → store session info + start capture → listening.
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      expect(store.getState().sessionId).toBe("sess-1");
+      expect(store.getState().conversationId).toBe("conv-1");
+      expect(capture.startCalls.length).toBe(1);
+      expect(store.getState().state).toBe("listening");
+
+      // Mic chunks forward to client.sendAudio; amplitude lands in store.
+      const pcm = new Int16Array([1, 2, 3, 4]);
+      capture.startCalls[0]!.onChunk({
+        pcm16: pcm,
+        frameCount: pcm.length,
+        amplitude: 0.42,
+      });
+      capture.startCalls[0]!.onAmplitude?.(0.42);
+      expect(client.sendAudioCalls).toEqual([pcm]);
+      expect(store.getState().inputAmplitude).toBe(0.42);
+
+      // sttPartial → transcribing + partial transcript recorded.
+      client.emit({ type: "sttPartial", text: "hello", seq: 1 });
+      expect(store.getState().state).toBe("transcribing");
+      expect(store.getState().partialTranscript).toBe("hello");
+
+      // sttFinal → final transcript stored, partial cleared.
+      client.emit({ type: "sttFinal", text: "hello world", seq: 2 });
+      expect(store.getState().finalTranscript).toBe("hello world");
+      expect(store.getState().partialTranscript).toBe("");
+
+      // thinking → state moves to thinking; assistant transcript cleared.
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      expect(store.getState().state).toBe("thinking");
+
+      // assistantTextDelta → speaking + appended.
+      client.emit({ type: "assistantTextDelta", text: "Hi ", seq: 3 });
+      expect(store.getState().state).toBe("speaking");
+      expect(store.getState().assistantTranscript).toBe("Hi ");
+
+      client.emit({ type: "assistantTextDelta", text: "there!", seq: 4 });
+      expect(store.getState().assistantTranscript).toBe("Hi there!");
+      // Second delta does not re-enter `speaking`.
+      expect(store.getState().state).toBe("speaking");
+
+      // ttsAudio → playback enqueued with pcm chunk payload.
+      const ttsPcm = new Uint8Array([0, 1, 2, 3]);
+      client.emit({
+        type: "ttsAudio",
+        pcm: ttsPcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 5,
+      });
+      expect(playback.enqueueCalls.length).toBe(1);
+      expect(playback.enqueueCalls[0]).toEqual({
+        pcm: ttsPcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      });
+
+      // ttsDone → waitUntilPlaybackFinishes runs, transcript reset,
+      // state back to listening.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(playback.waitCalls).toBe(1);
+      expect(playback.resetCalls).toBe(1);
+      expect(store.getState().assistantTranscript).toBe("");
+      expect(store.getState().state).toBe("listening");
+    });
+  });
+
+  describe("interrupt path", () => {
+    test("interruptSpeakingAndStartListening interrupts client + playback and restarts capture", async () => {
+      const { manager, client, capture, playback } = makeHarness();
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      const captureStartsBefore = capture.startCalls.length;
+
+      await manager.interruptSpeakingAndStartListening("conv-1");
+      await flushMicrotasks();
+
+      expect(client.interruptCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      expect(capture.startCalls.length).toBe(captureStartsBefore + 1);
+    });
+  });
+
+  describe("end path", () => {
+    test("end shuts down capture, drains playback, ends client, resets store", async () => {
+      const { manager, client, capture, playback, store } = makeHarness();
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Seed some store state to confirm reset clears it.
+      store.getState().setFinalTranscript("dirty");
+
+      await manager.end();
+
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleEndCalls).toBe(1);
+      expect(client.endCalls).toBe(1);
+      // The protocol-level `end` frame is sent — `close()` is not.
+      expect(client.closeCalls).toBe(0);
+
+      const state = store.getState();
+      expect(state.state).toBe("off");
+      expect(state.sessionId).toBeNull();
+      expect(state.conversationId).toBeNull();
+      expect(state.finalTranscript).toBe("");
+      expect(state.errorMessage).toBe("");
+    });
+  });
+
+  describe("early failure path", () => {
+    test("busy failure tears down capture+playback and surfaces error state", async () => {
+      const { manager, client, capture, playback, store } = makeHarness();
+
+      await manager.start("conv-1");
+      expect(store.getState().state).toBe("connecting");
+
+      // No `ready` yet — server reports another session is already active.
+      client.fail({ type: "busy", activeSessionId: "sess-other" });
+
+      expect(store.getState().state).toBe("failed");
+      expect(store.getState().errorMessage.length).toBeGreaterThan(0);
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      // No protocol `end` frame; we tear down via `close()`.
+      expect(client.endCalls).toBe(0);
+      expect(client.closeCalls).toBe(1);
+    });
+
+    test("failure with explicit message stores that message verbatim", async () => {
+      const { manager, client, store } = makeHarness();
+      await manager.start("conv-1");
+
+      client.fail({
+        type: "connectionFailed",
+        message: "WebSocket error",
+      });
+
+      expect(store.getState().errorMessage).toBe("WebSocket error");
+      expect(store.getState().state).toBe("failed");
+    });
+  });
+
+  describe("stopListening", () => {
+    test("releases push-to-talk and stops capture, keeps channel open", async () => {
+      const { manager, client, capture } = makeHarness();
+      await manager.start("conv-1");
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.stopListening();
+
+      expect(client.releasePushToTalkCalls).toBe(1);
+      expect(capture.stopCalls).toBe(1);
+      expect(client.endCalls).toBe(0);
+      expect(client.closeCalls).toBe(0);
+    });
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
@@ -91,6 +91,14 @@ describe("LiveVoiceStore", () => {
     );
   });
 
+  test("clearAssistantTranscript wipes the accumulated transcript", () => {
+    useLiveVoiceStore.getState().appendAssistantTranscript("hello");
+    useLiveVoiceStore.getState().appendAssistantTranscript(" world");
+    useLiveVoiceStore.getState().clearAssistantTranscript();
+
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe("");
+  });
+
   test("setInputAmplitude updates the amplitude", () => {
     useLiveVoiceStore.getState().setInputAmplitude(0.42);
     expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.42);

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -91,8 +91,25 @@ export interface LiveVoiceChannelManagerDeps {
    * new client each time the manager starts a session.
    */
   clientFactory?: () => LiveVoiceChannelClientLike;
-  capture?: LiveVoicePcmCaptureLike;
-  playback?: LiveVoicePcmPlaybackLike;
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoicePcmCapture`. Like the client, capture is single-shot:
+   * `shutdown()` (called by `end()` / failure paths) sets
+   * `isShutdown = true` and subsequent `start()` calls return `false`
+   * without ever restarting the microphone. We must instantiate a new
+   * capture each time the manager starts a session, otherwise the
+   * second session's `ready` event never transitions out of
+   * `connecting`.
+   */
+  captureFactory?: () => LiveVoicePcmCaptureLike;
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoicePcmPlayback`. Mirrors the capture factory rationale —
+   * playback teardown flips a one-shot disabled bit, so reusing the
+   * same instance across sessions leaves the next response unable to
+   * play any audio.
+   */
+  playbackFactory?: () => LiveVoicePcmPlaybackLike;
   store?: LiveVoiceStoreLike;
 }
 
@@ -111,8 +128,23 @@ export class LiveVoiceChannelManager {
    */
   private readonly clientFactory: () => LiveVoiceChannelClientLike;
   private client: LiveVoiceChannelClientLike | null = null;
-  private readonly capture: LiveVoicePcmCaptureLike;
-  private readonly playback: LiveVoicePcmPlaybackLike;
+  /**
+   * Per-session capture factory. We construct a fresh capture in
+   * `start()` because `LiveVoicePcmCapture.shutdown()` (called by
+   * `end()` / failure teardown) sets `isShutdown = true` and later
+   * `start()` returns `false`. Reusing the same instance across
+   * sessions left the next session's `ready` event unable to restart
+   * the microphone — the UI stayed stuck in `connecting` forever.
+   */
+  private readonly captureFactory: () => LiveVoicePcmCaptureLike;
+  private capture: LiveVoicePcmCaptureLike | null = null;
+  /**
+   * Per-session playback factory. Mirrors `captureFactory` — playback
+   * teardown is also one-shot disable, so a reused instance silently
+   * drops every subsequent response's audio.
+   */
+  private readonly playbackFactory: () => LiveVoicePcmPlaybackLike;
+  private playback: LiveVoicePcmPlaybackLike | null = null;
   private readonly store: LiveVoiceStoreLike;
 
   /**
@@ -148,8 +180,10 @@ export class LiveVoiceChannelManager {
   constructor(deps: LiveVoiceChannelManagerDeps = {}) {
     this.clientFactory =
       deps.clientFactory ?? (() => new LiveVoiceChannelClient());
-    this.capture = deps.capture ?? new LiveVoicePcmCapture();
-    this.playback = deps.playback ?? new LiveVoicePcmPlayback();
+    this.captureFactory =
+      deps.captureFactory ?? (() => new LiveVoicePcmCapture());
+    this.playbackFactory =
+      deps.playbackFactory ?? (() => new LiveVoicePcmPlayback());
     this.store = deps.store ?? useLiveVoiceStore;
   }
 
@@ -166,9 +200,11 @@ export class LiveVoiceChannelManager {
     actions.setState("connecting");
     actions.setError("");
 
-    // Build a fresh client for this session — see the field comment
-    // for why the client must not be reused across sessions.
+    // Build a fresh client/capture/playback for this session — see the
+    // field comments for why these must not be reused across sessions.
     this.client = this.clientFactory();
+    this.capture = this.captureFactory();
+    this.playback = this.playbackFactory();
     await this.client.start({
       conversationId,
       onEvent: (event) => this.handleEvent(event),
@@ -185,7 +221,7 @@ export class LiveVoiceChannelManager {
   ): Promise<void> {
     this.isUserMuted = false;
     this.client?.interrupt();
-    this.playback.handleInterrupt();
+    this.playback?.handleInterrupt();
     // The playback gate is now closed; the next assistant response's
     // first `ttsAudio` must call `resetForNextResponse()` before
     // enqueueing.
@@ -196,7 +232,7 @@ export class LiveVoiceChannelManager {
   async stopListening(): Promise<void> {
     this.isUserMuted = true;
     this.client?.releasePushToTalk();
-    this.capture.stop();
+    this.capture?.stop();
   }
 
   async end(): Promise<void> {
@@ -205,11 +241,14 @@ export class LiveVoiceChannelManager {
     this.sessionGeneration += 1;
     this.playbackReadyForResponse = false;
 
-    this.capture.shutdown();
-    this.playback.handleEnd();
+    this.capture?.shutdown();
+    this.playback?.handleEnd();
     await this.client?.end();
-    // Drop the closed client so the next `start()` builds a fresh one.
+    // Drop the closed collaborators so the next `start()` builds fresh
+    // ones — `shutdown()` permanently disables capture/playback.
     this.client = null;
+    this.capture = null;
+    this.playback = null;
     this.actions().reset();
   }
 
@@ -254,10 +293,10 @@ export class LiveVoiceChannelManager {
         // first audio chunk of a new response must re-open the gate
         // before enqueueing so the assistant's reply is actually heard.
         if (!this.playbackReadyForResponse) {
-          this.playback.resetForNextResponse();
+          this.playback?.resetForNextResponse();
           this.playbackReadyForResponse = true;
         }
-        this.playback.enqueueTtsAudio({
+        this.playback?.enqueueTtsAudio({
           pcm: event.pcm,
           mimeType: event.mimeType,
           sampleRate: event.sampleRate,
@@ -295,11 +334,14 @@ export class LiveVoiceChannelManager {
 
     // Same teardown as `end()` minus the protocol `end` frame — the
     // channel is already gone, so we use `close()` instead.
-    this.capture.shutdown();
-    this.playback.handleInterrupt();
+    this.capture?.shutdown();
+    this.playback?.handleInterrupt();
     this.client?.close();
-    // Drop the closed client so the next `start()` builds a fresh one.
+    // Drop the closed collaborators so the next `start()` builds fresh
+    // ones — `shutdown()` permanently disables capture/playback.
     this.client = null;
+    this.capture = null;
+    this.playback = null;
   }
 
   private async completeAssistantTurn(): Promise<void> {
@@ -309,24 +351,26 @@ export class LiveVoiceChannelManager {
     // with `listening` and re-open the playback gate for a session that
     // no longer exists.
     const myGeneration = this.sessionGeneration;
-    await this.playback.waitUntilPlaybackFinishes();
+    await this.playback?.waitUntilPlaybackFinishes();
     if (myGeneration !== this.sessionGeneration) {
       return;
     }
     // Re-arm the gate flag so the next response's first `ttsAudio`
     // calls `resetForNextResponse()` again before enqueueing.
     this.playbackReadyForResponse = false;
-    this.playback.resetForNextResponse();
+    this.playback?.resetForNextResponse();
     const actions = this.actions();
     // Clear the rolling assistant transcript so the next turn starts
     // from a clean buffer.
     actions.clearAssistantTranscript();
-    // Skip the transition back to `listening` if the user explicitly
-    // muted via `stopListening()` — re-arming the mic would silently
-    // override the user's mute. The next user action
-    // (`interruptSpeakingAndStartListening` or `end`) drives the next
-    // state transition.
+    // If the user has called `stopListening()` (i.e. PTT-released), the
+    // assistant server treats the `ptt_release` as terminal for this
+    // session — subsequent audio frames are rejected or ignored. The
+    // WebSocket is logically dead, so tear it down here instead of
+    // dangling in a half-alive state. The next user action will
+    // `start()` a fresh session.
     if (this.isUserMuted) {
+      await this.end();
       return;
     }
     actions.setState("listening");
@@ -337,7 +381,7 @@ export class LiveVoiceChannelManager {
   // -------------------------------------------------------------------------
 
   private async startCapture(): Promise<void> {
-    const started = await this.capture.start({
+    const started = await this.capture?.start({
       onChunk: (chunk) => {
         this.client?.sendAudio(chunk.pcm16);
       },

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -83,7 +83,14 @@ export interface LiveVoiceStoreLike {
 }
 
 export interface LiveVoiceChannelManagerDeps {
-  client?: LiveVoiceChannelClientLike;
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoiceChannelClient`. The underlying client is single-shot —
+   * after `end()` or a failure transitions it to `closed`, calling
+   * `start()` on the same instance is a no-op. We must instantiate a
+   * new client each time the manager starts a session.
+   */
+  clientFactory?: () => LiveVoiceChannelClientLike;
   capture?: LiveVoicePcmCaptureLike;
   playback?: LiveVoicePcmPlaybackLike;
   store?: LiveVoiceStoreLike;
@@ -96,7 +103,14 @@ export interface LiveVoiceChannelManagerDeps {
 const DEFAULT_FAILURE_MESSAGE = "Live voice session failed";
 
 export class LiveVoiceChannelManager {
-  private readonly client: LiveVoiceChannelClientLike;
+  /**
+   * Per-session client factory. We construct a fresh client in `start()`
+   * because `LiveVoiceChannelClient` is single-shot: once `end()` /
+   * `close()` move it to the `closed` state, subsequent `start()`
+   * calls early-return without ever emitting a `ready` event.
+   */
+  private readonly clientFactory: () => LiveVoiceChannelClientLike;
+  private client: LiveVoiceChannelClientLike | null = null;
   private readonly capture: LiveVoicePcmCaptureLike;
   private readonly playback: LiveVoicePcmPlaybackLike;
   private readonly store: LiveVoiceStoreLike;
@@ -122,8 +136,18 @@ export class LiveVoiceChannelManager {
    */
   private playbackReadyForResponse = false;
 
+  /**
+   * Set to `true` by `stopListening()` (user pressed PTT-release) and
+   * cleared by `start()` / `interruptSpeakingAndStartListening()`. When
+   * a `ttsDone` continuation lands after the user has muted, we skip
+   * the transition back to `listening` so the UI does not silently
+   * re-arm the mic against the user's wish.
+   */
+  private isUserMuted = false;
+
   constructor(deps: LiveVoiceChannelManagerDeps = {}) {
-    this.client = deps.client ?? new LiveVoiceChannelClient();
+    this.clientFactory =
+      deps.clientFactory ?? (() => new LiveVoiceChannelClient());
     this.capture = deps.capture ?? new LiveVoicePcmCapture();
     this.playback = deps.playback ?? new LiveVoicePcmPlayback();
     this.store = deps.store ?? useLiveVoiceStore;
@@ -136,11 +160,15 @@ export class LiveVoiceChannelManager {
   async start(conversationId: string): Promise<void> {
     this.sessionGeneration += 1;
     this.playbackReadyForResponse = false;
+    this.isUserMuted = false;
 
     const actions = this.actions();
     actions.setState("connecting");
     actions.setError("");
 
+    // Build a fresh client for this session — see the field comment
+    // for why the client must not be reused across sessions.
+    this.client = this.clientFactory();
     await this.client.start({
       conversationId,
       onEvent: (event) => this.handleEvent(event),
@@ -155,7 +183,8 @@ export class LiveVoiceChannelManager {
     // future work can reopen the channel when the id changes.
     _conversationId: string,
   ): Promise<void> {
-    this.client.interrupt();
+    this.isUserMuted = false;
+    this.client?.interrupt();
     this.playback.handleInterrupt();
     // The playback gate is now closed; the next assistant response's
     // first `ttsAudio` must call `resetForNextResponse()` before
@@ -165,7 +194,8 @@ export class LiveVoiceChannelManager {
   }
 
   async stopListening(): Promise<void> {
-    this.client.releasePushToTalk();
+    this.isUserMuted = true;
+    this.client?.releasePushToTalk();
     this.capture.stop();
   }
 
@@ -177,7 +207,9 @@ export class LiveVoiceChannelManager {
 
     this.capture.shutdown();
     this.playback.handleEnd();
-    await this.client.end();
+    await this.client?.end();
+    // Drop the closed client so the next `start()` builds a fresh one.
+    this.client = null;
     this.actions().reset();
   }
 
@@ -265,7 +297,9 @@ export class LiveVoiceChannelManager {
     // channel is already gone, so we use `close()` instead.
     this.capture.shutdown();
     this.playback.handleInterrupt();
-    this.client.close();
+    this.client?.close();
+    // Drop the closed client so the next `start()` builds a fresh one.
+    this.client = null;
   }
 
   private async completeAssistantTurn(): Promise<void> {
@@ -287,6 +321,14 @@ export class LiveVoiceChannelManager {
     // Clear the rolling assistant transcript so the next turn starts
     // from a clean buffer.
     actions.clearAssistantTranscript();
+    // Skip the transition back to `listening` if the user explicitly
+    // muted via `stopListening()` — re-arming the mic would silently
+    // override the user's mute. The next user action
+    // (`interruptSpeakingAndStartListening` or `end`) drives the next
+    // state transition.
+    if (this.isUserMuted) {
+      return;
+    }
     actions.setState("listening");
   }
 
@@ -297,7 +339,7 @@ export class LiveVoiceChannelManager {
   private async startCapture(): Promise<void> {
     const started = await this.capture.start({
       onChunk: (chunk) => {
-        this.client.sendAudio(chunk.pcm16);
+        this.client?.sendAudio(chunk.pcm16);
       },
       onAmplitude: (amplitude) => {
         this.actions().setInputAmplitude(amplitude);

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -1,0 +1,279 @@
+/**
+ * LiveVoiceChannelManager — orchestrates the live voice session lifecycle.
+ *
+ * TypeScript port of the public surface of
+ * `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`.
+ *
+ * Wires together three collaborators:
+ *
+ *   - `LiveVoiceChannelClient` — WebSocket transport (`/v1/live-voice`).
+ *   - `LiveVoicePcmCapture` — 16 kHz mono microphone capture.
+ *   - `LiveVoicePcmPlayback` — gapless TTS playback.
+ *
+ * State lives in the `useLiveVoiceStore` Zustand store; the manager is
+ * pure logic (no React) and mutates the store via `getState()`. The
+ * `state` field tracks the same machine as the macOS app:
+ * `off → connecting → listening → transcribing → thinking → speaking →
+ * ending`, with a `failed` branch on error.
+ *
+ * Collaborators are constructor-injected so tests can pass minimal fakes
+ * without touching the DOM, WebSocket, or Web Audio APIs.
+ */
+
+import type {
+  LiveVoiceChannelEvent,
+  LiveVoiceChannelFailure,
+  LiveVoiceChannelStartOptions,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import { LiveVoiceChannelClient } from "@/domains/voice/live-voice/live-voice-channel-client";
+import type {
+  LiveVoiceStore,
+  LiveVoiceStoreActions,
+  LiveVoiceStoreState,
+} from "@/domains/voice/live-voice/live-voice-store";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import type { LiveVoicePcmCaptureStartOptions } from "@/domains/voice/live-voice/pcm-capture";
+import { LiveVoicePcmCapture } from "@/domains/voice/live-voice/pcm-capture";
+import type { LiveVoiceTtsChunk } from "@/domains/voice/live-voice/pcm-playback";
+import { LiveVoicePcmPlayback } from "@/domains/voice/live-voice/pcm-playback";
+
+// ---------------------------------------------------------------------------
+// Dependency contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `LiveVoiceChannelClient` the manager depends on. The fake
+ * used in tests captures the `onEvent` / `onFailure` callbacks from
+ * `start()` so the test can drive event sequences synchronously.
+ */
+export interface LiveVoiceChannelClientLike {
+  start(options: LiveVoiceChannelStartOptions): Promise<void>;
+  sendAudio(data: ArrayBuffer | Int16Array): void;
+  releasePushToTalk(): void;
+  interrupt(): void;
+  end(): Promise<void>;
+  close(): void;
+}
+
+/** Subset of `LiveVoicePcmCapture` the manager depends on. */
+export interface LiveVoicePcmCaptureLike {
+  start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean>;
+  stop(): void;
+  shutdown(): void;
+}
+
+/** Subset of `LiveVoicePcmPlayback` the manager depends on. */
+export interface LiveVoicePcmPlaybackLike {
+  readonly isPlaying: boolean;
+  enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void;
+  handleInterrupt(): void;
+  handleEnd(): void;
+  handleSessionError(): void;
+  resetForNextResponse(): void;
+  waitUntilPlaybackFinishes(): Promise<void>;
+}
+
+/**
+ * Minimal store surface the manager pokes from outside React. Matches
+ * the `getState()` shape of `useLiveVoiceStore`; tests pass a fake that
+ * records mutations without spinning up the real Zustand store.
+ */
+export interface LiveVoiceStoreLike {
+  getState(): LiveVoiceStore;
+}
+
+export interface LiveVoiceChannelManagerDeps {
+  client?: LiveVoiceChannelClientLike;
+  capture?: LiveVoicePcmCaptureLike;
+  playback?: LiveVoicePcmPlaybackLike;
+  store?: LiveVoiceStoreLike;
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FAILURE_MESSAGE = "Live voice session failed";
+
+export class LiveVoiceChannelManager {
+  private readonly client: LiveVoiceChannelClientLike;
+  private readonly capture: LiveVoicePcmCaptureLike;
+  private readonly playback: LiveVoicePcmPlaybackLike;
+  private readonly store: LiveVoiceStoreLike;
+
+  constructor(deps: LiveVoiceChannelManagerDeps = {}) {
+    this.client = deps.client ?? new LiveVoiceChannelClient();
+    this.capture = deps.capture ?? new LiveVoicePcmCapture();
+    this.playback = deps.playback ?? new LiveVoicePcmPlayback();
+    this.store = deps.store ?? useLiveVoiceStore;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API (mirrors `LiveVoiceChannelManaging` from VoiceModeManager.swift)
+  // -------------------------------------------------------------------------
+
+  async start(conversationId: string): Promise<void> {
+    const actions = this.actions();
+    actions.setState("connecting");
+    actions.setError("");
+
+    await this.client.start({
+      conversationId,
+      onEvent: (event) => this.handleEvent(event),
+      onFailure: (failure) => this.handleFailure(failure),
+    });
+  }
+
+  async interruptSpeakingAndStartListening(
+    // Conversation id is part of the macOS protocol surface so callers
+    // can swap conversations atomically. The current web manager
+    // assumes the existing channel matches and just resumes capture —
+    // future work can reopen the channel when the id changes.
+    _conversationId: string,
+  ): Promise<void> {
+    this.client.interrupt();
+    this.playback.handleInterrupt();
+    await this.startCapture();
+  }
+
+  async stopListening(): Promise<void> {
+    this.client.releasePushToTalk();
+    this.capture.stop();
+  }
+
+  async end(): Promise<void> {
+    this.capture.shutdown();
+    this.playback.handleEnd();
+    await this.client.end();
+    this.actions().reset();
+  }
+
+  // -------------------------------------------------------------------------
+  // Event mapping
+  // -------------------------------------------------------------------------
+
+  private handleEvent(event: LiveVoiceChannelEvent): void {
+    const actions = this.actions();
+    switch (event.type) {
+      case "ready":
+        actions.setSessionInfo({
+          sessionId: event.sessionId,
+          conversationId: event.conversationId,
+        });
+        void this.startCapture();
+        return;
+      case "sttPartial":
+        actions.setPartialTranscript(event.text);
+        actions.setState("transcribing");
+        return;
+      case "sttFinal":
+        actions.setFinalTranscript(event.text);
+        actions.setPartialTranscript("");
+        return;
+      case "thinking":
+        actions.setState("thinking");
+        // Reset the rolling assistant transcript at the start of each
+        // response — mirrors `prepareForAssistantResponse()` in
+        // `LiveVoiceChannelManager.swift`.
+        actions.clearAssistantTranscript();
+        return;
+      case "assistantTextDelta":
+        if (this.currentState() !== "speaking") {
+          actions.setState("speaking");
+        }
+        actions.appendAssistantTranscript(event.text);
+        return;
+      case "ttsAudio":
+        this.playback.enqueueTtsAudio({
+          pcm: event.pcm,
+          mimeType: event.mimeType,
+          sampleRate: event.sampleRate,
+          channels: 1,
+        });
+        return;
+      case "ttsDone":
+        void this.completeAssistantTurn();
+        return;
+      case "metrics":
+        // Best-effort logging — metrics are diagnostic only.
+        console.debug("[LiveVoiceChannelManager] metrics", event.metrics);
+        return;
+      case "archived":
+        // No state change; just record the archival for diagnostics.
+        console.debug(
+          "[LiveVoiceChannelManager] archived",
+          event.conversationId,
+          event.sessionId,
+        );
+        return;
+    }
+  }
+
+  private handleFailure(failure: LiveVoiceChannelFailure): void {
+    const message = this.failureMessage(failure);
+    const actions = this.actions();
+    actions.setError(message);
+    actions.setState("failed");
+
+    // Same teardown as `end()` minus the protocol `end` frame — the
+    // channel is already gone, so we use `close()` instead.
+    this.capture.shutdown();
+    this.playback.handleInterrupt();
+    this.client.close();
+  }
+
+  private async completeAssistantTurn(): Promise<void> {
+    await this.playback.waitUntilPlaybackFinishes();
+    this.playback.resetForNextResponse();
+    const actions = this.actions();
+    // Clear the rolling assistant transcript so the next turn starts
+    // from a clean buffer.
+    actions.clearAssistantTranscript();
+    actions.setState("listening");
+  }
+
+  // -------------------------------------------------------------------------
+  // Capture lifecycle
+  // -------------------------------------------------------------------------
+
+  private async startCapture(): Promise<void> {
+    const started = await this.capture.start({
+      onChunk: (chunk) => {
+        this.client.sendAudio(chunk.pcm16);
+      },
+      onAmplitude: (amplitude) => {
+        this.actions().setInputAmplitude(amplitude);
+      },
+    });
+    if (!started) return;
+    if (this.currentState() !== "failed") {
+      this.actions().setState("listening");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Store helpers
+  // -------------------------------------------------------------------------
+
+  private actions(): LiveVoiceStoreActions {
+    return this.store.getState();
+  }
+
+  private currentState(): LiveVoiceStoreState["state"] {
+    return this.store.getState().state;
+  }
+
+  private failureMessage(failure: LiveVoiceChannelFailure): string {
+    switch (failure.type) {
+      case "connectionFailed":
+      case "protocolError":
+      case "timeout":
+        return failure.message || DEFAULT_FAILURE_MESSAGE;
+      case "abnormalClosure":
+        return failure.reason || DEFAULT_FAILURE_MESSAGE;
+      case "busy":
+      case "connectionRejected":
+        return DEFAULT_FAILURE_MESSAGE;
+    }
+  }
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -101,6 +101,27 @@ export class LiveVoiceChannelManager {
   private readonly playback: LiveVoicePcmPlaybackLike;
   private readonly store: LiveVoiceStoreLike;
 
+  /**
+   * Monotonically incremented whenever the session boundary changes
+   * (`start`, `end`, failure). The `ttsDone` continuation captures this
+   * before awaiting `waitUntilPlaybackFinishes()` and bails after the
+   * await if it no longer matches — that race lets us avoid clobbering
+   * the `off`/`failed` state that teardown set while we were waiting,
+   * and prevents `resetForNextResponse()` from re-opening the playback
+   * gate after the session has gone away.
+   */
+  private sessionGeneration = 0;
+
+  /**
+   * Tracks whether `playback.resetForNextResponse()` has been called for
+   * the current assistant response. The PCM playback flips its
+   * `acceptsAudio` gate closed on `handleInterrupt` / `handleEnd`, so
+   * the first `ttsAudio` of every new response must re-open the gate
+   * before enqueueing — otherwise the chunk is silently dropped (e.g.
+   * the barge-in -> new utterance flow leaves the assistant mute).
+   */
+  private playbackReadyForResponse = false;
+
   constructor(deps: LiveVoiceChannelManagerDeps = {}) {
     this.client = deps.client ?? new LiveVoiceChannelClient();
     this.capture = deps.capture ?? new LiveVoicePcmCapture();
@@ -113,6 +134,9 @@ export class LiveVoiceChannelManager {
   // -------------------------------------------------------------------------
 
   async start(conversationId: string): Promise<void> {
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+
     const actions = this.actions();
     actions.setState("connecting");
     actions.setError("");
@@ -133,6 +157,10 @@ export class LiveVoiceChannelManager {
   ): Promise<void> {
     this.client.interrupt();
     this.playback.handleInterrupt();
+    // The playback gate is now closed; the next assistant response's
+    // first `ttsAudio` must call `resetForNextResponse()` before
+    // enqueueing.
+    this.playbackReadyForResponse = false;
     await this.startCapture();
   }
 
@@ -142,6 +170,11 @@ export class LiveVoiceChannelManager {
   }
 
   async end(): Promise<void> {
+    // Bump the generation so any in-flight `ttsDone` continuation that
+    // resumes after this teardown bails before touching state.
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+
     this.capture.shutdown();
     this.playback.handleEnd();
     await this.client.end();
@@ -184,6 +217,14 @@ export class LiveVoiceChannelManager {
         actions.appendAssistantTranscript(event.text);
         return;
       case "ttsAudio":
+        // The PCM playback's `acceptsAudio` gate is flipped closed by
+        // any prior `handleInterrupt` / `handleEnd` / `ttsDone`. The
+        // first audio chunk of a new response must re-open the gate
+        // before enqueueing so the assistant's reply is actually heard.
+        if (!this.playbackReadyForResponse) {
+          this.playback.resetForNextResponse();
+          this.playbackReadyForResponse = true;
+        }
         this.playback.enqueueTtsAudio({
           pcm: event.pcm,
           mimeType: event.mimeType,
@@ -210,6 +251,11 @@ export class LiveVoiceChannelManager {
   }
 
   private handleFailure(failure: LiveVoiceChannelFailure): void {
+    // Bump the generation so any in-flight `ttsDone` continuation that
+    // resumes after this teardown bails before touching state.
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+
     const message = this.failureMessage(failure);
     const actions = this.actions();
     actions.setError(message);
@@ -223,7 +269,19 @@ export class LiveVoiceChannelManager {
   }
 
   private async completeAssistantTurn(): Promise<void> {
+    // Capture the generation before awaiting playback so we can detect
+    // a teardown (`end()` / failure) that happens while we wait. Without
+    // this guard the post-await mutations would clobber `off` / `failed`
+    // with `listening` and re-open the playback gate for a session that
+    // no longer exists.
+    const myGeneration = this.sessionGeneration;
     await this.playback.waitUntilPlaybackFinishes();
+    if (myGeneration !== this.sessionGeneration) {
+      return;
+    }
+    // Re-arm the gate flag so the next response's first `ttsAudio`
+    // calls `resetForNextResponse()` again before enqueueing.
+    this.playbackReadyForResponse = false;
     this.playback.resetForNextResponse();
     const actions = this.actions();
     // Clear the rolling assistant transcript so the next turn starts

--- a/apps/web/src/domains/voice/live-voice/live-voice-store.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-store.ts
@@ -74,6 +74,7 @@ export interface LiveVoiceStoreActions {
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   appendAssistantTranscript: (delta: string) => void;
+  clearAssistantTranscript: () => void;
   setInputAmplitude: (amp: number) => void;
   setError: (msg: string) => void;
   reset: () => void;
@@ -114,6 +115,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
 
   appendAssistantTranscript: (delta) =>
     set((prev) => ({ assistantTranscript: prev.assistantTranscript + delta })),
+
+  clearAssistantTranscript: () => set({ assistantTranscript: "" }),
 
   setInputAmplitude: (amp) => set({ inputAmplitude: amp }),
 


### PR DESCRIPTION
## Summary
- TS port of clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
- Owns the live voice state machine (connecting → listening → transcribing → thinking → speaking → ending)
- Maps WS server events to LiveVoice store mutations
- Drives PCM capture (mic) and PCM playback (TTS) lifecycles
- Handles interrupt + end + failure teardown paths

Part of plan: realtime-voice-web.md (PR 6 of 9)