### PR TITLE
feat(web/voice): wire LiveVoice button and overlay into chat composer (JARVIS-982)

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -11,10 +11,11 @@
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 
 import type { ChatAttachment } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
 import { INITIAL_TURN_STATE, type TurnState, useTurnStore } from "@/domains/messaging/turn-store";
+import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store";
 
 import { ChatComposer, computeGhostSuffix, shouldSubmitOnEnter } from "@/domains/chat/components/chat-composer/chat-composer";
 
@@ -472,6 +473,63 @@ describe("ChatComposer — optional slots", () => {
     // VoiceInputButton renders aria-label="Start voice input" / "Stop voice input".
     expect(html).not.toContain("Start voice input");
     expect(html).not.toContain("Stop voice input");
+  });
+
+  test("showLiveVoiceOverlay mounts the overlay slot ABOVE the form (off by default)", () => {
+    // Off: the overlay's `data-slot="live-voice-overlay"` is absent.
+    // The overlay itself renders `null` when `state === "off"`, but the
+    // gate around `<LiveVoiceOverlay />` is what we assert here, so we
+    // toggle it via the `showLiveVoiceOverlay` prop.
+    const offHtml = renderComposer({ showLiveVoiceOverlay: false });
+    expect(offHtml).not.toContain('data-slot="live-voice-overlay"');
+    // On: the live voice store's default state is `off`, so the
+    // overlay still renders `null` — but we can assert the surrounding
+    // `relative` wrapper still sits ABOVE the form to keep the
+    // structural contract intact.
+    const onHtml = renderComposer({ showLiveVoiceOverlay: true });
+    const wrapperIdx = onHtml.indexOf('class="relative"');
+    const formIdx = onHtml.indexOf("<form");
+    expect(wrapperIdx).toBeGreaterThan(-1);
+    expect(formIdx).toBeGreaterThan(-1);
+    expect(wrapperIdx).toBeLessThan(formIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTML rendering — LiveVoiceButton mount
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer — LiveVoiceButton mount", () => {
+  test("LiveVoiceButton renders in the toolbar when voice-mode flag is on + assistantId is set", () => {
+    // The button gates itself on `voiceMode` + `assistantId`. With the flag
+    // off (default), it short-circuits to null. Flip the flag on and assert
+    // the button surface lands in the rendered HTML. `act` wraps the
+    // store mutation so React's gate-close `useEffect` (which fires the
+    // manager `end()` cleanup) flushes inside the test boundary.
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: true });
+    });
+    const html = renderComposer({
+      assistantId: "asst_test",
+      conversationId: "conv_test",
+    });
+    // LiveVoiceButton uses aria-label "Start voice conversation" in the
+    // initial `off` state — that's the unambiguous signal it mounted.
+    expect(html).toContain("Start voice conversation");
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+  });
+
+  test("LiveVoiceButton is omitted when voice-mode flag is off (gate closed)", () => {
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+    const html = renderComposer({
+      assistantId: "asst_test",
+      conversationId: "conv_test",
+    });
+    expect(html).not.toContain("Start voice conversation");
   });
 });
 

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -23,6 +23,8 @@ import {
   VoiceInputButton,
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
+import { LiveVoiceButton } from "@/domains/voice/live-voice/live-voice-button";
+import { LiveVoiceOverlay } from "@/domains/voice/live-voice/live-voice-overlay";
 import { type TurnPhase, useTurnStore } from "@/domains/messaging/turn-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -194,6 +196,30 @@ export interface ChatComposerProps {
   assistantId: string | null;
 
   /**
+   * Active conversation id. Required for `LiveVoiceButton` to bind the
+   * live voice session to a specific chat; the button reads its own
+   * gating (voice-mode flag + assistantId) internally, so passing
+   * `null`/`undefined` simply disables the button.
+   */
+  conversationId?: string | null;
+
+  /**
+   * Mounts `<LiveVoiceOverlay />` above the composer form when `true`.
+   * The form is wrapped in a `relative` container so the overlay's
+   * `absolute bottom-full` anchors directly above the composer rather
+   * than the surrounding page. The main chat sets this to `true`; the
+   * app-editing variant leaves it `false` so the overlay doesn't bleed
+   * into the chat-on-the-side surface.
+   *
+   * Defined here (not in `chat-route-content.tsx`) because the chat
+   * domain isn't permitted to import from `domains/voice` — the
+   * composer already owns voice-domain wiring (live + dictation), so
+   * rendering the overlay alongside the button keeps the cross-domain
+   * import contained.
+   */
+  showLiveVoiceOverlay?: boolean;
+
+  /**
    * Whether the currently-active inference model accepts image input.
    * When `false`, the AttachFileButton is disabled so users can't pick a
    * file that the provider would reject downstream (MiniMax, Fireworks
@@ -247,6 +273,8 @@ export function ChatComposer({
   onVoiceBeforeStart,
   onStopGenerating,
   assistantId,
+  conversationId,
+  showLiveVoiceOverlay = false,
   thresholdPickerSlot,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
@@ -356,10 +384,17 @@ export function ChatComposer({
       {noticesAboveFormSlot}
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
-          <form
-            onSubmit={onSubmit}
-            className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
-          >
+          {/* `relative` wrapper anchors the live voice overlay's
+              `absolute bottom-full` directly above the composer form —
+              since the overlay is out of flow, the wrapper's content
+              height collapses to the form's height, so `bottom: 100%`
+              of the wrapper sits flush against the top of the form. */}
+          <div className="relative">
+            {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+            <form
+              onSubmit={onSubmit}
+              className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
+            >
             <ChatAttachmentsStrip
               attachments={chatAttachments}
               onRemove={onRemoveAttachment}
@@ -630,6 +665,16 @@ export function ChatComposer({
                         }}
                       />
                     )}
+                    {/* Live voice (always-on) sits next to the batch
+                    dictation button. The button gates itself internally
+                    on the `voice-mode` flag + `assistantId`, so it's
+                    cheap to render unconditionally — it short-circuits
+                    to `null` when either is falsy. */}
+                    <LiveVoiceButton
+                      assistantId={assistantId}
+                      conversationId={conversationId ?? null}
+                      disabled={typingDisabled}
+                    />
                     {/* macOS parity: the send button is hidden during recording
                     and while transcription is being processed. Only the voice
                     button (mic / stop / spinner) is shown. */}
@@ -659,7 +704,8 @@ export function ChatComposer({
                 )}
               </div>
             </div>
-          </form>
+            </form>
+          </div>
         </Popover.Anchor>
         <Popover.Content
           side="top"

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1278,6 +1278,7 @@ export function ChatRouteContent({
     onVoiceBeforeStart: handleVoiceBeforeStart,
     onStopGenerating: handleStopGenerating,
     assistantId,
+    conversationId: activeConversationId,
     modelSupportsVision: activeModelSupportsVision,
     textareaMaxHeightPx: isEmptyConversation ? 320 : undefined,
     thresholdPickerSlot: assistantId ? (
@@ -1457,7 +1458,11 @@ export function ChatRouteContent({
     );
   }
 
-  // Default: main chat content (with optional document panel)
+  // Default: main chat content (with optional document panel).
+  // `showLiveVoiceOverlay: true` mounts `<LiveVoiceOverlay />` above
+  // the composer — only on the main chat. The app-editing side panel
+  // omits it so the overlay doesn't bleed into the chat-on-the-side
+  // experience.
   const chatContent = (
     <ChatBody
       variant="main"
@@ -1465,7 +1470,10 @@ export function ChatRouteContent({
         ...chatBodyScrollAreaPropsBase,
         showMaintenanceRecoveryCard: isInMaintenanceWithNoMessages,
       }}
-      composerProps={chatBodyComposerProps}
+      composerProps={{
+        ...chatBodyComposerProps,
+        showLiveVoiceOverlay: true,
+      }}
       dragHandlers={attachmentDropHandlers}
       isAttachmentDragOver={isAttachmentDragOver}
       isKeyboardOpen={isKeyboardOpen}


### PR DESCRIPTION
## Summary
- Mount LiveVoiceButton in the composer toolbar (gated internally on voice-mode flag + assistantId)
- Mount LiveVoiceOverlay above the composer to surface live transcript + status during sessions
- Plumb conversationId through ChatComposerProps so the live voice session can be tied to the active chat

## Manual verification (run before merging the feature branch into main)
- Toggle the voice-mode flag on in Developer panel; confirm the new phone button appears in the composer.
- Click it -> mic permission, WebSocket opens to /v1/live-voice, overlay shows Listening...
- Speak; verify partial -> final transcript, then Thinking... -> Speaking... with TTS playback.
- Click during Speaking; verify playback stops within ~100 ms.
- Close the chat tab; verify the WebSocket closes (no orphan in DevTools Network).

Part of plan: realtime-voice-web.md (PR 9 of 9 - final)
Closes JARVIS-982