### PR TITLE
fix(web): fire feature-flag PATCH before store update

### DIFF
--- a/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
@@ -56,8 +56,9 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
         }),
 
       setFlag: (key: string, value: boolean, assistantId: string | null) => {
-        set({ [key]: value });
-
+        // Fire the PATCH before updating local state: the platform-features
+        // interceptor reads this store synchronously, so toggling
+        // platformFeaturesInLocalMode OFF would block its own request.
         const flagKey = storeKeyToFlagKey(key);
         if (assistantId && flagKey) {
           void client.patch({
@@ -66,6 +67,8 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
             throwOnError: false,
           } as Parameters<typeof client.patch>[0]);
         }
+
+        set({ [key]: value });
       },
 
       markHydrated: () => set({ hasHydrated: true }),


### PR DESCRIPTION
## Summary
- Reorder `setFlag` in the assistant feature flag store to fire the PATCH request *before* updating local state via `set()`.
- When toggling `platformFeaturesInLocalMode` OFF in local mode, the platform-client interceptor reads the store synchronously. If the store is updated first, the interceptor sees `false` and aborts the very PATCH that was supposed to persist the change.

## Original prompt
When navigating to `/assistant/settings/developer` and toggling off an assistant feature flag, no PATCH request was being sent to persist the change, even though toggling a flag on did fire the PATCH correctly. The root cause was a race condition in the assistant feature flag store: `set()` updated the zustand store synchronously before the PATCH was fired, causing the platform-features interceptor to read the already-updated `platformFeaturesInLocalMode` value and abort the outbound request.