### PR TITLE
fix(web): show conversation starters when iOS keyboard is open on empty state

### DIFF
--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -218,7 +218,7 @@ describe("ChatBody — startersSlot rendering", () => {
     expect(html).not.toContain("STARTER_CHIPS");
   });
 
-  test("hides starters when keyboard is open", () => {
+  test("renders starters when keyboard is open", () => {
     const html = renderToStaticMarkup(
       <ChatBody
         {...withEmptyState({
@@ -229,7 +229,7 @@ describe("ChatBody — startersSlot rendering", () => {
         })}
       />,
     );
-    expect(html).not.toContain("STARTER_CHIPS");
+    expect(html).toContain("STARTER_CHIPS");
   });
 });
 

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -272,7 +272,7 @@ export function ChatBody({
           ) : (
             <ChatComposer {...composerProps} />
           )}
-          {!isKeyboardOpen && startersSlot}
+          {startersSlot}
         </div>
       </div>
       {isAttachmentDragOver && (


### PR DESCRIPTION
When creating a new conversation on iOS, opening the keyboard hid the conversation-starter chips (via `!isKeyboardOpen && startersSlot`). This left a short greeting+composer block centered in the container via `justify-content: safe center`, creating a large white gap below the composer. Restoring starters when the keyboard is open matches the Figma design and fills the gap naturally.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e96226cc68f34ff1a28c03427676b2a9