### PR TITLE
refactor(messaging): convert enqueueMessage from 12 positional params to options object

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -534,12 +534,11 @@ describe("Conversation message queue", () => {
     expect(conversation.isProcessing()).toBe(true);
 
     // Enqueue second message — should NOT throw
-    const result = conversation.enqueueMessage(
-      "msg-2",
-      [],
-      (e) => events2.push(e),
-      "req-2",
-    );
+    const result = conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
     expect(result.queued).toBe(true);
     expect(result.requestId).toBe("req-2");
     expect(conversation.getQueueDepth()).toBe(1);
@@ -580,8 +579,16 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue two more sibling passthrough messages
-    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
-    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete run 0 → drain pulls msg-2 and msg-3 into ONE batched run.
@@ -642,12 +649,11 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue second — simulating what handleUserMessage does
-    const result = conversation.enqueueMessage(
-      "msg-2",
-      [],
-      (e) => events2.push(e),
-      "req-2",
-    );
+    const result = conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
     expect(result.queued).toBe(true);
 
     // Complete first
@@ -681,8 +687,16 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue two more
-    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
-    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Abort
@@ -760,13 +774,13 @@ describe("Conversation message queue", () => {
 
     expect(conversation.getQueueDepth()).toBe(0);
 
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
     expect(conversation.getQueueDepth()).toBe(1);
 
-    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
+    conversation.enqueueMessage({ content: "msg-3", requestId: "req-3" });
     expect(conversation.getQueueDepth()).toBe(2);
 
-    conversation.enqueueMessage("msg-4", [], () => {}, "req-4");
+    conversation.enqueueMessage({ content: "msg-4", requestId: "req-4" });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Complete first → drain pulls all three same-interface passthroughs
@@ -801,9 +815,17 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue a message with empty content (will fail persistUserMessage)
-    conversation.enqueueMessage("", [], (e) => events2.push(e), "req-2");
+    conversation.enqueueMessage({
+      content: "",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
     // Enqueue a valid message after the bad one
-    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete first message — triggers drain. The empty message should fail
@@ -861,42 +883,30 @@ describe("Batched drain", () => {
       userMessageInterface: iface,
       assistantMessageInterface: iface,
     });
-    conversation.enqueueMessage(
-      "msg-2",
-      [],
-      (e) => events2.push(e),
-      "req-2",
-      undefined,
-      undefined,
-      meta("macos"),
-    );
-    conversation.enqueueMessage(
-      "msg-3",
-      [],
-      (e) => events3.push(e),
-      "req-3",
-      undefined,
-      undefined,
-      meta("macos"),
-    );
-    conversation.enqueueMessage(
-      "msg-4",
-      [],
-      (e) => events4.push(e),
-      "req-4",
-      undefined,
-      undefined,
-      meta("cli"),
-    );
-    conversation.enqueueMessage(
-      "msg-5",
-      [],
-      (e) => events5.push(e),
-      "req-5",
-      undefined,
-      undefined,
-      meta("macos"),
-    );
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+      metadata: meta("macos"),
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+      metadata: meta("macos"),
+    });
+    conversation.enqueueMessage({
+      content: "msg-4",
+      onEvent: (e) => events4.push(e),
+      requestId: "req-4",
+      metadata: meta("cli"),
+    });
+    conversation.enqueueMessage({
+      content: "msg-5",
+      onEvent: (e) => events5.push(e),
+      requestId: "req-5",
+      metadata: meta("macos"),
+    });
     expect(conversation.getQueueDepth()).toBe(4);
 
     // Resolve msg-1 → batched run pulls macos msg-2 + msg-3.
@@ -978,24 +988,21 @@ describe("Batched drain", () => {
     // passthrough slash, so the batch builder stops at "hello" (length 1),
     // then /compact takes the single-message /compact short-circuit path
     // (no new runAgentLoop invocation), then "world" drains as its own run.
-    conversation.enqueueMessage(
-      "hello",
-      [],
-      (e) => eventsHello.push(e),
-      "req-hello",
-    );
-    conversation.enqueueMessage(
-      "/compact",
-      [],
-      (e) => eventsSlash.push(e),
-      "req-slash",
-    );
-    conversation.enqueueMessage(
-      "world",
-      [],
-      (e) => eventsWorld.push(e),
-      "req-world",
-    );
+    conversation.enqueueMessage({
+      content: "hello",
+      onEvent: (e) => eventsHello.push(e),
+      requestId: "req-hello",
+    });
+    conversation.enqueueMessage({
+      content: "/compact",
+      onEvent: (e) => eventsSlash.push(e),
+      requestId: "req-slash",
+    });
+    conversation.enqueueMessage({
+      content: "world",
+      onEvent: (e) => eventsWorld.push(e),
+      requestId: "req-world",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Resolve msg-1 → drain pulls "hello" as its own run (batch stops at
@@ -1052,24 +1059,21 @@ describe("Batched drain", () => {
     // unknown-slash short-circuit path (no new runAgentLoop invocation — it
     // emits assistant_text_delta + message_complete inline), then "plain-b"
     // drains as its own run.
-    conversation.enqueueMessage(
-      "plain-a",
-      [],
-      (e) => eventsPlainA.push(e),
-      "req-plain-a",
-    );
-    conversation.enqueueMessage(
-      "/status",
-      [],
-      (e) => eventsSlash.push(e),
-      "req-slash",
-    );
-    conversation.enqueueMessage(
-      "plain-b",
-      [],
-      (e) => eventsPlainB.push(e),
-      "req-plain-b",
-    );
+    conversation.enqueueMessage({
+      content: "plain-a",
+      onEvent: (e) => eventsPlainA.push(e),
+      requestId: "req-plain-a",
+    });
+    conversation.enqueueMessage({
+      content: "/status",
+      onEvent: (e) => eventsSlash.push(e),
+      requestId: "req-slash",
+    });
+    conversation.enqueueMessage({
+      content: "plain-b",
+      onEvent: (e) => eventsPlainB.push(e),
+      requestId: "req-plain-b",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Resolve msg-1 → drain pulls "plain-a" as its own run (batch stops at
@@ -1133,8 +1137,16 @@ describe("Batched drain", () => {
         filePath: "/tmp/b.png",
       },
     ];
-    conversation.enqueueMessage("with-A", attachA, () => {}, "req-A");
-    conversation.enqueueMessage("with-B", attachB, () => {}, "req-B");
+    conversation.enqueueMessage({
+      content: "with-A",
+      attachments: attachA,
+      requestId: "req-A",
+    });
+    conversation.enqueueMessage({
+      content: "with-B",
+      attachments: attachB,
+      requestId: "req-B",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     resolveRun(0);
@@ -1190,30 +1202,25 @@ describe("Batched drain", () => {
     await waitForPendingRun(1);
 
     // Fill to just-under budget: two ~500-char messages (1512+1512 = 3024 bytes).
-    const accepted1 = conversation.enqueueMessage(
-      "x".repeat(500),
-      [],
-      () => {},
-      "req-big-1",
-    );
-    const accepted2 = conversation.enqueueMessage(
-      "y".repeat(500),
-      [],
-      () => {},
-      "req-big-2",
-    );
+    const accepted1 = conversation.enqueueMessage({
+      content: "x".repeat(500),
+      requestId: "req-big-1",
+    });
+    const accepted2 = conversation.enqueueMessage({
+      content: "y".repeat(500),
+      requestId: "req-big-2",
+    });
     expect(accepted1.queued).toBe(true);
     expect(accepted2.queued).toBe(true);
     // A third would push the queue over budget → rejected. Capture its
     // onEvent callback so we can verify the queue_full error event reaches
     // the rejected caller (not just the synchronous return value).
     const rejectedEvents: ServerMessage[] = [];
-    const rejected = conversation.enqueueMessage(
-      "z".repeat(500),
-      [],
-      (e) => rejectedEvents.push(e),
-      "req-over",
-    );
+    const rejected = conversation.enqueueMessage({
+      content: "z".repeat(500),
+      onEvent: (e) => rejectedEvents.push(e),
+      requestId: "req-over",
+    });
     expect(rejected.queued).toBe(false);
     expect(rejected.rejected).toBe(true);
     expect(conversation.getQueueDepth()).toBe(2);
@@ -1247,12 +1254,16 @@ describe("Batched drain", () => {
     const p2 = conversation.processMessage("msg-2", [], () => {}, "req-2");
     await waitForPendingRun(3);
     expect(
-      conversation.enqueueMessage("a".repeat(500), [], () => {}, "req-a")
-        .queued,
+      conversation.enqueueMessage({
+        content: "a".repeat(500),
+        requestId: "req-a",
+      }).queued,
     ).toBe(true);
     expect(
-      conversation.enqueueMessage("b".repeat(500), [], () => {}, "req-b")
-        .queued,
+      conversation.enqueueMessage({
+        content: "b".repeat(500),
+        requestId: "req-b",
+      }).queued,
     ).toBe(true);
 
     resolveRun(2);
@@ -1290,19 +1301,17 @@ describe("Batched drain correctness fixes", () => {
     // same interface. The batch builder must reject the surface-action head
     // so each drains as its own run.
     conversation.surfaceActionRequestIds.add("req-surface");
-    conversation.enqueueMessage(
-      "surface action response",
-      [],
-      (e) => eventsSurface.push(e),
-      "req-surface",
-      "surface-1", // activeSurfaceId
-    );
-    conversation.enqueueMessage(
-      "regular follow-up",
-      [],
-      (e) => eventsRegular.push(e),
-      "req-regular",
-    );
+    conversation.enqueueMessage({
+      content: "surface action response",
+      onEvent: (e) => eventsSurface.push(e),
+      requestId: "req-surface",
+      activeSurfaceId: "surface-1",
+    });
+    conversation.enqueueMessage({
+      content: "regular follow-up",
+      onEvent: (e) => eventsRegular.push(e),
+      requestId: "req-regular",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete run 0 → drain must NOT batch the surface-action with the
@@ -1361,7 +1370,11 @@ describe("Batched drain correctness fixes", () => {
     // fresh one). Calling abort() now aborts that fresh controller, and
     // the drainBatch loop's abort check after msg-3's persist will break,
     // so msg-4 never persists.
-    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
 
     // Install a one-shot abort trigger on msg-3's dequeue event. We do
     // this before enqueueing so the wrapped callback is what drainBatch
@@ -1374,8 +1387,16 @@ describe("Batched drain correctness fixes", () => {
         conversation.abort();
       }
     };
-    conversation.enqueueMessage("msg-3", [], onMsg3Event, "req-3");
-    conversation.enqueueMessage("msg-4", [], (e) => events4.push(e), "req-4");
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: onMsg3Event,
+      requestId: "req-3",
+    });
+    conversation.enqueueMessage({
+      content: "msg-4",
+      onEvent: (e) => events4.push(e),
+      requestId: "req-4",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     const persistedUserRowCountBefore = capturedAddMessages.filter(
@@ -1427,24 +1448,21 @@ describe("Batched drain correctness fixes", () => {
     // msg-tail's requestId (the LAST successful persist), not msg-mid's.
     addMessageShouldThrowForContent.add("msg-mid-unique-marker");
 
-    conversation.enqueueMessage(
-      "msg-head",
-      [],
-      (e) => events2.push(e),
-      "req-head",
-    );
-    conversation.enqueueMessage(
-      "msg-mid-unique-marker",
-      [],
-      (e) => events3.push(e),
-      "req-mid",
-    );
-    conversation.enqueueMessage(
-      "msg-tail",
-      [],
-      (e) => events4.push(e),
-      "req-tail",
-    );
+    conversation.enqueueMessage({
+      content: "msg-head",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-head",
+    });
+    conversation.enqueueMessage({
+      content: "msg-mid-unique-marker",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-mid",
+    });
+    conversation.enqueueMessage({
+      content: "msg-tail",
+      onEvent: (e) => events4.push(e),
+      requestId: "req-tail",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Complete run 0 → batched drain.
@@ -1493,24 +1511,21 @@ describe("Batched drain correctness fixes", () => {
     // desync the client.
     addMessageShouldThrowForContent.add("fanout-mid-marker");
 
-    conversation.enqueueMessage(
-      "fanout-head",
-      [],
-      (e) => events2.push(e),
-      "req-fanout-head",
-    );
-    conversation.enqueueMessage(
-      "fanout-mid-marker",
-      [],
-      (e) => events3.push(e),
-      "req-fanout-mid",
-    );
-    conversation.enqueueMessage(
-      "fanout-tail",
-      [],
-      (e) => events4.push(e),
-      "req-fanout-tail",
-    );
+    conversation.enqueueMessage({
+      content: "fanout-head",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-fanout-head",
+    });
+    conversation.enqueueMessage({
+      content: "fanout-mid-marker",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-fanout-mid",
+    });
+    conversation.enqueueMessage({
+      content: "fanout-tail",
+      onEvent: (e) => events4.push(e),
+      requestId: "req-fanout-tail",
+    });
 
     resolveRun(0);
     await p1;
@@ -1545,9 +1560,9 @@ describe("Batched drain correctness fixes", () => {
     const baseline = activityStates.length;
 
     // Enqueue three sibling passthroughs.
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
-    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
-    conversation.enqueueMessage("msg-4", [], () => {}, "req-4");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
+    conversation.enqueueMessage({ content: "msg-3", requestId: "req-3" });
+    conversation.enqueueMessage({ content: "msg-4", requestId: "req-4" });
 
     // Complete run 0 → drain pulls the batched siblings as ONE run.
     resolveRun(0);
@@ -1615,7 +1630,7 @@ describe("Conversation queue policy helpers", () => {
     await waitForPendingRun(1);
 
     // Enqueue a message while processing
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
     expect(conversation.hasQueuedMessages()).toBe(true);
 
     // Cleanup: resolve the pending run
@@ -1659,7 +1674,7 @@ describe("Conversation queue policy helpers", () => {
     await waitForPendingRun(1);
 
     // Enqueue a message
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
 
     expect(conversation.isProcessing()).toBe(true);
     expect(conversation.hasQueuedMessages()).toBe(true);
@@ -1715,7 +1730,7 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
     expect(conversation.hasQueuedMessages()).toBe(true);
 
     // The pending run should have received an onCheckpoint callback.
@@ -1799,9 +1814,21 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue three sibling passthroughs while msg-1 is mid-turn
-    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
-    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
-    conversation.enqueueMessage("msg-4", [], (e) => events4.push(e), "req-4");
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+    });
+    conversation.enqueueMessage({
+      content: "msg-4",
+      onEvent: (e) => events4.push(e),
+      requestId: "req-4",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Simulate the agent loop yielding at the checkpoint (first run is mid-tool-use)
@@ -1855,7 +1882,11 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
-    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => events2.push(e),
+      requestId: "req-2",
+    });
     expect(conversation.hasQueuedMessages()).toBe(true);
 
     // Simulate tool-use turns: the agent loop calls onCheckpoint at each turn boundary.
@@ -1927,33 +1958,24 @@ describe("Conversation checkpoint handoff", () => {
       userMessageInterface: iface,
       assistantMessageInterface: iface,
     });
-    conversation.enqueueMessage(
-      "msg-B",
-      [],
-      makeHandler("B"),
-      "req-B",
-      undefined,
-      undefined,
-      meta("macos"),
-    );
-    conversation.enqueueMessage(
-      "msg-C",
-      [],
-      makeHandler("C"),
-      "req-C",
-      undefined,
-      undefined,
-      meta("cli"),
-    );
-    conversation.enqueueMessage(
-      "msg-D",
-      [],
-      makeHandler("D"),
-      "req-D",
-      undefined,
-      undefined,
-      meta("vellum"),
-    );
+    conversation.enqueueMessage({
+      content: "msg-B",
+      onEvent: makeHandler("B"),
+      requestId: "req-B",
+      metadata: meta("macos"),
+    });
+    conversation.enqueueMessage({
+      content: "msg-C",
+      onEvent: makeHandler("C"),
+      requestId: "req-C",
+      metadata: meta("cli"),
+    });
+    conversation.enqueueMessage({
+      content: "msg-D",
+      onEvent: makeHandler("D"),
+      requestId: "req-D",
+      metadata: meta("vellum"),
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Handoff from A -> B
@@ -2039,8 +2061,16 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue B (empty content — will fail to persist) and C (valid)
-    conversation.enqueueMessage("", [], (e) => eventsB.push(e), "req-B");
-    conversation.enqueueMessage("msg-C", [], (e) => eventsC.push(e), "req-C");
+    conversation.enqueueMessage({
+      content: "",
+      onEvent: (e) => eventsB.push(e),
+      requestId: "req-B",
+    });
+    conversation.enqueueMessage({
+      content: "msg-C",
+      onEvent: (e) => eventsC.push(e),
+      requestId: "req-C",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete message A — triggers drain. B should fail, C should proceed.
@@ -2154,9 +2184,9 @@ describe("Terminal trace events on rejection/failure", () => {
     await waitForPendingRun(1);
 
     // Enqueue empty content (will fail persistUserMessage)
-    conversation.enqueueMessage("", [], () => {}, "req-bad");
+    conversation.enqueueMessage({ content: "", requestId: "req-bad" });
     // Enqueue valid message so drain continues
-    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
+    conversation.enqueueMessage({ content: "msg-3", requestId: "req-3" });
 
     // Complete first — triggers drain, empty msg fails persist
     resolveRun(0);
@@ -2424,7 +2454,7 @@ describe("Conversation attachment event payloads", () => {
     await waitForPendingRun(1);
 
     // Queue a second message so the first run yields via checkpoint handoff.
-    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
 
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
@@ -2623,18 +2653,16 @@ describe("Regression: cancel semantics and error channel split", () => {
     );
     await waitForPendingRun(1);
 
-    conversation.enqueueMessage(
-      "msg-2",
-      [],
-      (e) => eventsPerMsg[1].push(e),
-      "req-2",
-    );
-    conversation.enqueueMessage(
-      "msg-3",
-      [],
-      (e) => eventsPerMsg[2].push(e),
-      "req-3",
-    );
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: (e) => eventsPerMsg[1].push(e),
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => eventsPerMsg[2].push(e),
+      requestId: "req-3",
+    });
 
     conversation.abort();
 
@@ -2678,7 +2706,11 @@ describe("Regression: cancel semantics and error channel split", () => {
       await waitForPendingRun(1);
 
       // Enqueue a second message while the first is processing
-      conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+      conversation.enqueueMessage({
+        content: "msg-2",
+        onEvent: (e) => events2.push(e),
+        requestId: "req-2",
+      });
 
       // Complete the first agent loop run
       resolveRun(0);

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -399,13 +399,16 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
 
     // Enqueue a slash-like passthrough and a normal passthrough after it.
     // Both resolve to passthrough, so the batch builder groups them into one run.
-    conversation.enqueueMessage(
-      "/not-a-skill",
-      [],
-      (e) => eventsSlash.push(e),
-      "req-slash",
-    );
-    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    conversation.enqueueMessage({
+      content: "/not-a-skill",
+      onEvent: (e) => eventsSlash.push(e),
+      requestId: "req-slash",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: (e) => events3.push(e),
+      requestId: "req-3",
+    });
     expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete first run — drain pulls both queued messages into one batched run.
@@ -441,12 +444,11 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     await waitForPendingRun(1);
 
     // Enqueue a slash command that matches a skill name — still passes through
-    conversation.enqueueMessage(
-      "/start-the-day",
-      [],
-      (e) => eventsSlash.push(e),
-      "req-slash",
-    );
+    conversation.enqueueMessage({
+      content: "/start-the-day",
+      onEvent: (e) => eventsSlash.push(e),
+      requestId: "req-slash",
+    });
 
     // Complete first run — triggers drain
     resolveRun(0);
@@ -484,14 +486,21 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     // batch builder stops at "hi" (length-1 batch → drainSingleMessage). Then
     // /compact takes its short-circuit path (no new runAgentLoop), and "bye"
     // drains as its own run.
-    conversation.enqueueMessage("hi", [], (e) => eventsHi.push(e), "req-hi");
-    conversation.enqueueMessage(
-      "/compact",
-      [],
-      (e) => eventsCompact.push(e),
-      "req-compact",
-    );
-    conversation.enqueueMessage("bye", [], (e) => eventsBye.push(e), "req-bye");
+    conversation.enqueueMessage({
+      content: "hi",
+      onEvent: (e) => eventsHi.push(e),
+      requestId: "req-hi",
+    });
+    conversation.enqueueMessage({
+      content: "/compact",
+      onEvent: (e) => eventsCompact.push(e),
+      requestId: "req-compact",
+    });
+    conversation.enqueueMessage({
+      content: "bye",
+      onEvent: (e) => eventsBye.push(e),
+      requestId: "req-bye",
+    });
     expect(conversation.getQueueDepth()).toBe(3);
 
     // Resolve msg-1 → drain pulls only "hi" (batch builder stops at /compact).

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -72,9 +72,12 @@ function createMockContext(
     hostCuProxy: undefined,
     hasNoClient: overrides?.hasNoClient ?? false,
     isProcessing: () => false,
-    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
-      const resolvedId = requestId ?? "mock-request-id";
-      enqueuedMessages.push({ content, requestId: resolvedId });
+    enqueueMessage: (options) => {
+      const resolvedId = options.requestId ?? "mock-request-id";
+      enqueuedMessages.push({
+        content: options.content,
+        requestId: resolvedId,
+      });
       return { queued: false, requestId: resolvedId };
     },
     getQueueDepth: () => 0,

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -63,9 +63,12 @@ function createMockContext(
     hostCuProxy: undefined,
     hasNoClient: overrides?.hasNoClient ?? false,
     isProcessing: () => false,
-    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
-      const resolvedId = requestId ?? "mock-request-id";
-      enqueuedMessages.push({ content, requestId: resolvedId });
+    enqueueMessage: (options) => {
+      const resolvedId = options.requestId ?? "mock-request-id";
+      enqueuedMessages.push({
+        content: options.content,
+        requestId: resolvedId,
+      });
       return { queued: false, requestId: resolvedId };
     },
     getQueueDepth: () => 0,

--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -45,9 +45,9 @@ function makeContext(opts?: {
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,
-    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
-      const resolvedId = requestId ?? "mock-request-id";
-      enqueueCalls.push({ content, requestId: resolvedId });
+    enqueueMessage: (options) => {
+      const resolvedId = options.requestId ?? "mock-request-id";
+      enqueueCalls.push({ content: options.content, requestId: resolvedId });
       return { queued: false, requestId: resolvedId };
     },
     getQueueDepth: () => 0,

--- a/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
@@ -64,25 +64,15 @@ function makeContext(): SurfaceConversationContext & {
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,
-    enqueueMessage: (
-      content,
-      attachments,
-      _onEvent,
-      requestId,
-      surfaceId,
-      _currentPage,
-      _metadata,
-      _options,
-      displayContent,
-    ) => {
+    enqueueMessage: (options) => {
       enqueueCalls.push({
-        content,
-        requestId: requestId ?? "enq-req",
-        attachments,
-        surfaceId,
-        displayContent,
+        content: options.content,
+        requestId: options.requestId ?? "enq-req",
+        attachments: options.attachments ?? [],
+        surfaceId: options.activeSurfaceId,
+        displayContent: options.displayContent,
       });
-      return { queued: false, requestId: requestId ?? "enq-req" };
+      return { queued: false, requestId: options.requestId ?? "enq-req" };
     },
     getQueueDepth: () => 0,
     processMessage: async (

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -184,8 +184,8 @@ function makeHangingConversation(): Conversation {
   const messages: unknown[] = [];
   const enqueuedMessages: Array<{
     content: string;
-    onEvent: (msg: ServerMessage) => void;
-    requestId: string;
+    onEvent?: (msg: ServerMessage) => void;
+    requestId?: string;
   }> = [];
   return {
     isProcessing: () => processing,
@@ -215,14 +215,20 @@ function makeHangingConversation(): Conversation {
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
     getQueueDepth: () => enqueuedMessages.length,
-    enqueueMessage: (
-      content: string,
-      _attachments: unknown[],
-      onEvent: (msg: ServerMessage) => void,
-      requestId: string,
-    ) => {
-      enqueuedMessages.push({ content, onEvent, requestId });
-      return { queued: true, requestId };
+    enqueueMessage: (options: {
+      content: string;
+      onEvent?: (msg: ServerMessage) => void;
+      requestId?: string;
+    }) => {
+      enqueuedMessages.push({
+        content: options.content,
+        onEvent: options.onEvent,
+        requestId: options.requestId,
+      });
+      return {
+        queued: true,
+        requestId: options.requestId ?? "hanging-req",
+      };
     },
     runAgentLoop: async () => {
       // Hang forever

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -251,14 +251,9 @@ function makePendingApprovalConversation(
   const messages: unknown[] = [];
   const runAgentLoopMock = mock(async () => {});
   const enqueueMessageMock = mock(
-    (
-      _content: string,
-      _attachments: unknown[],
-      _onEvent: (msg: ServerMessage) => void,
-      queuedRequestId: string,
-    ) => ({
+    (options: { content: string; requestId?: string }) => ({
       queued: true,
-      requestId: queuedRequestId,
+      requestId: options.requestId ?? "queued-req",
     }),
   );
   const denyAllPendingConfirmationsMock = mock(() => {

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -13,10 +13,10 @@ const capturedNotifications: {
 
 mock.module("../daemon/conversation-store.js", () => ({
   findConversation: (id: string) => ({
-    enqueueMessage: (content: string) => {
+    enqueueMessage: (options: { content: string }) => {
       capturedNotifications.push({
         parentConversationId: id,
-        message: content,
+        message: options.content,
       });
       return { queued: true };
     },

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -13,10 +13,10 @@ const capturedNotifications: {
 
 mock.module("../daemon/conversation-store.js", () => ({
   findConversation: (id: string) => ({
-    enqueueMessage: (content: string) => {
+    enqueueMessage: (options: { content: string }) => {
       capturedNotifications.push({
         parentConversationId: id,
-        message: content,
+        message: options.content,
       });
       return { queued: true };
     },

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -38,8 +38,8 @@ const capturedMessages: string[] = [];
 
 mock.module("../daemon/conversation-store.js", () => ({
   findConversation: (_id: string) => ({
-    enqueueMessage: (content: string) => {
-      capturedMessages.push(content);
+    enqueueMessage: (options: { content: string }) => {
+      capturedMessages.push(options.content);
       return { queued: true };
     },
     persistUserMessage: async () => ({ id: "mock-msg", deduplicated: false }),

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -460,10 +460,9 @@ export class AcpSessionManager {
             current.parentConversationId,
           );
           if (parentConversation) {
-            const enqueueResult = parentConversation.enqueueMessage(
-              notifyMessage,
-              [],
-            );
+            const enqueueResult = parentConversation.enqueueMessage({
+              content: notifyMessage,
+            });
             if (!enqueueResult.queued && !enqueueResult.rejected) {
               parentConversation
                 .persistUserMessage({ content: notifyMessage })

--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -44,10 +44,10 @@ mock.module("../../runtime/assistant-event.js", () => ({
   ...realEvent,
   // Pass-through so `focus` / `conversationId` can be asserted directly
   // on the captured event's `message` payload.
-  buildAssistantEvent: (
-    message: unknown,
-    conversationId?: string,
-  ) => ({ message, conversationId }),
+  buildAssistantEvent: (message: unknown, conversationId?: string) => ({
+    message,
+    conversationId,
+  }),
 }));
 
 // Stub DB helpers so the real `launchConversation` can run without a DB.
@@ -108,10 +108,7 @@ let processStartedPromise = new Promise<void>((resolve) => {
 const realProcessMessage = await import("../process-message.js");
 mock.module("../process-message.js", () => ({
   ...realProcessMessage,
-  processMessageInBackground: (
-    conversationId: string,
-    content: string,
-  ) => {
+  processMessageInBackground: (conversationId: string, content: string) => {
     processMessageCalls.push({ conversationId, content });
     markProcessStarted();
     return new Promise((resolve, reject) => {
@@ -178,8 +175,8 @@ function makeContext(
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,
-    enqueueMessage: (content: string) => {
-      enqueueCalls.push({ content });
+    enqueueMessage: (options) => {
+      enqueueCalls.push({ content: options.content });
       return { queued: false, requestId: "enq-req" };
     },
     getQueueDepth: () => 0,
@@ -257,7 +254,7 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
 
   test("launches new conversation with inherited trust context and no chat message", async () => {
     nextKeyStoreResult = { conversationId: "conv-launched-1" };
-    
+
     const originTrustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
@@ -352,7 +349,7 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
 
   test("omits originTrustContext when origin conversation has none", async () => {
     nextKeyStoreResult = { conversationId: "conv-launched-3" };
-    
+
     // No `trustContext` on the origin context — simulating the
     // no-inherited-guardian path.
     const ctx = makeContext();
@@ -383,7 +380,7 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
 
   test("handler returns before the seed turn resolves (fire-and-forget)", async () => {
     nextKeyStoreResult = { conversationId: "conv-nonblocking" };
-    
+
     const ctx = makeContext();
     registerCardSurface(ctx, "surface-4");
 
@@ -414,7 +411,7 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
 
   test("seed turn rejection is swallowed by the helper's .catch()", async () => {
     nextKeyStoreResult = { conversationId: "conv-seed-fails" };
-    
+
     const ctx = makeContext();
     registerCardSurface(ctx, "surface-5");
 
@@ -450,7 +447,7 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
     // message and triggering a full LLM round-trip on every click. The plan
     // claimed to eliminate that round-trip; this test enforces it.
     nextKeyStoreResult = { conversationId: "conv-pending-set" };
-    
+
     const ctx = makeContext();
     registerCardSurface(ctx, "surface-pending");
     // Simulate `ui_show` having stamped a pending entry for this surface

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -285,22 +285,44 @@ export function buildSlackMetaForPersistence(params: {
   return writeSlackMetadata(slackMeta);
 }
 
+// ── EnqueueMessageOptions ────────────────────────────────────────────
+
+/** Options for `enqueueMessage`. Only `content` is required; everything
+ *  else has a sensible default or is genuinely optional. */
+export interface EnqueueMessageOptions {
+  content: string;
+  attachments?: UserMessageAttachment[];
+  onEvent?: (msg: ServerMessage) => void;
+  requestId?: string;
+  activeSurfaceId?: string;
+  currentPage?: string;
+  metadata?: Record<string, unknown>;
+  isInteractive?: boolean;
+  displayContent?: string;
+  transport?: ConversationTransportMetadata;
+  clientMessageId?: string;
+}
+
 // ── enqueueMessage ───────────────────────────────────────────────────
 
 export function enqueueMessage(
   ctx: MessagingConversationContext,
-  content: string,
-  attachments: UserMessageAttachment[],
-  onEvent: (msg: ServerMessage) => void,
-  requestId: string,
-  activeSurfaceId?: string,
-  currentPage?: string,
-  metadata?: Record<string, unknown>,
-  options?: { isInteractive?: boolean },
-  displayContent?: string,
-  transport?: ConversationTransportMetadata,
-  clientMessageId?: string,
+  options: EnqueueMessageOptions,
 ): { queued: boolean; requestId: string; rejected?: boolean } {
+  const {
+    content,
+    attachments = [],
+    onEvent,
+    requestId = crypto.randomUUID(),
+    activeSurfaceId,
+    currentPage,
+    metadata,
+    isInteractive,
+    displayContent,
+    transport,
+    clientMessageId,
+  } = options;
+
   if (!ctx.processing) {
     return { queued: false, requestId };
   }
@@ -317,20 +339,20 @@ export function enqueueMessage(
     content,
     attachments,
     requestId,
-    onEvent,
+    onEvent: onEvent ?? (() => {}),
     activeSurfaceId,
     currentPage,
     metadata,
     turnChannelContext,
     turnInterfaceContext,
-    isInteractive: options?.isInteractive,
+    isInteractive,
     transport,
     displayContent,
     sentAt: Date.now(),
     clientMessageId,
   });
   if (!accepted) {
-    onEvent({
+    onEvent?.({
       type: "error",
       conversationId: ctx.conversationId,
       message:

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -28,6 +28,7 @@ import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
 import { launchConversation } from "./conversation-launch.js";
+import type { EnqueueMessageOptions } from "./conversation-messaging.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
@@ -45,7 +46,6 @@ import type {
   UiSurfaceShow,
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
-import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type { HostAppControlInput } from "./message-types/host-app-control.js";
 import type { UserMessageAttachment } from "./message-types/shared.js";
 import type { TrustContext } from "./trust-context.js";
@@ -518,18 +518,11 @@ export interface SurfaceConversationContext {
   /** True when no interactive client is connected (headless / channel-only). */
   readonly hasNoClient?: boolean;
   isProcessing(): boolean;
-  enqueueMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    onEvent?: (msg: ServerMessage) => void,
-    requestId?: string,
-    activeSurfaceId?: string,
-    currentPage?: string,
-    metadata?: Record<string, unknown>,
-    options?: { isInteractive?: boolean },
-    displayContent?: string,
-    transport?: ConversationTransportMetadata,
-  ): { queued: boolean; requestId: string; rejected?: boolean };
+  enqueueMessage(options: EnqueueMessageOptions): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+  };
   getQueueDepth(): number;
   processMessage(
     content: string,
@@ -1449,17 +1442,14 @@ export async function handleSurfaceAction(
       attributes: { source: "surface_action", surfaceId, actionId },
     });
 
-    const result = ctx.enqueueMessage(
+    const result = ctx.enqueueMessage({
       content,
       attachments,
       onEvent,
       requestId,
-      surfaceId,
-      undefined,
-      undefined,
-      undefined,
+      activeSurfaceId: surfaceId,
       displayContent,
-    );
+    });
 
     if (result.rejected) {
       ctx.surfaceActionRequestIds.delete(requestId);
@@ -1694,17 +1684,14 @@ export async function handleSurfaceAction(
     "Surface action follow-up: preparing to send message to model",
   );
 
-  const result = ctx.enqueueMessage(
+  const result = ctx.enqueueMessage({
     content,
-    pendingAttachments,
+    attachments: pendingAttachments,
     onEvent,
     requestId,
-    surfaceId,
-    undefined,
-    undefined,
-    undefined,
+    activeSurfaceId: surfaceId,
     displayContent,
-  );
+  });
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     return;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -87,6 +87,7 @@ import {
   loadFromDb as loadFromDbImpl,
 } from "./conversation-lifecycle.js";
 import type {
+  EnqueueMessageOptions,
   PersistMessageOptions,
   RedirectToSecurePromptOptions,
 } from "./conversation-messaging.js";
@@ -831,33 +832,15 @@ export class Conversation {
     );
   }
 
-  enqueueMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    onEvent?: (msg: ServerMessage) => void,
-    requestId?: string,
-    activeSurfaceId?: string,
-    currentPage?: string,
-    metadata?: Record<string, unknown>,
-    options?: { isInteractive?: boolean },
-    displayContent?: string,
-    transport?: ConversationTransportMetadata,
-    clientMessageId?: string,
-  ): { queued: boolean; requestId: string; rejected?: boolean } {
-    return enqueueMessageImpl(
-      this,
-      content,
-      attachments,
-      onEvent ?? this.sendToClient,
-      requestId ?? crypto.randomUUID(),
-      activeSurfaceId,
-      currentPage,
-      metadata,
-      options,
-      displayContent,
-      transport,
-      clientMessageId,
-    );
+  enqueueMessage(options: EnqueueMessageOptions): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+  } {
+    return enqueueMessageImpl(this, {
+      ...options,
+      onEvent: options.onEvent ?? this.sendToClient,
+    });
   }
 
   getQueueDepth(): number {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1579,25 +1579,22 @@ export async function handleSendMessage(
   if (conversation.isProcessing()) {
     // Queue the message so it's processed when the current turn completes
     const requestId = crypto.randomUUID();
-    const enqueueResult = conversation.enqueueMessage(
-      contentAfterScan,
+    const enqueueResult = conversation.enqueueMessage({
+      content: contentAfterScan,
       attachments,
-      broadcastMessage,
+      onEvent: broadcastMessage,
       requestId,
-      undefined, // activeSurfaceId
-      undefined, // currentPage
-      {
+      metadata: {
         userMessageChannel: sourceChannel,
         assistantMessageChannel: sourceChannel,
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
         ...(body.automated === true ? { automated: true } : {}),
       },
-      { isInteractive },
-      undefined, // displayContent
+      isInteractive,
       transport,
       clientMessageId,
-    );
+    });
     if (enqueueResult.rejected) {
       return new RouteResponse(
         JSON.stringify({ accepted: false, error: "queue_full" }),

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -120,20 +120,17 @@ async function dispatchUserMessage(params: {
     const requestId = crypto.randomUUID();
     const resolvedChannel = resolveTurnChannel(params.sourceChannel);
     const resolvedInterface = resolveTurnInterface(params.sourceInterface);
-    const result = conversation.enqueueMessage(
-      params.content,
-      resolvedAttachments,
-      undefined,
+    const result = conversation.enqueueMessage({
+      content: params.content,
+      attachments: resolvedAttachments,
       requestId,
-      undefined,
-      undefined,
-      {
+      metadata: {
         userMessageChannel: resolvedChannel,
         assistantMessageChannel: resolvedChannel,
         userMessageInterface: resolvedInterface,
         assistantMessageInterface: resolvedInterface,
       },
-    );
+    });
     return { accepted: !result.rejected };
   }
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -612,7 +612,7 @@ export class SubagentManager {
       return "terminal";
 
     // If the conversation is busy, queue the message; otherwise process immediately.
-    const result = managed.conversation.enqueueMessage(trimmed, []);
+    const result = managed.conversation.enqueueMessage({ content: trimmed });
     if (result.rejected) {
       return "sent"; // error event already delivered via sendToClient
     }
@@ -989,15 +989,10 @@ export class SubagentManager {
       );
       return;
     }
-    const enqueueResult = parentConversation.enqueueMessage(
-      message,
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    const enqueueResult = parentConversation.enqueueMessage({
+      content: message,
       metadata,
-    );
+    });
     if (!enqueueResult.queued && !enqueueResult.rejected) {
       parentConversation
         .persistUserMessage({ content: message, metadata })


### PR DESCRIPTION
Closes LUM-2018

## Prompt / plan

Follow-up to PR #32451 (LUM-2004). Convert `enqueueMessage` from 12 positional parameters to a single `EnqueueMessageOptions` object, eliminating `undefined` holes at call sites and improving readability.

## Why

`enqueueMessage` takes 12 positional parameters. 5 of 7 production call sites pass `undefined` holes to reach later params:\n```typescript\n// Before — 5 undefined holes\nconversation.enqueueMessage(\n  content, attachments, broadcastMessage, requestId,\n  undefined, undefined, metadata, { isInteractive },\n  undefined, transport, clientMessageId,\n);\n```\n\nThis is the same problem LUM-2004 solved for `persistUserMessage` / `persistQueuedMessageBody`.

## What

**Interface** (defined in `conversation-messaging.ts`):\n```typescript\nexport interface EnqueueMessageOptions {\n  content: string;\n  attachments?: UserMessageAttachment[];\n  onEvent?: (msg: ServerMessage) => void;\n  requestId?: string;\n  activeSurfaceId?: string;\n  currentPage?: string;\n  metadata?: Record<string, unknown>;\n  isInteractive?: boolean;\n  displayContent?: string;\n  transport?: ConversationTransportMetadata;\n  clientMessageId?: string;\n}\n```

Design decisions:\n- **Flattened `isInteractive`** — the nested `options?: { isInteractive?: boolean }` sub-object was unnecessary indirection\n- **`onEvent` defaults to no-op in impl** — the `Conversation` class proxy overrides to `this.sendToClient`\n- **`requestId` defaults to `crypto.randomUUID()` in impl** — matches previous class proxy behavior\n- **`attachments` defaults to `[]`** — eliminates the most common positional arg at call sites

## Scope

- 3 signature definitions (impl function, class method, interface)\n- 7 production call sites\n- 65 test call sites across 7 test files\n- 4 `mock.module` stubs (TypeScript can't catch these at compile time)\n- 1 unused import removed (`ConversationTransportMetadata` from `conversation-surfaces.ts`)\n- 18 files changed, net -211 lines

## Safety

Pure refactor — no behavioral changes. Same defaults, same call paths, same return types.\n- `tsc --noEmit`: 0 errors\n- `eslint`: 0 errors\n- Pre-push hook: 580 related tests all green (only pre-existing benchmark failures on main)

## Test plan

- TypeScript compilation (`tsc --noEmit`) — catches any missed statically-typed call sites\n- ESLint — 0 errors\n- Pre-push hook runs all 580 related tests — all pass\n- `conversation-queue.test.ts` (60 call sites) — exercises queue enqueue/drain/batch\n- `conversation-slash-queue.test.ts` (6 call sites) — slash command queueing\n- 5 surface test files — surface action enqueue paths\n- 4 subagent/notification test files — `mock.module` stubs verified at runtime

Link to Devin session: https://app.devin.ai/sessions/1a2be238d9704952b6682fc77696d9b3
Requested by: @ashleeradka