### PR TITLE
feat(web/voice): add LiveVoiceButton composer affordance behind voice-mode flag

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Tests for `LiveVoiceButton`.
+ *
+ * Exercises the render gating (feature flag + assistant id) and the
+ * state → method-call mapping. We inject a stub `managerFactory` so the
+ * real `LiveVoiceChannelManager` (and its WebSocket / mic / playback
+ * collaborators) never gets constructed in the test runner.
+ *
+ * The Zustand stores (`useAssistantFeatureFlagStore`, `useLiveVoiceStore`)
+ * are imported as-is so we can drive them with `.setState()` — they're
+ * module-scoped singletons but each test resets them in `beforeEach`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { LiveVoiceButtonManager } from "@/domains/voice/live-voice/live-voice-button";
+import { LiveVoiceButton } from "@/domains/voice/live-voice/live-voice-button";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/**
+ * Records every call the button forwards to the manager so each test
+ * can assert on (a) which method ran and (b) what payload it received.
+ * Mirrors the fake-collaborator pattern used in
+ * `live-voice-channel-manager.test.ts`.
+ */
+function createStubManager(): LiveVoiceButtonManager & {
+  startCalls: string[];
+  stopListeningCalls: number;
+  interruptCalls: string[];
+  endCalls: number;
+} {
+  const stub = {
+    startCalls: [] as string[],
+    stopListeningCalls: 0,
+    interruptCalls: [] as string[],
+    endCalls: 0,
+    async start(conversationId: string) {
+      stub.startCalls.push(conversationId);
+    },
+    async stopListening() {
+      stub.stopListeningCalls += 1;
+    },
+    async interruptSpeakingAndStartListening(conversationId: string) {
+      stub.interruptCalls.push(conversationId);
+    },
+    async end() {
+      stub.endCalls += 1;
+    },
+  };
+  return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// The Button component renders to a real `<button>` so the test's
+// `fireEvent.click` lands on the right handler — we mock it to a thin
+// shell that forwards the `iconOnly` slot and ARIA attributes. Avoids
+// pulling the design-library barrel (which imports Tailwind / radix
+// modules) into the test process.
+mock.module("@vellum/design-library", () => ({
+  Button: ({
+    iconOnly,
+    onClick,
+    disabled,
+    "aria-label": ariaLabel,
+    "aria-busy": ariaBusy,
+    title,
+  }: {
+    iconOnly?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    "aria-label"?: string;
+    "aria-busy"?: boolean;
+    title?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      aria-busy={ariaBusy}
+      title={title}
+    >
+      {iconOnly}
+    </button>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const CONVERSATION_ID = "conv-123";
+const ASSISTANT_ID = "asst-abc";
+
+beforeEach(() => {
+  // Reset Zustand singletons so each test starts from a clean slate.
+  // `setState` with the full snapshot avoids mutating the action
+  // closures the store holds onto.
+  useLiveVoiceStore.setState({
+    state: "off",
+    sessionId: null,
+    conversationId: null,
+    partialTranscript: "",
+    finalTranscript: "",
+    assistantTranscript: "",
+    inputAmplitude: 0,
+    errorMessage: "",
+  });
+  useAssistantFeatureFlagStore.setState({ voiceMode: true });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoiceButton — render gating", () => {
+  test("(a) returns null when the voice-mode flag is off", () => {
+    useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("(b) returns null when assistantId is null", () => {
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={null}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("(f) returns null even when assistantId is set if the flag is off", () => {
+    // The flag check must short-circuit before the assistantId check —
+    // a user without the flag should never see the button regardless of
+    // which assistant they're on.
+    useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("LiveVoiceButton — state → click handler", () => {
+  test("(c) clicking the idle button calls manager.start(conversationId)", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    fireEvent.click(getByRole("button"));
+    expect(stub.startCalls).toEqual([CONVERSATION_ID]);
+    expect(stub.stopListeningCalls).toBe(0);
+    expect(stub.interruptCalls).toEqual([]);
+  });
+
+  test("(d) in `speaking` state, click calls interruptSpeakingAndStartListening", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    // Drive the store into `speaking` — the component subscribes via
+    // `useLiveVoiceStore.use.state()` so this triggers a re-render and
+    // re-binds the click handler to `interruptSpeakingAndStartListening`.
+    // Wrap in `act()` because the Zustand subscription schedules a React
+    // state update inside the component.
+    act(() => {
+      useLiveVoiceStore.setState({ state: "speaking" });
+    });
+    fireEvent.click(getByRole("button"));
+    expect(stub.interruptCalls).toEqual([CONVERSATION_ID]);
+    expect(stub.startCalls).toEqual([]);
+  });
+
+  test("in `listening` state, click calls stopListening", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    act(() => {
+      useLiveVoiceStore.setState({ state: "listening" });
+    });
+    fireEvent.click(getByRole("button"));
+    expect(stub.stopListeningCalls).toBe(1);
+    expect(stub.startCalls).toEqual([]);
+  });
+
+  test("in `failed` state, click ends the session then starts a fresh one", async () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    act(() => {
+      useLiveVoiceStore.setState({
+        state: "failed",
+        errorMessage: "connection lost",
+      });
+    });
+    fireEvent.click(getByRole("button"));
+    // Failed retry chains `end()` before `start()` so the next call
+    // has a clean manager — yield to microtasks twice (one for the
+    // awaited `end()`, one for the awaited `start()`) before asserting.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(stub.endCalls).toBeGreaterThanOrEqual(1);
+    expect(stub.startCalls).toEqual([CONVERSATION_ID]);
+  });
+});
+
+describe("LiveVoiceButton — lifecycle", () => {
+  test("(e) unmounting calls manager.end()", () => {
+    const stub = createStubManager();
+    const { unmount } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+    unmount();
+    expect(stub.endCalls).toBe(1);
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
@@ -273,4 +273,49 @@ describe("LiveVoiceButton — lifecycle", () => {
     unmount();
     expect(stub.endCalls).toBe(1);
   });
+
+  test("flipping the voice-mode flag off mid-session ends the manager", () => {
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
+
+  test("dropping assistantId mid-session ends the manager", () => {
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={null}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
 });

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -95,6 +95,18 @@ export function LiveVoiceButton({
     };
   }, []);
 
+  // If the gate closes mid-session (flag flips off, assistant switches
+  // and assistantId goes null), the button stops rendering — but the
+  // underlying manager would silently keep the WebSocket and mic open
+  // with no visible control to stop it. Tear it down on every gate
+  // transition to closed so the session ends with the affordance.
+  const gateOpen = voiceModeEnabled && assistantId !== null;
+  useEffect(() => {
+    if (!gateOpen) {
+      void managerRef.current?.end();
+    }
+  }, [gateOpen]);
+
   if (!voiceModeEnabled || !assistantId) return null;
 
   const manager = managerRef.current;

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -1,0 +1,179 @@
+/**
+ * LiveVoiceButton — composer affordance that drives a live voice
+ * conversation backed by `LiveVoiceChannelManager`.
+ *
+ * Renders alongside the existing `VoiceInputButton` (batch dictation):
+ * both are siblings in the chat composer's icon row so users on the
+ * `voice-mode` feature flag get the always-on live channel in addition
+ * to push-to-talk dictation.
+ *
+ * The button is a thin React shell around a per-mount
+ * `LiveVoiceChannelManager` instance. The manager owns the WebSocket,
+ * mic capture, and PCM playback — this component just maps the current
+ * `useLiveVoiceStore` state to the right icon + click handler and
+ * forwards user intent to the manager. State is mirrored from the
+ * `LiveVoiceChannelManager.State` enum in
+ * `clients/macos/.../Features/Voice/VoiceModeManager.swift` so the web
+ * and macOS surfaces stay in lockstep.
+ *
+ * The render is gated on the `voice-mode` assistant feature flag (auto
+ * derived from the `voice-mode` registry entry) AND a non-null
+ * `assistantId`. Either falsy short-circuits to `null`.
+ */
+
+import { Loader2, Mic, Phone } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+import { Button } from "@vellum/design-library";
+
+import { LiveVoiceChannelManager } from "@/domains/voice/live-voice/live-voice-channel-manager";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `LiveVoiceChannelManager` the button drives. Pulled out so
+ * tests can inject a stub without instantiating the real manager (which
+ * would touch the WebSocket, mic, and Web Audio APIs at construction
+ * time via its default factories).
+ */
+export interface LiveVoiceButtonManager {
+  start(conversationId: string): Promise<void>;
+  stopListening(): Promise<void>;
+  interruptSpeakingAndStartListening(conversationId: string): Promise<void>;
+  end(): Promise<void>;
+}
+
+export interface LiveVoiceButtonProps {
+  assistantId: string | null;
+  conversationId: string | null;
+  disabled?: boolean;
+  /**
+   * Optional factory for the per-mount manager — defaults to a real
+   * `LiveVoiceChannelManager`. Tests inject a stub here so they can
+   * assert on the method calls without spinning up the WebSocket /
+   * mic / playback stack the real manager wires up on construction.
+   */
+  managerFactory?: () => LiveVoiceButtonManager;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LiveVoiceButton({
+  assistantId,
+  conversationId,
+  disabled = false,
+  managerFactory,
+}: LiveVoiceButtonProps) {
+  const voiceModeEnabled = useAssistantFeatureFlagStore.use.voiceMode();
+  const state = useLiveVoiceStore.use.state();
+  const errorMessage = useLiveVoiceStore.use.errorMessage();
+
+  // `useRef` (not `useState`) so React strict-mode's double-invoke of
+  // render doesn't build two managers and leak the first one's
+  // WebSocket / mic handles.
+  const managerRef = useRef<LiveVoiceButtonManager | null>(null);
+  if (managerRef.current === null) {
+    managerRef.current = managerFactory
+      ? managerFactory()
+      : new LiveVoiceChannelManager();
+  }
+
+  // Fire-and-forget: React's cleanup is sync, the manager's `end()` is
+  // async. Dropping the promise is safe — the component has already
+  // left the tree, so there's nothing to surface failures to.
+  useEffect(() => {
+    const manager = managerRef.current;
+    return () => {
+      void manager?.end();
+    };
+  }, []);
+
+  if (!voiceModeEnabled || !assistantId) return null;
+
+  const manager = managerRef.current;
+
+  // Map the live-voice state machine to (icon, click handler, label).
+  // Mirrors `VoiceModeManager.stateLabel` in the macOS client so the
+  // two surfaces share a vocabulary.
+  let icon: ReactNode;
+  let label: string;
+  let onClick: () => void;
+  let isBusy = false;
+  let isFailed = false;
+
+  switch (state) {
+    case "off":
+    case "ending":
+      icon = <Phone strokeWidth={2} />;
+      label = "Start voice conversation";
+      onClick = () => {
+        if (conversationId) {
+          void manager?.start(conversationId);
+        }
+      };
+      break;
+    case "connecting":
+    case "listening":
+    case "transcribing":
+      icon = <Mic strokeWidth={2} />;
+      label =
+        state === "connecting"
+          ? "Connecting voice conversation"
+          : "Stop voice listening";
+      isBusy = state === "connecting";
+      onClick = () => {
+        void manager?.stopListening();
+      };
+      break;
+    case "thinking":
+    case "speaking":
+      icon = <Loader2 className="animate-spin" strokeWidth={2} />;
+      label = "Interrupt and resume listening";
+      isBusy = true;
+      onClick = () => {
+        if (conversationId) {
+          void manager?.interruptSpeakingAndStartListening(conversationId);
+        }
+      };
+      break;
+    case "failed":
+      icon = <Phone strokeWidth={2} />;
+      label = errorMessage || "Voice conversation failed — tap to retry";
+      isFailed = true;
+      onClick = () => {
+        if (!conversationId) return;
+        // Chain `end → start` so the second call lands after teardown;
+        // the manager builds fresh collaborators on each `start()` so
+        // they don't fight over the failed session's stale WebSocket.
+        void (async () => {
+          await manager?.end();
+          await manager?.start(conversationId);
+        })();
+      };
+      break;
+  }
+
+  return (
+    <Button
+      // `dangerGhost` paints the negative tokens across light/dark/velvet
+      // themes — needed for the failed-state red icon.
+      variant={isFailed ? "dangerGhost" : "ghost"}
+      iconOnly={icon}
+      onClick={onClick}
+      disabled={disabled || !conversationId}
+      aria-label={label}
+      aria-busy={isBusy}
+      title={label}
+      // Match `VoiceInputButton`'s secondary tint so the two composer
+      // icons sit at the same visual weight.
+      className={isFailed ? undefined : "[--vbtn-fg:var(--content-secondary)]"}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add LiveVoiceButton composer affordance backed by LiveVoiceChannelManager
- Gated on voice-mode assistant feature flag + non-null assistantId
- State-driven icon: Phone (off) / Mic (listening) / Loader (thinking/speaking) / red Phone (failed)
- Cleanup on unmount tears down the WebSocket + mic

Part of plan: realtime-voice-web.md (PR 7 of 9)