### PR TITLE
feat(memory-v3): working-set class scaffold

### DIFF
--- a/assistant/src/memory/v3/__tests__/working-set-skeleton.test.ts
+++ b/assistant/src/memory/v3/__tests__/working-set-skeleton.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { WorkingSet } from "../working-set.js";
+
+describe("WorkingSet (skeleton)", () => {
+  test("recording a selection adds it to union()", () => {
+    const ws = new WorkingSet();
+    ws.recordSelection("alpha", 1, false);
+
+    expect(ws.union().has("alpha")).toBe(true);
+    expect(ws.size()).toBe(1);
+  });
+
+  test("recording the same slug twice preserves selectedAtTurn and updates lastSeenTurn", () => {
+    const ws = new WorkingSet();
+    ws.recordSelection("alpha", 1, false);
+    ws.recordSelection("alpha", 5, false);
+
+    expect(ws.size()).toBe(1);
+    const entry = [...ws.union()];
+    expect(entry).toEqual(["alpha"]);
+    // selectedAtTurn preserved at original turn, lastSeenTurn advanced.
+    const internal = (
+      ws as unknown as {
+        entries: Map<string, { selectedAtTurn: number; lastSeenTurn: number }>;
+      }
+    ).entries.get("alpha");
+    expect(internal?.selectedAtTurn).toBe(1);
+    expect(internal?.lastSeenTurn).toBe(5);
+  });
+
+  test("pinned propagates: non-pinned then pinned keeps pinned true", () => {
+    const ws = new WorkingSet();
+    ws.recordSelection("alpha", 1, false);
+    ws.recordSelection("alpha", 2, true);
+
+    const internal = (
+      ws as unknown as {
+        entries: Map<string, { pinned: boolean }>;
+      }
+    ).entries.get("alpha");
+    expect(internal?.pinned).toBe(true);
+  });
+});

--- a/assistant/src/memory/v3/working-set.ts
+++ b/assistant/src/memory/v3/working-set.ts
@@ -1,0 +1,25 @@
+import { Slug, WorkingSetEntry } from "./types.js";
+
+export class WorkingSet {
+  private entries = new Map<Slug, WorkingSetEntry>();
+
+  recordSelection(slug: Slug, turn: number, pinned: boolean): void {
+    const existing = this.entries.get(slug);
+    this.entries.set(slug, {
+      slug,
+      selectedAtTurn: existing?.selectedAtTurn ?? turn,
+      pinned: existing?.pinned || pinned,
+      lastSeenTurn: turn,
+    });
+  }
+
+  union(): Set<Slug> {
+    return new Set(this.entries.keys());
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  // evict(...) — added in a later PR
+}


### PR DESCRIPTION
## Summary
- Add the WorkingSet skeleton (recordSelection with selectedAtTurn-preservation + pinned-propagation, union, size). Eviction lands in a follow-up PR.

Part of plan: memory-v3-topic-tree-routing.md (PR 15 of 19)