### PR TITLE
refactor(web): convention compliance, DRY, type safety, and bug fixes across viewer/chat/terminal

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -24,7 +24,6 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useVisibleViewport } from "@/hooks/use-visible-viewport";
 import { useAuthStore } from "@/stores/auth-store";
 import { useAssistantContext } from "@/components/layout/assistant-context";
-import { useShallow } from "zustand/shallow";
 import { useConversationStore } from "@/domains/conversations/conversation-store";
 import {
   COMPOSER_FOCUS_EVENT,
@@ -235,20 +234,13 @@ export function ChatPage() {
   const activeConversationId = useConversationStore.use.activeConversationId();
   const editingConversationId = useConversationStore.use.editingConversationId();
   const processingConversationIds = useConversationStore.use.processingConversationIds();
-  const viewerState = useViewerStore(useShallow((s) => ({
-    mainView: s.mainView,
-    activeAppId: s.activeAppId,
-    openedAppState: s.openedAppState,
-    openedDocumentState: s.openedDocumentState,
-    isAppMinimized: s.isAppMinimized,
-    intelligenceTab: s.intelligenceTab,
-    assetsRefreshKey: s.assetsRefreshKey,
-    viewBeforeDocument: s.viewBeforeDocument,
-    activeSubagentId: s.activeSubagentId,
-    viewBeforeSubagentDetail: s.viewBeforeSubagentDetail,
-    activeToolDetail: s.activeToolDetail,
-  })));
-  const subagentState = useSubagentStore(useShallow((s) => ({ byId: s.byId, orderedIds: s.orderedIds })));
+  const mainView = useViewerStore.use.mainView();
+  const openedAppState = useViewerStore.use.openedAppState();
+  const openedDocumentState = useViewerStore.use.openedDocumentState();
+  const isAppMinimized = useViewerStore.use.isAppMinimized();
+  const activeSubagentId = useViewerStore.use.activeSubagentId();
+  const activeToolDetail = useViewerStore.use.activeToolDetail();
+  const subagentById = useSubagentStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
   const isTokenDialogOpen = useDeployStore.use.isTokenDialogOpen();
@@ -265,10 +257,10 @@ export function ChatPage() {
   // -------------------------------------------------------------------------
   // Pin-sync side-effect
   // -------------------------------------------------------------------------
-  // Cross-store coordination (clearing the app + editing-conversation when
-  // the active app gets unpinned) lives inside `viewer-store.handleAppUnpinned`,
-  // so every consumer gets the same behavior without re-implementing it.
-  useActiveAppPinSync(useViewerStore.getState().handleAppUnpinned);
+  useActiveAppPinSync(useCallback((appId: string) => {
+    useViewerStore.getState().handleAppUnpinned(appId);
+    useConversationStore.getState().setEditingConversationId(null);
+  }, []));
 
   // -------------------------------------------------------------------------
   // Shared refs — owned here, read/written by hooks
@@ -898,7 +890,7 @@ export function ChatPage() {
   }, [activeConversationId]);
   useEffect(() => {
     if (!assistantId) return;
-    const entries = Object.values(subagentState.byId);
+    const entries = Object.values(subagentById);
     for (const entry of entries) {
       if (entry.conversationId && entry.events.length === 0) {
         const fetchedAt = fetchedSubagentsRef.current.get(entry.subagentId);
@@ -907,7 +899,7 @@ export function ChatPage() {
         handleRequestSubagentDetail(entry.subagentId);
       }
     }
-  }, [assistantId, subagentState.byId, handleRequestSubagentDetail]);
+  }, [assistantId, subagentById, handleRequestSubagentDetail]);
 
   // -------------------------------------------------------------------------
   // Interaction actions
@@ -1482,9 +1474,9 @@ export function ChatPage() {
     activeConversationId,
     activeConversation,
     processingConversationIds,
-    mainView: viewerState.mainView,
-    openedAppState: viewerState.openedAppState,
-    openedDocumentState: viewerState.openedDocumentState,
+    mainView,
+    openedAppState,
+    openedDocumentState,
     editingConversationId,
     restoredDraftConversationId,
     setRestoredDraftConversationId,
@@ -1581,7 +1573,6 @@ export function ChatPage() {
     handleCloseApp: () => {
       useViewerStore.getState().closeApp();
       useConversationStore.getState().setEditingConversationId(null);
-      useViewerStore.getState().setMainView("chat");
     },
     handleCloseEditPanel: () => {
       useConversationStore.getState().setEditingConversationId(null);
@@ -1611,8 +1602,8 @@ export function ChatPage() {
     } : undefined,
     handleForkConversation,
     handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
-    subagentState,
-    activeSubagentId: viewerState.activeSubagentId,
+    subagentState: { byId: subagentById },
+    activeSubagentId,
     onSubagentClick: (id: string) => { useViewerStore.getState().openSubagentDetail(id); },
     onCloseSubagentDetail: () => { useViewerStore.getState().closeSubagentDetail(); },
     onStopSubagent: async (subagentId: string) => {
@@ -1708,9 +1699,9 @@ export function ChatPage() {
           <>
             <MobileAppOverlay
               openedAppState={
-                viewerState.mainView === "app" ? viewerState.openedAppState : null
+                mainView === "app" ? openedAppState : null
               }
-              isAppMinimized={viewerState.isAppMinimized}
+              isAppMinimized={isAppMinimized}
               assistantId={assistantId}
               onToggleMinimized={() => {
                 useViewerStore.getState().toggleAppMinimized();
@@ -1718,7 +1709,6 @@ export function ChatPage() {
               onClose={() => {
                 useViewerStore.getState().closeApp();
                 useConversationStore.getState().setEditingConversationId(null);
-                useViewerStore.getState().setMainView("chat");
               }}
               onShare={() => {
                 const app = useViewerStore.getState().openedAppState;
@@ -1737,8 +1727,8 @@ export function ChatPage() {
             />
             <MobileDocumentOverlay
               openedDocumentState={
-                viewerState.mainView === "document"
-                  ? viewerState.openedDocumentState
+                mainView === "document"
+                  ? openedDocumentState
                   : null
               }
               assistantId={assistantId}
@@ -1756,9 +1746,9 @@ export function ChatPage() {
             />
             <MobileSubagentDetailOverlay
               entry={
-                viewerState.mainView === "subagent-detail" &&
-                viewerState.activeSubagentId
-                  ? subagentState.byId[viewerState.activeSubagentId] ?? null
+                mainView === "subagent-detail" &&
+                activeSubagentId
+                  ? subagentById[activeSubagentId] ?? null
                   : null
               }
               onClose={() => {
@@ -1780,8 +1770,8 @@ export function ChatPage() {
             />
             <MobileToolDetailOverlay
               detail={
-                viewerState.mainView === "tool-detail"
-                  ? viewerState.activeToolDetail
+                mainView === "tool-detail"
+                  ? activeToolDetail
                   : null
               }
               onClose={() => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -258,8 +258,10 @@ export function ChatPage() {
   // Pin-sync side-effect
   // -------------------------------------------------------------------------
   useActiveAppPinSync(useCallback((appId: string) => {
-    useViewerStore.getState().handleAppUnpinned(appId);
-    useConversationStore.getState().setEditingConversationId(null);
+    const didClose = useViewerStore.getState().handleAppUnpinned(appId);
+    if (didClose) {
+      useConversationStore.getState().setEditingConversationId(null);
+    }
   }, []));
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
+++ b/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
@@ -7,13 +7,13 @@
  * - Text selection tracking with character offset conversion
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { Extension } from "@tiptap/core";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { EditorContent, useEditor } from "@tiptap/react";
 import Link from "@tiptap/extension-link";
 import StarterKit from "@tiptap/starter-kit";
-import { Markdown } from "tiptap-markdown";
+import { Markdown, type MarkdownStorage } from "tiptap-markdown";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import {
@@ -51,6 +51,16 @@ interface TiptapDocumentEditorProps {
   onCommentSubmit?: (comment: string) => void;
   commentSubmitting?: boolean;
   className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the current markdown from a tiptap editor with the Markdown extension. */
+function getEditorMarkdown(editor: import("@tiptap/core").Editor): string {
+  const storage = editor.storage as unknown as { markdown: MarkdownStorage };
+  return storage.markdown.getMarkdown();
 }
 
 // ---------------------------------------------------------------------------
@@ -236,7 +246,7 @@ function BubbleToolbar({ editor, onCommentSubmit, commentSubmitting }: BubbleToo
 
   const buttons: {
     name: MarkName;
-    icon: React.ReactNode;
+    icon: ReactNode;
     action: () => void;
     separator?: boolean;
   }[] = [
@@ -400,9 +410,7 @@ export function TiptapDocumentEditor({
     content,
     editable,
     onUpdate({ editor: ed }) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const md = (ed.storage as any).markdown.getMarkdown() as string;
-      onContentChangeRef.current?.(md);
+      onContentChangeRef.current?.(getEditorMarkdown(ed));
     },
     onSelectionUpdate({ editor: ed }) {
       const { from, to } = ed.state.selection;
@@ -438,8 +446,7 @@ export function TiptapDocumentEditor({
     if (content === prevContentRef.current) return;
     prevContentRef.current = content;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const currentMd = (editor.storage as any).markdown.getMarkdown() as string;
+    const currentMd = getEditorMarkdown(editor);
     if (currentMd === content) return; // avoid cursor-reset loops
 
     editor.commands.setContent(content);

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -16,6 +16,7 @@
  *    subagents).
  */
 
+import { type ComponentProps } from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -61,7 +62,7 @@ function makeToolCall(
 function renderCard(
   toolCalls: ChatMessageToolCall[],
   overrides: Partial<
-    React.ComponentProps<typeof ToolCallProgressCard>
+    ComponentProps<typeof ToolCallProgressCard>
   > = {},
 ) {
   return render(

--- a/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/__tests__/tool-progress-card-shell.test.tsx
@@ -12,7 +12,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { act, useState } from "react";
+import { type ComponentProps, act, useState } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import {
@@ -26,7 +26,7 @@ afterEach(() => {
 
 function renderShell(
   overrides: Partial<
-    React.ComponentProps<typeof ToolProgressCardShell>
+    ComponentProps<typeof ToolProgressCardShell>
   > = {},
 ) {
   return render(

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.reduced-motion.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.reduced-motion.test.tsx
@@ -7,6 +7,7 @@
  * pattern used by `website-carousel.test.tsx`.
  */
 
+import { type ReactNode } from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
@@ -33,7 +34,7 @@ describe("WebSearchProgressCard — reduced motion", () => {
         // as unknown attributes (would log a React warning).
         ...rest
       }: {
-        children?: React.ReactNode;
+        children?: ReactNode;
         animate?: Record<string, unknown>;
         initial?: Record<string, unknown>;
         exit?: Record<string, unknown>;
@@ -56,7 +57,7 @@ describe("WebSearchProgressCard — reduced motion", () => {
         transition: _t,
         ...rest
       }: {
-        children?: React.ReactNode;
+        children?: ReactNode;
         animate?: unknown;
         initial?: unknown;
         exit?: unknown;
@@ -65,7 +66,7 @@ describe("WebSearchProgressCard — reduced motion", () => {
       }) => <div {...rest}>{children}</div>;
       return {
         motion: { div: motionDiv, span: motionSpan },
-        AnimatePresence: ({ children }: { children?: React.ReactNode }) => (
+        AnimatePresence: ({ children }: { children?: ReactNode }) => (
           <>{children}</>
         ),
         useReducedMotion: () => true,

--- a/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act } from "react";
+import { type ReactNode, act } from "react";
 
 import { cleanup, render } from "@testing-library/react";
 
@@ -181,7 +181,7 @@ describe("WebsiteCarousel — reduced motion", () => {
         transition,
         ...rest
       }: {
-        children?: React.ReactNode;
+        children?: ReactNode;
         animate?: Record<string, unknown>;
         initial?: Record<string, unknown>;
         exit?: Record<string, unknown>;
@@ -200,12 +200,12 @@ describe("WebsiteCarousel — reduced motion", () => {
         children,
         ...rest
       }: {
-        children?: React.ReactNode;
+        children?: ReactNode;
         [key: string]: unknown;
       }) => <span {...rest}>{children}</span>;
       return {
         motion: { div: motionDiv, span: motionSpan },
-        AnimatePresence: ({ children }: { children?: React.ReactNode }) => (
+        AnimatePresence: ({ children }: { children?: ReactNode }) => (
           <>{children}</>
         ),
         useReducedMotion: () => true,

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -24,7 +24,6 @@ import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { getSlackLinkUrl, type Surface } from "@/domains/chat/types/types";
 import { isPointerCoarse } from "@/utils/pointer";
-import { useShallow } from "zustand/shallow";
 import {
   EMPTY_SUBAGENT_ENTRIES,
   useSubagentStore,
@@ -48,8 +47,7 @@ export interface OpenRuleEditorContext {
  * grouping rules for tool calls / text / inline surfaces are duplicated
  * verbatim so the virtualized transcript produces byte-identical markup to
  * the legacy rendering path. Do NOT change the grouping rules in this file
- * without updating the legacy path in lockstep — PR 7 wires this component
- * in and will delete the legacy loop.
+ * without updating the legacy path in lockstep.
  */
 export interface TranscriptMessageBodyProps {
   message: DisplayMessage;
@@ -488,16 +486,16 @@ export function TranscriptMessageBody({
   // `resolveSpawnedSubagentIds` render an inline card even when the spawn
   // tool call has no `result` yet.
   const linkedSubagentEntries = useSubagentStore(
-    useShallow((s) => lookupSubagentEntriesForMessage(s.byParent, message)),
+    (s) => lookupSubagentEntriesForMessage(s.byParent, message),
   );
 
   // Subscribe to the tool-use-id index alongside the per-message bucket above.
-  // Spawns are infrequent, so subscribing to the whole map is acceptable; PR 2
-  // keeps the map reference stable across non-spawn mutations, so this does not
-  // re-render message bodies on unrelated subagent activity. This anchors each
-  // `subagent_spawn` tool call to its subagent by `tc.id`, independent of the
-  // (optimistic→server) message id.
-  const byToolUseId = useSubagentStore(useShallow((s) => s.byToolUseId));
+  // Spawns are infrequent, so subscribing to the whole map is acceptable; the
+  // store keeps the map reference stable across non-spawn mutations, so this
+  // does not re-render message bodies on unrelated subagent activity. This
+  // anchors each `subagent_spawn` tool call to its subagent by `tc.id`,
+  // independent of the (optimistic→server) message id.
+  const byToolUseId = useSubagentStore.use.byToolUseId();
 
   // Message-scoped: two non-consecutive `subagent_spawn` tool-call groups
   // must not both positional-match the same linked entry. Accumulates across

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -1,5 +1,5 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { cn } from "@vellum/design-library";
 import { CATEGORY_STYLES } from "./home-feed-filter-bar";
@@ -14,7 +14,7 @@ function HoverIconButton({
   title: string;
   onClick: () => void;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <span

--- a/apps/web/src/domains/intelligence/memory-v2/hooks.ts
+++ b/apps/web/src/domains/intelligence/memory-v2/hooks.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { listConceptPages, readConceptPage } from "./api";
 import type { ListConceptPagesResult } from "./types";
 
+/** Fetches the paginated list of memory-v2 concept pages for the assistant. */
 export function useListConceptPages(assistantId: string) {
   return useQuery<ListConceptPagesResult>({
     queryKey: ["memory-v2-concept-pages", assistantId],
@@ -11,6 +12,7 @@ export function useListConceptPages(assistantId: string) {
   });
 }
 
+/** Fetches the full content of a single concept page by slug. */
 export function useReadConceptPage(assistantId: string, slug: string) {
   return useQuery<string | null>({
     queryKey: ["concept-page", assistantId, slug],

--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@vellum/design-library/components/toast";
-import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/index";
+import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal";
 import { BillingPanel } from "@/domains/settings/components/billing-panel";
 import { BillingPortalReturnHandler } from "@/domains/settings/components/billing-portal-return-handler";

--- a/apps/web/src/domains/settings/billing/pro-onboarding/index.ts
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/index.ts
@@ -1,3 +1,0 @@
-export { BillingOnboardingModal } from "./billing-onboarding-modal";
-export type { BillingOnboardingModalProps } from "./billing-onboarding-modal";
-export { allowedMachineSizesForTier, extractOnboardingErrorMessage, ONBOARDING_ERROR_CODE_MESSAGES } from "./utils";

--- a/apps/web/src/domains/terminal/components/terminal-console.tsx
+++ b/apps/web/src/domains/terminal/components/terminal-console.tsx
@@ -1,4 +1,5 @@
 import { type MutableRefObject, useEffect, useRef } from "react";
+import type { Terminal as TerminalType, IDisposable } from "xterm";
 import "xterm/css/xterm.css";
 
 export interface TerminalDimensions {
@@ -22,8 +23,7 @@ export function TerminalConsole({
   writeRef,
 }: TerminalConsoleProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const terminalRef = useRef<any>(null);
+  const terminalRef = useRef<TerminalType | null>(null);
   const onDataRef = useRef(onData);
   const onResizeRef = useRef(onResize);
   const readOnlyRef = useRef(readOnly);
@@ -47,21 +47,16 @@ export function TerminalConsole({
     const el = containerRef.current;
     let disposed = false;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let terminal: any = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let fitAddon: any = null;
+    let terminal: TerminalType | null = null;
     let resizeObserver: ResizeObserver | null = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let dataDisposable: any = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let resizeDisposable: any = null;
+    let dataDisposable: IDisposable | null = null;
+    let resizeDisposable: IDisposable | null = null;
 
     Promise.all([import("xterm"), import("xterm-addon-fit")]).then(
       ([{ Terminal }, { FitAddon }]) => {
         if (disposed || !el) return;
 
-        terminal = new Terminal({
+        const term = new Terminal({
           cursorBlink: true,
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
           fontSize: 14,
@@ -89,13 +84,14 @@ export function TerminalConsole({
           disableStdin: readOnly,
           scrollback: 2000,
         });
+        terminal = term;
 
-        fitAddon = new FitAddon();
-        terminal.loadAddon(fitAddon);
-        terminal.open(el);
-        terminalRef.current = terminal;
+        const fit = new FitAddon();
+        term.loadAddon(fit);
+        term.open(el);
+        terminalRef.current = term;
 
-        terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+        term.attachCustomKeyEventHandler((event: KeyboardEvent) => {
           if (
             event.key === "k" &&
             event.metaKey &&
@@ -105,7 +101,7 @@ export function TerminalConsole({
           ) {
             if (event.type === "keydown") {
               event.preventDefault();
-              terminal.clear();
+              term.clear();
             }
             return false;
           }
@@ -113,24 +109,24 @@ export function TerminalConsole({
         });
 
         try {
-          fitAddon.fit();
-          if (terminal.cols && terminal.rows) {
+          fit.fit();
+          if (term.cols && term.rows) {
             onResizeRef.current?.({
-              cols: terminal.cols,
-              rows: terminal.rows,
+              cols: term.cols,
+              rows: term.rows,
             });
           }
         } catch {
           // fit() can throw if the container has no layout yet
         }
 
-        dataDisposable = terminal.onData((data: string) => {
+        dataDisposable = term.onData((data: string) => {
           if (!readOnlyRef.current) {
             onDataRef.current?.(data);
           }
         });
 
-        resizeDisposable = terminal.onResize(
+        resizeDisposable = term.onResize(
           ({ cols, rows }: { cols: number; rows: number }) => {
             onResizeRef.current?.({ cols, rows });
           },
@@ -138,7 +134,7 @@ export function TerminalConsole({
 
         resizeObserver = new ResizeObserver(() => {
           try {
-            fitAddon.fit();
+            fit.fit();
           } catch {
             // Ignore layout not ready errors
           }
@@ -146,7 +142,7 @@ export function TerminalConsole({
         resizeObserver.observe(el);
 
         if (writeRef) {
-          writeRef.current = (data: string) => terminal.write(data);
+          writeRef.current = (data: string) => term.write(data);
         }
       },
     );

--- a/apps/web/src/hooks/use-current-platform-assistant.ts
+++ b/apps/web/src/hooks/use-current-platform-assistant.ts
@@ -19,6 +19,12 @@ export interface UseCurrentPlatformAssistantResult {
   platformAssistants: Assistant[];
 }
 
+/**
+ * Resolves and manages the active platform-hosted assistant for the
+ * current organization. Fetches the platform assistant list, persists
+ * the user's selection per-org, and auto-selects the first assistant
+ * when no prior selection exists.
+ */
 export function useCurrentPlatformAssistant(): UseCurrentPlatformAssistantResult {
   const orgId = useOrganizationStore.use.currentOrganizationId();
   const byOrg = useCurrentPlatformAssistantStore.use.byOrg();

--- a/apps/web/src/hooks/use-home-unread-badge.ts
+++ b/apps/web/src/hooks/use-home-unread-badge.ts
@@ -1,5 +1,9 @@
 import { useHomeFeedQuery } from "@/domains/home/hooks/use-home-feed-query";
 
+/**
+ * Returns whether the home feed has any unread ("new") items for the
+ * given assistant. Used to drive the sidebar badge indicator.
+ */
 export function useHomeUnreadBadge(assistantId: string | null) {
   const homeFeedQuery = useHomeFeedQuery(assistantId);
   const hasUnreadHome =

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -116,8 +116,9 @@ describe("toggleAppMinimized", () => {
 describe("handleAppUnpinned", () => {
   it("resets to chat when the pinned app matches the active app in 'app' view", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1", openedAppState: SAMPLE_APP });
-    getState().handleAppUnpinned("app-1");
+    const didClose = getState().handleAppUnpinned("app-1");
     const state = getState();
+    expect(didClose).toBe(true);
     expect(state.mainView).toBe("chat");
     expect(state.activeAppId).toBeNull();
     expect(state.openedAppState).toBeNull();
@@ -125,20 +126,23 @@ describe("handleAppUnpinned", () => {
 
   it("resets when in app-editing view", () => {
     useViewerStore.setState({ mainView: "app-editing", activeAppId: "app-1" });
-    getState().handleAppUnpinned("app-1");
+    const didClose = getState().handleAppUnpinned("app-1");
+    expect(didClose).toBe(true);
     expect(getState().mainView).toBe("chat");
   });
 
   it("is a no-op when appId does not match", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1" });
-    getState().handleAppUnpinned("app-2");
+    const didClose = getState().handleAppUnpinned("app-2");
+    expect(didClose).toBe(false);
     expect(getState().mainView).toBe("app");
     expect(getState().activeAppId).toBe("app-1");
   });
 
   it("is a no-op when not in app or app-editing view", () => {
     useViewerStore.setState({ mainView: "chat", activeAppId: "app-1" });
-    getState().handleAppUnpinned("app-1");
+    const didClose = getState().handleAppUnpinned("app-1");
+    expect(didClose).toBe(false);
     expect(getState().mainView).toBe("chat");
     expect(getState().activeAppId).toBe("app-1");
   });

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -89,19 +89,14 @@ describe("handleAppLoadFailed", () => {
 });
 
 describe("closeApp", () => {
-  it("clears app state and resets minimized", () => {
-    useViewerStore.setState({ activeAppId: "app-1", openedAppState: SAMPLE_APP, isAppMinimized: true });
+  it("resets to chat view, clears app state, and resets minimized", () => {
+    useViewerStore.setState({ mainView: "app", activeAppId: "app-1", openedAppState: SAMPLE_APP, isAppMinimized: true });
     getState().closeApp();
     const state = getState();
+    expect(state.mainView).toBe("chat");
     expect(state.activeAppId).toBeNull();
     expect(state.openedAppState).toBeNull();
     expect(state.isAppMinimized).toBe(false);
-  });
-
-  it("does not change mainView (caller decides)", () => {
-    useViewerStore.setState({ mainView: "app" });
-    getState().closeApp();
-    expect(getState().mainView).toBe("app");
   });
 });
 

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -122,7 +122,7 @@ export interface ViewerActions {
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   toggleAppMinimized: () => void;
-  handleAppUnpinned: (appId: string) => void;
+  handleAppUnpinned: (appId: string) => boolean;
   enterAppEditing: () => void;
   exitAppEditing: () => void;
 
@@ -255,9 +255,10 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       state.activeAppId !== appId ||
       (state.mainView !== "app" && state.mainView !== "app-editing")
     ) {
-      return;
+      return false;
     }
     get().closeApp();
+    return true;
   },
 
   enterAppEditing: () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -25,8 +25,29 @@ import { create } from "zustand";
 
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
-import { useConversationStore } from "@/domains/conversations/conversation-store";
 import { createSelectors } from "@/utils/create-selectors";
+
+/** Views that overlay the main content and track a "back" destination. */
+type OverlayView = "document" | "subagent-detail" | "tool-detail";
+
+/**
+ * Resolve the "view before" value for overlay navigation.
+ *
+ * When navigating to an overlay view (document, subagent-detail, tool-detail),
+ * the previous non-overlay view is preserved so the close action can restore
+ * it. If already inside an overlay, the existing saved view is kept rather
+ * than capturing the current overlay as the "back" destination.
+ */
+function resolveViewBefore(
+  state: ViewerState,
+  field: "viewBeforeDocument" | "viewBeforeSubagentDetail" | "viewBeforeToolDetail",
+): Exclude<MainView, OverlayView> {
+  const mv = state.mainView;
+  if (mv === "document" || mv === "subagent-detail" || mv === "tool-detail") {
+    return state[field];
+  }
+  return mv as Exclude<MainView, OverlayView>;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -217,6 +238,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   closeApp: () => {
     set({
+      mainView: "chat",
       activeAppId: null,
       openedAppState: null,
       isAppMinimized: false,
@@ -235,16 +257,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     ) {
       return;
     }
-    set({
-      mainView: "chat",
-      activeAppId: null,
-      openedAppState: null,
-    });
-    // The viewer state and the conversation store's `editingConversationId`
-    // are coupled: leaving the app-editing view should drop the editing
-    // pointer too. Owning this here keeps the cross-store coordination in
-    // one place instead of pushing it onto every caller of `useActiveAppPinSync`.
-    useConversationStore.getState().setEditingConversationId(null);
+    get().closeApp();
   },
 
   enterAppEditing: () => {
@@ -258,17 +271,10 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   // --- Subagent detail ---
 
   openSubagentDetail: (subagentId) => {
-    const state = get();
-    const viewBeforeSubagentDetail =
-      state.mainView === "subagent-detail" ||
-      state.mainView === "document" ||
-      state.mainView === "tool-detail"
-        ? state.viewBeforeSubagentDetail
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "subagent-detail",
       activeSubagentId: subagentId,
-      viewBeforeSubagentDetail,
+      viewBeforeSubagentDetail: resolveViewBefore(get(), "viewBeforeSubagentDetail"),
     });
   },
 
@@ -282,17 +288,10 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   // --- Tool detail ---
 
   openToolDetail: (payload) => {
-    const state = get();
-    const viewBeforeToolDetail =
-      state.mainView === "tool-detail" ||
-      state.mainView === "subagent-detail" ||
-      state.mainView === "document"
-        ? state.viewBeforeToolDetail
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "tool-detail",
       activeToolDetail: payload,
-      viewBeforeToolDetail,
+      viewBeforeToolDetail: resolveViewBefore(get(), "viewBeforeToolDetail"),
     });
   },
 
@@ -306,28 +305,15 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   // --- Document viewer ---
 
   openDocument: () => {
-    const state = get();
-    const viewBeforeDocument =
-      state.mainView === "document" ||
-      state.mainView === "subagent-detail" ||
-      state.mainView === "tool-detail"
-        ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
     set({
       mainView: "document",
       openedDocumentState: null,
-      viewBeforeDocument,
+      viewBeforeDocument: resolveViewBefore(get(), "viewBeforeDocument"),
     });
   },
 
   loadDocument: async (assistantId, documentSurfaceId) => {
-    const state = get();
-    const viewBeforeDocument =
-      state.mainView === "document" ||
-      state.mainView === "subagent-detail" ||
-      state.mainView === "tool-detail"
-        ? state.viewBeforeDocument
-        : (state.mainView as Exclude<MainView, "document" | "subagent-detail" | "tool-detail">);
+    const viewBeforeDocument = resolveViewBefore(get(), "viewBeforeDocument");
     set({
       mainView: "document",
       activeDocumentSurfaceId: documentSurfaceId,


### PR DESCRIPTION
## Prompt / plan

Comprehensive audit of `apps/web/` against the repo's convention docs ([STATE_MANAGEMENT.md](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/STATE_MANAGEMENT.md), [STYLE_GUIDE.md](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/STYLE_GUIDE.md), [CONVENTIONS.md](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/CONVENTIONS.md)) and React 19 / Zustand best practices. Findings validated against first principles before implementation.

### Why needed

The web app had accumulated several convention violations and a latent bug as code was ported and evolved:
- `useShallow` usage that STATE_MANAGEMENT.md explicitly marks as legacy
- A `closeApp()` store action that didn't reset `mainView`, forcing every caller to manually fix up state (fragile, bug-prone)
- A cross-domain import from `stores/` into `domains/` violating the dependency direction in CONVENTIONS.md
- `any` types with eslint-disable comments where proper types existed
- Missing docstrings on exported hooks per STYLE_GUIDE.md

### Changes

**Convention compliance — `useShallow` → atomic selectors (Finding 1)**
- `chat-page.tsx`: Replaced `useViewerStore(useShallow(s => ({...})))` (10+ fields) with individual `.use.field()` atomic selector calls
- `chat-page.tsx`: Replaced `useSubagentStore(useShallow(...))` with `.use.byId()`
- `transcript-message-body.tsx`: Replaced `useSubagentStore(useShallow(s => s.byToolUseId))` with `.use.byToolUseId()`
- `transcript-message-body.tsx`: Removed `useShallow` from `lookupSubagentEntriesForMessage` — the selector returns reference-stable bucket references, so Zustand's default `Object.is` equality works correctly without `useShallow`
- Removed 3 dead selector subscriptions (`activeAppId`, `intelligenceTab`, `viewerAssetsRefreshKey`) that were destructured but never used, causing unnecessary re-renders

**DRY — `resolveViewBefore()` helper (Finding 2)**
- Extracted identical 4-line \"resolve previous view\" logic from `openDocument`, `loadDocument`, `openSubagentDetail`, `openToolDetail` into a single typed `resolveViewBefore()` helper in `viewer-store.ts`
- Added `OverlayView` type alias for the overlay view union

**Bug fix + architecture — `closeApp()` + cross-domain import (Findings 3 & 4)**
- **Bug:** `closeApp()` didn't reset `mainView` to `\"chat\"`, forcing every caller to manually call `setMainView(\"chat\")` afterward. Any future caller that forgot would leave the UI in a broken state showing a stale app panel. Now `closeApp()` includes `mainView: \"chat\"` in its `set()` call.
- **Architecture:** Removed cross-domain import (`viewer-store.ts` → `@/domains/conversations/conversation-store`). Top-level `stores/` must not depend on `domains/` per CONVENTIONS.md. The `setEditingConversationId(null)` call moved to the ChatPage callback (the only consumer).
- `handleAppUnpinned` now delegates to `closeApp()` instead of duplicating its field-clearing logic.

**Type safety — xterm dynamic imports (Finding 5)**
- Replaced 5 `any` types with proper `Terminal`, `IDisposable` from `xterm` (type-only imports, zero runtime cost)
- Removed 5 `eslint-disable @typescript-eslint/no-explicit-any` comments
- Used `const term`/`const fit` pattern inside `.then()` callback to give closures non-nullable references

**Type safety — tiptap markdown storage (Finding 6)**
- Created typed `getEditorMarkdown()` helper using `MarkdownStorage` from `tiptap-markdown`
- Replaced 2 `(ed.storage as any).markdown.getMarkdown()` casts

**Style — `React.TypeName` → destructured imports (Finding 7)**
- Fixed 10 instances across 6 files (2 production, 8 test) per STYLE_GUIDE.md

**Docs — missing JSDoc on exported hooks (Finding 8)**
- Added docstrings to `useHomeUnreadBadge`, `useCurrentPlatformAssistant`, `useListConceptPages`, `useReadConceptPage`

**Convention — barrel file removal**
- Deleted `settings/billing/pro-onboarding/index.ts` (no-barrel-files rule)
- Updated `billing-page.tsx` to import directly from source module

### Benefits

- Fewer unnecessary re-renders (dead selectors removed, atomic selectors are more granular than `useShallow` object destructuring)
- `closeApp()` is now self-contained — callers can't accidentally leave the UI in a broken state
- Dependency direction is correct (`stores/` no longer depends on `domains/`)
- 4 identical code blocks consolidated into one typed helper
- Zero `any` types or `eslint-disable` comments in terminal-console.tsx
- All exported hooks have JSDoc explaining purpose and constraints

### Safety

- All changes are in `apps/web/` only — no CLI, assistant, or gateway impact
- `bun run lint` passes clean (0 errors, 0 warnings)
- `bunx tsc --noEmit` produces zero new errors (all errors are pre-existing `@vellumai/assistant-api` missing exports, verified by running typecheck on `main`)
- `viewer-store.test.ts` updated to verify `closeApp()` now resets `mainView: \"chat\"`
- The `closeApp()` change is safe because every existing caller already called `setMainView(\"chat\")` immediately after — the behavior is identical, just no longer fragile

### Root cause analysis (closeApp bug)

- **How did this happen?** `closeApp()` was written to only clear app-specific state (`activeAppId`, `openedAppState`), with each caller responsible for also resetting the view. This split responsibility was never documented.
- **Warning signs:** Every caller immediately following `closeApp()` with `setMainView(\"chat\")` — a 100% co-occurrence pattern indicating the responsibility is in the wrong place.
- **Prevention:** The `resolveViewBefore()` extraction and `closeApp()` fix together establish that view transitions are the store's responsibility, not the caller's.

### Alternatives not taken

- **Finding 1 special case:** For `lookupSubagentEntriesForMessage` in `transcript-message-body.tsx`, we kept the custom selector instead of using atomic selectors. Using `.use.byToolUseId()` would cause all 50+ message bodies to re-render on any subagent mutation, even when their individual bucket didn't change. The custom selector with Zustand's default `Object.is` check is correct because the bucket references are stable across mutations.
- **`closeApp()` as event:** Considered using the event bus for the `closeApp` → `setEditingConversationId(null)` coordination, but a direct callback in the single consumer (ChatPage) is simpler and doesn't warrant the indirection.

## Test plan

- `bun run lint` — 0 errors
- `bunx tsc --noEmit` — 0 new errors (verified against main)
- `viewer-store.test.ts` updated and passing
- Pre-commit hooks pass (secrets check, generic-examples check, lint)

Link to Devin session: https://app.devin.ai/sessions/4370103ab5e547ae8696d39b423f7103
Requested by: @ashleeradka