### PR TITLE
fix(web): replace document viewer back arrow with X close button on right

### DIFF
--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -18,12 +18,12 @@ import {
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import {
-  ArrowLeft,
   Check,
   Download,
   FileText,
   Loader2,
   MessageSquareText,
+  X,
 } from "lucide-react";
 import { Button, Typography } from "@vellum/design-library";
 
@@ -274,13 +274,6 @@ export function DocumentViewerContainer({
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-[var(--border-base)] bg-[var(--surface-overlay)]">
       {/* Navbar */}
       <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-base)] px-4 py-2">
-        <Button
-          variant="ghost"
-          size="compact"
-          iconOnly={<ArrowLeft />}
-          aria-label="Close document"
-          onClick={onClose}
-        />
         <FileText
           size={16}
           style={{ color: "var(--content-secondary)" }}
@@ -328,6 +321,15 @@ export function DocumentViewerContainer({
         >
           Comments
         </Button>
+
+        <Button
+          variant="ghost"
+          size="compact"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close document"
+          tooltip="Close"
+        />
       </div>
 
       {/* Body: editor + optional comment panel */}


### PR DESCRIPTION
The document editor details panel used a left-side back arrow (`ArrowLeft`) for its close button, making it the only detail/overlay panel with that pattern. All other panels — `ToolDetailPanel`, `SubagentDetailPanel`, and `AppNavBar` — use an X button on the right side. This replaces the back arrow with a matching X close button for visual consistency across all detail panels, particularly important on iOS where the document overlay is full-screen.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/3ce4d7a139db434d96c6c18f1777a504