### PR TITLE
fix(web/voice): end session on conversation switch + reorder notices under overlay

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -380,21 +380,22 @@ export function ChatComposer({
   );
 
   return (
-    <>
-      {noticesAboveFormSlot}
-      <Popover.Root open={emoji.show || slash.show}>
-        <Popover.Anchor asChild>
-          {/* `relative` wrapper anchors the live voice overlay's
-              `absolute bottom-full` directly above the composer form —
-              since the overlay is out of flow, the wrapper's content
-              height collapses to the form's height, so `bottom: 100%`
-              of the wrapper sits flush against the top of the form. */}
-          <div className="relative">
-            {showLiveVoiceOverlay && <LiveVoiceOverlay />}
-            <form
-              onSubmit={onSubmit}
-              className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
-            >
+    <Popover.Root open={emoji.show || slash.show}>
+      <Popover.Anchor asChild>
+        {/* `relative` wrapper anchors the live voice overlay's
+            `absolute bottom-full` directly above the composer's notices
+            + form stack. Because `noticesAboveFormSlot` is rendered as
+            an in-flow sibling of the form inside this wrapper, the
+            overlay's `bottom: 100%` clears both notices and form rather
+            than clipping into the notices region (billing banner,
+            maintenance banner, voice errors, etc.). */}
+        <div className="relative">
+          {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+          {noticesAboveFormSlot}
+          <form
+            onSubmit={onSubmit}
+            className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
+          >
             <ChatAttachmentsStrip
               attachments={chatAttachments}
               onRemove={onRemoveAttachment}
@@ -704,36 +705,35 @@ export function ChatComposer({
                 )}
               </div>
             </div>
-            </form>
-          </div>
-        </Popover.Anchor>
-        <Popover.Content
-          side="top"
-          align="start"
-          sideOffset={4}
-          className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
-          onOpenAutoFocus={(e: Event) => e.preventDefault()}
-          onCloseAutoFocus={(e: Event) => e.preventDefault()}
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: Event) => e.preventDefault()}
-          onPointerDownOutside={(e: Event) => e.preventDefault()}
-        >
-          {emoji.show && (
-            <EmojiPickerPopup
-              entries={emoji.items}
-              selectedIndex={emoji.selectedIndex}
-              onSelect={insertEmoji}
-            />
-          )}
-          {slash.show && (
-            <SlashCommandPopup
-              commands={slash.items}
-              selectedIndex={slash.selectedIndex}
-              onSelect={handleSlashCommandSelect}
-            />
-          )}
-        </Popover.Content>
-      </Popover.Root>
-    </>
+          </form>
+        </div>
+      </Popover.Anchor>
+      <Popover.Content
+        side="top"
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
+        onOpenAutoFocus={(e: Event) => e.preventDefault()}
+        onCloseAutoFocus={(e: Event) => e.preventDefault()}
+        onInteractOutside={(e: Event) => e.preventDefault()}
+        onEscapeKeyDown={(e: Event) => e.preventDefault()}
+        onPointerDownOutside={(e: Event) => e.preventDefault()}
+      >
+        {emoji.show && (
+          <EmojiPickerPopup
+            entries={emoji.items}
+            selectedIndex={emoji.selectedIndex}
+            onSelect={insertEmoji}
+          />
+        )}
+        {slash.show && (
+          <SlashCommandPopup
+            commands={slash.items}
+            selectedIndex={slash.selectedIndex}
+            onSelect={handleSlashCommandSelect}
+          />
+        )}
+      </Popover.Content>
+    </Popover.Root>
   );
 }

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
@@ -318,4 +318,58 @@ describe("LiveVoiceButton — lifecycle", () => {
     );
     expect(stub.endCalls).toBe(1);
   });
+
+  test("switching conversationId mid-session ends the manager", () => {
+    // The composer is stable across conversation navigation — only the
+    // `conversationId` prop changes. Without the switch-detection effect
+    // the existing WebSocket would keep streaming against conversation A
+    // while the UI shows conversation B.
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-A"
+        managerFactory={() => stub}
+      />,
+    );
+    // Drive the store into `listening` so the conversation is meaningfully
+    // bound to a live session at the moment of navigation.
+    act(() => {
+      useLiveVoiceStore.setState({ state: "listening" });
+    });
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-B"
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
+
+  test("initial null→value conversationId binding does NOT end the manager", () => {
+    // Mounting with no conversation, then a conversation activates for
+    // the first time, is initial binding — not a switch. End() must not
+    // fire or we'd kill the session before it can begin.
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={null}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-A"
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+  });
 });

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -107,6 +107,27 @@ export function LiveVoiceButton({
     }
   }, [gateOpen]);
 
+  // The composer is stable across conversation navigation — only
+  // `conversationId` changes as a prop. Without this effect, an active
+  // WebSocket would keep streaming audio/STT/LLM/TTS frames against the
+  // previous conversation's session while the UI shows the new one.
+  // Tear down the manager when the user navigates between two real
+  // conversations. Skip the initial mount (no previous id) and the
+  // null→value transition (a new conversation activating for the first
+  // time, not a switch).
+  const previousConversationIdRef = useRef<string | null>(conversationId);
+  useEffect(() => {
+    const previous = previousConversationIdRef.current;
+    previousConversationIdRef.current = conversationId;
+    if (
+      previous !== null &&
+      conversationId !== null &&
+      previous !== conversationId
+    ) {
+      void managerRef.current?.end();
+    }
+  }, [conversationId]);
+
   if (!voiceModeEnabled || !assistantId) return null;
 
   const manager = managerRef.current;


### PR DESCRIPTION
## Summary
Fixes two gaps from realtime-voice-web plan self-review (I2 + I3).

- **Conversation switch leak**: previously, switching conversations kept the
  voice session bound to the previous one. The WebSocket continued streaming
  STT/LLM/TTS frames against conversation A while UI showed conversation B.
- **Overlay/notices overlap**: the overlay's absolute bottom-full positioning
  anchored above only the form wrapper, so any notices (billing, maintenance,
  voice errors) rendered ABOVE the wrapper were overlapped by the overlay.

Part of plan: realtime-voice-web.md (self-review remediation)