### PR TITLE
refactor(web): DRY deploy/share dialogs, unify share logic (LUM-2006)

### DIFF
--- a/apps/web/src/components/apps/library-view.tsx
+++ b/apps/web/src/components/apps/library-view.tsx
@@ -18,7 +18,6 @@ import {
 import type { AppSummary } from "@/types/app-types";
 import { clearAppHtmlCache, getCachedAppHtml, primeAppHtmlCache } from "@/utils/app-html-cache";
 import { importBundle } from "@/utils/import-bundle";
-import { shareApp } from "@/utils/share-app";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store";
@@ -29,7 +28,7 @@ import {
   toast,
 } from "@vellum/design-library";
 import { AppViewerContainer } from "@/components/apps/app-viewer-container";
-import { VercelTokenDialog } from "@/components/vercel-token-dialog";
+import { DeployDialogs } from "@/components/deploy-dialogs";
 import { LibraryAppCard } from "@/components/apps/library-app-card";
 import { LibraryDocumentCard } from "@/components/apps/library-document-card";
 
@@ -59,8 +58,7 @@ export function LibraryView({
 
   // Deploy store — shared with chat-page for consistent deploy UX
   const isDeploying = useDeployStore.use.isDeploying();
-  const isTokenDialogOpen = useDeployStore.use.isTokenDialogOpen();
-  const complexDeployApp = useDeployStore.use.complexDeployApp();
+  const isSharing = useDeployStore.use.isSharing();
 
   const { data: apps = [], isLoading: appsLoading, error: appsError } = useQuery({
     ...appsGetOptions({ path: { assistant_id: assistantId } }),
@@ -86,7 +84,6 @@ export function LibraryView({
   const [appPendingDelete, setAppPendingDelete] = useState<AppSummary | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
-  const [isSharing, setIsSharing] = useState(false);
   const [lastImportedAppId, setLastImportedAppId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -144,20 +141,10 @@ export function LibraryView({
     setOpenedApp(null);
   }, []);
 
-  const handleShareOpenedApp = useCallback(async () => {
-    if (!openedApp || isSharing) return;
-    setIsSharing(true);
-    try {
-      await shareApp(assistantId, openedApp.appId, openedApp.name);
-      toast.success("App exported", { description: `${openedApp.name}.vellum` });
-    } catch (err) {
-      toast.error("Failed to share app", {
-        description: err instanceof Error ? err.message : undefined,
-      });
-    } finally {
-      setIsSharing(false);
-    }
-  }, [assistantId, openedApp, isSharing]);
+  const handleShareOpenedApp = useCallback(() => {
+    if (!openedApp) return;
+    void useDeployStore.getState().shareApp(assistantId, openedApp.appId, openedApp.name);
+  }, [assistantId, openedApp]);
 
   const handleDeploy = useCallback(async (appId: string) => {
     if (isDeploying) return;
@@ -245,29 +232,10 @@ export function LibraryView({
           onDeploy={deployToVercel ? () => handleDeploy(openedApp.appId) : undefined}
           isDeploying={isDeploying}
         />
-        <VercelTokenDialog
-          open={isTokenDialogOpen}
-          onOpenChange={(open) => {
-            if (!open) useDeployStore.getState().hideTokenDialog();
-          }}
+        <DeployDialogs
           assistantId={assistantId}
-          onTokenSaved={() => {
-            void useDeployStore.getState().deployAfterTokenSaved(assistantId);
-          }}
-        />
-        <ConfirmDialog
-          open={complexDeployApp !== null}
-          title="This app needs a full deploy"
-          message={`"${complexDeployApp?.name ?? ""}" uses backend services that won't work on a static Vercel page. ${assistantName ?? "Your assistant"} can deploy it properly with serverless functions.`}
-          confirmLabel={`Let ${assistantName ?? "your assistant"} handle it`}
-          onConfirm={() => {
-            const appName = useDeployStore.getState().complexDeployApp?.name ?? "this app";
-            useDeployStore.getState().setComplexDeployApp(null);
-            onNewConversation?.(
-              `Deploy my app "${appName}" to Vercel. It uses backend services that need serverless functions — please use the deploy-fullstack-vercel skill to handle it properly.`,
-            );
-          }}
-          onCancel={() => useDeployStore.getState().setComplexDeployApp(null)}
+          assistantName={assistantName}
+          onStartConversation={onNewConversation}
         />
       </>
     );
@@ -469,30 +437,10 @@ export function LibraryView({
         )}
       </div>
 
-      <VercelTokenDialog
-        open={isTokenDialogOpen}
-        onOpenChange={(open) => {
-          if (!open) useDeployStore.getState().hideTokenDialog();
-        }}
+      <DeployDialogs
         assistantId={assistantId}
-        onTokenSaved={() => {
-          void useDeployStore.getState().deployAfterTokenSaved(assistantId);
-        }}
-      />
-
-      <ConfirmDialog
-        open={complexDeployApp !== null}
-        title="This app needs a full deploy"
-        message={`"${complexDeployApp?.name ?? ""}" uses backend services that won't work on a static Vercel page. ${assistantName ?? "Your assistant"} can deploy it properly with serverless functions.`}
-        confirmLabel={`Let ${assistantName ?? "your assistant"} handle it`}
-        onConfirm={() => {
-          const appName = useDeployStore.getState().complexDeployApp?.name ?? "this app";
-          useDeployStore.getState().setComplexDeployApp(null);
-          onNewConversation?.(
-            `Deploy my app "${appName}" to Vercel. It uses backend services that need serverless functions — please use the deploy-fullstack-vercel skill to handle it properly.`,
-          );
-        }}
-        onCancel={() => useDeployStore.getState().setComplexDeployApp(null)}
+        assistantName={assistantName}
+        onStartConversation={onNewConversation}
       />
 
       <ConfirmDialog

--- a/apps/web/src/components/deploy-dialogs.tsx
+++ b/apps/web/src/components/deploy-dialogs.tsx
@@ -1,0 +1,61 @@
+/**
+ * Shared deploy/share dialog UI driven by {@link useDeployStore}.
+ *
+ * Renders:
+ * - **VercelTokenDialog** — shown when a deploy requires a Vercel API token
+ * - **ComplexDeployConfirmDialog** — shown when an app uses backend services
+ *   and needs a full-stack deploy via the assistant
+ *
+ * Mount this component wherever deploy actions can be triggered (library page,
+ * chat page, etc.). The dialogs are idempotent — only one instance will be
+ * visible at a time since they're gated by Zustand store booleans.
+ */
+
+import { ConfirmDialog } from "@vellum/design-library";
+import { VercelTokenDialog } from "@/components/vercel-token-dialog";
+import { useDeployStore } from "@/stores/deploy-store";
+
+export interface DeployDialogsProps {
+  assistantId: string;
+  assistantName?: string;
+  onStartConversation?: (initialMessage: string) => void;
+}
+
+export function DeployDialogs({
+  assistantId,
+  assistantName,
+  onStartConversation,
+}: DeployDialogsProps) {
+  const isTokenDialogOpen = useDeployStore.use.isTokenDialogOpen();
+  const complexDeployApp = useDeployStore.use.complexDeployApp();
+
+  return (
+    <>
+      <VercelTokenDialog
+        open={isTokenDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) useDeployStore.getState().hideTokenDialog();
+        }}
+        assistantId={assistantId}
+        onTokenSaved={() => {
+          void useDeployStore.getState().deployAfterTokenSaved(assistantId);
+        }}
+      />
+      <ConfirmDialog
+        open={complexDeployApp !== null}
+        title="This app needs a full deploy"
+        message={`"${complexDeployApp?.name ?? ""}" uses backend services that won't work on a static Vercel page. ${assistantName ?? "Your assistant"} can deploy it properly with serverless functions.`}
+        confirmLabel={`Let ${assistantName ?? "your assistant"} handle it`}
+        onConfirm={() => {
+          const appName =
+            useDeployStore.getState().complexDeployApp?.name ?? "this app";
+          useDeployStore.getState().setComplexDeployApp(null);
+          onStartConversation?.(
+            `Deploy my app "${appName}" to Vercel. It uses backend services that need serverless functions — please use the deploy-fullstack-vercel skill to handle it properly.`,
+          );
+        }}
+        onCancel={() => useDeployStore.getState().setComplexDeployApp(null)}
+      />
+    </>
+  );
+}

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -59,7 +59,7 @@ import { createDraftConversationId } from "@/domains/chat/utils/conversation-sel
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 
-import { Button, ConfirmDialog } from "@vellum/design-library";
+import { Button } from "@vellum/design-library";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useSyncChatStore } from "@/domains/chat/chat-store";
 import { useChatAttachments } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
@@ -110,12 +110,12 @@ const AddCreditsModal = lazy(() =>
     default: m.AddCreditsModal,
   })),
 );
-// Vercel token dialog is only shown when the deploy flow needs a token, and
-// CommandPalette only renders when the user opens it (Cmd+K / Ctrl+K). Defer
+// Deploy dialogs (VercelTokenDialog + complex-deploy confirm) are only shown
+// during the deploy flow. CommandPalette only renders on Cmd+K / Ctrl+K. Defer
 // loading to keep their form/list deps out of the chat-critical bundle.
-const VercelTokenDialog = lazy(() =>
-  import("@/components/vercel-token-dialog").then((m) => ({
-    default: m.VercelTokenDialog,
+const DeployDialogs = lazy(() =>
+  import("@/components/deploy-dialogs").then((m) => ({
+    default: m.DeployDialogs,
   })),
 );
 const CommandPalette = lazy(() =>
@@ -1709,17 +1709,12 @@ export function ChatPage() {
           />
         </LazyBoundary>
       ) : null}
-      {assistantId && isTokenDialogOpen ? (
+      {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>
-          <VercelTokenDialog
-            open={isTokenDialogOpen}
-            onOpenChange={(open) => {
-              if (!open) useDeployStore.getState().hideTokenDialog();
-            }}
+          <DeployDialogs
             assistantId={assistantId}
-            onTokenSaved={() => {
-              void useDeployStore.getState().deployAfterTokenSaved(assistantId);
-            }}
+            assistantName={assistantName ?? undefined}
+            onStartConversation={(msg) => startNewConversation({ initialMessage: msg })}
           />
         </LazyBoundary>
       ) : null}
@@ -1728,20 +1723,6 @@ export function ChatPage() {
         currentTitle={renameRequest?.currentTitle ?? ""}
         onSubmit={submitRenameConversation}
         onCancel={cancelRenameConversation}
-      />
-      <ConfirmDialog
-        open={complexDeployApp !== null}
-        title="This app needs a full deploy"
-        message={`"${complexDeployApp?.name ?? ""}" uses backend services that won't work on a static Vercel page. ${assistantName ?? "Your assistant"} can deploy it properly with serverless functions.`}
-        confirmLabel={`Let ${assistantName ?? "assistant"} handle it`}
-        onConfirm={() => {
-          const appName = useDeployStore.getState().complexDeployApp?.name ?? "this app";
-          useDeployStore.getState().setComplexDeployApp(null);
-          startNewConversation({
-            initialMessage: `Deploy my app "${appName}" to Vercel. It uses backend services that need serverless functions — please use the deploy-fullstack-vercel skill to handle it properly.`,
-          });
-        }}
-        onCancel={() => useDeployStore.getState().setComplexDeployApp(null)}
       />
       {overlayTarget &&
         createPortal(

--- a/apps/web/src/stores/deploy-store.test.ts
+++ b/apps/web/src/stores/deploy-store.test.ts
@@ -15,54 +15,6 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Sharing
-// ---------------------------------------------------------------------------
-
-describe("startSharing", () => {
-  it("sets isSharing to true", () => {
-    getState().startSharing();
-    expect(getState().isSharing).toBe(true);
-  });
-});
-
-describe("finishSharing", () => {
-  it("sets isSharing to false", () => {
-    useDeployStore.setState({ isSharing: true });
-    getState().finishSharing();
-    expect(getState().isSharing).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Deploying
-// ---------------------------------------------------------------------------
-
-describe("startDeploying", () => {
-  it("sets isDeploying to true", () => {
-    getState().startDeploying();
-    expect(getState().isDeploying).toBe(true);
-  });
-});
-
-describe("finishDeploying", () => {
-  it("sets isDeploying to false and keeps pendingDeployAppId by default", () => {
-    useDeployStore.setState({ isDeploying: true, pendingDeployAppId: "app-1" });
-    getState().finishDeploying();
-    const state = getState();
-    expect(state.isDeploying).toBe(false);
-    expect(state.pendingDeployAppId).toBe("app-1");
-  });
-
-  it("clears pendingDeployAppId when clearPendingAppId is true", () => {
-    useDeployStore.setState({ isDeploying: true, pendingDeployAppId: "app-1" });
-    getState().finishDeploying(true);
-    const state = getState();
-    expect(state.isDeploying).toBe(false);
-    expect(state.pendingDeployAppId).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Token dialog
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/stores/deploy-store.ts
+++ b/apps/web/src/stores/deploy-store.ts
@@ -44,11 +44,7 @@ export interface DeployState {
 }
 
 export interface DeployActions {
-  startSharing: () => void;
-  finishSharing: () => void;
   shareApp: (assistantId: string, appId: string, appName: string) => Promise<void>;
-  startDeploying: () => void;
-  finishDeploying: (clearPendingAppId?: boolean) => void;
   deployApp: (assistantId: string, appId: string, appName: string, appHtml: string) => Promise<void>;
   deployAfterTokenSaved: (assistantId: string) => Promise<void>;
   showTokenDialog: (pendingAppId: string) => void;
@@ -96,14 +92,6 @@ const INITIAL_STATE: DeployState = {
 const useDeployStoreBase = create<DeployStore>()((set, get) => ({
   ...INITIAL_STATE,
 
-  startSharing: () => {
-    set({ isSharing: true });
-  },
-
-  finishSharing: () => {
-    set({ isSharing: false });
-  },
-
   shareApp: async (assistantId, appId, appName) => {
     if (get().isSharing) return;
     set({ isSharing: true });
@@ -117,17 +105,6 @@ const useDeployStoreBase = create<DeployStore>()((set, get) => ({
     } finally {
       set({ isSharing: false });
     }
-  },
-
-  startDeploying: () => {
-    set({ isDeploying: true });
-  },
-
-  finishDeploying: (clearPendingAppId) => {
-    set({
-      isDeploying: false,
-      ...(clearPendingAppId ? { pendingDeployAppId: null } : {}),
-    });
   },
 
   deployApp: async (assistantId, appId, appName, appHtml) => {


### PR DESCRIPTION
## Prompt / plan

Eliminate duplicated deploy/share dialog rendering and inconsistent share logic across `library-view.tsx` and `chat-page.tsx`. [LUM-2006](https://linear.app/vellum/issue/LUM-2006/dry-deployshare-dialogs-and-unify-share-logic-in-library-view)

### Why needed

1. **Duplicated dialog rendering** — `VercelTokenDialog` and the complex-deploy `ConfirmDialog` were rendered identically in both `library-view.tsx` and `chat-page.tsx` (same store state, same callbacks, same UI). Both are driven entirely by Zustand store booleans (`isTokenDialogOpen`, `complexDeployApp`), so they should be rendered from a shared component.

2. **Duplicated share logic** — `library-view.tsx` had its own `handleShareOpenedApp` with local `useState(false)` + try/catch + toast, duplicating what `deploy-store.shareApp()` already does. `chat-page.tsx` correctly delegates to the store.

3. **Inconsistent state source** — `library-view.tsx` used local `isSharing` state while `chat-page.tsx` used `useDeployStore.use.isSharing()` for the same operation.

4. **Leaked internals** — `startSharing`/`finishSharing`/`startDeploying`/`finishDeploying` were part of the public `DeployActions` interface but never called by any consumer — they're internal state transitions used only within `shareApp`/`deployApp`.

### What changed

- **New `src/components/deploy-dialogs.tsx`** — shared component rendering `VercelTokenDialog` + complex-deploy `ConfirmDialog`, driven by deploy-store state. Accepts `assistantId`, `assistantName`, and `onStartConversation` callback.
- **`library-view.tsx`** — removed local `isSharing` state, removed `handleShareOpenedApp` try/catch/toast logic (now calls `useDeployStore.getState().shareApp()`), replaced two dialog blocks with `<DeployDialogs>`.
- **`chat-page.tsx`** — replaced inline `VercelTokenDialog` + `ConfirmDialog` with lazy-loaded `<DeployDialogs>` (preserves code-splitting). Removed unused `ConfirmDialog` import.
- **`deploy-store.ts`** — removed `startSharing`/`finishSharing`/`startDeploying`/`finishDeploying` from `DeployActions` interface (internal implementation only).
- **`deploy-store.test.ts`** — removed tests for deleted public actions.

### Benefits

- **DRY** — dialog rendering logic exists once instead of twice
- **Consistency** — share state always comes from the store
- **Smaller public API** — deploy-store only exposes meaningful actions
- **Code splitting preserved** — chat-page lazy-loads DeployDialogs

### Safety

- Zero behavioral changes — same dialogs, same callbacks, same store state
- Typecheck passes (only pre-existing `@vellumai/assistant-api` errors remain)
- All deploy-store tests pass
- Lint clean

### References

- [Zustand docs — atomic selectors](https://zustand.docs.pmnd.rs/)
- [React.lazy — code splitting](https://react.dev/reference/react/lazy)
- `docs/STATE_MANAGEMENT.md` — shared cross-domain state in Zustand stores

## Test plan

- `bunx tsc --noEmit` — no new type errors (10 pre-existing from `@vellumai/assistant-api` on main)
- `bun run lint` — clean
- `bun test src/stores/deploy-store.test.ts` — 5/5 pass
- CI will exercise full build + test suite

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka