### PR TITLE
test(schedule): de-flake store-level sync invalidation test

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -9,6 +9,17 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
+// Stub the background-wake publisher so these store-level unit tests stay
+// hermetic. `notifySchedulesChanged()` fires a debounced background-wake
+// refresh on every mutation; left real, that 250ms timer performs a
+// synchronous DB read plus a platform-client lookup which compete with the
+// serialized async event delivery and can push a `sync_changed` past the
+// wait deadline on loaded runners. Background-wake behavior is covered by the
+// background-wake tests.
+mock.module("../background-wake/publisher.js", () => ({
+  refreshBackgroundWakeIntent: () => {},
+}));
+
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -38,7 +49,11 @@ function getRawDb(): import("bun:sqlite").Database {
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 500;
+  // Event delivery is async (serialized through the hub's broadcast chain),
+  // so poll until it lands. The deadline is generous to absorb scheduling
+  // jitter on loaded CI runners — the happy path returns the moment the
+  // predicate holds, so a larger budget costs nothing when events flow.
+  const deadline = Date.now() + 2000;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 5));


### PR DESCRIPTION
## Summary
- The store-level schedule sync-invalidation test flaked in CI (run 26603184430): a `sync_changed` event arrived after the 500ms `waitFor` deadline under load.
- Root cause: every mutation also fires a 250ms debounced background-wake refresh (synchronous DB read + platform-client lookup). On a loaded runner that timer fires mid-test and competes with the serialized async event delivery, occasionally pushing one event past the deadline.
- Fix (test-only): stub `background-wake/publisher.js` so this store-level unit test stays hermetic, and raise the event-wait deadline to 2s to absorb CI scheduling jitter. Verified locally with 40/40 sequential and 10/10 concurrent passes.

## Original prompt
Invoked via `/do --yolo` to fix the specific failing CI job (run 26603184430, the assistant Test job) and only that issue. The schedule-store sync-invalidation test was timing out waiting for a `sync_changed` event; the task was scoped to de-flaking that single test without touching unrelated code.