### PR TITLE
Fix self-hosted Models & Services profile loading

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -62,9 +62,15 @@ import {
   WEB_SEARCH_PROVIDER_KEY_STORAGE,
 } from "@/assistant/generated/web-search-provider-catalog.gen";
 import { routes } from "@/utils/routes";
+import { useRootOutletContext } from "@/root-layout";
 import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
 import { synthesizeTTS } from "@/lib/tts-synthesize";
 import { getLocalSetting, removeLocalSetting, setLocalSetting } from "@/lib/local-settings";
+import {
+  aiSettingsAssistantListHosting,
+  isSelfHostedAiSettingsAssistant,
+  resolveAiSettingsAssistantId,
+} from "@/domains/settings/ai/assistant-selection";
 import { CallSiteOverridesModal, type CallSiteOverrideDraft } from "@/domains/settings/ai/call-site-overrides-modal";
 import { ManageProfilesModal } from "@/domains/settings/ai/manage-profiles-modal";
 import { ManageProvidersModal } from "@/domains/settings/ai/manage-providers-modal";
@@ -1455,6 +1461,12 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
 // ---------------------------------------------------------------------------
 
 export function AiPage() {
+  const { lifecycle } = useRootOutletContext();
+  const isSelfHosted = isSelfHostedAiSettingsAssistant(
+    lifecycle.assistantState,
+  );
+  const lifecycleAssistantId = lifecycle.assistantId;
+  const navigate = useNavigate();
   const [webSearchSaving, setWebSearchSaving] = useState(false);
   const [imageGenSaving, setImageGenSaving] = useState(false);
 
@@ -1478,8 +1490,22 @@ export function AiPage() {
 
   // -- Backend provisioning (matches desktop SettingsStore) --
   const queryClient = useQueryClient();
-  const { data: assistantList } = useQuery(assistantsListOptions());
-  const assistantId = assistantList?.results?.[0]?.id;
+  const assistantListOptionsForMode = useMemo(
+    () =>
+      assistantsListOptions({
+        query: { hosting: aiSettingsAssistantListHosting(isSelfHosted) },
+      }),
+    [isSelfHosted],
+  );
+  const assistantListQuery = useQuery(assistantListOptionsForMode);
+  const assistantList = assistantListQuery.data;
+  const assistantId = resolveAiSettingsAssistantId({
+    isSelfHosted,
+    lifecycleAssistantId,
+    assistantList,
+  });
+  const assistantListResolved = !assistantListQuery.isPending;
+  const showPreHatchState = assistantListResolved && !assistantId;
 
   // Fetch daemon config on mount and reconcile state so that settings changed
   // on macOS are reflected here without requiring a manual save first.
@@ -1545,9 +1571,9 @@ export function AiPage() {
     if (assistantId) {
       return assistantId;
     }
-    const list = await queryClient.fetchQuery(assistantsListOptions());
+    const list = await queryClient.fetchQuery(assistantListOptionsForMode);
     return list.results?.[0]?.id ?? null;
-  }, [assistantId, queryClient]);
+  }, [assistantId, assistantListOptionsForMode, queryClient]);
 
   const provisionProviderKey = useCallback(
     async (providerName: string, key: string): Promise<void> => {
@@ -2002,7 +2028,12 @@ export function AiPage() {
               onChange={(val) => {
                 setActiveProfile(val === "" ? null : val);
               }}
-              placeholder="Select a default profile…"
+              disabled={!assistantId}
+              placeholder={
+                showPreHatchState
+                  ? "Hatch an assistant to configure profiles"
+                  : "Select a default profile…"
+              }
               options={defaultProfilePickerEntries.map((p) => ({
                 value: p.name,
                 label:
@@ -2018,7 +2049,24 @@ export function AiPage() {
                 </span>
               </div>
             )}
-            {defaultProfilePickerEntries.length === 0 ? (
+            {showPreHatchState ? (
+              <Notice
+                tone="info"
+                title="Hatch an assistant to configure profiles"
+                actions={
+                  <Button
+                    variant="outlined"
+                    size="compact"
+                    onClick={() => void navigate(routes.assistant)}
+                  >
+                    Go to chat
+                  </Button>
+                }
+              >
+                Profiles are stored in the assistant runtime config, so they appear after the assistant is created.
+              </Notice>
+            ) : null}
+            {assistantId && defaultProfilePickerEntries.length === 0 ? (
               <Typography
                 variant="body-small-default"
                 as="p"
@@ -2033,6 +2081,7 @@ export function AiPage() {
             <Button
               variant="outlined"
               size="compact"
+              disabled={!assistantId}
               onClick={() => setManageProvidersOpen(true)}
             >
               Providers
@@ -2040,6 +2089,7 @@ export function AiPage() {
             <Button
               variant="outlined"
               size="compact"
+              disabled={!assistantId}
               onClick={() => setManageProfilesOpen(true)}
             >
               Profiles
@@ -2047,6 +2097,7 @@ export function AiPage() {
             <Button
               variant="outlined"
               size="compact"
+              disabled={!assistantId}
               onClick={() => setOverridesOpen(true)}
             >
               {overrideLabel}

--- a/apps/web/src/domains/settings/ai/assistant-selection.test.ts
+++ b/apps/web/src/domains/settings/ai/assistant-selection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  aiSettingsAssistantListHosting,
+  isSelfHostedAiSettingsAssistant,
+  resolveAiSettingsAssistantId,
+} from "@/domains/settings/ai/assistant-selection";
+
+describe("AI settings assistant selection", () => {
+  test("uses the lifecycle assistant id for self-hosted assistants", () => {
+    expect(
+      resolveAiSettingsAssistantId({
+        isSelfHosted: true,
+        lifecycleAssistantId: "self-hosted-assistant",
+        assistantList: { results: [] },
+      }),
+    ).toBe("self-hosted-assistant");
+  });
+
+  test("falls back to the fetched list when no lifecycle id is available", () => {
+    expect(
+      resolveAiSettingsAssistantId({
+        isSelfHosted: true,
+        lifecycleAssistantId: null,
+        assistantList: { results: [{ id: "local-assistant" }] },
+      }),
+    ).toBe("local-assistant");
+  });
+
+  test("uses the fetched platform assistant for platform-hosted settings", () => {
+    expect(
+      resolveAiSettingsAssistantId({
+        isSelfHosted: false,
+        lifecycleAssistantId: "active-runtime-assistant",
+        assistantList: { results: [{ id: "platform-assistant" }] },
+      }),
+    ).toBe("platform-assistant");
+  });
+
+  test("requests the assistant list for the active hosting mode", () => {
+    expect(aiSettingsAssistantListHosting(true)).toBe("local");
+    expect(aiSettingsAssistantListHosting(false)).toBe("platform");
+  });
+
+  test("treats both self-hosted and local-active lifecycle states as local", () => {
+    expect(isSelfHostedAiSettingsAssistant({ kind: "self_hosted" })).toBeTrue();
+    expect(
+      isSelfHostedAiSettingsAssistant({ kind: "active", isLocal: true }),
+    ).toBeTrue();
+    expect(
+      isSelfHostedAiSettingsAssistant({ kind: "active", isLocal: false }),
+    ).toBeFalse();
+  });
+});

--- a/apps/web/src/domains/settings/ai/assistant-selection.ts
+++ b/apps/web/src/domains/settings/ai/assistant-selection.ts
@@ -1,0 +1,41 @@
+export interface AssistantListLike {
+  results?: Array<{ id?: string | null }> | null;
+}
+
+export type AiSettingsAssistantListHosting = "local" | "platform";
+
+export interface AiSettingsAssistantStateLike {
+  kind: string;
+  isLocal?: boolean;
+}
+
+export function isSelfHostedAiSettingsAssistant(
+  assistantState: AiSettingsAssistantStateLike,
+): boolean {
+  return (
+    assistantState.kind === "self_hosted" ||
+    (assistantState.kind === "active" && assistantState.isLocal === true)
+  );
+}
+
+export function aiSettingsAssistantListHosting(
+  isSelfHosted: boolean,
+): AiSettingsAssistantListHosting {
+  return isSelfHosted ? "local" : "platform";
+}
+
+export function resolveAiSettingsAssistantId({
+  isSelfHosted,
+  lifecycleAssistantId,
+  assistantList,
+}: {
+  isSelfHosted: boolean;
+  lifecycleAssistantId: string | null;
+  assistantList?: AssistantListLike | null;
+}): string | undefined {
+  if (isSelfHosted && lifecycleAssistantId) {
+    return lifecycleAssistantId;
+  }
+
+  return assistantList?.results?.[0]?.id ?? undefined;
+}

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Outlet, useLocation } from "react-router";
 
+import { useRootOutletContext } from "@/root-layout";
 import { useClientFeatureFlagStore } from "@/lib/feature-flags/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store";
 import { routes } from "@/utils/routes";
@@ -18,6 +19,7 @@ import { useSettingsSync } from "@/domains/settings/hooks/use-settings-sync";
  * fresh while the user is on any settings page.
  */
 export function SettingsLayout() {
+  const rootContext = useRootOutletContext();
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
   const sounds = useAssistantFeatureFlagStore.use.sounds();
@@ -68,7 +70,7 @@ export function SettingsLayout() {
       }
       title={pageTitle}
     >
-      <Outlet />
+      <Outlet context={rootContext} />
     </SidebarShell>
   );
 }

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -203,6 +203,22 @@ describe("api-interceptors / self-hosted rewriting", () => {
     expect(output.headers.get("X-Vellum-Interface-Id")).toBe("vellum");
   });
 
+  test("rewrites Models & Services runtime settings segments", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+
+    for (const segment of ["config", "secrets", "inference", "model"]) {
+      const input = new Request(
+        `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/${segment}/`,
+        { method: "POST" },
+      );
+      const output = await requestInterceptor(input);
+      expect(new URL(output.url).origin).toBe(INGRESS);
+      expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
+      expect(output.headers.get("Vellum-Organization-Id")).toBeNull();
+      expect(output.headers.get("X-CSRFToken")).toBeNull();
+    }
+  });
+
   test("omits cookie credentials on the rewritten request", async () => {
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
     const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`);

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -54,11 +54,17 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * `maintenance-mode/`, `system-events/`, `terminal/`, `doctor/` when a
  * new one is added on the backend.
  *
- * Today's only consumer is the chat-page bootstrap — `conversations/`
- * has to land on the gateway so the chat surface can fail-and-render the
- * error state. Add segments here as additional self-hosted flows light up.
+ * These are runtime-owned surfaces the SPA needs while a self-hosted
+ * assistant is selected. Platform-owned actions intentionally stay on
+ * the platform path.
  */
-const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>(["conversations"]);
+const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
+  "config",
+  "conversations",
+  "inference",
+  "model",
+  "secrets",
+]);
 
 const ASSISTANT_PATH_RE =
   /^\/v1\/assistants\/[^/]+\/([^/?#]+)(?:\/.*)?$/;


### PR DESCRIPTION
## Summary
- use the root assistant lifecycle on the AI settings page so self-hosted assistants resolve from the local assistant id/list instead of the platform-only list
- preserve root outlet context through SettingsLayout so nested settings pages can read lifecycle state
- route self-hosted Models & Services runtime endpoints config/secrets/inference/model through direct ingress alongside conversations

## Testing
- cd apps/web && bun test src/domains/settings/ai/assistant-selection.test.ts src/lib/api-interceptors.test.ts
- cd apps/web && bunx tsc --noEmit
- cd apps/web && bun run lint src/domains/settings/ai/assistant-selection.ts src/domains/settings/ai/assistant-selection.test.ts src/domains/settings/ai/ai-page.tsx src/domains/settings/settings-layout.tsx src/lib/api-interceptors.ts src/lib/api-interceptors.test.ts
- git diff --check