### PR TITLE
fix(assistant): green the Test CI job broken on main

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -186,7 +186,6 @@ describe("buildSystemPrompt", () => {
     const result = buildSystemPrompt();
     // SOUL still renders; the template scaffolding must not.
     expect(result).toContain("# Soul\n\nBe thoughtful.");
-    expect(result).not.toContain("This file is yours.");
     expect(result).not.toContain("(not yet chosen)");
   });
 
@@ -204,7 +203,10 @@ describe("buildSystemPrompt", () => {
       "# First run\n\nGet started.",
     );
     const result = buildSystemPrompt();
-    expect(result).toContain("This file is yours.");
+    // The bundled template's placeholder scaffolding (the `(not yet chosen)`
+    // field markers) renders verbatim during bootstrap — the mirror of the
+    // gating test above, which asserts it is absent without BOOTSTRAP.md.
+    expect(result).toContain("(not yet chosen)");
   });
 
   test("trims whitespace from file content", () => {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -872,6 +872,12 @@ registerPolicy("notifications/events", {
   allowedPrincipalTypes: ["local"],
 });
 
+// Edit an already-sent notification: local-only (CLI / IPC callers)
+registerPolicy("notifications/edit", {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ["local"],
+});
+
 // Defer operations: local-only (CLI / IPC callers)
 registerPolicy("defer/create", {
   requiredScopes: ["settings.write"],


### PR DESCRIPTION
## Summary

- Register a route policy for the `notifications/edit` endpoint (added in #32483 with no policy), gating it `local`-only with `settings.write` — identical to the sibling `notifications/emit` CLI/IPC endpoint. Fixes the `guard-tests.test.ts` route-policy-coverage failure.
- Refresh the `system-prompt.test.ts` bootstrap assertion: #31841 removed the `"This file is yours."` self-ownership line from the IDENTITY.md template, so the test now pivots onto the `(not yet chosen)` field marker (the exact mirror of the sibling gating test), and the now-dead `not.toContain("This file is yours.")` assertion is dropped.

## Original prompt

Fix the specific CI failure in the **Test** job of run 26603904162 on `main` (job 78394171544). Two unrelated commits had each broken a regression/guard test: #32483 introduced the `notifications/edit` endpoint without a route policy, and #31841 removed template text the system-prompt bootstrap test still asserted on. Scope was limited to that one job — the separate OpenAPI Spec Check job had already been resolved on main by #32486.