### PR TITLE
feat(memory-v3): per-leaf L2 selector + memoryV3SelectL2 callsite

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -27,6 +27,7 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     contextWindow: { maxInputTokens: 1000000 },
   },
   memoryV3RouteL1: { profile: "balanced", temperature: 0 },
+  memoryV3SelectL2: { profile: "balanced", temperature: 0 },
   recall: {
     profile: "balanced",
     maxTokens: 4096,

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -128,6 +128,13 @@ const CATALOG_RECORD: CatalogRecord = {
       "Picks which leaves of the topic tree to open for the next agent turn by routing over a cache-warm static leaf block.",
     domain: "memory",
   },
+  memoryV3SelectL2: {
+    id: "memoryV3SelectL2",
+    displayName: "Memory V3 L2 Selector",
+    description:
+      "Selects which pages within an opened topic-tree leaf are relevant for the next agent turn, one bounded call per leaf over a cache-warm static page block.",
+    domain: "memory",
+  },
   memoryV2Consolidation: {
     id: "memoryV2Consolidation",
     displayName: "Memory V2 Consolidation",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -50,6 +50,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryV2Sweep",
   "memoryRouter",
   "memoryV3RouteL1",
+  "memoryV3SelectL2",
   "memoryV2Consolidation",
   "memoryRetrospective",
   "recall",

--- a/assistant/src/memory/v3/__tests__/selector.test.ts
+++ b/assistant/src/memory/v3/__tests__/selector.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for `assistant/src/memory/v3/selector.ts`.
+ *
+ * Coverage matrix:
+ *   - Returned IDs map to the right member slugs by 1-based index, with
+ *     `pinned` driven by `pinned_ids`.
+ *   - Omitted `ids` → ALL members of the leaf (recall-safe).
+ *   - Explicit `ids: []` → no pages (deliberate abstention).
+ *   - No provider / missing tool_use / schema mismatch / throw → ALL members.
+ *   - The per-leaf `<pages>` prefix is byte-identical across two calls with
+ *     different turns (the cache invariant).
+ *   - `selectAcrossLeaves` flattens per-leaf results and never exceeds the
+ *     configured concurrency.
+ *
+ * The provider is stubbed so no network calls fire.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+  ToolUseContent,
+} from "../../../providers/types.js";
+import type {
+  LeafNode,
+  LeafPath,
+  LeafTree,
+  Slug,
+  TurnContext,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks installed BEFORE the selector import so the module observes them at
+// load time.
+// ---------------------------------------------------------------------------
+
+let providerStub: Provider | null = null;
+
+interface ProviderCall {
+  messages: Message[];
+  tools: ToolDefinition[] | undefined;
+  systemPrompt: string | undefined;
+  options: SendMessageOptions | undefined;
+}
+const providerCalls: ProviderCall[] = [];
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_t, prop) => (prop === "child" ? () => ({}) : () => {}),
+    }),
+}));
+
+const { selectFromLeaf, selectAcrossLeaves } = await import("../selector.js");
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+function makeProvider(response: ProviderResponse): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (messages, tools, systemPrompt, options) => {
+      providerCalls.push({ messages, tools, systemPrompt, options });
+      return response;
+    },
+  };
+}
+
+function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "tool_use", id: "tu-1", name: "select_pages", input }],
+  };
+}
+
+function makeLeaf(path: LeafPath, members: Slug[]): LeafNode {
+  return {
+    path,
+    frontmatter: { path, in_core: false },
+    description: `description for ${path}`,
+    members,
+    domain: path.split("/")[0],
+  };
+}
+
+/** Tree with two leaves; `people/alice` has three member pages. */
+function makeTree(): LeafTree {
+  const leaves: LeafNode[] = [
+    makeLeaf("people/alice", ["alice-bio", "alice-1on1", "alice-feedback"]),
+    makeLeaf("projects/atlas", ["atlas-roadmap", "atlas-status"]),
+  ];
+  const byPage = new Map<Slug, LeafPath[]>();
+  for (const leaf of leaves) {
+    for (const slug of leaf.members) {
+      byPage.set(slug, [...(byPage.get(slug) ?? []), leaf.path]);
+    }
+  }
+  return {
+    leaves: new Map(leaves.map((n) => [n.path, n])),
+    byPage,
+  };
+}
+
+const ALICE_MEMBERS = ["alice-bio", "alice-1on1", "alice-feedback"];
+
+function makeTurn(currentMessage: string): TurnContext {
+  return {
+    conversationId: "conv-xyz",
+    turnNumber: 1,
+    currentMessage,
+    recentContext: "earlier we talked about the timeline",
+  };
+}
+
+/** Deterministic summary stub so the rendered prefix is reproducible. */
+const summaryOf = async (slug: Slug): Promise<string> => `summary of ${slug}`;
+
+beforeEach(() => {
+  providerStub = null;
+  providerCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// selectFromLeaf — id mapping.
+// ---------------------------------------------------------------------------
+
+describe("selectFromLeaf — id mapping", () => {
+  test("returned IDs map to member slugs, pinned driven by pinned_ids", async () => {
+    providerStub = makeProvider(
+      toolUseResponse({ ids: [3, 1], pinned_ids: [1] }),
+    );
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("how's alice?"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual([
+      { slug: "alice-feedback", pinned: false },
+      { slug: "alice-bio", pinned: true },
+    ]);
+  });
+
+  test("omitted ids selects ALL members (recall-safe)", async () => {
+    providerStub = makeProvider(toolUseResponse({}));
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("anything"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual(
+      ALICE_MEMBERS.map((slug) => ({ slug, pinned: false })),
+    );
+  });
+
+  test("explicit empty ids selects no pages (abstention)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("nothing relevant"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("out-of-range and duplicate IDs are ignored without throwing", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("the 1:1"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual([{ slug: "alice-1on1", pinned: false }]);
+  });
+
+  test("empty leaf returns no pages and never calls the provider", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const result = await selectFromLeaf(
+      "people/empty",
+      makeTurn("hi"),
+      {
+        leaves: new Map([["people/empty", makeLeaf("people/empty", [])]]),
+        byPage: new Map(),
+      },
+      summaryOf,
+    );
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectFromLeaf — recall-safe fallbacks.
+// ---------------------------------------------------------------------------
+
+describe("selectFromLeaf — recall-safe fallbacks", () => {
+  const allAlice = ALICE_MEMBERS.map((slug) => ({ slug, pinned: false }));
+
+  test("no provider → ALL members", async () => {
+    providerStub = null;
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("x"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual(allAlice);
+  });
+
+  test("missing tool_use → ALL members", async () => {
+    providerStub = makeProvider({
+      model: "stub-model",
+      stopReason: "end_turn",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      content: [{ type: "text", text: "no tool call" }],
+    });
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("x"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual(allAlice);
+  });
+
+  test("schema mismatch → ALL members", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("x"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual(allAlice);
+  });
+
+  test("provider throw → ALL members", async () => {
+    providerStub = {
+      name: "throwing",
+      sendMessage: async () => {
+        throw new Error("boom");
+      },
+    };
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("x"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual(allAlice);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectFromLeaf — request shape and cache invariant.
+// ---------------------------------------------------------------------------
+
+describe("selectFromLeaf — request shape", () => {
+  test("forces tool_choice to select_pages with the v3 L2 call site", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectFromLeaf(
+      "people/alice",
+      makeTurn("alice?"),
+      makeTree(),
+      summaryOf,
+    );
+
+    expect(providerCalls).toHaveLength(1);
+    const [call] = providerCalls;
+    const cfg = call.options?.config as Record<string, unknown>;
+    expect(cfg?.callSite).toBe("memoryV3SelectL2");
+    expect(cfg?.tool_choice).toEqual({ type: "tool", name: "select_pages" });
+    expect(call.tools?.[0].name).toBe("select_pages");
+  });
+
+  test("pages block is the first content block with an ephemeral cache breakpoint", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectFromLeaf(
+      "people/alice",
+      makeTurn("alice?"),
+      makeTree(),
+      summaryOf,
+    );
+
+    const [blockA, blockB] = providerCalls[0].messages[0].content as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string };
+    }>;
+    expect(blockA.type).toBe("text");
+    expect(blockA.text).toContain("<leaf>people/alice</leaf>");
+    expect(blockA.text).toContain("<pages>");
+    expect(blockA.text).toContain("[1] alice-bio — summary of alice-bio");
+    expect(blockA.cache_control).toEqual({ type: "ephemeral" });
+
+    expect(blockB.type).toBe("text");
+    expect(blockB.text).toContain("<current_message>alice?</current_message>");
+    expect(blockB.text).toContain("<recent_context>");
+    expect(blockB.cache_control).toBeUndefined();
+  });
+
+  test("system prompt mentions pinned (locks the pinning commitment)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectFromLeaf("people/alice", makeTurn("x"), makeTree(), summaryOf);
+    expect(providerCalls[0].systemPrompt).toMatch(/pinned/);
+  });
+});
+
+describe("selectFromLeaf — per-leaf cache invariant", () => {
+  test("the pages prefix is byte-identical across two calls with different turns", async () => {
+    const tree = makeTree();
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+
+    await selectFromLeaf(
+      "people/alice",
+      makeTurn("first query"),
+      tree,
+      summaryOf,
+    );
+    await selectFromLeaf(
+      "people/alice",
+      makeTurn("totally different second query"),
+      tree,
+      summaryOf,
+    );
+
+    const prefixA = (
+      providerCalls[0].messages[0].content[0] as { text: string }
+    ).text;
+    const prefixB = (
+      providerCalls[1].messages[0].content[0] as { text: string }
+    ).text;
+    expect(prefixA).toBe(prefixB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectAcrossLeaves — fan-out and bounded concurrency.
+// ---------------------------------------------------------------------------
+
+describe("selectAcrossLeaves", () => {
+  test("flattens per-leaf selections", async () => {
+    // The selector forces the tool, so omitted ids → all members per leaf.
+    providerStub = makeProvider(toolUseResponse({}));
+    const result = await selectAcrossLeaves(
+      ["people/alice", "projects/atlas"],
+      makeTurn("x"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result.map((p) => p.slug)).toEqual([
+      "alice-bio",
+      "alice-1on1",
+      "alice-feedback",
+      "atlas-roadmap",
+      "atlas-status",
+    ]);
+  });
+
+  test("never exceeds the configured concurrency", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let calls = 0;
+    providerStub = {
+      name: "tracking",
+      sendMessage: async () => {
+        calls++;
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return toolUseResponse({ ids: [] });
+      },
+    };
+
+    // Build a tree with eight single-member leaves so there are eight calls.
+    const leaves: LeafNode[] = Array.from({ length: 8 }, (_, i) =>
+      makeLeaf(`misc/leaf-${i}`, [`page-${i}`]),
+    );
+    const tree: LeafTree = {
+      leaves: new Map(leaves.map((n) => [n.path, n])),
+      byPage: new Map(),
+    };
+    const paths = leaves.map((l) => l.path);
+
+    await selectAcrossLeaves(paths, makeTurn("x"), tree, summaryOf, 3);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(calls).toBe(8);
+  });
+});

--- a/assistant/src/memory/v3/selector.ts
+++ b/assistant/src/memory/v3/selector.ts
@@ -1,0 +1,231 @@
+/**
+ * Memory v3 — L2 per-leaf page selector.
+ *
+ * After the L1 router (`./router.ts`) decides which leaves to open, the L2
+ * selector runs ONE forced-tool LLM call PER opened leaf to pick which pages
+ * inside that leaf are relevant for the next reply. `selectAcrossLeaves` fans
+ * the per-leaf calls out with bounded concurrency.
+ *
+ * Cache strategy. Each leaf's `<pages>` block — the numbered list of its member
+ * pages with their full summaries — is STABLE for that leaf: it changes only
+ * when pages are added/removed or a summary is rewritten, never per turn. We
+ * render it FIRST in the per-leaf user message and tag it with an ephemeral
+ * `cache_control` breakpoint so the provider serves it from the prompt cache
+ * turn after turn. The trailing recent-context / current-message block changes
+ * every turn and carries no breakpoint. This mirrors `./router.ts`.
+ *
+ * Recall-safe fallbacks. Like the router, the selector exists to widen recall,
+ * so every failure degrades toward selecting MORE pages, never fewer:
+ *   - omitted `ids` → select ALL members of the leaf,
+ *   - missing/failed tool_use, provider unavailable, or any throw → ALL members.
+ * Only an explicit empty `ids: []` returns nothing (deliberate abstention).
+ */
+
+import { z } from "zod";
+
+import {
+  extractToolUse,
+  getConfiguredProvider,
+} from "../../providers/provider-send-message.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { mapLimit } from "../../util/map-limit.js";
+import { membersOf } from "./tree.js";
+import type { LeafPath, LeafTree, Slug, TurnContext } from "./types.js";
+
+const log = getLogger("memory-v3-selector");
+
+/** A page selected from an opened leaf, with whether the turn centers on it. */
+export interface SelectedPage {
+  slug: Slug;
+  pinned: boolean;
+}
+
+/** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
+const SELECT_PAGES_TOOL_NAME = "select_pages";
+
+const SelectPagesSchema = z.object({
+  // Optional: an omitted `ids` field is the recall-safe "select everything"
+  // signal, distinct from an explicit empty array (deliberate abstention).
+  ids: z.array(z.number().int()).optional(),
+  pinned_ids: z.array(z.number().int()).optional(),
+});
+
+const SELECT_PAGES_TOOL: ToolDefinition = {
+  name: SELECT_PAGES_TOOL_NAME,
+  description:
+    "Select the pages in this leaf whose content is relevant or useful for " +
+    "the next reply. Lean toward inclusion — a missed relevant page is a " +
+    "worse error than an unused one. Pass `pinned_ids` for pages the " +
+    "conversation is centrally about. Omit `ids` entirely to select every " +
+    "page; return `[]` only when none of the pages could possibly help.",
+  input_schema: {
+    type: "object",
+    properties: {
+      ids: {
+        type: "array",
+        items: { type: "integer" },
+      },
+      pinned_ids: {
+        type: "array",
+        items: { type: "integer" },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `This leaf of the topic tree is potentially relevant to the conversation. Select the pages whose content is relevant or useful for responding.
+
+Be inclusive — include frame and affect matches, not just literal-topic matches. A page that shares the conversation's mode or register can be as useful as one that names the same entity. Missing a relevant page is a worse error than selecting an unused one.
+
+If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` to select every page; return \`[]\` only when none of the pages could possibly help.`;
+
+/**
+ * Render the STATIC numbered `<pages>` block for a leaf from its member slugs.
+ * Identical across turns for a given leaf, which is what makes the per-leaf
+ * prompt-cache breakpoint pay off. Summaries are rendered in full (no
+ * truncation) so the selector sees each page's complete description.
+ */
+async function renderPagesBlock(
+  members: Slug[],
+  pageSummary: (slug: Slug) => Promise<string>,
+): Promise<string> {
+  const lines = await Promise.all(
+    members.map(async (slug, i) => {
+      const summary = await pageSummary(slug);
+      return `[${i + 1}] ${slug} — ${summary}`;
+    }),
+  );
+  return `<pages>\n${lines.join("\n")}\n</pages>`;
+}
+
+/**
+ * Run the L2 selector for a single opened leaf. Returns the pages to inject.
+ *
+ * Recall-safe: any failure to obtain an explicit selection returns ALL members
+ * of the leaf. Only an explicit empty `ids` array returns no pages.
+ */
+export async function selectFromLeaf(
+  leaf: LeafPath,
+  turn: TurnContext,
+  tree: LeafTree,
+  pageSummary: (slug: Slug) => Promise<string>,
+): Promise<SelectedPage[]> {
+  const members = membersOf(tree, leaf);
+  if (members.length === 0) return [];
+
+  const allMembers = (): SelectedPage[] =>
+    members.map((slug) => ({ slug, pinned: false }));
+
+  const provider = await getConfiguredProvider("memoryV3SelectL2");
+  if (!provider) {
+    log.warn({ leaf }, "memoryV3SelectL2 provider unavailable; selecting all");
+    return allMembers();
+  }
+
+  const userMsg: Message = {
+    role: "user",
+    content: [
+      cachedTextBlock(
+        `<leaf>${leaf}</leaf>\n` +
+          (await renderPagesBlock(members, pageSummary)),
+      ),
+      {
+        type: "text",
+        text:
+          `<recent_context>${turn.recentContext}</recent_context>\n` +
+          `<current_message>${turn.currentMessage}</current_message>`,
+      },
+    ],
+  };
+
+  let response;
+  try {
+    response = await provider.sendMessage(
+      [userMsg],
+      [SELECT_PAGES_TOOL],
+      SYSTEM_PROMPT,
+      {
+        config: {
+          callSite: "memoryV3SelectL2" as const,
+          tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
+        },
+      },
+    );
+  } catch (err) {
+    log.warn({ err, leaf }, "L2 selector call threw; selecting all");
+    return allMembers();
+  }
+
+  const toolBlock = extractToolUse(response);
+  if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) {
+    log.warn(
+      { stopReason: response.stopReason, leaf },
+      "L2 selector returned no select_pages tool_use; selecting all",
+    );
+    return allMembers();
+  }
+
+  const parsed = SelectPagesSchema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { error: parsed.error.message, leaf },
+      "L2 selector tool input did not match schema; selecting all",
+    );
+    return allMembers();
+  }
+
+  // Omitted `ids` is the recall-safe "select everything" signal.
+  if (parsed.data.ids === undefined) return allMembers();
+
+  const pinned = new Set(parsed.data.pinned_ids ?? []);
+
+  // Map 1-based IDs back to member slugs, dropping out-of-range IDs without
+  // throwing. De-duplicate while preserving model-returned order.
+  const seen = new Set<number>();
+  const selected: SelectedPage[] = [];
+  for (const id of parsed.data.ids) {
+    if (id < 1 || id > members.length || seen.has(id)) continue;
+    seen.add(id);
+    selected.push({ slug: members[id - 1]!, pinned: pinned.has(id) });
+  }
+  return selected;
+}
+
+/**
+ * Run the L2 selector across every opened leaf with bounded concurrency and
+ * flatten the per-leaf selections.
+ *
+ * A page assigned to more than one opened leaf may appear more than once in the
+ * result; de-duplication across leaves is the orchestrator's job in a later PR.
+ */
+export async function selectAcrossLeaves(
+  leaves: LeafPath[],
+  turn: TurnContext,
+  tree: LeafTree,
+  pageSummary: (slug: Slug) => Promise<string>,
+  concurrency = 4,
+): Promise<SelectedPage[]> {
+  const perLeaf = await mapLimit(leaves, concurrency, (leaf) =>
+    selectFromLeaf(leaf, turn, tree, pageSummary),
+  );
+  return perLeaf.flat();
+}
+
+/**
+ * Text content block carrying an ephemeral `cache_control` breakpoint. Our
+ * internal `TextContent` type omits the field (only the Anthropic provider
+ * transforms it onto the wire), so we reach through a `Record` cast — the same
+ * approach `./router.ts` uses to keep the core types provider-agnostic.
+ */
+function cachedTextBlock(text: string): ContentBlock {
+  const block: ContentBlock = { type: "text", text };
+  (block as unknown as Record<string, unknown>).cache_control = {
+    type: "ephemeral",
+  };
+  return block;
+}

--- a/assistant/src/util/map-limit.ts
+++ b/assistant/src/util/map-limit.ts
@@ -1,0 +1,27 @@
+/**
+ * Map `fn` over `items` with bounded concurrency, preserving input order in the
+ * result array. At most `limit` invocations of `fn` are in flight at once.
+ *
+ * Each of the `min(limit, items.length)` workers pulls the next index off a
+ * shared cursor and processes it, so faster items don't block on slower ones.
+ * Results are written back to their original positions, so `out[i]` always
+ * corresponds to `items[i]` regardless of completion order.
+ */
+export async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (t: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (true) {
+        const i = next++;
+        if (i >= items.length) return;
+        out[i] = await fn(items[i]!);
+      }
+    }),
+  );
+  return out;
+}


### PR DESCRIPTION
## Summary
- Add selectFromLeaf (one bounded forced-tool LLM call per opened leaf over a static cache-warm <pages> prefix; pinned via pinned_ids; recall-safe omitted-ids→all fallback) and selectAcrossLeaves (bounded-concurrency fan-out via new mapLimit util). Registers the memoryV3SelectL2 callsite.

Part of plan: memory-v3-topic-tree-routing.md (PR 18 of 19)