### PR TITLE
Add notifications edit subcommand

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -620,6 +620,157 @@ Examples:
             }
           },
         );
+
+      // -------------------------------------------------------------------------
+      // edit
+      // -------------------------------------------------------------------------
+
+      notifications
+        .command("edit")
+        .description(
+          "Edit an already-sent notification. Patches the home-feed entry and updates the delivered channel message in place where supported (Slack today).",
+        )
+        .requiredOption(
+          "--id <id>",
+          "Feed item id (notif:<uuid>) from `notifications list --json`. Bare uuids without the `notif:` prefix are also accepted.",
+        )
+        .option(
+          "--message <message>",
+          "New notification body. Updates the home-feed summary and the delivered channel message text where supported.",
+        )
+        .option("--title <title>", "New short headline (≤ 8 words).")
+        .option(
+          "--urgency <urgency>",
+          "Set urgency (low|medium|high|critical). Feed-only — does not re-push channel messages.",
+        )
+        .option(
+          "--status <status>",
+          "Set lifecycle status (new|seen|acted_on|dismissed). Feed-only.",
+        )
+        .addHelpText(
+          "after",
+          `
+At least one of --message, --title, --urgency, or --status must be
+supplied. --urgency and --status only update the home-feed entry —
+they never re-push channel messages.
+
+Channel updates are best-effort: Slack messages get updated via
+chat.update; other channels (push, email, SMS) cannot be edited and
+are reported as "unsupported".
+
+Examples:
+  $ assistant notifications edit --id notif:abc12345-... --message "Fixed body"
+  $ assistant notifications edit --id abc12345-... --title "Backup complete"
+  $ assistant notifications edit --id notif:abc12345-... --urgency low
+  $ assistant notifications edit --id notif:abc12345-... --status dismissed`,
+        )
+        .action(
+          async (
+            opts: {
+              id: string;
+              message?: string;
+              title?: string;
+              urgency?: string;
+              status?: string;
+            },
+            cmd: Command,
+          ) => {
+            try {
+              const id = opts.id.trim();
+              if (!id) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: "--id must be a non-empty string",
+                });
+                process.exitCode = 1;
+                return;
+              }
+
+              if (
+                opts.message === undefined &&
+                opts.title === undefined &&
+                opts.urgency === undefined &&
+                opts.status === undefined
+              ) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error:
+                    "At least one of --message, --title, --urgency, or --status must be supplied",
+                });
+                process.exitCode = 1;
+                return;
+              }
+
+              if (
+                opts.urgency != null &&
+                !["low", "medium", "high", "critical"].includes(opts.urgency)
+              ) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: `Invalid urgency "${opts.urgency}". Must be one of: low, medium, high, critical`,
+                });
+                process.exitCode = 1;
+                return;
+              }
+              if (
+                opts.status != null &&
+                !["new", "seen", "acted_on", "dismissed"].includes(opts.status)
+              ) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: `Invalid status "${opts.status}". Must be one of: new, seen, acted_on, dismissed`,
+                });
+                process.exitCode = 1;
+                return;
+              }
+
+              const body: Record<string, unknown> = { id };
+              if (opts.message !== undefined) body.body = opts.message;
+              if (opts.title !== undefined) body.title = opts.title;
+              if (opts.urgency !== undefined) body.urgency = opts.urgency;
+              if (opts.status !== undefined) body.status = opts.status;
+
+              const result = await cliIpcCall<{
+                feedItem: FeedItem;
+                channels: Array<{
+                  channel: string;
+                  deliveryId: string;
+                  outcome: "updated" | "unsupported" | "skipped" | "failed";
+                  reason?: string;
+                }>;
+              }>("edit_notification", { body });
+
+              if (!result.ok) {
+                writeOutput(cmd, { ok: false, error: result.error });
+                process.exitCode = exitCodeFromIpcResult(result);
+                return;
+              }
+
+              const payload = result.result!;
+              writeOutput(cmd, { ok: true, ...payload });
+
+              if (!shouldOutputJson(cmd)) {
+                const item = payload.feedItem;
+                log.info(`Updated ${item.id}`);
+                const headline = item.title ?? item.summary;
+                log.info(`  ${headline}`);
+                if (payload.channels.length === 0) {
+                  log.info("  No channel deliveries to update.");
+                } else {
+                  log.info("  Channels:");
+                  for (const ch of payload.channels) {
+                    const reason = ch.reason ? ` — ${ch.reason}` : "";
+                    log.info(`    ${ch.channel}: ${ch.outcome}${reason}`);
+                  }
+                }
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              writeOutput(cmd, { ok: false, error: message });
+              process.exitCode = 1;
+            }
+          },
+        );
     },
   });
 }

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -44,6 +44,7 @@ import { getDataDir } from "../util/platform.js";
 import {
   type FeedItem,
   type FeedItemStatus,
+  type FeedItemUrgency,
   type HomeFeedFile,
   parseFeedFile,
 } from "./feed-types.js";
@@ -156,6 +157,38 @@ export async function patchFeedItemStatus(
 }
 
 /**
+ * Patch the user-editable copy fields on a single feed item by id.
+ *
+ * Returns the updated `FeedItem`, or `null` if no item with the given
+ * id exists. Used by the `assistant notifications edit` flow. Patches
+ * are applied inside the same coalescing queue as appends and status
+ * patches so overlapping writes don't race.
+ *
+ * Only fields explicitly present on `patch` are touched. Pass an empty
+ * object and the call is a no-op that returns the existing item (or
+ * `null` if the id isn't on disk).
+ */
+export interface FeedItemContentPatch {
+  title?: string;
+  summary?: string;
+  urgency?: FeedItemUrgency;
+  status?: FeedItemStatus;
+}
+
+export async function patchFeedItemContent(
+  id: string,
+  patch: FeedItemContentPatch,
+): Promise<FeedItem | null> {
+  let resolveResult!: (value: FeedItem | null) => void;
+  const resultPromise = new Promise<FeedItem | null>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingContentPatches.push({ id, patch, resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
+/**
  * Remove the `conversationId` field from all feed items that reference
  * the given conversation. Returns the number of items modified.
  *
@@ -202,6 +235,11 @@ const pendingPatches: Array<{
   status: FeedItemStatus;
   resolve: (value: FeedItem | null) => void;
 }> = [];
+const pendingContentPatches: Array<{
+  id: string;
+  patch: FeedItemContentPatch;
+  resolve: (value: FeedItem | null) => void;
+}> = [];
 const pendingStrips: Array<{
   conversationId: string;
   resolve: (count: number) => void;
@@ -244,6 +282,10 @@ function scheduleWrite(): Promise<void> {
 async function runWrite(): Promise<void> {
   const appendsToApply = pendingAppends.splice(0, pendingAppends.length);
   const patchesToApply = pendingPatches.splice(0, pendingPatches.length);
+  const contentPatchesToApply = pendingContentPatches.splice(
+    0,
+    pendingContentPatches.length,
+  );
   const stripsToApply = pendingStrips.splice(0, pendingStrips.length);
 
   const current = readHomeFeed();
@@ -270,6 +312,39 @@ async function runWrite(): Promise<void> {
     const updated: FeedItem = { ...items[idx]!, status: patch.status };
     items[idx] = updated;
     patchResults.push({ resolve: patch.resolve, value: updated });
+  }
+
+  const contentPatchResults: Array<{
+    resolve: (v: FeedItem | null) => void;
+    value: FeedItem | null;
+  }> = [];
+  for (const { id, patch, resolve } of contentPatchesToApply) {
+    const idx = items.findIndex((i) => i.id === id);
+    if (idx === -1) {
+      contentPatchResults.push({ resolve, value: null });
+      continue;
+    }
+    const existing = items[idx]!;
+    const updated: FeedItem = { ...existing };
+    if (patch.title !== undefined) {
+      const trimmed = patch.title.trim();
+      if (trimmed.length === 0) {
+        delete updated.title;
+      } else {
+        updated.title = trimmed;
+      }
+    }
+    if (patch.summary !== undefined) {
+      updated.summary = patch.summary;
+    }
+    if (patch.urgency !== undefined) {
+      updated.urgency = patch.urgency;
+    }
+    if (patch.status !== undefined) {
+      updated.status = patch.status;
+    }
+    items[idx] = updated;
+    contentPatchResults.push({ resolve, value: updated });
   }
 
   // Strip conversationId from matching items.
@@ -325,6 +400,9 @@ async function runWrite(): Promise<void> {
   // promises with `0` — the state was not persisted, and callers must
   // not report success when the underlying write failed.
   for (const { resolve, value } of patchResults) {
+    resolve(wrote ? value : null);
+  }
+  for (const { resolve, value } of contentPatchResults) {
     resolve(wrote ? value : null);
   }
   for (const { resolve, count } of stripResults) {

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -16,6 +16,8 @@ import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
   ChannelDestination,
+  ChannelUpdateContext,
+  ChannelUpdatePayload,
   DeliveryResult,
   NotificationChannel,
 } from "../types.js";
@@ -52,9 +54,7 @@ function resolveSlackMessageText(payload: ChannelDeliveryPayload): string {
  * - Optional context: message preview
  * - Context: approval code instructions + invite directive
  */
-function buildAccessRequestBlocks(
-  payload: Record<string, unknown>,
-): unknown[] {
+function buildAccessRequestBlocks(payload: Record<string, unknown>): unknown[] {
   const blocks: unknown[] = [];
 
   // Header
@@ -209,24 +209,58 @@ export class SlackAdapter implements ChannelAdapter {
       payload.contextPayload != null;
 
     try {
-      if (isAccessRequest) {
-        const blocks = buildAccessRequestBlocks(payload.contextPayload!);
-        await sendSlackReply(chatId, messageText, { blocks });
-      } else {
-        await sendSlackReply(chatId, messageText, { useBlocks: true });
-      }
+      const result = isAccessRequest
+        ? await sendSlackReply(chatId, messageText, {
+            blocks: buildAccessRequestBlocks(payload.contextPayload!),
+          })
+        : await sendSlackReply(chatId, messageText, { useBlocks: true });
 
       log.info(
-        { sourceEventName: payload.sourceEventName, chatId },
+        { sourceEventName: payload.sourceEventName, chatId, ts: result.ts },
         "Slack notification delivered",
       );
 
-      return { success: true };
+      return { success: true, messageId: result.ts };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(
         { err, sourceEventName: payload.sourceEventName, chatId },
         "Failed to deliver Slack notification",
+      );
+      return { success: false, error: message };
+    }
+  }
+
+  async update(
+    delivery: ChannelUpdateContext,
+    patch: ChannelUpdatePayload,
+  ): Promise<DeliveryResult> {
+    if (!delivery.messageId) {
+      return {
+        success: false,
+        error:
+          "missing_message_id: this delivery has no captured Slack ts (sent before edit support landed)",
+      };
+    }
+    const text = patch.body?.trim() || patch.title?.trim();
+    if (!text) {
+      return { success: false, error: "no body or title supplied for update" };
+    }
+    try {
+      const result = await sendSlackReply(delivery.destination, text, {
+        messageTs: delivery.messageId,
+        useBlocks: true,
+      });
+      log.info(
+        { chatId: delivery.destination, messageTs: delivery.messageId },
+        "Slack notification updated",
+      );
+      return { success: true, messageId: result.ts ?? delivery.messageId };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, chatId: delivery.destination, messageTs: delivery.messageId },
+        "Failed to update Slack notification",
       );
       return { success: false, error: message };
     }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -73,6 +73,11 @@ export class NotificationBroadcaster {
     this.onConversationCreated = fn;
   }
 
+  /** Return the registered adapter for a channel, if any. */
+  getAdapter(channel: NotificationChannel): ChannelAdapter | undefined {
+    return this.adapters.get(channel);
+  }
+
   /**
    * Broadcast a notification decision to all selected channels.
    *
@@ -370,8 +375,21 @@ export class NotificationBroadcaster {
         const adapterResult = await adapter.send(payload, destination);
 
         if (adapterResult.success) {
+          // Prefer the channel-native id the adapter just captured (e.g.
+          // Slack `ts`) so later edits can target the same message; fall
+          // back to the pairing-supplied id for channels that surface it
+          // through conversation pairing instead.
+          const resolvedMessageId =
+            adapterResult.messageId ?? pairing.messageId ?? undefined;
           if (hasPersistedDecision) {
-            updateDeliveryStatus(deliveryId, "sent");
+            updateDeliveryStatus(
+              deliveryId,
+              "sent",
+              undefined,
+              adapterResult.messageId
+                ? { messageId: adapterResult.messageId }
+                : undefined,
+            );
           }
           results.push({
             channel,
@@ -379,7 +397,7 @@ export class NotificationBroadcaster {
             status: "sent",
             sentAt: Date.now(),
             conversationId: pairing.conversationId ?? undefined,
-            messageId: pairing.messageId ?? undefined,
+            messageId: resolvedMessageId,
             conversationStrategy: pairing.strategy,
           });
         } else {

--- a/assistant/src/notifications/decisions-store.ts
+++ b/assistant/src/notifications/decisions-store.ts
@@ -7,7 +7,7 @@
  * were routed.
  */
 
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { getDb } from "../memory/db-connection.js";
 import { notificationDecisions } from "../memory/schema.js";
@@ -93,4 +93,35 @@ export function updateDecision(id: string, params: UpdateDecisionParams): void {
     .set(updates)
     .where(eq(notificationDecisions.id, id))
     .run();
+}
+
+/**
+ * Return the most recent decision for a given notification event, or
+ * `undefined` if none exists. The decision engine writes exactly one
+ * decision per event today, but ordering by createdAt DESC keeps this
+ * stable if that ever changes (e.g. re-decisions on retry).
+ */
+export function findLatestDecisionByEventId(
+  eventId: string,
+): NotificationDecisionRow | undefined {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(notificationDecisions)
+    .where(eq(notificationDecisions.notificationEventId, eventId))
+    .orderBy(desc(notificationDecisions.createdAt))
+    .get();
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    notificationEventId: row.notificationEventId,
+    shouldNotify: row.shouldNotify === 1,
+    selectedChannels: row.selectedChannels,
+    reasoningSummary: row.reasoningSummary,
+    confidence: row.confidence,
+    fallbackUsed: row.fallbackUsed === 1,
+    promptVersion: row.promptVersion,
+    validationResults: row.validationResults,
+    createdAt: row.createdAt,
+  };
 }

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -137,6 +137,7 @@ export function updateDeliveryStatus(
   id: string,
   status: NotificationDeliveryStatus,
   error?: { code?: string; message?: string },
+  patch?: { messageId?: string },
 ): boolean {
   const db = getDb();
   const now = Date.now();
@@ -151,8 +152,39 @@ export function updateDeliveryStatus(
   if (error?.message) {
     updates.errorMessage = error.message;
   }
+  if (patch?.messageId !== undefined) {
+    updates.messageId = patch.messageId;
+  }
 
   db.update(notificationDeliveries)
+    .set(updates)
+    .where(eq(notificationDeliveries.id, id))
+    .run();
+
+  return rawChanges() > 0;
+}
+
+/**
+ * Update the rendered copy on an existing delivery row.
+ *
+ * Used by the edit pipeline so the delivery audit reflects the latest
+ * title/body shown to the user, not just the original send.
+ */
+export function updateDeliveryRenderedCopy(
+  id: string,
+  patch: { renderedTitle?: string; renderedBody?: string },
+): boolean {
+  const updates: Record<string, unknown> = { updatedAt: Date.now() };
+  if (patch.renderedTitle !== undefined) {
+    updates.renderedTitle = patch.renderedTitle;
+  }
+  if (patch.renderedBody !== undefined) {
+    updates.renderedBody = patch.renderedBody;
+  }
+  if (Object.keys(updates).length === 1) return false;
+
+  getDb()
+    .update(notificationDeliveries)
     .set(updates)
     .where(eq(notificationDeliveries.id, id))
     .run();
@@ -177,4 +209,17 @@ export function findDeliveryByDecisionAndChannel(
     )
     .get();
   return row ? rowToDelivery(row) : undefined;
+}
+
+/** Return every delivery row for a given decision. */
+export function findDeliveriesByDecisionId(
+  decisionId: string,
+): NotificationDeliveryRow[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(notificationDeliveries)
+    .where(eq(notificationDeliveries.notificationDecisionId, decisionId))
+    .all();
+  return rows.map(rowToDelivery);
 }

--- a/assistant/src/notifications/edit-notification.ts
+++ b/assistant/src/notifications/edit-notification.ts
@@ -1,0 +1,201 @@
+/**
+ * Edit an already-sent notification.
+ *
+ * Patches the home-feed entry the user actually sees, then attempts a
+ * best-effort update of any per-channel deliveries that support
+ * in-place edits (Slack via chat.update today). Feed-only fields
+ * (`urgency`, `status`) skip the channel hop — channel messages don't
+ * carry that metadata, only body/title.
+ */
+
+import {
+  type FeedItem,
+  type FeedItemStatus,
+  type FeedItemUrgency,
+} from "../home/feed-types.js";
+import { patchFeedItemContent } from "../home/feed-writer.js";
+import { getLogger } from "../util/logger.js";
+import { findLatestDecisionByEventId } from "./decisions-store.js";
+import {
+  findDeliveriesByDecisionId,
+  type NotificationDeliveryRow,
+  updateDeliveryRenderedCopy,
+} from "./deliveries-store.js";
+import { getBroadcaster } from "./emit-signal.js";
+import type { NotificationChannel } from "./types.js";
+
+const log = getLogger("edit-notification");
+
+/** Prefix used by `home-feed-side-effect` when minting feed item ids. */
+export const FEED_ITEM_ID_PREFIX = "notif:";
+
+export interface EditNotificationParams {
+  /** Feed item id (`notif:<uuid>`) or bare signal uuid. */
+  id: string;
+  title?: string;
+  body?: string;
+  urgency?: FeedItemUrgency;
+  status?: FeedItemStatus;
+}
+
+export type ChannelEditOutcome =
+  | "updated"
+  | "unsupported"
+  | "skipped"
+  | "failed";
+
+export interface ChannelEditResult {
+  channel: NotificationChannel;
+  deliveryId: string;
+  outcome: ChannelEditOutcome;
+  /** Reason for skip/failure when `outcome` is not `"updated"`. */
+  reason?: string;
+}
+
+export interface EditNotificationResult {
+  feedItem: FeedItem;
+  channels: ChannelEditResult[];
+}
+
+/**
+ * Normalize a user-supplied id into the canonical feed-item form
+ * (`notif:<uuid>`). Accepts either the full prefixed id or a bare uuid.
+ */
+export function normalizeFeedItemId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.startsWith(FEED_ITEM_ID_PREFIX)) return trimmed;
+  return `${FEED_ITEM_ID_PREFIX}${trimmed}`;
+}
+
+/** Strip the `notif:` prefix to recover the original signal/event id. */
+export function feedItemIdToSignalId(feedItemId: string): string {
+  return feedItemId.startsWith(FEED_ITEM_ID_PREFIX)
+    ? feedItemId.slice(FEED_ITEM_ID_PREFIX.length)
+    : feedItemId;
+}
+
+/**
+ * Apply an edit to a previously-sent notification.
+ *
+ * Returns the updated feed item plus per-channel update outcomes.
+ * Resolves to `null` when the feed item id isn't on disk so callers
+ * can surface a clear "not found" to the user.
+ */
+export async function editNotification(
+  params: EditNotificationParams,
+): Promise<EditNotificationResult | null> {
+  const feedItemId = normalizeFeedItemId(params.id);
+
+  const feedItem = await patchFeedItemContent(feedItemId, {
+    title: params.title,
+    summary: params.body,
+    urgency: params.urgency,
+    status: params.status,
+  });
+  if (!feedItem) {
+    log.warn({ feedItemId }, "Edit requested for unknown feed item");
+    return null;
+  }
+
+  // Only edit channel messages when the user-visible text changed.
+  // Urgency/status are feed-only — pushing a channel update for those
+  // alone would re-deliver the same body and confuse the recipient.
+  const shouldUpdateChannels =
+    params.title !== undefined || params.body !== undefined;
+  if (!shouldUpdateChannels) {
+    return { feedItem, channels: [] };
+  }
+
+  const signalId = feedItemIdToSignalId(feedItemId);
+  const decision = findLatestDecisionByEventId(signalId);
+  if (!decision) {
+    log.info(
+      { feedItemId, signalId },
+      "Feed item has no persisted decision — skipping channel updates",
+    );
+    return { feedItem, channels: [] };
+  }
+
+  const deliveries = findDeliveriesByDecisionId(decision.id);
+  const channels = await updateChannelDeliveries(deliveries, {
+    title: params.title,
+    body: params.body,
+  });
+
+  return { feedItem, channels };
+}
+
+async function updateChannelDeliveries(
+  deliveries: NotificationDeliveryRow[],
+  patch: { title?: string; body?: string },
+): Promise<ChannelEditResult[]> {
+  const broadcaster = getBroadcaster();
+  const results: ChannelEditResult[] = [];
+
+  for (const delivery of deliveries) {
+    const channel = delivery.channel as NotificationChannel;
+    if (delivery.status !== "sent") {
+      results.push({
+        channel,
+        deliveryId: delivery.id,
+        outcome: "skipped",
+        reason: `delivery status is ${delivery.status}`,
+      });
+      continue;
+    }
+
+    const adapter = broadcaster.getAdapter(channel);
+    if (!adapter?.update) {
+      results.push({
+        channel,
+        deliveryId: delivery.id,
+        outcome: "unsupported",
+        reason: `${channel} adapter does not support in-place edits`,
+      });
+      continue;
+    }
+
+    try {
+      const result = await adapter.update(
+        {
+          deliveryId: delivery.id,
+          destination: delivery.destination,
+          messageId: delivery.messageId,
+        },
+        patch,
+      );
+      if (!result.success) {
+        results.push({
+          channel,
+          deliveryId: delivery.id,
+          outcome: "failed",
+          reason: result.error ?? "unknown error",
+        });
+        continue;
+      }
+      updateDeliveryRenderedCopy(delivery.id, {
+        renderedTitle: patch.title,
+        renderedBody: patch.body,
+      });
+      results.push({
+        channel,
+        deliveryId: delivery.id,
+        outcome: "updated",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, channel, deliveryId: delivery.id },
+        "Channel adapter update threw",
+      );
+      results.push({
+        channel,
+        deliveryId: delivery.id,
+        outcome: "failed",
+        reason: message,
+      });
+    }
+  }
+
+  return results;
+}

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -51,7 +51,7 @@ const log = getLogger("emit-signal");
 
 let broadcasterInstance: NotificationBroadcaster | null = null;
 
-function getBroadcaster(): NotificationBroadcaster {
+export function getBroadcaster(): NotificationBroadcaster {
   if (!broadcasterInstance) {
     broadcasterInstance = new NotificationBroadcaster([
       new VellumAdapter(broadcastMessage),

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -45,6 +45,12 @@ export interface NotificationDeliveryResult {
 export interface DeliveryResult {
   success: boolean;
   error?: string;
+  /**
+   * Channel-native message identifier captured at send time (e.g. Slack `ts`).
+   * Persisted onto `notification_deliveries.messageId` so later edits can
+   * target the same message via `ChannelAdapter.update()`.
+   */
+  messageId?: string;
 }
 
 /** Resolved destination for a specific channel. */
@@ -91,6 +97,16 @@ export interface ChannelDeliveryPayload {
   urgency: AttentionHints["urgency"];
 }
 
+/**
+ * Patch supplied when an already-delivered notification is edited.
+ * Adapters only need to act on `title` and `body` — feed-only fields
+ * like `urgency` and `status` are handled by the home-feed patch.
+ */
+export interface ChannelUpdatePayload {
+  title?: string;
+  body?: string;
+}
+
 /** Interface that each channel adapter must implement. */
 export interface ChannelAdapter {
   channel: NotificationChannel;
@@ -98,6 +114,27 @@ export interface ChannelAdapter {
     payload: ChannelDeliveryPayload,
     destination: ChannelDestination,
   ): Promise<DeliveryResult>;
+  /**
+   * Optional: edit a previously-sent message in place. Channels that
+   * cannot edit (push, email, SMS) omit this and the router treats
+   * them as `"unsupported"`. Adapters that implement it use
+   * `delivery.messageId` (captured at send time) as the channel-native
+   * handle for the in-place update.
+   */
+  update?(
+    delivery: ChannelUpdateContext,
+    patch: ChannelUpdatePayload,
+  ): Promise<DeliveryResult>;
+}
+
+/** Per-delivery state an adapter needs to update a previously-sent message. */
+export interface ChannelUpdateContext {
+  /** notification_deliveries.id */
+  deliveryId: string;
+  /** Channel-native destination (e.g. Slack chat id). */
+  destination: string;
+  /** Channel-native message identifier captured at send time. */
+  messageId: string | null;
 }
 
 // -- Decision engine output ---------------------------------------------------

--- a/assistant/src/runtime/routes/notification-routes.ts
+++ b/assistant/src/runtime/routes/notification-routes.ts
@@ -8,10 +8,11 @@ import { z } from "zod";
 import { getDb } from "../../memory/db-connection.js";
 import { notificationDeliveries } from "../../memory/schema.js";
 import { bufferIfDeferred } from "../../notifications/deferred-emit.js";
+import { editNotification } from "../../notifications/edit-notification.js";
 import { emitNotificationSignal } from "../../notifications/emit-signal.js";
 import { listEvents } from "../../notifications/events-store.js";
 import type { AttentionHints } from "../../notifications/signal.js";
-import { BadRequestError } from "./errors.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 function handleNotificationIntentResult({ body = {} }: RouteHandlerArgs) {
@@ -89,6 +90,26 @@ const ListNotificationEventsParams = z.object({
   sourceEventName: z.string().optional(),
 });
 
+const EditNotificationParams = z
+  .object({
+    id: z.string().min(1).describe("Feed item id (notif:<uuid>) or bare uuid"),
+    title: z.string().optional(),
+    body: z.string().optional(),
+    urgency: z.enum(["low", "medium", "high", "critical"]).optional(),
+    status: z.enum(["new", "seen", "acted_on", "dismissed"]).optional(),
+  })
+  .refine(
+    (v) =>
+      v.title !== undefined ||
+      v.body !== undefined ||
+      v.urgency !== undefined ||
+      v.status !== undefined,
+    {
+      message:
+        "At least one of `title`, `body`, `urgency`, or `status` must be supplied",
+    },
+  );
+
 // ── Notification pipeline handlers ───────────────────────────────────
 
 async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
@@ -122,6 +143,19 @@ async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
     dispatched: result.dispatched,
     deduplicated: result.deduplicated,
     reason: result.reason,
+  };
+}
+
+async function handleEditNotification({ body = {} }: RouteHandlerArgs) {
+  const validated = EditNotificationParams.parse(body);
+  const result = await editNotification(validated);
+  if (!result) {
+    throw new NotFoundError(`No notification found for id ${validated.id}`);
+  }
+  return {
+    ok: true,
+    feedItem: result.feedItem,
+    channels: result.channels,
   };
 }
 
@@ -174,6 +208,34 @@ export const ROUTES: RouteDefinition[] = [
       deduplicated: z.boolean(),
       reason: z.string(),
     }),
+  },
+  {
+    operationId: "edit_notification",
+    endpoint: "notifications/edit",
+    method: "POST",
+    handler: handleEditNotification,
+    summary: "Edit an already-sent notification",
+    description:
+      "Patch the home-feed entry for a notification and, where supported (Slack today), update the delivered message in place.",
+    tags: ["notifications"],
+    requestBody: EditNotificationParams,
+    responseBody: z.object({
+      ok: z.boolean(),
+      feedItem: z.record(z.string(), z.unknown()),
+      channels: z.array(
+        z.object({
+          channel: z.string(),
+          deliveryId: z.string(),
+          outcome: z.enum(["updated", "unsupported", "skipped", "failed"]),
+          reason: z.string().optional(),
+        }),
+      ),
+    }),
+    additionalResponses: {
+      "404": {
+        description: "No notification found for the supplied id",
+      },
+    },
   },
   {
     operationId: "list_notification_events",

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -142,6 +142,73 @@ assistant notifications list --limit 20 --offset 20 --json
 }
 ```
 
+## Editing Notifications
+
+Use `edit` when an already-sent notification needs revising — a typo in the body, a status update on something you previously surfaced (e.g. "in progress" → "done"), or de-escalating the urgency of a stale alert. **Prefer editing over re-sending**: a fresh notification with the corrected text creates duplicate noise in the user's inbox and pings them twice.
+
+```bash
+assistant notifications edit --id <notif:uuid> --message "Corrected body"
+```
+
+### Finding the id
+
+The `id` field is the full `notif:<uuid>` printed by `notifications list --json` under `items[].id`. Bare uuids (without the `notif:` prefix) are also accepted.
+
+```bash
+assistant notifications list --json | jq '.items[] | {id, title, summary}'
+```
+
+### Command Reference
+
+| Flag                | Required | Description                                                                                       |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `--id <id>`         | Yes      | Feed item id (`notif:<uuid>`) or bare uuid                                                        |
+| `--message <text>`  | No*      | New body — updates the home-feed summary AND the delivered channel message where supported       |
+| `--title <text>`    | No*      | New short headline (≤ 8 words)                                                                    |
+| `--urgency <level>` | No*      | Change urgency (`low`/`medium`/`high`/`critical`). **Feed-only** — does not re-push channel messages |
+| `--status <state>`  | No*      | Lifecycle transition (`new`/`seen`/`acted_on`/`dismissed`). **Feed-only**                         |
+| `--json`            | No       | Machine-readable JSON                                                                             |
+
+*At least one of `--message`, `--title`, `--urgency`, or `--status` must be supplied.
+
+### Channel behavior
+
+| Channel | Edit behavior |
+| --- | --- |
+| Home feed (macOS/iOS inbox) | Always updated when the item exists. |
+| Slack | Updated in-place via `chat.update` when the original delivery captured a Slack `ts`. Deliveries older than this feature returned `messageId: null` and report `outcome: "unsupported"`. |
+| Push, email, SMS | Cannot be edited — reported as `outcome: "unsupported"` in the result. |
+
+### Response shape
+
+```json
+{
+  "ok": true,
+  "feedItem": { "id": "notif:...", "title": "...", "summary": "...", "status": "new", "urgency": "low" },
+  "channels": [
+    { "channel": "slack", "deliveryId": "...", "outcome": "updated" },
+    { "channel": "platform", "deliveryId": "...", "outcome": "unsupported", "reason": "platform adapter does not support in-place edits" }
+  ]
+}
+```
+
+`outcome` values: `"updated"` (channel message edited successfully), `"unsupported"` (channel cannot edit at all), `"skipped"` (delivery wasn't in `sent` status), `"failed"` (channel-side error — see `reason`).
+
+### Examples
+
+```bash
+# Fix a typo in the body
+assistant notifications edit \
+  --id notif:abc12345-... \
+  --message "Backup completed — 12.4 GB archived to cold storage."
+
+# De-escalate an urgent alert that resolved itself
+assistant notifications edit --id notif:abc12345-... --urgency low
+
+# Dismiss a notification you previously surfaced
+assistant notifications edit --id notif:abc12345-... --status dismissed
+```
+
 ## Important
 
 - Do **NOT** use AppleScript `display notification` or other OS-level notification commands for assistant-managed alerts. Always use `assistant notifications send`.


### PR DESCRIPTION
## Summary

- Adds `assistant notifications edit --id <notif:uuid>` with `--message`, `--title`, `--urgency`, `--status` so the assistant can fix typos, update progress, or de-escalate stale alerts instead of re-sending duplicates.
- Plumbs the captured Slack `ts` into `notification_deliveries.messageId` at send time (the column already existed but was never populated) and introduces an optional `ChannelAdapter.update()` hook implemented for Slack via `chat.update`.
- New `editNotification()` pipeline patches the home-feed entry through a `patchFeedItemContent()` addition that reuses the existing coalescing queue, then walks deliveries for the signal's decision and dispatches per-channel updates, returning per-channel outcomes (`updated` / `unsupported` / `skipped` / `failed`). Exposed via a new `edit_notification` IPC + HTTP route and documented in the `notifications` skill.

## Original prompt

The user asked for a new subcommand on `assistant notifications` that lets the assistant edit notifications that have already been sent. We aligned on scope before implementing: edit the home-feed entry AND attempt to update the delivered channel message where supported (best-effort — Slack works via `chat.update`, push/email/SMS report as unsupported); look up by FeedItem id (UUID — accepted with or without the `notif:` prefix); editable fields are `--message`, `--title`, `--urgency`, `--status` (with `--urgency` and `--status` being feed-only since channel messages don't carry that metadata). The notifications skill was updated alongside the code so the assistant knows when to prefer editing over re-sending.

## Test plan

- [ ] \`assistant notifications send --title \"T\" --message \"Body\"\` then \`assistant notifications list --json\` to grab the \`notif:<uuid>\`.
- [ ] \`assistant notifications edit --id <notif:uuid> --message \"Fixed\"\` and confirm the feed item shows the new body.
- [ ] If Slack is connected: confirm the Slack DM message visibly updates in place.
- [ ] \`--urgency low\` and \`--status dismissed\` only touch the feed (no channel re-push).
- [ ] Negative: missing \`--id\`, no editable fields, and unknown id each exit non-zero with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)