### PR TITLE
fix(macos): load /assistant path in Electron dev URL

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -29,10 +29,11 @@ which is a fast no-op when the lockfile already matches).
 proxy) with a 1.5s timeout and picks one of two paths:
 
 1. **vel up is running** → dispatches to `dev:electron-only` with
-   `VELLUM_DEV_URL=http://localhost:3000`. No Vite is spawned here; the
-   Electron BrowserWindow loads the edge proxy URL and reuses vel's
-   backends (Django, gateway, daemon) the same way Swift Vellum does
-   today. This is the common case once you have `vel up` going.
+   `VELLUM_DEV_URL=http://localhost:3000/assistant`. No Vite is spawned
+   here; the Electron BrowserWindow loads the edge proxy at the
+   `/assistant` path (the bare root is the marketing site) and reuses
+   vel's backends (Django, gateway, daemon) the same way Swift Vellum
+   does today. This is the common case once you have `vel up` going.
 
 2. **No vel up** → dispatches to `dev:standalone`, which uses
    [`concurrently`](https://github.com/open-cli-tools/concurrently) to
@@ -53,9 +54,14 @@ proxy) with a 1.5s timeout and picks one of two paths:
    chrome), not for feature development against the real stack.
 
 The main-process URL choice lives in `src/main/index.ts`:
-`process.env.VELLUM_DEV_URL ?? "http://localhost:5173"`. Override the
-env var yourself (e.g., `VELLUM_DEV_URL=http://localhost:3002 bun run
-dev:electron-only`) if you need to point at a non-default service.
+`process.env.VELLUM_DEV_URL ?? "http://localhost:5173/assistant"`.
+`VELLUM_DEV_URL` is treated as the full URL — callers must include the
+`/assistant` path themselves because `apps/web/vite.config.ts` sets
+`base: "/assistant/"` (so the bare origin lands the BrowserWindow on
+the marketing page in vel-up mode, or on a Vite 404 in standalone).
+Override the env var yourself (e.g.,
+`VELLUM_DEV_URL=http://localhost:3002/assistant bun run dev:electron-only`)
+if you need to point at a non-default service.
 
 The app shows up as **Vellum Electron** in the menu bar and Dock
 (via `app.setName`, gated to `!app.isPackaged` in `src/main/index.ts`),
@@ -69,8 +75,8 @@ You don't have to ship a DMG to try it. Packaging (DMG, signing,
 notarization, auto-update) lands in follow-up tickets once we actually
 need a distributable artifact.
 
-- **Dev (vel up)** — Electron loads `http://localhost:3000` (edge proxy).
-- **Dev (standalone)** — Electron loads `http://localhost:5173` (our Vite).
+- **Dev (vel up)** — Electron loads `http://localhost:3000/assistant` (edge proxy + the path apps/web's Vite is configured for).
+- **Dev (standalone)** — Electron loads `http://localhost:5173/assistant` (our Vite, same path).
 - **Prod (future)** — A custom `app://vellum.ai/` protocol serves the
   static `apps/web/dist/` bundle. Same-origin policy treats `app://` as
   a secure standard scheme.

--- a/apps/macos/scripts/dev.ts
+++ b/apps/macos/scripts/dev.ts
@@ -8,9 +8,11 @@
  * repo) and dispatches accordingly:
  *
  *   - vel up detected → `bun run dev:electron-only` with
- *     `VELLUM_DEV_URL=http://localhost:3000`. The renderer attaches to
- *     the running stack and the BrowserWindow loads the edge proxy URL,
- *     so backend calls work the same way they do for the Swift app.
+ *     `VELLUM_DEV_URL=http://localhost:3000/assistant`. The renderer
+ *     attaches to the running stack and the BrowserWindow loads the
+ *     edge proxy at the `/assistant` path (the bare root is the
+ *     marketing site), so backend calls work the same way they do for
+ *     the Swift app.
  *   - no vel up        → `bun run dev:standalone`. Spawns our own Vite
  *     on :5173 plus Electron. No backends, but the shell — menus, IPC
  *     bridge, window chrome, settings — is fully exercisable.

--- a/apps/macos/scripts/dev.ts
+++ b/apps/macos/scripts/dev.ts
@@ -21,14 +21,22 @@
  */
 import { spawn } from "node:child_process";
 
-const VEL_EDGE_PROXY_URL = "http://localhost:3000";
+// Edge-proxy origin used by the probe — vel up serves the marketing site
+// at the bare root and reverse-proxies `/assistant/*` to apps/web's Vite,
+// so we probe the origin and load `/assistant` (the renderer path) when
+// attaching. apps/web's `vite.config.ts` declares `base: "/assistant/"`,
+// which is the same path Swift Vellum hits today.
+const VEL_EDGE_PROXY_ORIGIN = "http://localhost:3000";
+const VEL_RENDERER_URL = `${VEL_EDGE_PROXY_ORIGIN}/assistant`;
 const PROBE_TIMEOUT_MS = 1_500;
 
 async function isVelUp(): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
   try {
-    const res = await fetch(VEL_EDGE_PROXY_URL, { signal: controller.signal });
+    const res = await fetch(VEL_EDGE_PROXY_ORIGIN, {
+      signal: controller.signal,
+    });
     // Any non-5xx response counts — even a 404 means something is
     // listening on that port and serving HTTP, which is enough signal
     // that we're not running cold.
@@ -43,16 +51,16 @@ async function isVelUp(): Promise<boolean> {
 const velRunning = await isVelUp();
 const downstreamScript = velRunning ? "dev:electron-only" : "dev:standalone";
 const env: NodeJS.ProcessEnv = velRunning
-  ? { ...process.env, VELLUM_DEV_URL: VEL_EDGE_PROXY_URL }
+  ? { ...process.env, VELLUM_DEV_URL: VEL_RENDERER_URL }
   : process.env;
 
 if (velRunning) {
   console.log(
-    `[dev] detected vel up at ${VEL_EDGE_PROXY_URL} — attaching Electron`,
+    `[dev] detected vel up at ${VEL_EDGE_PROXY_ORIGIN} — attaching Electron to ${VEL_RENDERER_URL}`,
   );
 } else {
   console.log(
-    `[dev] no vel up at ${VEL_EDGE_PROXY_URL} — running standalone (Vite :5173, no backends)`,
+    `[dev] no vel up at ${VEL_EDGE_PROXY_ORIGIN} — running standalone (Vite :5173, no backends)`,
   );
 }
 

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -11,17 +11,28 @@ import { readSetting, writeSetting } from "./settings";
 // point the BrowserWindow at whichever Vite-or-equivalent is actually
 // up:
 //
-//   - Standalone `bun run dev` → unset, falls back to localhost:5173
-//     (our own Vite, spawned by `dev:standalone`).
+//   - Standalone `bun run dev` → unset, falls back to
+//     `http://localhost:5173/assistant` (our own Vite, spawned by
+//     `dev:standalone`).
 //   - `bun run dev` while `vel up` is running → the probe shim sets it
-//     to `http://localhost:3000` (the edge proxy that Swift Vellum also
-//     hits), so the renderer is same-origin with the running backends.
+//     to `http://localhost:3000/assistant` (vel's edge proxy + the
+//     renderer path that Swift Vellum hits), so the renderer is
+//     same-origin with the running backends.
 //   - Future `vel up electron` → vel sets it directly when spawning us.
+//
+// The `/assistant` path matters: `apps/web/vite.config.ts` declares
+// `base: "/assistant/"`, and vel's edge proxy reserves the `:3000` root
+// for the marketing site and routes `/assistant/*` to apps/web. Loading
+// the bare origin lands the BrowserWindow on the marketing page instead
+// of the renderer. Callers (vel, the probe shim, a developer setting
+// the env var by hand) are responsible for including the path —
+// `VELLUM_DEV_URL` is treated as the full URL to load.
 //
 // The port-5173 fallback agrees with `dev:web` in package.json, which
 // passes `--port 5173 --strictPort` so apps/web's `.env` defaults can't
 // silently move it.
-const DEV_SERVER_URL = process.env.VELLUM_DEV_URL ?? "http://localhost:5173";
+const DEV_SERVER_URL =
+  process.env.VELLUM_DEV_URL ?? "http://localhost:5173/assistant";
 const DEV_SERVER_ORIGIN = new URL(DEV_SERVER_URL).origin;
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the


### PR DESCRIPTION
## Summary

Second small hotfix on top of #32450. After the Electron binary install was fixed and `bun run dev` actually launches, the BrowserWindow loaded the *marketing* page from vel up's edge proxy instead of the renderer.

## Root cause

`apps/web/vite.config.ts:37`:

```ts
base: "/assistant/",
```

apps/web is served under the `/assistant` path — even by its own Vite. You can see Vite confirming that on startup:

```
Local:   http://localhost:5173/assistant/
```

vel up's edge proxy on `:3000` follows the same convention:
- `/` → marketing site
- `/assistant/*` → apps/web (Swift Vellum hits this URL today)

So the BrowserWindow loading `http://localhost:3000/` landed on the marketing page (`Vellum: Your Personal Intelligence`), and `http://localhost:5173/` would land on a Vite 404 in standalone mode. Neither is what we want.

## Fix

Three places, all small:

- **`src/main/index.ts`** — default fallback is now `http://localhost:5173/assistant`.
- **`scripts/dev.ts`** — probe shim sets `VELLUM_DEV_URL=http://localhost:3000/assistant` when vel is detected (logged on startup so it's clear what got chosen).
- **`README.md`** — documented that `VELLUM_DEV_URL` is the **full URL** (callers include the path themselves), so a future `vel up electron` integration or a developer pointing at `:3002/assistant` or `:3000/some-other-app` composes cleanly.

## How to test

```sh
git checkout claude/fix-electron-renderer-path
cd apps/macos
bun install
bun run dev    # with vel up running
```

`[dev] detected vel up at http://localhost:3000 — attaching Electron to http://localhost:3000/assistant`. BrowserWindow shows the actual Vellum renderer (auth screen / your assistant), not the marketing site.

Standalone path (`bun run dev` with no vel up) loads `http://localhost:5173/assistant`, which is what apps/web's Vite serves.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_