### PR TITLE
feat(web): add up-arrow message recall to edit and resend (JARVIS-840)

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -224,6 +224,10 @@ export interface ChatComposerProps {
   // Ghost text autocomplete — shown as a dimmed suffix in the textarea when
   // the suggestion endpoint returns a completion for the current conversation.
   suggestion?: string | null;
+
+  // Edit-message recall — up-arrow on empty input recalls last user message.
+  onRecallLastMessage?: () => void;
+  onCancelEdit?: () => void;
 }
 
 export function ChatComposer({
@@ -254,6 +258,8 @@ export function ChatComposer({
   cmdEnterMode = false,
   suggestion,
   modelSupportsVision = true,
+  onRecallLastMessage,
+  onCancelEdit,
 }: ChatComposerProps) {
   const voicePhase = useVoiceRecordingStore.use.phase();
   const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
@@ -464,6 +470,22 @@ export function ChatComposer({
                       emoji.dismiss();
                       return;
                     }
+                  }
+
+                  if (
+                    e.key === "ArrowUp" &&
+                    !input.trim() &&
+                    onRecallLastMessage
+                  ) {
+                    e.preventDefault();
+                    onRecallLastMessage();
+                    return;
+                  }
+
+                  if (e.key === "Escape" && onCancelEdit) {
+                    e.preventDefault();
+                    onCancelEdit();
+                    return;
                   }
 
                   const marker = matchFormattingShortcut(e);

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -74,6 +74,8 @@ const ToolDetailPanel = lazy(() =>
 );
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
+import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
+import { conversationsByIdUndoPost } from "@/generated/daemon/sdk.gen";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 
 import { Link, useNavigate } from "react-router";
@@ -599,6 +601,12 @@ export function ChatRouteContent({
   });
 
   // -------------------------------------------------------------------------
+  // Edit-message recall (up-arrow)
+  // -------------------------------------------------------------------------
+
+  const { editingMessageId, isEditing, startEditing, cancelEditing } = useEditMessage(messages);
+
+  // -------------------------------------------------------------------------
   // Derived values
   // -------------------------------------------------------------------------
 
@@ -936,8 +944,18 @@ export function ChatRouteContent({
     // initial response render (which expands LatestTurnRow via
     // useViewportMinHeight) stays anchored at the latest message.
     scrollCoordinator.scrollToLatest({ behavior: "auto" });
+    if (isEditing && editingMessageId && assistantId && activeConversationId) {
+      cancelEditing();
+      try {
+        await conversationsByIdUndoPost({
+          path: { assistant_id: assistantId, id: activeConversationId },
+        });
+      } catch {
+        // If undo fails, still send the message as a new one
+      }
+    }
     await sendMessage(trimmed, attachmentsToSend);
-  }, [input, sendDisabled, attachmentUploadedIds.length, attachmentsUploadingCount, activeConversationId, chatAttachments, resetChatAttachments, sendMessage, setInput, clearDraft, inputRef, scrollCoordinator]);
+  }, [input, sendDisabled, attachmentUploadedIds.length, attachmentsUploadingCount, activeConversationId, chatAttachments, resetChatAttachments, sendMessage, setInput, clearDraft, inputRef, scrollCoordinator, isEditing, editingMessageId, assistantId, cancelEditing]);
 
   const handleSelectStarter = (starter: { prompt: string }) => {
     setInput(starter.prompt);
@@ -1274,6 +1292,16 @@ export function ChatRouteContent({
     onStopGenerating: handleStopGenerating,
     assistantId,
     modelSupportsVision: activeModelSupportsVision,
+    onRecallLastMessage: () => {
+      const content = startEditing();
+      if (content !== null) {
+        setInput(content);
+      }
+    },
+    onCancelEdit: () => {
+      cancelEditing();
+      setInput("");
+    },
     textareaMaxHeightPx: isEmptyConversation ? 320 : undefined,
     thresholdPickerSlot: assistantId ? (
       <ComposerSettingsMenu

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1292,16 +1292,16 @@ export function ChatRouteContent({
     onStopGenerating: handleStopGenerating,
     assistantId,
     modelSupportsVision: activeModelSupportsVision,
-    onRecallLastMessage: () => {
+    onRecallLastMessage: phase === "idle" ? () => {
       const content = startEditing();
       if (content !== null) {
         setInput(content);
       }
-    },
-    onCancelEdit: () => {
+    } : undefined,
+    onCancelEdit: isEditing ? () => {
       cancelEditing();
       setInput("");
-    },
+    } : undefined,
     textareaMaxHeightPx: isEmptyConversation ? 320 : undefined,
     thresholdPickerSlot: assistantId ? (
       <ComposerSettingsMenu

--- a/apps/web/src/domains/chat/hooks/use-edit-message.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-edit-message.test.ts
@@ -17,7 +17,7 @@ describe("useEditMessage", () => {
     ];
     const { result } = renderHook(() => useEditMessage(messages));
 
-    let content: string | null = null;
+    let content: string | null | undefined;
     act(() => {
       content = result.current.startEditing();
     });
@@ -36,7 +36,7 @@ describe("useEditMessage", () => {
     ];
     const { result } = renderHook(() => useEditMessage(messages));
 
-    let content: string | null = null;
+    let content: string | null | undefined;
     act(() => {
       content = result.current.startEditing();
     });
@@ -51,7 +51,7 @@ describe("useEditMessage", () => {
     ];
     const { result } = renderHook(() => useEditMessage(messages));
 
-    let content: string | null = null;
+    let content: string | null | undefined;
     act(() => {
       content = result.current.startEditing();
     });

--- a/apps/web/src/domains/chat/hooks/use-edit-message.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-edit-message.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useEditMessage } from "./use-edit-message";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+function makeMsg(overrides: Partial<DisplayMessage> & { id: string; role: DisplayMessage["role"]; content: string }): DisplayMessage {
+  return { ...overrides };
+}
+
+describe("useEditMessage", () => {
+  test("startEditing returns content of last confirmed user message", () => {
+    const messages: DisplayMessage[] = [
+      makeMsg({ id: "1", role: "user", content: "first" }),
+      makeMsg({ id: "2", role: "assistant", content: "reply" }),
+      makeMsg({ id: "3", role: "user", content: "second" }),
+      makeMsg({ id: "4", role: "assistant", content: "reply2" }),
+    ];
+    const { result } = renderHook(() => useEditMessage(messages));
+
+    let content: string | null = null;
+    act(() => {
+      content = result.current.startEditing();
+    });
+
+    expect(content).toBe("second");
+    expect(result.current.isEditing).toBe(true);
+    expect(result.current.editingMessageId).toBe("3");
+  });
+
+  test("startEditing skips queued and optimistic messages", () => {
+    const messages: DisplayMessage[] = [
+      makeMsg({ id: "1", role: "user", content: "confirmed" }),
+      makeMsg({ id: "2", role: "assistant", content: "reply" }),
+      makeMsg({ id: "3", role: "user", content: "queued", queueStatus: "queued" }),
+      makeMsg({ id: "4", role: "user", content: "optimistic", isOptimistic: true }),
+    ];
+    const { result } = renderHook(() => useEditMessage(messages));
+
+    let content: string | null = null;
+    act(() => {
+      content = result.current.startEditing();
+    });
+
+    expect(content).toBe("confirmed");
+    expect(result.current.editingMessageId).toBe("1");
+  });
+
+  test("startEditing returns null when no user messages exist", () => {
+    const messages: DisplayMessage[] = [
+      makeMsg({ id: "1", role: "assistant", content: "hello" }),
+    ];
+    const { result } = renderHook(() => useEditMessage(messages));
+
+    let content: string | null = null;
+    act(() => {
+      content = result.current.startEditing();
+    });
+
+    expect(content).toBeNull();
+    expect(result.current.isEditing).toBe(false);
+  });
+
+  test("cancelEditing clears edit state", () => {
+    const messages: DisplayMessage[] = [
+      makeMsg({ id: "1", role: "user", content: "hello" }),
+    ];
+    const { result } = renderHook(() => useEditMessage(messages));
+
+    act(() => {
+      result.current.startEditing();
+    });
+    expect(result.current.isEditing).toBe(true);
+
+    act(() => {
+      result.current.cancelEditing();
+    });
+    expect(result.current.isEditing).toBe(false);
+    expect(result.current.editingMessageId).toBeNull();
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-edit-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-edit-message.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from "react";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+export function useEditMessage(messages: DisplayMessage[]) {
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+
+  const startEditing = useCallback((): string | null => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.role === "user" && !m.queueStatus && !m.isOptimistic) {
+        setEditingMessageId(m.id);
+        return m.content;
+      }
+    }
+    return null;
+  }, [messages]);
+
+  const cancelEditing = useCallback(() => {
+    setEditingMessageId(null);
+  }, []);
+
+  return { editingMessageId, isEditing: editingMessageId !== null, startEditing, cancelEditing } as const;
+}


### PR DESCRIPTION
## Summary
- Press up-arrow on an empty composer to recall the last user message into the input
- Submitting the edited message undoes the previous exchange (via existing `/undo` endpoint) and sends the new content
- Escape cancels edit mode and clears the input
- Frontend-only change — no new backend endpoints

## Test plan
- [x] `bunx tsc --noEmit` passes (no new type errors)
- [x] 4 new `useEditMessage` hook tests pass
- [x] 43 existing composer tests pass (no regressions)
- [ ] Playwright/manual: up-arrow on empty input recalls last message
- [ ] Playwright/manual: submitting edited message undoes + resends
- [ ] Playwright/manual: Escape cancels edit mode

Closes JARVIS-840

🤖 Generated with [Claude Code](https://claude.com/claude-code)