### PR TITLE
fix(memory): drop retired memory_v3_* jobs gracefully

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -44,6 +44,7 @@ export type MemoryJobType =
   | "memory_v2_migrate"
   | "memory_v2_reembed"
   | "memory_v2_activation_recompute"
+  // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"
   | "memory_v3_edge_learning"

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -123,6 +123,11 @@ const LEGACY_JOB_TYPES = new Set([
   "generate_capability_cards",
   "generate_thread_starters",
   "memory_v2_rebuild_edges",
+  // Retired memory-v3 job types — handlers were removed in the v3 rip. Kept
+  // here so pre-upgrade rows enqueued by the old write path drop gracefully.
+  "memory_v3_consolidate",
+  "memory_v3_index_maintenance",
+  "memory_v3_edge_learning",
 ]);
 
 export const POLL_INTERVAL_MIN_MS = 1_500;


### PR DESCRIPTION
## Summary
Fixes a backwards-compat gap from the v3 rip: existing installs with pending memory_v3_consolidate/index_maintenance/edge_learning job rows would hit the processJob default case and throw 'Unknown memory job type' (retry-looping). Adds the three retired types to LEGACY_JOB_TYPES so stale rows drop with a debug log, matching every other retired job type.

Gap found during plan review for memory-v3-topic-tree-routing.md.