### PR TITLE
refactor(routes): DRY up metadata construction + route slash commands through persistQueuedMessageBody

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -153,6 +153,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   setConversationHistoryStrippedAt: mock(() => {}),
   wipeConversation: mock(() => ({ memoryIds: [] })),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  extractImageSourcePaths: () => undefined,
 }));
 
 mock.module("../memory/conversation-title-service.js", () => ({

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -82,6 +82,7 @@ const addMessageMock = mock(
     _metadata?: Record<string, unknown>,
   ) => ({
     id: role === "user" ? "persisted-user-id" : "persisted-assistant-id",
+    deduplicated: false,
   }),
 );
 
@@ -131,6 +132,8 @@ mock.module("../memory/conversation-crud.js", () => ({
     content: string,
     metadata?: Record<string, unknown>,
   ) => addMessageMock(conversationId, role, content, metadata),
+  extractImageSourcePaths: () => undefined,
+  getConversation: () => null,
   getConversationOverrideProfile: () => "short-context",
   getMessages: () => [],
   provenanceFromTrustContext: (ctx: unknown) =>
@@ -140,6 +143,20 @@ mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+  updateMetaFile: () => {},
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  getAttachmentsByIds: () => [],
+  getSourcePathsForAttachments: () => new Map(),
+  attachmentExists: () => false,
+  linkAttachmentToMessage: () => {},
+  attachInlineAttachmentToMessage: () => {},
+  validateAttachmentUpload: () => ({ ok: true }),
 }));
 
 mock.module("../daemon/conversation-process.js", () => ({
@@ -239,12 +256,20 @@ function makeConversation() {
   const events: unknown[] = [];
   const messages: unknown[] = [];
   const conversation = {
+    conversationId: "conv-slash-test",
+    messages,
+    processing: false,
+    abortController: null,
+    currentRequestId: undefined,
+    queue: { length: 0 },
     setTrustContext: () => {},
     updateClient: (_fn: unknown, _b: boolean) => {},
     emitConfirmationStateChanged: () => {},
     emitActivityState: () => {},
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
     ensureActorScopedHistory: async () => {},
     isProcessing: () => false,
     hasAnyPendingConfirmation: () => false,

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -26,6 +26,7 @@ import {
 } from "../memory/attachments-store.js";
 import {
   addMessage,
+  extractImageSourcePaths,
   getConversation,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
@@ -440,13 +441,7 @@ export async function persistQueuedMessageBody(
     const turnIfCtx =
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
-    const imageSourcePaths: Record<string, string> = {};
-    for (let i = 0; i < attachments.length; i++) {
-      const a = attachments[i];
-      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
-      }
-    }
+    const imageSourcePaths = extractImageSourcePaths(attachments);
 
     // Strip the transient `slackInbound` carrier key from the persisted
     // metadata — it's an in-memory plumbing field, not a stored column value.
@@ -477,7 +472,7 @@ export async function persistQueuedMessageBody(
             assistantMessageInterface: turnIfCtx.assistantMessageInterface,
           }
         : {}),
-      ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
+      ...(imageSourcePaths ? { imageSourcePaths } : {}),
       ...(slackMeta ? { slackMeta } : {}),
     };
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -184,6 +184,24 @@ export function provenanceFromTrustContext(
   };
 }
 
+/** Extract image file paths from resolved attachments for message metadata. */
+export function extractImageSourcePaths(
+  attachments: ReadonlyArray<{
+    filename: string;
+    mimeType: string;
+    filePath?: string;
+  }>,
+): Record<string, string> | undefined {
+  const paths: Record<string, string> = {};
+  for (let i = 0; i < attachments.length; i++) {
+    const a = attachments[i];
+    if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+      paths[`${i}:${a.filename}`] = a.filePath;
+    }
+  }
+  return Object.keys(paths).length > 0 ? paths : undefined;
+}
+
 export interface ConversationRow {
   id: string;
   title: string | null;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -26,6 +26,7 @@ import {
 } from "../../conversations/message-consolidation.js";
 import { createApprovalConversationGenerator } from "../../daemon/approval-generators.js";
 import type { Conversation } from "../../daemon/conversation.js";
+import { persistQueuedMessageBody } from "../../daemon/conversation-messaging.js";
 import {
   buildModelInfoEvent,
   formatCleanResult,
@@ -83,8 +84,6 @@ import {
   type MessageRow,
   provenanceFromTrustContext,
   setConversationInferenceProfile,
-  setConversationOriginChannelIfUnset,
-  setConversationOriginInterfaceIfUnset,
 } from "../../memory/conversation-crud.js";
 import {
   getConversationByKey,
@@ -1413,28 +1412,25 @@ export async function handleSendMessage(
       const attachments = hasAttachments
         ? smDeps.resolveAttachments(attachmentIds)
         : [];
-      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
-        trustContext: conversation.trustContext,
-      });
-      const userMsg = createUserMessage(rawContent, attachments);
-      const persisted = await addMessage(
-        mapping.conversationId,
-        "user",
-        JSON.stringify(userMsg.content),
-        channelMeta,
-      );
-      conversation.getMessages().push(userMsg);
-
-      setConversationOriginChannelIfUnset(
-        mapping.conversationId,
-        sourceChannel,
-      );
-      setConversationOriginInterfaceIfUnset(
-        mapping.conversationId,
-        sourceInterface,
+      const greetingMeta = {
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      };
+      const persisted = await persistQueuedMessageBody(
+        conversation,
+        rawContent,
+        attachments,
+        crypto.randomUUID(),
+        greetingMeta,
+        undefined,
       );
 
       const conversationId = mapping.conversationId;
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+      });
 
       const assistantMsg = createAssistantMessage(cannedGreeting);
       const persistedAssistant = await addMessage(
@@ -1723,18 +1719,19 @@ export async function handleSendMessage(
     conversation.processing = true;
     let cleanupDeferred = false;
     try {
-      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
-        trustContext: conversation.trustContext,
-        automated: body.automated === true,
+      const slashMeta = {
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+        ...(body.automated === true ? { automated: true } : {}),
+      };
+      const persisted = await persistQueuedMessageBody(
+        conversation,
+        rawContent,
         attachments,
-      });
-      const cleanMsg = createUserMessage(rawContent, attachments);
-      const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
-      const persisted = await addMessage(
-        mapping.conversationId,
-        "user",
-        JSON.stringify(cleanMsg.content),
-        channelMeta,
+        crypto.randomUUID(),
+        slashMeta,
         undefined,
         clientMessageId,
       );
@@ -1745,8 +1742,10 @@ export async function handleSendMessage(
           conversationId: mapping.conversationId,
         };
       }
-      conversation.getMessages().push(llmMsg);
 
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+      });
       const assistantMsg = createAssistantMessage(slashResult.message);
       const persistedAssistant = await addMessage(
         mapping.conversationId,
@@ -1755,15 +1754,6 @@ export async function handleSendMessage(
         channelMeta,
       );
       conversation.getMessages().push(assistantMsg);
-
-      setConversationOriginChannelIfUnset(
-        mapping.conversationId,
-        sourceChannel,
-      );
-      setConversationOriginInterfaceIfUnset(
-        mapping.conversationId,
-        sourceInterface,
-      );
 
       // Snapshot model info now so the deferred callback cannot observe
       // a config change from a concurrent request.
@@ -1827,17 +1817,20 @@ export async function handleSendMessage(
 
   if (slashResult.kind === "compact") {
     conversation.processing = true;
-    const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
-      trustContext: conversation.trustContext,
-    });
-    const cleanMsg = createUserMessage(rawContent, attachments);
-    let persisted: Awaited<ReturnType<typeof addMessage>>;
+    const slashMeta = {
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+      userMessageInterface: sourceInterface,
+      assistantMessageInterface: sourceInterface,
+    };
+    let persisted: Awaited<ReturnType<typeof persistQueuedMessageBody>>;
     try {
-      persisted = await addMessage(
-        mapping.conversationId,
-        "user",
-        JSON.stringify(cleanMsg.content),
-        channelMeta,
+      persisted = await persistQueuedMessageBody(
+        conversation,
+        rawContent,
+        attachments,
+        crypto.randomUUID(),
+        slashMeta,
         undefined,
         clientMessageId,
       );
@@ -1858,9 +1851,11 @@ export async function handleSendMessage(
         conversationId: mapping.conversationId,
       };
     }
-    conversation.getMessages().push(cleanMsg);
 
     const conversationId = mapping.conversationId;
+    const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+      trustContext: conversation.trustContext,
+    });
 
     // Fire-and-forget: return 202 immediately, run compaction async.
     // forceCompact() makes an LLM call that can exceed the client's
@@ -1943,15 +1938,18 @@ export async function handleSendMessage(
     // initial user-message persist below, which would otherwise leave the
     // conversation stuck in queued mode indefinitely.
     try {
-      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
-        trustContext: conversation.trustContext,
-      });
-      const cleanMsg = createUserMessage(rawContent, attachments);
-      const persisted = await addMessage(
-        mapping.conversationId,
-        "user",
-        JSON.stringify(cleanMsg.content),
-        channelMeta,
+      const slashMeta = {
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      };
+      const persisted = await persistQueuedMessageBody(
+        conversation,
+        rawContent,
+        attachments,
+        crypto.randomUUID(),
+        slashMeta,
         undefined,
         clientMessageId,
       );
@@ -1962,8 +1960,10 @@ export async function handleSendMessage(
           conversationId,
         };
       }
-      conversation.getMessages().push(cleanMsg);
 
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+      });
       let assistantMessagePersisted = false;
       try {
         broadcastMessage({

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -75,6 +75,7 @@ import {
 } from "../../memory/canonical-guardian-store.js";
 import {
   addMessage,
+  extractImageSourcePaths,
   getConversation,
   getMessages,
   getMessagesPaginated,
@@ -395,23 +396,10 @@ async function tryConsumeCanonicalGuardianReply(params: {
   // is not re-processed as a new user turn.
   let messageId: string | undefined;
   try {
-    const guardianImageSourcePaths: Record<string, string> = {};
-    for (let i = 0; i < attachments.length; i++) {
-      const a = attachments[i];
-      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        guardianImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
-      }
-    }
-    const channelMeta = {
-      userMessageChannel: sourceChannel,
-      assistantMessageChannel: sourceChannel,
-      userMessageInterface: sourceInterface,
-      assistantMessageInterface: sourceInterface,
-      provenanceTrustClass: "guardian" as const,
-      ...(Object.keys(guardianImageSourcePaths).length > 0
-        ? { imageSourcePaths: guardianImageSourcePaths }
-        : {}),
-    };
+    const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+      provenanceOverride: { provenanceTrustClass: "guardian" },
+      attachments,
+    });
 
     const cleanUserMessage = createUserMessage(content, attachments);
     const llmUserMessage = enrichMessageWithSourcePaths(
@@ -1421,19 +1409,13 @@ export async function handleSendMessage(
     conversation.processing = true;
     let cleanupDeferred = false;
     try {
-      const provenance = provenanceFromTrustContext(conversation.trustContext);
-      const channelMeta = {
-        ...provenance,
-        userMessageChannel: sourceChannel,
-        assistantMessageChannel: sourceChannel,
-        userMessageInterface: sourceInterface,
-        assistantMessageInterface: sourceInterface,
-      };
-
       const rawContent = content ?? "";
       const attachments = hasAttachments
         ? smDeps.resolveAttachments(attachmentIds)
         : [];
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+      });
       const userMsg = createUserMessage(rawContent, attachments);
       const persisted = await addMessage(
         mapping.conversationId,
@@ -1741,25 +1723,11 @@ export async function handleSendMessage(
     conversation.processing = true;
     let cleanupDeferred = false;
     try {
-      const provenance = provenanceFromTrustContext(conversation.trustContext);
-      const imageSourcePaths: Record<string, string> = {};
-      for (let i = 0; i < attachments.length; i++) {
-        const a = attachments[i];
-        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
-        }
-      }
-      const channelMeta = {
-        ...provenance,
-        userMessageChannel: sourceChannel,
-        assistantMessageChannel: sourceChannel,
-        userMessageInterface: sourceInterface,
-        assistantMessageInterface: sourceInterface,
-        ...(body.automated === true ? { automated: true } : {}),
-        ...(Object.keys(imageSourcePaths).length > 0
-          ? { imageSourcePaths }
-          : {}),
-      };
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+        automated: body.automated === true,
+        attachments,
+      });
       const cleanMsg = createUserMessage(rawContent, attachments);
       const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
@@ -1859,14 +1827,9 @@ export async function handleSendMessage(
 
   if (slashResult.kind === "compact") {
     conversation.processing = true;
-    const provenance = provenanceFromTrustContext(conversation.trustContext);
-    const channelMeta = {
-      ...provenance,
-      userMessageChannel: sourceChannel,
-      assistantMessageChannel: sourceChannel,
-      userMessageInterface: sourceInterface,
-      assistantMessageInterface: sourceInterface,
-    };
+    const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+      trustContext: conversation.trustContext,
+    });
     const cleanMsg = createUserMessage(rawContent, attachments);
     let persisted: Awaited<ReturnType<typeof addMessage>>;
     try {
@@ -1980,14 +1943,9 @@ export async function handleSendMessage(
     // initial user-message persist below, which would otherwise leave the
     // conversation stuck in queued mode indefinitely.
     try {
-      const provenance = provenanceFromTrustContext(conversation.trustContext);
-      const channelMeta = {
-        ...provenance,
-        userMessageChannel: sourceChannel,
-        assistantMessageChannel: sourceChannel,
-        userMessageInterface: sourceInterface,
-        assistantMessageInterface: sourceInterface,
-      };
+      const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
+        trustContext: conversation.trustContext,
+      });
       const cleanMsg = createUserMessage(rawContent, attachments);
       const persisted = await addMessage(
         mapping.conversationId,
@@ -2399,6 +2357,47 @@ function handleSearchConversations({
   });
 
   return { query, results };
+}
+
+// ---------------------------------------------------------------------------
+// Metadata helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the standard channel metadata object for message persistence.
+ *
+ * Combines provenance (trust context), channel/interface routing, and
+ * optional per-message fields (automated flag, image source paths) into the
+ * Record that `addMessage` stores in the `metadata` column.
+ */
+function buildChannelMetadata(
+  sourceChannel: string,
+  sourceInterface: string,
+  opts?: {
+    trustContext?: Parameters<typeof provenanceFromTrustContext>[0];
+    provenanceOverride?: Record<string, unknown>;
+    automated?: boolean;
+    attachments?: ReadonlyArray<{
+      filename: string;
+      mimeType: string;
+      filePath?: string;
+    }>;
+  },
+): Record<string, unknown> {
+  const provenance =
+    opts?.provenanceOverride ?? provenanceFromTrustContext(opts?.trustContext);
+  const imageSourcePaths = opts?.attachments
+    ? extractImageSourcePaths(opts.attachments)
+    : undefined;
+  return {
+    ...provenance,
+    userMessageChannel: sourceChannel,
+    assistantMessageChannel: sourceChannel,
+    userMessageInterface: sourceInterface,
+    assistantMessageInterface: sourceInterface,
+    ...(opts?.automated ? { automated: true } : {}),
+    ...(imageSourcePaths ? { imageSourcePaths } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Prompt / plan

LUM-2003: Eliminate metadata construction DRY violations across conversation-routes.ts and conversation-messaging.ts, and route slash command / canned greeting user-message persistence through `persistQueuedMessageBody` for consistent metadata assembly.

## Why

Metadata construction for persisted messages was duplicated across 6+ sites in `conversation-routes.ts` — each manually assembling `channelMeta` objects with the same core shape (`userMessageChannel`, `assistantMessageChannel`, `userMessageInterface`, `assistantMessageInterface`) plus provenance, imageSourcePaths, and automated flags. The `imageSourcePaths` extraction loop (iterate attachments, filter image MIME types, build `Record<string, string>`) was also copy-pasted in 3 places.

Worse, the slash command branches (`unknown`, `compact`, `clean`) and the canned greeting path all called `addMessage()` directly, bypassing `persistQueuedMessageBody`. This meant they silently lost:
- **slackMeta** — Slack context was never persisted for slash command messages
- **Attachment indexing** — attachments weren't recorded in the attachments table
- **Disk-view sync** — persisted messages weren't synced to the disk view
- **Meta file updates** — conversation origin metadata wasn't updated

## Changes

### Commit 1: Extract metadata construction helpers (Option A)

- **`extractImageSourcePaths()`** in `conversation-crud.ts` — shared helper replacing 3 identical loops. Returns `Record<string, string> | undefined` (undefined instead of empty object simplifies callers).
- **`buildChannelMetadata()`** in `conversation-routes.ts` — route-level helper combining provenance, channel/interface routing, automated flag, and image source paths. Replaces 5 inline `channelMeta` object constructions.
- Updated `persistQueuedMessageBody` in `conversation-messaging.ts` to use `extractImageSourcePaths` helper.

No behavioral change — all call sites produce identical metadata objects.

### Commit 2: Route slash commands through persistQueuedMessageBody (Option B)

- Slash command branches (`unknown`, `compact`, `clean`) and canned greeting now delegate user-message persistence to `persistQueuedMessageBody` instead of calling `addMessage()` directly.
- This gives them full metadata assembly: provenance, channel/interface routing, imageSourcePaths, **slackMeta**, attachment indexing, disk sync, and origin channel/interface tracking.
- Assistant message persistence still uses `addMessage()` directly via `buildChannelMetadata()` since `persistQueuedMessageBody` is user-message specific.
- Removed unused `setConversationOriginChannelIfUnset` / `setConversationOriginInterfaceIfUnset` imports (now handled by `persistQueuedMessageBody`).
- Test mocks updated to satisfy `MessagingConversationContext` interface requirements and provide stubs for newly-exercised modules.

## Benefits

1. **Single point of metadata assembly** — future metadata field additions only need to be made in one place
2. **Fixed silent data loss** — slash command messages now get slackMeta, attachment indexing, and disk sync
3. **Consistent message persistence** — all user-message paths now go through the same function
4. **Reduced surface area** — ~25 fewer lines of duplicated logic across route handlers

## Safety

- **No wire-format changes** — HTTP responses, SSE events, IPC schemas unchanged
- **Additive metadata** — slash command messages now get *more* metadata (slackMeta, etc.), not less
- **TypeScript verified** — 0 type errors
- **All affected tests pass** individually (43/43 across 5 test files)
- **Pre-existing test isolation issue** — 7 tests in `send-endpoint-busy` fail when run in the same process as other route tests; verified this exists identically on `main`

## Alternatives not taken

1. **Mock `persistQueuedMessageBody` in tests instead of providing full `MessagingConversationContext`** — would have been simpler test changes but would hide integration issues between the route handler and persistence layer. Testing with the real function (backed by mocked dependencies) gives higher confidence.
2. **Route assistant message persistence through a shared helper too** — `persistQueuedMessageBody` is specifically designed for user messages (it manages the in-memory message array, which assistant messages don't need). Forcing assistant messages through it would require either a new function or awkward parameter overrides.
3. **Eliminate `buildChannelMetadata` entirely** — still needed for assistant message persistence in slash command/canned greeting paths. Could be removed if assistant messages were handled differently, but that's a larger refactor (LUM-2004 scope).

## Root cause analysis

1. **How did the code get into this state?** The slash command handling was added incrementally — each new command copied the persistence pattern from the previous one rather than abstracting it. `persistQueuedMessageBody` was created later for the queue drain path but the existing slash command code was never updated to use it.
2. **What mistakes or decisions led to it?** Copy-paste coding without refactoring the extraction point. Each slash command had slightly different requirements (automated flag, image extraction, etc.) which made the copy-paste seem justified at the time.
3. **Were there warning signs we missed?** The slackMeta gap was invisible because slash commands are rarely used from Slack. The attachment indexing gap was invisible because slash commands rarely include attachments.
4. **What can we do to prevent this pattern from recurring?** The extracted helpers make it obvious where to add new metadata fields. The fact that slash commands now use `persistQueuedMessageBody` means any future improvements to message persistence automatically apply.
5. **Should we update AGENTS.md?** No — the existing DRY and backwards-compatibility guidelines already cover this. The issue was execution, not missing guidance.

## Test plan

- TypeScript type check: 0 errors
- ESLint: 0 errors
- Unit tests: 43/43 pass across 5 affected test files (slash-commands, send-endpoint-busy, guardian-reply, app-control-preactivation, process-message-background-slack) when run individually
- CI verification pending

Closes LUM-2003

Link to Devin session: https://app.devin.ai/sessions/1a2be238d9704952b6682fc77696d9b3
Requested by: @ashleeradka