### PR TITLE
feat(memory-v3): leaf-tree loader honoring canon-not-derived

### DIFF
--- a/assistant/src/memory/v3/__tests__/tree.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { leavesOf, loadLeafTree, membersOf, resolveDataDir } from "../tree.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_DATA_DIR = join(HERE, "..", "data");
+
+describe("loadLeafTree", () => {
+  test("loads leaves with frontmatter, description, and domain", async () => {
+    const tree = await loadLeafTree(BUNDLED_DATA_DIR);
+
+    expect([...tree.leaves.keys()].sort()).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+      "domain-b/topic-z",
+    ]);
+
+    const topicX = tree.leaves.get("domain-a/topic-x");
+    expect(topicX).toBeDefined();
+    expect(topicX?.path).toBe("domain-a/topic-x");
+    expect(topicX?.frontmatter).toEqual({
+      path: "domain-a/topic-x",
+      in_core: true,
+    });
+    expect(topicX?.domain).toBe("domain-a");
+    expect(topicX?.description.length).toBeGreaterThan(0);
+    expect(topicX?.description.startsWith("---")).toBe(false);
+
+    const topicZ = tree.leaves.get("domain-b/topic-z");
+    expect(topicZ?.frontmatter.in_core).toBe(false);
+    expect(topicZ?.domain).toBe("domain-b");
+  });
+
+  test("builds members and byPage from assignments", async () => {
+    const tree = await loadLeafTree(BUNDLED_DATA_DIR);
+
+    // byPage is the inverted assignment map.
+    expect(tree.byPage.get("page-a")).toEqual(["domain-a/topic-x"]);
+    expect(tree.byPage.get("page-b")).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+    ]);
+    expect(tree.byPage.get("page-c")).toEqual(["domain-b/topic-z"]);
+
+    // members are the slugs assigned to each leaf.
+    expect(membersOf(tree, "domain-a/topic-x").sort()).toEqual([
+      "page-a",
+      "page-b",
+    ]);
+    expect(membersOf(tree, "domain-a/topic-y")).toEqual(["page-b"]);
+    expect(membersOf(tree, "domain-b/topic-z")).toEqual(["page-c"]);
+  });
+
+  test("membersOf and leavesOf return empty arrays for unknown keys", async () => {
+    const tree = await loadLeafTree(BUNDLED_DATA_DIR);
+    expect(membersOf(tree, "nope/missing")).toEqual([]);
+    expect(leavesOf(tree, "missing-slug")).toEqual([]);
+  });
+
+  test("leavesOf mirrors byPage", async () => {
+    const tree = await loadLeafTree(BUNDLED_DATA_DIR);
+    expect(leavesOf(tree, "page-b")).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+    ]);
+  });
+});
+
+describe("resolveDataDir", () => {
+  let tmpRoot: string;
+  const prevWorkspace = process.env.VELLUM_WORKSPACE_DIR;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "v3-tree-"));
+  });
+
+  afterEach(async () => {
+    if (prevWorkspace === undefined) delete process.env.VELLUM_WORKSPACE_DIR;
+    else process.env.VELLUM_WORKSPACE_DIR = prevWorkspace;
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("falls back to bundled stub when no workspace override exists", () => {
+    process.env.VELLUM_WORKSPACE_DIR = join(tmpRoot, "workspace");
+    expect(resolveDataDir()).toBe(BUNDLED_DATA_DIR);
+  });
+
+  test("prefers workspace override when <workspace>/memory/v3/data exists", async () => {
+    const workspace = join(tmpRoot, "workspace");
+    const workspaceData = join(workspace, "memory", "v3", "data");
+    const leafDir = join(workspaceData, "leaves", "domain-w");
+    await mkdir(leafDir, { recursive: true });
+    await writeFile(
+      join(leafDir, "topic-real.md"),
+      "---\npath: domain-w/topic-real\nin_core: false\n---\n\nReal workspace leaf.\n",
+    );
+    await writeFile(
+      join(workspaceData, "assignments.json"),
+      JSON.stringify({ "real-page": ["domain-w/topic-real"] }),
+    );
+
+    process.env.VELLUM_WORKSPACE_DIR = workspace;
+
+    expect(resolveDataDir()).toBe(workspaceData);
+
+    const tree = await loadLeafTree(resolveDataDir());
+    expect([...tree.leaves.keys()]).toEqual(["domain-w/topic-real"]);
+    expect(membersOf(tree, "domain-w/topic-real")).toEqual(["real-page"]);
+    expect(leavesOf(tree, "real-page")).toEqual(["domain-w/topic-real"]);
+  });
+});

--- a/assistant/src/memory/v3/tree.ts
+++ b/assistant/src/memory/v3/tree.ts
@@ -1,0 +1,147 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import type {
+  LeafFrontmatter,
+  LeafNode,
+  LeafPath,
+  LeafTree,
+  Slug,
+} from "./types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Bundled stub data shipped alongside the loader. */
+const BUNDLED_DATA_DIR = join(HERE, "data");
+
+/**
+ * Resolve the directory the loaders should read leaf-tree artifacts from.
+ *
+ * Prefers a maintainer's per-instance workspace override
+ * (`<workspace>/memory/v3/data/`) when present, otherwise falls back to the
+ * generic bundled stub shipped in this package.
+ *
+ * The public {@link loadLeafTree} API still takes an explicit `dataDir` for
+ * testability; orchestrators that want the runtime default call this helper.
+ */
+export function resolveDataDir(): string {
+  const workspaceData = join(getWorkspaceDir(), "memory", "v3", "data");
+  if (existsSync(workspaceData)) return workspaceData;
+  return BUNDLED_DATA_DIR;
+}
+
+/** Recursively collect every `*.md` file under `dir`. */
+async function collectMarkdownFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectMarkdownFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Split a leaf `.md` file into its YAML frontmatter and body.
+ *
+ * Frontmatter is the `---`-delimited block at the top of the file; everything
+ * after the closing delimiter is the description body.
+ */
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } {
+  const normalized = raw.replace(/^﻿/, "");
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(normalized);
+  if (!match) {
+    throw new Error("leaf markdown is missing YAML frontmatter");
+  }
+  return { frontmatter: match[1], body: match[2] };
+}
+
+function parseLeafFrontmatter(yaml: string, file: string): LeafFrontmatter {
+  const parsed = parseYaml(yaml) as unknown;
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`leaf ${file} frontmatter is not a mapping`);
+  }
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.path !== "string") {
+    throw new Error(`leaf ${file} frontmatter is missing a string \`path\``);
+  }
+  if (typeof record.in_core !== "boolean") {
+    throw new Error(
+      `leaf ${file} frontmatter is missing a boolean \`in_core\``,
+    );
+  }
+  return { path: record.path, in_core: record.in_core };
+}
+
+/** Derive the canonical leaf path from a file's location under `leaves/`. */
+function pathFromLocation(leavesDir: string, file: string): LeafPath {
+  return relative(leavesDir, file).replace(/\.md$/, "").split(sep).join("/");
+}
+
+/**
+ * Load the leaf tree from `dataDir`. READ-ONLY: walks `leaves/**\/*.md` and
+ * reads `assignments.json` without mutating anything on disk.
+ *
+ * Builds:
+ * - `leaves`: leaf path → {@link LeafNode} (frontmatter, description, domain,
+ *   and the slugs assigned to it).
+ * - `byPage`: slug → the leaf paths it is assigned to (inverted assignments).
+ */
+export async function loadLeafTree(dataDir: string): Promise<LeafTree> {
+  const leavesDir = join(dataDir, "leaves");
+  const files = await collectMarkdownFiles(leavesDir);
+
+  const nodes = await Promise.all(
+    files.map(async (file): Promise<LeafNode> => {
+      const raw = await readFile(file, "utf8");
+      const { frontmatter, body } = splitFrontmatter(raw);
+      const path = pathFromLocation(leavesDir, file);
+      return {
+        path,
+        frontmatter: parseLeafFrontmatter(frontmatter, file),
+        description: body.trim(),
+        members: [],
+        domain: path.split("/")[0],
+      };
+    }),
+  );
+
+  const leaves = new Map<LeafPath, LeafNode>(
+    nodes.map((node) => [node.path, node]),
+  );
+
+  const assignmentsRaw = await readFile(
+    join(dataDir, "assignments.json"),
+    "utf8",
+  );
+  const assignments = JSON.parse(assignmentsRaw) as Record<Slug, LeafPath[]>;
+
+  const byPage = new Map<Slug, LeafPath[]>();
+  for (const [slug, leafPaths] of Object.entries(assignments)) {
+    byPage.set(slug, [...leafPaths]);
+    for (const leafPath of leafPaths) {
+      leaves.get(leafPath)?.members.push(slug);
+    }
+  }
+
+  return { leaves, byPage };
+}
+
+/** The slugs assigned to a leaf. */
+export function membersOf(tree: LeafTree, leaf: LeafPath): Slug[] {
+  return tree.leaves.get(leaf)?.members ?? [];
+}
+
+/** The leaf paths a slug is assigned to. */
+export function leavesOf(tree: LeafTree, slug: Slug): LeafPath[] {
+  return tree.byPage.get(slug) ?? [];
+}


### PR DESCRIPTION
## Summary
- Add loadLeafTree (read-only walk of data/leaves/**/*.md + assignments.json, building the leaves + byPage maps), membersOf/leavesOf accessors, and workspace-override resolution preferring <workspace>/memory/v3/data over the bundled stub.

Part of plan: memory-v3-topic-tree-routing.md (PR 12 of 19)