### PR TITLE
fix(web): remove Home title, fix new-chat routing, add icon tooltips

### DIFF
--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -67,6 +67,7 @@ export function ChatLayoutHeader({
             aria-label="Open navigation"
             aria-expanded={drawerOpen}
             aria-controls="chat-side-menu"
+            tooltip="Open navigation"
             onClick={toggleSidebar}
           />
         ) : (
@@ -76,6 +77,7 @@ export function ChatLayoutHeader({
             aria-label="Toggle sidebar"
             aria-expanded={!collapsed}
             aria-controls="chat-side-menu"
+            tooltip="Toggle sidebar"
             onClick={toggleSidebar}
           />
         )}
@@ -86,6 +88,7 @@ export function ChatLayoutHeader({
               iconOnly={<House />}
               aria-label={hasUnreadHome && !isHomeActive ? "Home (unread notifications)" : "Home"}
               aria-current={isHomeActive ? "page" : undefined}
+              tooltip="Home"
               onClick={onOpenHome}
             />
             {hasUnreadHome && !isHomeActive ? (

--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -63,6 +63,7 @@ export function HomeDetailPanel({
             iconOnly={<ArrowLeft />}
             onClick={onClose}
             aria-label="Back"
+            tooltip="Back"
           />
 
           <Typography
@@ -79,6 +80,7 @@ export function HomeDetailPanel({
               onUpdateStatus(item.id, isUnread ? "seen" : "new")
             }
             aria-label={isUnread ? "Mark as read" : "Mark as unread"}
+            tooltip={isUnread ? "Mark as read" : "Mark as unread"}
           />
           {isDismissed ? (
             <Button
@@ -86,6 +88,7 @@ export function HomeDetailPanel({
               iconOnly={<RotateCcw />}
               onClick={() => onUpdateStatus(item.id, "seen")}
               aria-label="Restore"
+              tooltip="Restore"
             />
           ) : (
             <Button
@@ -93,6 +96,7 @@ export function HomeDetailPanel({
               iconOnly={<Trash2 />}
               onClick={() => onDismiss(item.id)}
               aria-label="Dismiss"
+              tooltip="Dismiss"
             />
           )}
         </div>
@@ -195,6 +199,7 @@ export function HomeDetailPanel({
               size="compact"
               iconOnly={<MoreVertical />}
               aria-label="More actions"
+              tooltip="More actions"
             />
           </Menu.Trigger>
           <Menu.Content align="end">
@@ -238,6 +243,7 @@ export function HomeDetailPanel({
           iconOnly={<X />}
           onClick={onClose}
           aria-label="Close detail panel"
+          tooltip="Close"
         />
       </div>
 

--- a/apps/web/src/domains/home/home-greeting-header.tsx
+++ b/apps/web/src/domains/home/home-greeting-header.tsx
@@ -53,6 +53,7 @@ export function HomeGreetingHeader({
           iconOnly={<SquarePen />}
           onClick={onStartNewChat}
           aria-label="New Chat"
+          tooltip="New Chat"
           className="!rounded-full"
         />
       ) : (

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router";
 
-import { Typography } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate";
-import { useAssistantContext } from "@/components/layout/assistant-context";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationListQuery } from "@/domains/conversations/conversation-queries";
@@ -15,31 +13,21 @@ import { routes } from "@/utils/routes";
 export function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useActiveAssistantContext();
-  const { setTopBarCenter } = useAssistantContext();
   const { conversations } = useConversationListQuery(assistantId);
   const validConversationIds = useMemo(
     () => new Set(conversations.map((c) => c.conversationId)),
     [conversations],
   );
 
-  useEffect(() => {
-    setTopBarCenter(
-      <Typography
-        variant="body-medium-default"
-        className="text-[var(--content-secondary)]"
-      >
-        Home
-      </Typography>,
-    );
-    return () => { setTopBarCenter(null); };
-  }, [setTopBarCenter]);
-
   return (
     <HomePage
       assistantId={assistantId}
       validConversationIds={validConversationIds}
       onStartNewChat={() => {
-        navigate(routes.assistant);
+        useViewerStore.getState().setMainView("chat");
+        const draftConversationId = createDraftConversationId();
+        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        navigate(routes.conversation(draftConversationId));
         requestComposerFocus();
       }}
       onOpenConversation={(conversationId) =>


### PR DESCRIPTION
Fixes three homepage UI issues: removes the redundant "Home" top-bar label, fixes the New Chat button so it opens an empty chat instead of resuming the last conversation, and adds hover tooltips to all icon-only buttons in the header and home page area. All changes apply to both web and iOS (Capacitor).

---

## Root cause analysis

### "Home" text in top bar
`HomePageRoute` set `setTopBarCenter` with a `<Typography>Home</Typography>` element. The greeting header already serves as the page title, making the top-bar text redundant.

### New Chat opens last conversation
`onStartNewChat` navigated to `routes.assistant` (`/assistant`), where `ConversationRedirect` renders `ChatPage` without a URL conversation ID. The `useConversationLoader` bootstrap logic calls `resolveBootstrappedConversationId`, which sees the still-set `activeConversationId` in the Zustand store from the user's last chat session and routes back to it. The fix mirrors the existing `startNewConversation` pattern from `chat-layout.tsx`: create a fresh draft conversation ID, write it to the store, and navigate directly to its conversation route — bypassing the bootstrap "resume last conversation" fallback.

**How did the code get into this state?** When the homepage was ported from the platform repo, `onStartNewChat` was wired to simply navigate to `/assistant`, which works correctly only when no previous conversation state exists in the store. The bootstrap logic in `useConversationLoader` was designed for cold loads and assistant switches — it wasn't designed to handle an explicit "start new chat" intent from within the same session.

**Prevention:** When creating navigation actions that should produce a specific destination state (empty chat, specific conversation), always navigate to an explicit route with a concrete ID rather than relying on bootstrap/fallback logic at the target route.

### Missing tooltips
Icon-only `<Button>` components used `aria-label` for screen readers but lacked the `tooltip` prop (which maps to the native `title` attribute for browser hover text). The Search and Back/Forward buttons already had `title`; the sidebar toggle, Home, New Chat, and detail panel buttons did not.

## Alternatives considered

- **New Chat: Clear `activeConversationId` before navigating to `/assistant`** — Rejected. Fragile because `resolveBootstrappedConversationId` has multiple fallback paths (stored conversation, default conversation) that could still pick a non-empty state.
- **Tooltips via Radix Tooltip component** — Rejected. The design library's `Button` already exposes `tooltip` → `title`; switching to Radix Tooltip would be a design system scope change.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- Pre-commit hooks pass (lint, typecheck, generic-examples)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e8cdc685deed4f3f96db09a3ddd84c8a