### PR TITLE
docs(apps): fix misleading NodeNext default claim in AGENTS.md (LUM-2008)

### DIFF
--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -9,11 +9,11 @@ Applies to all code under `apps/`. Subordinate to root [`AGENTS.md`](../AGENTS.m
 - No workspaces, no Turborepo. Per-package `bun install`. Exact version
   pinning is enforced repo-wide; see root `AGENTS.md` for the dependency,
   license, and tool-version rules.
-- Default module resolution is NodeNext with `.js` extensions on all
-  imports. Apps that ship with a bundler (`apps/web/` via Vite,
-  `apps/macos/` via electron-vite) use `moduleResolution: "Bundler"`
-  with `module: "ESNext"`. Bundler-mode apps omit `.js` extensions;
-  NodeNext apps require them.
+- All current apps use bundlers (`apps/web/` via Vite, `apps/macos/`
+  via electron-vite) and therefore use `moduleResolution: "Bundler"`
+  with `module: "ESNext"`. Bundler-mode apps omit `.js` extensions on
+  imports. If a future app compiles without a bundler, use NodeNext
+  with `.js` extensions (matching `assistant/`, `gateway/`, `cli/`).
 
 ## Adding a new app
 


### PR DESCRIPTION
## Prompt / plan

Fixes LUM-2008 — the `apps/AGENTS.md` stated "Default module resolution is NodeNext with `.js` extensions on all imports" which is incorrect. All apps under `apps/` use bundlers (Vite, electron-vite) and therefore use `moduleResolution: "Bundler"` with `module: "ESNext"`. No app currently uses NodeNext.

**Why needed:** The previous wording could mislead contributors into using `.js` extensions when creating new code under `apps/web/` or `apps/macos/`, which would fail at runtime since neither bundler requires or expects them.

**What changed:** Replaced the misleading "default is NodeNext" framing with an accurate "all current apps use bundlers" statement, while preserving guidance for hypothetical future non-bundled apps.

**Safety:** Documentation-only change. No code, no runtime behavior change.

Closes LUM-2008

## Test plan

N/A — documentation-only change. Verified the claim against actual `tsconfig.json` files:
- `apps/web/tsconfig.json`: `"module": "ESNext"`, `"moduleResolution": "Bundler"`
- `apps/macos/tsconfig.json`: `"module": "ESNext"`, `"moduleResolution": "Bundler"`
- `apps/ios/`: No tsconfig (Capacitor iOS shell, no TS compilation)

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka