### PR TITLE
feat(memory-v3): introduce core types

### DIFF
--- a/assistant/src/memory/v3/__tests__/types.test.ts
+++ b/assistant/src/memory/v3/__tests__/types.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+
+import type {
+  LeafFrontmatter,
+  LeafNode,
+  LeafPath,
+  LeafTree,
+  SelectionSource,
+  Slug,
+  TurnContext,
+  WorkingSetEntry,
+} from "../types.js";
+
+test("v3 core types instantiate", () => {
+  const path: LeafPath = "domain/topic/leaf";
+  const slug: Slug = "page-123";
+
+  const frontmatter: LeafFrontmatter = { path, in_core: true };
+
+  const node: LeafNode = {
+    path,
+    frontmatter,
+    description: "an example leaf node",
+    members: [slug],
+    domain: "example",
+  };
+
+  const tree: LeafTree = {
+    leaves: new Map<LeafPath, LeafNode>([[path, node]]),
+    byPage: new Map<Slug, LeafPath[]>([[slug, [path]]]),
+  };
+
+  const entry: WorkingSetEntry = {
+    slug,
+    selectedAtTurn: 1,
+    pinned: false,
+    lastSeenTurn: 2,
+  };
+
+  const turnContext: TurnContext = {
+    conversationId: "conv-xyz",
+    turnNumber: 3,
+    currentMessage: "hello",
+    recentContext: "prior turns",
+  };
+
+  const source: SelectionSource = "carry-forward";
+
+  expect(tree.leaves.get(path)).toBe(node);
+  expect(tree.byPage.get(slug)).toEqual([path]);
+  expect(entry.slug).toBe(slug);
+  expect(turnContext.turnNumber).toBe(3);
+  expect(source).toBe("carry-forward");
+});

--- a/assistant/src/memory/v3/types.ts
+++ b/assistant/src/memory/v3/types.ts
@@ -1,0 +1,36 @@
+export type LeafPath = string; // dot- or slash-pathed taxonomy node
+export type Slug = string;
+
+export interface LeafFrontmatter {
+  path: LeafPath;
+  in_core: boolean;
+}
+
+export interface LeafNode {
+  path: LeafPath;
+  frontmatter: LeafFrontmatter;
+  description: string;
+  members: Slug[];
+  domain: string;
+}
+
+export interface LeafTree {
+  leaves: Map<LeafPath, LeafNode>;
+  byPage: Map<Slug, LeafPath[]>;
+}
+
+export interface WorkingSetEntry {
+  slug: Slug;
+  selectedAtTurn: number;
+  pinned: boolean;
+  lastSeenTurn: number;
+}
+
+export interface TurnContext {
+  conversationId: string;
+  turnNumber: number;
+  currentMessage: string;
+  recentContext: string;
+}
+
+export type SelectionSource = "l1+l2" | "core+l2" | "needle" | "carry-forward";


### PR DESCRIPTION
## Summary
- Add the foundational memory-v3 types (LeafPath/Slug, LeafFrontmatter, LeafNode, LeafTree, WorkingSetEntry, TurnContext, SelectionSource) plus a compile-time smoke test.

Part of plan: memory-v3-topic-tree-routing.md (PR 10 of 19)