### PR TITLE
fix(onboarding): run domain step before machine resize/restart

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -144,7 +144,15 @@ export function BillingOnboardingModal({
     }
 
     if (step === "welcome") {
-      return <WelcomeState onContinue={advanceFromWelcome} />;
+      // Gate "Get started" until the onboarding query settles: advanceFromWelcome
+      // routes on domain_setup_available, and a click while it's still pending
+      // (undefined) would skip the intended bypass for orgs without domain setup.
+      return (
+        <WelcomeState
+          onContinue={advanceFromWelcome}
+          continueDisabled={onboardingQuery.isPending}
+        />
+      );
     }
 
     if (step === "domain") {

--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -147,14 +147,16 @@ export function BillingOnboardingModal({
       if (onboardingQuery.isError) {
         return <FetchErrorState onGoToBilling={onClose} />;
       }
-      // Gate "Get started" until the onboarding query settles: advanceFromWelcome
-      // routes on domain_setup_available, and a click while it's still pending
-      // (undefined) would skip the intended bypass for orgs without domain setup.
+      // Gate "Get started" until fresh onboarding data has settled:
+      // advanceFromWelcome routes on domain_setup_available. isPending covers the
+      // cold load; isFetching covers the background refetch from the on-open
+      // invalidation, during which TanStack still serves stale cached data — a
+      // fast click then would route on a pre-checkout domain_setup_available.
       // On error we show FetchErrorState above rather than routing on stale data.
       return (
         <WelcomeState
           onContinue={advanceFromWelcome}
-          continueDisabled={onboardingQuery.isPending}
+          continueDisabled={onboardingQuery.isPending || onboardingQuery.isFetching}
         />
       );
     }

--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -93,9 +93,21 @@ export function BillingOnboardingModal({
   });
 
   const domainSetupAvailable = onboardingQuery.data?.domain_setup_available;
-  const advanceFromSetup = useCallback(() => {
+  // Domain/email/guardian registration must run while the assistant's machine
+  // is still online: registering the email triggers a guardian-channel write to
+  // the machine's gateway. The SetupStep's "Apply & Restart" takes the machine
+  // offline, so the domain step runs *before* setup — otherwise that write hangs
+  // against a restarting machine.
+  const advanceFromWelcome = useCallback(() => {
     if (domainSetupAvailable === false) {
-      setStep("complete");
+      setStep("setup");
+    } else {
+      setStep("domain");
+    }
+  }, [domainSetupAvailable]);
+  const backFromSetup = useCallback(() => {
+    if (domainSetupAvailable === false) {
+      setStep("welcome");
     } else {
       setStep("domain");
     }
@@ -132,7 +144,16 @@ export function BillingOnboardingModal({
     }
 
     if (step === "welcome") {
-      return <WelcomeState onContinue={() => setStep("setup")} />;
+      return <WelcomeState onContinue={advanceFromWelcome} />;
+    }
+
+    if (step === "domain") {
+      return (
+        <DomainStep
+          onBack={() => setStep("welcome")}
+          onExit={() => setStep("setup")}
+        />
+      );
     }
 
     if (step === "setup") {
@@ -145,24 +166,14 @@ export function BillingOnboardingModal({
         <SetupStep
           storageGib={onboardingQuery.data?.selected_storage_gib ?? null}
           maxTier={maxTier}
-          onBack={() => setStep("welcome")}
-          onAdvance={advanceFromSetup}
-        />
-      );
-    }
-
-    if (step === "domain") {
-      return (
-        <DomainStep
-          onBack={() => setStep("setup")}
-          onExit={() => setStep("complete")}
+          onBack={backFromSetup}
+          onAdvance={() => setStep("complete")}
         />
       );
     }
 
     if (step === "complete") {
-      const backFromComplete = domainSetupAvailable === false ? "setup" : "domain";
-      return <CompleteState onBack={() => setStep(backFromComplete)} />;
+      return <CompleteState onBack={() => setStep("setup")} />;
     }
 
     return null;

--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -170,12 +170,17 @@ export function BillingOnboardingModal({
       }
       const maxTier = (onboardingQuery.data?.max_machine_tier ??
         null) as MachineTierEnum | null;
+      // When domain setup is unavailable the domain step is skipped, so setup is
+      // the sole step in the indicator; otherwise it's the second of two.
+      const domainStepIncluded = domainSetupAvailable !== false;
       return (
         <SetupStep
           storageGib={onboardingQuery.data?.selected_storage_gib ?? null}
           maxTier={maxTier}
           onBack={backFromSetup}
           onAdvance={() => setStep("complete")}
+          dotIndex={domainStepIncluded ? 1 : 0}
+          dotTotal={domainStepIncluded ? 2 : 1}
         />
       );
     }

--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -144,9 +144,13 @@ export function BillingOnboardingModal({
     }
 
     if (step === "welcome") {
+      if (onboardingQuery.isError) {
+        return <FetchErrorState onGoToBilling={onClose} />;
+      }
       // Gate "Get started" until the onboarding query settles: advanceFromWelcome
       // routes on domain_setup_available, and a click while it's still pending
       // (undefined) would skip the intended bypass for orgs without domain setup.
+      // On error we show FetchErrorState above rather than routing on stale data.
       return (
         <WelcomeState
           onContinue={advanceFromWelcome}

--- a/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -181,7 +181,7 @@ export function DomainStep({ onBack, onExit }: { onBack: () => void; onExit: () 
           Back
         </Button>
         <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <StepDots current={1} />
+          <StepDots current={0} />
         </div>
         <div className="flex items-center gap-2">
           {isLocked ? (

--- a/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -194,7 +194,7 @@ export function SetupStep({
           Back
         </Button>
         <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <StepDots current={0} />
+          <StepDots current={1} />
         </div>
         <div className="flex gap-2">
           <Button

--- a/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -85,11 +85,15 @@ export function SetupStep({
   maxTier,
   onBack,
   onAdvance,
+  dotIndex,
+  dotTotal,
 }: {
   storageGib: number | null;
   maxTier: MachineTierEnum | null;
   onBack: () => void;
   onAdvance: () => void;
+  dotIndex: number;
+  dotTotal: number;
 }) {
   const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
   const currentSize = (activeAssistant?.machine_size as MachineSizeEnum) || "small";
@@ -194,7 +198,7 @@ export function SetupStep({
           Back
         </Button>
         <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <StepDots current={1} />
+          <StepDots current={dotIndex} total={dotTotal} />
         </div>
         <div className="flex gap-2">
           <Button

--- a/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
@@ -2,7 +2,13 @@ import { Crown } from "lucide-react";
 
 import { Button } from "@vellum/design-library/components/button";
 
-export function WelcomeState({ onContinue }: { onContinue: () => void }) {
+export function WelcomeState({
+  onContinue,
+  continueDisabled = false,
+}: {
+  onContinue: () => void;
+  continueDisabled?: boolean;
+}) {
   return (
     <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 text-center">
       <div
@@ -68,6 +74,7 @@ export function WelcomeState({ onContinue }: { onContinue: () => void }) {
         <Button
           variant="primary"
           data-testid="onboarding-welcome-continue"
+          disabled={continueDisabled}
           onClick={onContinue}
         >
           Get started


### PR DESCRIPTION
## Summary
- Reorder the Pro onboarding wizard from `welcome -> setup -> domain` to `welcome -> domain -> setup` so domain/email/guardian registration happens **before** the "Apply & Restart" machine resize.
- Fixes the indefinite hang on the domain step: registering an email triggers a synchronous guardian-channel write to the assistant's machine gateway, which the resize step had just taken offline. Running the domain step first means the machine is still online (the same reason the settings flow works).
- Swap the `StepDots` progress indices (domain=0, setup=1) and simplify the back/complete navigation accordingly. Frontend-only; no backend change.

## Original prompt
While investigating an onboarding bug where the final "register domain" step hung indefinitely, we traced it to a race: the preceding setup step issues an "Apply & Restart" resize that takes the assistant's machine offline, and the domain step's email registration then makes a synchronous guardian-email auto-verify callback into that offline machine. Rather than make the platform call async (which can't truly fire-and-forget since it needs the machine to respond), the fix is to reorder the wizard so domain/email/guardian registration runs first, while the machine is still online.