### PR TITLE
fix(ios): close keyboard-to-composer gap by extending container to fill visual viewport

### DIFF
--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -230,7 +230,7 @@ export function ChatBody({
           on first send (LUM-1506 / LUM-1516). */}
       <div
         className={`relative px-3 pt-2 sm:px-6 sm:pb-0 ${
-          isKeyboardOpen ? "pb-2" : "pb-4"
+          isKeyboardOpen ? "pb-1" : "pb-4"
         }`}
       >
         {refreshFeedback && (

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -32,15 +32,8 @@ interface MobileAppOverlayProps {
  * minimized (`isAppMinimized=true`) so the chat behind becomes interactive
  * again.
  *
- * **Mounting constraint**: must render outside `RootLayout`'s inner
- * transformed wrapper (see `src/root-layout.tsx`). When
- * the soft keyboard opens, `RootLayout` applies a `translate3d(...)` to its
- * inner div to follow the visual viewport — any `position: fixed` element
- * inside that transformed wrapper anchors to the transform's origin rather
- * than the viewport's initial containing block, and the overlay drifts with
- * the keyboard. Render as a sibling of the inner wrapper instead.
- *
- * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
  */
 export function MobileAppOverlay({
   openedAppState,

--- a/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
@@ -16,13 +16,8 @@ interface MobileDocumentOverlayProps {
  * Mobile-only full-screen overlay that hosts the document viewer for a
  * surface referenced from chat.
  *
- * **Mounting constraint**: must render outside `RootLayout`'s inner
- * transformed wrapper (see `src/root-layout.tsx`) so
- * `position: fixed` anchors to the viewport's initial containing block
- * rather than the keyboard-following transform `RootLayout` applies when
- * the soft keyboard opens.
- *
- * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
  */
 export function MobileDocumentOverlay({
   openedDocumentState,

--- a/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
@@ -23,13 +23,8 @@ interface MobileSubagentDetailOverlayProps {
 /**
  * Mobile-only full-screen overlay that hosts the subagent detail panel.
  *
- * **Mounting constraint**: must render outside `RootLayout`'s inner
- * transformed wrapper (see `src/root-layout.tsx`) so
- * `position: fixed` anchors to the viewport's initial containing block
- * rather than the keyboard-following transform `RootLayout` applies when
- * the soft keyboard opens.
- *
- * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
  */
 export function MobileSubagentDetailOverlay({
   entry,

--- a/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-tool-detail-overlay.tsx
@@ -19,13 +19,8 @@ interface MobileToolDetailOverlayProps {
 /**
  * Mobile-only full-screen overlay that hosts the tool-call detail panel.
  *
- * **Mounting constraint**: must render outside `RootLayout`'s inner
- * transformed wrapper (see `src/root-layout.tsx`) so
- * `position: fixed` anchors to the viewport's initial containing block
- * rather than the keyboard-following transform `RootLayout` applies when
- * the soft keyboard opens.
- *
- * https://www.w3.org/TR/css-transforms-1/#transform-rendering
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
  */
 export function MobileToolDetailOverlay({
   detail,

--- a/apps/web/src/domains/chat/hooks/use-mobile-overlay-target.ts
+++ b/apps/web/src/domains/chat/hooks/use-mobile-overlay-target.ts
@@ -5,8 +5,8 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 /**
  * Resolves the mobile overlay portal target after DOM commit so chat-side
  * full-screen overlays (`MobileDocumentOverlay`, `MobileSubagentDetailOverlay`,
- * `MobileAppOverlay`) can be portaled outside `RootLayout`'s transformed
- * wrapper.
+ * `MobileAppOverlay`) can be portaled into `RootLayout`'s `#viewport-overlays`
+ * container, outside the main content wrapper.
  *
  * Why the `useEffect` instead of resolving the element during render:
  * `document.getElementById("viewport-overlays")` is a DOM read that needs

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -99,14 +99,17 @@ export function RootLayout() {
     visibleViewport !== null &&
     visibleViewport.keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
 
-  const followVisualViewport =
-    keyboardOpen &&
-    visibleViewport !== null &&
-    (visibleViewport.offsetTop !== 0 || visibleViewport.offsetLeft !== 0);
-
-  const innerTransform = followVisualViewport
-    ? `translate3d(${visibleViewport.offsetLeft}px, ${visibleViewport.offsetTop}px, 0)`
-    : undefined;
+  // When the iOS keyboard opens, the system scrolls the layout viewport
+  // down by `offsetTop` to keep the focused input visible. Size the outer
+  // container to `height + offsetTop` and add matching `paddingTop` so the
+  // content area stays exactly `visualViewport.height` (border-box) while
+  // the container's background fills the entire visible region. This
+  // replaces the previous `translate3d(0, offsetTop, 0)` approach which
+  // positioned the content correctly but left the bottom `offsetTop` pixels
+  // outside the container's background, exposing the body's default
+  // background as a visible gap above the keyboard.
+  const keyboardOffsetTop =
+    keyboardOpen && visibleViewport ? visibleViewport.offsetTop : 0;
 
   const outletContext: RootOutletContext = { lifecycle };
 
@@ -118,8 +121,9 @@ export function RootLayout() {
         background: "var(--surface-base)",
         height:
           keyboardOpen && visibleViewport
-            ? `${visibleViewport.height}px`
+            ? `${visibleViewport.height + keyboardOffsetTop}px`
             : "100dvh",
+        paddingTop: keyboardOffsetTop > 0 ? `${keyboardOffsetTop}px` : undefined,
         paddingBottom: keyboardOpen
           ? "0px"
           : "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
@@ -130,20 +134,11 @@ export function RootLayout() {
         isolation: "isolate",
       }}
     >
-      <div
-        className="flex min-w-0 flex-col overflow-hidden h-full w-full"
-        style={{
-          transform: innerTransform,
-          transformOrigin: innerTransform ? "0 0" : undefined,
-        }}
-      >
+      <div className="flex min-w-0 flex-col overflow-hidden h-full w-full">
         <Outlet context={outletContext} />
       </div>
 
-      {/* Portal target for mobile overlays that use `position: fixed`.
-          Lives outside the inner wrapper so the keyboard-following
-          `translate3d(...)` doesn't shift the overlay's containing block.
-          See: https://www.w3.org/TR/css-transforms-1/#transform-rendering */}
+      {/* Portal target for mobile overlays that use `position: fixed`. */}
       <div id="viewport-overlays" />
     </div>
   );


### PR DESCRIPTION
Closes the visible gap between the chat composer and the iOS soft keyboard by fixing how `RootLayout` sizes its outer container when the keyboard is open. The previous `translate3d` approach positioned content correctly but left the container's background short of the visual viewport edge, exposing the body's default background as a visible band above the keyboard.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/8fc6a8fd15bb40b588c6d014a6daa4a5