### PR TITLE
chore(gateway): drop stale memory v3 entries from risk registry

### DIFF
--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -160,9 +160,6 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v2 reembed-skills",
   "memory v2 activation",
   "memory v2 validate",
-  "memory v3",
-  "memory v3 validate",
-  "memory v3 tree",
   "notifications",
   "notifications send",
   "notifications list",
@@ -487,16 +484,6 @@ const riskOverrides: AssistantRiskOverride[] = [
     path: "memory v2 validate",
     risk: "low",
     reason: "Read-only diagnostic walk over concept pages and edges",
-  },
-  {
-    path: "memory v3 validate",
-    risk: "low",
-    reason: "Read-only structural validation of the v3 tree DAG",
-  },
-  {
-    path: "memory v3 tree",
-    risk: "low",
-    reason: "Read-only print of the v3 tree DAG structure",
   },
   { path: "notifications send", risk: "low" },
   {


### PR DESCRIPTION
## Summary
The memory-v3 rip removed the assistant's 'memory v3' CLI subcommands, but the gateway risk command-registry still listed them (with v3-tree-DAG risk reasons). Remove the stale known-subcommand and risk entries so the registry reflects reality.

Gap found during plan review for memory-v3-topic-tree-routing.md.