### PR TITLE
feat(memory-v3): sparse needle arm via BM25

### DIFF
--- a/assistant/src/memory/v3/__tests__/needle.test.ts
+++ b/assistant/src/memory/v3/__tests__/needle.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+
+import { buildNeedleIndex } from "../needle.js";
+import type { LeafNode, LeafPath, LeafTree, Slug } from "../types.js";
+
+/**
+ * Builds a small synthetic LeafTree + summary stub. No real content — every
+ * label, summary, and slug here is invented for the test.
+ */
+function makeFixture(): {
+  tree: LeafTree;
+  summaries: Map<Slug, string>;
+} {
+  const leaves = new Map<LeafPath, LeafNode>();
+  const byPage = new Map<Slug, LeafPath[]>();
+
+  const leaf = (path: LeafPath, description: string, members: Slug[]): void => {
+    leaves.set(path, {
+      path,
+      frontmatter: { path, in_core: false },
+      description,
+      members,
+      domain: "synthetic",
+    });
+    for (const slug of members) {
+      const list = byPage.get(slug) ?? [];
+      list.push(path);
+      byPage.set(slug, list);
+    }
+  };
+
+  leaf("animals/aquatic", "creatures that swim in water", ["dolphin-notes"]);
+  leaf("animals/birds", "winged creatures that fly", ["sparrow-notes"]);
+  leaf("vehicles/land", "machines with wheels for roads", ["bicycle-notes"]);
+
+  const summaries = new Map<Slug, string>([
+    ["dolphin-notes", "observations about marine mammals and echolocation"],
+    ["sparrow-notes", "field journal of garden visitors"],
+    ["bicycle-notes", "maintenance log for chains and brakes"],
+  ]);
+
+  return { tree: { leaves, byPage }, summaries };
+}
+
+test("query matches a literal term in a page summary", async () => {
+  const { tree, summaries } = makeFixture();
+  const index = await buildNeedleIndex(
+    tree,
+    async (slug) => summaries.get(slug) ?? "",
+  );
+
+  const results = index.query("echolocation", 3);
+  expect(results[0]).toBe("dolphin-notes");
+});
+
+test("query matches a term that appears only in a leaf label", async () => {
+  const { tree, summaries } = makeFixture();
+  const index = await buildNeedleIndex(
+    tree,
+    async (slug) => summaries.get(slug) ?? "",
+  );
+
+  // "wheels" appears only in the vehicles/land leaf description, not in any
+  // summary or slug — it must still surface bicycle-notes.
+  const results = index.query("wheels", 3);
+  expect(results).toContain("bicycle-notes");
+});
+
+test("query matches a term in the slug title segment", async () => {
+  const { tree, summaries } = makeFixture();
+  const index = await buildNeedleIndex(
+    tree,
+    async (slug) => summaries.get(slug) ?? "",
+  );
+
+  const results = index.query("sparrow", 3);
+  expect(results[0]).toBe("sparrow-notes");
+});
+
+test("nonsense query returns no spurious results", async () => {
+  const { tree, summaries } = makeFixture();
+  const index = await buildNeedleIndex(
+    tree,
+    async (slug) => summaries.get(slug) ?? "",
+  );
+
+  expect(index.query("xyzzyplugh", 3)).toEqual([]);
+});
+
+test("results are capped at k and ordered by score", async () => {
+  const { tree, summaries } = makeFixture();
+  const index = await buildNeedleIndex(
+    tree,
+    async (slug) => summaries.get(slug) ?? "",
+  );
+
+  // "creatures" appears in both animal leaf labels; vehicles should be absent.
+  const results = index.query("creatures", 1);
+  expect(results.length).toBe(1);
+  expect(results[0]).not.toBe("bicycle-notes");
+});
+
+test("empty corpus yields empty results", async () => {
+  const tree: LeafTree = { leaves: new Map(), byPage: new Map() };
+  const index = await buildNeedleIndex(tree, async () => "");
+  expect(index.query("anything", 5)).toEqual([]);
+});

--- a/assistant/src/memory/v3/needle.ts
+++ b/assistant/src/memory/v3/needle.ts
@@ -1,0 +1,115 @@
+import type { LeafTree, Slug } from "./types.js";
+
+/**
+ * Sparse "needle" arm for memory-v3 routing: a lexical BM25 search over page
+ * titles, slug tokens, summaries, and the labels of the leaves each page
+ * belongs to. It augments topical (tree) routing by surfacing pages that share
+ * a literal term with the query even when topical routing would miss them.
+ *
+ * Implementation notes:
+ * - Hand-rolled Okapi BM25 (no dependency). The corpus is bounded (one doc per
+ *   page), so a plain inverted index is plenty.
+ * - The index is built once and held in memory. The orchestrator/plugin
+ *   lazy-inits it. Rebuilding on consolidation is a documented fast-follow and
+ *   intentionally out of scope here.
+ */
+
+/** Okapi BM25 term-frequency saturation parameter. */
+export const k1 = 1.5;
+/** Okapi BM25 length-normalization parameter. */
+export const b = 0.75;
+
+export interface NeedleIndex {
+  /** Returns up to `k` slugs ranked by BM25 score (descending, ties by slug). */
+  query(text: string, k: number): Slug[];
+}
+
+/** Lowercase, split on non-alphanumeric, drop empties. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0);
+}
+
+interface Posting {
+  doc: number;
+  tf: number;
+}
+
+export async function buildNeedleIndex(
+  tree: LeafTree,
+  pageSummary: (slug: Slug) => Promise<string>,
+): Promise<NeedleIndex> {
+  const slugs: Slug[] = [...tree.byPage.keys()];
+
+  // term -> postings (doc index + term frequency in that doc)
+  const postings = new Map<string, Posting[]>();
+  const docLengths: number[] = new Array(slugs.length).fill(0);
+  let totalLength = 0;
+
+  for (let doc = 0; doc < slugs.length; doc++) {
+    const slug = slugs[doc]!;
+
+    // Title = last path segment of the slug; also index the slug tokens.
+    const segments = slug.split(/[/.]/);
+    const title = segments[segments.length - 1] ?? "";
+
+    const parts: string[] = [title, slug, await pageSummary(slug)];
+
+    for (const leafPath of tree.byPage.get(slug) ?? []) {
+      const leaf = tree.leaves.get(leafPath);
+      if (leaf) parts.push(leaf.description);
+    }
+
+    const tokens = tokenize(parts.join(" "));
+    docLengths[doc] = tokens.length;
+    totalLength += tokens.length;
+
+    const termFreqs = new Map<string, number>();
+    for (const token of tokens) {
+      termFreqs.set(token, (termFreqs.get(token) ?? 0) + 1);
+    }
+    for (const [term, tf] of termFreqs) {
+      let list = postings.get(term);
+      if (!list) {
+        list = [];
+        postings.set(term, list);
+      }
+      list.push({ doc, tf });
+    }
+  }
+
+  const docCount = slugs.length;
+  const avgDocLength = docCount > 0 ? totalLength / docCount : 0;
+
+  function query(text: string, k: number): Slug[] {
+    if (k <= 0 || docCount === 0) return [];
+
+    const queryTerms = new Set(tokenize(text));
+    const scores = new Map<number, number>();
+
+    // O(query-terms x matching-docs): walk only the postings of query terms.
+    for (const term of queryTerms) {
+      const list = postings.get(term);
+      if (!list) continue;
+
+      const idf = Math.log(
+        1 + (docCount - list.length + 0.5) / (list.length + 0.5),
+      );
+
+      for (const { doc, tf } of list) {
+        const norm = tf * (k1 + 1);
+        const denom = tf + k1 * (1 - b + b * (docLengths[doc]! / avgDocLength));
+        scores.set(doc, (scores.get(doc) ?? 0) + idf * (norm / denom));
+      }
+    }
+
+    return [...scores.entries()]
+      .sort((a, c) => c[1] - a[1] || slugs[a[0]]!.localeCompare(slugs[c[0]]!))
+      .slice(0, k)
+      .map(([doc]) => slugs[doc]!);
+  }
+
+  return { query };
+}


### PR DESCRIPTION
## Summary
- Add buildNeedleIndex/NeedleIndex.query: a dependency-free Okapi BM25 (k1=1.5, b=0.75) over page titles/slugs/summaries/leaf-labels, with postings-based top-k lookup. Index built once in memory; rebuild-on-consolidation is a documented fast-follow. Tests run against a synthetic corpus.

Part of plan: memory-v3-topic-tree-routing.md (PR 14 of 19)