### PR TITLE
fix(web/voice): resume suspended AudioContext + surface capture failures

### DIFF
--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -543,6 +543,49 @@ describe("LiveVoiceChannelManager", () => {
     });
   });
 
+  describe("capture failure after ready", () => {
+    test("capture.start() returning false transitions to failed and tears down", async () => {
+      // Regression: previously the manager silently dropped a `false`
+      // return from `capture.start()` (mic permission denied / no
+      // AudioContext / etc.), leaving the store stuck in `connecting`
+      // and the UI showing "Connecting voice conversation" forever.
+      // After the ready frame the WS-side connection timeout has already
+      // been cancelled, so there is no other recovery path.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      expect(store.getState().state).toBe("connecting");
+
+      // Mic will fail to start once `ready` triggers `startCapture()`.
+      capture.startResult = false;
+
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // Manager transitioned the session to `failed` via the same path
+      // as a server-driven failure, surfacing an error message to the
+      // overlay.
+      expect(store.getState().state).toBe("failed");
+      expect(store.getState().errorMessage.length).toBeGreaterThan(0);
+
+      // Same teardown shape as `handleFailure`: capture shutdown,
+      // playback interrupt, client closed (not `end()`).
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      expect(client.closeCalls).toBe(1);
+      expect(client.endCalls).toBe(0);
+    });
+  });
+
   describe("stopListening", () => {
     test("releases push-to-talk and stops capture, keeps channel open", async () => {
       const harness = makeHarness();

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -101,9 +101,56 @@ class MockGainNode {
 }
 
 class MockAudioContext {
+  /**
+   * Initial `state` for the next-constructed `MockAudioContext`. The
+   * capture instantiates its context internally, so tests use this
+   * static hook to drive the suspended-context branch without reaching
+   * into private state.
+   */
+  static nextInitialState: "suspended" | "running" | "closed" | null = null;
+  /**
+   * Override `resume()` impl for the next-constructed context. Lets
+   * tests simulate a resume rejection without prototype patching.
+   */
+  static nextResumeImpl: (() => Promise<void>) | null = null;
+  static lastInstance: MockAudioContext | null = null;
   audioWorklet = new MockAudioWorklet();
   destination = new MockAudioDestinationNode();
   closed = false;
+  /**
+   * Mirrors the real `AudioContext.state` so the capture's
+   * suspended-context branch can be exercised. Defaults to `"running"`;
+   * tests that need to drive the suspended path set
+   * `MockAudioContext.nextInitialState = "suspended"` before invoking
+   * `start()` and supply a `resumeImpl` via `MockAudioContext.lastInstance`.
+   */
+  state: "suspended" | "running" | "closed" = "running";
+
+  constructor() {
+    if (MockAudioContext.nextInitialState !== null) {
+      this.state = MockAudioContext.nextInitialState;
+      MockAudioContext.nextInitialState = null;
+    }
+    if (MockAudioContext.nextResumeImpl !== null) {
+      this.resumeImpl = MockAudioContext.nextResumeImpl;
+      MockAudioContext.nextResumeImpl = null;
+    }
+    MockAudioContext.lastInstance = this;
+  }
+  /**
+   * Number of times `resume()` has been called. Tests assert this
+   * to verify the suspended-context branch ran.
+   */
+  resumeCalls = 0;
+  /**
+   * Override hook for `resume()` — by default it flips `state` to
+   * `"running"` and resolves. Tests that need to simulate a rejection
+   * (e.g. user-gesture missing) overwrite this with a rejecting impl.
+   */
+  resumeImpl: () => Promise<void> = () => {
+    this.state = "running";
+    return Promise.resolve();
+  };
   lastWorkletNode: MockAudioWorkletNode | null = null;
   lastSourceNode: MockMediaStreamAudioSourceNode | null = null;
   lastGainNode: MockGainNode | null = null;
@@ -116,6 +163,10 @@ class MockAudioContext {
     const node = new MockGainNode(this);
     this.lastGainNode = node;
     return node;
+  }
+  resume(): Promise<void> {
+    this.resumeCalls += 1;
+    return this.resumeImpl();
   }
   close(): Promise<void> {
     this.closed = true;
@@ -195,6 +246,9 @@ beforeEach(() => {
   mockStream = null;
   getUserMediaImpl = () =>
     Promise.reject(new Error("getUserMedia not configured"));
+  MockAudioContext.nextInitialState = null;
+  MockAudioContext.nextResumeImpl = null;
+  MockAudioContext.lastInstance = null;
   installMocks();
 });
 
@@ -451,6 +505,48 @@ describe("LiveVoicePcmCapture", () => {
       capture as unknown as { stream: MockMediaStream | null }
     ).stream;
     expect(internalStream).toBe(streams[1]!);
+  });
+
+  it("resumes a suspended AudioContext before reporting capture started", async () => {
+    // Regression: Chrome's autoplay policy and mobile Safari's tab
+    // lifecycle can leave the AudioContext in `"suspended"` immediately
+    // after construction. Without an explicit `resume()`, the worklet's
+    // `process()` never runs and live voice gets zero PCM chunks while
+    // the UI silently reports "Listening…".
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+    MockAudioContext.nextInitialState = "suspended";
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(true);
+    const ctx = getInternalContext(capture);
+    expect(ctx.resumeCalls).toBe(1);
+    expect(ctx.state).toBe("running");
+  });
+
+  it("returns false when resuming a suspended AudioContext rejects", async () => {
+    // Regression companion to the suspended-resume test: if the browser
+    // refuses to resume (e.g. no preceding user gesture on Safari),
+    // returning `true` would leave the manager reporting "Listening…"
+    // with no audio flowing. Treat the rejection as a start failure so
+    // the manager can transition the UI to `failed` and offer retry.
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+    MockAudioContext.nextInitialState = "suspended";
+    MockAudioContext.nextResumeImpl = () =>
+      Promise.reject(new Error("blocked"));
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(false);
+    const ctx = MockAudioContext.lastInstance;
+    expect(ctx).not.toBeNull();
+    expect(ctx!.resumeCalls).toBe(1);
+    // Stream must be released on the failure path.
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
   });
 
   it("two overlapping start() calls — earlier resolves last, latest still wins", async () => {

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -381,7 +381,9 @@ export class LiveVoiceChannelManager {
   // -------------------------------------------------------------------------
 
   private async startCapture(): Promise<void> {
-    const started = await this.capture?.start({
+    const capture = this.capture;
+    if (!capture) return;
+    const started = await capture.start({
       onChunk: (chunk) => {
         this.client?.sendAudio(chunk.pcm16);
       },
@@ -389,7 +391,23 @@ export class LiveVoiceChannelManager {
         this.actions().setInputAmplitude(amplitude);
       },
     });
-    if (!started) return;
+    // A concurrent `end()` / failure may have nulled or replaced
+    // `this.capture` while we awaited start(). If so the session is
+    // gone and we must not clobber the resulting `off` / `failed` state.
+    if (this.capture !== capture) return;
+    if (!started) {
+      // Capture failed to start (mic permission denied, suspended-
+      // context resume rejection, worklet load failure, etc.).
+      // Without audio frames the WS would dangle in `connecting`
+      // forever — its 10s timeout was already cleared by the `ready`
+      // frame. Surface as a connection failure so the overlay shows the
+      // error and the button enters retry mode.
+      this.handleFailure({
+        type: "connectionFailed",
+        message: "Microphone permission denied or unavailable",
+      });
+      return;
+    }
     if (this.currentState() !== "failed") {
       this.actions().setState("listening");
     }

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -161,6 +161,26 @@ export class LiveVoicePcmCapture {
         return false;
       }
 
+      // Chrome's autoplay policy and Safari's tab lifecycle can leave
+      // the AudioContext in `"suspended"` after construction. A
+      // suspended context never schedules `process()` on the worklet —
+      // we'd report capture as started but deliver zero PCM chunks.
+      // Resume it before publishing the new graph; on rejection
+      // (no user gesture, etc.) bail so the manager surfaces an error.
+      if (audioContext.state === "suspended") {
+        try {
+          await audioContext.resume();
+        } catch {
+          releaseStream(stream);
+          return false;
+        }
+        // Re-check after the await — same race window as `addModule()`.
+        if (myGen !== this.startGeneration || this.isShutdown) {
+          releaseStream(stream);
+          return false;
+        }
+      }
+
       const sourceNode = audioContext.createMediaStreamSource(stream);
       const workletNode = new AudioWorkletNode(
         audioContext,


### PR DESCRIPTION
## Summary
Fixes two gaps from realtime-voice-web plan self-review (G1 / I1).

- **AudioContext suspend handling**: browsers may auto-suspend the AudioContext
  during the mic permission prompt or tab lifecycle. Without resuming, the
  AudioWorklet never runs and no PCM chunks are delivered — symptom is
  'Listening…' status with no transcription.
- **Failed capture surfacing**: previously, capture.start() returning false
  was silently ignored by the manager, leaving the UI stuck in 'Connecting…'
  forever. Now treats it as a connection failure.

Part of plan: realtime-voice-web.md (self-review remediation)