### PR TITLE
feat(memory-v3): working-set eviction policy + config

### DIFF
--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+/**
+ * Memory v3 (topic-tree routing) working-set configuration.
+ *
+ * The working set is the per-conversation set of concept pages carried
+ * forward across turns. Eviction keeps it bounded: pages unseen for longer
+ * than `evictWindow` turns are dropped, and the set is capped at `maxPages`.
+ */
+export const MemoryV3WorkingSetSchema = z
+  .object({
+    maxPages: z
+      .number({ error: "memory.v3.workingSet.maxPages must be a number" })
+      .int("memory.v3.workingSet.maxPages must be an integer")
+      .positive("memory.v3.workingSet.maxPages must be a positive integer")
+      .default(150)
+      .describe(
+        "Upper bound on the number of pages retained in the working set. Once exceeded, the least-salient non-pinned pages are evicted until the set fits.",
+      ),
+    evictWindow: z
+      .number({ error: "memory.v3.workingSet.evictWindow must be a number" })
+      .int("memory.v3.workingSet.evictWindow must be an integer")
+      .positive("memory.v3.workingSet.evictWindow must be a positive integer")
+      .default(5)
+      .describe(
+        "Number of turns a non-pinned page may go unseen before it is evicted from the working set.",
+      ),
+  })
+  .describe("Memory v3 working-set retention/eviction tuning.");
+
+export const MemoryV3ConfigSchema = z
+  .object({
+    workingSet: MemoryV3WorkingSetSchema.default(
+      MemoryV3WorkingSetSchema.parse({}),
+    ),
+  })
+  .describe("Memory v3 — topic-tree routing with a carry-forward working set");
+
+export type MemoryV3Config = z.infer<typeof MemoryV3ConfigSchema>;

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -17,6 +17,7 @@ import {
   QdrantConfigSchema,
 } from "./memory-storage.js";
 import { MemoryV2ConfigSchema } from "./memory-v2.js";
+import { MemoryV3ConfigSchema } from "./memory-v3.js";
 
 export const MemoryConfigSchema = z
   .object({
@@ -50,6 +51,7 @@ export const MemoryConfigSchema = z
       MemorySummarizationConfigSchema.parse({}),
     ),
     v2: MemoryV2ConfigSchema.default(MemoryV2ConfigSchema.parse({})),
+    v3: MemoryV3ConfigSchema.default(MemoryV3ConfigSchema.parse({})),
     retrospective: MemoryRetrospectiveConfigSchema.default(
       MemoryRetrospectiveConfigSchema.parse({}),
     ),

--- a/assistant/src/memory/v3/__tests__/working-set-eviction.test.ts
+++ b/assistant/src/memory/v3/__tests__/working-set-eviction.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+
+import { WorkingSetEntry } from "../types.js";
+import { ScoreFn, WorkingSet } from "../working-set.js";
+
+describe("WorkingSet.evict", () => {
+  test("evicts a page unseen past the window", () => {
+    const ws = new WorkingSet(150, 5);
+    ws.recordSelection("alpha", 0, false);
+
+    // currentTurn 6, lastSeen 0 → gap 6 > window 5 → evict.
+    ws.evict(6, new Set());
+
+    expect(ws.union().has("alpha")).toBe(false);
+    expect(ws.size()).toBe(0);
+  });
+
+  test("keeps a page still inside the window", () => {
+    const ws = new WorkingSet(150, 5);
+    ws.recordSelection("alpha", 0, false);
+
+    // gap 5 is not > 5 → keep.
+    ws.evict(5, new Set());
+
+    expect(ws.union().has("alpha")).toBe(true);
+  });
+
+  test("pinned page never evicts past the window", () => {
+    const ws = new WorkingSet(150, 5);
+    ws.recordSelection("alpha", 0, true);
+
+    ws.evict(100, new Set());
+
+    expect(ws.union().has("alpha")).toBe(true);
+  });
+
+  test("exceeding maxPages evicts the least-recently-selected non-pinned page first", () => {
+    const ws = new WorkingSet(2, 1000);
+    ws.recordSelection("oldest", 1, false);
+    ws.recordSelection("middle", 2, false);
+    ws.recordSelection("newest", 3, false);
+
+    // No window eviction (window huge); cap is 2 → drop lowest lastSeenTurn.
+    ws.evict(3, new Set());
+
+    expect(ws.size()).toBe(2);
+    expect(ws.union().has("oldest")).toBe(false);
+    expect(ws.union().has("middle")).toBe(true);
+    expect(ws.union().has("newest")).toBe(true);
+  });
+
+  test("cap eviction never drops pinned pages even when over capacity", () => {
+    const ws = new WorkingSet(1, 1000);
+    ws.recordSelection("pinned-a", 1, true);
+    ws.recordSelection("pinned-b", 2, true);
+    ws.recordSelection("loose", 3, false);
+
+    ws.evict(3, new Set());
+
+    // Only the non-pinned page can go; pinned pages stay even over cap.
+    expect(ws.union().has("pinned-a")).toBe(true);
+    expect(ws.union().has("pinned-b")).toBe(true);
+    expect(ws.union().has("loose")).toBe(false);
+    expect(ws.size()).toBe(2);
+  });
+
+  test("core slugs passed to evict are dropped if present", () => {
+    const ws = new WorkingSet(150, 5);
+    ws.recordSelection("alpha", 5, false);
+    ws.recordSelection("beta", 5, true); // pinned, but core still wins
+    ws.recordSelection("gamma", 5, false);
+
+    ws.evict(5, new Set(["alpha", "beta"]));
+
+    expect(ws.union().has("alpha")).toBe(false);
+    expect(ws.union().has("beta")).toBe(false);
+    expect(ws.union().has("gamma")).toBe(true);
+  });
+
+  test("custom scoreFn reorders cap-evictions", () => {
+    // Score by selectedAtTurn instead of lastSeenTurn: the page selected
+    // earliest becomes most evictable regardless of recent activity.
+    const bySelectedAt: ScoreFn = (e: WorkingSetEntry) => e.selectedAtTurn;
+    const ws = new WorkingSet(2, 1000, bySelectedAt);
+
+    ws.recordSelection("first", 0, false);
+    ws.recordSelection("second", 1, false);
+    ws.recordSelection("third", 2, false);
+    // Bump "first" so plain LRU would protect it, but selectedAt still lowest.
+    ws.recordSelection("first", 9, false);
+
+    ws.evict(9, new Set());
+
+    expect(ws.size()).toBe(2);
+    // Under custom score, "first" (selectedAt 0) evicts despite recent touch.
+    expect(ws.union().has("first")).toBe(false);
+    expect(ws.union().has("second")).toBe(true);
+    expect(ws.union().has("third")).toBe(true);
+  });
+
+  test("default no-arg constructor still works for existing callers", () => {
+    const ws = new WorkingSet();
+    ws.recordSelection("alpha", 0, false);
+    expect(ws.size()).toBe(1);
+  });
+});

--- a/assistant/src/memory/v3/working-set.ts
+++ b/assistant/src/memory/v3/working-set.ts
@@ -1,7 +1,25 @@
 import { Slug, WorkingSetEntry } from "./types.js";
 
+/**
+ * Scores a working-set entry for cap eviction. Lower score = more evictable.
+ * This is the pluggable seam for a future salience-weighted policy; the
+ * default is plain LRU on `lastSeenTurn`.
+ */
+export type ScoreFn = (entry: WorkingSetEntry) => number;
+
+/** Default eviction score: least-recently-seen entries evict first. */
+function lruScore(entry: WorkingSetEntry): number {
+  return entry.lastSeenTurn;
+}
+
 export class WorkingSet {
   private entries = new Map<Slug, WorkingSetEntry>();
+
+  constructor(
+    private readonly maxPages = 150,
+    private readonly evictWindow = 5,
+    private readonly scoreFn: ScoreFn = lruScore,
+  ) {}
 
   recordSelection(slug: Slug, turn: number, pinned: boolean): void {
     const existing = this.entries.get(slug);
@@ -21,5 +39,50 @@ export class WorkingSet {
     return this.entries.size;
   }
 
-  // evict(...) — added in a later PR
+  /**
+   * Prune the working set, in order:
+   *   1. Core slugs never belong here — drop any entry whose slug is core.
+   *   2. Pinned entries never evict.
+   *   3. Window eviction: drop a non-pinned entry unseen for more than
+   *      `evictWindow` turns.
+   *   4. Cap eviction: while over `maxPages`, evict the lowest-scoring
+   *      non-pinned entry first (ties broken deterministically).
+   */
+  evict(currentTurn: number, coreSlugs: Set<Slug>): void {
+    // 1. Core slugs are owned by core, not the working set.
+    for (const slug of this.entries.keys()) {
+      if (coreSlugs.has(slug)) {
+        this.entries.delete(slug);
+      }
+    }
+
+    // 2 + 3. Window eviction for stale non-pinned entries.
+    for (const [slug, entry] of this.entries) {
+      if (
+        !entry.pinned &&
+        currentTurn - entry.lastSeenTurn > this.evictWindow
+      ) {
+        this.entries.delete(slug);
+      }
+    }
+
+    // 4. Cap eviction: evict the lowest-scoring non-pinned entry until the
+    // set fits. Sort once (ascending score, then slug for determinism) and
+    // walk the candidates.
+    if (this.entries.size <= this.maxPages) {
+      return;
+    }
+    const evictable = [...this.entries.values()]
+      .filter((entry) => !entry.pinned)
+      .sort(
+        (a, b) =>
+          this.scoreFn(a) - this.scoreFn(b) || (a.slug < b.slug ? -1 : 1),
+      );
+    for (const entry of evictable) {
+      if (this.entries.size <= this.maxPages) {
+        break;
+      }
+      this.entries.delete(entry.slug);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add WorkingSet.evict (core-drop, pinned-never-evict, K-turn window, LRU cap) with a pluggable ScoreFn seam for future salience-weighting.
- Add memory.v3 config schema (workingSet.maxPages=150, evictWindow=5) wired into the composed memory schema.

Part of plan: memory-v3-topic-tree-routing.md (PR 16 of 19)