### PR TITLE
feat(memory-v3): orchestrator composing the four lanes

### DIFF
--- a/assistant/src/memory/v3/__tests__/fixtures/eval-turns.json
+++ b/assistant/src/memory/v3/__tests__/fixtures/eval-turns.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Synthetic, generic eval turns for the memory-v3 orchestrator. No real content. Domains/slugs are placeholders (domain-a/topic-x, page-a). Each turn names which leaves L1 should open and which page IDs L2 should select per opened leaf; expectedFinalInjection is the orchestrator's deduped slug list for that turn given a SHARED working set across the sequence.",
+  "turns": [
+    {
+      "name": "turn 1 — open topic-x, select page-a (pinned) and page-b",
+      "currentMessage": "tell me about page a",
+      "routeIds": [1],
+      "leafSelections": {
+        "domain-a/topic-x": { "ids": [1, 2], "pinned_ids": [1] }
+      },
+      "expectedOpenedLeaves": ["domain-a/topic-x"],
+      "expectedFinalInjection": ["page-a", "page-b"]
+    },
+    {
+      "name": "turn 2 — open topic-y, select page-c; page-a carries forward (pinned)",
+      "currentMessage": "now about page c",
+      "routeIds": [2],
+      "leafSelections": {
+        "domain-a/topic-y": { "ids": [1], "pinned_ids": [] }
+      },
+      "expectedOpenedLeaves": ["domain-a/topic-y"],
+      "expectedFinalInjection": ["page-c", "page-a", "page-b"]
+    },
+    {
+      "name": "turn 3 — open both leaves, select page-b and page-c",
+      "currentMessage": "compare page b and page c",
+      "routeIds": [1, 2],
+      "leafSelections": {
+        "domain-a/topic-x": { "ids": [2], "pinned_ids": [] },
+        "domain-a/topic-y": { "ids": [1], "pinned_ids": [] }
+      },
+      "expectedOpenedLeaves": ["domain-a/topic-x", "domain-a/topic-y"],
+      "expectedFinalInjection": ["page-b", "page-c", "page-a"]
+    }
+  ]
+}

--- a/assistant/src/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/memory/v3/__tests__/orchestrate.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for `assistant/src/memory/v3/orchestrate.ts`.
+ *
+ * The orchestrator composes four lanes: L1 routing + BM25 needle (parallel) →
+ * open set (routed ∪ core ∪ needle-owning leaves) → bounded per-leaf L2
+ * selection → carry-forward working set (record + evict) → final injection.
+ *
+ * The provider is stubbed (no network). A single stub answers BOTH the L1
+ * `open_leaves` call and the per-leaf L2 `select_pages` calls by inspecting the
+ * forced tool name and, for L2, the `<leaf>...</leaf>` tag in the prompt. The
+ * needle is a hand-built fake so we control its hits directly.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../../../providers/types.js";
+import type { NeedleIndex } from "../needle.js";
+import type {
+  LeafNode,
+  LeafPath,
+  LeafTree,
+  Slug,
+  TurnContext,
+} from "../types.js";
+import evalTurns from "./fixtures/eval-turns.json" with { type: "json" };
+
+// ---------------------------------------------------------------------------
+// Provider mock installed BEFORE the orchestrator import so router.ts and
+// selector.ts observe it at load time.
+// ---------------------------------------------------------------------------
+
+let providerStub: Provider | null = null;
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b) => b.type === "tool_use"),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_t, prop) => (prop === "child" ? () => ({}) : () => {}),
+    }),
+}));
+
+const { orchestrate, DEFAULT_NEEDLE_K } = await import("../orchestrate.js");
+const { WorkingSet } = await import("../working-set.js");
+
+// ---------------------------------------------------------------------------
+// Fixture types + helpers.
+// ---------------------------------------------------------------------------
+
+interface LeafSelection {
+  ids: number[];
+  pinned_ids: number[];
+}
+interface EvalTurn {
+  name: string;
+  currentMessage: string;
+  routeIds: number[];
+  leafSelections: Record<LeafPath, LeafSelection>;
+  expectedOpenedLeaves: LeafPath[];
+  expectedFinalInjection: Slug[];
+}
+const TURNS = (evalTurns as { turns: EvalTurn[] }).turns;
+
+function makeLeaf(path: LeafPath, members: Slug[]): LeafNode {
+  return {
+    path,
+    frontmatter: { path, in_core: false },
+    description: `description for ${path}`,
+    members,
+    domain: path.split("/")[0],
+  };
+}
+
+/**
+ * Synthetic tree. Sorted leaf order is [domain-a/topic-x, domain-a/topic-y],
+ * so L1 id 1 → topic-x, id 2 → topic-y.
+ */
+function makeTree(): LeafTree {
+  const leaves: LeafNode[] = [
+    makeLeaf("domain-a/topic-x", ["page-a", "page-b"]),
+    makeLeaf("domain-a/topic-y", ["page-c"]),
+  ];
+  const byPage = new Map<Slug, LeafPath[]>();
+  for (const leaf of leaves) {
+    for (const slug of leaf.members) {
+      byPage.set(slug, [...(byPage.get(slug) ?? []), leaf.path]);
+    }
+  }
+  return { leaves: new Map(leaves.map((n) => [n.path, n])), byPage };
+}
+
+const summaryOf = async (slug: Slug): Promise<string> => `summary of ${slug}`;
+
+/** Needle that returns a fixed slug list, ignoring the query. */
+function fakeNeedle(hits: Slug[]): NeedleIndex {
+  return { query: (_text, k) => hits.slice(0, k) };
+}
+
+function makeTurn(turnNumber: number, currentMessage: string): TurnContext {
+  return {
+    conversationId: "conv-xyz",
+    turnNumber,
+    currentMessage,
+    recentContext: "prior context",
+  };
+}
+
+function toolUseResponse(
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "tool_use", id: "tu-1", name, input }],
+  };
+}
+
+/** Last `<leaf>X</leaf>` tag found in an L2 request, or undefined. */
+function leafFromMessages(messages: Message[]): LeafPath | undefined {
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      if (block.type === "text") {
+        const m = /<leaf>([^<]+)<\/leaf>/.exec(block.text);
+        if (m) return m[1];
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a provider that answers L1 `open_leaves` with `routeIds` and each L2
+ * `select_pages` call with the per-leaf selection from the fixture turn.
+ */
+function providerForTurn(turn: EvalTurn): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (messages, tools) => {
+      const toolName = tools?.[0]?.name;
+      if (toolName === "open_leaves") {
+        return toolUseResponse("open_leaves", { ids: turn.routeIds });
+      }
+      // L2 select_pages — pick the selection for the leaf under selection.
+      const leaf = leafFromMessages(messages);
+      const sel = (leaf ? turn.leafSelections[leaf] : undefined) ?? {
+        ids: [],
+        pinned_ids: [],
+      };
+      return toolUseResponse("select_pages", {
+        ids: sel.ids,
+        pinned_ids: sel.pinned_ids,
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  providerStub = null;
+});
+
+// ---------------------------------------------------------------------------
+// Integration: drive the whole fixture sequence through ONE shared WorkingSet.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — fixture sequence (carry-forward)", () => {
+  test("each turn's finalInjection matches the fixture", async () => {
+    const tree = makeTree();
+    const workingSet = new WorkingSet();
+    const needle = fakeNeedle([]);
+
+    for (const turn of TURNS) {
+      providerStub = providerForTurn(turn);
+      const result = await orchestrate(
+        makeTurn(TURNS.indexOf(turn) + 1, turn.currentMessage),
+        { tree, core: new Set(), needle, workingSet, pageSummary: summaryOf },
+      );
+      expect(result.openedLeaves).toEqual(turn.expectedOpenedLeaves);
+      expect(result.finalInjection).toEqual(turn.expectedFinalInjection);
+    }
+  });
+
+  test("a slug pinned in turn 1 carries into turn 2 without re-selection", async () => {
+    const tree = makeTree();
+    const workingSet = new WorkingSet();
+    const needle = fakeNeedle([]);
+
+    // Turn 1 selects+pins page-a.
+    providerStub = providerForTurn(TURNS[0]);
+    await orchestrate(makeTurn(1, TURNS[0].currentMessage), {
+      tree,
+      core: new Set(),
+      needle,
+      workingSet,
+      pageSummary: summaryOf,
+    });
+
+    // Turn 2 opens a DIFFERENT leaf and never re-selects page-a.
+    providerStub = providerForTurn(TURNS[1]);
+    const t2 = await orchestrate(makeTurn(2, TURNS[1].currentMessage), {
+      tree,
+      core: new Set(),
+      needle,
+      workingSet,
+      pageSummary: summaryOf,
+    });
+
+    expect(t2.currentSelections.map((s) => s.slug)).not.toContain("page-a");
+    expect(t2.finalInjection).toContain("page-a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lane composition: needle and core fold into the open set.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — open set composition", () => {
+  test("needle hits add their owning leaves to the open set", async () => {
+    const tree = makeTree();
+    // L1 routes only topic-x; the needle hit page-c lives in topic-y, so the
+    // open set must include topic-y too.
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages, tools) => {
+        if (tools?.[0]?.name === "open_leaves") {
+          return toolUseResponse("open_leaves", { ids: [1] });
+        }
+        const leaf = leafFromMessages(messages);
+        const ids = leaf === "domain-a/topic-y" ? [1] : [];
+        return toolUseResponse("select_pages", { ids, pinned_ids: [] });
+      },
+    };
+    const result = await orchestrate(makeTurn(1, "anything"), {
+      tree,
+      core: new Set(),
+      needle: fakeNeedle(["page-c"]),
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    expect(result.openedLeaves).toContain("domain-a/topic-y");
+    expect(result.finalInjection).toContain("page-c");
+  });
+
+  test("core leaves are always opened even when routing abstains", async () => {
+    const tree = makeTree();
+    // L1 abstains (empty ids); only the core leaf should open.
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages, tools) => {
+        if (tools?.[0]?.name === "open_leaves") {
+          return toolUseResponse("open_leaves", { ids: [] });
+        }
+        const leaf = leafFromMessages(messages);
+        const ids = leaf === "domain-a/topic-y" ? [1] : [];
+        return toolUseResponse("select_pages", { ids, pinned_ids: [] });
+      },
+    };
+    const result = await orchestrate(makeTurn(1, "nothing topical"), {
+      tree,
+      core: new Set(["domain-a/topic-y"]),
+      needle: fakeNeedle([]),
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    expect(result.openedLeaves).toEqual(["domain-a/topic-y"]);
+    // page-c (topic-y member) is core, so the working set must NOT retain it.
+    expect(result.workingSetUnion.has("page-c")).toBe(false);
+    // It still injects this turn via the current selection.
+    expect(result.finalInjection).toContain("page-c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — edge cases", () => {
+  test("empty needle results do not break orchestration", async () => {
+    const tree = makeTree();
+    providerStub = providerForTurn(TURNS[0]);
+    const result = await orchestrate(makeTurn(1, "tell me about page a"), {
+      tree,
+      core: new Set(),
+      needle: fakeNeedle([]),
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    expect(result.openedLeaves).toEqual(["domain-a/topic-x"]);
+    expect(result.finalInjection).toEqual(["page-a", "page-b"]);
+  });
+
+  test("L1 routing fallback (omitted ids → all leaves) still works", async () => {
+    const tree = makeTree();
+    // Omitted ids → routeL1 opens ALL leaves; select everything per leaf.
+    providerStub = {
+      name: "stub",
+      sendMessage: async (_messages, tools) => {
+        if (tools?.[0]?.name === "open_leaves") {
+          return toolUseResponse("open_leaves", {}); // omitted ids
+        }
+        return toolUseResponse("select_pages", {}); // omitted → all members
+      },
+    };
+    const result = await orchestrate(makeTurn(1, "x"), {
+      tree,
+      core: new Set(),
+      needle: fakeNeedle([]),
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    expect(result.openedLeaves).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+    ]);
+    expect(result.finalInjection).toEqual(["page-a", "page-b", "page-c"]);
+  });
+
+  test("pinned current-turn selections land in the working set", async () => {
+    const tree = makeTree();
+    providerStub = providerForTurn(TURNS[0]); // pins page-a
+    const ws = new WorkingSet();
+    await orchestrate(makeTurn(1, "tell me about page a"), {
+      tree,
+      core: new Set(),
+      needle: fakeNeedle([]),
+      workingSet: ws,
+      pageSummary: summaryOf,
+    });
+    expect(ws.union().has("page-a")).toBe(true);
+    expect(ws.union().has("page-b")).toBe(true);
+  });
+
+  test("a page in multiple opened leaves is deduped with pinned ORed", async () => {
+    // Build a tree where page-shared belongs to BOTH leaves; pin it in one.
+    const leaves: LeafNode[] = [
+      makeLeaf("domain-a/topic-x", ["page-shared"]),
+      makeLeaf("domain-a/topic-y", ["page-shared"]),
+    ];
+    const byPage = new Map<Slug, LeafPath[]>([
+      ["page-shared", ["domain-a/topic-x", "domain-a/topic-y"]],
+    ]);
+    const tree: LeafTree = {
+      leaves: new Map(leaves.map((n) => [n.path, n])),
+      byPage,
+    };
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages, tools) => {
+        if (tools?.[0]?.name === "open_leaves") {
+          return toolUseResponse("open_leaves", { ids: [1, 2] });
+        }
+        const leaf = leafFromMessages(messages);
+        // Pin only in topic-x; select (unpinned) in topic-y.
+        const pinned_ids = leaf === "domain-a/topic-x" ? [1] : [];
+        return toolUseResponse("select_pages", { ids: [1], pinned_ids });
+      },
+    };
+    const result = await orchestrate(makeTurn(1, "x"), {
+      tree,
+      core: new Set(),
+      needle: fakeNeedle([]),
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    // One deduped selection, pinned because it was pinned in topic-x.
+    expect(result.currentSelections).toEqual([
+      { slug: "page-shared", pinned: true },
+    ]);
+    expect(result.finalInjection).toEqual(["page-shared"]);
+  });
+
+  test("needleK defaults to DEFAULT_NEEDLE_K", async () => {
+    const tree = makeTree();
+    let seenK = -1;
+    const needle: NeedleIndex = {
+      query: (_text, k) => {
+        seenK = k;
+        return [];
+      },
+    };
+    providerStub = providerForTurn(TURNS[0]);
+    await orchestrate(makeTurn(1, "x"), {
+      tree,
+      core: new Set(),
+      needle,
+      workingSet: new WorkingSet(),
+      pageSummary: summaryOf,
+    });
+    expect(seenK).toBe(DEFAULT_NEEDLE_K);
+  });
+});

--- a/assistant/src/memory/v3/orchestrate.ts
+++ b/assistant/src/memory/v3/orchestrate.ts
@@ -1,0 +1,117 @@
+/**
+ * Memory v3 — orchestrator composing the four routing lanes into one turn.
+ *
+ * Each turn runs:
+ *   1. L1 topical routing (`routeL1`) and the lexical BM25 needle
+ *      (`NeedleIndex.query`) IN PARALLEL. Routing is the slow LLM arm; the
+ *      needle is a synchronous in-memory lookup, so we wrap it in a resolved
+ *      promise and let them settle together.
+ *   2. Open set = unique union of routed leaves ∪ always-on core leaves ∪ the
+ *      leaves that own each needle hit. Every lane only ever ADDS leaves — the
+ *      union is recall-safe by construction.
+ *   3. Bounded per-leaf L2 selection (`selectAcrossLeaves`) over the open set,
+ *      then dedup by slug (a page assigned to multiple opened leaves comes back
+ *      once per leaf) ORing the pinned flag so a page pinned anywhere stays
+ *      pinned.
+ *   4. Record each deduped selection into the carry-forward working set and
+ *      evict (core slugs, stale non-pinned entries, then the cap).
+ *   5. Final injection = unique union of this turn's selected slugs and the
+ *      working-set union, so pages selected on earlier turns carry forward even
+ *      when this turn does not re-select them.
+ */
+
+import type { NeedleIndex } from "./needle.js";
+import { routeL1 } from "./router.js";
+import type { SelectedPage } from "./selector.js";
+import { selectAcrossLeaves } from "./selector.js";
+import { leavesOf, membersOf } from "./tree.js";
+import type { LeafPath, LeafTree, Slug, TurnContext } from "./types.js";
+import { WorkingSet } from "./working-set.js";
+
+/** Default number of needle hits to fold into the open set when unspecified. */
+export const DEFAULT_NEEDLE_K = 10;
+
+export interface OrchestrateDeps {
+  tree: LeafTree;
+  core: Set<LeafPath>;
+  needle: NeedleIndex;
+  workingSet: WorkingSet;
+  pageSummary: (slug: Slug) => Promise<string>;
+  /** Number of BM25 needle hits to fold in. Defaults to {@link DEFAULT_NEEDLE_K}. */
+  needleK?: number;
+  /** Bounded fan-out for per-leaf L2 selection. */
+  l2Concurrency?: number;
+}
+
+export interface OrchestrateResult {
+  /** The unique open set: routed ∪ core ∪ needle-owning leaves. */
+  openedLeaves: LeafPath[];
+  /** This turn's L2 selections, deduped by slug (pinned flags ORed). */
+  currentSelections: SelectedPage[];
+  /** Snapshot of the working-set union after record + evict. */
+  workingSetUnion: Set<Slug>;
+  /** Slugs to inject: this turn's selections ∪ the carried-forward working set. */
+  finalInjection: Slug[];
+}
+
+/** Stable-order de-duplication preserving first occurrence. */
+function unique<T>(items: Iterable<T>): T[] {
+  return [...new Set(items)];
+}
+
+export async function orchestrate(
+  turn: TurnContext,
+  deps: OrchestrateDeps,
+): Promise<OrchestrateResult> {
+  // Step 1: routing (LLM) and needle (sync BM25) run in parallel.
+  const needleK = deps.needleK ?? DEFAULT_NEEDLE_K;
+  const [routed, needled] = await Promise.all([
+    routeL1(turn, deps.tree),
+    Promise.resolve(deps.needle.query(turn.currentMessage, needleK)),
+  ]);
+
+  // Step 2: open set = routed ∪ core ∪ leaves owning each needle hit.
+  const openedLeaves = unique<LeafPath>([
+    ...routed,
+    ...deps.core,
+    ...needled.flatMap((slug) => leavesOf(deps.tree, slug)),
+  ]);
+
+  // Step 3: per-leaf L2 selection, then dedup by slug ORing pinned flags.
+  const selected = await selectAcrossLeaves(
+    openedLeaves,
+    turn,
+    deps.tree,
+    deps.pageSummary,
+    deps.l2Concurrency,
+  );
+  const bySlug = new Map<Slug, SelectedPage>();
+  for (const page of selected) {
+    const existing = bySlug.get(page.slug);
+    bySlug.set(page.slug, {
+      slug: page.slug,
+      pinned: (existing?.pinned ?? false) || page.pinned,
+    });
+  }
+  const currentSelections = [...bySlug.values()];
+
+  // Step 4: record this turn's selections into the carry-forward working set.
+  for (const sel of currentSelections) {
+    deps.workingSet.recordSelection(sel.slug, turn.turnNumber, sel.pinned);
+  }
+
+  // Step 5: evict. Core slugs are owned by core, not the working set.
+  const coreSlugs = new Set<Slug>(
+    [...deps.core].flatMap((leaf) => membersOf(deps.tree, leaf)),
+  );
+  deps.workingSet.evict(turn.turnNumber, coreSlugs);
+
+  // Step 6: final injection = this turn's selections ∪ carried-forward set.
+  const workingSetUnion = deps.workingSet.union();
+  const finalInjection = unique<Slug>([
+    ...currentSelections.map((s) => s.slug),
+    ...workingSetUnion,
+  ]);
+
+  return { openedLeaves, currentSelections, workingSetUnion, finalInjection };
+}


### PR DESCRIPTION
## Summary
- Add orchestrate(): runs L1 routing + BM25 needle in parallel, unions routed ∪ core ∪ needle-leaves, runs bounded per-leaf L2 selection, records selections into the carry-forward working set and evicts, then returns the deduped final injection. Integration + edge-case tests against a synthetic fixture, including cross-turn carry-forward.

Part of plan: memory-v3-topic-tree-routing.md (PR 19 of 19 implementation; shadow plugin follows)