### PR TITLE
fix(web/voice): drop stale server frames on end + restore popover anchor scope

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -381,17 +381,23 @@ export function ChatComposer({
 
   return (
     <Popover.Root open={emoji.show || slash.show}>
-      <Popover.Anchor asChild>
-        {/* `relative` wrapper anchors the live voice overlay's
-            `absolute bottom-full` directly above the composer's notices
-            + form stack. Because `noticesAboveFormSlot` is rendered as
-            an in-flow sibling of the form inside this wrapper, the
-            overlay's `bottom: 100%` clears both notices and form rather
-            than clipping into the notices region (billing banner,
-            maintenance banner, voice errors, etc.). */}
-        <div className="relative">
-          {showLiveVoiceOverlay && <LiveVoiceOverlay />}
-          {noticesAboveFormSlot}
+      {/* `relative` wrapper anchors the live voice overlay's
+          `absolute bottom-full` directly above the composer's notices
+          + form stack. Because `noticesAboveFormSlot` is rendered as
+          an in-flow sibling of the form inside this wrapper, the
+          overlay's `bottom: 100%` clears both notices and form rather
+          than clipping into the notices region (billing banner,
+          maintenance banner, voice errors, etc.).
+
+          `Popover.Anchor` is scoped to the form only — not the whole
+          wrapper — so the slash/emoji popup's `side="top"` positioning
+          stays anchored at the textarea instead of floating above any
+          visible notice banner with the banner sandwiched between the
+          popup and the textarea. */}
+      <div className="relative">
+        {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+        {noticesAboveFormSlot}
+        <Popover.Anchor asChild>
           <form
             onSubmit={onSubmit}
             className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
@@ -706,8 +712,8 @@ export function ChatComposer({
               </div>
             </div>
           </form>
-        </div>
-      </Popover.Anchor>
+        </Popover.Anchor>
+      </div>
       <Popover.Content
         side="top"
         align="start"

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -826,6 +826,92 @@ describe("LiveVoiceChannelManager", () => {
     });
   });
 
+  describe("stale frame guard after end", () => {
+    test("late server frames after end() do not mutate playback or store", async () => {
+      // Repro of the conversation-switch leak: `end()` is graceful — it
+      // sends the protocol `end` frame and waits up to 1s for the server
+      // to close. During that grace window the WebSocket can still
+      // dispatch frames (sttFinal, assistantTextDelta, ttsAudio, etc.)
+      // and without the generation guard each one would mutate the
+      // global store / playback, leaking the old session's STT and
+      // assistant audio into the new conversation's UI.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "hello", seq: 1 });
+      expect(store.getState().state).toBe("speaking");
+
+      const enqueueCallsBeforeEnd = playback.enqueueCalls.length;
+
+      // Kick off end() (don't await) — the manager bumps the generation
+      // synchronously inside end() before awaiting `client.end()`, so by
+      // the time we emit the late frame the guard is already in effect.
+      const endPromise = manager.end();
+
+      // Server frames slip in during the grace window. With the guard
+      // in place the dispatcher bails before `handleEvent` runs, so
+      // `playback.enqueueTtsAudio` and `actions.appendAssistantTranscript`
+      // are never called.
+      client.emit({
+        type: "assistantTextDelta",
+        text: " from-old-session",
+        seq: 2,
+      });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([9, 9, 9]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+
+      await endPromise;
+      await flushMicrotasks();
+
+      expect(playback.enqueueCalls.length).toBe(enqueueCallsBeforeEnd);
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().assistantTranscript).toBe("");
+    });
+
+    test("late failure callback after end() does not flip state to failed", async () => {
+      // Same race on the failure callback: if the server closes
+      // abnormally during the grace window, the late `onFailure`
+      // dispatch would otherwise clobber the `off` state with `failed`
+      // and surface a confusing error message in the new conversation.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.end();
+      expect(store.getState().state).toBe("off");
+
+      // Late failure callback from the still-open fake — the guard at
+      // the dispatch boundary drops it.
+      client.fail({ type: "abnormalClosure", code: 1006, reason: "boom" });
+
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().errorMessage).toBe("");
+    });
+  });
+
   describe("client factory", () => {
     test("start → end → start uses a fresh client each time", async () => {
       const { manager, clients, store } = makeHarness();

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -193,6 +193,14 @@ export class LiveVoiceChannelManager {
 
   async start(conversationId: string): Promise<void> {
     this.sessionGeneration += 1;
+    // Snapshot the generation at handler-registration time. Server frames
+    // that arrive after `end()` / failure (which bump the generation) are
+    // dropped at the dispatch boundary so they cannot leak STT, assistant
+    // text, or TTS playback from a torn-down session into the global
+    // store — e.g. a conversation switch during the 1s `end()` grace
+    // window must not surface frames from the old conversation in the
+    // new conversation's UI.
+    const sessionGen = this.sessionGeneration;
     this.playbackReadyForResponse = false;
     this.isUserMuted = false;
 
@@ -207,8 +215,14 @@ export class LiveVoiceChannelManager {
     this.playback = this.playbackFactory();
     await this.client.start({
       conversationId,
-      onEvent: (event) => this.handleEvent(event),
-      onFailure: (failure) => this.handleFailure(failure),
+      onEvent: (event) => {
+        if (sessionGen !== this.sessionGeneration) return;
+        this.handleEvent(event);
+      },
+      onFailure: (failure) => {
+        if (sessionGen !== this.sessionGeneration) return;
+        this.handleFailure(failure);
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
Fixes two gaps from realtime-voice-web plan self-review (round 1).

- **Stale frame leak (Pass 1)**: graceful end() leaves up to 1s where
  server frames keep flowing into the global store after a conversation
  switch. The new sessionGeneration guard at the dispatch boundary drops
  all late frames in one place.
- **Popover anchor regression (Pass 3)**: I3's notices-inside-wrapper
  change inadvertently made the slash/emoji popup anchor above the
  notices stack. Scope the Popover.Anchor to just the form so the popup
  anchors at the textarea as before.

Part of plan: realtime-voice-web.md (self-review round 2 remediation)