### PR TITLE
fix: guard against ChatGPT subscription model incompatibility

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -604,6 +604,16 @@ function ProfileEditorModalInner({
     availableConnectionsForProvider,
   ]);
 
+  useEffect(() => {
+    if (
+      model &&
+      availableModels.length > 0 &&
+      !availableModels.some((m) => m.id === model)
+    ) {
+      setModel("");
+    }
+  }, [model, availableModels]);
+
   return (
     <Modal.Content size="md">
       <Modal.Header>

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -565,6 +565,13 @@ function ProfileEditorModalInner({
       if (selectedConn?.auth.type === "oauth_subscription") {
         return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
       }
+      if (
+        !providerConnection &&
+        availableConnectionsForProvider.length > 0 &&
+        availableConnectionsForProvider.every((c) => c.auth.type === "oauth_subscription")
+      ) {
+        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
+      }
       return catalogModels;
     }
     // Static catalog is empty (openai-compatible) — derive from connections.

--- a/assistant/src/__tests__/connection-model-compat.test.ts
+++ b/assistant/src/__tests__/connection-model-compat.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  describeSubscriptionModelIncompatibility,
+  isConnectionCompatibleWithModel,
+} from "../providers/connection-model-compat.js";
+
+describe("isConnectionCompatibleWithModel", () => {
+  test("non-oauth_subscription connections are always compatible", () => {
+    expect(
+      isConnectionCompatibleWithModel(
+        { auth: { type: "api_key" } as never },
+        "o3",
+      ),
+    ).toBe(true);
+  });
+
+  test("oauth_subscription is compatible with Codex models", () => {
+    expect(
+      isConnectionCompatibleWithModel(
+        { auth: { type: "oauth_subscription" } as never },
+        "gpt-5.4",
+      ),
+    ).toBe(true);
+  });
+
+  test("oauth_subscription is incompatible with non-Codex models", () => {
+    expect(
+      isConnectionCompatibleWithModel(
+        { auth: { type: "oauth_subscription" } as never },
+        "o3",
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined model is always compatible", () => {
+    expect(
+      isConnectionCompatibleWithModel(
+        { auth: { type: "oauth_subscription" } as never },
+        undefined,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("describeSubscriptionModelIncompatibility", () => {
+  const subscriptionConn = { auth: { type: "oauth_subscription" as const } as never };
+  const apiKeyConn = { auth: { type: "api_key" as const } as never };
+
+  test("returns message when all candidates are oauth_subscription and model is incompatible", () => {
+    const msg = describeSubscriptionModelIncompatibility(
+      [subscriptionConn],
+      "o3",
+    );
+    expect(msg).toContain("o3");
+    expect(msg).toContain("ChatGPT subscription");
+  });
+
+  test("returns null when no candidates", () => {
+    expect(describeSubscriptionModelIncompatibility([], "o3")).toBeNull();
+  });
+
+  test("returns null when model is undefined", () => {
+    expect(
+      describeSubscriptionModelIncompatibility([subscriptionConn], undefined),
+    ).toBeNull();
+  });
+
+  test("returns null when some candidates are compatible", () => {
+    expect(
+      describeSubscriptionModelIncompatibility(
+        [subscriptionConn, apiKeyConn],
+        "o3",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when model is Codex-compatible", () => {
+    expect(
+      describeSubscriptionModelIncompatibility([subscriptionConn], "gpt-5.4"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -24,7 +24,10 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { getDb } from "../memory/db-connection.js";
-import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
+import {
+  describeSubscriptionModelIncompatibility,
+  isConnectionCompatibleWithModel,
+} from "./connection-model-compat.js";
 import {
   ConnectionResolutionError,
   tryResolveProviderForConnectionName,
@@ -156,12 +159,13 @@ export class CallSiteRoutingProvider implements Provider {
     // auto-resolve a connection for the provider (handles the case where the
     // profile set provider but not provider_connection, and the merge didn't
     // inherit one).
+    let autoResolveCandidates: import("./inference/auth.js").ProviderConnection[] | undefined;
     if (!connectionName && resolved.provider !== this.defaultProvider.name) {
       try {
-        const candidates = listConnections(getDb(), {
+        autoResolveCandidates = listConnections(getDb(), {
           provider: resolved.provider,
         });
-        const active = candidates.find((c) =>
+        const active = autoResolveCandidates.find((c) =>
           isConnectionCompatibleWithModel(c, resolved.model),
         );
         if (active) {
@@ -184,6 +188,20 @@ export class CallSiteRoutingProvider implements Provider {
 
     if (resolved.provider === this.defaultProvider.name) {
       return this.defaultProvider;
+    }
+
+    if (autoResolveCandidates) {
+      const incompatMsg = describeSubscriptionModelIncompatibility(
+        autoResolveCandidates,
+        resolved.model,
+      );
+      if (incompatMsg) {
+        throw new ConnectionResolutionError(
+          "<resolved-callsite>",
+          "model_incompatible",
+          incompatMsg,
+        );
+      }
     }
 
     throw new ConnectionResolutionError(

--- a/assistant/src/providers/connection-model-compat.ts
+++ b/assistant/src/providers/connection-model-compat.ts
@@ -36,3 +36,26 @@ export function isConnectionCompatibleWithModel(
   if (!model) return true;
   return isCodexSubscriptionModel(model);
 }
+
+/**
+ * When auto-resolution found candidates but none were model-compatible,
+ * return a user-facing explanation if the incompatibility is specifically
+ * due to all candidates being `oauth_subscription` (ChatGPT) connections.
+ *
+ * Returns `null` when the incompatibility has a different cause (callers
+ * should fall through to their existing generic error).
+ */
+export function describeSubscriptionModelIncompatibility(
+  candidates: Pick<ProviderConnection, "auth">[],
+  model: string | undefined,
+): string | null {
+  if (!model || candidates.length === 0) return null;
+  if (candidates.some((c) => isConnectionCompatibleWithModel(c, model))) {
+    return null;
+  }
+  const allSubscription = candidates.every(
+    (c) => c.auth.type === "oauth_subscription",
+  );
+  if (!allSubscription) return null;
+  return `Model "${model}" isn't available through your ChatGPT subscription. Select a supported model or add an OpenAI API key connection.`;
+}

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -30,7 +30,10 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getDb } from "../memory/db-connection.js";
 import { getLogger } from "../util/logger.js";
-import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
+import {
+  describeSubscriptionModelIncompatibility,
+  isConnectionCompatibleWithModel,
+} from "./connection-model-compat.js";
 import { getConnection, listConnections } from "./inference/connections.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
@@ -52,7 +55,8 @@ export class ConnectionResolutionError extends Error {
       | "lookup_failed"
       | "not_found"
       | "provider_mismatch"
-      | "missing_connection",
+      | "missing_connection"
+      | "model_incompatible",
     message: string,
     public readonly cause?: unknown,
   ) {
@@ -116,10 +120,11 @@ export async function tryResolveProviderForConnectionName(
     // "anthropic-managed" leaked through). Try to find an active connection
     // for the expected provider before giving up.
     let resolved = false;
+    let mismatchCandidates: import("./inference/auth.js").ProviderConnection[] | undefined;
     try {
       const db = getDb();
-      const candidates = listConnections(db, { provider: expectedProvider });
-      const active = candidates.find((c) =>
+      mismatchCandidates = listConnections(db, { provider: expectedProvider });
+      const active = mismatchCandidates.find((c) =>
         isConnectionCompatibleWithModel(c, model),
       );
       if (active) {
@@ -138,6 +143,16 @@ export async function tryResolveProviderForConnectionName(
       // DB not available — fall through to the original error.
     }
     if (!resolved) {
+      const incompatMsg = mismatchCandidates
+        ? describeSubscriptionModelIncompatibility(mismatchCandidates, model)
+        : null;
+      if (incompatMsg) {
+        throw new ConnectionResolutionError(
+          connectionName,
+          "model_incompatible",
+          incompatMsg,
+        );
+      }
       throw new ConnectionResolutionError(
         connectionName,
         "provider_mismatch",
@@ -188,12 +203,13 @@ export async function resolveDefaultProvider(
     // provider without a connection ("Any active" selection), and the merge
     // cleared or failed to inherit one. Try to find an active connection
     // for the provider before giving up.
+    let autoResolveCandidates: import("./inference/auth.js").ProviderConnection[] | undefined;
     if (resolved.provider) {
       try {
-        const candidates = listConnections(getDb(), {
+        autoResolveCandidates = listConnections(getDb(), {
           provider: resolved.provider,
         });
-        const active = candidates.find((c) =>
+        const active = autoResolveCandidates.find((c) =>
           isConnectionCompatibleWithModel(c, resolved.model),
         );
         if (active) {
@@ -208,6 +224,19 @@ export async function resolveDefaultProvider(
       }
     }
     if (!connectionName) {
+      const incompatMsg = autoResolveCandidates
+        ? describeSubscriptionModelIncompatibility(
+            autoResolveCandidates,
+            resolved.model,
+          )
+        : null;
+      if (incompatMsg) {
+        throw new ConnectionResolutionError(
+          "<llm.default>",
+          "model_incompatible",
+          incompatMsg,
+        );
+      }
       throw new ConnectionResolutionError(
         "<llm.default>",
         "missing_connection",

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -9,7 +9,10 @@ import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getDb } from "../memory/db-connection.js";
 import { getLogger } from "../util/logger.js";
-import { isConnectionCompatibleWithModel } from "./connection-model-compat.js";
+import {
+  describeSubscriptionModelIncompatibility,
+  isConnectionCompatibleWithModel,
+} from "./connection-model-compat.js";
 import { tryResolveProviderForConnectionName } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import { initializeProviders, listProviders } from "./registry.js";
@@ -132,6 +135,14 @@ export async function resolveConfiguredProvider(
         );
         if (active) {
           connectionName = active.name;
+        } else {
+          const incompatMsg = describeSubscriptionModelIncompatibility(
+            candidates,
+            resolved.model,
+          );
+          if (incompatMsg) {
+            log.warn({ callSite, inferenceProvider, model: resolved.model }, incompatMsg);
+          }
         }
       } catch {
         // DB not available — fall through to the existing null-return path.


### PR DESCRIPTION
## Summary

- **UI**: When `providerConnection` is empty ("Any") and *all* available connections for the provider are `oauth_subscription` (ChatGPT), filter the model picker to Codex-compatible models only. Prevents users from saving a profile with a non-Codex model that will fail at dispatch.
- **Daemon**: When auto-resolution finds connections for the provider but none are model-compatible due to subscription constraints, surface a specific error ("Model X isn't available through your ChatGPT subscription") instead of the generic "no provider configured" message. Applied to all three auto-resolution sites: `provider-send-message.ts`, `call-site-routing.ts`, and `connection-resolution.ts`.
- **Tests**: Added unit tests for the new `describeSubscriptionModelIncompatibility` helper alongside the existing `isConnectionCompatibleWithModel` tests.

Follow-up to #32341 (provider connection status removal).

## Test plan

- [x] `bunx tsc --noEmit` passes (assistant)
- [x] `bun test connection-model-compat.test.ts` — 9/9 pass
- [x] `bun test call-site-routing-provider.test.ts connection-policy.test.ts` — 16/16 pass
- [x] `bun test openai-responses-provider.test.ts cross-provider-web-search.test.ts` — 84/84 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)