### PR TITLE
docs(notifications): guide assistants toward markdown body formatting

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -113,7 +113,7 @@ Examples:
         )
         .requiredOption(
           "--message <message>",
-          "Notification message the user should receive",
+          "Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text.",
         )
         .option(
           "--urgent",

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -30,7 +30,7 @@ assistant notifications send --title "..." --message "..." --urgent
 
 | Flag                  | Required | Description                                  |
 | --------------------- | -------- | -------------------------------------------- |
-| `--message <message>` | Yes      | Notification message the user should receive |
+| `--message <message>` | Yes      | Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text. |
 | `--title <title>`     | Yes in practice | Short headline (≤ 8 words). Omitting it triggers a body-truncation fallback that shows up as a duplicate of `--message` — always write a real title. |
 | `--urgent`            | No       | Mark as needing attention now/soon           |
 | `--json`              | No       | Output machine-readable JSON                 |
@@ -41,6 +41,21 @@ Write a `--title` for every notification. It's the only line the user sees in th
 
 Avoid restating the first sentence of `--message` verbatim — the title should add scannability, not duplicate.
 
+### Message
+
+The body renders as markdown (GFM) in the home feed detail panel — where the user actually opens the notification on web, iOS, and macOS. Light markdown makes multi-fact bodies scannable. The OS lock-screen banner shows the body as plain text, so prefer inline emphasis over heavy structure that looks ugly unrendered.
+
+Supported: `**bold**`, `*italic*`, `` `inline code` ``, fenced code blocks, links, bulleted and numbered lists, blockquotes, headings, GFM tables, `~~strikethrough~~`.
+
+Use it like this:
+
+- **Bold** the headline fact when the body has more than one sentence.
+- Bullets or numbered lists when surfacing multiple discrete items (failures, files touched, missed messages).
+- Inline `code` for identifiers, paths, commands, and short snippets.
+- Fenced code blocks for multi-line output (stack traces, diffs).
+
+Avoid large headings (`#`, `##`) and wide tables — they render fine in the panel but look noisy in the banner preview.
+
 ### Urgent semantics
 
 Use `--urgent` for items needing attention now/soon (blocked work, broken auth, time-sensitive issues). Skip for items the user should see when they have time.
@@ -48,15 +63,15 @@ Use `--urgent` for items needing attention now/soon (blocked work, broken auth, 
 ### Examples
 
 ```bash
-# Plain notification
+# Plain notification — bold the headline fact
 assistant notifications send \
   --title "Backup complete" \
-  --message "Nightly backup finished — 12.4 GB archived to cold storage."
+  --message "Nightly backup finished — **12.4 GB** archived to cold storage across **3** datasets."
 
-# Urgent notification
+# Urgent notification — inline code for the identifier
 assistant notifications send \
   --title "Auth token expired" \
-  --message "Sync is paused until you reauthenticate the GitHub integration." \
+  --message "Sync is paused until you reauthenticate the \`GitHub\` integration." \
   --urgent
 ```
 


### PR DESCRIPTION
## Summary

- Add a `### Message` section to the notifications SKILL.md noting that the body renders as GFM markdown in the home feed detail panel (web/iOS/macOS), with concrete guidance on when to reach for bold, lists, inline code, and fenced code blocks.
- Caution against heavy structure (large headings, wide tables) since the OS lock-screen banner shows the body as plain text.
- Refresh the two existing examples to demonstrate light markdown so the pattern is visible at a glance, and mirror the same one-line nudge into the CLI \`--message\` \`--help\` text (same pattern as the \`--title\` update in 3813b705da).

## Original prompt

Update the notifications skill to encourage readable formatting and mention that markdown is supported for the body. Confirmed via \`apps/web/src/domains/home/detail-panel/home-markdown-content.tsx\` that \`item.summary\` (which \`--message\` flows into) is rendered through \`react-markdown\` + \`remarkGfm\`, while the OS lock-screen banner remains plain text — so guidance should encourage light markdown that degrades gracefully.