### PR TITLE
fix(openrouter): don't send reasoning: { enabled: false } to reasoning-only models

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1557,32 +1557,32 @@ describe("OpenRouterProvider reasoning", () => {
     });
   });
 
-  test("sends reasoning.enabled=false when thinking is explicitly disabled", async () => {
+  test("omits reasoning when thinking is explicitly disabled", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
       config: { thinking: { type: "disabled" } },
     });
 
     expect(lastCreateParams).toBeTruthy();
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+    expect(lastCreateParams!.reasoning).toBeUndefined();
   });
 
-  test("sends reasoning.enabled=false when thinking config is absent", async () => {
+  test("omits reasoning when thinking config is absent", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
       config: {},
     });
 
     expect(lastCreateParams).toBeTruthy();
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+    expect(lastCreateParams!.reasoning).toBeUndefined();
   });
 
-  test("sends reasoning.enabled=false when no options are provided", async () => {
+  test("omits reasoning when no options are provided", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")]);
 
     expect(lastCreateParams).toBeTruthy();
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+    expect(lastCreateParams!.reasoning).toBeUndefined();
   });
 
   test("sends OpenRouter app-attribution headers on OpenAI-compatible requests", async () => {
@@ -1623,15 +1623,14 @@ describe("OpenRouterProvider reasoning", () => {
     });
   });
 
-  test("RetryProvider + OpenRouterProvider disables thinking end-to-end", async () => {
+  test("RetryProvider + OpenRouterProvider omits reasoning when thinking disabled", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     const retry = new RetryProvider(provider);
 
-    // thinking disabled at loop-level can arrive as an explicit disabled config.
     await retry.sendMessage([userMsg("hi")], undefined, undefined, {
       config: { thinking: { type: "disabled" } },
     });
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+    expect(lastCreateParams!.reasoning).toBeUndefined();
   });
 
   test("nests effort under reasoning and omits top-level reasoning_effort", async () => {

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -182,6 +182,17 @@ describe("OpenRouter provider.only plumbing", () => {
       });
     });
 
+    test("effort without thinking does not emit reasoning", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({
+        config: { thinking: { type: "disabled" }, effort: "low" },
+      });
+      expect(extras.reasoning).toBe(undefined);
+    });
+
     test("omitting reasoning avoids 400 from reasoning-only models like DeepSeek R1", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -101,19 +101,19 @@ describe("OpenRouter provider.only plumbing", () => {
         config: { openrouter: { only: ["xAI"] } },
       });
       expect(extras).toEqual({
-        reasoning: { enabled: false },
         provider: { only: ["xAI"] },
       });
     });
 
-    test("omits provider when openrouter.only is absent", () => {
+    test("omits reasoning and provider when config is empty", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",
         "x-ai/grok-4.20-beta",
       );
       const extras = provider.probeExtras({ config: {} });
-      expect(extras).toEqual({ reasoning: { enabled: false } });
+      expect(extras).toEqual({});
       expect(extras.provider).toBe(undefined);
+      expect(extras.reasoning).toBe(undefined);
     });
 
     test("enables thinking with default detailed summary alongside provider.only", () => {
@@ -133,7 +133,7 @@ describe("OpenRouter provider.only plumbing", () => {
       });
     });
 
-    test("disabled thinking keeps reasoning disabled and omits summary", () => {
+    test("disabled thinking omits reasoning entirely", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",
         "x-ai/grok-4.20-beta",
@@ -145,9 +145,9 @@ describe("OpenRouter provider.only plumbing", () => {
         },
       });
       expect(extras).toEqual({
-        reasoning: { enabled: false },
         provider: { only: ["xAI"] },
       });
+      expect(extras.reasoning).toBe(undefined);
     });
 
     test("nests effort under reasoning and maps `max` to xhigh", () => {
@@ -180,6 +180,17 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extras).toEqual({
         reasoning: { enabled: true, summary: "concise" },
       });
+    });
+
+    test("omitting reasoning avoids 400 from reasoning-only models like DeepSeek R1", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "deepseek/deepseek-r1-0528",
+      );
+      const extras = provider.probeExtras({
+        config: { thinking: { type: "disabled" } },
+      });
+      expect(extras.reasoning).toBe(undefined);
     });
 
     test("ignores an invalid summary override and falls back to detailed", () => {

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -200,11 +200,11 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       ? EFFORT_TO_REASONING_EFFORT[effort]
       : undefined;
     const summaryOverride = extractReasoningSummaryOverride(config);
-    // Only send `reasoning` when explicitly enabling it. Omitting the field
-    // lets OpenRouter use the model's natural default, which avoids 400s from
-    // reasoning-only models (e.g. DeepSeek R1) that reject `enabled: false`.
+    // Only send `reasoning` when explicitly enabling thinking. Omitting the
+    // field lets OpenRouter use the model's natural default, which avoids 400s
+    // from reasoning-only models (e.g. DeepSeek R1) that reject `enabled: false`.
     const extras: Record<string, unknown> = {};
-    if (thinkingEnabled || mappedEffort) {
+    if (thinkingEnabled) {
       const reasoning: Record<string, unknown> = { enabled: true };
       if (mappedEffort) {
         reasoning.effort = clampReasoningEffort(

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -200,17 +200,21 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       ? EFFORT_TO_REASONING_EFFORT[effort]
       : undefined;
     const summaryOverride = extractReasoningSummaryOverride(config);
-    const reasoning: Record<string, unknown> = { enabled: thinkingEnabled };
-    if (mappedEffort) {
-      reasoning.effort = clampReasoningEffort(
-        mappedEffort,
-        this.resolveMaxReasoningEffort(this.resolveEffectiveModel(options)),
-      );
-    }
-    if (thinkingEnabled) {
+    // Only send `reasoning` when explicitly enabling it. Omitting the field
+    // lets OpenRouter use the model's natural default, which avoids 400s from
+    // reasoning-only models (e.g. DeepSeek R1) that reject `enabled: false`.
+    const extras: Record<string, unknown> = {};
+    if (thinkingEnabled || mappedEffort) {
+      const reasoning: Record<string, unknown> = { enabled: true };
+      if (mappedEffort) {
+        reasoning.effort = clampReasoningEffort(
+          mappedEffort,
+          this.resolveMaxReasoningEffort(this.resolveEffectiveModel(options)),
+        );
+      }
       reasoning.summary = summaryOverride ?? "detailed";
+      extras.reasoning = reasoning;
     }
-    const extras: Record<string, unknown> = { reasoning };
     const only = extractOnlyList(config);
     if (only.length > 0) {
       const existingProvider = (config?.provider ?? {}) as Record<


### PR DESCRIPTION
## Summary
- Reasoning-only models on OpenRouter (e.g. DeepSeek R1) reject `reasoning: { enabled: false }` with HTTP 400: "Reasoning is mandatory for this endpoint and cannot be disabled"
- The `buildExtraCreateParams` override was unconditionally sending `reasoning: { enabled: false }` when thinking was disabled, which breaks these models
- Fix: only include the `reasoning` field when explicitly enabling reasoning. When omitted, OpenRouter uses the model's natural default — reasoning-only models reason, others don't

## Test plan
- [x] Reproduced locally: DeepSeek R1 via OpenRouter with thinking disabled → 400
- [x] Verified fix via script: all 8 model/thinking combinations pass (DeepSeek R1, DeepSeek V3, Grok 4.3, Claude Sonnet — each with thinking on/off)
- [x] Verified fix end-to-end in browser: same prompt that 400'd before now returns a response
- [x] Updated existing unit tests and added regression test for reasoning-only model case
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)