### PR TITLE
refactor(web): drop activeConversationIdRef ref-mirror (LUM-2015)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -76,10 +76,18 @@
     "messaging"
   ],
   "src/domains/chat/hooks/use-message-reconciliation.test.tsx": [
+    "conversations",
     "messaging"
   ],
   "src/domains/chat/hooks/use-message-reconciliation.ts": [
+    "conversations",
     "messaging"
+  ],
+  "src/domains/chat/hooks/use-refresh-latest-messages.test.ts": [
+    "conversations"
+  ],
+  "src/domains/chat/hooks/use-refresh-latest-messages.ts": [
+    "conversations"
   ],
   "src/domains/chat/hooks/use-send-message.ts": [
     "conversations",
@@ -111,9 +119,11 @@
     "subagents"
   ],
   "src/domains/chat/utils/debug-api.test.ts": [
+    "conversations",
     "messaging"
   ],
   "src/domains/chat/utils/debug-api.ts": [
+    "conversations",
     "messaging"
   ],
   "src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts": [
@@ -136,6 +146,9 @@
   ],
   "src/domains/chat/utils/stream-handlers/navigation-handlers.ts": [
     "settings"
+  ],
+  "src/domains/chat/utils/stream-handlers/queue-handlers.ts": [
+    "conversations"
   ],
   "src/domains/chat/utils/stream-handlers/subagent-handlers.ts": [
     "subagents"

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -307,8 +307,6 @@ export function ChatPage() {
       window.removeEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
   }, []);
 
-  const activeConversationIdRef = useRef<string | null>(activeConversationId);
-  useEffect(() => { activeConversationIdRef.current = activeConversationId; }, [activeConversationId]);
 
   const assistantIdRef = useRef<string | null>(assistantId);
   useEffect(() => { assistantIdRef.current = assistantId; }, [assistantId]);
@@ -496,7 +494,6 @@ export function ChatPage() {
     draftConversationIdResolutionRef,
     previousConversationIdRef,
     onboardingDraftConversationIdRef,
-    activeConversationIdRef,
     contextWindowUsageByConversationRef,
     dismissedSurfaceIdsRef,
     streamingMessageIdsRef,
@@ -579,7 +576,6 @@ export function ChatPage() {
     setMessages,
     streamContextRef,
     streamEpochRef,
-    activeConversationIdRef,
     initialPageOldestTsRef,
   });
 
@@ -616,7 +612,6 @@ export function ChatPage() {
 
   useEffect(() => {
     const syncRouter = createWebSyncRouter({
-      activeConversationIdRef,
       invalidateAvatar,
       refreshAssistantIdentity,
       invalidateAssistantConfig: () => {},
@@ -651,7 +646,6 @@ export function ChatPage() {
     push,
     isNative,
     streamEpochRef,
-    activeConversationIdRef,
     streamContextRef,
     assistantIdRef,
     setMessages,
@@ -693,7 +687,6 @@ export function ChatPage() {
     diskPressureChatBlockReason,
     messages,
     assistantIdRef,
-    activeConversationIdRef,
     messagesRef,
     streamRef,
     streamContextRef,
@@ -928,7 +921,6 @@ export function ChatPage() {
     setError,
     messagesRef,
     streamContextRef,
-    activeConversationIdRef,
     confirmationToolCallMapRef,
   });
 
@@ -962,7 +954,6 @@ export function ChatPage() {
   // -------------------------------------------------------------------------
   const refreshLatestMessages = useRefreshLatestMessages({
     assistantId,
-    activeConversationIdRef,
     messagesRef,
     setMessages,
     dismissedSurfaceIdsRef,
@@ -985,7 +976,6 @@ export function ChatPage() {
     streamContextRef,
     streamRef,
     streamEpochRef,
-    activeConversationIdRef,
     getAssistantId: () => assistantIdRef.current,
     getTurnState: () => useTurnStore.getState(),
     getUIContext: () => _uiContext,
@@ -1657,7 +1647,6 @@ export function ChatPage() {
       messagesRef,
       sanitizedMessagesRef,
       transcriptItemsRef,
-      activeConversationIdRef,
       assistantIdRef,
       streamContextRef,
       expandedToolCallIdsRef,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -234,7 +234,6 @@ export interface ChatRouteRefs {
   messagesRef: MutableRefObject<DisplayMessage[]>;
   sanitizedMessagesRef: MutableRefObject<DisplayMessage[]>;
   transcriptItemsRef: MutableRefObject<TranscriptItem[]>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   assistantIdRef: MutableRefObject<string | null>;
   streamContextRef: MutableRefObject<StreamContext | null>;
   expandedToolCallIdsRef: MutableRefObject<Set<string>>;
@@ -520,7 +519,6 @@ export function ChatRouteContent({
     messagesRef,
     sanitizedMessagesRef,
     transcriptItemsRef,
-    activeConversationIdRef: _activeConversationIdRef,
     assistantIdRef: _assistantIdRef,
     streamContextRef,
     expandedToolCallIdsRef,

--- a/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
@@ -69,7 +69,6 @@ export interface UseInteractionActionsParams {
   setError: Dispatch<ChatError | null>;
   messagesRef: MutableRefObject<DisplayMessage[]>;
   streamContextRef: MutableRefObject<StreamContext | null>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   confirmationToolCallMapRef: MutableRefObject<Map<string, string>>;
 }
 
@@ -106,7 +105,6 @@ export function useInteractionActions({
   setError,
   messagesRef,
   streamContextRef,
-  activeConversationIdRef,
   confirmationToolCallMapRef,
 }: UseInteractionActionsParams): UseInteractionActionsReturn {
   const pendingSecret = useInteractionStore.use.pendingSecret();
@@ -154,7 +152,7 @@ export function useInteractionActions({
         }
 
         useInteractionStore.getState().submitSecretEnd(true);
-        const convKey = activeConversationIdRef.current;
+        const convKey = useConversationStore.getState().activeConversationId;
         if (convKey) {
           useConversationStore.getState().removeAttentionConversationId(convKey);
         }
@@ -181,7 +179,7 @@ export function useInteractionActions({
       submitSecretResponse(ctx.assistantId, requestId, "", "none").catch(() => {});
     }
     useInteractionStore.getState().dismissSecret();
-    const convKey = activeConversationIdRef.current;
+    const convKey = useConversationStore.getState().activeConversationId;
     if (convKey) {
       useConversationStore.getState().removeAttentionConversationId(convKey);
     }
@@ -256,7 +254,7 @@ export function useInteractionActions({
       const confirmationDecisionValue = decision === "allow" ? "approved" : "denied";
       useInteractionStore.getState().dismissConfirmation();
       useInteractionStore.getState().setInlineConfirmationToolCallId(null);
-      const convKey = activeConversationIdRef.current;
+      const convKey = useConversationStore.getState().activeConversationId;
       if (convKey) {
         useConversationStore.getState().removeAttentionConversationId(convKey);
       }

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -19,6 +19,7 @@ import { createElement, type Dispatch, type RefObject, type SetStateAction } fro
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 import { INITIAL_TURN_STATE, type TurnState, useTurnStore } from "@/domains/messaging/turn-store";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 // ---------------------------------------------------------------------------
 // Mocks — module mocks MUST come before importing the subject under test.
@@ -128,7 +129,6 @@ interface HarnessProps {
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   streamContextRef: RefObject<{ assistantId: string; conversationId: string } | null>;
   streamEpochRef: RefObject<number>;
-  activeConversationIdRef: RefObject<string | null>;
   initialPageOldestTsRef?: RefObject<number | null>;
   collect: (result: HookReturn) => void;
 }
@@ -142,7 +142,6 @@ function HookHarness(props: HarnessProps): null {
     setMessages: props.setMessages,
     streamContextRef: props.streamContextRef,
     streamEpochRef: props.streamEpochRef,
-    activeConversationIdRef: props.activeConversationIdRef,
     initialPageOldestTsRef: props.initialPageOldestTsRef ?? makeRef(null),
   });
   props.collect(result);
@@ -185,13 +184,18 @@ function createHarness(overrides?: {
   onPollReconciledSpy = mock();
   useTurnStore.setState({ onPollReconciled: onPollReconciledSpy as never });
 
+  // Seed the conversation store with the active conversation id — the
+  // hook reads it via `useConversationStore.getState().activeConversationId`.
+  useConversationStore.setState({
+    activeConversationId: overrides?.activeConversationId ?? "conv-1",
+  });
+
   let captured: HookReturn | null = null;
   renderToStaticMarkup(
     createElement(HookHarness, {
       setMessages,
       streamContextRef: makeRef(overrides?.streamContext ?? null),
       streamEpochRef: overrides?.streamEpochRef ?? makeRef(overrides?.streamEpoch ?? 0),
-      activeConversationIdRef: makeRef(overrides?.activeConversationId ?? "conv-1"),
       collect: (result) => { captured = result; },
     }),
   );

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -12,6 +12,7 @@ import {
 import { type DisplayMessage, reconcileMessages } from "@/domains/chat/utils/reconcile";
 import { isSending, useTurnStore } from "@/domains/messaging/turn-store";
 import { fetchConversationMessages, type RuntimeMessage } from "@/domains/chat/api/messages";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 const RECONCILE_DELAY_MS = 5000;
 const RECONCILE_MAX_MS = 60_000;
@@ -21,7 +22,6 @@ interface UseMessageReconciliationArgs {
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   streamContextRef: RefObject<{ assistantId: string; conversationId: string } | null>;
   streamEpochRef: RefObject<number>;
-  activeConversationIdRef: RefObject<string | null>;
   initialPageOldestTsRef: RefObject<number | null>;
 }
 
@@ -118,7 +118,6 @@ export function useMessageReconciliation({
   setMessages,
   streamContextRef,
   streamEpochRef,
-  activeConversationIdRef,
   initialPageOldestTsRef,
 }: UseMessageReconciliationArgs): UseMessageReconciliationReturn {
   const reconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -421,7 +420,7 @@ export function useMessageReconciliation({
           ctx.assistantId,
           ctx.conversationId,
         );
-        if (activeConversationIdRef.current !== ctx.conversationId) return empty;
+        if (useConversationStore.getState().activeConversationId !== ctx.conversationId) return empty;
         // If the epoch changed during the fetch (e.g. page went hidden
         // and back), this reconciliation is stale — bail out.
         if (streamEpochRef.current !== snapshotEpoch) return empty;
@@ -446,7 +445,6 @@ export function useMessageReconciliation({
     [
     streamContextRef,
     streamEpochRef,
-    activeConversationIdRef,
     reconcileFetchedMessages,
   ]);
 

--- a/apps/web/src/domains/chat/hooks/use-refresh-latest-messages.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-refresh-latest-messages.test.ts
@@ -101,6 +101,7 @@ import {
   type RefreshLatestOutcome,
   useRefreshLatestMessages,
 } from "@/domains/chat/hooks/use-refresh-latest-messages";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -119,7 +120,6 @@ function makeMsg(
 interface HostState {
   messages: DisplayMessage[];
   messagesRef: MutableRefObject<DisplayMessage[]>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
   setMessagesCalls: Array<DisplayMessage[]>;
   setMessages: (
@@ -134,10 +134,10 @@ function makeHost(
   conversationId: string | null,
   dismissed: Set<string> = new Set(),
 ): HostState {
+  useConversationStore.setState({ activeConversationId: conversationId });
   const host: HostState = {
     messages: initial,
     messagesRef: { current: initial },
-    activeConversationIdRef: { current: conversationId },
     dismissedSurfaceIdsRef: { current: dismissed },
     setMessagesCalls: [],
     setMessages: (update) => {
@@ -186,7 +186,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -208,7 +207,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: null,
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -262,7 +260,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -317,7 +314,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -363,7 +359,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -401,11 +396,11 @@ describe("useRefreshLatestMessages", () => {
     const host = makeHost([conv1Msg], "conv-1");
 
     // Simulate the user switching to conv-2 between the fetch dispatch
-    // and the fetch resolving. Inside the fetch impl, we mutate
-    // activeConversationIdRef directly — this races the post-fetch
-    // staleness check the hook performs.
+    // and the fetch resolving. Inside the fetch impl, we mutate the
+    // conversation store directly — this races the post-fetch staleness
+    // check the hook performs.
     fetchLatestImpl = async () => {
-      host.activeConversationIdRef.current = "conv-2";
+      useConversationStore.setState({ activeConversationId: "conv-2" });
       host.messagesRef.current = [conv2Msg];
       host.messages = [conv2Msg];
       // Return a "latest" page for the original conversation. If the
@@ -430,7 +425,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -465,7 +459,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -506,7 +499,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -565,7 +557,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,
@@ -633,7 +624,6 @@ describe("useRefreshLatestMessages", () => {
     const { result } = renderHook(() =>
       useRefreshLatestMessages({
         assistantId: "asst-1",
-        activeConversationIdRef: host.activeConversationIdRef,
         messagesRef: host.messagesRef,
         setMessages: host.setMessages,
         dismissedSurfaceIdsRef: host.dismissedSurfaceIdsRef,

--- a/apps/web/src/domains/chat/hooks/use-refresh-latest-messages.ts
+++ b/apps/web/src/domains/chat/hooks/use-refresh-latest-messages.ts
@@ -12,6 +12,7 @@ import {
 } from "@/domains/chat/utils/dismissed-surfaces-storage";
 import { fetchLatestHistoryPage } from "@/domains/chat/api/history";
 import { fetchSurfaceContent } from "@/domains/chat/api/surfaces";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 import {
   type DisplayMessage,
   reconcileDisplayMessagesWithLatestHistory,
@@ -25,7 +26,6 @@ export type RefreshLatestOutcome =
 
 interface UseRefreshLatestMessagesArgs {
   assistantId: string | null;
-  activeConversationIdRef: MutableRefObject<string | null>;
   messagesRef: MutableRefObject<DisplayMessage[]>;
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
@@ -136,7 +136,6 @@ function refreshSurfacesForFetchedMessages({
  */
 export function useRefreshLatestMessages({
   assistantId,
-  activeConversationIdRef,
   messagesRef,
   setMessages,
   dismissedSurfaceIdsRef,
@@ -144,13 +143,13 @@ export function useRefreshLatestMessages({
   const refreshTokenRef = useRef(0);
   return useCallback(async (): Promise<RefreshLatestOutcome> => {
     if (!assistantId) return { kind: "no-change" };
-    const conversationId = activeConversationIdRef.current;
+    const conversationId = useConversationStore.getState().activeConversationId;
     if (!conversationId) return { kind: "no-change" };
 
     const myToken = ++refreshTokenRef.current;
     const isStale = (): boolean =>
       refreshTokenRef.current !== myToken ||
-      activeConversationIdRef.current !== conversationId;
+      useConversationStore.getState().activeConversationId !== conversationId;
 
     let fetched;
     try {
@@ -200,7 +199,6 @@ export function useRefreshLatestMessages({
     return outcome;
   }, [
     assistantId,
-    activeConversationIdRef,
     messagesRef,
     setMessages,
     dismissedSurfaceIdsRef,

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -119,7 +119,6 @@ interface UseSendMessageParams {
 
   // Refs
   assistantIdRef: MutableRefObject<string | null>;
-  activeConversationIdRef: MutableRefObject<string | null>;
 
   messagesRef: MutableRefObject<DisplayMessage[]>;
   streamRef: MutableRefObject<ChatEventStream | null>;
@@ -162,7 +161,6 @@ export function useSendMessage({
   diskPressureChatBlockReason,
   messages,
   assistantIdRef,
-  activeConversationIdRef,
   messagesRef,
   streamRef,
   streamContextRef,
@@ -266,7 +264,7 @@ export function useSendMessage({
       const isCurrentSendScope = (resolvedConversationId?: string | null) =>
         isAsyncChatScopeCurrent({
           currentAssistantId: assistantIdRef.current,
-          currentConversationId: activeConversationIdRef.current,
+          currentConversationId: useConversationStore.getState().activeConversationId,
           requestAssistantId,
           requestConversationId,
           resolvedConversationId,
@@ -314,7 +312,7 @@ export function useSendMessage({
             assistantId: requestAssistantId,
             conversationId: requestConversationId,
             activeAssistantId: assistantIdRef.current,
-            activeConversationId: activeConversationIdRef.current,
+            activeConversationId: useConversationStore.getState().activeConversationId,
           });
           return { status: "ignored" };
         }
@@ -357,7 +355,7 @@ export function useSendMessage({
           conversationId: requestConversationId,
           resolvedConversationId: effectiveConversationId,
           activeAssistantId: assistantIdRef.current,
-          activeConversationId: activeConversationIdRef.current,
+          activeConversationId: useConversationStore.getState().activeConversationId,
         });
         return {
           status: "ok",
@@ -398,7 +396,7 @@ export function useSendMessage({
               conversationId: requestConversationId,
               resolvedConversationId: effectiveConversationId,
               activeAssistantId: assistantIdRef.current,
-              activeConversationId: activeConversationIdRef.current,
+              activeConversationId: useConversationStore.getState().activeConversationId,
             });
             return;
           }
@@ -719,7 +717,7 @@ export function useSendMessage({
           resolveEditChatDraftConversationId(activeConversationId, newConversationId);
 
           // Only update active view state if the user is still on this conversation.
-          if (activeConversationIdRef.current === activeConversationId) {
+          if (useConversationStore.getState().activeConversationId === activeConversationId) {
             draftConversationIdResolutionRef.current = true;
             previousConversationIdRef.current = newConversationId;
             useConversationStore.getState().setActiveConversationId(newConversationId);

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -106,7 +106,6 @@ export interface UseStreamEventHandlerParams {
 
   // --- Stream context ---
   streamEpochRef: MutableRefObject<number>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   streamContextRef: MutableRefObject<StreamContext | null>;
   assistantIdRef: MutableRefObject<string | null>;
 
@@ -183,7 +182,6 @@ export function useStreamEventHandler(
     push,
     isNative,
     streamEpochRef,
-    activeConversationIdRef,
     streamContextRef,
     assistantIdRef,
     setMessages,
@@ -240,7 +238,7 @@ export function useStreamEventHandler(
         recordChatDiagnostic("sse_event_stale", {
           epoch,
           currentEpoch: streamEpochRef.current,
-          activeConversationId: activeConversationIdRef.current,
+          activeConversationId: useConversationStore.getState().activeConversationId,
           ...eventSummary,
         });
         return;
@@ -258,7 +256,7 @@ export function useStreamEventHandler(
         if (!event.conversationId || !streamConversationId) {
           recordChatDiagnostic("sse_event_wrong_conversation", {
             epoch,
-            activeConversationId: activeConversationIdRef.current,
+            activeConversationId: useConversationStore.getState().activeConversationId,
             streamContext: streamContextRef.current,
             reason: !event.conversationId ? "missing" : "no_stream_context",
             ...eventSummary,
@@ -268,7 +266,7 @@ export function useStreamEventHandler(
         if (event.conversationId !== streamConversationId) {
           recordChatDiagnostic("sse_event_wrong_conversation", {
             epoch,
-            activeConversationId: activeConversationIdRef.current,
+            activeConversationId: useConversationStore.getState().activeConversationId,
             streamContext: streamContextRef.current,
             reason: "mismatch",
             ...eventSummary,
@@ -290,7 +288,7 @@ export function useStreamEventHandler(
             : "sse_event",
           {
             epoch,
-            activeConversationId: activeConversationIdRef.current,
+            activeConversationId: useConversationStore.getState().activeConversationId,
             streamContext: streamContextRef.current,
             ...eventSummary,
           },
@@ -302,7 +300,6 @@ export function useStreamEventHandler(
         router: { push },
         isNative,
         streamContextRef,
-        activeConversationIdRef,
         assistantIdRef,
         setMessages,
         messagesRef,
@@ -514,7 +511,6 @@ export function useStreamEventHandler(
       dispatchSyncChanged,
       queryClient,
       streamEpochRef,
-      activeConversationIdRef,
       streamContextRef,
       assistantIdRef,
       setMessages,

--- a/apps/web/src/domains/chat/utils/debug-api.test.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.test.ts
@@ -24,6 +24,7 @@ import {
   type TurnState,
 } from "@/domains/messaging/turn-store";
 import type { UIContext } from "@/domains/messaging/turn-selectors";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 // ---------------------------------------------------------------------------
 //  Helpers
@@ -107,7 +108,6 @@ function makeRefs(
     } | null>,
     streamRef: { current: null } as MutableRefObject<ChatEventStream | null>,
     streamEpochRef: { current: 0 } as MutableRefObject<number>,
-    activeConversationIdRef: { current: null } as MutableRefObject<string | null>,
     getAssistantId: () => "asst-1",
     getTurnState: () => turnState,
     getUIContext: () => resolvedUIContext,
@@ -510,8 +510,9 @@ describe("createChatDebugApi.thinkingIndicator", () => {
 
 describe("createChatDebugApi.serverMessages", () => {
   test("throws when no context or assistant", async () => {
+    useConversationStore.setState({ activeConversationId: null });
     const api = createChatDebugApi(
-      makeRefs({ getAssistantId: () => null, activeConversationIdRef: { current: null } }),
+      makeRefs({ getAssistantId: () => null }),
     );
     await expect(api.serverMessages()).rejects.toThrow(
       "no active assistant/conversation context",
@@ -519,21 +520,21 @@ describe("createChatDebugApi.serverMessages", () => {
   });
 
   test("returns raw RuntimeMessage[] from injected historyFetcher", async () => {
-    const activeConversationIdRef = { current: "conv-1" } as MutableRefObject<string | null>;
+    useConversationStore.setState({ activeConversationId: "conv-1" });
     const serverList = [
       fakeRuntimeMessage({ id: "srv-1" }),
       fakeRuntimeMessage({ id: "srv-2", role: "user" }),
     ];
     const historyFetcher = async () => serverList;
-    const api = createChatDebugApi(makeRefs({ historyFetcher, activeConversationIdRef }));
+    const api = createChatDebugApi(makeRefs({ historyFetcher }));
     const result = await api.serverMessages();
     expect(result).toBe(serverList);
     expect(result).toHaveLength(2);
     expect(result[0]!.id).toBe("srv-1");
   });
 
-  test("prefers streamContextRef over activeConversationIdRef + getAssistantId", async () => {
-    const activeConversationIdRef = { current: "conv-fallback" } as MutableRefObject<string | null>;
+  test("prefers streamContextRef over conversation store + getAssistantId", async () => {
+    useConversationStore.setState({ activeConversationId: "conv-fallback" });
     const streamContextRef = {
       current: { assistantId: "asst-stream", conversationId: "conv-stream" },
     } as MutableRefObject<{ assistantId: string; conversationId: string } | null>;
@@ -546,7 +547,6 @@ describe("createChatDebugApi.serverMessages", () => {
       makeRefs({
         getAssistantId: () => "asst-fallback",
         streamContextRef,
-        activeConversationIdRef,
         historyFetcher,
       }),
     );

--- a/apps/web/src/domains/chat/utils/debug-api.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.ts
@@ -60,6 +60,7 @@ import {
   type UIContext,
   shouldShowThinkingIndicator,
 } from "@/domains/messaging/turn-selectors";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -347,7 +348,6 @@ export interface ChatDebugRefs {
   } | null>;
   streamRef: MutableRefObject<ChatEventStream | null>;
   streamEpochRef: MutableRefObject<number>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   /**
    * Reads the latest transcript pagination state (`hasMore`,
    * `isLoadingOlder`) for {@link ChatDebugApi.getScrollState}. Held as a
@@ -539,12 +539,12 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
 
   async function forceReconcile(): Promise<ReconcileActiveConversationResult> {
     recordChatDiagnostic("debug_force_reconcile_start", {
-      activeConversationId: refs.activeConversationIdRef.current,
+      activeConversationId: useConversationStore.getState().activeConversationId,
       assistantId: refs.getAssistantId(),
     });
     const result = await refs.reconcileActiveConversation();
     recordChatDiagnostic("debug_force_reconcile_result", {
-      activeConversationId: refs.activeConversationIdRef.current,
+      activeConversationId: useConversationStore.getState().activeConversationId,
       changed: result.changed,
       messagesAdded: result.messagesAdded,
       assistantProgress: result.assistantProgress,
@@ -562,7 +562,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       streamContext?.assistantId ?? refs.getAssistantId() ?? null;
     const conversationId =
       streamContext?.conversationId ??
-      refs.activeConversationIdRef.current ??
+      useConversationStore.getState().activeConversationId ??
       null;
     if (!assistantId || !conversationId) {
       throw new Error(
@@ -813,7 +813,6 @@ export function useChatDebugApi(refs: ChatDebugRefs): void {
       streamContextRef: refs.streamContextRef,
       streamRef: refs.streamRef,
       streamEpochRef: refs.streamEpochRef,
-      activeConversationIdRef: refs.activeConversationIdRef,
       getAssistantId: () => latestRefs.current.getAssistantId(),
       getTurnState: () => latestRefs.current.getTurnState(),
       getUIContext: () => latestRefs.current.getUIContext(),

--- a/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
@@ -8,6 +8,7 @@ import {
 import { patchConversation } from "@/domains/conversations/conversation-queries";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type { AvatarUpdatedEvent, CompactionCircuitClosedEvent, CompactionCircuitOpenEvent, ConversationTitleUpdatedEvent, DiskPressureStatusChangedEvent, IdentityChangedEvent, NotificationIntentEvent, TurnProfileAutoRoutedEvent, UsageUpdateEvent } from "@/domains/chat/api/event-types";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 export function handleUsageUpdate(
   event: UsageUpdateEvent,
@@ -87,7 +88,7 @@ export function handleNotificationIntent(
   );
   if (
     metadataConversationId &&
-    metadataConversationId === ctx.activeConversationIdRef.current
+    metadataConversationId === useConversationStore.getState().activeConversationId
   ) {
     if (ackAssistantId && event.deliveryId) {
       void sendNotificationIntentAck(

--- a/apps/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -6,6 +6,7 @@ import {
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type { MessageDequeuedEvent, MessageQueuedDeletedEvent, MessageQueuedEvent, MessageRequestCompleteEvent } from "@/domains/chat/api/event-types";
 import { deleteQueuedMessage } from "@/domains/chat/api/messages";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 export function handleMessageQueued(
   event: MessageQueuedEvent,
@@ -20,13 +21,12 @@ export function handleMessageQueued(
 
   if (ctx.pendingLocalDeletionsRef.current.has(messageId)) {
     ctx.pendingLocalDeletionsRef.current.delete(messageId);
-    if (
-      ctx.assistantIdRef.current &&
-      ctx.activeConversationIdRef.current
-    ) {
+    const conversationId =
+      useConversationStore.getState().activeConversationId;
+    if (ctx.assistantIdRef.current && conversationId) {
       void deleteQueuedMessage(
         ctx.assistantIdRef.current,
-        ctx.activeConversationIdRef.current,
+        conversationId,
         requestId,
       );
     }

--- a/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -16,7 +16,6 @@ export function makeCtx(
     streamContextRef: {
       current: { assistantId: "ast-1", conversationId: "conv-1" },
     },
-    activeConversationIdRef: { current: "conv-1" },
     assistantIdRef: { current: "ast-1" },
     setMessages: mock(() => {}),
     messagesRef: { current: [] },

--- a/apps/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -34,7 +34,6 @@ export interface StreamHandlerContext {
 
   // --- Stream context ---
   streamContextRef: MutableRefObject<StreamContext | null>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   assistantIdRef: MutableRefObject<string | null>;
 
   // --- Messages ---

--- a/apps/web/src/domains/conversations/use-conversation-loader.ts
+++ b/apps/web/src/domains/conversations/use-conversation-loader.ts
@@ -81,7 +81,6 @@ interface UseConversationLoaderParams {
   draftConversationIdResolutionRef: MutableRefObject<boolean>;
   previousConversationIdRef: MutableRefObject<string | null>;
   onboardingDraftConversationIdRef: MutableRefObject<string | null>;
-  activeConversationIdRef: MutableRefObject<string | null>;
   contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
   streamingMessageIdsRef: MutableRefObject<Set<string>>;
@@ -148,7 +147,6 @@ export function useConversationLoader({
   draftConversationIdResolutionRef,
   previousConversationIdRef,
   onboardingDraftConversationIdRef,
-  activeConversationIdRef,
   contextWindowUsageByConversationRef,
   dismissedSurfaceIdsRef,
   streamingMessageIdsRef,
@@ -404,7 +402,7 @@ export function useConversationLoader({
     const key = resolveBootstrappedConversationId({
       queryParamKey: explicitConversationId,
       onboardingDraftConversationId,
-      currentConversationId: activeConversationIdRef.current,
+      currentConversationId: useConversationStore.getState().activeConversationId,
       currentAssistantId: assistantIdRef.current,
       nextAssistantId: assistantId,
       storedConversationId: loadLastViewedConversationId(assistantId),
@@ -425,7 +423,6 @@ export function useConversationLoader({
     searchParams,
     navigate,
     assistantIdRef,
-    activeConversationIdRef,
     onboardingDraftConversationIdRef,
   ]);
 

--- a/apps/web/src/lib/sync/web-sync-router.test.ts
+++ b/apps/web/src/lib/sync/web-sync-router.test.ts
@@ -26,6 +26,7 @@ import {
   type SyncChangedEvent,
 } from "@/lib/sync/types";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 const OTHER_CLIENT_ID = "22222222-2222-2222-2222-222222222222";
 
@@ -34,9 +35,9 @@ interface HarnessOptions {
 }
 
 function createHarness(opts: HarnessOptions = {}) {
-  const activeConversationIdRef = {
-    current: opts.activeConversationId ?? null,
-  };
+  useConversationStore.setState({
+    activeConversationId: opts.activeConversationId ?? null,
+  });
   const calls = {
     invalidateAvatar: 0,
     refreshAssistantIdentity: 0,
@@ -47,7 +48,6 @@ function createHarness(opts: HarnessOptions = {}) {
     refreshActiveConversationMessages: 0,
   };
   const router = createWebSyncRouter({
-    activeConversationIdRef,
     invalidateAvatar: () => {
       calls.invalidateAvatar += 1;
     },
@@ -71,7 +71,7 @@ function createHarness(opts: HarnessOptions = {}) {
       return { changed: false, messagesAdded: 0, assistantProgress: false };
     },
   });
-  return { router, calls, activeConversationIdRef };
+  return { router, calls };
 }
 
 describe("createWebSyncRouter — self-echo drop", () => {

--- a/apps/web/src/lib/sync/web-sync-router.ts
+++ b/apps/web/src/lib/sync/web-sync-router.ts
@@ -11,6 +11,7 @@ import {
   type SyncChangedEvent,
 } from "@/lib/sync/types";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { useConversationStore } from "@/domains/conversations/conversation-store";
 
 export interface ActiveConversationMessagesRefreshResult {
   changed: boolean;
@@ -18,12 +19,7 @@ export interface ActiveConversationMessagesRefreshResult {
   assistantProgress: boolean;
 }
 
-interface CurrentRef<T> {
-  current: T;
-}
-
 export interface WebSyncRouterOptions {
-  activeConversationIdRef: CurrentRef<string | null>;
   invalidateAvatar: () => void;
   refreshAssistantIdentity: (force?: boolean) => Promise<void>;
   invalidateAssistantConfig: () => void;
@@ -90,7 +86,7 @@ export function createWebSyncRouter(
       // We still need the active-conversation message refetch when
       // the tag matches the currently-open conversation — those
       // message rows are owned by a separate query.
-      if (tagMatchesActiveConversation(tag, options.activeConversationIdRef)) {
+      if (tagMatchesActiveConversation(tag)) {
         return options.refreshActiveConversationMessages().then(() => {});
       }
     }),
@@ -117,7 +113,7 @@ export function createWebSyncRouter(
     },
     dispatchReconnect: async () => {
       const dispatch = await registry.dispatchReconnect();
-      const activeConversationId = options.activeConversationIdRef.current;
+      const activeConversationId = useConversationStore.getState().activeConversationId;
       let activeConversationMessages: ActiveConversationMessagesRefreshResult | null =
         null;
       if (activeConversationId) {
@@ -140,11 +136,10 @@ export function createWebSyncRouter(
 
 function tagMatchesActiveConversation(
   tag: string,
-  activeConversationIdRef: CurrentRef<string | null>,
 ): boolean {
   const parsed = parseConversationSyncTag(tag);
   return (
     parsed !== null &&
-    parsed.conversationId === activeConversationIdRef.current
+    parsed.conversationId === useConversationStore.getState().activeConversationId
   );
 }


### PR DESCRIPTION
## Summary

- Removes the `activeConversationIdRef` ref-mirror anti-pattern from `chat-page.tsx` and the 12+ hooks/handlers it was plumbed through.
- Every consumer now reads `useConversationStore.getState().activeConversationId` directly. Zustand stores are imperative, so the ref was redundant and introduced a stale-window bug where the ref hadn't caught up to the store yet.
- Tests seed the active conversation via `useConversationStore.setState(...)` instead of constructing a fake ref.

## Why

`useEffect(() => { ref.current = state }, [state])` mirrors store state into a ref so non-React code paths can read a snapshot. Zustand already exposes that snapshot via `getState()`, so the mirror was both unnecessary and an extra moving part — a re-render had to commit before the ref reflected reality.

Removing it:
- Deletes the declaration + mirror effect in `chat-page.tsx`.
- Drops the param from every consumer's interface (`UseRefreshLatestMessagesArgs`, `UseMessageReconciliationArgs`, `StreamHandlerContext`, `WebSyncRouterOptions`, `ChatDebugRefs`, etc.).
- Converts each read site to `useConversationStore.getState().activeConversationId`.
- Adds `conversations` to the cross-domain allowlist for the files that now import the store (consistent with existing chat → conversations entries like `chat-page`, `chat-layout`, `use-send-message`).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [x] `bun test src/domains/chat/hooks/use-refresh-latest-messages.test.ts src/domains/chat/hooks/use-message-reconciliation.test.tsx src/domains/chat/utils/debug-api.test.ts src/lib/sync/web-sync-router.test.ts src/domains/chat/utils/stream-handlers/` — all pass

Linear: [LUM-2015](https://linear.app/vellum/issue/LUM-2015)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_