### PR TITLE
fix(ios): use stable reference height for keyboard detection in WKWebView

### DIFF
--- a/apps/web/src/hooks/use-visible-viewport.ts
+++ b/apps/web/src/hooks/use-visible-viewport.ts
@@ -24,6 +24,28 @@ export interface VisibleViewport {
   offsetLeft: number;
 }
 
+// Stable reference for the viewport height when no keyboard is present.
+//
+// In Safari, `window.innerHeight` stays at the layout viewport height when the
+// keyboard opens and only `visualViewport.height` shrinks, so
+// `innerHeight - vv.height` directly yields the keyboard height.
+//
+// In WKWebView (Capacitor iOS without `@capacitor/keyboard`), the web view
+// frame itself is resized to fit above the keyboard. Both `innerHeight` and
+// `vv.height` shrink together, making `innerHeight - vv.height ≈ 0` even when
+// the keyboard is visible. By comparing against the maximum observed
+// `innerHeight` — which corresponds to the keyboard-dismissed state — keyboard
+// detection works correctly across both runtimes.
+//
+// Orientation changes are tracked so the reference resets when the viewport
+// dimensions change due to rotation rather than a keyboard event.
+let referenceInnerHeight =
+  typeof window !== "undefined" ? window.innerHeight : 0;
+let lastOrientationType: string =
+  typeof window !== "undefined"
+    ? (window.screen.orientation?.type ?? "portrait-primary")
+    : "portrait-primary";
+
 /**
  * Read the current visual-viewport state.
  *
@@ -35,13 +57,32 @@ export function readVisibleViewport(): VisibleViewport | null {
     return null;
   }
   const vv = window.visualViewport;
+
+  // Reset the reference when the device orientation changes — a rotation
+  // legitimately changes the viewport dimensions and would otherwise look
+  // like a keyboard event.
+  const orientation =
+    window.screen.orientation?.type ?? "portrait-primary";
+  if (orientation !== lastOrientationType) {
+    lastOrientationType = orientation;
+    referenceInnerHeight = window.innerHeight;
+  }
+
+  // Update the reference whenever the viewport grows (keyboard dismissed,
+  // or first observation after an orientation change that settled).
+  if (window.innerHeight > referenceInnerHeight) {
+    referenceInnerHeight = window.innerHeight;
+  }
+
   // When pinch-zoomed (scale > 1) the visual viewport height shrinks in CSS
   // pixels, which would otherwise inflate keyboardHeight and falsely trigger
   // keyboard-open detection. Only derive keyboardHeight at ~1.0 scale.
   const isZoomed = Math.abs(vv.scale - 1) > 0.05;
   return {
     height: vv.height,
-    keyboardHeight: isZoomed ? 0 : Math.max(0, window.innerHeight - vv.height),
+    keyboardHeight: isZoomed
+      ? 0
+      : Math.max(0, referenceInnerHeight - vv.height),
     offsetTop: isZoomed ? 0 : vv.offsetTop,
     offsetLeft: isZoomed ? 0 : vv.offsetLeft,
   };
@@ -51,9 +92,12 @@ export function readVisibleViewport(): VisibleViewport | null {
  * Tracks the VisualViewport API so callers can size and position containers
  * to the area actually visible to the user.
  *
- * On iOS the soft keyboard shrinks `visualViewport.height` while
- * `window.innerHeight` (and `100dvh`) stays at the full layout viewport.
- * Sizing a container to `height` keeps the layout inside the visible region.
+ * In Safari, the soft keyboard shrinks `visualViewport.height` while
+ * `window.innerHeight` stays at the full layout viewport. In Capacitor's
+ * WKWebView (without `@capacitor/keyboard`), the web view frame itself
+ * resizes, shrinking both values together. The `referenceInnerHeight`
+ * approach in `readVisibleViewport` handles both cases — see the module-level
+ * comment above it.
  *
  * Returns `null` in browsers that lack the API; callers should fall back to
  * `100dvh` (and no transform) in that case.

--- a/apps/web/src/hooks/use-visible-viewport.ts
+++ b/apps/web/src/hooks/use-visible-viewport.ts
@@ -41,10 +41,16 @@ export interface VisibleViewport {
 // dimensions change due to rotation rather than a keyboard event.
 let referenceInnerHeight =
   typeof window !== "undefined" ? window.innerHeight : 0;
-let lastOrientationType: string =
-  typeof window !== "undefined"
-    ? (window.screen.orientation?.type ?? "portrait-primary")
-    : "portrait-primary";
+
+// Orientation detection via matchMedia — universally supported (iOS 9+),
+// unlike screen.orientation which was only added in Safari 16.4.
+function isPortrait(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return window.matchMedia("(orientation: portrait)").matches;
+}
+let lastIsPortrait: boolean = isPortrait();
 
 /**
  * Read the current visual-viewport state.
@@ -61,10 +67,9 @@ export function readVisibleViewport(): VisibleViewport | null {
   // Reset the reference when the device orientation changes — a rotation
   // legitimately changes the viewport dimensions and would otherwise look
   // like a keyboard event.
-  const orientation =
-    window.screen.orientation?.type ?? "portrait-primary";
-  if (orientation !== lastOrientationType) {
-    lastOrientationType = orientation;
+  const currentIsPortrait = isPortrait();
+  if (currentIsPortrait !== lastIsPortrait) {
+    lastIsPortrait = currentIsPortrait;
     referenceInnerHeight = window.innerHeight;
   }
 


### PR DESCRIPTION
Keyboard detection in `useVisibleViewport` was broken in Capacitor's WKWebView because the web view frame resizes when the keyboard opens — both `window.innerHeight` and `visualViewport.height` shrink together, so `innerHeight - vv.height ≈ 0` and `keyboardOpen` is never true. This made all keyboard-conditional code dead: safe-area bottom padding (34px) was never removed, composer padding stayed at `pb-4` (16px) instead of `pb-1` (4px), producing a ~50px gap between the composer and keyboard.

Fixes this by tracking the maximum observed `innerHeight` as a module-level reference (the keyboard-dismissed height) and comparing `visualViewport.height` against that instead of the live `innerHeight`. Resets the reference on orientation changes to avoid false positives. Backward compatible with Safari where `innerHeight` already stays constant.

## Prompt / plan
Investigation traced the gap to `keyboardOpen` never being true in WKWebView. Safari keeps `innerHeight` constant when the keyboard opens (only `visualViewport.height` shrinks), but WKWebView without `@capacitor/keyboard` resizes the entire viewport, shrinking both values together. The fix uses a stable reference height captured before any keyboard interaction.

## Test plan
- Lint and typecheck pass
- All existing `chat-body.test.tsx` tests pass (12/12)
- The detection logic is backward compatible: in Safari, `referenceInnerHeight === window.innerHeight` always, so the formula produces identical results to before

### Root cause analysis

1. **How did the code get into this state?** The `useVisibleViewport` hook was ported from the platform repo where it assumed standard Safari viewport behavior. That assumption is correct in Safari but wrong in Capacitor's WKWebView, which resizes the viewport frame when the keyboard opens.
2. **What decisions led to it?** The hook's JSDoc even documents the Safari assumption ("the soft keyboard shrinks `visualViewport.height` while `window.innerHeight` stays at the full layout viewport") but this was never validated against WKWebView's different resize behavior.
3. **Warning signs missed?** The `@capacitor/keyboard` plugin is not installed — without it, WKWebView uses default resize behavior which differs from Safari. The Capacitor docs recommend the plugin for keyboard management.
4. **Prevention?** Any keyboard-related code should be tested in the actual WKWebView runtime (via TestFlight or Xcode simulator), not just in Safari — the viewport resize behaviors differ significantly.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/8fc6a8fd15bb40b588c6d014a6daa4a5