### PR TITLE
refactor(messaging): convert persistUserMessage/persistQueuedMessageBody to options object

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -154,13 +154,9 @@ function makeIdleSession(opts?: {
   let processing = false;
   return {
     isProcessing: () => processing,
-    persistUserMessage: (
-      _content: string,
-      _attachments: unknown[],
-      requestId?: string,
-    ) => {
+    persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
-      return requestId ?? "msg-1";
+      return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
     memoryPolicy: {
       scopeId: "default",
@@ -223,13 +219,9 @@ function makeConfirmationEmittingSession(opts?: {
   const tool = opts?.toolName ?? "shell_command";
   return {
     isProcessing: () => processing,
-    persistUserMessage: (
-      _content: string,
-      _attachments: unknown[],
-      requestId?: string,
-    ) => {
+    persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
-      return requestId ?? "msg-1";
+      return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
     memoryPolicy: {
       scopeId: "default",
@@ -266,7 +258,11 @@ function makeConfirmationEmittingSession(opts?: {
           input: { command: "ls" },
           riskLevel: "medium",
           allowlistOptions: [
-            { label: "Allow ls", description: "Allow ls command", pattern: "ls" },
+            {
+              label: "Allow ls",
+              description: "Allow ls command",
+              pattern: "ls",
+            },
           ],
           scopeOptions: [{ label: "This conversation", scope: "session" }],
           persistentDecisionsAllowed: true,

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -536,7 +536,7 @@ describe("loadFromDb history repair", () => {
       trustClass: "guardian",
       sourceChannel: "telegram",
     });
-    await conversation.persistUserMessage("Guardian follow-up", []);
+    await conversation.persistUserMessage({ content: "Guardian follow-up" });
     const messagesAfterPersist = conversation.getMessages();
 
     expect(messagesAfterPersist).toHaveLength(5);

--- a/assistant/src/__tests__/conversation-routes-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-routes-disk-view.test.ts
@@ -229,26 +229,11 @@ function createFakeConversation(conversationId: string): Conversation {
     },
     persistUserMessage(
       this: Conversation,
-      content: string,
-      attachments: Array<{
-        id: string;
-        filename: string;
-        mimeType: string;
-        data: string;
-        extractedText?: string;
-        filePath?: string;
-      }>,
-      requestId?: string,
-      metadata?: Record<string, unknown>,
-      displayContent?: string,
+      options: Parameters<typeof persistUserMessage>[1],
     ): Promise<{ id: string; deduplicated: boolean }> {
       return persistUserMessage(
         this as Parameters<typeof persistUserMessage>[0],
-        content,
-        attachments,
-        requestId,
-        metadata,
-        displayContent,
+        options,
       );
     },
     async runAgentLoop(

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -150,7 +150,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       replyText: "Access approved. Verification code: 123456.",
     });
 
-    const persistUserMessage = mock(async () => "should-not-be-called");
+    const persistUserMessage = mock(async () => ({
+      id: "should-not-be-called",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -234,7 +237,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       type: "not_consumed",
     });
 
-    const persistUserMessage = mock(async () => "persisted-user-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -313,7 +319,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       type: "not_consumed",
     });
 
-    const persistUserMessage = mock(async () => "persisted-user-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -398,7 +407,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       requestId: "tool-req-code-1",
     });
 
-    const persistUserMessage = mock(async () => "should-not-be-called");
+    const persistUserMessage = mock(async () => ({
+      id: "should-not-be-called",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -478,7 +490,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       requestId: "pending-reject-1",
     });
 
-    const persistUserMessage = mock(async () => "should-not-be-called");
+    const persistUserMessage = mock(async () => ({
+      id: "should-not-be-called",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -552,7 +567,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       type: "not_consumed",
     });
 
-    const persistUserMessage = mock(async () => "persisted-user-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -628,7 +646,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     });
 
     const mockGenerator = mock(async () => ({}));
-    const persistUserMessage = mock(async () => "persisted-user-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},
@@ -705,7 +726,10 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     });
 
     const mockGenerator = mock(async () => ({}));
-    const persistUserMessage = mock(async () => "persisted-user-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const session = {
       setTrustContext: () => {},

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -226,8 +226,13 @@ const _testAuthContext: AuthContext = {
 
 function makeConversation() {
   const persistUserMessage = mock(
-    async (_content: string, _attachments: unknown[], _requestId?: string) =>
-      "persisted-user-id",
+    async (_options: {
+      content: string;
+      attachments?: unknown[];
+      requestId?: string;
+      metadata?: Record<string, unknown>;
+      clientMessageId?: string;
+    }) => ({ id: "persisted-user-id", deduplicated: false }),
   );
   const runAgentLoop = mock(
     async (

--- a/assistant/src/__tests__/dm-persistence.test.ts
+++ b/assistant/src/__tests__/dm-persistence.test.ts
@@ -121,20 +121,17 @@ describe("PR 16 — Slack DM persistence parity", () => {
     // ingress handler builds a `slackInbound` with no `threadTs` and threads
     // it through to persistence.
     const ctx = createSlackTurnContext();
-    await persistQueuedMessageBody(
-      ctx,
-      "hello from DM",
-      [],
-      "req-dm",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "hello from DM",
+      requestId: "req-dm",
+      metadata: {
         slackInbound: {
           channelId: "D0123DM",
           channelTs: "1700000000.123456",
           displayName: "Alice",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = lastPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -158,19 +155,16 @@ describe("PR 16 — Slack DM persistence parity", () => {
     // gateway can't resolve the user). The envelope should still be written;
     // only the optional displayName field is omitted.
     const ctx = createSlackTurnContext();
-    await persistQueuedMessageBody(
-      ctx,
-      "anonymous DM",
-      [],
-      "req-dm-anon",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "anonymous DM",
+      requestId: "req-dm-anon",
+      metadata: {
         slackInbound: {
           channelId: "D9999DM",
           channelTs: "1700000000.555555",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = lastPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -182,12 +176,10 @@ describe("PR 16 — Slack DM persistence parity", () => {
 
   test("DM inbound persists Slack actor timezone metadata", async () => {
     const ctx = createSlackTurnContext();
-    await persistQueuedMessageBody(
-      ctx,
-      "hello across timezones",
-      [],
-      "req-dm-timezone",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "hello across timezones",
+      requestId: "req-dm-timezone",
+      metadata: {
         slackInbound: {
           channelId: "D0123DM",
           channelTs: "1700000000.777777",
@@ -200,8 +192,7 @@ describe("PR 16 — Slack DM persistence parity", () => {
           speakerTimezoneLabel: "ET",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = lastPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -216,12 +207,10 @@ describe("PR 16 — Slack DM persistence parity", () => {
   test("DM and channel-message envelopes differ only by threadTs", async () => {
     // Capture the channel-thread case first.
     const ctx = createSlackTurnContext();
-    await persistQueuedMessageBody(
-      ctx,
-      "channel thread reply",
-      [],
-      "req-channel",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "channel thread reply",
+      requestId: "req-channel",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHAN",
           channelTs: "1700000000.999999",
@@ -229,8 +218,7 @@ describe("PR 16 — Slack DM persistence parity", () => {
           displayName: "Bob",
         },
       },
-      undefined,
-    );
+    });
     const channelMeta = lastPersistedSlackMeta();
     expect(channelMeta).not.toBeNull();
     expect(channelMeta!.threadTs).toBe("1700000000.111111");
@@ -238,20 +226,17 @@ describe("PR 16 — Slack DM persistence parity", () => {
     // Now dispatch a DM and assert that every shared field has the same
     // shape — only `threadTs` (and the inputs themselves) differ.
     addMessageCalls.length = 0;
-    await persistQueuedMessageBody(
-      ctx,
-      "DM reply",
-      [],
-      "req-dm-2",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "DM reply",
+      requestId: "req-dm-2",
+      metadata: {
         slackInbound: {
           channelId: "D9999DM",
           channelTs: "1700000000.222222",
           displayName: "Carol",
         },
       },
-      undefined,
-    );
+    });
     const dmMeta = lastPersistedSlackMeta();
     expect(dmMeta).not.toBeNull();
     expect(dmMeta!.source).toBe(channelMeta!.source);

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -219,7 +219,10 @@ function makeConversation(overrides: Record<string, unknown> = {}) {
     hasAnyPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
     enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
-    persistUserMessage: mock(async () => "persisted-user-id"),
+    persistUserMessage: mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    })),
     runAgentLoop: mock(async () => undefined),
     getMessages: () => [] as unknown[],
     assistantId: "self",
@@ -297,7 +300,10 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     // Dedicated /v1/recording/* endpoints handle recording lifecycle.
     // Text-based recording intent interception was retired with the
     // legacy handleUserMessage entry point.
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
@@ -314,7 +320,10 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     // content, conversationKey, attachmentIds, sourceChannel, and interface.
     // This ensures a future regression that starts parsing commandIntent would
     // be caught.
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
@@ -328,7 +337,10 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
   });
 
   test("stop recording commands pass through to the agent loop", async () => {
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
@@ -352,7 +364,10 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
   });
 
   test("passes canonical clientTimezone through host-proxy transport", async () => {
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
     let capturedOptions: Record<string, unknown> | undefined;
@@ -379,7 +394,10 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
   });
 
   test("passes canonical clientTimezone through non-host-proxy transport", async () => {
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
     let capturedOptions: Record<string, unknown> | undefined;
@@ -406,7 +424,10 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
   });
 
   test("drops invalid clientTimezone without rejecting the message", async () => {
-    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-msg-id",
+      deduplicated: false,
+    }));
     const runAgentLoop = mock(async () => undefined);
     const conversation = makeConversation({ persistUserMessage, runAgentLoop });
     let capturedOptions: Record<string, unknown> | undefined;

--- a/assistant/src/__tests__/inbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/inbound-slack-persistence.test.ts
@@ -141,12 +141,10 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Reply inside a thread",
-      [],
-      "req-thread",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Reply inside a thread",
+      requestId: "req-thread",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHANNEL",
           channelName: "engineering",
@@ -156,8 +154,7 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
           actorExternalUserId: "U_ALICE",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = readPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -177,20 +174,17 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Top-level channel post",
-      [],
-      "req-top",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Top-level channel post",
+      requestId: "req-top",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHANNEL",
           channelTs: "1700000010.222222",
           displayName: "Bob",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = readPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -206,20 +200,17 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "@leo can you check this?",
-      [],
-      "req-normalized-content",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "@leo can you check this?",
+      requestId: "req-normalized-content",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHANNEL",
           channelTs: "1700000015.123456",
           displayName: "Alice",
         },
       },
-      undefined,
-    );
+    });
 
     expect(JSON.parse(addMessageCalls.at(-1)!.content)).toEqual([
       { type: "text", text: "@leo can you check this?" },
@@ -237,19 +228,16 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Anonymous channel post",
-      [],
-      "req-anon",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Anonymous channel post",
+      requestId: "req-anon",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHANNEL",
           channelTs: "1700000020.333333",
         },
       },
-      undefined,
-    );
+    });
 
     const slackMeta = readPersistedSlackMeta();
     expect(slackMeta).not.toBeNull();
@@ -262,14 +250,10 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "telegram",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Telegram message",
-      [],
-      "req-tg",
-      undefined,
-      undefined,
-    );
+    await persistQueuedMessageBody(ctx, {
+      content: "Telegram message",
+      requestId: "req-tg",
+    });
 
     const metadata = lastPersistedMetadata();
     expect("slackMeta" in metadata).toBe(false);
@@ -285,19 +269,16 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "telegram",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Telegram message with stray slackInbound",
-      [],
-      "req-tg-stray",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Telegram message with stray slackInbound",
+      requestId: "req-tg-stray",
+      metadata: {
         slackInbound: {
           channelId: "C0_DOES_NOT_APPLY",
           channelTs: "1700000030.444444",
         },
       },
-      undefined,
-    );
+    });
 
     const metadata = lastPersistedMetadata();
     expect("slackMeta" in metadata).toBe(false);
@@ -313,14 +294,10 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Slack wake without inbound metadata",
-      [],
-      "req-no-slack-inbound",
-      undefined,
-      undefined,
-    );
+    await persistQueuedMessageBody(ctx, {
+      content: "Slack wake without inbound metadata",
+      requestId: "req-no-slack-inbound",
+    });
 
     const metadata = lastPersistedMetadata();
     expect("slackMeta" in metadata).toBe(false);
@@ -332,19 +309,16 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Malformed inbound payload",
-      [],
-      "req-malformed",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Malformed inbound payload",
+      requestId: "req-malformed",
+      metadata: {
         slackInbound: {
           // channelTs intentionally missing — simulates a bug upstream.
           channelId: "C0123CHANNEL",
         } as unknown as Record<string, unknown>,
       },
-      undefined,
-    );
+    });
 
     const metadata = lastPersistedMetadata();
     expect("slackMeta" in metadata).toBe(false);
@@ -356,19 +330,16 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       assistantMessageChannel: "slack",
     });
 
-    await persistQueuedMessageBody(
-      ctx,
-      "Verify carrier is stripped",
-      [],
-      "req-strip",
-      {
+    await persistQueuedMessageBody(ctx, {
+      content: "Verify carrier is stripped",
+      requestId: "req-strip",
+      metadata: {
         slackInbound: {
           channelId: "C0123CHANNEL",
           channelTs: "1700000040.555555",
         },
       },
-      undefined,
-    );
+    });
 
     const metadata = lastPersistedMetadata();
     expect("slackInbound" in metadata).toBe(false);

--- a/assistant/src/__tests__/process-message-background-slack.test.ts
+++ b/assistant/src/__tests__/process-message-background-slack.test.ts
@@ -85,12 +85,14 @@ type Deferred<T> = {
 };
 type PersistUserMessageMock = ReturnType<
   typeof mock<
-    (
-      content: string,
-      attachments: unknown[],
-      requestId?: string,
-      metadata?: Record<string, unknown>,
-    ) => Promise<{ id: string; deduplicated: boolean }>
+    (options: {
+      content: string;
+      attachments?: unknown[];
+      requestId?: string;
+      metadata?: Record<string, unknown>;
+      displayContent?: string;
+      clientMessageId?: string;
+    }) => Promise<{ id: string; deduplicated: boolean }>
   >
 >;
 type RunAgentLoopMock = ReturnType<
@@ -210,12 +212,14 @@ function makeConversation(): TestConversation {
       estimatedCost: 0,
     },
     persistUserMessage: mock(
-      async (
-        _content: string,
-        _attachments: unknown[],
-        _requestId?: string,
-        _metadata?: Record<string, unknown>,
-      ) => ({ id: "persisted-user-message-id", deduplicated: false }),
+      async (_options: {
+        content: string;
+        attachments?: unknown[];
+        requestId?: string;
+        metadata?: Record<string, unknown>;
+        displayContent?: string;
+        clientMessageId?: string;
+      }) => ({ id: "persisted-user-message-id", deduplicated: false }),
     ),
     runAgentLoop: mock(async (..._args: unknown[]) => {
       await loopDeferred.promise;
@@ -260,9 +264,9 @@ describe("processMessageInBackground Slack option propagation", () => {
 
     expect(result).toEqual({ messageId: "persisted-user-message-id" });
     expect(activeConversation.persistUserMessage).toHaveBeenCalledTimes(1);
-    expect(activeConversation.persistUserMessage.mock.calls[0][3]).toEqual({
-      slackInbound,
-    });
+    expect(
+      activeConversation.persistUserMessage.mock.calls[0][0].metadata,
+    ).toEqual({ slackInbound });
     expect(activeConversation.runAgentLoop).toHaveBeenCalledTimes(1);
 
     activeConversation.__loopDeferred.resolve();
@@ -325,7 +329,7 @@ describe("processMessageInBackground Slack option propagation", () => {
 
     expect(activeConversation.persistUserMessage).toHaveBeenCalledTimes(1);
     expect(
-      activeConversation.persistUserMessage.mock.calls[0][3],
+      activeConversation.persistUserMessage.mock.calls[0][0].metadata,
     ).toBeUndefined();
     expect(activeConversation.runAgentLoop.mock.calls[0][3]).toEqual({
       isInteractive: false,

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -182,21 +182,18 @@ function makeTestConversation() {
     getTurnChannelContext: () => turnChannelContext,
     getTurnInterfaceContext: () => turnInterfaceContext,
     getMessages: () => messages,
-    persistUserMessage: async (
-      content: string,
-      attachments: UserMessageAttachment[],
-      requestId?: string,
-      metadata?: Record<string, unknown>,
-      displayContent?: string,
-    ) =>
-      persistQueuedMessageBody(
-        messagingCtx,
-        content,
-        attachments,
-        requestId ?? "req-display-content",
-        metadata,
-        displayContent,
-      ),
+    persistUserMessage: async (options: {
+      content: string;
+      attachments?: UserMessageAttachment[];
+      requestId?: string;
+      metadata?: Record<string, unknown>;
+      displayContent?: string;
+      clientMessageId?: string;
+    }) =>
+      persistQueuedMessageBody(messagingCtx, {
+        ...options,
+        requestId: options.requestId ?? "req-display-content",
+      }),
     runAgentLoop,
     updateClient: () => {},
     getCurrentSender: () => undefined,
@@ -341,9 +338,9 @@ describe("processMessage displayContent", () => {
     const modelContent =
       '<external_content source="slack">\n\n</external_content>';
 
-    await conversation.persistUserMessage(
-      modelContent,
-      [
+    await conversation.persistUserMessage({
+      content: modelContent,
+      attachments: [
         {
           id: "att-1",
           filename: "attachment.pdf",
@@ -351,10 +348,9 @@ describe("processMessage displayContent", () => {
           data: Buffer.from("pdf bytes").toString("base64"),
         },
       ],
-      "req-display-content",
-      undefined,
-      "",
-    );
+      requestId: "req-display-content",
+      displayContent: "",
+    });
 
     expect(addMessageCalls).toHaveLength(1);
     const persistedBlocks = JSON.parse(addMessageCalls[0]!.content);

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -424,16 +424,15 @@ describe("relay-server", () => {
             includeDefaultFallback: false,
           },
           isProcessing: () => false,
-          persistUserMessage: async (
-            content: string,
-            _attachments: unknown[],
-            requestId?: string,
-          ) => {
-            session.currentRequestId = requestId;
+          persistUserMessage: async (options: {
+            content: string;
+            requestId?: string;
+          }) => {
+            session.currentRequestId = options.requestId;
             const message = await addMessage(
               conversationId,
               "user",
-              JSON.stringify([{ type: "text", text: content }]),
+              JSON.stringify([{ type: "text", text: options.content }]),
               {
                 userMessageChannel: "phone",
                 assistantMessageChannel: "phone",
@@ -441,7 +440,7 @@ describe("relay-server", () => {
                 assistantMessageInterface: "phone",
               },
             );
-            return message.id;
+            return { id: message.id, deduplicated: false };
           },
           setChannelCapabilities: () => {},
           setAssistantId: () => {},

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -188,7 +188,10 @@ function makeRequest(
   });
 }
 
-const persistUserMessageMock = mock(async () => "persisted-id");
+const persistUserMessageMock = mock(async () => ({
+  id: "persisted-id",
+  deduplicated: false,
+}));
 const runAgentLoopMock = mock(async () => undefined);
 
 function makeSendMessageDeps() {

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -136,13 +136,9 @@ function makeCompletingConversation(): Conversation {
   const messages: unknown[] = [];
   return {
     isProcessing: () => processing,
-    persistUserMessage: (
-      _content: string,
-      _attachments: unknown[],
-      requestId?: string,
-    ) => {
+    persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
-      return { id: requestId ?? "msg-1", deduplicated: false };
+      return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
     memoryPolicy: {
       scopeId: "default",
@@ -193,13 +189,9 @@ function makeHangingConversation(): Conversation {
   }> = [];
   return {
     isProcessing: () => processing,
-    persistUserMessage: (
-      _content: string,
-      _attachments: unknown[],
-      requestId?: string,
-    ) => {
+    persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
-      return { id: requestId ?? "msg-1", deduplicated: false };
+      return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
     memoryPolicy: {
       scopeId: "default",
@@ -278,11 +270,10 @@ function makePendingApprovalConversation(
 
   const conversation = {
     isProcessing: () => processing,
-    persistUserMessage: (
-      _content: string,
-      _attachments: unknown[],
-      reqId?: string,
-    ) => ({ id: reqId ?? "msg-1", deduplicated: false }),
+    persistUserMessage: (options: { requestId?: string }) => ({
+      id: options.requestId ?? "msg-1",
+      deduplicated: false,
+    }),
     memoryPolicy: {
       scopeId: "default",
       includeDefaultFallback: false,

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -14,7 +14,7 @@ interface FakeManagedSubagent {
       content: Array<{ type: string; text: string }>;
     }>;
     sendToClient: (msg: ServerMessage) => void;
-    persistUserMessage?: (msg: string) => string;
+    persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     enqueueMessage?: () => { rejected: boolean; queued: boolean };
     usageStats: {
@@ -64,7 +64,8 @@ function injectFakeSubagent(
   const internals = asInternals(manager);
 
   internals.subagents.set(subagentId, {
-    conversation: conversation === undefined ? makeFakeConversation() : conversation,
+    conversation:
+      conversation === undefined ? makeFakeConversation() : conversation,
     state,
     parentSendToClient: parentSendToClient ?? (() => {}),
   });
@@ -104,7 +105,10 @@ describe("SubagentManager terminal disposal", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -127,7 +131,10 @@ describe("SubagentManager terminal disposal", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("LLM error");
     };
@@ -148,7 +155,10 @@ describe("SubagentManager terminal disposal", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("Conversation aborted");
     };
@@ -167,7 +177,10 @@ describe("SubagentManager terminal disposal", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -269,7 +282,10 @@ describe("SubagentManager terminal disposal", () => {
       outputTokens: 200,
       estimatedCost: 0.05,
     };
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -291,7 +307,10 @@ describe("SubagentManager terminal disposal", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
     // Simulate that a message was enqueued during the run.
     managed.hadEnqueuedMessages = true;

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -20,7 +20,7 @@ mock.module("../daemon/conversation-store.js", () => ({
       });
       return { queued: true };
     },
-    persistUserMessage: async () => "mock-msg",
+    persistUserMessage: async () => ({ id: "mock-msg", deduplicated: false }),
     runAgentLoop: async () => {},
   }),
   addConversation: () => {},
@@ -46,7 +46,7 @@ interface FakeManagedSubagent {
     }>;
     sendToClient: (msg: ServerMessage) => void;
     loadFromDb?: () => Promise<void>;
-    persistUserMessage?: (msg: string) => string;
+    persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     usageStats: {
       inputTokens: number;
@@ -152,7 +152,10 @@ describe("Fork completion notifications", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Analyze data");
@@ -171,7 +174,10 @@ describe("Fork completion notifications", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Analyze data");
@@ -195,7 +201,10 @@ describe("Fork completion notifications", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("Context too large");
     };
@@ -260,7 +269,10 @@ describe("Regular sub-agent notifications are unchanged", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -283,7 +295,10 @@ describe("Regular sub-agent notifications are unchanged", () => {
     injectFakeSubagent(manager, subagentId, state);
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("Something went wrong");
     };

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -17,7 +17,7 @@ interface FakeManagedSubagent {
     dispose: () => void;
     messages: Message[];
     sendToClient: (msg: ServerMessage) => void;
-    persistUserMessage?: (msg: string) => string;
+    persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     enqueueMessage?: () => { rejected: boolean; queued: boolean };
     injectInheritedContext?: (messages: Message[]) => void;
@@ -127,7 +127,10 @@ describe("SubagentManager fork spawn", () => {
 
     const injectedMessages: Message[][] = [];
     const fakeConversation = makeFakeConversation();
-    fakeConversation.persistUserMessage = () => "msg-1";
+    fakeConversation.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     fakeConversation.runAgentLoop = async () => {};
     fakeConversation.injectInheritedContext = (msgs: Message[]) => {
       injectedMessages.push(msgs);
@@ -197,7 +200,10 @@ describe("SubagentManager fork spawn", () => {
 
     let injectCalled = false;
     const fakeConversation = makeFakeConversation();
-    fakeConversation.persistUserMessage = () => "msg-1";
+    fakeConversation.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     fakeConversation.runAgentLoop = async () => {};
     fakeConversation.injectInheritedContext = () => {
       injectCalled = true;
@@ -272,7 +278,10 @@ describe("SubagentManager fork spawn", () => {
     const subagentId = "sub-fork-role";
 
     const fakeConversation = makeFakeConversation();
-    fakeConversation.persistUserMessage = () => "msg-1";
+    fakeConversation.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     fakeConversation.runAgentLoop = async () => {};
     fakeConversation.injectInheritedContext = () => {};
     fakeConversation.setSubagentAllowedTools = () => {};

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -20,7 +20,7 @@ mock.module("../daemon/conversation-store.js", () => ({
       });
       return { queued: true };
     },
-    persistUserMessage: async () => "mock-msg",
+    persistUserMessage: async () => ({ id: "mock-msg", deduplicated: false }),
     runAgentLoop: async () => {},
   }),
   addConversation: () => {},
@@ -46,7 +46,7 @@ interface FakeManagedSubagent {
     }>;
     sendToClient: (msg: ServerMessage) => void;
     loadFromDb?: () => Promise<void>;
-    persistUserMessage?: (msg: string) => string;
+    persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     usageStats: {
       inputTokens: number;
@@ -298,7 +298,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     // Patch the fake conversation to simulate a successful agent loop.
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -329,7 +332,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     // Patch the fake conversation to simulate a failure.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("API rate limit exceeded");
     };
@@ -362,7 +368,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {
       throw new Error("Conversation aborted");
     };
@@ -436,7 +445,10 @@ describe("SubagentManager abort race guard", () => {
     // Patch conversation to simulate successful completion after abort.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.conversation!.persistUserMessage = () => "msg-1";
+    managed.conversation!.persistUserMessage = () => ({
+      id: "msg-1",
+      deduplicated: false,
+    });
     managed.conversation!.runAgentLoop = async () => {};
     managed.conversation!.messages = [
       { role: "assistant", content: [{ type: "text", text: "Done!" }] },

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -42,7 +42,7 @@ mock.module("../daemon/conversation-store.js", () => ({
       capturedMessages.push(content);
       return { queued: true };
     },
-    persistUserMessage: async () => "mock-msg",
+    persistUserMessage: async () => ({ id: "mock-msg", deduplicated: false }),
     runAgentLoop: async () => {},
   }),
   addConversation: () => {},
@@ -107,7 +107,7 @@ function injectSubagent(
     sendToClient: () => {},
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     enqueueMessage: () => ({ queued: false }),
-    persistUserMessage: () => "msg-1",
+    persistUserMessage: async () => ({ id: "msg-1", deduplicated: false }),
     runAgentLoop: async () => {},
   };
   internals.subagents.set(subagentId, {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -98,7 +98,7 @@ function injectSubagent(
     sendToClient: () => {},
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     enqueueMessage: () => ({ queued: false }),
-    persistUserMessage: () => "msg-1",
+    persistUserMessage: async () => ({ id: "msg-1", deduplicated: false }),
     runAgentLoop: async () => {},
   };
   internals.subagents.set(subagentId, {

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -138,7 +138,7 @@ function createMockSession(opts?: {
     setVoiceCallControlPrompt: () => {},
     currentRequestId: requestId,
     abort: () => {},
-    persistUserMessage: async () => "msg-1",
+    persistUserMessage: async () => ({ id: "msg-1", deduplicated: false }),
     updateClient: (cb: (msg: ServerMessage) => void, _reset?: boolean) => {
       clientCallback = cb;
     },

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -265,12 +265,8 @@ describe("voice-session-bridge", () => {
     const session = {
       isProcessing: () => false,
       currentRequestId: undefined as string | undefined,
-      persistUserMessage: (
-        _content: string,
-        _attachments: unknown[],
-        requestId?: string,
-      ) => {
-        session.currentRequestId = requestId;
+      persistUserMessage: (options: { requestId?: string }) => {
+        session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
       },
       memoryPolicy: {
@@ -356,12 +352,8 @@ describe("voice-session-bridge", () => {
     const session = {
       isProcessing: () => false,
       currentRequestId: undefined as string | undefined,
-      persistUserMessage: (
-        _content: string,
-        _attachments: unknown[],
-        requestId?: string,
-      ) => {
-        session.currentRequestId = requestId;
+      persistUserMessage: (options: { requestId?: string }) => {
+        session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
       },
       memoryPolicy: {
@@ -1409,12 +1401,8 @@ describe("voice-session-bridge", () => {
     const session = {
       isProcessing: () => false,
       currentRequestId: undefined as string | undefined,
-      persistUserMessage: (
-        _content: string,
-        _attachments: unknown[],
-        requestId?: string,
-      ) => {
-        session.currentRequestId = requestId;
+      persistUserMessage: (options: { requestId?: string }) => {
+        session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
       },
       memoryPolicy: {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -466,7 +466,7 @@ export class AcpSessionManager {
             );
             if (!enqueueResult.queued && !enqueueResult.rejected) {
               parentConversation
-                .persistUserMessage(notifyMessage, [])
+                .persistUserMessage({ content: notifyMessage })
                 .then(({ id: messageId }) =>
                   parentConversation.runAgentLoop(notifyMessage, messageId),
                 )

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -434,11 +434,10 @@ export async function startVoiceTurn(
     );
     conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
 
-    const persistResult = await conversation.persistUserMessage(
-      persistedContent,
-      [],
+    const persistResult = await conversation.persistUserMessage({
+      content: persistedContent,
       requestId,
-    );
+    });
     messageId = persistResult.id;
   } catch (err) {
     cleanup();

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -342,17 +342,26 @@ export function enqueueMessage(
   return { queued: true, requestId };
 }
 
+// ── PersistMessageOptions ────────────────────────────────────────────
+
+/** Shared options for `persistUserMessage` and `persistQueuedMessageBody`. */
+export interface PersistMessageOptions {
+  content: string;
+  attachments?: UserMessageAttachment[];
+  requestId?: string;
+  metadata?: Record<string, unknown>;
+  displayContent?: string;
+  clientMessageId?: string;
+}
+
 // ── persistUserMessage ───────────────────────────────────────────────
 
 export async function persistUserMessage(
   ctx: MessagingConversationContext,
-  content: string,
-  attachments: UserMessageAttachment[],
-  requestId?: string,
-  metadata?: Record<string, unknown>,
-  displayContent?: string,
-  clientMessageId?: string,
+  options: PersistMessageOptions,
 ): Promise<{ id: string; deduplicated: boolean }> {
+  const { content, attachments = [] } = options;
+
   if (ctx.processing) {
     throw new Error("Conversation is already processing a message");
   }
@@ -361,21 +370,17 @@ export async function persistUserMessage(
     throw new Error("Message content or attachments are required");
   }
 
-  const reqId = requestId ?? uuid();
+  const reqId = options.requestId ?? uuid();
   ctx.currentRequestId = reqId;
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
   try {
-    const result = await persistQueuedMessageBody(
-      ctx,
-      content,
+    const result = await persistQueuedMessageBody(ctx, {
+      ...options,
       attachments,
-      reqId,
-      metadata,
-      displayContent,
-      clientMessageId,
-    );
+      requestId: reqId,
+    });
     if (result.deduplicated) {
       ctx.processing = false;
       ctx.abortController = null;
@@ -403,13 +408,16 @@ export async function persistUserMessage(
  */
 export async function persistQueuedMessageBody(
   ctx: MessagingConversationContext,
-  content: string,
-  attachments: UserMessageAttachment[],
-  requestId: string,
-  metadata: Record<string, unknown> | undefined,
-  displayContent: string | undefined,
-  clientMessageId?: string,
+  options: PersistMessageOptions,
 ): Promise<{ id: string; deduplicated: boolean }> {
+  const {
+    content,
+    attachments = [],
+    requestId = uuid(),
+    metadata,
+    displayContent,
+    clientMessageId,
+  } = options;
   const attachmentInputs = attachments.map((attachment) => ({
     id: attachment.id,
     filename: attachment.filename,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -34,6 +34,7 @@ import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import type { CleanResult } from "./conversation.js";
+import type { PersistMessageOptions } from "./conversation-messaging.js";
 import {
   persistQueuedMessageBody,
   serializePersistedUserMessageContent,
@@ -158,12 +159,7 @@ export interface ProcessConversationContext {
   currentTurnChannelCapabilities?: ChannelCapabilities;
   ensureActorScopedHistory(): Promise<void>;
   persistUserMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    requestId?: string,
-    metadata?: Record<string, unknown>,
-    displayContent?: string,
-    clientMessageId?: string,
+    options: PersistMessageOptions,
   ): Promise<{ id: string; deduplicated: boolean }>;
   runAgentLoop(
     content: string,
@@ -924,14 +920,14 @@ async function drainSingleMessage(
   // resolves early (no runAgentLoop call), so we must continue draining.
   let persistResult: { id: string; deduplicated: boolean };
   try {
-    persistResult = await conversation.persistUserMessage(
-      resolvedContent,
-      next.attachments,
-      next.requestId,
-      { ...next.metadata, sentAt: next.sentAt },
-      next.displayContent,
-      next.clientMessageId,
-    );
+    persistResult = await conversation.persistUserMessage({
+      content: resolvedContent,
+      attachments: next.attachments,
+      requestId: next.requestId,
+      metadata: { ...next.metadata, sentAt: next.sentAt },
+      displayContent: next.displayContent,
+      clientMessageId: next.clientMessageId,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error(
@@ -1232,24 +1228,21 @@ async function drainBatch(
 
     try {
       let batchPersistResult: { id: string; deduplicated: boolean };
+      const persistOptions = {
+        content: qmContent,
+        attachments: qm.attachments,
+        requestId: qm.requestId,
+        metadata: { ...qm.metadata, sentAt: qm.sentAt },
+        displayContent: qm.displayContent,
+        clientMessageId: qm.clientMessageId,
+      };
       if (i === 0) {
-        batchPersistResult = await conversation.persistUserMessage(
-          qmContent,
-          qm.attachments,
-          qm.requestId,
-          { ...qm.metadata, sentAt: qm.sentAt },
-          qm.displayContent,
-          qm.clientMessageId,
-        );
+        batchPersistResult =
+          await conversation.persistUserMessage(persistOptions);
       } else {
         batchPersistResult = await persistQueuedMessageBody(
           conversation,
-          qmContent,
-          qm.attachments,
-          qm.requestId,
-          { ...qm.metadata, sentAt: qm.sentAt },
-          qm.displayContent,
-          qm.clientMessageId,
+          persistOptions,
         );
       }
       if (batchPersistResult.deduplicated) {
@@ -1895,13 +1888,12 @@ export async function processMessage(
 
   let pmResult: { id: string; deduplicated: boolean };
   try {
-    pmResult = await conversation.persistUserMessage(
-      resolvedContent,
+    pmResult = await conversation.persistUserMessage({
+      content: resolvedContent,
       attachments,
       requestId,
-      undefined,
       displayContent,
-    );
+    });
     publishConversationMessagesChanged(conversation.conversationId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -86,7 +86,10 @@ import {
   disposeConversation,
   loadFromDb as loadFromDbImpl,
 } from "./conversation-lifecycle.js";
-import type { RedirectToSecurePromptOptions } from "./conversation-messaging.js";
+import type {
+  PersistMessageOptions,
+  RedirectToSecurePromptOptions,
+} from "./conversation-messaging.js";
 import {
   enqueueMessage as enqueueMessageImpl,
   persistUserMessage as persistUserMessageImpl,
@@ -1283,25 +1286,12 @@ export class Conversation {
   }
 
   async persistUserMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    requestId?: string,
-    metadata?: Record<string, unknown>,
-    displayContent?: string,
-    clientMessageId?: string,
+    options: PersistMessageOptions,
   ): Promise<{ id: string; deduplicated: boolean }> {
     if (!this.processing) {
       await this.ensureActorScopedHistory();
     }
-    return persistUserMessageImpl(
-      this,
-      content,
-      attachments,
-      requestId,
-      metadata,
-      displayContent,
-      clientMessageId,
-    );
+    return persistUserMessageImpl(this, options);
   }
 
   // ── Agent Loop ───────────────────────────────────────────────────

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1085,13 +1085,11 @@ export async function runDaemon(): Promise<void> {
           // its own finally block.
           conversation.toolsDisabledDepth++;
           try {
-            const { id: messageId } = await conversation.persistUserMessage(
-              instruction,
-              [],
-              undefined,
-              { pointerInstruction: true },
-              "[Call status event]",
-            );
+            const { id: messageId } = await conversation.persistUserMessage({
+              content: instruction,
+              metadata: { pointerInstruction: true },
+              displayContent: "[Call status event]",
+            });
 
             // Helper: roll back persisted messages on failure, then reload
             // in-memory history from the (now cleaned) DB. Reloading avoids

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -508,13 +508,13 @@ export async function processMessage(
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;
-  const { id: messageId } = await conversation.persistUserMessage(
-    resolvedContent,
+  const { id: messageId } = await conversation.persistUserMessage({
+    content: resolvedContent,
     attachments,
     requestId,
-    persistMetadata,
-    options?.displayContent,
-  );
+    metadata: persistMetadata,
+    displayContent: options?.displayContent,
+  });
   publishConversationMessagesChanged(conversationId);
 
   if (options?.isInteractive === true) {
@@ -571,13 +571,13 @@ export async function processMessageInBackground(
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;
-  const { id: messageId } = await conversation.persistUserMessage(
+  const { id: messageId } = await conversation.persistUserMessage({
     content,
     attachments,
     requestId,
-    persistMetadata,
-    options?.displayContent,
-  );
+    metadata: persistMetadata,
+    displayContent: options?.displayContent,
+  });
   publishConversationMessagesChanged(conversationId);
 
   if (options?.isInteractive === true) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1418,14 +1418,12 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
       };
-      const persisted = await persistQueuedMessageBody(
-        conversation,
-        rawContent,
+      const persisted = await persistQueuedMessageBody(conversation, {
+        content: rawContent,
         attachments,
-        crypto.randomUUID(),
-        greetingMeta,
-        undefined,
-      );
+        requestId: crypto.randomUUID(),
+        metadata: greetingMeta,
+      });
 
       const conversationId = mapping.conversationId;
       const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
@@ -1726,15 +1724,13 @@ export async function handleSendMessage(
         assistantMessageInterface: sourceInterface,
         ...(body.automated === true ? { automated: true } : {}),
       };
-      const persisted = await persistQueuedMessageBody(
-        conversation,
-        rawContent,
+      const persisted = await persistQueuedMessageBody(conversation, {
+        content: rawContent,
         attachments,
-        crypto.randomUUID(),
-        slashMeta,
-        undefined,
+        requestId: crypto.randomUUID(),
+        metadata: slashMeta,
         clientMessageId,
-      );
+      });
       if (persisted.deduplicated) {
         return {
           accepted: true,
@@ -1825,15 +1821,13 @@ export async function handleSendMessage(
     };
     let persisted: Awaited<ReturnType<typeof persistQueuedMessageBody>>;
     try {
-      persisted = await persistQueuedMessageBody(
-        conversation,
-        rawContent,
+      persisted = await persistQueuedMessageBody(conversation, {
+        content: rawContent,
         attachments,
-        crypto.randomUUID(),
-        slashMeta,
-        undefined,
+        requestId: crypto.randomUUID(),
+        metadata: slashMeta,
         clientMessageId,
-      );
+      });
     } catch (err) {
       // The fire-and-forget compaction below owns clearing `processing`, but a
       // throw from this initial persist never reaches it — reset here so the
@@ -1944,15 +1938,13 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
       };
-      const persisted = await persistQueuedMessageBody(
-        conversation,
-        rawContent,
+      const persisted = await persistQueuedMessageBody(conversation, {
+        content: rawContent,
         attachments,
-        crypto.randomUUID(),
-        slashMeta,
-        undefined,
+        requestId: crypto.randomUUID(),
+        metadata: slashMeta,
         clientMessageId,
-      );
+      });
       if (persisted.deduplicated) {
         return {
           accepted: true,
@@ -2027,14 +2019,13 @@ export async function handleSendMessage(
   const resolvedContent = slashResult.content;
 
   const requestId = crypto.randomUUID();
-  const persistResult = await conversation.persistUserMessage(
-    resolvedContent,
+  const persistResult = await conversation.persistUserMessage({
+    content: resolvedContent,
     attachments,
     requestId,
-    body.automated === true ? { automated: true } : undefined,
-    undefined,
+    metadata: body.automated === true ? { automated: true } : undefined,
     clientMessageId,
-  );
+  });
 
   const messageId = persistResult.id;
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -436,10 +436,9 @@ export class SubagentManager {
             "⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
           ].join("\n")
         : objective;
-      const { id: messageId } = await conversation.persistUserMessage(
-        message,
-        [],
-      );
+      const { id: messageId } = await conversation.persistUserMessage({
+        content: message,
+      });
       await conversation.runAgentLoop(message, messageId, undefined, {
         callSite: "subagentSpawn",
         ...(managed.state.config.overrideProfile
@@ -624,10 +623,9 @@ export class SubagentManager {
       // Capture conversation before the await — managed.conversation may be
       // nulled by an external dispose() while persistUserMessage is awaited.
       const conversation = managed.conversation;
-      const { id: messageId } = await conversation.persistUserMessage(
-        trimmed,
-        [],
-      );
+      const { id: messageId } = await conversation.persistUserMessage({
+        content: trimmed,
+      });
       conversation
         .runAgentLoop(trimmed, messageId, undefined, {
           callSite: "subagentSpawn",
@@ -1002,7 +1000,7 @@ export class SubagentManager {
     );
     if (!enqueueResult.queued && !enqueueResult.rejected) {
       parentConversation
-        .persistUserMessage(message, [], undefined, metadata)
+        .persistUserMessage({ content: message, metadata })
         .then(({ id: messageId }) =>
           parentConversation.runAgentLoop(message, messageId),
         )


### PR DESCRIPTION
## Prompt / plan

Convert `persistUserMessage` and `persistQueuedMessageBody` from 7 positional parameters to a single `PersistMessageOptions` options object. Follow-up to PR #32407 (DB-level message idempotency) which added `clientMessageId` as the 7th positional param, creating `undefined` holes at call sites.

Closes LUM-2004

## Why this change is needed

Both functions accumulated 7 positional parameters over time:
```typescript
persistUserMessage(ctx, content, attachments, requestId, metadata, displayContent, clientMessageId)
```

Call sites that only needed `clientMessageId` (param 7) but not `displayContent` (param 6) had to pass explicit `undefined` holes:
```typescript
// Before — what does each undefined mean?
persistUserMessage(ctx, content, attachments, requestId, undefined, undefined, clientMessageId)
```

This is the textbook case for the [options object pattern](https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters) — 2 required fields (ctx + content) and 5 optional ones.

## What changed

**Interface definition** (`conversation-messaging.ts`):
```typescript
export interface PersistMessageOptions {
  content: string;
  attachments?: UserMessageAttachment[];
  requestId?: string;
  metadata?: Record<string, unknown>;
  displayContent?: string;
  clientMessageId?: string;
}
```

**Production call sites** (12 total):
- `conversation-routes.ts` — 5 paths (HTTP idle, 3 slash commands, canned greeting)
- `conversation-process.ts` — 3 paths (queue drain, batch drain, processConversation)
- `process-message.ts` — 2 paths (Slack/scheduler surfaces)
- `subagent/manager.ts` — 3 paths
- `lifecycle.ts`, `voice-session-bridge.ts`, `acp/session-manager.ts` — 1 each

**Test files** (21 total): Updated mocks, call sites, and type annotations. Also fixed pre-existing test mock return types — several subagent and guardian reply test mocks were returning `string` instead of `{ id: string; deduplicated: boolean }`, which would cause `undefined` messageIds if those paths were ever exercised in test assertions.

## Benefits

1. **Self-documenting** — field names are visible at every call site
2. **No undefined holes** — callers specify only the fields they need
3. **Extensible** — adding a new optional field doesn't require updating every call site
4. **Type-safe** — TypeScript catches misspelled field names at compile time

## Why it's safe

- **Pure signature refactor** — no behavioral change, no new logic
- **Compile-time verified** — `bunx tsc --noEmit` passes with 0 errors; any caller using the old positional signature would fail to compile
- **All 30 affected files pass lint + format + typecheck**
- **All affected tests pass individually** (multi-file batch runs show pre-existing test isolation failures unrelated to this change)

## Alternatives not taken

1. **Partial refactor (only the 2 functions, not tests)** — Rejected because test mocks with wrong signatures would silently diverge from production code. Mock.module substitutions bypass TypeScript's compile-time checking, so keeping them in sync manually is the only defense.

2. **Include `enqueueMessage` in this refactor** — `enqueueMessage` has 12 positional params and 60+ call sites. Genuinely too large to bundle here without ballooning the PR. Tracked as a separate follow-up (LUM-2005).

3. **Use a class instead of an interface** — Interfaces are lighter-weight for pure data shapes. A class would add unnecessary runtime overhead for a parameter bag.

## Root cause analysis

1. **How did the code get into this state?** The functions started with 3-4 params and grew organically as features were added (metadata, displayContent, clientMessageId). Each addition was small enough to not trigger a refactor.

2. **What mistakes or decisions led to it?** No policy against positional parameter accumulation. Each PR that added a param was individually reasonable.

3. **Were there warning signs we missed?** The first `undefined` hole appeared when `displayContent` was added as param 5 but most callers didn't need it. That was the signal to switch to an options object.

4. **What can we do to prevent this pattern from recurring?** The existing AGENTS.md guidance on function signature design is sufficient — the issue was that incremental additions didn't trigger a threshold check.

5. **Should we update AGENTS.md?** No — adding a "max N positional params" rule would be overly prescriptive and could go stale. The real fix is the options object pattern itself, which is now established as the convention for these functions.

## Test plan

- All 21 affected test files pass individually
- `bunx tsc --noEmit` — 0 errors
- `bun run lint` — clean
- Prettier formatting — clean
- Pre-commit hooks pass (secrets, formatting, lint, typecheck)

Link to Devin session: https://app.devin.ai/sessions/1a2be238d9704952b6682fc77696d9b3
Requested by: @ashleeradka