### PR TITLE
fix(web): wait for local assistant readiness before redirecting from onboarding

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -190,7 +190,23 @@ export function useAssistantLifecycle({
   }, []);
 
   const checkAssistant = useCallback(async () => {
-    if (isGatewayAuthMode()) return;
+    if (isGatewayAuthMode()) {
+      let ingressUrl = window.location.origin;
+      let resolvedAssistantId = "self";
+      const localGateway = getLocalGatewayUrl();
+      if (localGateway) {
+        const assistant = getSelectedAssistant();
+        ingressUrl = `${window.location.origin}${localGateway}`;
+        resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;
+      }
+      setSelfHostedConnection({
+        url: ingressUrl,
+        token: getGatewayToken(),
+      });
+      setAssistantId(resolvedAssistantId);
+      setAssistantState({ kind: "active", isLocal: true });
+      return;
+    }
     const generation = initializingGenerationRef.current;
     try {
       const result = await getAssistant();

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -27,10 +27,9 @@ import {
  *   2. In local mode with zero assistants, clear any stale completion flag
  *      (lockfile was lost/emptied since last onboarding).
  *   3. If onboarding is already marked completed, let the user through.
- *   4. If the intended destination isn't the chat surface itself
- *      (`/assistant`), let them through — sibling paths
- *      `/assistant/settings/...`, `/assistant/onboarding/...`,
- *      `/admin/...` etc. shouldn't be gated.
+ *   4. If the intended destination is outside `/assistant` entirely, or
+ *      inside the onboarding flow (`/assistant/onboarding/...`), let
+ *      them through — the former isn't ours, the latter avoids loops.
  *   5. Otherwise, route them to welcome (local mode) or privacy (platform).
  */
 export function resolveOnboardingRedirect({
@@ -49,7 +48,8 @@ export function resolveOnboardingRedirect({
   // `//assistant.host/`). Parse out the pathname before matching so we
   // don't miss absolute URLs whose path is the assistant surface.
   const path = extractPathname(intendedDestination);
-  if (path !== routes.assistant) return null;
+  if (!path.startsWith(routes.assistant)) return null;
+  if (path.startsWith(`${routes.assistant}/onboarding`)) return null;
   return getOnboardingEntrypoint();
 }
 

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -159,6 +159,7 @@ mock.module("@/lib/local-mode", () => ({
   setSelectedAssistantId: () => {},
   saveLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
+  getLocalGatewayUrl: () => undefined,
 }));
 
 mock.module("@/stores/auth-store", () => ({

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -18,7 +18,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/lib/api-errors";
-import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection } from "@/lib/local-mode";
+import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection, getLocalGatewayUrl } from "@/lib/local-mode";
 import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
 import { useRootOutletContext } from "@/root-layout";
 import {
@@ -169,6 +169,7 @@ export function HatchingScreen() {
     let cancelled = false;
     let pollTimer: ReturnType<typeof setTimeout> | null = null;
     let navigateTimer: ReturnType<typeof setTimeout> | null = null;
+    let readyPollTimer: ReturnType<typeof setTimeout> | null = null;
     const pollStartMs = Date.now();
 
     const pinnedVersion = readSelectedVersion();
@@ -190,9 +191,7 @@ export function HatchingScreen() {
       navigateTimer = setTimeout(() => {
         if (cancelled) return;
         void (async () => {
-          if (!useLocalHatch) {
-            await checkAssistant();
-          }
+          await checkAssistant();
           if (cancelled) return;
           if (isNativePlatform()) {
             try {
@@ -244,7 +243,43 @@ export function HatchingScreen() {
           if (result.assistantId) {
             setSelectedAssistantId(result.assistantId);
           }
-          await primeLocalGatewayConnection();
+
+          // Wait for the gateway + daemon to be fully ready before proceeding.
+          // The CLI's hatch command spawns them as background processes and exits
+          // before they finish starting up. We poll /readyz (gateway + upstream
+          // daemon) and then attempt to acquire the gateway auth token. Both must
+          // succeed before we navigate away — the guardian token file may not
+          // exist on disk until after /readyz passes.
+          transitionPhase("connecting");
+          let gatewayReady = false;
+          while (!cancelled && !gatewayReady) {
+            const gatewayUrl = getLocalGatewayUrl();
+            if (gatewayUrl) {
+              try {
+                const res = await fetch(`${gatewayUrl}/readyz`);
+                if (res.ok) {
+                  const body = await res.json() as { status: string };
+                  if (body.status === "ok") {
+                    await primeLocalGatewayConnection();
+                    gatewayReady = true;
+                    break;
+                  }
+                }
+              } catch {
+                // Gateway not ready yet
+              }
+            }
+            if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
+              setError("Your assistant is taking longer than expected. Please try again.");
+              return;
+            }
+            await new Promise<void>(resolve => {
+              readyPollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+            });
+            readyPollTimer = null;
+          }
+          if (cancelled) return;
+
           handleHatchReady();
         } catch {
           localHatchPromise = null;
@@ -360,6 +395,7 @@ export function HatchingScreen() {
       cancelled = true;
       if (pollTimer) clearTimeout(pollTimer);
       if (navigateTimer) clearTimeout(navigateTimer);
+      if (readyPollTimer) clearTimeout(readyPollTimer);
     };
   }, [
     attempt,

--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -28,9 +28,10 @@ interface RetireAssistantProps {
 export function RetireAssistant({ assistantId }: RetireAssistantProps) {
   const navigate = useNavigate();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
 
   const handleRetire = async () => {
-    setConfirmOpen(false);
+    setIsPending(true);
     try {
       const selected = getSelectedAssistant();
       const useLocal =
@@ -40,8 +41,10 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
         const result = await retireLocalAssistant(assistantId);
         if (result.ok) {
           clearOnboardingFlags();
+          setConfirmOpen(false);
           toast.success("Assistant retired.");
-          navigate(getPostRetireRoute());
+          navigate(getPostRetireRoute(), { replace: true });
+          return;
         } else {
           toast.error(result.error || "Failed to retire assistant.");
         }
@@ -49,8 +52,10 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
         const result = await retireAssistantById(assistantId);
         if (result.ok || result.status === 404) {
           clearOnboardingFlags();
+          setConfirmOpen(false);
           toast.success("Assistant retired.");
-          navigate(getPostRetireRoute());
+          navigate(getPostRetireRoute(), { replace: true });
+          return;
         } else {
           const detail =
             typeof result.error?.detail === "string"
@@ -62,6 +67,8 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
     } catch {
       toast.error("Failed to retire assistant.");
     }
+    setIsPending(false);
+    setConfirmOpen(false);
   };
 
   return (
@@ -79,6 +86,7 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
         message="This will permanently retire this assistant and all of its data. You will need to go through the onboarding flow again to create a new one. This action cannot be undone."
         confirmLabel="Retire"
         destructive
+        isPending={isPending}
         onConfirm={handleRetire}
         onCancel={() => setConfirmOpen(false)}
       />

--- a/packages/design-library/src/components/confirm-dialog.tsx
+++ b/packages/design-library/src/components/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Button } from "./button";
@@ -23,6 +23,7 @@ interface ConfirmDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;
+  isPending?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -36,6 +37,7 @@ function ConfirmDialog({
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
   destructive = false,
+  isPending = false,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
@@ -43,7 +45,7 @@ function ConfirmDialog({
     <Modal.Root
       open={open}
       onOpenChange={(next) => {
-        if (!next) {
+        if (!next && !isPending) {
           onCancel();
         }
       }}
@@ -64,7 +66,7 @@ function ConfirmDialog({
         onEscapeKeyDown={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          onCancel();
+          if (!isPending) onCancel();
         }}
       >
         <Modal.Header>
@@ -76,12 +78,14 @@ function ConfirmDialog({
           <Modal.Description>{message}</Modal.Description>
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="outlined" onClick={onCancel}>
+          <Button variant="outlined" onClick={onCancel} disabled={isPending}>
             {cancelLabel}
           </Button>
           <Button
             variant={destructive ? "danger" : "primary"}
             onClick={onConfirm}
+            disabled={isPending}
+            leftIcon={isPending ? <Loader2 className="animate-spin" /> : undefined}
             {...{ [CONFIRM_BUTTON_ATTR]: "" }}
           >
             {confirmLabel}


### PR DESCRIPTION
## Summary
- **Hatching readiness poll**: After the CLI's `hatch` command completes, poll the gateway's `/readyz` endpoint until the full stack (gateway + daemon) is healthy, then acquire the guardian token and gateway auth token before navigating away
- **Lifecycle state fix**: `checkAssistant()` now properly handles gateway auth mode by setting up the self-hosted connection and transitioning to `active` state — previously it silently returned, leaving the state stuck at `awaiting_version_selection`
- **Onboarding gate broadened**: The redirect gate now intercepts all `/assistant/*` paths (except `/assistant/onboarding/*`) when no assistant exists, not just the exact `/assistant` path
- **Retire flow UX**: Keeps the confirm dialog open with a loading spinner during the retire API call; uses `replace: true` on post-retire navigation

## Test plan
- [ ] Set `VITE_PLATFORM_MODE=false`, clear lockfile, go through web UI onboarding to hatch a local bare-metal assistant
- [ ] Verify the hatching screen shows "Connecting to your assistant…" while waiting for the gateway
- [ ] Verify redirect to pre-chat flow only happens once the gateway is healthy
- [ ] Verify landing on `/assistant` shows the chat UI (not the version selection screen)
- [ ] Navigate directly to `/assistant/conversations/<id>` with no assistant in lockfile — verify redirect to onboarding
- [ ] Navigate directly to `/assistant/settings/general` with no assistant — verify redirect to onboarding
- [ ] Retire assistant from settings → verify dialog stays open with spinner, then navigates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)