### PR TITLE
feat(feature-flags): add memory-v3-shadow flag (default off)

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -440,6 +440,14 @@
       "label": "Platform Features in Local Mode",
       "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
       "defaultEnabled": true
+    },
+    {
+      "id": "memory-v3-shadow",
+      "scope": "assistant",
+      "key": "memory-v3-shadow",
+      "label": "Memory v3 Shadow",
+      "description": "When on, runs the new memory-v3 topic-tree retrieval alongside v2 in shadow mode: logs selections to memory_v3_selections, does not modify injected context. Off by default.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/PENDING_PLATFORM_PRS.md
+++ b/meta/feature-flags/PENDING_PLATFORM_PRS.md
@@ -15,3 +15,4 @@ Remove an entry from this file once its companion platform PR is merged.
 | Flag key | Registry declaration date | Owner | Status | Required platform work |
 |---|---|---|---|---|
 | `meet` | 2026-04-19 | sidd@vellum.ai | Platform PR not yet opened (as of 2026-04-19) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `skills/meet-join/SKILL.md`. |
+| `memory-v3-shadow` | 2026-05-28 | memory-v3 owner | Platform PR not yet opened (as of 2026-05-28) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` provisioning the `memory-v3-shadow` assistant flag before it is flipped on in any hosted instance. |

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -440,6 +440,14 @@
       "label": "Platform Features in Local Mode",
       "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
       "defaultEnabled": true
+    },
+    {
+      "id": "memory-v3-shadow",
+      "scope": "assistant",
+      "key": "memory-v3-shadow",
+      "label": "Memory v3 Shadow",
+      "description": "When on, runs the new memory-v3 topic-tree retrieval alongside v2 in shadow mode: logs selections to memory_v3_selections, does not modify injected context. Off by default.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register the default-off memory-v3-shadow assistant feature flag (kebab-case key per feature-flags AGENTS.md), sync bundled copies, and record the companion Terraform PR requirement in PENDING_PLATFORM_PRS.md. No platform PR created (feature-branch only; nothing deploys).

Part of plan: memory-v3-topic-tree-routing.md (PR 7 of 19)