### PR TITLE
chore(openapi): regenerate spec for notifications/edit endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14072,6 +14072,92 @@ paths:
               required:
                 - deliveryId
               additionalProperties: false
+  /v1/notifications/edit:
+    post:
+      operationId: notifications_edit_post
+      summary: Edit an already-sent notification
+      description:
+        Patch the home-feed entry for a notification and, where supported (Slack today), update the delivered
+        message in place.
+      tags:
+        - notifications
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  feedItem:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties: {}
+                  channels:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        channel:
+                          type: string
+                        deliveryId:
+                          type: string
+                        outcome:
+                          type: string
+                          enum:
+                            - updated
+                            - unsupported
+                            - skipped
+                            - failed
+                        reason:
+                          type: string
+                      required:
+                        - channel
+                        - deliveryId
+                        - outcome
+                      additionalProperties: false
+                required:
+                  - ok
+                  - feedItem
+                  - channels
+                additionalProperties: false
+        "404":
+          description: No notification found for the supplied id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  minLength: 1
+                  description: Feed item id (notif:<uuid>) or bare uuid
+                title:
+                  type: string
+                body:
+                  type: string
+                urgency:
+                  type: string
+                  enum:
+                    - low
+                    - medium
+                    - high
+                    - critical
+                status:
+                  type: string
+                  enum:
+                    - new
+                    - seen
+                    - acted_on
+                    - dismissed
+              required:
+                - id
+              additionalProperties: false
   /v1/notifications/emit:
     post:
       operationId: notifications_emit_post


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to include the `/v1/notifications/edit` endpoint added in #32483, fixing the failing "OpenAPI Spec Check" CI job on `main`.
- Purely additive (446 paths, was 445); produced by `bun run generate:openapi` from committed route sources, not hand-edited.

## Original prompt
Fix the specific CI issue in the failing "OpenAPI Spec Check" job on the post-merge `main` CI run (runs/26603904162/job/78394171530). That job failed because `openapi.yaml` was stale — commit #32483 added the `notifications/edit` endpoint without regenerating the spec. Scope was limited to this one job; a separate Test-job route-policy failure for the same endpoint is being handled independently.