### PR TITLE
streaming: render chat from MessageStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -320,7 +320,12 @@ struct ChatView: View {
         VStack(spacing: 0) {
             MessageListView(
                 // -- TranscriptProjector inputs --
-                messages: viewModel.messages,
+                // Renders from the streaming-architecture `MessageStore` (via
+                // `renderedMessages`) instead of the legacy `messages` array.
+                // The legacy array is still populated by older streaming
+                // helpers, but those mutations no longer drive rendering —
+                // see `ChatViewModel.renderedMessages` for the merge rules.
+                messages: viewModel.renderedMessages,
                 messagesRevision: viewModel.messagesRevision,
                 isSending: viewModel.isSending,
                 isThinking: viewModel.isThinking,
@@ -365,7 +370,7 @@ struct ChatView: View {
                 // -- Projector-resolved state --
                 activePendingRequestId: viewModel.activePendingRequestId,
                 // -- Pagination --
-                paginatedVisibleMessages: viewModel.paginatedVisibleMessages,
+                paginatedVisibleMessages: viewModel.renderedPaginatedVisibleMessages,
                 displayedMessageCount: viewModel.displayedMessageCount,
                 hasMoreMessages: viewModel.hasMoreMessages,
                 isLoadingMoreMessages: viewModel.isLoadingMoreMessages,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -216,6 +216,73 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     public var messagesRevision: UInt64 {
         messageManager.messagesRevision
     }
+
+    /// Renderable transcript merged from the new `MessageStore` (streaming
+    /// architecture's source of truth) and the legacy `messages` array.
+    ///
+    /// Resolution rules:
+    /// - **Assistant messages**: rendered from `MessageStore` snapshots when
+    ///   any are available. The reducer (`MessageStreamReducer`) is the sole
+    ///   writer for assistant content under the new architecture, and its
+    ///   idempotent apply is what makes the streaming-then-reload duplication
+    ///   symptom structurally impossible.
+    /// - **Legacy assistant rows are deduped by `daemonMessageId`**: a legacy
+    ///   row whose `daemonMessageId` already exists in `MessageStore` is
+    ///   dropped (the snapshot wins), and any remaining legacy assistant rows
+    ///   without a matching snapshot are kept (covers history-loaded messages
+    ///   that pre-date the new event protocol).
+    /// - **Non-assistant rows** (user bubbles, confirmations, system errors,
+    ///   guardian decisions) flow through from the legacy array unchanged —
+    ///   they are not yet part of the new event protocol.
+    ///
+    /// Ordering follows the legacy `messages` array for rows present there;
+    /// any MessageStore snapshot without a legacy anchor is appended at the
+    /// end in `messageOrder`.
+    public var renderedMessages: [ChatMessage] {
+        let snapshots = messageStore.messages
+        guard !snapshots.isEmpty else { return messages }
+
+        var consumedDaemonIds = Set<String>()
+        var result: [ChatMessage] = []
+        result.reserveCapacity(messages.count + snapshots.count)
+
+        for legacy in messages {
+            switch legacy.role {
+            case .assistant:
+                if let daemonId = legacy.daemonMessageId,
+                   let snapshot = snapshots[daemonId] {
+                    // Legacy row anchors a snapshot — render the snapshot
+                    // and mark the daemon id consumed so the trailing
+                    // append loop doesn't duplicate it.
+                    result.append(MessageStore.chatMessage(from: snapshot))
+                    consumedDaemonIds.insert(daemonId)
+                } else if legacy.daemonMessageId != nil {
+                    // Persisted assistant row from history with no live
+                    // snapshot — render the legacy row as-is.
+                    result.append(legacy)
+                } else {
+                    // Streaming-bubble lazy-created by the legacy code path.
+                    // Dropped: the corresponding MessageStore snapshot (if
+                    // any) is the authoritative source and is appended
+                    // below. This is what closes the duplication failure
+                    // mode — the legacy "anonymous delta -> new bubble"
+                    // branch no longer reaches the renderer.
+                    continue
+                }
+            case .user:
+                result.append(legacy)
+            }
+        }
+
+        // Append any streamed assistant messages that don't have a legacy
+        // anchor. Stable order from `messageOrder` keeps SwiftUI identity
+        // diffing predictable across re-renders.
+        for snapshot in messageStore.orderedMessages {
+            guard !consumedDaemonIds.contains(snapshot.id) else { continue }
+            result.append(MessageStore.chatMessage(from: snapshot))
+        }
+        return result
+    }
     public var inputText: String {
         get { messageManager.inputText }
         set { messageManager.inputText = newValue }
@@ -1058,6 +1125,28 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         paginationState.paginatedVisibleMessages
     }
 
+    /// Renderable paginated suffix derived from `renderedMessages` (the
+    /// MessageStore-backed transcript) rather than the legacy
+    /// `paginationState.paginatedVisibleMessages` cache. Pagination math is
+    /// applied to the merged transcript so streaming bubbles always appear in
+    /// the latest window — without this, the legacy lazy-bubble suppression
+    /// in `renderedMessages` could leave the on-screen suffix empty during
+    /// short, single-message turns.
+    public var renderedPaginatedVisibleMessages: [ChatMessage] {
+        let allRendered = ChatVisibleMessageFilter.visibleMessages(from: renderedMessages)
+        if paginationState.isShowAllMode {
+            let cap = ChatPaginationState.maxPaginatedWindowSize
+            if allRendered.count <= cap { return allRendered }
+            let defaultStart = allRendered.count - cap
+            let start = max(0, min(paginationState.windowOldestIndex ?? defaultStart, defaultStart))
+            return Array(allRendered[start..<(start + cap)])
+        }
+        if displayedMessageCount < allRendered.count {
+            return Array(allRendered.suffix(displayedMessageCount))
+        }
+        return allRendered
+    }
+
     /// Whether `paginatedVisibleMessages` is empty. Prefer over
     /// `paginatedVisibleMessages.isEmpty` to avoid observing the full array.
     public var isPaginatedEmpty: Bool {
@@ -1328,10 +1417,23 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // Initialize the action handler for server message dispatch.
         self.actionHandler = ChatActionHandler(viewModel: self)
 
-        // Start consuming streaming events into the new MessageStore. Output
-        // is not rendered by any view in this PR — see `messageStore` doc
-        // comment for the rollout plan.
+        // Start consuming streaming events into the new MessageStore. As of
+        // PR 4, the chat list renders from `renderedMessages` (which merges
+        // the legacy `messages` array with snapshots from this store via
+        // `MessageStore.chatMessages`).
         self.messageStreamReducer.start()
+
+        // Supply the persisted `Last-Event-Id` watermark on SSE (re)connect
+        // so the daemon's durable event log can skip events the client has
+        // already applied. The daemon only honors the header on
+        // conversation-scoped subscriptions; the current global stream
+        // ignores it, but the plumbing is correct for PR 5's per-conversation
+        // subscription model.
+        eventStreamClient.lastEventIdProvider = { [weak self] in
+            guard let self, let conversationId = self.conversationId else { return nil }
+            guard let seq = LastAppliedSeqStore.shared.seq(forConversation: conversationId) else { return nil }
+            return String(seq)
+        }
 
         // Surface attachment validation errors in the error manager so the UI
         // can show them without the attachment manager needing a direct reference.

--- a/clients/shared/Features/Chat/LastAppliedSeqStore.swift
+++ b/clients/shared/Features/Chat/LastAppliedSeqStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "LastAppliedSeqStore")
+
+/// Persists the highest `seq` the client has successfully applied for each
+/// conversation. The reducer (`MessageStreamReducer`) records every applied
+/// event here; on SSE (re)connect, `EventStreamClient` reads the value back
+/// and sends it as the `Last-Event-Id` (a `?lastEventId=N` query parameter,
+/// since the daemon accepts both) so the durable event log only replays
+/// events the client hasn't seen.
+///
+/// Backed by `UserDefaults` under the `vellum.streaming.lastAppliedSeq`
+/// namespace. The value space is per-conversation — `setSeq` is a monotonic
+/// max so out-of-order updates can't move the watermark backward.
+///
+/// Concurrency: the store is `Sendable`-safe via a NSLock; `UserDefaults`
+/// itself is thread-safe but the read-then-write `max` operation needs
+/// serialization to avoid losing increments under concurrent writers.
+public final class LastAppliedSeqStore: @unchecked Sendable {
+
+    public static let shared = LastAppliedSeqStore()
+
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private static let keyPrefix = "vellum.streaming.lastAppliedSeq."
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Returns the stored seq for `conversationId`, or `nil` if the client
+    /// has never applied an event for this conversation.
+    public func seq(forConversation conversationId: String) -> Int? {
+        let key = Self.key(for: conversationId)
+        lock.lock()
+        defer { lock.unlock() }
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return defaults.integer(forKey: key)
+    }
+
+    /// Monotonically advance the stored seq for `conversationId`. A `seq`
+    /// less than or equal to the existing watermark is a no-op so replayed
+    /// events can't move the watermark backward.
+    public func setSeq(_ seq: Int, forConversation conversationId: String) {
+        guard seq > 0 else { return }
+        let key = Self.key(for: conversationId)
+        lock.lock()
+        defer { lock.unlock() }
+        let existing = defaults.object(forKey: key) != nil ? defaults.integer(forKey: key) : 0
+        if seq > existing {
+            defaults.set(seq, forKey: key)
+        }
+    }
+
+    /// Clear the stored seq for `conversationId`. Called when the user
+    /// deletes a conversation so the next replay isn't gated on a stale
+    /// watermark.
+    public func clear(conversationId: String) {
+        let key = Self.key(for: conversationId)
+        lock.lock()
+        defer { lock.unlock() }
+        defaults.removeObject(forKey: key)
+    }
+
+    private static func key(for conversationId: String) -> String {
+        keyPrefix + conversationId
+    }
+}

--- a/clients/shared/Features/Chat/MessageStore+ChatMessageBridge.swift
+++ b/clients/shared/Features/Chat/MessageStore+ChatMessageBridge.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Bridge from the new `MessageStore` (the streaming-message-architecture
+/// reducer's source of truth) to the legacy `ChatMessage` shape that the
+/// existing chat renderer consumes.
+///
+/// As of PR 4 of the streaming-message-architecture plan, the chat view list
+/// renders from `ChatViewModel.renderedMessages`, which merges the legacy
+/// `messages` array (user bubbles, history, confirmations, system messages)
+/// with assistant content materialized from `MessageStore` snapshots through
+/// this bridge.
+///
+/// The legacy streaming helpers on `ChatViewModel` still mutate the legacy
+/// `messages` array as a side effect, but those mutations no longer drive
+/// rendering for messages that have a corresponding `MessageStore` snapshot.
+/// This is what makes the streaming-then-reload duplication symptom
+/// structurally impossible: the renderer reads a single source of truth keyed
+/// by the daemon's stable `messageId` regardless of how many times the legacy
+/// path lazy-creates bubbles.
+///
+/// PR 6 of the plan will remove the legacy `messages` array entirely.
+@MainActor
+extension MessageStore {
+
+    /// Materializes the store's snapshots as a `[ChatMessage]` ordered by
+    /// insertion (the order `upsertMessage` first saw each `messageId`).
+    ///
+    /// Each `MessageSnapshot` becomes one `ChatMessage`:
+    /// - `.text` blocks are joined as `textSegments` and placed in
+    ///   `contentOrder` interleaved with tool calls in `blockIndex` order.
+    /// - `.toolUse` blocks become entries in `toolCalls` with input, result,
+    ///   and completion state copied verbatim from the snapshot.
+    ///
+    /// The resulting `ChatMessage.id` is a deterministic UUID derived from
+    /// the daemon's stable `messageId` so the same snapshot always maps to
+    /// the same SwiftUI identity across re-renders.
+    public var chatMessages: [ChatMessage] {
+        orderedMessages.map { snapshot in
+            Self.chatMessage(from: snapshot)
+        }
+    }
+
+    /// Materialize a single `MessageSnapshot` into the legacy `ChatMessage`
+    /// shape consumed by the existing renderer.
+    static func chatMessage(from snapshot: MessageSnapshot) -> ChatMessage {
+        let role: ChatRole = (snapshot.role == "user") ? .user : .assistant
+
+        var textSegments: [String] = []
+        var toolCalls: [ToolCallData] = []
+        var contentOrder: [ContentBlockRef] = []
+
+        // Walk blocks in `blockIndex` order so rendering matches the wire
+        // ordering. The reducer enforces idempotency, so repeated apply()
+        // calls converge on the same shape here.
+        for (_, block) in snapshot.orderedBlocks {
+            switch block.type {
+            case .text:
+                let segIdx = textSegments.count
+                textSegments.append(block.text)
+                contentOrder.append(.text(segIdx))
+            case .toolUse:
+                let tcIdx = toolCalls.count
+                let inputDict = block.toolInput ?? [:]
+                let inputSummary = HistoryReconstructionService.summarizeToolInputStatic(inputDict)
+                let inputFull = ToolCallData.formatAllToolInput(inputDict)
+                let inputRawValue = HistoryReconstructionService.extractToolInputStatic(inputDict)
+                var toolCall = ToolCallData(
+                    toolName: block.toolName ?? "",
+                    inputSummary: inputSummary,
+                    inputFull: inputFull,
+                    inputRawValue: inputRawValue,
+                    result: block.toolResult?.result,
+                    isError: block.toolResult?.isError ?? false,
+                    isComplete: block.isComplete || block.toolResult != nil,
+                    arrivedBeforeText: textSegments.isEmpty
+                )
+                toolCall.toolUseId = block.toolUseId
+                toolCall.inputRawDict = inputDict.isEmpty ? nil : inputDict
+                if let result = block.toolResult {
+                    toolCall.riskLevel = result.riskLevel
+                    toolCall.riskReason = result.riskReason
+                    toolCall.matchedTrustRuleId = result.matchedTrustRuleId
+                    toolCall.approvalMode = result.approvalMode
+                    toolCall.approvalReason = result.approvalReason
+                    toolCall.riskThreshold = result.riskThreshold
+                    toolCall.riskScopeOptions = result.riskScopeOptions
+                    toolCall.riskAllowlistOptions = result.riskAllowlistOptions
+                    toolCall.riskDirectoryScopeOptions = result.riskDirectoryScopeOptions
+                    if let containerized = result.isContainerized { toolCall.isContainerized = containerized }
+                }
+                toolCalls.append(toolCall)
+                contentOrder.append(.toolCall(tcIdx))
+            }
+        }
+
+        var message = ChatMessage(
+            id: Self.deterministicUUID(for: snapshot.id),
+            role: role,
+            text: "",
+            isStreaming: !snapshot.isComplete
+        )
+        message.textSegments = textSegments
+        message.toolCalls = toolCalls
+        message.contentOrder = contentOrder
+        message.daemonMessageId = snapshot.id
+        return message
+    }
+
+    /// Maps a daemon `messageId` (UUIDv7 string) to a stable `Foundation.UUID`
+    /// usable as `ChatMessage.id`. Deterministic — the same string always
+    /// produces the same UUID — so SwiftUI sees a stable identity across
+    /// re-renders. UUIDv7 ids parse directly; non-UUID ids fall back to an
+    /// FNV-1a hash spread across 16 bytes (collisions astronomically
+    /// unlikely within a single conversation).
+    static func deterministicUUID(for messageId: String) -> UUID {
+        if let parsed = UUID(uuidString: messageId) { return parsed }
+        var h: UInt64 = 0xcbf29ce484222325
+        let prime: UInt64 = 0x100000001b3
+        for b in messageId.utf8 {
+            h ^= UInt64(b)
+            h = h &* prime
+        }
+        var bytes = uuid_t(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        withUnsafeMutableBytes(of: &bytes) { buf in
+            for i in 0..<16 {
+                h ^= h &<< 13
+                h ^= h &>> 7
+                h ^= h &<< 17
+                buf[i] = UInt8(truncatingIfNeeded: h &>> UInt64((i % 8) * 8))
+            }
+        }
+        return UUID(uuid: bytes)
+    }
+}

--- a/clients/shared/Features/Chat/MessageStreamReducer.swift
+++ b/clients/shared/Features/Chat/MessageStreamReducer.swift
@@ -27,12 +27,22 @@ public final class MessageStreamReducer {
     /// The store this reducer mutates. Owned by the caller.
     public let store: MessageStore
 
+    /// Persistent per-conversation `seq` watermark. Updated for every event
+    /// the reducer applies so the next SSE (re)connect can send
+    /// `Last-Event-Id` and skip re-applying durable-log replays.
+    private let lastAppliedSeqStore: LastAppliedSeqStore
+
     private let eventStreamClient: EventStreamClient
     private var subscriptionTask: Task<Void, Never>?
 
-    public init(store: MessageStore, eventStreamClient: EventStreamClient) {
+    public init(
+        store: MessageStore,
+        eventStreamClient: EventStreamClient,
+        lastAppliedSeqStore: LastAppliedSeqStore = .shared
+    ) {
         self.store = store
         self.eventStreamClient = eventStreamClient
+        self.lastAppliedSeqStore = lastAppliedSeqStore
     }
 
     deinit {
@@ -94,7 +104,7 @@ public final class MessageStreamReducer {
     private func applyMessageOpen(_ msg: MessageOpenMessage) {
         guard shouldApply(messageId: msg.messageId, blockIndex: Self.messageLevelBlockIndex, seq: msg.seq) else { return }
         store.upsertMessage(id: msg.messageId, role: msg.role)
-        recordSeq(messageId: msg.messageId, blockIndex: Self.messageLevelBlockIndex, seq: msg.seq)
+        recordSeq(messageId: msg.messageId, blockIndex: Self.messageLevelBlockIndex, seq: msg.seq, conversationId: msg.conversationId)
     }
 
     private func applyBlockOpen(_ msg: BlockOpenMessage) {
@@ -113,7 +123,7 @@ public final class MessageStreamReducer {
                 )
             }
         }
-        recordSeq(messageId: msg.messageId, blockIndex: msg.blockIndex, seq: msg.seq)
+        recordSeq(messageId: msg.messageId, blockIndex: msg.blockIndex, seq: msg.seq, conversationId: msg.conversationId)
     }
 
     private func applyBlockClose(_ msg: BlockCloseMessage) {
@@ -121,7 +131,7 @@ public final class MessageStreamReducer {
         store.updateMessage(id: msg.messageId) { snapshot in
             snapshot.blocks[msg.blockIndex]?.isComplete = true
         }
-        recordSeq(messageId: msg.messageId, blockIndex: msg.blockIndex, seq: msg.seq)
+        recordSeq(messageId: msg.messageId, blockIndex: msg.blockIndex, seq: msg.seq, conversationId: msg.conversationId)
     }
 
     private func applyMessageClose(_ msg: MessageCloseMessage) {
@@ -129,7 +139,7 @@ public final class MessageStreamReducer {
         store.updateMessage(id: msg.messageId) { snapshot in
             snapshot.isComplete = true
         }
-        recordSeq(messageId: msg.messageId, blockIndex: Self.messageLevelBlockIndex, seq: msg.seq)
+        recordSeq(messageId: msg.messageId, blockIndex: Self.messageLevelBlockIndex, seq: msg.seq, conversationId: msg.conversationId)
     }
 
     private func applyTextDelta(_ msg: AssistantTextDeltaMessage) {
@@ -149,7 +159,7 @@ public final class MessageStreamReducer {
             snapshot.blocks[blockIndex]?.text.append(msg.text)
         }
         if let seq = msg.seq {
-            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq)
+            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq, conversationId: msg.conversationId)
         }
     }
 
@@ -167,7 +177,7 @@ public final class MessageStreamReducer {
             snapshot.blocks[blockIndex]?.toolInput = msg.input
         }
         if let seq = msg.seq {
-            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq)
+            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq, conversationId: msg.conversationId)
         }
     }
 
@@ -182,7 +192,7 @@ public final class MessageStreamReducer {
             snapshot.blocks[blockIndex]?.toolInputJson.append(msg.content)
         }
         if let seq = msg.seq {
-            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq)
+            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq, conversationId: msg.conversationId)
         }
     }
 
@@ -197,7 +207,7 @@ public final class MessageStreamReducer {
             snapshot.blocks[blockIndex]?.toolResult = msg
         }
         if let seq = msg.seq {
-            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq)
+            recordSeq(messageId: messageId, blockIndex: blockIndex, seq: seq, conversationId: msg.conversationId)
         }
     }
 
@@ -217,12 +227,18 @@ public final class MessageStreamReducer {
         return true
     }
 
-    private func recordSeq(messageId: String, blockIndex: Int, seq: Int) {
+    private func recordSeq(messageId: String, blockIndex: Int, seq: Int, conversationId: String?) {
         store.updateMessage(id: messageId) { snapshot in
             if let existing = snapshot.seqWatermarks[blockIndex], existing >= seq {
                 return
             }
             snapshot.seqWatermarks[blockIndex] = seq
+        }
+        // Persist the per-conversation watermark so the next SSE (re)connect
+        // can send `Last-Event-Id` and skip durable-log replays the client
+        // has already applied (see `LastAppliedSeqStore`).
+        if let conversationId, !conversationId.isEmpty {
+            lastAppliedSeqStore.setSeq(seq, forConversation: conversationId)
         }
     }
 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -168,6 +168,15 @@ public final class EventStreamClient {
     /// Called when a token_rotated event is received.
     var onTokenRefreshed: ((String) -> Void)?
 
+    /// Resolves the `Last-Event-Id` value to send on the next SSE connect /
+    /// reconnect. Returning `nil` skips the header. Set by `ChatViewModel`
+    /// from the persisted `LastAppliedSeqStore` watermark for the currently
+    /// active conversation. The daemon only honors the header when the
+    /// stream is conversation-scoped — today's global `/v1/events` stream
+    /// ignores it, but the wiring is in place for PR 5's per-conversation
+    /// subscription model.
+    public var lastEventIdProvider: (() -> String?)?
+
 
     // MARK: - Init
 
@@ -402,10 +411,12 @@ public final class EventStreamClient {
 
             do {
                 await self.sseHandshakeDiagnostics.reset()
+                let lastEventId = self.lastEventIdProvider?()
                 let (bytes, response) = try await GatewayHTTPClient.stream(
                     path: "events",
                     timeout: .infinity,
-                    session: session
+                    session: session,
+                    lastEventId: lastEventId
                 )
 
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -489,13 +489,25 @@ public enum GatewayHTTPClient {
     ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func stream(path: String, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func stream(
+        path: String,
+        timeout: TimeInterval = 30,
+        session: URLSession = .shared,
+        lastEventId: String? = nil
+    ) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
         var request = try buildRequest(path: path, params: nil, method: "GET", timeout: timeout, connection: connection)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
         request.setValue(ProcessInfo.processInfo.hostName, forHTTPHeaderField: "X-Vellum-Machine-Name")
+        // Standard SSE reconnect field — the daemon's `/v1/events` route
+        // honors it when the stream is conversation-scoped, replaying
+        // persisted events with `seq > Last-Event-Id` from the durable log
+        // before delivering live events. Ignored on global subscriptions.
+        if let lastEventId, !lastEventId.isEmpty {
+            request.setValue(lastEventId, forHTTPHeaderField: "Last-Event-Id")
+        }
         logOutgoing(request, quiet: false)
         let (bytes, response) = try await session.bytes(for: request)
         if let http = response as? HTTPURLResponse {


### PR DESCRIPTION
## Summary
- Repoints chat view to render from MessageStore (PR 3) instead of the legacy messages array via a new `ChatViewModel.renderedMessages` bridge that materializes `MessageStore` snapshots into `ChatMessage` values and drops the legacy lazy-bubble-creation rows that the streaming helpers would otherwise duplicate.
- Persists `lastAppliedSeq` per conversation in a new `LastAppliedSeqStore` (UserDefaults), updated by every event the reducer applies, and threads it through `EventStreamClient` → `GatewayHTTPClient.stream(lastEventId:)` as the `Last-Event-Id` header on SSE (re)connect (PR 2 wired the server side; the daemon honors it on per-conversation subscriptions).
- The structural duplication symptom should now be impossible for assistant bubbles: every assistant message has exactly one identity (the daemon's stable `messageId`), and the reducer's idempotent apply is the sole writer for what the renderer sees.

## Scope note
This PR removes the legacy `currentAssistantMessageId` field and `clearCurrentTurnTracking()` helper from the renderer source-of-truth — they no longer influence which rows the view shows. Physical deletion of those symbols is deferred to PR 6 (the "retire legacy vocabulary" cleanup), which is where the legacy `messages` array goes away entirely. Removing them in PR 4 would touch ~136 call sites across `MessageSendCoordinator`, `ChatActionHandler`, and `ChatViewModel+SurfaceHandling` — work that belongs in the same PR that retires the array those helpers mutate.

Part of plan: streaming-message-architecture.md (PR 4 of 6)