### PR TITLE
fix(macos): run electron's install.js on bun install

### DIFF
--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -5,6 +5,7 @@
   "description": "Electron wrapper for the Vellum Assistant macOS app.",
   "main": "out/main/index.js",
   "scripts": {
+    "postinstall": "node node_modules/electron/install.js",
     "dev": "bun run install:all && bun scripts/dev.ts",
     "dev:standalone": "bun run install:all && concurrently --kill-others --names web,electron --prefix-colors blue,green \"bun run dev:web\" \"bun run dev:electron\"",
     "dev:electron-only": "bun install && electron-vite dev",


### PR DESCRIPTION
## Summary

Hotfix for `bun run dev` failing on a fresh `bun install` in `apps/macos/`. After the dev-runner PR (#32210) merged, anyone pulling main and running `bun run dev` hit:

```
Error: Electron uninstall
  at getElectronPath (...electron-vite/.../lib-q6ns0vZr.js:155:19)
```

## Root cause

Electron 42.x **removed** the `postinstall` script from its own `package.json`. From the project's own packaging notes, they explicitly delegate binary fetching to the consuming package. With no `postinstall` declared on `electron` itself, neither npm nor bun fires `node_modules/electron/install.js` — so `dist/electron` and `path.txt` never get written, and `electron-vite`'s `getElectronPath()` throws on first launch.

(`trustedDependencies: ["electron"]` doesn't help here — there's no script to trust.)

## Fix

One line — a root-level `postinstall` in `apps/macos/package.json` that calls the installer directly:

```json
"postinstall": "node node_modules/electron/install.js"
```

`apps/macos` is the install root for its own `bun install`, so root-level `postinstall` runs unconditionally.

## How to test

```sh
cd apps/macos
rm -rf node_modules/electron/dist node_modules/electron/path.txt
bun install
# postinstall fires, writes path.txt and dist/electron
bun run dev
# Electron now launches
```

Verified locally — the install script is idempotent (re-runs are cheap when binary is already present).

## After this lands

Anyone on main who already has a busted `node_modules/electron`:

```sh
cd apps/macos
node node_modules/electron/install.js   # one-time recovery
# OR
rm -rf node_modules && bun install      # nuke and reinstall
```

Going forward, `bun install` self-heals.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_