### PR TITLE
feat(web/voice): add LiveVoiceOverlay live transcript and status surface

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for `LiveVoiceOverlay`.
+ *
+ * Verifies the overlay's lifecycle contract:
+ *   - Renders `null` when state is `off` (no DOM presence).
+ *   - Renders a non-empty status label for every other state.
+ *   - Renders the error message in the `failed` state.
+ *   - Re-renders partial / final / assistant transcript text when the
+ *     store mutates.
+ *
+ * Uses `@testing-library/react` against happy-dom (registered via
+ * `apps/web/test-setup.ts`). The store is mutated via `act()` so React
+ * flushes the resulting re-render before assertions.
+ */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { LiveVoiceOverlay } from "@/domains/voice/live-voice/live-voice-overlay";
+import {
+  type LiveVoiceState,
+  useLiveVoiceStore,
+} from "@/domains/voice/live-voice/live-voice-store";
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+});
+
+describe("LiveVoiceOverlay", () => {
+  test("renders null when state is off", () => {
+    const { container } = render(<LiveVoiceOverlay />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders a status label for each non-off state", () => {
+    const cases: ReadonlyArray<{ state: LiveVoiceState; label: string }> = [
+      { state: "connecting", label: "Connecting…" },
+      { state: "listening", label: "Listening…" },
+      { state: "transcribing", label: "Listening…" },
+      { state: "thinking", label: "Thinking…" },
+      { state: "speaking", label: "Speaking…" },
+      { state: "ending", label: "Ending…" },
+      { state: "failed", label: "Connection failed" },
+    ];
+
+    for (const { state, label } of cases) {
+      act(() => {
+        useLiveVoiceStore.getState().setState(state);
+      });
+
+      const { unmount } = render(<LiveVoiceOverlay />);
+      const status = screen.getByRole("status");
+      expect(status.textContent ?? "").toContain(label);
+      unmount();
+
+      act(() => {
+        useLiveVoiceStore.getState().reset();
+      });
+    }
+  });
+
+  test("renders the error message when state is failed", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("failed");
+      useLiveVoiceStore.getState().setError("mic permission denied");
+    });
+
+    render(<LiveVoiceOverlay />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("mic permission denied");
+  });
+
+  test("does not render the error region in non-failed states", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+      // Even if an old error message is hanging around in the store, a
+      // non-failed state must not surface it — error display is gated
+      // on state, not on the presence of an errorMessage.
+      useLiveVoiceStore.getState().setError("stale error");
+    });
+
+    render(<LiveVoiceOverlay />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("re-renders partial, final, and assistant transcripts when the store updates", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    render(<LiveVoiceOverlay />);
+
+    act(() => {
+      useLiveVoiceStore.getState().setFinalTranscript("hello");
+    });
+    expect(screen.getByRole("status").textContent).toContain("hello");
+
+    act(() => {
+      useLiveVoiceStore.getState().setPartialTranscript("world");
+    });
+    expect(screen.getByRole("status").textContent).toContain("hello");
+    expect(screen.getByRole("status").textContent).toContain("world");
+
+    act(() => {
+      useLiveVoiceStore.getState().appendAssistantTranscript("sure thing");
+    });
+    expect(screen.getByRole("status").textContent).toContain("sure thing");
+  });
+
+  test("amplitude bar width tracks the input amplitude (clamped to [0, 1])", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+      useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    });
+
+    const { container } = render(<LiveVoiceOverlay />);
+    const fill = container.querySelector(
+      '[data-slot="live-voice-overlay-amplitude-fill"]',
+    ) as HTMLElement | null;
+    expect(fill).not.toBeNull();
+    expect(fill?.style.width).toBe("42%");
+
+    // Out-of-range values must clamp rather than overflow the bar.
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(2);
+    });
+    expect(fill?.style.width).toBe("100%");
+
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(-1);
+    });
+    expect(fill?.style.width).toBe("0%");
+  });
+
+  test("forwards className overrides onto the overlay root", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    const { container } = render(<LiveVoiceOverlay className="custom-layout" />);
+    const root = container.querySelector(
+      '[data-slot="live-voice-overlay"]',
+    ) as HTMLElement | null;
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain("custom-layout");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
@@ -134,6 +134,21 @@ describe("LiveVoiceOverlay", () => {
     expect(fill?.style.width).toBe("0%");
   });
 
+  test("root does not disable pointer events so scrollable transcripts work", () => {
+    // Regression: previously the root applied `pointer-events-none`, which is
+    // inherited and made the overflow-y-auto transcript regions unscrollable.
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    const { container } = render(<LiveVoiceOverlay />);
+    const root = container.querySelector(
+      '[data-slot="live-voice-overlay"]',
+    ) as HTMLElement | null;
+    expect(root).not.toBeNull();
+    expect(root?.className).not.toContain("pointer-events-none");
+  });
+
   test("forwards className overrides onto the overlay root", () => {
     act(() => {
       useLiveVoiceStore.getState().setState("listening");

--- a/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
@@ -1,0 +1,130 @@
+/**
+ * Live transcript and status surface for the live voice mode.
+ *
+ * Renders an absolute-positioned overlay above the composer while a
+ * live voice session is in progress. Mirrors the macOS
+ * `VoiceTranscriptionWindow` / `VoiceModeManager.stateLabel` surface
+ * (`clients/macos/.../Features/Voice/VoiceTranscriptionWindow.swift`)
+ * so the web and native clients show the same status, amplitude, and
+ * transcript hierarchy during a live session.
+ *
+ * State is read from `useLiveVoiceStore` via atomic per-field selectors
+ * so unrelated mutations (e.g. amplitude updates flowing at audio rate)
+ * don't re-render the entire overlay.
+ *
+ * Returns `null` when the live voice state is `off`.
+ *
+ * @see https://zustand.docs.pmnd.rs/guides/auto-generating-selectors
+ */
+
+import { cn } from "@vellum/design-library";
+
+import {
+  type LiveVoiceState,
+  useLiveVoiceStore,
+} from "@/domains/voice/live-voice/live-voice-store";
+
+/**
+ * User-facing label for each live voice lifecycle state. Mirrors the
+ * macOS `VoiceModeManager.stateLabel` switch. `off` is present so the
+ * lookup is total — callers gate rendering by checking `state === "off"`
+ * before selecting a label.
+ */
+const STATE_LABELS: Record<LiveVoiceState, string> = {
+  off: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Listening…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "Connection failed",
+};
+
+interface LiveVoiceOverlayProps {
+  className?: string;
+}
+
+export function LiveVoiceOverlay({ className }: LiveVoiceOverlayProps) {
+  const state = useLiveVoiceStore.use.state();
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
+  const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  const errorMessage = useLiveVoiceStore.use.errorMessage();
+
+  if (state === "off") return null;
+
+  // Defend against out-of-range amplitudes so the bar can't overflow.
+  const amplitudePct = Math.max(0, Math.min(1, inputAmplitude)) * 100;
+  const isFailed = state === "failed";
+
+  return (
+    <div
+      data-slot="live-voice-overlay"
+      data-state={state}
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "pointer-events-none absolute inset-x-0 bottom-full mb-2 flex flex-col gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-overlay)] p-3 shadow-[var(--shadow-popover)]",
+        className,
+      )}
+    >
+      <div
+        data-slot="live-voice-overlay-status"
+        className="text-body-small-emphasised text-[var(--content-default)]"
+      >
+        {STATE_LABELS[state]}
+      </div>
+
+      <div
+        data-slot="live-voice-overlay-amplitude"
+        className="h-1 w-full overflow-hidden rounded-full bg-[var(--surface-active)]"
+        aria-hidden="true"
+      >
+        <div
+          data-slot="live-voice-overlay-amplitude-fill"
+          className="h-full bg-[var(--primary-base)] transition-[width] duration-75 ease-out"
+          style={{ width: `${amplitudePct}%` }}
+        />
+      </div>
+
+      {(partialTranscript || finalTranscript) && (
+        <div
+          data-slot="live-voice-overlay-transcript"
+          className="max-h-32 overflow-y-auto text-body-medium-default text-[var(--content-default)]"
+        >
+          {finalTranscript && <span>{finalTranscript}</span>}
+          {finalTranscript && partialTranscript ? " " : null}
+          {partialTranscript && (
+            <span
+              data-slot="live-voice-overlay-partial"
+              className="text-[var(--content-secondary)]"
+            >
+              {partialTranscript}
+            </span>
+          )}
+        </div>
+      )}
+
+      {assistantTranscript && (
+        <div
+          data-slot="live-voice-overlay-assistant"
+          className="max-h-32 overflow-y-auto text-body-medium-lighter italic text-[var(--content-tertiary)]"
+        >
+          {assistantTranscript}
+        </div>
+      )}
+
+      {isFailed && errorMessage && (
+        <div
+          data-slot="live-voice-overlay-error"
+          role="alert"
+          className="text-body-small-default text-[var(--system-negative-strong)]"
+        >
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
@@ -66,7 +66,7 @@ export function LiveVoiceOverlay({ className }: LiveVoiceOverlayProps) {
       role="status"
       aria-live="polite"
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-full mb-2 flex flex-col gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-overlay)] p-3 shadow-[var(--shadow-popover)]",
+        "absolute inset-x-0 bottom-full mb-2 flex flex-col gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-overlay)] p-3 shadow-[var(--shadow-popover)]",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Add LiveVoiceOverlay rendering live transcript + status during voice sessions
- State-driven label, amplitude bar, partial/final transcript, assistant streaming text
- Error message in failed state; renders null when off
- Atomic store selectors so unrelated updates don't re-render the overlay

Part of plan: realtime-voice-web.md (PR 8 of 9)