### PR TITLE
fix(web): clear processing key on silent-stall rescue (LUM-1952)

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -217,6 +217,15 @@ beforeEach(async () => {
   mockFetchError = null;
   mockFetchSideEffect = null;
   fetchCallCount = 0;
+  // Zustand stores survive across tests in the same Bun process; reset
+  // the conversation-list state so each test sees a clean slate.
+  useConversationStore.setState({
+    processingConversationIds: new Set(),
+    processingSnapshots: new Map(),
+    attentionConversationIds: new Set(),
+    activeConversationId: null,
+    editingConversationId: null,
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -365,6 +374,95 @@ describe("reconcileActiveConversation", () => {
     await reconcileActiveConversation();
     expect(onPollReconciledSpy).toHaveBeenCalledTimes(1);
     expect(onPollReconciledSpy).toHaveBeenCalledWith("turn-42");
+  });
+
+  test("clears active conversation processing key on silent-stall rescue (LUM-1952)", async () => {
+    // Repro for LUM-1952. The send pathway adds the active conversation id
+    // to `processingConversationIds`; the SSE terminal-event handlers
+    // (`handleAssistantActivityState(idle)`, `handleMessageComplete`,
+    // `handleGenerationCancelled`, error handlers) are the only sites that
+    // clear it for the active conversation — the graduation effect in
+    // `useAttentionTracking` explicitly skips the active conversation. When
+    // SSE drops the terminal event, the silent-stall rescue here is the
+    // last line of defense. If it only clears the turn-store but not the
+    // processing key, `canStopGeneration` and the sidebar processing dot
+    // stay "true" even though the assistant message has already rendered.
+    messages = [makeMessage({ id: "m1", role: "user", content: "Hello" })];
+    mockFetchResult = [
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "m2", role: "assistant", content: "Response" },
+    ];
+    useConversationStore.setState({
+      processingConversationIds: new Set(["conv-1"]),
+    });
+    const stuckTurnState: TurnState = {
+      phase: "thinking",
+      pendingQueuedCount: 0,
+      activeToolCallCount: 0,
+      activeTurnId: "turn-42",
+      lastTerminalReason: null,
+      statusText: null,
+      liveWebActivity: {},
+      autoRoutedProfileLabel: null,
+    };
+    const { reconcileActiveConversation } = createHarness({
+      streamContext: { assistantId: "asst-1", conversationId: "conv-1" },
+      activeConversationId: "conv-1",
+      turnState: stuckTurnState,
+    });
+
+    await reconcileActiveConversation();
+
+    expect(onPollReconciledSpy).toHaveBeenCalledTimes(1);
+    expect(
+      useConversationStore.getState().processingConversationIds.has("conv-1"),
+    ).toBe(false);
+  });
+
+  test("does NOT touch processing key during a healthy mid-stream sync reconcile", async () => {
+    // Regression guard paired with LUM-1952. The processing-key clear
+    // must only fire on the rescue path. During a healthy mid-stream
+    // reconcile (no content drift, server matches local), the rescue
+    // does not fire, and the processing key must stay set — clearing
+    // it would prematurely hide the sidebar processing dot while the
+    // turn is still legitimately running.
+    const msg = makeMessage({ id: "m1", role: "user", content: "Hello" });
+    const assistantMsg = makeMessage({
+      id: "m2",
+      role: "assistant",
+      content: "Working on it...",
+      isStreaming: true,
+    });
+    messages = [msg, assistantMsg];
+    mockFetchResult = [
+      { id: "m1", role: "user", content: "Hello" },
+      { id: "m2", role: "assistant", content: "Working on it..." },
+    ];
+    useConversationStore.setState({
+      processingConversationIds: new Set(["conv-1"]),
+    });
+    const liveStreamingState: TurnState = {
+      phase: "streaming",
+      pendingQueuedCount: 0,
+      activeToolCallCount: 0,
+      activeTurnId: "turn-42",
+      lastTerminalReason: null,
+      statusText: null,
+      liveWebActivity: {},
+      autoRoutedProfileLabel: null,
+    };
+    const { reconcileActiveConversation } = createHarness({
+      streamContext: { assistantId: "asst-1", conversationId: "conv-1" },
+      activeConversationId: "conv-1",
+      turnState: liveStreamingState,
+    });
+
+    await reconcileActiveConversation();
+
+    expect(onPollReconciledSpy).not.toHaveBeenCalled();
+    expect(
+      useConversationStore.getState().processingConversationIds.has("conv-1"),
+    ).toBe(true);
   });
 
   test("does NOT call onPollReconciled when turnId is null", async () => {

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -189,6 +189,7 @@ export function useMessageReconciliation({
     (
       serverMessages: RuntimeMessage[],
       snapshotTurnId: string | null,
+      snapshotConversationId: string,
     ): ReconcileActiveConversationResult => {
       const { changed, assistantProgress, messagesAdded } =
         reconcileFromServerDetailed(serverMessages);
@@ -224,6 +225,20 @@ export function useMessageReconciliation({
         useTurnStore.getState().activeTurnId === snapshotTurnId;
       if (wasStuck) {
         useTurnStore.getState().onPollReconciled(snapshotTurnId);
+        // The rescue must also clear the conversation-level processing
+        // key — `processingConversationIds` is set at send time and is
+        // normally cleared by the SSE terminal-event handlers
+        // (`handleAssistantActivityState(idle)`, `handleMessageComplete`,
+        // `handleGenerationCancelled`, error handlers). When SSE drops
+        // the terminal event, those handlers never run, and the
+        // graduation effect in `useAttentionTracking` explicitly skips
+        // the active conversation. Without this call the rescue would
+        // leave `activeConversationIsProcessing` stuck at `true` — which
+        // keeps `canStopGeneration` true and the sidebar processing dot
+        // visible even though the turn has clearly completed (LUM-1952).
+        useConversationStore
+          .getState()
+          .removeProcessingConversationId(snapshotConversationId);
         // `POLL_RECONCILED` is the silent-stall rescue: the server
         // reports assistant progress that the client never observed
         // via SSE, meaning a terminal event (`message_complete`
@@ -341,6 +356,7 @@ export function useMessageReconciliation({
             const { changed } = reconcileFetchedMessages(
               serverMessages,
               snapshotTurnId,
+              ctx.conversationId,
             );
             if (changed) {
               stableCount = 0;
@@ -430,7 +446,11 @@ export function useMessageReconciliation({
           epoch: snapshotEpoch,
           server: summarizeRuntimeMessages(serverMessages),
         });
-        return reconcileFetchedMessages(serverMessages, snapshotTurnId);
+        return reconcileFetchedMessages(
+          serverMessages,
+          snapshotTurnId,
+          ctx.conversationId,
+        );
       } catch {
         // Non-fatal: a fetch failure doesn't prove the turn completed.
         // The .finally() nonce bump reopens SSE to deliver terminal events.

--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -152,6 +152,26 @@ describe("handleMessageComplete", () => {
     expect(ctx.startReconciliationLoop).not.toHaveBeenCalled();
   });
 
+  it("prefers event.conversationId over streamContextRef when both differ (LUM-1952)", () => {
+    // streamContextRef is a mirror that may be cleared by a stream
+    // teardown that races the terminal event. When the event itself
+    // carries the canonical conversationId, the handler must use it
+    // — otherwise the processing key for the conversation that
+    // actually completed would never clear.
+    const ctx = makeCtx({
+      streamContextRef: { current: null },
+    });
+    handleMessageComplete(
+      {
+        type: "message_complete",
+        messageId: "msg-1",
+        conversationId: "conv-from-event",
+      },
+      ctx,
+    );
+    expect(ctx.clearProcessingKey).toHaveBeenCalledWith("conv-from-event");
+  });
+
   it("re-anchors a spawned subagent from the streaming id to the server messageId", () => {
     useSubagentStore.getState().reset();
     // Spawn stamped with the optimistic streaming bubble id.
@@ -250,5 +270,16 @@ describe("handleGenerationCancelled", () => {
     expect(ctx.turnActions.cancelGeneration).toHaveBeenCalled();
     expect(ctx.clearProcessingKey).toHaveBeenCalledWith("conv-1");
     expect(ctx.setMessages).toHaveBeenCalled();
+  });
+
+  it("prefers event.conversationId over streamContextRef when both differ (LUM-1952)", () => {
+    const ctx = makeCtx({
+      streamContextRef: { current: null },
+    });
+    handleGenerationCancelled(
+      { type: "generation_cancelled", conversationId: "conv-from-event" },
+      ctx,
+    );
+    expect(ctx.clearProcessingKey).toHaveBeenCalledWith("conv-from-event");
   });
 });

--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -111,7 +111,14 @@ export function handleMessageComplete(
 
   const turnPhaseBefore = ctx.getTurnState().phase;
   ctx.turnActions.completeTurn();
-  const convId = ctx.streamContextRef.current?.conversationId;
+  // Prefer the event's own `conversationId` over `streamContextRef` —
+  // `handleAssistantActivityState` does the same. The event carries the
+  // canonical id; the ref is a mirror that may be cleared by a stream
+  // teardown that races the terminal event. Matching the three terminal
+  // handlers on this fallback chain keeps the processing-key clear
+  // reliable across reconnects (LUM-1952).
+  const convId =
+    event.conversationId ?? ctx.streamContextRef.current?.conversationId;
   if (convId) {
     ctx.clearProcessingKey(convId);
   }
@@ -134,11 +141,14 @@ export function handleGenerationHandoff(
 }
 
 export function handleGenerationCancelled(
-  _event: GenerationCancelledEvent,
+  event: GenerationCancelledEvent,
   ctx: StreamHandlerContext,
 ): void {
   ctx.turnActions.cancelGeneration();
-  const convId = ctx.streamContextRef.current?.conversationId;
+  // See `handleMessageComplete` for the rationale on the event-first
+  // fallback chain (LUM-1952).
+  const convId =
+    event.conversationId ?? ctx.streamContextRef.current?.conversationId;
   if (convId) {
     ctx.clearProcessingKey(convId);
   }


### PR DESCRIPTION
## Summary

Fixes [LUM-1952](https://linear.app/vellum/issue/LUM-1952): "Web: loading states not clearing after assistant message completes." Reported by Akash via Loom (May 25):

> "multiple loading states despite assistant message getting completed"

## Root cause

`useMessageReconciliation` runs a silent-stall rescue: when polling sees server-confirmed assistant progress that the client never observed via SSE (i.e., a terminal event was lost), it calls `useTurnStore.getState().onPollReconciled()` to idle the turn-store.

But `processingConversationIds` (a separate Zustand store used for sidebar processing dots and the `canStopGeneration` selector) was **never cleared by this rescue path**. It's normally cleared by the four SSE terminal-event handlers (`handleAssistantActivityState(idle)`, `handleMessageComplete`, `handleGenerationCancelled`, error handlers). When SSE drops the terminal event, those handlers don't run — and the graduation effect in `useAttentionTracking` **explicitly skips the active conversation** (see `if (key === activeConversationId) continue;` at `use-attention-tracking.ts:151`), so there's no fallback.

Result: turn-store idles, the assistant message renders, but `activeConversationIsProcessing` stays `true`. The Stop-generating button stays visible, the sidebar processing dot stays lit, and any other UI surface that reads the processing key reports the conversation as still working — matching Akash's "multiple loading states despite assistant message getting completed."

## What changed

### Primary fix — `useMessageReconciliation`
- Added `snapshotConversationId` parameter to `reconcileFetchedMessages` so the conversation id is captured at fetch-dispatch time (not read from the store when the fetch resolves — that would race conversation switches).
- In the `wasStuck` branch, the rescue now calls `useConversationStore.getState().removeProcessingConversationId(snapshotConversationId)` alongside `onPollReconciled`.
- Both callers (the polling tick and `reconcileActiveConversation`) pass `ctx.conversationId`.

### Adjacent hardening — `message-handlers.ts`
The three terminal-event handlers were inconsistent: `handleAssistantActivityState` read `event.conversationId ?? streamContextRef.current?.conversationId`, while `handleMessageComplete` and `handleGenerationCancelled` only read `streamContextRef`. DRY them: all three now use the event-first fallback. This hardens against a stream teardown that races the terminal event from leaving the processing key set.

## Why not the no-op `handleMessageRequestComplete`?

An earlier investigation flagged the no-op `handleMessageRequestComplete` in `queue-handlers.ts:68` as a candidate. Verified the daemon side: `message_request_complete` is defined and tested for SSE wire-parity but is **never emitted by the daemon in production code in this repo** (only `cli.ts` handles it; no daemon path constructs it). The web no-op is correct — that wasn't the bug.

## Why not the "refresh shows no response" half of the report?

Akash also said: "when I refresh the UI I still don't see any response come back." `conversation-store` has no `persist` middleware, so a refresh clears `processingConversationIds` regardless. The "no response after refresh" line is likely either (a) correlating with the broken loading-state UI ("dots still up → I assume the response didn't land"), or (b) a separate "message didn't persist server-side" issue that needs more telemetry to pin down. This PR covers the verifiable loading-state path; if (b) turns out to be real, it can be filed as a follow-up with reproducible evidence.

## Test plan

- New regression test: `clears active conversation processing key on silent-stall rescue (LUM-1952)` — fails before this change, passes after.
- New regression guard: `does NOT touch processing key during a healthy mid-stream sync reconcile` — ensures the clear only fires on the rescue path, not on every reconcile.
- New tests for `message-handlers`: confirm `handleMessageComplete` and `handleGenerationCancelled` prefer `event.conversationId` when `streamContextRef` is null.
- `bunx tsc --noEmit` clean
- `bun run lint` clean
- All `use-message-reconciliation` + `stream-handlers` tests pass via `bun scripts/run-tests.ts`

## Out of scope (queued separately)

- [LUM-2017](https://linear.app/vellum/issue/LUM-2017) — lift `conversation-store` to `src/stores/` so cross-store coupling like the one this fix introduces becomes import-clean.
- [LUM-2013](https://linear.app/vellum/issue/LUM-2013) — messages → TanStack Query.

Linear: [LUM-1952](https://linear.app/vellum/issue/LUM-1952)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_