### PR TITLE
fix(web): show Home top-bar title on mobile only

### DIFF
--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,23 +1,44 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router";
 
+import { Typography } from "@vellum/design-library";
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate";
+import { useAssistantContext } from "@/components/layout/assistant-context";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationListQuery } from "@/domains/conversations/conversation-queries";
 import { useConversationStore } from "@/stores/conversation-store";
 import { HomePage } from "@/domains/home/home-page";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 export function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useActiveAssistantContext();
+  const { setTopBarCenter } = useAssistantContext();
+  const isMobile = useIsMobile();
   const { conversations } = useConversationListQuery(assistantId);
   const validConversationIds = useMemo(
     () => new Set(conversations.map((c) => c.conversationId)),
     [conversations],
   );
+
+  useEffect(() => {
+    if (isMobile) {
+      setTopBarCenter(
+        <Typography
+          variant="body-medium-default"
+          className="text-[var(--content-secondary)]"
+        >
+          Home
+        </Typography>,
+      );
+    } else {
+      setTopBarCenter(null);
+    }
+    return () => { setTopBarCenter(null); };
+  }, [isMobile, setTopBarCenter]);
 
   return (
     <HomePage


### PR DESCRIPTION
Restores the "Home" top-bar title that was removed in #32434, but gates it behind `useIsMobile()` so it only renders on narrow viewports. On desktop the top-bar center slot stays empty. This matches the existing "Details" title pattern in the detail panel, which is already mobile-only via the `isMobile` prop.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e8cdc685deed4f3f96db09a3ddd84c8a