### PR TITLE
refactor(memory): drop createV3Retriever import from v2 routes

### DIFF
--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -39,7 +39,6 @@ import {
 import { ROUTER_PROMPT } from "../../memory/v2/prompts/router.js";
 import { type RouterSource, runRouter } from "../../memory/v2/router.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
-import { createV3Retriever } from "../../memory/v3/retriever.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
@@ -640,13 +639,8 @@ export async function handleCompareRetrievers({
   const db = getDb();
 
   // The router is always comparand #1 (the harness self-test against its own
-  // logged ground truth). v3 joins as comparand #2 only when explicitly
-  // enabled, so the default compare surface is unchanged until v3 is switched
-  // on. v3 is offline-only here — the loop reads `db` but mutates nothing.
+  // logged ground truth).
   const retrievers: Retriever[] = [createRouterRetriever(db)];
-  if (config.memory.v3.enabled) {
-    retrievers.push(createV3Retriever(db));
-  }
 
   return runComparisonOverHistory({
     db,


### PR DESCRIPTION
## Summary
- Remove the dead config.memory.v3.enabled shadow branch and createV3Retriever import from memory-v2-routes; v2 primary path unchanged. Part of ripping the never-shipped shadow-only v3 module.

Part of plan: memory-v3-topic-tree-routing.md (PR 4 of 19)