### PR TITLE
strengthen notification title guidance

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -128,7 +128,10 @@ Examples:
           "--source-event-name <name>",
           "Event name for audit, routing, and dedupe grouping (default: assistant.share)",
         )
-        .option("--title <title>", "Optional notification title")
+        .option(
+          "--title <title>",
+          "Short headline (≤ 8 words). Always provide one — the auto-derived fallback just truncates --message.",
+        )
         .option(
           "--urgency <urgency>",
           "Urgency hint: low, medium, high, critical (default: low; use --urgent for critical)",

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -12,6 +12,8 @@ Call this when something happened that the user would want to know about — a c
 
 ## Sending Notifications
 
+Always pass `--title`. Skipping it triggers a fallback that just truncates `--message` to 60 chars and shows it as the title — the user sees the same text twice with no scannability gained.
+
 ```bash
 assistant notifications send \
   --title "Short headline" \
@@ -29,13 +31,15 @@ assistant notifications send --title "..." --message "..." --urgent
 | Flag                  | Required | Description                                  |
 | --------------------- | -------- | -------------------------------------------- |
 | `--message <message>` | Yes      | Notification message the user should receive |
-| `--title <title>`     | No       | Short headline (≤ 8 words). Strongly recommended — auto-derived from `--message` if omitted. |
+| `--title <title>`     | Yes in practice | Short headline (≤ 8 words). Omitting it triggers a body-truncation fallback that shows up as a duplicate of `--message` — always write a real title. |
 | `--urgent`            | No       | Mark as needing attention now/soon           |
 | `--json`              | No       | Output machine-readable JSON                 |
 
 ### Title
 
-Include a deliberate `--title` whenever you can. It's what the user sees in the lock-screen popup and notification list, so a short headline (noun phrase, ≤ 8 words) is much easier to scan than an auto-derived snippet from the message body. Avoid restating the first sentence of `--message` verbatim — the title should add scannability, not duplicate.
+Write a `--title` for every notification. It's the only line the user sees in the lock-screen popup and the collapsed row of the notification list, so a short noun phrase (≤ 8 words) is what makes the notification scannable. If you omit `--title`, the system falls back to the first sentence of `--message` (truncated at 60 chars) — that's almost always worse than what you'd write, because it duplicates body text the user is already going to read.
+
+Avoid restating the first sentence of `--message` verbatim — the title should add scannability, not duplicate.
 
 ### Urgent semantics
 


### PR DESCRIPTION
## Summary
- Reframe `skills/notifications/SKILL.md` so `--title` reads as the default expectation rather than an optional add-on; spell out the body-truncation fallback as the failure mode the user actually sees in the title row.
- Update the `--title` `--help` description in `assistant/src/cli/commands/notifications.ts` to match.
- No schema or runtime change — `--title` is still optional in the CLI, and `deriveTitle()` remains as the safety net.

## Original prompt
Assistants are frequently emitting notifications without a `--title`, so the
title row in the notification UI ends up as a truncated copy of the body. The
ask was to diagnose why the model skips titles and tighten the guidance — not
to make `--title` strictly required at the schema level, just to make the
prompt-side instruction strong enough that the model treats titles as the
default. Root cause was three weak signals in the notifications skill:
"Required: No" in the table, "Strongly recommended" / "whenever you can" in
the prose, and a `deriveTitle()` fallback that auto-fills a plausible-looking
title from the message body so the model gets no negative feedback for
omitting one.