### PR TITLE
Stop creating graveyard conversations for passive notifications

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -123,6 +123,11 @@ function makeSignal(
       isAsyncBackground: true,
       visibleInSourceNow: false,
     },
+    // Most existing pairing tests pre-date the passive-by-default gate and
+    // exercise the conversation-creation path. Default to the opt-in flag so
+    // they continue to assert creation semantics; the dedicated passive-gate
+    // test below explicitly omits it to cover the new default.
+    requiresConversation: true,
     ...overrides,
   };
 }
@@ -814,6 +819,53 @@ describe("pairDeliveryWithConversation", () => {
     expect(createConversationMock).toHaveBeenCalledTimes(1);
     // Binding lookup should not be called for non-continue_existing channels
     expect(getBindingByChannelChatMock).not.toHaveBeenCalled();
+  });
+
+  // ── Passive default: vellum no-creates without opt-in ─────────────
+
+  test("passive vellum signal does not create a conversation or message", async () => {
+    const signal = makeSignal({ requiresConversation: undefined });
+    const copy = makeCopy();
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+    );
+
+    expect(result.conversationId).toBeNull();
+    expect(result.messageId).toBeNull();
+    expect(result.strategy).toBe("start_new_conversation");
+    expect(result.createdNewConversation).toBe(false);
+    expect(result.conversationFallbackUsed).toBe(false);
+    expect(createConversationMock).not.toHaveBeenCalled();
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("passive vellum signal still honors explicit reuse_existing action", async () => {
+    mockExistingConversations["conv-explicit-passive"] = {
+      id: "conv-explicit-passive",
+      source: "notification",
+      title: "Existing",
+    };
+    const signal = makeSignal({ requiresConversation: undefined });
+    const copy = makeCopy();
+    const conversationAction: ConversationAction = {
+      action: "reuse_existing",
+      conversationId: "conv-explicit-passive",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+      { conversationAction },
+    );
+
+    expect(result.conversationId).toBe("conv-explicit-passive");
+    expect(result.createdNewConversation).toBe(false);
+    expect(createConversationMock).not.toHaveBeenCalled();
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
   });
 
   // ── conversationMetadata.conversationType override ─────────────────

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -38,6 +38,13 @@ mock.module("../notifications/deliveries-store.js", () => ({
   findDeliveryByDecisionAndChannel: () => undefined,
 }));
 
+// Mock conversation-crud so the broadcaster's source-context fallback lookup
+// can be driven from tests without DB access.
+let mockExistingConversations: Record<string, { id: string }> = {};
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversation: (id: string) => mockExistingConversations[id] ?? null,
+}));
+
 // Configurable mock for conversation-pairing
 let nextPairingResult:
   | import("../notifications/conversation-pairing.js").PairingResult
@@ -141,6 +148,7 @@ class MockAdapter implements ChannelAdapter {
 describe("notification deep-link metadata", () => {
   beforeEach(() => {
     nextPairingResult = null;
+    mockExistingConversations = {};
   });
 
   describe("VellumAdapter", () => {
@@ -599,6 +607,60 @@ describe("notification deep-link metadata", () => {
       // But each has a distinct messageId for scroll targeting
       expect(deepLink1!.messageId).toBe("msg-delivery-1");
       expect(deepLink2!.messageId).toBe("msg-delivery-2");
+    });
+
+    // ── Source-context fallback when pairing yields no conversation ──
+
+    test("falls back to signal.sourceContextId for deep link when pairing returns no conversation and sourceContextId resolves", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+      // Passive vellum signal: pairing skips creation, returns null.
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      const originConvId = "conv-origin-of-event";
+      mockExistingConversations[originConvId] = { id: originConvId };
+
+      const signal = makeSignal({ sourceContextId: originConvId });
+      const decision = makeDecision();
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(vellumAdapter.sent).toHaveLength(1);
+      const deepLink = vellumAdapter.sent[0].deepLinkTarget;
+      expect(deepLink).toBeDefined();
+      expect(deepLink!.conversationId).toBe(originConvId);
+    });
+
+    test("omits conversationId from deep link when pairing returns no conversation and sourceContextId is a sentinel", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      // Sentinel sourceContextId (job ID, access-req-*, etc.) — getConversation returns null.
+      const signal = makeSignal({ sourceContextId: "access-req-sentinel-xyz" });
+      const decision = makeDecision();
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(vellumAdapter.sent).toHaveLength(1);
+      const deepLink = vellumAdapter.sent[0].deepLinkTarget;
+      // Decision did not carry a deepLinkTarget either — the resulting
+      // deep link should be undefined or have no conversationId.
+      expect(deepLink?.conversationId).toBeUndefined();
     });
   });
 });

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -186,6 +186,7 @@ async function dispatchGuardianQuestionInner(
       sourceEventName: "guardian.question",
       sourceChannel: "phone",
       sourceContextId: callSessionId,
+      requiresConversation: true,
       attentionHints: {
         requiresAction: true,
         urgency: "high",

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -11,6 +11,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { getConversation } from "../memory/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
 import { isGuardianSensitiveEvent } from "./adapters/macos.js";
 import { pairDeliveryWithConversation } from "./conversation-pairing.js";
@@ -231,76 +232,91 @@ export class NotificationBroadcaster {
       );
 
       // For the vellum channel, merge the conversationId into deep-link metadata
-      // so the macOS client can navigate directly to the notification conversation.
+      // so the macOS client can navigate directly to the conversation. Prefer
+      // the paired conversation (interactive opt-in flows); otherwise fall back
+      // to the originating conversation referenced by `sourceContextId` when it
+      // resolves to a real row. Sentinel context ids (job IDs, call session IDs,
+      // access-req-* strings) leave the deep link without a conversation, and
+      // the macOS handler opens the app to its default landing.
       let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === "vellum" && pairing.conversationId) {
-        deepLinkTarget = {
-          ...deepLinkTarget,
-          conversationId: pairing.conversationId,
-        };
-        if (pairing.messageId) {
-          deepLinkTarget = { ...deepLinkTarget, messageId: pairing.messageId };
-        }
-
-        // Resolve guardian scoping for conversation-created events so clients
-        // can filter guardian-sensitive conversations the same way they filter
-        // guardian-sensitive notification intents.
-        const guardianPrincipalId =
-          typeof destination.metadata?.guardianPrincipalId === "string"
-            ? destination.metadata.guardianPrincipalId
-            : undefined;
-        const targetGuardianPrincipalId =
-          guardianPrincipalId &&
-          isGuardianSensitiveEvent(signal.sourceEventName)
-            ? guardianPrincipalId
-            : undefined;
-
-        const conversationTitle =
-          copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-        const conversationSilent =
-          signal.attentionHints.urgency !== "high" &&
-          signal.attentionHints.urgency !== "critical";
-        const info: ConversationCreatedInfo = {
-          conversationId: pairing.conversationId,
-          title: conversationTitle,
-          sourceEventName: signal.sourceEventName,
-          targetGuardianPrincipalId,
-          groupId: signal.conversationMetadata?.groupId,
-          source: signal.conversationMetadata?.source,
-          silent: conversationSilent,
-        };
-
-        // The per-dispatch onConversationCreated callback fires whenever a vellum
-        // conversation is paired (new or reused) because callers like
-        // dispatchGuardianQuestion rely on it to create delivery bookkeeping
-        // rows before emitNotificationSignal() returns.
-        if (options?.onConversationCreated) {
-          try {
-            options.onConversationCreated(info);
-          } catch (err) {
-            log.error(
-              { err, signalId: signal.signalId },
-              "per-dispatch onConversationCreated callback failed — continuing broadcast",
-            );
+      if (channel === "vellum") {
+        const deepLinkConversationId =
+          pairing.conversationId ??
+          resolveSourceConversationId(signal.sourceContextId);
+        if (deepLinkConversationId) {
+          deepLinkTarget = {
+            ...deepLinkTarget,
+            conversationId: deepLinkConversationId,
+          };
+          if (pairing.messageId) {
+            deepLinkTarget = {
+              ...deepLinkTarget,
+              messageId: pairing.messageId,
+            };
           }
         }
 
-        // Emit notification_conversation_created event only when a NEW
-        // conversation was actually created. Reusing an existing conversation
-        // should not fire the event — the client already knows about the
-        // conversation.
-        if (
-          pairing.createdNewConversation &&
-          pairing.strategy === "start_new_conversation"
-        ) {
-          if (this.onConversationCreated) {
+        if (pairing.conversationId) {
+          // Resolve guardian scoping for conversation-created events so clients
+          // can filter guardian-sensitive conversations the same way they filter
+          // guardian-sensitive notification intents.
+          const guardianPrincipalId =
+            typeof destination.metadata?.guardianPrincipalId === "string"
+              ? destination.metadata.guardianPrincipalId
+              : undefined;
+          const targetGuardianPrincipalId =
+            guardianPrincipalId &&
+            isGuardianSensitiveEvent(signal.sourceEventName)
+              ? guardianPrincipalId
+              : undefined;
+
+          const conversationTitle =
+            copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+          const conversationSilent =
+            signal.attentionHints.urgency !== "high" &&
+            signal.attentionHints.urgency !== "critical";
+          const info: ConversationCreatedInfo = {
+            conversationId: pairing.conversationId,
+            title: conversationTitle,
+            sourceEventName: signal.sourceEventName,
+            targetGuardianPrincipalId,
+            groupId: signal.conversationMetadata?.groupId,
+            source: signal.conversationMetadata?.source,
+            silent: conversationSilent,
+          };
+
+          // The per-dispatch onConversationCreated callback fires whenever a vellum
+          // conversation is paired (new or reused) because callers like
+          // dispatchGuardianQuestion rely on it to create delivery bookkeeping
+          // rows before emitNotificationSignal() returns.
+          if (options?.onConversationCreated) {
             try {
-              this.onConversationCreated(info);
+              options.onConversationCreated(info);
             } catch (err) {
               log.error(
                 { err, signalId: signal.signalId },
-                "onConversationCreated callback failed — continuing broadcast",
+                "per-dispatch onConversationCreated callback failed — continuing broadcast",
               );
+            }
+          }
+
+          // Emit notification_conversation_created event only when a NEW
+          // conversation was actually created. Reusing an existing conversation
+          // should not fire the event — the client already knows about the
+          // conversation.
+          if (
+            pairing.createdNewConversation &&
+            pairing.strategy === "start_new_conversation"
+          ) {
+            if (this.onConversationCreated) {
+              try {
+                this.onConversationCreated(info);
+              } catch (err) {
+                log.error(
+                  { err, signalId: signal.signalId },
+                  "onConversationCreated callback failed — continuing broadcast",
+                );
+              }
             }
           }
         }
@@ -412,5 +428,22 @@ export class NotificationBroadcaster {
     }
 
     return results;
+  }
+}
+
+/**
+ * Resolve a signal's `sourceContextId` to a conversation id if it points at a
+ * real row. Producers may pass sentinels (job IDs, call session IDs,
+ * `access-req-*` strings) here; those simply return undefined so the deep
+ * link omits the conversation target.
+ */
+function resolveSourceConversationId(
+  sourceContextId: string | undefined,
+): string | undefined {
+  if (!sourceContextId) return undefined;
+  try {
+    return getConversation(sourceContextId) ? sourceContextId : undefined;
+  } catch {
+    return undefined;
   }
 }

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -113,6 +113,29 @@ export async function pairDeliveryWithConversation(
       };
     }
 
+    const conversationAction = options?.conversationAction;
+    const bindingContext = options?.bindingContext;
+
+    // Passive vellum notifications surface via the home feed alone and link
+    // back to the originating conversation via `signal.sourceContextId`.
+    // Materializing a fresh per-notification conversation just to host the
+    // seed message leaves a graveyard entry in the sidebar; skip it unless
+    // the producer opted in via `requiresConversation` or the decision engine
+    // requested explicit reuse of a target conversation.
+    if (
+      strategy === "start_new_conversation" &&
+      !signal.requiresConversation &&
+      conversationAction?.action !== "reuse_existing"
+    ) {
+      return {
+        conversationId: null,
+        messageId: null,
+        strategy,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+    }
+
     const title =
       copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
 
@@ -129,9 +152,6 @@ export async function pairDeliveryWithConversation(
     const messageContent = isConversationSeedSane(copy.conversationSeedMessage)
       ? copy.conversationSeedMessage
       : composeConversationSeed(signal, channel, copy);
-
-    const conversationAction = options?.conversationAction;
-    const bindingContext = options?.bindingContext;
 
     // Attempt to reuse an existing conversation when the model requests it
     if (conversationAction?.action === "reuse_existing") {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -188,6 +188,15 @@ export interface EmitSignalParams<TEventName extends string = string> {
     source?: string;
     conversationType?: ConversationCreateType;
   };
+  /**
+   * When true, the vellum-channel delivery materializes a fresh conversation
+   * to host the notification (and any follow-up interaction). Set this only
+   * for flows where the conversation IS the interaction surface — e.g.
+   * guardian.question, tool grant requests, ingress access requests. Passive
+   * notifications leave this unset; they surface via the home feed and link
+   * back to their originating conversation via `sourceContextId`.
+   */
+  requiresConversation?: boolean;
 }
 
 export interface EmitSignalResult {
@@ -223,6 +232,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     routingHints: params.routingHints,
     conversationAffinityHint: params.conversationAffinityHint,
     conversationMetadata: params.conversationMetadata,
+    requiresConversation: params.requiresConversation,
   };
 
   try {

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -213,4 +213,14 @@ export interface NotificationSignal<TEventName extends string = string> {
     source?: string;
     conversationType?: ConversationCreateType;
   };
+  /**
+   * When true, the vellum-channel delivery materializes a fresh conversation
+   * to host the notification (and any follow-up interaction). Set this only
+   * for flows where the conversation IS the interaction surface — e.g.
+   * guardian.question, tool grant requests, ingress access requests. Passive
+   * notifications (scheduler fired, watcher alert, activity complete, etc.)
+   * should leave this unset; they surface via the home feed and link back
+   * to their originating conversation via `sourceContextId`.
+   */
+  requiresConversation?: boolean;
 }

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -217,6 +217,7 @@ export function notifyGuardianOfAccessRequest(
     sourceEventName: "ingress.access_request",
     sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceContextId: `access-req-${sourceChannel}-${actorExternalId}`,
+    requiresConversation: true,
     ...(sameChannelOnly ? { routingIntent: "single_channel" as const } : {}),
     attentionHints: {
       requiresAction: true,

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -12,7 +12,6 @@
  * canonical records.
  */
 
-
 import type { TrustContext } from "../daemon/trust-context.js";
 import {
   type CanonicalGuardianRequest,
@@ -150,6 +149,7 @@ export function bridgeConfirmationRequestToGuardian(
     sourceEventName: "guardian.question",
     sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceContextId: conversationId,
+    requiresConversation: true,
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -147,6 +147,7 @@ export function createOrReuseToolGrantRequest(
     sourceEventName: "guardian.question",
     sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceContextId: conversationId,
+    requiresConversation: true,
     attentionHints: {
       requiresAction: true,
       urgency: "high",


### PR DESCRIPTION
## Summary
- Passive vellum notifications no longer create a per-notification conversation; they surface via the home feed and the "Go to conversation" button links to the originating conversation referenced by `sourceContextId`.
- Interactive flows (guardian.question, tool grants, ingress access requests) opt in via a new `requiresConversation: true` flag on the signal and keep their conversation creation behavior unchanged.
- macOS deep-link now prefers paired conversation → originating conversation (validated) → no conversation target; the macOS handler already opens the app to its default landing when no conversationId is set.

## Original prompt
> Right now, notifications result in a new conversation being created with the notification as the only message. This isn't very helpful. Can we stop creating these new conversations by default? The "Go to conversation" button on the notification in the homepage should link to the conversation where the notification was emitted not the new conversation.

The home feed's `resolveHomeFeedMirror` already preferred `signal.sourceContextId` for the deep link, so most of the work was forward-only: stop the unwanted creation in `pairDeliveryWithConversation`, plumb the same source-context fallback into the macOS deep link, and opt-in only the few callers (4) that genuinely depend on a paired conversation for follow-up bookkeeping. Existing notification conversations are left in users' sidebars (no migration).

## Test plan
- [ ] Trigger a passive vellum notification (e.g. via background-job-runner activity.failed) and confirm: home feed entry appears, no new sidebar conversation, "Go to conversation" links to the originating background job conversation.
- [ ] Trigger an interactive flow (guardian question, tool grant request) and confirm: conversation still materializes, deep link still navigates to it, downstream `createCanonicalGuardianDelivery` bookkeeping still fires.
- [ ] Click a passive notification banner on macOS; should open the app to its default landing (or to the resolved source conversation when present).