### PR TITLE
feat: add Claude Opus 4.8 support

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.ts
+++ b/apps/web/src/assistant/llm-model-catalog.ts
@@ -22,6 +22,15 @@ export interface LlmCatalogModel {
 export const MODELS_BY_PROVIDER = {
   anthropic: [
     {
+      id: "claude-opus-4-8",
+      displayName: "Claude Opus 4.8",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
+    {
       id: "claude-opus-4-7",
       displayName: "Claude Opus 4.7",
       contextWindowTokens: 1_000_000,
@@ -226,6 +235,15 @@ export const MODELS_BY_PROVIDER = {
     },
   ],
   openrouter: [
+    {
+      id: "anthropic/claude-opus-4.8",
+      displayName: "Claude Opus 4.8",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
     {
       id: "anthropic/claude-opus-4.7",
       displayName: "Claude Opus 4.7",

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -190,7 +190,7 @@
       "scope": "assistant",
       "key": "fast-mode",
       "label": "Fast Mode",
-      "description": "Enable Anthropic fast mode for Opus models (4.6, 4.7), delivering up to 2.5x higher output tokens per second at premium pricing",
+      "description": "Enable Anthropic fast mode for Opus models (4.6, 4.7, 4.8), delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
     },
     {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -87,7 +87,7 @@ describe("AssistantConfigSchema", () => {
     // llm.default.{provider,model}, auth routing via provider_connections.
     expect(result.services.inference).toEqual({});
     expect(result.llm.default.provider).toBe("anthropic");
-    expect(result.llm.default.model).toBe("claude-opus-4-7");
+    expect(result.llm.default.model).toBe("claude-opus-4-8");
     expect(result.services["image-generation"].provider).toBe("gemini");
     expect(result.services["image-generation"].model).toBe(
       "gemini-3.1-flash-image-preview",
@@ -179,7 +179,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.llm).toBeDefined();
     expect(result.llm.default).toEqual({
       provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-4-8",
       maxTokens: 64000,
       effort: "max",
       speed: "standard",
@@ -318,7 +318,7 @@ describe("AssistantConfigSchema", () => {
       (result.services.inference as Record<string, unknown>).model,
     ).toBeUndefined();
     expect(result.llm.default.provider).toBe("anthropic");
-    expect(result.llm.default.model).toBe("claude-opus-4-7");
+    expect(result.llm.default.model).toBe("claude-opus-4-8");
   });
 
   test("partial llm config (empty `llm: {}`) doesn't trigger full config reset", () => {
@@ -333,7 +333,7 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.llm.default.maxTokens).toBe(32000);
     expect(result.llm.default.provider).toBe("anthropic");
-    expect(result.llm.default.model).toBe("claude-opus-4-7");
+    expect(result.llm.default.model).toBe("claude-opus-4-8");
   });
 
   test("llm.default with one missing field still parses (defaults applied)", () => {
@@ -2096,7 +2096,7 @@ describe("loadConfig with schema validation", () => {
     writeConfig({});
     const config = loadConfig();
     expect(config.llm.default.provider).toBe("anthropic");
-    expect(config.llm.default.model).toBe("claude-opus-4-7");
+    expect(config.llm.default.model).toBe("claude-opus-4-8");
     expect(config.llm.default.maxTokens).toBe(64000);
     expect(config.llm.default.thinking).toEqual({
       enabled: true,

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -72,7 +72,7 @@ describe("LLMSchema", () => {
     const parsed = LLMSchema.parse({});
     expect(parsed.default).toEqual({
       provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-4-8",
       maxTokens: 64000,
       effort: "max",
       speed: "standard",

--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -20,7 +20,7 @@ describe("model intents", () => {
       "claude-haiku-4-5-20251001",
     );
     expect(resolveModelIntent("anthropic", "quality-optimized")).toBe(
-      "claude-opus-4-7",
+      "claude-opus-4-8",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
       "claude-opus-4-6",
@@ -44,9 +44,9 @@ describe("model intents", () => {
   });
 
   test("falls back to provider default for unknown providers", () => {
-    expect(getProviderDefaultModel("unknown-provider")).toBe("claude-opus-4-7");
+    expect(getProviderDefaultModel("unknown-provider")).toBe("claude-opus-4-8");
     expect(resolveModelIntent("unknown-provider", "quality-optimized")).toBe(
-      "claude-opus-4-7",
+      "claude-opus-4-8",
     );
   });
 });

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -309,7 +309,7 @@ export const LLMConfigBase = z.object({
    * naturally — the underlying profile-level field is on `ProfileEntry`.
    */
   provider_connection: z.string().min(1).optional(),
-  model: ModelSchema.default("claude-opus-4-7"),
+  model: ModelSchema.default("claude-opus-4-8"),
   maxTokens: MaxTokensSchema.default(64000),
   effort: EffortEnum.default("max"),
   speed: SpeedEnum.default("standard"),

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -145,6 +145,23 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "claude-opus-4-8",
+        displayName: "Claude Opus 4.8",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens: 200000,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 5,
+          outputPer1mTokens: 25,
+          cacheWritePer1mTokens: 6.25,
+          cacheReadPer1mTokens: 0.5,
+        },
+      },
+      {
         id: "claude-opus-4-7",
         displayName: "Claude Opus 4.7",
         contextWindowTokens: 1000000,
@@ -244,7 +261,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
     ],
-    defaultModel: "claude-opus-4-7",
+    defaultModel: "claude-opus-4-8",
     apiKeyUrl: "https://console.anthropic.com/settings/keys",
     apiKeyPlaceholder: "sk-ant-api03-...",
   },
@@ -703,6 +720,23 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // OpenRouter proxies anthropic/* through Anthropic's Messages API, so
       // prompt caching and cache TTL metadata pass through unchanged and
       // billing matches Anthropic's direct rates.
+      {
+        id: "anthropic/claude-opus-4.8",
+        displayName: "Claude Opus 4.8",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens: 200000,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 5,
+          outputPer1mTokens: 25,
+          cacheWritePer1mTokens: 6.25,
+          cacheReadPer1mTokens: 0.5,
+        },
+      },
       {
         id: "anthropic/claude-opus-4.7",
         displayName: "Claude Opus 4.7",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -13,7 +13,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     balanced: "claude-sonnet-4-6",
     "latency-optimized": "claude-haiku-4-5-20251001",
-    "quality-optimized": "claude-opus-4-7",
+    "quality-optimized": "claude-opus-4-8",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
@@ -43,12 +43,12 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   openrouter: {
     balanced: "anthropic/claude-sonnet-4.6",
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-opus-4.7",
+    "quality-optimized": "anthropic/claude-opus-4.8",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };
 
-const FALLBACK_DEFAULT_MODEL = "claude-opus-4-7";
+const FALLBACK_DEFAULT_MODEL = "claude-opus-4-8";
 
 const MODEL_INTENTS = new Set<ModelIntent>([
   "balanced",

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -15,8 +15,27 @@
         "linkLabel": "Open Anthropic Console"
       },
       "supportsPlatformAuth": true,
-      "defaultModel": "claude-opus-4-7",
+      "defaultModel": "claude-opus-4-8",
       "models": [
+        {
+          "id": "claude-opus-4-8",
+          "displayName": "Claude Opus 4.8",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
+          }
+        },
         {
           "id": "claude-opus-4-7",
           "displayName": "Claude Opus 4.7",
@@ -628,6 +647,25 @@
       "supportsPlatformAuth": false,
       "defaultModel": "x-ai/grok-4.20-beta",
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8",
+          "displayName": "Claude Opus 4.8",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
+          }
+        },
         {
           "id": "anthropic/claude-opus-4.7",
           "displayName": "Claude Opus 4.7",

--- a/evals/src/lib/pricing.ts
+++ b/evals/src/lib/pricing.ts
@@ -57,6 +57,7 @@ const PRICING_TABLE: Record<string, ModelRow> = {
   // generation is priced at $5/$25 in the catalog (older Opus 3.x and
   // pre-4.5 Opus generations carried the $15/$75 rate but are not in
   // the evals profile coverage set).
+  "anthropic:claude-opus-4-8": { inputPer1M: 5, outputPer1M: 25 },
   "anthropic:claude-opus-4-7": { inputPer1M: 5, outputPer1M: 25 },
   "anthropic:claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
   "anthropic:claude-opus-4-5": { inputPer1M: 5, outputPer1M: 25 },

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -190,7 +190,7 @@
       "scope": "assistant",
       "key": "fast-mode",
       "label": "Fast Mode",
-      "description": "Enable Anthropic fast mode for Opus models (4.6, 4.7), delivering up to 2.5x higher output tokens per second at premium pricing",
+      "description": "Enable Anthropic fast mode for Opus models (4.6, 4.7, 4.8), delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
     },
     {

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -15,8 +15,27 @@
         "linkLabel": "Open Anthropic Console"
       },
       "supportsPlatformAuth": true,
-      "defaultModel": "claude-opus-4-7",
+      "defaultModel": "claude-opus-4-8",
       "models": [
+        {
+          "id": "claude-opus-4-8",
+          "displayName": "Claude Opus 4.8",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
+          }
+        },
         {
           "id": "claude-opus-4-7",
           "displayName": "Claude Opus 4.7",
@@ -628,6 +647,25 @@
       "supportsPlatformAuth": false,
       "defaultModel": "x-ai/grok-4.20-beta",
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8",
+          "displayName": "Claude Opus 4.8",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
+          }
+        },
         {
           "id": "anthropic/claude-opus-4.7",
           "displayName": "Claude Opus 4.7",

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -208,7 +208,7 @@ assistant inference providers connections create my-anthropic-key \
   --auth api_key \
   --credential credential/anthropic/api_key
 
-assistant config set llm.profiles.opus-personal '{"provider":"anthropic","model":"claude-opus-4-7","label":"Opus (Personal)","provider_connection":"my-anthropic-key"}'
+assistant config set llm.profiles.opus-personal '{"provider":"anthropic","model":"claude-opus-4-8","label":"Opus (Personal)","provider_connection":"my-anthropic-key"}'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-8` (Anthropic) and `anthropic/claude-opus-4.8` (OpenRouter) to the model catalog with the same pricing and capabilities as 4.7 (1M context, 128k max output, thinking/caching/vision/tool-use, $5/$25/$6.25/$0.50 per 1M)
- Promote 4.8 to the new default everywhere 4.7 was the default: Anthropic provider `defaultModel`, `quality-optimized` intent for `anthropic` and `openrouter`, `FALLBACK_DEFAULT_MODEL`, and the `llm.default.model` schema default. 4.7 stays in the catalog as a selectable option; user configs that pin 4.7 keep working
- Update the fast-mode feature-flag description to mention 4.8, refresh the `llm-cost-optimizer` SKILL.md example, and add an `anthropic:claude-opus-4-8` row to the evals pricing table

## Original prompt
Anthropic released Claude Opus 4.8 today. The ask was to add support for 4.8 everywhere we currently support 4.7, including through OpenRouter (called out explicitly). Per clarifying decisions: 4.8 becomes the new default in every place 4.7 is currently the default, pricing/capabilities mirror 4.7 exactly, and the fast-mode flag description grows to include 4.8.