### PR TITLE
streaming: durable event log + Last-Event-Id replay

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -71,7 +71,7 @@ import {
 } from "./conversation-error.js";
 import { isProviderOrderingError } from "./conversation-slash.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
-import { nextSeq } from "./streaming-events.js";
+import { appendEvent } from "./event-log.js";
 import type {
   CardSurfaceData,
   ServerMessage,
@@ -82,6 +82,7 @@ import type {
   WebSearchMetadata,
   WebSearchResultItem,
 } from "./message-types/web-activity.js";
+import { nextSeq } from "./streaming-events.js";
 
 const log = getLogger("agent-loop-handlers");
 
@@ -440,6 +441,24 @@ function resolveAssistantReplyTimestampTimezone(
 // and order events deterministically.
 
 /**
+ * Emit a streaming event over the live SSE channel and append it to the
+ * durable event log so `Last-Event-Id` reconnect replay can resume from
+ * any point in the turn. Caller is responsible for stamping `seq`
+ * (typically via {@link nextSeq}) before invocation — `appendEvent`
+ * filters out events without a `seq` and is a no-op for non-streaming
+ * event types.
+ *
+ * The publish-then-log order matches the priority of the two paths:
+ * the live consumer sees the event as soon as possible, and a DB
+ * failure during the durable write is logged inside `appendEvent` but
+ * never tears down the in-flight turn.
+ */
+function emitWithLog(deps: EventHandlerDeps, event: ServerMessage): void {
+  deps.onEvent(event);
+  appendEvent(deps.ctx.conversationId, event);
+}
+
+/**
  * Ensure the turn's assistant message id is allocated and `message_open`
  * has been emitted. Called from the first text-delta and tool-use entry
  * points. Idempotent — subsequent calls in the same turn are no-ops.
@@ -451,7 +470,7 @@ function ensureMessageOpen(
   if (state.currentMessageId) return state.currentMessageId;
   const messageId = uuidv7();
   state.currentMessageId = messageId;
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "message_open",
     conversationId: deps.ctx.conversationId,
     messageId,
@@ -474,7 +493,7 @@ function closeCurrentBlock(
     return;
   const messageId = state.currentMessageId;
   if (!messageId) return;
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "block_close",
     conversationId: deps.ctx.conversationId,
     messageId,
@@ -504,7 +523,7 @@ function openBlock(
   if (blockType === "tool_use" && toolInfo) {
     state.toolUseIdToBlockIndex.set(toolInfo.toolUseId, nextIndex);
   }
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "block_open",
     conversationId: deps.ctx.conversationId,
     messageId,
@@ -568,7 +587,7 @@ function handleTextDelta(
     }
     const messageId = ensureMessageOpen(state, deps);
     const blockIndex = ensureBlockForKind(state, deps, "text");
-    deps.onEvent({
+    emitWithLog(deps, {
       type: "assistant_text_delta",
       text: drained.emitText,
       conversationId: deps.ctx.conversationId,
@@ -641,7 +660,7 @@ export function handleToolUse(
     toolName: event.name,
     toolUseId: event.id,
   });
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "tool_use_start",
     toolName: event.name,
     input: event.input,
@@ -759,7 +778,7 @@ export function handleInputJsonDelta(
   // cumulative JSON on every delta with no benefit.
   if (!APP_TOOL_NAMES.has(event.toolName)) return;
   const blockIndex = state.toolUseIdToBlockIndex.get(event.toolUseId);
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "tool_input_delta",
     toolName: event.toolName,
     content: event.accumulatedJson,
@@ -887,7 +906,7 @@ export function handleToolResult(
 
   // Send to client last so state is consistent even if onEvent throws.
   const toolBlockIndex = state.toolUseIdToBlockIndex.get(event.toolUseId);
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "tool_result",
     toolName: "",
     result: event.content,
@@ -1164,7 +1183,7 @@ export async function handleMessageComplete(
   if (state.pendingDirectiveDisplayBuffer.length > 0) {
     const flushMessageId = ensureMessageOpen(state, deps);
     const flushBlockIndex = ensureBlockForKind(state, deps, "text");
-    deps.onEvent({
+    emitWithLog(deps, {
       type: "assistant_text_delta",
       text: state.pendingDirectiveDisplayBuffer,
       conversationId: deps.ctx.conversationId,
@@ -1374,7 +1393,7 @@ export async function handleMessageComplete(
   // for every persisted assistant row.
   if (!state.currentMessageId) {
     state.currentMessageId = assistantMsg.id;
-    deps.onEvent({
+    emitWithLog(deps, {
       type: "message_open",
       conversationId: deps.ctx.conversationId,
       messageId: assistantMsg.id,
@@ -1385,7 +1404,7 @@ export async function handleMessageComplete(
   if (state.currentBlockType !== null) {
     closeCurrentBlock(state, deps);
   }
-  deps.onEvent({
+  emitWithLog(deps, {
     type: "message_close",
     conversationId: deps.ctx.conversationId,
     messageId: state.currentMessageId,
@@ -1660,7 +1679,7 @@ export async function dispatchAgentEvent(
           toolName: event.name,
           toolUseId: event.toolUseId,
         });
-        deps.onEvent({
+        emitWithLog(deps, {
           type: "tool_use_start",
           toolName: event.name,
           input: event.input,
@@ -1744,7 +1763,7 @@ export async function dispatchAgentEvent(
         const serverToolBlockIndex = state.toolUseIdToBlockIndex.get(
           event.toolUseId,
         );
-        deps.onEvent({
+        emitWithLog(deps, {
           type: "tool_result",
           toolName: "web_search",
           result: resultText,

--- a/assistant/src/daemon/event-log.ts
+++ b/assistant/src/daemon/event-log.ts
@@ -1,0 +1,215 @@
+/**
+ * Durable per-conversation streaming-event log.
+ *
+ * Every streaming event emitted during an assistant turn is appended to the
+ * `conversation_events` table alongside the live SSE publish. The table
+ * backs the SSE `Last-Event-Id` reconnect protocol: when a client drops a
+ * stream mid-turn, it re-subscribes with the last `seq` it observed and
+ * the daemon replays every persisted row with `seq > last_event_id`
+ * before fanning live events into the new connection.
+ *
+ * Storage is intentionally append-only; rows are pruned by
+ * {@link trimEventsOlderThan} (called from the daemon's startup cleanup
+ * hook) rather than per-conversation truncation, so a reconnecting client
+ * can always resume from the last `seq` it observed even when the
+ * conversation has since been evicted from in-memory state.
+ *
+ * The neutral `AssistantEvent` envelope is what subscribers receive on the
+ * wire, so we persist the full envelope JSON to keep replay verbatim. The
+ * `event_type`, `message_id`, and `block_index` columns are denormalized
+ * from the payload to support targeted queries (debugging, future
+ * per-message replay) without re-parsing every row.
+ */
+
+import { rawAll, rawRun } from "../memory/raw-query.js";
+import { getLogger } from "../util/logger.js";
+import type { ServerMessage } from "./message-protocol.js";
+
+const log = getLogger("event-log");
+
+/**
+ * Event types persisted to the durable log. Restricting writes to the
+ * streaming-architecture event set keeps the log small and avoids racing
+ * with bespoke broadcasts (sync invalidations, host-proxy traffic) that
+ * are not part of the replay protocol. The set mirrors the events PR 1
+ * stamped with `seq` — `message_complete` and `generation_handoff` are
+ * intentionally absent because they still emit without `seq` from the
+ * orchestrator and replay would deliver them out of order relative to
+ * the addressable events around them.
+ */
+const LOGGED_EVENT_TYPES = new Set<string>([
+  "message_open",
+  "block_open",
+  "block_close",
+  "message_close",
+  "assistant_text_delta",
+  "tool_use_start",
+  "tool_input_delta",
+  "tool_result",
+]);
+
+/** Row shape returned by {@link readEventsAfter}. */
+export interface ConversationEventRow {
+  conversationId: string;
+  seq: number;
+  eventType: string;
+  messageId: string | null;
+  blockIndex: number | null;
+  payloadJson: string;
+  createdAt: number;
+}
+
+/** True when the event type is one we persist to the durable log. */
+export function isLoggableEvent(eventType: string): boolean {
+  return LOGGED_EVENT_TYPES.has(eventType);
+}
+
+interface EventLike {
+  type: string;
+  seq?: number;
+  messageId?: string;
+  blockIndex?: number;
+}
+
+/**
+ * Append a streaming event to the durable log.
+ *
+ * No-op when the event type is not in {@link LOGGED_EVENT_TYPES} or when
+ * the event does not carry a `seq` field (only post-PR-1 streaming events
+ * are addressable, so writing a row without `seq` would create a gap that
+ * the replay path cannot honor).
+ *
+ * Errors from the DB write are caught and logged — the live SSE publish
+ * already succeeded, so a write failure here only degrades replay, never
+ * the in-flight turn. Mirrors the non-fatal stance used across the
+ * agent-loop persistence calls.
+ */
+export function appendEvent(
+  conversationId: string,
+  message: ServerMessage,
+): void {
+  if (!isLoggableEvent(message.type)) return;
+  const event = message as EventLike;
+  if (typeof event.seq !== "number") return;
+  try {
+    rawRun(
+      `INSERT INTO conversation_events
+       (conversation_id, seq, event_type, message_id, block_index, payload_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (conversation_id, seq) DO NOTHING`,
+      conversationId,
+      event.seq,
+      message.type,
+      typeof event.messageId === "string" ? event.messageId : null,
+      typeof event.blockIndex === "number" ? event.blockIndex : null,
+      JSON.stringify(message),
+      Date.now(),
+    );
+  } catch (err) {
+    log.warn(
+      { err, conversationId, eventType: message.type, seq: event.seq },
+      "Failed to append conversation event (non-fatal)",
+    );
+  }
+}
+
+/**
+ * Return every event for `conversationId` with `seq > afterSeq`, in seq
+ * order. Used by the SSE handshake to replay events the client missed
+ * before subscribing to live events.
+ */
+export function readEventsAfter(
+  conversationId: string,
+  afterSeq: number,
+): ConversationEventRow[] {
+  return rawAll<{
+    conversation_id: string;
+    seq: number;
+    event_type: string;
+    message_id: string | null;
+    block_index: number | null;
+    payload_json: string;
+    created_at: number;
+  }>(
+    `SELECT conversation_id, seq, event_type, message_id, block_index,
+            payload_json, created_at
+     FROM conversation_events
+     WHERE conversation_id = ? AND seq > ?
+     ORDER BY seq ASC`,
+    conversationId,
+    afterSeq,
+  ).map((row) => ({
+    conversationId: row.conversation_id,
+    seq: row.seq,
+    eventType: row.event_type,
+    messageId: row.message_id,
+    blockIndex: row.block_index,
+    payloadJson: row.payload_json,
+    createdAt: row.created_at,
+  }));
+}
+
+/**
+ * Read the highest persisted `seq` for `conversationId`. Used by
+ * {@link nextSeq} to reseed the in-memory counter when a conversation
+ * re-enters memory after eviction, so a fresh `nextSeq()` cannot collide
+ * with rows the previous incarnation wrote.
+ *
+ * Returns `0` when the DB is unavailable or the query fails — the worst
+ * case is a sequence-collision risk for evicted conversations under DB
+ * stress, which is bounded by the 7-day retention window. The fallback
+ * also keeps unit tests that exercise streaming handlers without a real
+ * DB working without per-test mocking.
+ */
+export function maxSeqForConversation(conversationId: string): number {
+  try {
+    const row = rawAll<{ max_seq: number | null }>(
+      `SELECT MAX(seq) AS max_seq FROM conversation_events WHERE conversation_id = ?`,
+      conversationId,
+    )[0];
+    return row?.max_seq ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Drop event rows older than `cutoffMs` (epoch ms). Returns the number of
+ * rows deleted. The default retention window is 7 days — long enough to
+ * absorb realistic reconnect gaps (network drops, app backgrounding,
+ * device sleep) while keeping the table bounded.
+ */
+export function trimEventsOlderThan(cutoffMs: number): number {
+  try {
+    return rawRun(
+      `DELETE FROM conversation_events WHERE created_at < ?`,
+      cutoffMs,
+    );
+  } catch (err) {
+    log.warn(
+      { err, cutoffMs },
+      "Failed to trim conversation_events (non-fatal)",
+    );
+    return 0;
+  }
+}
+
+/** Default retention window for the durable event log. */
+export const EVENT_LOG_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Run a single retention sweep using {@link EVENT_LOG_RETENTION_MS}.
+ *
+ * Called once at daemon startup. Keeping the cleanup minimal (single
+ * sweep at boot rather than a periodic cron) is intentional — the table
+ * is small for active installs and the next boot will catch up any
+ * accumulation between restarts.
+ */
+export function runEventLogCleanup(): number {
+  const cutoff = Date.now() - EVENT_LOG_RETENTION_MS;
+  const deleted = trimEventsOlderThan(cutoff);
+  if (deleted > 0) {
+    log.info({ deleted, cutoff }, "Trimmed conversation_events");
+  }
+  return deleted;
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -938,6 +938,17 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
+    // Trim the durable streaming-event log to the configured retention window
+    // so the table cannot grow unbounded across daemon restarts. Single
+    // sweep at startup is intentional — the next boot catches up anything
+    // accumulated since.
+    try {
+      const { runEventLogCleanup } = await import("./event-log.js");
+      runEventLogCleanup();
+    } catch (err) {
+      log.warn({ err }, "Conversation event-log cleanup failed — continuing");
+    }
+
     registerWatcherProviders();
     registerMessagingProviders();
 

--- a/assistant/src/daemon/streaming-events.ts
+++ b/assistant/src/daemon/streaming-events.ts
@@ -3,12 +3,17 @@
  *
  * The streaming architecture (see `.private/plans/streaming-message-architecture.md`)
  * tags every event the daemon emits for a conversation with a monotonically
- * increasing `seq`. The sequence persists for the lifetime of the daemon
- * process — it is keyed by `conversationId`, initialized to `0` on first
- * access, and bumped on every `nextSeq()` call. PR 2 in the plan will
- * persist these sequences to durable storage and reseed from the max
- * persisted value at daemon startup; for now we only need monotonic
- * in-memory uniqueness so reconnecting clients can detect replays.
+ * increasing `seq`. The sequence persists across daemon restarts and
+ * conversation evictions via the durable `conversation_events` table:
+ * `nextSeq` lazily reseeds the in-memory counter from the max persisted
+ * `seq` the first time a conversation surfaces (after boot, or after an
+ * eviction that called {@link resetSeq}). Subsequent calls bump the
+ * in-memory counter without touching the DB.
+ *
+ * Reseeding from durable state is required so post-eviction emits cannot
+ * collide with rows the previous incarnation already wrote — replay
+ * relies on `(conversation_id, seq)` being globally unique within the
+ * retention window.
  *
  * The counter is intentionally a module-level map keyed by conversationId
  * (rather than living on `Conversation` / `AgentLoopConversationContext`)
@@ -17,11 +22,22 @@
  * conversation context through every call site.
  */
 
+import { maxSeqForConversation } from "./event-log.js";
+
 const seqCounters = new Map<string, number>();
 
-/** Return the next monotonic `seq` for the given conversation. */
+/**
+ * Return the next monotonic `seq` for the given conversation.
+ *
+ * On first access for a conversation, the counter is seeded from the max
+ * persisted `seq` in `conversation_events` so a daemon restart or a
+ * post-eviction re-entry cannot replay an existing seq value.
+ */
 export function nextSeq(conversationId: string): number {
-  const current = seqCounters.get(conversationId) ?? 0;
+  let current = seqCounters.get(conversationId);
+  if (current === undefined) {
+    current = maxSeqForConversation(conversationId);
+  }
   const next = current + 1;
   seqCounters.set(conversationId, next);
   return next;
@@ -33,7 +49,8 @@ export function peekSeq(conversationId: string): number {
 }
 
 /** Drop the seq counter for a conversation. Used when a conversation is
- *  evicted/destroyed so process memory does not grow unbounded. */
+ *  evicted/destroyed so process memory does not grow unbounded. The next
+ *  `nextSeq` for this conversation will reseed from durable storage. */
 export function resetSeq(conversationId: string): void {
   seqCounters.delete(conversationId);
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -67,6 +67,7 @@ import {
   migrateContactsRolePrincipal,
   migrateContactsUserFileColumn,
   migrateConversationCleanedAt,
+  migrateConversationEvents,
   migrateConversationForkLineage,
   migrateConversationHostAccess,
   migrateConversationInferenceProfileSession,
@@ -466,6 +467,7 @@ export function initializeDb(): void {
     migrateLlmRequestLogCallSite,
     migrateDropProviderConnectionStatus,
     migrateMessagesClientMessageId,
+    migrateConversationEvents,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/267-conversation-events.ts
+++ b/assistant/src/memory/migrations/267-conversation-events.ts
@@ -1,0 +1,56 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Create the `conversation_events` table — a durable, append-only log of
+ * streaming events emitted during an assistant turn.
+ *
+ * Each row records one event the daemon published over the SSE channel for
+ * a conversation, tagged with its per-conversation monotonic `seq`. The
+ * table backs `Last-Event-Id` replay on SSE reconnect (see PR 2 of the
+ * streaming-message-architecture plan) so a client that drops a stream
+ * mid-turn can resume without losing or duplicating events.
+ *
+ * Columns:
+ * - `conversation_id` — owner conversation; rows are scoped per-conversation
+ *   for cheap range scans on reconnect replay.
+ * - `seq` — the per-conversation monotonic sequence stamped on the event by
+ *   {@link nextSeq}. The composite `(conversation_id, seq)` is the natural
+ *   primary key and the only index used during replay.
+ * - `event_type` — the `ServerMessage.type` discriminant (e.g.
+ *   `assistant_text_delta`, `block_open`, `message_close`).
+ * - `message_id` — the assistant `messageId` the event references, when one
+ *   is in scope. Stored separately from the payload so future queries can
+ *   filter by message without parsing the JSON blob.
+ * - `block_index` — the 0-based block coordinate within the message, when
+ *   applicable. Same rationale as `message_id`.
+ * - `payload_json` — the full event payload, serialized so the SSE handshake
+ *   can replay it verbatim.
+ * - `created_at` — wall-clock insertion time (epoch ms). Drives the periodic
+ *   trimmer that drops rows older than the retention window.
+ *
+ * Idempotent — re-running the migration is a no-op once the table and index
+ * exist. Uses CREATE TABLE/INDEX IF NOT EXISTS so no checkpoint entry is
+ * required.
+ */
+export function migrateConversationEvents(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversation_events (
+      conversation_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      event_type TEXT NOT NULL,
+      message_id TEXT,
+      block_index INTEGER,
+      payload_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (conversation_id, seq)
+    )
+  `);
+  // Time-range index for the cleanup task that trims rows older than the
+  // retention window. The composite primary key already covers the replay
+  // path, so no additional `(conversation_id, seq)` index is needed.
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_conversation_events_created_at
+      ON conversation_events (created_at)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -253,6 +253,7 @@ export {
 export { migrateLlmRequestLogCallSite } from "./264-llm-request-log-call-site.js";
 export { migrateDropProviderConnectionStatus } from "./265-drop-provider-connection-status.js";
 export { migrateMessagesClientMessageId } from "./266-messages-client-message-id.js";
+export { migrateConversationEvents } from "./267-conversation-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -26,10 +26,17 @@ import { z } from "zod";
 import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
+import { readEventsAfter } from "../../daemon/event-log.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
 import { getConversation } from "../../memory/conversation-crud.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
-import { formatSseFrame, formatSseHeartbeat } from "../assistant-event.js";
+import type { AssistantEvent } from "../assistant-event.js";
+import {
+  buildAssistantEvent,
+  formatSseFrame,
+  formatSseHeartbeat,
+} from "../assistant-event.js";
 import type {
   AssistantEventCallback,
   AssistantEventFilter,
@@ -240,10 +247,24 @@ const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
  * Headers (optional):
  *   X-Vellum-Client-Id    -- stable per-install UUID identifying this client.
  *   X-Vellum-Interface-Id -- interface type (e.g. "macos", "ios", "web").
+ *   Last-Event-Id         -- last `seq` the client successfully processed for
+ *                            this conversation. When set, the daemon replays
+ *                            persisted events with `seq > last_event_id` from
+ *                            `conversation_events` before fanning out live
+ *                            events. Standard SSE field — `EventSource`
+ *                            sends it automatically on reconnect. Only honored
+ *                            when the stream is scoped to one conversation
+ *                            (via `conversationId` or `conversationKey`).
  *
- *   When both are present, the subscriber is registered as a client in the
- *   event hub with metadata (interfaceId, capabilities). The hub handles
- *   lifecycle — dispose() unregisters the client automatically.
+ *   When both client-id headers are present, the subscriber is registered as
+ *   a client in the event hub with metadata (interfaceId, capabilities). The
+ *   hub handles lifecycle — dispose() unregisters the client automatically.
+ *
+ * Query params (optional):
+ *   lastEventId       -- alternative to the `Last-Event-Id` header for
+ *                        transports that cannot set arbitrary headers
+ *                        (mobile WKWebView quirks, native SDKs). Header
+ *                        wins if both are supplied.
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
@@ -281,6 +302,19 @@ export function handleSubscribeAssistantEvents(
   const rawInterfaceId = headers?.["x-vellum-interface-id"];
   const rawMachineName = headers?.["x-vellum-machine-name"];
   const rawActorPrincipalId = headers?.["x-vellum-actor-principal-id"];
+  // `Last-Event-Id` is the standard SSE reconnect field; `lastEventId` query
+  // param is the fallback for transports that cannot set arbitrary headers.
+  // Header wins when both are supplied so an explicit reconnect always
+  // outranks a stale URL.
+  const rawLastEventId =
+    headers?.["last-event-id"]?.trim() ||
+    queryParams?.lastEventId?.trim() ||
+    "";
+  const lastEventIdParsed = rawLastEventId ? Number(rawLastEventId) : NaN;
+  const lastEventId =
+    Number.isFinite(lastEventIdParsed) && lastEventIdParsed >= 0
+      ? Math.trunc(lastEventIdParsed)
+      : null;
   const clientId = rawClientId?.trim() || null;
   const interfaceId = clientId
     ? parseInterfaceId(rawInterfaceId?.trim())
@@ -357,6 +391,39 @@ export function handleSubscribeAssistantEvents(
     conversationKey: scopeConversationKey,
   };
 
+  // -- Last-Event-Id replay state --------------------------------------------
+  // When the client supplies a `Last-Event-Id`, we replay persisted events
+  // with `seq > lastEventId` from the durable log before delivering live
+  // events. Two pieces of state coordinate the handoff so neither path
+  // delivers a duplicate:
+  //
+  //   - `replayMaxSeq` — the highest seq written to the client during
+  //     replay. Live events with `seq <= replayMaxSeq` are dropped by the
+  //     callback because the replay already covered them.
+  //   - `replayComplete` + `pendingLiveEvents` — until replay finishes,
+  //     live events are buffered in order rather than written directly to
+  //     the SSE stream, so replay and live can never interleave.
+  //
+  // When `lastEventId` is null we skip replay entirely; the callback then
+  // writes live events straight through.
+  const replayRequested =
+    lastEventId !== null && filter.conversationId !== undefined;
+  let replayMaxSeq = lastEventId ?? 0;
+  let replayComplete = !replayRequested;
+  const pendingLiveEvents: AssistantEvent[] = [];
+
+  function writeEventFrame(event: AssistantEvent): void {
+    const controller = controllerRef;
+    if (!controller) return;
+    controller.enqueue(encoder.encode(formatSseFrame(event)));
+    instrumentation.eventsDelivered += 1;
+  }
+
+  function eventSeq(event: AssistantEvent): number | undefined {
+    const msg = event.message as { seq?: unknown };
+    return typeof msg.seq === "number" ? msg.seq : undefined;
+  }
+
   ensureEventLoopDelayMonitorStarted();
 
   function cleanup() {
@@ -381,8 +448,19 @@ export function handleSubscribeAssistantEvents(
         cleanup();
         return;
       }
-      controller.enqueue(encoder.encode(formatSseFrame(event)));
-      instrumentation.eventsDelivered += 1;
+      // Buffer live events until replay completes so the SSE stream observes
+      // replayed-then-live order. After replay, fall through to the dedupe
+      // check that drops events the replay already covered.
+      if (!replayComplete) {
+        pendingLiveEvents.push(event);
+        return;
+      }
+      const seq = eventSeq(event);
+      if (seq !== undefined && seq <= replayMaxSeq) {
+        // Replay already delivered this seq (or a higher one) — drop.
+        return;
+      }
+      writeEventFrame(event);
     } catch {
       sub.dispose();
       cleanup();
@@ -433,6 +511,56 @@ export function handleSubscribeAssistantEvents(
 
         controller.enqueue(encoder.encode(formatSseHeartbeat()));
         instrumentation.heartbeatsSent += 1;
+
+        // Replay persisted events with `seq > lastEventId` for this
+        // conversation, then drain anything the live callback buffered
+        // while we were reading from the DB. Skipping the conversation-
+        // unscoped case is intentional — replay needs a single
+        // conversation to scope the query and is the only mode the
+        // reconnect protocol cares about.
+        if (replayRequested && filter.conversationId) {
+          try {
+            const rows = readEventsAfter(
+              filter.conversationId,
+              lastEventId ?? 0,
+            );
+            for (const row of rows) {
+              try {
+                const payload = JSON.parse(row.payloadJson) as ServerMessage;
+                const replayEvent = buildAssistantEvent(
+                  payload,
+                  filter.conversationId,
+                );
+                writeEventFrame(replayEvent);
+                if (row.seq > replayMaxSeq) replayMaxSeq = row.seq;
+              } catch (err) {
+                log.warn(
+                  {
+                    err,
+                    conversationId: filter.conversationId,
+                    seq: row.seq,
+                  },
+                  "Failed to replay conversation event (skipping)",
+                );
+              }
+            }
+          } catch (err) {
+            log.warn(
+              { err, conversationId: filter.conversationId, lastEventId },
+              "Failed to read events for Last-Event-Id replay",
+            );
+          }
+        }
+
+        // Drain any live events buffered while replay ran, dropping any
+        // whose seq the replay already covered.
+        replayComplete = true;
+        for (const buffered of pendingLiveEvents) {
+          const seq = eventSeq(buffered);
+          if (seq !== undefined && seq <= replayMaxSeq) continue;
+          writeEventFrame(buffered);
+        }
+        pendingLiveEvents.length = 0;
 
         heartbeatTimer = setInterval(() => {
           try {
@@ -517,6 +645,11 @@ export const ROUTES: RouteDefinition[] = [
         name: "conversationKey",
         description:
           "Scope to a single conversation by an external key (non-vellum channels) or the web idempotency key. Materializes a row on first use. Ignored when conversationId is also provided.",
+      },
+      {
+        name: "lastEventId",
+        description:
+          "Last per-conversation seq the client successfully processed. Equivalent to the standard `Last-Event-Id` SSE header; provided as a query param for transports that cannot set arbitrary request headers. The daemon replays persisted events with `seq > lastEventId` before delivering live events.",
       },
     ],
     responseHeaders: {

--- a/packages/skill-host-contracts/src/assistant-event.ts
+++ b/packages/skill-host-contracts/src/assistant-event.ts
@@ -66,13 +66,26 @@ export function buildAssistantEvent<TMessage>(
  *
  * ```
  * event: assistant_event\n
- * id: <event.id>\n
+ * id: <id>\n
  * data: <JSON>\n
  * \n
  * ```
+ *
+ * When the envelope's `message` payload carries a numeric `seq`, that value
+ * is used for the SSE `id:` field so a reconnecting `EventSource` populates
+ * the `Last-Event-Id` header with the daemon's per-conversation sequence
+ * number (which the runtime route uses to drive durable-log replay). The
+ * envelope's UUID `event.id` remains in the JSON payload for legacy
+ * consumers and as a stable correlator across logs.
+ *
+ * The id line is sanitized (newlines stripped, value cast to string) so a
+ * crafted `seq` or `event.id` cannot inject extra SSE fields.
  */
 export function formatSseFrame(event: AssistantEvent): string {
-  const sanitizedId = event.id.replace(/[\n\r]/g, "");
+  const seq = (event.message as { seq?: unknown } | null | undefined)?.seq;
+  const rawId =
+    typeof seq === "number" && Number.isFinite(seq) ? String(seq) : event.id;
+  const sanitizedId = rawId.replace(/[\n\r]/g, "");
   const data = JSON.stringify(event);
   return `event: assistant_event\nid: ${sanitizedId}\ndata: ${data}\n\n`;
 }


### PR DESCRIPTION
## Summary
- Persists all streaming events to a new conversation_events SQLite table.
- Adds Last-Event-Id-based replay on SSE reconnect.
- Adds id: <seq> field on each SSE event line.
- Adds simple 7-day cleanup of old event log rows.

Part of plan: streaming-message-architecture.md (PR 2 of 6)