### PR TITLE
feat(memory-v3): L1 router + memoryV3RouteL1 callsite

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -26,6 +26,7 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     profile: "cost-optimized",
     contextWindow: { maxInputTokens: 1000000 },
   },
+  memoryV3RouteL1: { profile: "balanced", temperature: 0 },
   recall: {
     profile: "balanced",
     maxTokens: 4096,

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -121,6 +121,13 @@ const CATALOG_RECORD: CatalogRecord = {
       "Selects which concept pages to inject for the next agent turn by routing over a cached page index.",
     domain: "memory",
   },
+  memoryV3RouteL1: {
+    id: "memoryV3RouteL1",
+    displayName: "Memory V3 L1 Router",
+    description:
+      "Picks which leaves of the topic tree to open for the next agent turn by routing over a cache-warm static leaf block.",
+    domain: "memory",
+  },
   memoryV2Consolidation: {
     id: "memoryV2Consolidation",
     displayName: "Memory V2 Consolidation",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -49,6 +49,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryV2Migration",
   "memoryV2Sweep",
   "memoryRouter",
+  "memoryV3RouteL1",
   "memoryV2Consolidation",
   "memoryRetrospective",
   "recall",

--- a/assistant/src/memory/v3/__tests__/router.test.ts
+++ b/assistant/src/memory/v3/__tests__/router.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for `assistant/src/memory/v3/router.ts`.
+ *
+ * Coverage matrix:
+ *   - Returned IDs map to the right leaves by 1-based index, in model order.
+ *   - Omitted `ids` → ALL leaves (recall-safe).
+ *   - Explicit `ids: []` → no leaves (deliberate abstention).
+ *   - Out-of-range / duplicate IDs ignored, no throw.
+ *   - No provider / missing tool_use / schema mismatch / throw → ALL leaves.
+ *   - The rendered leaf block is byte-identical across two calls with
+ *     different queries (the cache invariant).
+ *   - The system prompt mentions "register" (locks the routing commitment).
+ *
+ * The provider is stubbed so no network calls fire.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+  ToolUseContent,
+} from "../../../providers/types.js";
+import type { LeafNode, LeafPath, LeafTree, TurnContext } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks installed BEFORE the router import so the module observes them at
+// load time.
+// ---------------------------------------------------------------------------
+
+let providerStub: Provider | null = null;
+
+interface ProviderCall {
+  messages: Message[];
+  tools: ToolDefinition[] | undefined;
+  systemPrompt: string | undefined;
+  options: SendMessageOptions | undefined;
+}
+const providerCalls: ProviderCall[] = [];
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_t, prop) => (prop === "child" ? () => ({}) : () => {}),
+    }),
+}));
+
+const { routeL1, renderLeafBlock } = await import("../router.js");
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+function makeProvider(response: ProviderResponse): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (messages, tools, systemPrompt, options) => {
+      providerCalls.push({ messages, tools, systemPrompt, options });
+      return response;
+    },
+  };
+}
+
+function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "tool_use", id: "tu-1", name: "open_leaves", input }],
+  };
+}
+
+function makeLeaf(path: LeafPath, description: string): LeafNode {
+  return {
+    path,
+    frontmatter: { path, in_core: false },
+    description,
+    members: [],
+    domain: path.split("/")[0],
+  };
+}
+
+/** Tree whose leaves are intentionally inserted out of sorted order so the
+ * tests verify the router sorts by path (not insertion order) before
+ * assigning 1-based IDs. Sorted → [people/alice, people/bob, projects/atlas]. */
+function makeTree(): LeafTree {
+  const entries: LeafNode[] = [
+    makeLeaf("projects/atlas", "The Atlas project roadmap and status."),
+    makeLeaf("people/bob", "Bob — colleague, prefers async."),
+    makeLeaf("people/alice", "Alice — manager, weekly 1:1s."),
+  ];
+  return {
+    leaves: new Map(entries.map((n) => [n.path, n])),
+    byPage: new Map(),
+  };
+}
+
+const SORTED_PATHS = ["people/alice", "people/bob", "projects/atlas"];
+
+function makeTurn(currentMessage: string): TurnContext {
+  return {
+    conversationId: "conv-xyz",
+    turnNumber: 1,
+    currentMessage,
+    recentContext: "earlier we talked about the timeline",
+  };
+}
+
+beforeEach(() => {
+  providerStub = null;
+  providerCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+describe("routeL1 — id mapping", () => {
+  test("returned IDs map to leaves by 1-based index, in model order", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [3, 1] }));
+    const result = await routeL1(makeTurn("how's atlas?"), makeTree());
+    expect(result).toEqual(["projects/atlas", "people/alice"]);
+  });
+
+  test("omitted ids opens ALL leaves (recall-safe)", async () => {
+    providerStub = makeProvider(toolUseResponse({}));
+    const result = await routeL1(makeTurn("anything"), makeTree());
+    expect(result).toEqual(SORTED_PATHS);
+  });
+
+  test("explicit empty ids opens no leaves (abstention)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const result = await routeL1(makeTurn("nothing relevant"), makeTree());
+    expect(result).toEqual([]);
+  });
+
+  test("out-of-range and duplicate IDs are ignored without throwing", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
+    const result = await routeL1(makeTurn("bob?"), makeTree());
+    expect(result).toEqual(["people/bob"]);
+  });
+
+  test("empty tree returns no leaves and never calls the provider", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const result = await routeL1(makeTurn("hi"), {
+      leaves: new Map(),
+      byPage: new Map(),
+    });
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+describe("routeL1 — recall-safe fallbacks", () => {
+  test("no provider → ALL leaves", async () => {
+    providerStub = null;
+    const result = await routeL1(makeTurn("x"), makeTree());
+    expect(result).toEqual(SORTED_PATHS);
+  });
+
+  test("missing tool_use → ALL leaves", async () => {
+    providerStub = makeProvider({
+      model: "stub-model",
+      stopReason: "end_turn",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      content: [{ type: "text", text: "no tool call" }],
+    });
+    const result = await routeL1(makeTurn("x"), makeTree());
+    expect(result).toEqual(SORTED_PATHS);
+  });
+
+  test("schema mismatch → ALL leaves", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
+    const result = await routeL1(makeTurn("x"), makeTree());
+    expect(result).toEqual(SORTED_PATHS);
+  });
+
+  test("provider throw → ALL leaves", async () => {
+    providerStub = {
+      name: "throwing",
+      sendMessage: async () => {
+        throw new Error("boom");
+      },
+    };
+    const result = await routeL1(makeTurn("x"), makeTree());
+    expect(result).toEqual(SORTED_PATHS);
+  });
+});
+
+describe("routeL1 — request shape", () => {
+  test("forces tool_choice to open_leaves with the v3 call site", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(makeTurn("alice?"), makeTree());
+
+    expect(providerCalls).toHaveLength(1);
+    const [call] = providerCalls;
+    const cfg = call.options?.config as Record<string, unknown>;
+    expect(cfg?.callSite).toBe("memoryV3RouteL1");
+    expect(cfg?.tool_choice).toEqual({ type: "tool", name: "open_leaves" });
+    expect(call.tools?.[0].name).toBe("open_leaves");
+  });
+
+  test("leaf block is the first content block with an ephemeral cache breakpoint", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(makeTurn("alice?"), makeTree());
+
+    const [blockA, blockB] = providerCalls[0].messages[0].content as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string };
+    }>;
+    expect(blockA.type).toBe("text");
+    expect(blockA.text).toContain("<leaves>");
+    expect(blockA.cache_control).toEqual({ type: "ephemeral" });
+
+    expect(blockB.type).toBe("text");
+    expect(blockB.text).toContain("<current_message>alice?</current_message>");
+    expect(blockB.text).toContain("<recent_context>");
+    expect(blockB.cache_control).toBeUndefined();
+  });
+
+  test("system prompt mentions register (locks the routing commitment)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(makeTurn("x"), makeTree());
+    expect(providerCalls[0].systemPrompt).toMatch(/register/);
+  });
+});
+
+describe("renderLeafBlock — cache invariant", () => {
+  test("is byte-identical across two calls with different queries", async () => {
+    const tree = makeTree();
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+
+    await routeL1(makeTurn("first query about alice"), tree);
+    await routeL1(makeTurn("totally different query about atlas"), tree);
+
+    const prefixA = (
+      providerCalls[0].messages[0].content[0] as { text: string }
+    ).text;
+    const prefixB = (
+      providerCalls[1].messages[0].content[0] as { text: string }
+    ).text;
+    expect(prefixA).toBe(prefixB);
+    // And it equals the pure renderer's output.
+    expect(prefixA).toBe(renderLeafBlock(tree));
+  });
+
+  test("renders leaves sorted by path with 1-based numbering", () => {
+    const block = renderLeafBlock(makeTree());
+    expect(block).toContain("[1] people/alice — ");
+    expect(block).toContain("[2] people/bob — ");
+    expect(block).toContain("[3] projects/atlas — ");
+  });
+});

--- a/assistant/src/memory/v3/router.ts
+++ b/assistant/src/memory/v3/router.ts
@@ -1,0 +1,204 @@
+/**
+ * Memory v3 — L1 leaf router.
+ *
+ * One forced-tool LLM call per turn that picks which leaves of the topic tree
+ * to open for the next reply. The design mirrors `../v2/router.ts`:
+ *   - resolve the configured provider via `getConfiguredProvider`,
+ *   - call `provider.sendMessage` with a forced `tool_choice`,
+ *   - validate the tool input via Zod,
+ *   - map numbered IDs back to leaf paths.
+ *
+ * Cache strategy. The numbered leaf block is the single largest input and is
+ * STABLE across turns — it changes only when leaves are added/removed/edited.
+ * We render it first in the user message and tag it with an ephemeral
+ * `cache_control` breakpoint so the provider can serve it from the prompt
+ * cache turn after turn. The trailing recent-context / current-message block
+ * changes every turn, so it carries no breakpoint.
+ *
+ * Recall-safe fallbacks. The router exists to widen recall, so every failure
+ * mode degrades toward opening MORE leaves, never fewer:
+ *   - omitted `ids` (model didn't pass the field) → open ALL leaves,
+ *   - missing/failed tool_use, provider unavailable, or any throw → ALL leaves.
+ * The one path that returns nothing is an explicit empty array (`ids: []`),
+ * which is the model deliberately abstaining.
+ */
+
+import { z } from "zod";
+
+import {
+  extractToolUse,
+  getConfiguredProvider,
+} from "../../providers/provider-send-message.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { LeafPath, LeafTree, TurnContext } from "./types.js";
+
+const log = getLogger("memory-v3-router");
+
+/** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
+const OPEN_LEAVES_TOOL_NAME = "open_leaves";
+
+const OpenLeavesSchema = z.object({
+  // Optional: an omitted `ids` field is the recall-safe "open everything"
+  // signal, distinct from an explicit empty array (deliberate abstention).
+  ids: z.array(z.number().int()).optional(),
+});
+
+const OPEN_LEAVES_TOOL: ToolDefinition = {
+  name: OPEN_LEAVES_TOOL_NAME,
+  description:
+    "Open the leaves whose contents could plausibly bear on the next reply. " +
+    "Lean toward inclusion — a missed relevant leaf is a worse error than an " +
+    "unused one. Omit `ids` entirely to open every leaf; return `[]` only " +
+    "when nothing in the tree could possibly help.",
+  input_schema: {
+    type: "object",
+    properties: {
+      ids: {
+        type: "array",
+        items: { type: "integer" },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `You route a conversation turn to the leaves of a topic tree that should be opened for the next reply.
+
+Each leaf has a numbered ID, a path, and a description of what it holds. Decide which leaves to open by weighing three signals:
+
+- Topic — entities, projects, and events named or implied by the turn.
+- Register — the affect and mode of the message (e.g. playful, distressed, formal). A register signal is enough to open a leaf even when no entity is named.
+- Recent context — the immediately preceding exchange, which resolves references like "this", "that", or "the same thing" to concrete topics.
+
+Include on doubt: open every leaf that could plausibly hold something useful. Missing a relevant leaf is a worse error than opening an unused one. Call \`open_leaves\` with the chosen IDs. Omit \`ids\` to open every leaf; return \`[]\` only when nothing in the tree could possibly help.`;
+
+/** Leaves sorted deterministically by path so the numbered block is stable. */
+function sortedLeaves(tree: LeafTree): LeafPath[] {
+  return [...tree.leaves.keys()].sort();
+}
+
+/**
+ * Render the STATIC numbered leaf block from a pre-sorted path list. Identical
+ * across turns for any given tree, which is what makes the prompt-cache
+ * breakpoint pay off.
+ */
+function renderLeafBlockFromPaths(tree: LeafTree, paths: LeafPath[]): string {
+  const lines = paths.map((path, i) => {
+    const description = tree.leaves.get(path)?.description ?? "";
+    // Collapse the (possibly multi-line) description to a single line so each
+    // leaf is exactly one numbered entry.
+    const oneLine = description.replace(/\s+/g, " ").trim();
+    return `[${i + 1}] ${path} — ${oneLine}`;
+  });
+  return `<leaves>\n${lines.join("\n")}\n</leaves>`;
+}
+
+/**
+ * Render the static numbered leaf block for a tree. Exported for the test that
+ * locks the byte-identical cache invariant; `routeL1` renders from its already
+ * sorted path list to avoid sorting twice.
+ */
+export function renderLeafBlock(tree: LeafTree): string {
+  return renderLeafBlockFromPaths(tree, sortedLeaves(tree));
+}
+
+/**
+ * Run the L1 router for one turn. Returns the leaf paths to open.
+ *
+ * Recall-safe: any failure to obtain an explicit selection returns ALL leaves.
+ * Only an explicit empty `ids` array returns no leaves.
+ */
+export async function routeL1(
+  turn: TurnContext,
+  tree: LeafTree,
+): Promise<LeafPath[]> {
+  const paths = sortedLeaves(tree);
+  if (paths.length === 0) return [];
+
+  const provider = await getConfiguredProvider("memoryV3RouteL1");
+  if (!provider) {
+    log.warn("memoryV3RouteL1 provider unavailable; opening all leaves");
+    return paths;
+  }
+
+  const userMsg: Message = {
+    role: "user",
+    content: [
+      cachedTextBlock(renderLeafBlockFromPaths(tree, paths)),
+      {
+        type: "text",
+        text:
+          `<recent_context>${turn.recentContext}</recent_context>\n` +
+          `<current_message>${turn.currentMessage}</current_message>`,
+      },
+    ],
+  };
+
+  let response;
+  try {
+    response = await provider.sendMessage(
+      [userMsg],
+      [OPEN_LEAVES_TOOL],
+      SYSTEM_PROMPT,
+      {
+        config: {
+          callSite: "memoryV3RouteL1" as const,
+          tool_choice: { type: "tool" as const, name: OPEN_LEAVES_TOOL_NAME },
+        },
+      },
+    );
+  } catch (err) {
+    log.warn({ err }, "L1 router call threw; opening all leaves");
+    return paths;
+  }
+
+  const toolBlock = extractToolUse(response);
+  if (!toolBlock || toolBlock.name !== OPEN_LEAVES_TOOL_NAME) {
+    log.warn(
+      { stopReason: response.stopReason },
+      "L1 router returned no open_leaves tool_use; opening all leaves",
+    );
+    return paths;
+  }
+
+  const parsed = OpenLeavesSchema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { error: parsed.error.message },
+      "L1 router tool input did not match schema; opening all leaves",
+    );
+    return paths;
+  }
+
+  // Omitted `ids` is the recall-safe "open everything" signal.
+  if (parsed.data.ids === undefined) return paths;
+
+  // Map 1-based IDs back to leaf paths, dropping out-of-range IDs without
+  // throwing. De-duplicate while preserving model-returned order.
+  const seen = new Set<number>();
+  const selected: LeafPath[] = [];
+  for (const id of parsed.data.ids) {
+    if (id < 1 || id > paths.length || seen.has(id)) continue;
+    seen.add(id);
+    selected.push(paths[id - 1]);
+  }
+  return selected;
+}
+
+/**
+ * Text content block carrying an ephemeral `cache_control` breakpoint. Our
+ * internal `TextContent` type omits the field (only the Anthropic provider
+ * transforms it onto the wire), so we reach through a `Record` cast for the
+ * same reason `v2/router.ts` does — it keeps the core types provider-agnostic.
+ */
+function cachedTextBlock(text: string): ContentBlock {
+  const block: ContentBlock = { type: "text", text };
+  (block as unknown as Record<string, unknown>).cache_control = {
+    type: "ephemeral",
+  };
+  return block;
+}


### PR DESCRIPTION
## Summary
- Add routeL1: one forced-tool LLM call/turn over a static, cache-warm numbered leaf-block (cache_control ephemeral), routing by topic + register/affect + recent context, with numbered-id mapping and recall-safe fallbacks (omitted ids / failure → all leaves). Registers the memoryV3RouteL1 callsite.

Part of plan: memory-v3-topic-tree-routing.md (PR 17 of 19)