### PR TITLE
fix: use raw SSE stream for Codex subscription to avoid SDK crash

### DIFF
--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -128,7 +128,7 @@ mock.module("openai", () => {
         },
       };
       responses = {
-        stream: (params: Record<string, unknown>) => {
+        create: async (params: Record<string, unknown>) => {
           lastOpenAIResponsesParams = JSON.parse(JSON.stringify(params));
           return (async function* () {
             yield {

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -47,7 +47,7 @@ mock.module("openai", () => ({
       lastConstructorOptions = opts;
     }
     responses = {
-      stream: (
+      create: async (
         params: Record<string, unknown>,
         options?: Record<string, unknown>,
       ) => {
@@ -1155,7 +1155,7 @@ describe("OpenAIResponsesProvider", () => {
       "System prompt",
     );
 
-    // rawRequest should contain the params sent to responses.stream()
+    // rawRequest should contain the params sent to responses.create()
     const rawReq = result.rawRequest as Record<string, unknown>;
     expect(rawReq.model).toBe("gpt-5.2");
     expect(rawReq.instructions).toBe("System prompt");

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -259,20 +259,26 @@ export class OpenAIResponsesProvider implements Provider {
       let rawFinalResponse: unknown = undefined;
 
       try {
-        // The SDK exposes `client.responses.stream()` — cast through
-        // `unknown` to avoid `any` while the SDK's exported types stabilise.
+        // Use `create()` with `stream: true` instead of the higher-level
+        // `stream()` helper. The `stream()` helper wraps the response in a
+        // `ResponseStream` that runs `maybeParseResponse()` after iteration,
+        // which crashes when the Codex subscription endpoint omits `output`
+        // from the `response.completed` event payload.
         const responsesApi = this.client.responses as unknown as {
-          stream(
+          create(
             p: Record<string, unknown>,
-            o: { signal: AbortSignal; headers?: Record<string, string> },
-          ): AsyncIterable<ResponsesStreamEvent>;
+            o?: { signal?: AbortSignal; headers?: Record<string, string> },
+          ): Promise<AsyncIterable<ResponsesStreamEvent>>;
         };
-        const stream = responsesApi.stream(params, {
-          signal: timeoutSignal,
-          ...(usageAttributionHeaders
-            ? { headers: usageAttributionHeaders }
-            : {}),
-        });
+        const stream = await responsesApi.create(
+          { ...params, stream: true },
+          {
+            signal: timeoutSignal,
+            ...(usageAttributionHeaders
+              ? { headers: usageAttributionHeaders }
+              : {}),
+          },
+        );
 
         for await (const event of stream) {
           switch (event.type) {


### PR DESCRIPTION
## Summary
- The OpenAI SDK's `client.responses.stream()` wraps responses in a `ResponseStream` that runs `maybeParseResponse()` after stream iteration, which calls `response.output.map()` on the final snapshot
- The Codex subscription endpoint's `response.completed` event omits the `output` field, causing "undefined is not an object (evaluating 'response.output.map')"
- Switch to `client.responses.create({ ...params, stream: true })` which returns a raw `Stream` of SSE events without the finalization layer — our code already manually accumulates the response from stream events, so the SDK's built-in accumulation was redundant

## Test plan
- [x] Typecheck passes
- [x] OpenAI provider tests pass (18/18)
- [x] Manually tested ChatGPT subscription conversation locally — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)