### PR TITLE
fix(web/voice): gate manager construction + reset flag in composer tests

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -9,7 +9,7 @@
  *   2. `@testing-library/react` `render` for HTML surface checks (placeholder,
  *      send/stop button, disabled attribute).
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 
@@ -277,7 +277,23 @@ describe("computeGhostSuffix", () => {
 // HTML rendering — placeholder and send/stop button surface
 // ---------------------------------------------------------------------------
 
-afterEach(cleanup);
+// Snapshot the `voiceMode` flag before each test and restore it in
+// `afterEach`. The flag store is a module-scoped Zustand singleton, so
+// without this guard a mid-test failure in any voice-mode-on case
+// (`setState({ voiceMode: true })` ... assertion throws ... restore
+// `false` never runs) leaves the flag set for every subsequent test in
+// the file. Mirrors the explicit reset pattern from
+// `live-voice-button.test.tsx`.
+let voiceModeSnapshot = false;
+beforeEach(() => {
+  voiceModeSnapshot = useAssistantFeatureFlagStore.getState().voiceMode;
+  useAssistantFeatureFlagStore.setState({ voiceMode: false });
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantFeatureFlagStore.setState({ voiceMode: voiceModeSnapshot });
+});
 
 function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
   const { container } = render(
@@ -501,11 +517,13 @@ describe("ChatComposer — optional slots", () => {
 
 describe("ChatComposer — LiveVoiceButton mount", () => {
   test("LiveVoiceButton renders in the toolbar when voice-mode flag is on + assistantId is set", () => {
-    // The button gates itself on `voiceMode` + `assistantId`. With the flag
-    // off (default), it short-circuits to null. Flip the flag on and assert
-    // the button surface lands in the rendered HTML. `act` wraps the
-    // store mutation so React's gate-close `useEffect` (which fires the
-    // manager `end()` cleanup) flushes inside the test boundary.
+    // The button gates itself on `voiceMode` + `assistantId`. The shared
+    // `beforeEach` already reset the flag to `false`; flip it on and
+    // assert the button surface lands in the rendered HTML. `act` wraps
+    // the store mutation so React's gate-close `useEffect` (which fires
+    // the manager `end()` cleanup) flushes inside the test boundary.
+    // The shared `afterEach` restores the snapshot so a thrown assertion
+    // here can't leak `voiceMode: true` into subsequent tests.
     act(() => {
       useAssistantFeatureFlagStore.setState({ voiceMode: true });
     });
@@ -516,15 +534,11 @@ describe("ChatComposer — LiveVoiceButton mount", () => {
     // LiveVoiceButton uses aria-label "Start voice conversation" in the
     // initial `off` state — that's the unambiguous signal it mounted.
     expect(html).toContain("Start voice conversation");
-    act(() => {
-      useAssistantFeatureFlagStore.setState({ voiceMode: false });
-    });
   });
 
   test("LiveVoiceButton is omitted when voice-mode flag is off (gate closed)", () => {
-    act(() => {
-      useAssistantFeatureFlagStore.setState({ voiceMode: false });
-    });
+    // `beforeEach` already set the flag to `false`; no explicit
+    // mutation needed here.
     const html = renderComposer({
       assistantId: "asst_test",
       conversationId: "conv_test",

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -75,11 +75,17 @@ export function LiveVoiceButton({
   const state = useLiveVoiceStore.use.state();
   const errorMessage = useLiveVoiceStore.use.errorMessage();
 
+  const gateOpen = voiceModeEnabled && assistantId !== null;
+
   // `useRef` (not `useState`) so React strict-mode's double-invoke of
   // render doesn't build two managers and leak the first one's
-  // WebSocket / mic handles.
+  // WebSocket / mic handles. We only construct the manager once the
+  // gate is open — for flag-off or assistantId-null mounts, leaving the
+  // ref null keeps the unmount + gate-close `end()` calls no-ops so we
+  // don't churn `useLiveVoiceStore` (which the manager's `end()` resets
+  // via `actions().reset()`) on every disabled render.
   const managerRef = useRef<LiveVoiceButtonManager | null>(null);
-  if (managerRef.current === null) {
+  if (managerRef.current === null && gateOpen) {
     managerRef.current = managerFactory
       ? managerFactory()
       : new LiveVoiceChannelManager();
@@ -87,11 +93,12 @@ export function LiveVoiceButton({
 
   // Fire-and-forget: React's cleanup is sync, the manager's `end()` is
   // async. Dropping the promise is safe — the component has already
-  // left the tree, so there's nothing to surface failures to.
+  // left the tree, so there's nothing to surface failures to. When the
+  // gate was closed for the lifetime of this mount, `managerRef.current`
+  // stays null and the cleanup is a no-op.
   useEffect(() => {
-    const manager = managerRef.current;
     return () => {
-      void manager?.end();
+      void managerRef.current?.end();
     };
   }, []);
 
@@ -100,7 +107,6 @@ export function LiveVoiceButton({
   // underlying manager would silently keep the WebSocket and mic open
   // with no visible control to stop it. Tear it down on every gate
   // transition to closed so the session ends with the affordance.
-  const gateOpen = voiceModeEnabled && assistantId !== null;
   useEffect(() => {
     if (!gateOpen) {
       void managerRef.current?.end();


### PR DESCRIPTION
## Summary
Fixes two gaps from realtime-voice-web plan self-review (I4 + I5).

- **Lazy-init under gate**: only construct the manager when voice-mode is on
  and assistantId is non-null. Avoids store churn for flag-off mounts.
- **Test isolation**: reset voiceMode flag in beforeEach/afterEach so a
  thrown assertion doesn't leave the singleton flag store in a non-default
  state for subsequent tests.

Part of plan: realtime-voice-web.md (self-review remediation)