### PR TITLE
fix(web): remove redundant category icon from home detail panel content

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-generic-detail.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-generic-detail.tsx
@@ -1,13 +1,5 @@
-import { CATEGORY_STYLES } from "../home-feed-filter-bar";
 import { HomeMarkdownContent } from "./home-markdown-content";
-import type { FeedItem, FeedItemCategory } from "../types";
-
-function resolveStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES.system;
-}
+import type { FeedItem } from "../types";
 
 export interface HomeGenericDetailProps {
   item: FeedItem;
@@ -15,28 +7,8 @@ export interface HomeGenericDetailProps {
 
 /**
  * Fallback renderer for feed items that don't have a specialized
- * detail panel. Renders the item summary as markdown alongside a
- * category-colored icon.
+ * detail panel. Renders the item summary as markdown.
  */
 export function HomeGenericDetail({ item }: HomeGenericDetailProps) {
-  const style = resolveStyle(item.category);
-  const Icon = style.icon;
-
-  return (
-    <div className="flex items-start gap-[var(--app-spacing-md)]">
-      <span
-        className="mt-0.5 flex shrink-0 items-center justify-center rounded-full"
-        style={{
-          width: 26,
-          height: 26,
-          backgroundColor: style.weak,
-        }}
-        aria-hidden="true"
-      >
-        <Icon width={12} height={12} style={{ color: style.strong }} />
-      </span>
-
-      <HomeMarkdownContent content={item.summary} />
-    </div>
-  );
+  return <HomeMarkdownContent content={item.summary} />;
 }


### PR DESCRIPTION
The category icon already appears in the detail panel header (`HomeDetailPanel`). `HomeGenericDetail` was rendering the same icon a second time alongside the markdown summary, making the content area visually redundant. This removes the duplicate icon from the content body so only the header icon remains.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/54fc47db011843dabcb15a64b64747c4