### PR TITLE
feat(macos): persist + restore main window geometry across launches

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import { installApplicationMenu } from "./menu";
 import { readSetting, writeSetting } from "./settings";
+import { restoreBounds, track as trackWindowState } from "./window-state";
 
 // Dev-mode renderer URL. Honors `VELLUM_DEV_URL` so the launcher can
 // point the BrowserWindow at whichever Vite-or-equivalent is actually
@@ -82,8 +83,7 @@ let mainWindow: BrowserWindow | null = null;
 
 const createWindow = (): void => {
   mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 800,
+    ...restoreBounds("main", { width: 1280, height: 800 }),
     show: false,
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.js"),
@@ -96,6 +96,12 @@ const createWindow = (): void => {
       devTools: isDev,
     },
   });
+
+  // Subscribe to resize/move/close so the next launch can restore the
+  // user's last geometry. See `window-state.ts` for the persistence
+  // model (separate electron-store file, debounced saves, fullscreen
+  // tracked as a flag rather than as bounds).
+  trackWindowState("main", mainWindow);
 
   mainWindow.once("ready-to-show", () => {
     mainWindow?.show();

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -9,9 +9,10 @@ import Store, { type Schema } from "electron-store";
  *
  * Note: window geometry (position, size) is intentionally NOT here. It's a
  * main-process-managed concern in Electron (system-managed on iOS,
- * browser-managed on web), and the renderer never reads or writes it. If
- * window-state restore is wired in a future ticket, it lives in its own
- * keyspace or via a dedicated library (e.g. `electron-window-state`).
+ * browser-managed on web), and the renderer never reads or writes it.
+ * The persistence for that lives in `./window-state.ts`, which uses its
+ * own `electron-store` instance keyed by window kind so it doesn't have
+ * to share this file's strict schema.
  */
 export interface AppSettings {
   hotkeys: Record<string, string>;

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -1,0 +1,132 @@
+import { BrowserWindow, screen, type Rectangle } from "electron";
+import Store from "electron-store";
+
+/**
+ * Window-geometry persistence. Kept in its own `electron-store` instance
+ * (`window-state.json`) so it doesn't collide with the renderer-facing
+ * `settings` store, which has `additionalProperties: false` at the root
+ * and a strict per-key schema. Window state is a main-process concern
+ * the renderer never reads or writes — it doesn't belong on the
+ * `window.vellum.settings.*` bridge.
+ *
+ * `key` namespaces the stored shape, so future windows (thread pop-outs,
+ * About, onboarding) can persist alongside the main window without
+ * clobbering each other — `track("main", win)`,
+ * `track("thread.<id>", win)`, etc.
+ */
+
+interface SavedWindowState extends Rectangle {
+  isFullScreen: boolean;
+}
+
+interface StoreSchema {
+  windows: Record<string, SavedWindowState>;
+}
+
+let instance: Store<StoreSchema> | null = null;
+
+const store = (): Store<StoreSchema> => {
+  if (!instance) {
+    instance = new Store<StoreSchema>({
+      name: "window-state",
+      defaults: { windows: {} },
+    });
+  }
+  return instance;
+};
+
+interface Defaults {
+  width: number;
+  height: number;
+}
+
+export interface RestoredWindowState {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  fullscreen?: boolean;
+}
+
+/**
+ * Resolve the bounds to construct a `BrowserWindow` with, falling through
+ * to the supplied defaults when no state has been persisted for `key`.
+ *
+ * When state IS present, the saved rectangle is matched to the closest
+ * still-connected display via `screen.getDisplayMatching` and clamped
+ * into that display's work area, so:
+ *
+ *   - An external monitor that was unplugged since the last run doesn't
+ *     leave the window 100% off-screen — it shows up on whatever's left.
+ *   - A monitor that shrunk (resolution change) doesn't leave the window
+ *     extending past the new edge.
+ *
+ * Omitting `x` / `y` when no state exists is intentional — Electron
+ * centers the window in that case, which is the right first-run UX.
+ */
+export const restoreBounds = (
+  key: string,
+  defaults: Defaults,
+): RestoredWindowState => {
+  const saved = store().get("windows", {})[key];
+  if (!saved) return defaults;
+
+  const display = screen.getDisplayMatching(saved);
+  const wa = display.workArea;
+
+  const width = Math.min(saved.width, wa.width);
+  const height = Math.min(saved.height, wa.height);
+  const x = Math.max(wa.x, Math.min(saved.x, wa.x + wa.width - width));
+  const y = Math.max(wa.y, Math.min(saved.y, wa.y + wa.height - height));
+
+  return { x, y, width, height, fullscreen: saved.isFullScreen };
+};
+
+/**
+ * Persist this window's geometry under `key` so the next launch can
+ * restore it. Saves on:
+ *
+ *   - `close` — synchronous, the normal-exit path. Captures whatever
+ *     state the user left the window in.
+ *   - `resize` / `move` — debounced 500ms. Covers the crash case where
+ *     `close` never fires; users lose at most half a second of drag.
+ *
+ * Reads `getNormalBounds()` rather than `getBounds()` so a maximized or
+ * fullscreen window persists its restored-size geometry instead of the
+ * full-display rectangle — otherwise un-maximizing on the next run
+ * would leave a tiny window. `isFullScreen()` is tracked separately and
+ * passed through to the `BrowserWindow` constructor on restore, so the
+ * window comes back in the same display mode it was left in.
+ *
+ * Skips persisting when the window is minimized — the bounds at that
+ * moment are not meaningful.
+ */
+export const track = (key: string, win: BrowserWindow): void => {
+  const SAVE_DEBOUNCE_MS = 500;
+  let saveTimer: NodeJS.Timeout | null = null;
+
+  const persist = (): void => {
+    if (win.isDestroyed() || win.isMinimized()) return;
+    const bounds = win.getNormalBounds();
+    const existing = store().get("windows", {});
+    store().set("windows", {
+      ...existing,
+      [key]: { ...bounds, isFullScreen: win.isFullScreen() },
+    });
+  };
+
+  const schedulePersist = (): void => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(persist, SAVE_DEBOUNCE_MS);
+  };
+
+  win.on("resize", schedulePersist);
+  win.on("move", schedulePersist);
+  win.on("close", () => {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    persist();
+  });
+};

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -94,19 +94,19 @@ export const restoreBounds = (
  * Reads `getNormalBounds()` rather than `getBounds()` so a maximized or
  * fullscreen window persists its restored-size geometry instead of the
  * full-display rectangle — otherwise un-maximizing on the next run
- * would leave a tiny window. `isFullScreen()` is tracked separately and
- * passed through to the `BrowserWindow` constructor on restore, so the
- * window comes back in the same display mode it was left in.
- *
- * Skips persisting when the window is minimized — the bounds at that
- * moment are not meaningful.
+ * would leave a tiny window. `getNormalBounds()` also returns the
+ * pre-minimize bounds when the window is minimized, so no special
+ * handling is needed for the common macOS "minimize to dock, then
+ * Cmd+Q" path. `isFullScreen()` is tracked separately and passed
+ * through to the `BrowserWindow` constructor on restore, so the window
+ * comes back in the same display mode it was left in.
  */
 export const track = (key: string, win: BrowserWindow): void => {
   const SAVE_DEBOUNCE_MS = 500;
   let saveTimer: NodeJS.Timeout | null = null;
 
   const persist = (): void => {
-    if (win.isDestroyed() || win.isMinimized()) return;
+    if (win.isDestroyed()) return;
     const bounds = win.getNormalBounds();
     const existing = store().get("windows", {});
     store().set("windows", {


### PR DESCRIPTION
## Summary

Wires window-geometry persistence in the Electron app so the main window comes back where you left it. Restores width/height/x/y on launch and tracks fullscreen state. Handles the disconnected-display case so the window can't end up off-screen.

Closes [LUM-1936](https://linear.app/vellum/issue/LUM-1936).

## What's in

### `apps/macos/src/main/window-state.ts` (new, ~140 lines)

Two functions:

- **`restoreBounds(key, defaults)`** — returns a bounds object to spread into the `BrowserWindow` constructor. Falls through to `defaults` on first run (no `x`/`y`, so Electron centers the window — the right first-run UX). When state exists, matches the saved rectangle to the closest still-connected display via `screen.getDisplayMatching` and clamps it into that display's `workArea`. Covers two failure modes that bit `electron-window-state` users in similar codebases:
  - The external monitor with the saved bounds was unplugged → window lands on whatever display is closest, not in negative coordinates.
  - The display resolution dropped (4K → 1080p, dock change) → window doesn't extend past the new edge.
- **`track(key, win)`** — wires the window to persist on `close` (synchronous, normal-exit path) and on `resize`/`move` with a 500ms debounce (crash recovery — covers the case where `close` never fires). Reads `getNormalBounds()` so un-fullscreening on the next launch reveals the proper restored size, not a 1×1 sliver of the last fullscreen state. `isFullScreen()` is tracked separately as a flag and passed back through the constructor on restore, so the window comes up in the same display mode it was left in.

Storage uses its own `electron-store` instance (`window-state.json` under `userData`) rather than the renderer-facing `settings.ts` store. Three reasons:

1. The settings store has `additionalProperties: false` and a strict per-key schema — geometry has no business sitting alongside `hotkeys` / `theme` / `featureFlags`.
2. Window position is a main-process-only concern; exposing it through the contextBridge to a renderer that can't render anything outside the BrowserWindow makes no sense.
3. Future windows (thread pop-outs from [LUM-1870](https://linear.app/vellum/issue/LUM-1870), About from [LUM-1971](https://linear.app/vellum/issue/LUM-1971), onboarding) can `track("thread.<id>", win)` / `track("about", win)` against the same store without colliding with each other or the strict settings schema.

### `apps/macos/src/main/index.ts`

`createWindow()` now spreads `restoreBounds("main", { width: 1280, height: 800 })` into the constructor and calls `trackWindowState("main", mainWindow)` right after creation.

### `apps/macos/src/main/settings.ts`

Docstring updated — the "if window-state restore is wired in a future ticket, it lives in its own keyspace or via a dedicated library" note now points at `./window-state.ts` instead of describing it hypothetically.

## How to test locally

1. `bun run dev`
2. Resize and move the window, quit (Cmd+Q), relaunch → window should reopen at the same geometry.
3. Maximize (Cmd+Ctrl+F for macOS native fullscreen), quit, relaunch → window should reopen fullscreen.
4. With the window on an external monitor: disconnect the monitor, quit, relaunch → window appears on the still-connected display at a clamped size, NOT off-screen.
5. Force-kill the app mid-drag (e.g. via Activity Monitor) → on next launch, the window should be within ~500ms of where it was at kill time, not at its previous-close location.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run build` clean. Main bundle 408.19 kB (+1.5 kB from window-state module).
- [ ] Manual check of the five flows above on a real Mac.

## Out of scope (deliberate)

- **Main window default-size change to 1200×900 + `minWidth: 800, minHeight: 600`** — that's [LUM-1965](https://linear.app/vellum/issue/LUM-1965) alongside the tray icon work. Kept the existing 1280×800 default here so this PR is just the persistence layer.
- **Tracking the other window kinds** — thread pop-outs / About / onboarding don't exist on main yet. The module already supports them via the `key` parameter; their respective tickets will call `track("...", win)` when each window lands.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_