### PR TITLE
fix(web): mark notification as read when clicking to open detail panel

### DIFF
--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -62,9 +62,15 @@ export function HomePage({
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
 
-  const handleSelectItem = useCallback((item: FeedItem) => {
-    setSelectedItem(item);
-  }, []);
+  const handleSelectItem = useCallback(
+    (item: FeedItem) => {
+      setSelectedItem(item);
+      if (item.status === "new") {
+        feedQuery.updateStatus.mutate({ itemId: item.id, status: "seen" });
+      }
+    },
+    [feedQuery.updateStatus],
+  );
 
   const handleCloseDetail = useCallback(() => {
     setSelectedItem(null);


### PR DESCRIPTION
Clicking an unread notification on the homepage now marks it as "seen" via the existing `updateStatus` mutation, so the blue unread dot disappears from the feed list. The detail panel still receives the original item snapshot (status `"new"`), so the envelope icon correctly reflects the pre-click state and the user can toggle back to unread if desired.

PR #32414 removed the mark-as-read side effect to fix a detail panel icon bug where `selectedItem.status` was overwritten to `"seen"` before the panel rendered — making `isUnread` always false. This fix restores the mutation call without the local state overwrite, separating the two concerns: (1) backend/cache status update, and (2) detail panel display state.

## Root cause analysis

1. **How did the code get into this state?** PR #32414 removed both the `feedQuery.updateStatus.mutate()` call *and* the `setSelectedItem({ ...item, status: "seen" })` overwrite in a single deletion. The mutation was collateral damage — only the state overwrite was causing the icon bug.
2. **What decisions led to it?** The two concerns (marking as read on the server vs. setting local display state) were interleaved in a single `if` block, making it easy to treat them as one unit.
3. **Were there warning signs?** The "Go to thread" hover action already had the correct pattern — calling the mutation without overwriting `selectedItem` — but the inconsistency wasn't noticed.
4. **Prevention:** Keep mutation side effects and local state updates as separate statements so they can be independently added/removed. The existing `handleUpdateStatus` callback is a good example of this pattern.

### Alternatives not taken

- **Revert #32414 entirely:** Rejected because the original code's approach of overwriting `selectedItem.status` was wrong — it made the detail panel unable to show the true unread state.
- **Mark as read on detail panel mount via `useEffect`:** Rejected because it couples a side effect to rendering. The click handler is the natural place for this intent.
- **Mark as read only when closing the detail panel:** Rejected because standard notification UX (Gmail, Slack, iOS) marks items as read on open, not on close.

## Prompt / plan

Investigate and fix: homepage notification items not marked as read when clicked to open the detail panel.

## Test plan

- Typecheck (`bunx tsc --noEmit`) and lint (`bun run lint`) pass
- CI checks

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ee9b8c3876f5420e9873a847c849711b