### PR TITLE
docs(web): ELECTRON.md for renderer-side bridge conventions (LUM-2022)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -11,6 +11,7 @@ Read these before making changes:
 - **[`docs/EVENT_BUS.md`](./docs/EVENT_BUS.md)** — Cross-domain push signals (SSE, app lifecycle, network). Single connection, typed events, no per-component `visibilitychange` handlers.
 - **[`docs/STYLE_GUIDE.md`](./docs/STYLE_GUIDE.md)** — Naming, imports, TypeScript, component authoring, formatting.
 - **[`docs/CAPACITOR.md`](./docs/CAPACITOR.md)** — Capacitor / iOS patterns: lazy plugin imports, native auth, deep links, autogrowing textareas, streaming watchdogs, OS permission UI, capability detection, keyboard-only affordances. Mandatory reading if any code path you're touching might run inside the iOS WKWebView shell.
+- **[`docs/ELECTRON.md`](./docs/ELECTRON.md)** — Electron renderer patterns: `runtime/` wrapper modules for `window.vellum.*`, domain-owned bridge hooks, the three-file dance for new bridge surfaces. Read this if your change touches anything under `src/runtime/` that uses `window.vellum`.
 
 ## Common pitfalls
 

--- a/apps/web/docs/ELECTRON.md
+++ b/apps/web/docs/ELECTRON.md
@@ -1,0 +1,69 @@
+# Electron Conventions
+
+The web app ships as both a browser SPA and the renderer of an Electron desktop shell (see [`apps/macos/`](../../../apps/macos/)). The shell exposes a typed bridge to the renderer as `window.vellum`, defined in [`apps/macos/src/preload/index.ts`](../../../apps/macos/src/preload/index.ts) and mirrored as an ambient declaration in [`apps/web/src/runtime/is-electron.ts`](../src/runtime/is-electron.ts).
+
+> **Read this only if your change touches Electron code paths.** For browser-only and iOS-only contributions you can skip this document. Building the Electron app itself additionally requires running `apps/macos/`'s dev scripts; the main-process source lives in [`apps/macos/src/main/`](../../../apps/macos/src/main/).
+
+If you're touching anything in [`apps/web/src/runtime/`](../src/runtime/) that calls `window.vellum.*`, or adding a new bridge surface — start here.
+
+---
+
+## Wrap `window.vellum.*` access in a per-capability `runtime/` module
+
+`window.vellum` is `undefined` on web and Capacitor iOS — the bridge only exists when the renderer is loaded inside the Electron shell. Feature code that reaches into `window.vellum.*` directly crashes off-Electron and forces every call site to repeat an `isElectron()` check.
+
+**The wrappers in [`apps/web/src/runtime/`](../src/runtime/) are the only files in `apps/web/` that touch `window.vellum.*` directly.** Feature code imports the wrapper functions, not the bridge. Pattern, copied from [`native-biometric.ts`](../src/runtime/native-biometric.ts):
+
+```ts
+// apps/web/src/runtime/<capability>.ts
+import { isElectron } from "@/runtime/is-electron";
+
+export async function setDockBadge(count: number): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.dock.setBadge(count);
+}
+```
+
+Two things this buys:
+
+- **No-op off Electron.** Callers don't need an `isElectron()` check at every call site, so the same hook works on web/iOS/Electron.
+- **One place to change** if the bridge surface evolves — rename a method, swap the underlying IPC channel — without touching feature code.
+
+This parallels the [Capacitor plugin lazy-import rule](./CAPACITOR.md#capacitor-plugins-must-be-destructured-inline-lazy-import-rule): both keep host-specific globals out of feature modules so the same React tree mounts on every platform.
+
+See [`apps/web/src/runtime/dock.ts`](../src/runtime/dock.ts) and [`apps/web/src/runtime/vellum-commands.ts`](../src/runtime/vellum-commands.ts) for the established shape.
+
+---
+
+## Hooks that bridge feature state to the Electron host live in the domain, not in `runtime/`
+
+The `runtime/` wrappers expose **imperative functions** (`setDockBadge(count)`, `useVellumCommands(handlers)`). When a feature needs to publish state changes to the host on every tick (e.g. unread count → Dock badge), the React hook that does that **lives in the domain that owns the source data**, not in the runtime layer.
+
+```
+apps/web/src/runtime/dock.ts                              ← imperative bridge
+apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts ← domain hook
+```
+
+The chat domain knows what counts as "unread" (see [`utils/conversation-predicates.ts`](../src/utils/conversation-predicates.ts)); only the chat domain should decide when to call the bridge. Putting the hook in `runtime/` would invert that — the runtime layer would need to import domain types and predicates, which couples the platform-shim to feature semantics.
+
+See [`apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts`](../src/domains/chat/hooks/use-electron-dock-sync.ts).
+
+---
+
+## Adding a new bridge surface
+
+When extending `window.vellum.*`, three files change together because the three TypeScript projects (main, preload, renderer) don't share a workspace symbol table:
+
+1. **[`apps/macos/src/preload/index.ts`](../../../apps/macos/src/preload/index.ts)** — adds the IPC plumbing + the typed `VellumBridge` field.
+2. **[`apps/web/src/runtime/is-electron.ts`](../src/runtime/is-electron.ts)** — mirrors the new field on the renderer-side ambient `Window.vellum?` declaration.
+3. **`apps/web/src/runtime/<capability>.ts`** — per-capability wrapper module exposing the no-op-off-Electron functions feature code calls.
+
+The main-process handler itself lives in `apps/macos/src/main/`; that's a main-process concern, not a renderer one. For main-process conventions see [`apps/macos/README.md`](../../../apps/macos/README.md).
+
+---
+
+## See also
+
+- [`CONVENTIONS.md`](./CONVENTIONS.md) — architecture, code organization, component patterns.
+- [`CAPACITOR.md`](./CAPACITOR.md) — Capacitor / iOS patterns (parallel host).
+- [`apps/macos/README.md`](../../../apps/macos/README.md) — Electron shell setup, dev scripts, main-process source layout.


### PR DESCRIPTION
## Summary

Adds [`apps/web/docs/ELECTRON.md`](https://github.com/vellum-ai/vellum-assistant/blob/claude/lum-2022-patterns-doc/apps/web/docs/ELECTRON.md), a short reference for renderer-side Electron patterns, modeled on the existing [`apps/web/docs/CAPACITOR.md`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/CAPACITOR.md).

Goal: give Electron-specific contributor guidance an obvious home alongside the other `docs/*` files, without writing speculative doctrine. Documents only what's known-painful today; future gotchas can be added as they're discovered (same evolution path as CAPACITOR.md).

### Contents

- **`runtime/` wrapper rule for `window.vellum.*`** — feature code never touches the bridge directly; per-capability wrappers in `apps/web/src/runtime/` keep host-branching in one place and let the same React tree mount on every platform. Parallel to the Capacitor plugin lazy-import rule.
- **Domain-owned bridge hooks** — `runtime/` exposes imperative functions; hooks that wire feature state to the host live in the domain that owns the source data (e.g. `use-electron-dock-sync.ts` in `chat/`, not `runtime/`).
- **Three-file dance for new bridge surfaces** — preload + ambient declaration + per-capability wrapper, because the three TS projects don't share a workspace symbol table.

### Also

- Links the new doc from [`apps/web/AGENTS.md`](https://github.com/vellum-ai/vellum-assistant/blob/claude/lum-2022-patterns-doc/apps/web/AGENTS.md) so agents pick it up alongside the other `docs/*` files.

### Out of scope

- **Main-process patterns** — lifecycle hooks, electron-store conventions, `installX()` bootstraps — stay documented by the code itself in `apps/macos/src/main/` and `apps/macos/README.md`. The earlier draft of this PR tried to codify them in an `apps/macos/docs/PATTERNS.md`, but with only seven main-process files, "good examples in code" is doing the job a doctrine doc would do. Revisit if and when contributors actually trip on the patterns.

## Test plan

- [ ] Confirm `apps/web/docs/ELECTRON.md` link targets resolve.
- [ ] Confirm `apps/web/AGENTS.md` entry renders alongside the other doc bullets.
- [ ] No internal-issue references in either file.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe