### PR TITLE
fix: skip platform-features flag check in platform mode

### DIFF
--- a/assistant/src/platform/feature-gate.ts
+++ b/assistant/src/platform/feature-gate.ts
@@ -1,4 +1,5 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getIsPlatform } from "../config/env-registry.js";
 import type { AssistantConfig } from "../config/schema.js";
 
 const FLAG_KEY = "platform-features-in-local-mode" as const;
@@ -6,6 +7,7 @@ const FLAG_KEY = "platform-features-in-local-mode" as const;
 export function arePlatformFeaturesEnabled(
   config?: AssistantConfig,
 ): boolean {
+  if (getIsPlatform()) return true;
   return isAssistantFeatureFlagEnabled(
     FLAG_KEY,
     (config ?? {}) as AssistantConfig,

--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -25,6 +25,12 @@ export function isFeatureFlagEnabled(key: string): boolean {
   return defaults[key]?.defaultEnabled ?? false;
 }
 
+function isPlatformMode(): boolean {
+  const v = process.env.IS_PLATFORM?.trim().toLowerCase();
+  return v === "true" || v === "1";
+}
+
 export function arePlatformFeaturesEnabled(): boolean {
+  if (isPlatformMode()) return true;
   return isFeatureFlagEnabled("platform-features-in-local-mode");
 }


### PR DESCRIPTION
## Summary
- `arePlatformFeaturesEnabled()` in both daemon and gateway now short-circuits to `true` when `IS_PLATFORM` is set, bypassing the feature flag check entirely
- The `platform-features-in-local-mode` flag is only consulted when running locally — platform/managed deployments always have platform features available

## Original prompt
After merging the `platform-features-in-local-mode` feature flag, we realized the flag check should be scoped to local mode only. In platform/managed deployments (`IS_PLATFORM=true`), platform features are inherently available and the flag value should be ignored. The web UI already had this guard (`isLocalMode()` check before the flag), but the daemon and gateway helpers were missing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)