### PR TITLE
fix(web): mark notification as read in both feed list and detail panel

### DIFF
--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -64,9 +64,11 @@ export function HomePage({
 
   const handleSelectItem = useCallback(
     (item: FeedItem) => {
-      setSelectedItem(item);
       if (item.status === "new") {
+        setSelectedItem({ ...item, status: "seen" });
         feedQuery.updateStatus.mutate({ itemId: item.id, status: "seen" });
+      } else {
+        setSelectedItem(item);
       }
     },
     [feedQuery.updateStatus],


### PR DESCRIPTION
When clicking an unread notification on the homepage, both the feed list and the detail panel now reflect the "seen" state. This restores the original `handleSelectItem` behavior that was removed in PR #32414, which had stripped both the mutation call and the local `selectedItem` overwrite to fix a perceived detail panel icon bug — but that "bug" was actually correct behavior (an opened notification should show as read).

## Root cause analysis

1. **How did the code get into this state?** PR #32414 removed both the `feedQuery.updateStatus.mutate()` call and the `setSelectedItem({ ...item, status: "seen" })` overwrite as a single deletion, treating them as one concern. The mutation (marking as read on the backend) was collateral damage — only the local state overwrite was thought to be problematic.
2. **What decisions led to it?** The detail panel showing "Mark as unread" after clicking an unread item was misidentified as a bug. In standard notification UX (Gmail, Slack, iOS), opening a notification marks it as read — the detail panel correctly reflecting "seen" state is the intended behavior.
3. **Were there warning signs?** The "Go to thread" hover action in `home-recap-row.tsx` already followed the correct pattern (mark as read then navigate), but the inconsistency with the primary click handler wasn't noticed.
4. **Prevention:** When removing code that serves multiple purposes, evaluate each effect independently rather than removing the entire block.

### Alternatives not taken

- **Mutation without local state overwrite** (PR #32474): Fires the mutation but keeps `selectedItem` with `status: "new"`, so the detail panel shows the pre-click state. Rejected because the user expects the detail panel to reflect the current "read" state after clicking.
- **Mark as read on detail panel mount via `useEffect`:** Rejected because it couples a side effect to rendering. The click handler is the natural place for this intent.

## Prompt / plan

Follow-up to PR #32474 — update `handleSelectItem` to also overwrite `selectedItem.status` to `"seen"` so the detail panel reflects the read state, matching standard notification UX.

## Test plan

- Typecheck (`bunx tsc --noEmit`) and lint (`bun run lint`) pass
- CI checks

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ee9b8c3876f5420e9873a847c849711b