### PR TITLE
feat(memory-v3): always-on core loader

### DIFF
--- a/assistant/src/memory/v3/__tests__/core.test.ts
+++ b/assistant/src/memory/v3/__tests__/core.test.ts
@@ -1,0 +1,70 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { loadCore } from "../core.js";
+
+const BUNDLED_DATA_DIR = join(import.meta.dir, "..", "data");
+
+describe("loadCore", () => {
+  const originalWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  let tmpDirs: string[] = [];
+
+  beforeEach(() => {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+    tmpDirs = [];
+  });
+
+  afterEach(async () => {
+    if (originalWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceEnv;
+    }
+    await Promise.all(
+      tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "v3-core-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  test("loads alwaysOn from bundled core.json into a Set", async () => {
+    // No workspace override → resolves to the supplied bundled dataDir.
+    process.env.VELLUM_WORKSPACE_DIR = await makeTmpDir();
+    const core = await loadCore(BUNDLED_DATA_DIR);
+    expect(core).toBeInstanceOf(Set);
+    expect(core.has("domain-a/topic-x")).toBe(true);
+    expect(core.size).toBe(1);
+  });
+
+  test("prefers workspace override when present", async () => {
+    const workspace = await makeTmpDir();
+    const overrideDataDir = join(workspace, "memory", "v3", "data");
+    await mkdir(overrideDataDir, { recursive: true });
+    await writeFile(
+      join(overrideDataDir, "core.json"),
+      JSON.stringify({ alwaysOn: ["domain-z/topic-override"] }),
+    );
+    process.env.VELLUM_WORKSPACE_DIR = workspace;
+
+    const core = await loadCore(BUNDLED_DATA_DIR);
+    expect(core.has("domain-z/topic-override")).toBe(true);
+    expect(core.has("domain-a/topic-x")).toBe(false);
+    expect(core.size).toBe(1);
+  });
+
+  test("returns empty set when core.json is missing", async () => {
+    // Point the workspace at a dir with no override so resolution is
+    // deterministic and falls back to the (empty) supplied dataDir.
+    process.env.VELLUM_WORKSPACE_DIR = await makeTmpDir();
+    const emptyDataDir = await makeTmpDir();
+    const core = await loadCore(emptyDataDir);
+    expect(core).toBeInstanceOf(Set);
+    expect(core.size).toBe(0);
+  });
+});

--- a/assistant/src/memory/v3/core.ts
+++ b/assistant/src/memory/v3/core.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import { LeafPath } from "./types.js";
+
+/**
+ * Resolves the directory to load `core.json` from, preferring a
+ * workspace-local override at `<workspace>/memory/v3/data` when present.
+ * Falls back to the supplied bundled `dataDir`.
+ *
+ * Kept local (rather than imported from tree.ts) to avoid coupling between
+ * v3 modules.
+ */
+export function resolveDataDir(bundledDir: string): string {
+  const workspaceDir = join(getWorkspaceDir(), "memory", "v3", "data");
+  if (existsSync(join(workspaceDir, "core.json"))) return workspaceDir;
+  return bundledDir;
+}
+
+/**
+ * Loads the always-on core leaf set from `<dataDir>/core.json`.
+ *
+ * Prefers a workspace-local override when present. A missing `core.json`
+ * yields an empty set (new workspaces may have no curated core).
+ */
+export async function loadCore(dataDir: string): Promise<Set<LeafPath>> {
+  const path = join(resolveDataDir(dataDir), "core.json");
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return new Set();
+    }
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as { alwaysOn?: LeafPath[] };
+  return new Set(parsed.alwaysOn ?? []);
+}


### PR DESCRIPTION
## Summary
- Add loadCore reading core.json (alwaysOn) into a Set<LeafPath>, with workspace-override preference and graceful empty-set fallback when core.json is absent.

Part of plan: memory-v3-topic-tree-routing.md (PR 13 of 19)