### PR TITLE
feat(memory-v3): add memory_v3_selections table

### DIFF
--- a/assistant/src/memory/__tests__/memory-v3-selections-migration.test.ts
+++ b/assistant/src/memory/__tests__/memory-v3-selections-migration.test.ts
@@ -1,0 +1,103 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../db-connection.js";
+import { migrateAddMemoryV3Selections } from "../migrations/267-add-memory-v3-selections.js";
+import * as schema from "../schema.js";
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface IndexRow {
+  name: string;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+describe("memory_v3_selections migration", () => {
+  test("creates table with expected columns", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateAddMemoryV3Selections(db);
+
+    const columns = raw
+      .query(`PRAGMA table_info(memory_v3_selections)`)
+      .all() as ColumnRow[];
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("conversation_id")?.type).toBe("TEXT");
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("conversation_id")?.pk).toBe(1);
+
+    expect(byName.get("turn")?.type).toBe("INTEGER");
+    expect(byName.get("turn")?.notnull).toBe(1);
+    expect(byName.get("turn")?.pk).toBe(2);
+
+    expect(byName.get("slug")?.type).toBe("TEXT");
+    expect(byName.get("slug")?.notnull).toBe(1);
+    expect(byName.get("slug")?.pk).toBe(3);
+
+    expect(byName.get("source")?.type).toBe("TEXT");
+    expect(byName.get("source")?.notnull).toBe(1);
+
+    expect(byName.get("pinned")?.type).toBe("INTEGER");
+    expect(byName.get("pinned")?.notnull).toBe(1);
+    expect(byName.get("pinned")?.dflt_value).toBe("0");
+
+    expect(byName.get("created_at")?.type).toBe("INTEGER");
+    expect(byName.get("created_at")?.notnull).toBe(1);
+  });
+
+  test("creates the conversation-turn index", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateAddMemoryV3Selections(db);
+
+    const indexes = raw
+      .query(`PRAGMA index_list(memory_v3_selections)`)
+      .all() as IndexRow[];
+    const indexNames = new Set(indexes.map((i) => i.name));
+
+    expect(indexNames.has("idx_memory_v3_selections_conv")).toBe(true);
+  });
+
+  test("is idempotent — re-running does not throw and preserves rows", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateAddMemoryV3Selections(db);
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO memory_v3_selections (
+          conversation_id, turn, slug, source, pinned, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run("conv-abc", 3, "page-slug", "lane-a", 1, 1000);
+
+    expect(() => migrateAddMemoryV3Selections(db)).not.toThrow();
+
+    const row = raw
+      .query(
+        `SELECT slug FROM memory_v3_selections WHERE conversation_id = 'conv-abc' AND turn = 3`,
+      )
+      .get() as { slug: string } | null;
+    expect(row?.slug).toBe("page-slug");
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -43,6 +43,7 @@ import {
   migrateActivationState,
   migrateActivationStateFkCascade,
   migrateAddConversationInferenceProfile,
+  migrateAddMemoryV3Selections,
   migrateAddSourceTypeColumns,
   migrateAssistantContactMetadata,
   migrateBackfillAudioAttachmentMimeTypes,
@@ -466,6 +467,7 @@ export function initializeDb(): void {
     migrateLlmRequestLogCallSite,
     migrateDropProviderConnectionStatus,
     migrateMessagesClientMessageId,
+    migrateAddMemoryV3Selections,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/267-add-memory-v3-selections.ts
+++ b/assistant/src/memory/migrations/267-add-memory-v3-selections.ts
@@ -1,0 +1,28 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Adds `memory_v3_selections` for memory-v3 working-set persistence:
+ * one row per (conversation, turn, page-slug) the v3 retriever selected,
+ * tagged with the lane (`source`) that produced it. `pinned` marks slugs
+ * carried forward across turns rather than re-selected cold.
+ *
+ * Idempotent — re-running is a no-op once the table and index exist.
+ */
+export function migrateAddMemoryV3Selections(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_v3_selections (
+      conversation_id TEXT NOT NULL,
+      turn INTEGER NOT NULL,
+      slug TEXT NOT NULL,
+      source TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (conversation_id, turn, slug)
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_conv
+      ON memory_v3_selections (conversation_id, turn DESC)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -253,6 +253,7 @@ export {
 export { migrateLlmRequestLogCallSite } from "./264-llm-request-log-call-site.js";
 export { migrateDropProviderConnectionStatus } from "./265-drop-provider-connection-status.js";
 export { migrateMessagesClientMessageId } from "./266-messages-client-message-id.js";
+export { migrateAddMemoryV3Selections } from "./267-add-memory-v3-selections.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Add migration 267 creating memory_v3_selections (conversation/turn/slug PK + source/pinned/created_at) plus a conv-turn index, for memory-v3 working-set persistence. Function-style idempotent migration registered in db-init + migrations/index. Scoped idempotency/schema test included.

Part of plan: memory-v3-topic-tree-routing.md (PR 8 of 19)