### PR TITLE
fix(web): eliminate iOS keyboard padding flicker on empty state

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -21,7 +21,6 @@ import { ChevronDown } from "lucide-react";
 import * as Sentry from "@sentry/react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useVisibleViewport } from "@/hooks/use-visible-viewport";
 import { useAuthStore } from "@/stores/auth-store";
 import { useAssistantContext } from "@/components/layout/assistant-context";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -151,9 +150,6 @@ export function ChatPage() {
   const authUser = useAuthStore.use.user();
   const showLlmInspector = canUseLlmInspector(authUser);
   const isMobile = useIsMobile();
-  const visibleViewport = useVisibleViewport();
-  const keyboardOpen =
-    isMobile && visibleViewport !== null && visibleViewport.keyboardHeight > 100;
   const isNative = useIsNativePlatform();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -1464,7 +1460,6 @@ export function ChatPage() {
     deployToVercel,
     doctor,
     isMobile,
-    isKeyboardOpen: keyboardOpen,
     messages,
     setMessages,
     input,

--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -113,7 +113,6 @@ function baseProps(
       onDrop: noopDrag,
     },
     isAttachmentDragOver: false,
-    isKeyboardOpen: false,
     showScrollToLatest: false,
     onScrollToLatest: noop,
     refreshFeedback: null,
@@ -218,19 +217,6 @@ describe("ChatBody — startersSlot rendering", () => {
     expect(html).not.toContain("STARTER_CHIPS");
   });
 
-  test("renders starters when keyboard is open", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...withEmptyState({
-          isKeyboardOpen: true,
-          startersSlot: (
-            <div data-testid="starters">STARTER_CHIPS</div>
-          ),
-        })}
-      />,
-    );
-    expect(html).toContain("STARTER_CHIPS");
-  });
 });
 
 describe("ChatBody — read-only cancellation", () => {

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -67,12 +67,6 @@ export interface ChatBodyProps {
   /** True when an attachment drag is active; shows a drop-target overlay. */
   isAttachmentDragOver: boolean;
 
-  /**
-   * True when the soft keyboard is open. Tightens bottom padding around
-   * the composer so the input stays close to the keyboard's top edge.
-   */
-  isKeyboardOpen: boolean;
-
   /** True when the "Go to Newest" pill should be shown above the composer. */
   showScrollToLatest: boolean;
   /** Click handler for the "Go to Newest" pill. */
@@ -173,7 +167,6 @@ export function ChatBody({
   composerProps,
   dragHandlers,
   isAttachmentDragOver,
-  isKeyboardOpen,
   showScrollToLatest,
   onScrollToLatest,
   isStreaming = false,
@@ -229,9 +222,7 @@ export function ChatBody({
           draft text, attachments) and iOS Safari does not blur the input
           on first send (LUM-1506 / LUM-1516). */}
       <div
-        className={`relative px-3 pt-2 sm:px-6 sm:pb-0 ${
-          isKeyboardOpen ? "pb-1" : "pb-4"
-        }`}
+        className="relative px-3 pt-2 pb-2 sm:px-6 sm:pb-0"
       >
         {refreshFeedback && (
           <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2">

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -272,7 +272,6 @@ export interface ChatRouteContentProps {
 
   // Platform
   isMobile: boolean;
-  isKeyboardOpen: boolean;
 
   // Messages
   messages: DisplayMessage[];
@@ -288,8 +287,6 @@ export interface ChatRouteContentProps {
 
   // Loading
   isLoadingHistory: boolean;
-
-
 
   // Conversation
   conversations: Conversation[];
@@ -404,7 +401,6 @@ export function ChatRouteContent({
   deployToVercel,
   doctor: doctorEnabled,
   isMobile,
-  isKeyboardOpen,
   messages,
   setMessages: _setMessages,
   input,
@@ -1394,7 +1390,6 @@ export function ChatRouteContent({
             composerProps={chatBodyComposerProps}
             dragHandlers={attachmentDropHandlers}
             isAttachmentDragOver={isAttachmentDragOver}
-            isKeyboardOpen={isKeyboardOpen}
             showScrollToLatest={
               scrollCoordinator.showScrollToLatest && messages.length > 0
             }
@@ -1467,7 +1462,6 @@ export function ChatRouteContent({
       composerProps={chatBodyComposerProps}
       dragHandlers={attachmentDropHandlers}
       isAttachmentDragOver={isAttachmentDragOver}
-      isKeyboardOpen={isKeyboardOpen}
       showScrollToLatest={
         scrollCoordinator.showScrollToLatest && messages.length > 0
       }


### PR DESCRIPTION
Eliminates a visible layout flicker on the iOS empty-state chat page caused by a discrete padding jump (`pb-4` → `pb-1`) when `isKeyboardOpen` toggles at the 100px keyboard-height threshold. Uses consistent `pb-2` padding regardless of keyboard state, and removes the now-dead `isKeyboardOpen` prop chain along with the duplicate `useVisibleViewport()` subscription in `ChatPage`.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e96226cc68f34ff1a28c03427676b2a9
