### PR TITLE
fix(macos): remove dead provider connection status toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -28,9 +28,8 @@ struct InferenceProfileEditor: View {
     var isReadOnly: Bool = false
     var isCreating: Bool = false
     /// Provider connections available for the Connection sub-dropdown. The
-    /// editor reads this list, filters by the currently-selected provider
-    /// and `.status == .active`, and lets the user route the profile to a
-    /// specific row. Defaults to nil so test constructions and callers
+    /// editor reads this list, filters by the currently-selected provider,
+    /// and lets the user route the profile to a specific connection row. Defaults to nil so test constructions and callers
     /// that don't care about connection routing still compile — daemons
     /// older than the `provider_connection`-aware profile schema continue
     /// to behave as "pick the first active connection for the provider."
@@ -474,7 +473,7 @@ struct InferenceProfileEditor: View {
         guard let connections else { return store.dynamicProviderIds }
 
         var activeProviderSet = Set<String>()
-        for connection in connections where connection.status == .active {
+        for connection in connections {
             activeProviderSet.insert(connection.provider)
         }
         if let bound = profile.provider, !bound.isEmpty {
@@ -509,8 +508,8 @@ struct InferenceProfileEditor: View {
                         // Reset connection binding too: a stale name almost
                         // certainly points at a different provider's row, and
                         // the daemon would reject it at resolve time. Falling
-                        // back to "Any active <provider> connection" matches
-                        // the dispatcher's legacy behavior.
+                        // back to "Any <provider> connection" matches the
+                        // dispatcher's legacy behavior.
                         profile.providerConnection = nil
                         Self.clampMaxOutputTokensForSelectedModel(&profile)
                         Self.clampContextWindowForSelectedModel(&profile)
@@ -521,20 +520,20 @@ struct InferenceProfileEditor: View {
                 }
             )
             if availableProviderIds.isEmpty && !isReadOnly {
-                Text("No active provider connections. Open Providers to add or enable one.")
+                Text("No provider connections. Open Providers to add one.")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
         }
     }
 
-    /// Active connections that match the currently-selected provider. Used
-    /// by `connectionField` to populate its dropdown. During pre-load
+    /// Connections that match the currently-selected provider. Used by
+    /// `connectionField` to populate its dropdown. During pre-load
     /// (`connections == nil`) there's nothing to pick — the connection
     /// sub-dropdown stays hidden until the fetch completes.
     var availableConnectionsForProvider: [ProviderConnection] {
         guard let provider = profile.provider, !provider.isEmpty else { return [] }
-        return (connections ?? []).filter { $0.provider == provider && $0.status == .active }
+        return (connections ?? []).filter { $0.provider == provider }
     }
 
     /// The currently-saved binding when it does NOT resolve to any active

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -43,12 +43,6 @@ struct ProvidersSheet: View {
     /// that matches the user's current credential selection.
     @State private var loadMaskedTask: Task<Void, Never>?
 
-    /// Connection names with an in-flight status PATCH from the inline row
-    /// toggle. Used to drop subsequent toggle attempts so a fast off→on→off
-    /// sequence can't produce out-of-order responses that clobber the user's
-    /// final intent.
-    @State private var inFlightStatusToggles: Set<String> = []
-
     // -- ChatGPT Subscription OAuth state -----------------------------------
 
     enum ChatgptOAuthState {
@@ -88,7 +82,6 @@ struct ProvidersSheet: View {
         var provider = ""
         var authType = "api_key"
         var credential = ""
-        var status: ConnectionStatus = .active
         // Inline credential editing
         var apiKeyValue = ""
         var isAdvancedExpanded = false
@@ -107,14 +100,14 @@ struct ProvidersSheet: View {
         /// gemini-managed rows). The daemon write-protects DELETE + PATCH-auth
         /// on these rows. The UI mirrors that by disabling the auth-related
         /// fields (Auth Type, API Key, Advanced/Credential Reference) but
-        /// leaves Display Name + Status editable — those are exactly the
-        /// PATCH fields the daemon allows on managed rows.
+        /// leaves Display Name editable — that is exactly the PATCH field
+        /// the daemon allows on managed rows.
         case managedEdit(name: String)
     }
 
     /// True when the editor is in managed-edit mode. Selectively disables the
     /// auth-related fields (Auth Type, API Key, Credential Reference) while
-    /// leaving Display Name + Status editable.
+    /// leaving Display Name editable.
     private var isAuthLocked: Bool {
         if case .managedEdit = editorState { return true }
         return false
@@ -270,7 +263,6 @@ struct ProvidersSheet: View {
 
     private func connectionRow(_ conn: ProviderConnection) -> some View {
         let isManaged = conn.isManaged
-        let isDisabled = conn.status == .disabled
         return HStack(alignment: .center, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 if let label = conn.label, !label.isEmpty {
@@ -289,19 +281,8 @@ struct ProvidersSheet: View {
                     connectionRowMetadata(conn, primary: nil)
                 }
             }
-            .opacity(isDisabled ? 0.55 : 1.0)
             Spacer(minLength: 0)
             HStack(spacing: VSpacing.sm) {
-                VToggle(
-                    isOn: Binding(
-                        get: { conn.status == .active },
-                        set: { newActive in
-                            Task { await setStatus(conn, active: newActive) }
-                        }
-                    )
-                )
-                .accessibilityLabel("\(isDisabled ? "Activate" : "Disable") connection \(conn.label?.isEmpty == false ? conn.label! : conn.name)")
-                .help(isDisabled ? "Disabled — toggle to activate" : "Active — toggle to disable")
                 VButton(label: "Edit", style: .ghost) {
                     if isManaged {
                         beginManagedEdit(conn)
@@ -334,7 +315,7 @@ struct ProvidersSheet: View {
             }
             if conn.isManaged {
                 VBadge(label: "Platform", tone: .positive, emphasis: .subtle)
-                    .help("Managed by Platform — auth is locked, but you can rename or disable this connection.")
+                    .help("Managed by Platform — auth is locked, but you can rename this connection.")
             }
             VBadge(
                 label: store.dynamicProviderDisplayName(conn.provider),
@@ -413,7 +394,6 @@ struct ProvidersSheet: View {
                         }
                     }
                     .disabled(isAuthLocked)
-                    editorStatusToggle
                     if let actionError {
                         Text(actionError)
                             .font(VFont.bodySmallDefault)
@@ -458,7 +438,7 @@ struct ProvidersSheet: View {
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
                 if isAuthLocked {
-                    Text("Managed by Vellum — auth is locked, but you can rename or disable this connection.")
+                    Text("Managed by Vellum — auth is locked, but you can rename this connection.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
                 }
@@ -513,21 +493,6 @@ struct ProvidersSheet: View {
                 )
             )
             .disabled(editorState != .create)
-        }
-    }
-
-    private var editorStatusToggle: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text("Status")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
-            VToggle(
-                isOn: Binding(
-                    get: { editorDraft.status == .active },
-                    set: { editorDraft.status = $0 ? .active : .disabled }
-                ),
-                label: "Active"
-            )
         }
     }
 
@@ -1118,7 +1083,6 @@ struct ProvidersSheet: View {
             provider: conn.provider,
             authType: conn.auth.type,
             credential: conn.auth.credential ?? "",
-            status: conn.status,
             baseUrl: conn.baseUrl ?? "",
             connectionModels: conn.models?.map(\.id).joined(separator: ", ") ?? ""
         )
@@ -1135,8 +1099,8 @@ struct ProvidersSheet: View {
     /// Open the editor for a Vellum-managed connection. Auth-related fields
     /// (Auth Type, API Key, Credential Reference) are disabled via
     /// `isAuthLocked` so the daemon's write-protection on `auth` for managed
-    /// rows isn't surprising; Display Name + Status remain editable to match
-    /// what the daemon allows on managed PATCHes.
+    /// rows isn't surprising; Display Name remains editable to match what the
+    /// daemon allows on managed PATCHes.
     private func beginManagedEdit(_ conn: ProviderConnection) {
         actionError = nil
         isKeyDirty = true
@@ -1146,7 +1110,6 @@ struct ProvidersSheet: View {
             provider: conn.provider,
             authType: conn.auth.type,
             credential: conn.auth.credential ?? "",
-            status: conn.status,
             baseUrl: conn.baseUrl ?? "",
             connectionModels: conn.models?.map(\.id).joined(separator: ", ") ?? ""
         )
@@ -1201,9 +1164,6 @@ struct ProvidersSheet: View {
         editorDraft.apiKeyValue = ""
         editorDraft.baseUrl = ""
         editorDraft.connectionModels = ""
-        // New connection starts active by convention; user can toggle off
-        // before saving if they want it disabled.
-        editorDraft.status = .active
         // Reset masked credential — there's no key for the new connection
         // yet, so the API Key field shows its placeholder instead of the
         // managed source's masked value. Cancel any in-flight masked-
@@ -1241,45 +1201,6 @@ struct ProvidersSheet: View {
         return "\(base)-\(index)"
     }
 
-    /// Inline status toggle from the list row. Optimistically updates the
-    /// row, PATCHes the daemon with just the new status (auth + label stay
-    /// untouched), and rolls back on failure. Mirrors the daemon's accept-
-    /// status-only PATCH path so managed connections can be toggled too.
-    ///
-    /// `inFlightStatusToggles` guards against overlapping toggles for the
-    /// same row — a fast off→on→off sequence would otherwise produce
-    /// out-of-order PATCH responses that clobber the user's final intent.
-    private func setStatus(_ conn: ProviderConnection, active: Bool) async {
-        guard !inFlightStatusToggles.contains(conn.name) else { return }
-        let newStatus: ConnectionStatus = active ? .active : .disabled
-        let previous = conn.status
-        inFlightStatusToggles.insert(conn.name)
-        defer { inFlightStatusToggles.remove(conn.name) }
-
-        // Optimistic update — `ProviderConnection` is an immutable struct,
-        // so swap in a new value with just `status` flipped.
-        if let idx = connections.firstIndex(where: { $0.name == conn.name }) {
-            connections[idx] = conn.withStatus(newStatus)
-        }
-        guard let updated = await client.updateProviderConnection(
-            name: conn.name,
-            auth: conn.auth,
-            status: newStatus,
-            label: .none,
-            baseUrl: .none,
-            models: .none
-        ) else {
-            // Roll back on failure.
-            if let idx = connections.firstIndex(where: { $0.name == conn.name }) {
-                connections[idx] = conn.withStatus(previous)
-            }
-            actionError = "Couldn't update \"\(conn.name)\". Please try again."
-            return
-        }
-        if let idx = connections.firstIndex(where: { $0.name == conn.name }) {
-            connections[idx] = updated
-        }
-    }
 
     private func commitEditor() async {
         actionError = nil
@@ -1306,8 +1227,7 @@ struct ProvidersSheet: View {
         // commitEditor in create mode so a user who selects "ChatGPT
         // Subscription" and clicks Create without completing the OAuth flow
         // doesn't end up with a broken connection missing OAuth tokens.
-        // In edit mode the OAuth tokens are already set up, so allow saves
-        // for display name / status changes.
+        // In edit mode the OAuth tokens are already set up, so allow saves.
         if draft.authType == "oauth_subscription" && editorState == .create {
             actionError = "Use the \"Sign in with ChatGPT\" button to connect your subscription."
             return
@@ -1352,7 +1272,6 @@ struct ProvidersSheet: View {
             credential: (draft.authType == "api_key" || draft.authType == "oauth_subscription") ? credentialRef : nil
         )
         let label: String? = draft.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft.label.trimmingCharacters(in: .whitespacesAndNewlines)
-        let status = draft.status
 
         let baseUrlValue: String? = draft.isOpenAICompatible && !draft.baseUrl.trimmingCharacters(in: .whitespaces).isEmpty
             ? draft.baseUrl.trimmingCharacters(in: .whitespaces)
@@ -1374,7 +1293,6 @@ struct ProvidersSheet: View {
                 provider: draft.provider,
                 auth: auth,
                 label: label,
-                status: status,
                 baseUrl: baseUrlValue,
                 models: modelsValue
             )
@@ -1410,7 +1328,6 @@ struct ProvidersSheet: View {
             guard let updated = await client.updateProviderConnection(
                 name: originalName,
                 auth: auth,
-                status: status,
                 label: .some(label),
                 baseUrl: draft.isOpenAICompatible ? .some(baseUrlValue) : .none,
                 models: draft.isOpenAICompatible ? .some(modelsValue) : .none

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -968,15 +968,15 @@ final class InferenceProfileEditorTests: XCTestCase {
 
     // MARK: - Connection sub-dropdown (audit finding #5)
 
-    /// Two active openai connections + one disabled + one of a different
-    /// provider. With provider == "openai" the filter must yield exactly
-    /// the two active openai rows in input order.
-    func testAvailableConnectionsForProviderFiltersByProviderAndStatus() {
+    /// Three openai connections + one of a different provider. With
+    /// provider == "openai" the filter must yield exactly the three openai
+    /// rows in input order.
+    func testAvailableConnectionsForProviderFiltersByProvider() {
         let connections: [ProviderConnection] = [
-            Self.makeConnection(name: "personal-openai", provider: "openai", status: .active, label: "Personal"),
-            Self.makeConnection(name: "work-openai", provider: "openai", status: .active, label: "Work"),
-            Self.makeConnection(name: "legacy-openai", provider: "openai", status: .disabled, label: "Legacy"),
-            Self.makeConnection(name: "anthropic-main", provider: "anthropic", status: .active, label: "Main"),
+            Self.makeConnection(name: "personal-openai", provider: "openai", label: "Personal"),
+            Self.makeConnection(name: "work-openai", provider: "openai", label: "Work"),
+            Self.makeConnection(name: "legacy-openai", provider: "openai", label: "Legacy"),
+            Self.makeConnection(name: "anthropic-main", provider: "anthropic", label: "Main"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -986,7 +986,7 @@ final class InferenceProfileEditorTests: XCTestCase {
             onCancel: {}
         )
         let available = editor.availableConnectionsForProvider
-        XCTAssertEqual(available.map { $0.name }, ["personal-openai", "work-openai"])
+        XCTAssertEqual(available.map { $0.name }, ["personal-openai", "work-openai", "legacy-openai"])
     }
 
     /// When no provider is selected, no connections are surfaced — the
@@ -994,7 +994,7 @@ final class InferenceProfileEditorTests: XCTestCase {
     /// picks a provider, so the dropdown stays hidden.
     func testAvailableConnectionsForProviderIsEmptyWhenProviderUnset() {
         let connections = [
-            Self.makeConnection(name: "openai", provider: "openai", status: .active),
+            Self.makeConnection(name: "openai", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1039,7 +1039,7 @@ final class InferenceProfileEditorTests: XCTestCase {
     /// dropdown option that lets the user clear it.
     func testStaleProviderConnectionReturnsNameWhenBindingMissing() {
         let connections = [
-            Self.makeConnection(name: "personal-openai", provider: "openai", status: .active),
+            Self.makeConnection(name: "personal-openai", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1055,33 +1055,11 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertEqual(editor.staleProviderConnection, "ghost-openai")
     }
 
-    /// A disabled-status connection with a matching name is NOT in the
-    /// active-for-provider set, so the binding is "stale" from the
-    /// editor's POV (the daemon would skip it on dispatch). User can clear
-    /// or pick a different one.
-    func testStaleProviderConnectionReturnsNameWhenBindingMatchesDisabled() {
-        let connections = [
-            Self.makeConnection(name: "legacy-openai", provider: "openai", status: .disabled),
-        ]
-        let editor = InferenceProfileEditor(
-            store: store,
-            profile: .constant(InferenceProfile(
-                name: "draft",
-                provider: "openai",
-                providerConnection: "legacy-openai"
-            )),
-            connections: connections,
-            onSave: {},
-            onCancel: {}
-        )
-        XCTAssertEqual(editor.staleProviderConnection, "legacy-openai")
-    }
-
     /// Binding resolves cleanly to an active row → `nil`, picker renders
     /// in its non-stale shape.
     func testStaleProviderConnectionNilWhenBindingMatches() {
         let connections = [
-            Self.makeConnection(name: "personal-openai", provider: "openai", status: .active),
+            Self.makeConnection(name: "personal-openai", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1101,7 +1079,7 @@ final class InferenceProfileEditorTests: XCTestCase {
     /// when there are active matches; hides entirely when there are none.
     func testStaleProviderConnectionNilWhenBindingEmpty() {
         let connections = [
-            Self.makeConnection(name: "personal-openai", provider: "openai", status: .active),
+            Self.makeConnection(name: "personal-openai", provider: "openai"),
         ]
         let unboundEditor = InferenceProfileEditor(
             store: store,
@@ -1136,7 +1114,7 @@ final class InferenceProfileEditorTests: XCTestCase {
     /// SwiftUI compile. Safety net for the picker's stale-state UI.
     func testEditorBodyBuildsWithStaleBinding() {
         let connections = [
-            Self.makeConnection(name: "personal-openai", provider: "openai", status: .active),
+            Self.makeConnection(name: "personal-openai", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1179,14 +1157,11 @@ final class InferenceProfileEditorTests: XCTestCase {
 
     // MARK: - Provider picker filter (iter3 QA issue #1, parity with web PR #6509)
 
-    /// Only providers with at least one ACTIVE connection are surfaced in
-    /// the picker. A provider whose only connection is disabled (openai
-    /// below) must not appear, because binding a profile to it would
-    /// route through a credential the daemon will skip on dispatch.
-    func testAvailableProviderIdsHidesProvidersWithoutActiveConnection() {
+    /// All providers with at least one connection are surfaced in the picker.
+    func testAvailableProviderIdsShowsProvidersWithConnections() {
         let connections: [ProviderConnection] = [
-            Self.makeConnection(name: "active-anthropic", provider: "anthropic", status: .active),
-            Self.makeConnection(name: "disabled-openai", provider: "openai", status: .disabled),
+            Self.makeConnection(name: "active-anthropic", provider: "anthropic"),
+            Self.makeConnection(name: "openai-conn", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1195,17 +1170,17 @@ final class InferenceProfileEditorTests: XCTestCase {
             onSave: {},
             onCancel: {}
         )
-        XCTAssertEqual(editor.availableProviderIds, ["anthropic"])
+        XCTAssertEqual(editor.availableProviderIds, ["anthropic", "openai"])
     }
 
     /// Stale binding recovery: the editor is opened on a profile whose
-    /// `provider` value no longer has any active connection. The bound
-    /// provider must still appear in the picker so the user can see it
-    /// (and pick a different one) instead of finding an empty trigger.
+    /// `provider` value is bound. The bound provider must still appear in
+    /// the picker so the user can see it (and pick a different one)
+    /// instead of finding an empty trigger.
     func testAvailableProviderIdsKeepsCurrentBoundProvider() {
         let connections: [ProviderConnection] = [
-            Self.makeConnection(name: "active-anthropic", provider: "anthropic", status: .active),
-            Self.makeConnection(name: "disabled-openai", provider: "openai", status: .disabled),
+            Self.makeConnection(name: "active-anthropic", provider: "anthropic"),
+            Self.makeConnection(name: "openai-conn", provider: "openai"),
         ]
         let editor = InferenceProfileEditor(
             store: store,
@@ -1266,23 +1241,6 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertTrue(editor.availableProviderIds.isEmpty)
     }
 
-    /// All-disabled connections + no bound provider → the filter yields
-    /// empty. The picker still renders (the empty-state hint below it
-    /// drives the user to Providers), but no provider rows appear.
-    func testAvailableProviderIdsIsEmptyWhenOnlyDisabledConnectionsAndNoBoundProvider() {
-        let connections = [
-            Self.makeConnection(name: "disabled-openai", provider: "openai", status: .disabled),
-        ]
-        let editor = InferenceProfileEditor(
-            store: store,
-            profile: .constant(InferenceProfile(name: "draft")),
-            connections: connections,
-            onSave: {},
-            onCancel: {}
-        )
-        XCTAssertTrue(editor.availableProviderIds.isEmpty)
-    }
-
     // MARK: - ChatGPT subscription model filter (parity with web CODEX_SUBSCRIPTION_MODEL_IDS)
 
     /// The constant set must contain exactly the Codex-supported model IDs.
@@ -1304,7 +1262,6 @@ final class InferenceProfileEditorTests: XCTestCase {
                 name: "chatgpt-sub",
                 provider: "openai",
                 authType: "oauth_subscription",
-                status: .active,
                 label: "ChatGPT Subscription"
             ),
         ]
@@ -1331,8 +1288,7 @@ final class InferenceProfileEditorTests: XCTestCase {
             Self.makeConnection(
                 name: "openai-key",
                 provider: "openai",
-                authType: "api_key",
-                status: .active
+                authType: "api_key"
             ),
         ]
         let editor = InferenceProfileEditor(
@@ -1358,8 +1314,7 @@ final class InferenceProfileEditorTests: XCTestCase {
             Self.makeConnection(
                 name: "chatgpt-sub",
                 provider: "openai",
-                authType: "oauth_subscription",
-                status: .active
+                authType: "oauth_subscription"
             ),
         ]
         let editor = InferenceProfileEditor(
@@ -1383,14 +1338,12 @@ final class InferenceProfileEditorTests: XCTestCase {
         name: String = "my-conn",
         provider: String = "openai",
         authType: String = "api_key",
-        status: ConnectionStatus = .active,
         label: String? = nil
     ) -> ProviderConnection {
         ProviderConnection(
             name: name,
             provider: provider,
             auth: ProviderConnectionAuth(type: authType, credential: "sk-test"),
-            status: status,
             label: label,
             createdAt: 0,
             updatedAt: 0

--- a/clients/macos/vellum-assistantTests/Features/Settings/ProvidersSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/ProvidersSheetTests.swift
@@ -40,14 +40,12 @@ final class ProvidersSheetTests: XCTestCase {
         name: String = "my-conn",
         provider: String = "anthropic",
         authType: String = "api_key",
-        status: ConnectionStatus = .active,
         label: String? = nil
     ) -> ProviderConnection {
         ProviderConnection(
             name: name,
             provider: provider,
             auth: ProviderConnectionAuth(type: authType, credential: "sk-test"),
-            status: status,
             label: label,
             createdAt: 0,
             updatedAt: 0
@@ -85,7 +83,6 @@ final class ProvidersSheetTests: XCTestCase {
             provider: "openai",
             auth: ProviderConnectionAuth(type: "api_key", credential: "sk-open"),
             label: nil,
-            status: nil,
             baseUrl: nil,
             models: nil
         )
@@ -120,7 +117,6 @@ final class ProvidersSheetTests: XCTestCase {
         let result = await mockClient.updateProviderConnection(
             name: "gone",
             auth: ProviderConnectionAuth(type: "api_key", credential: "sk-x"),
-            status: nil,
             label: nil,
             baseUrl: nil,
             models: nil
@@ -158,27 +154,10 @@ final class ProvidersSheetTests: XCTestCase {
         XCTAssertEqual(InferenceProfileEditor.toKebabCase("hello world!"), "hello-world")
     }
 
-    // MARK: - Status toggle default
-
-    func testNewConnectionDraftDefaultsToActiveStatus() {
-        let sheet = makeSheet()
-        // Verify the draft starts active; the sheet body builds without issues.
-        XCTAssertNotNil(sheet.body)
-    }
-
     // MARK: - Connections with label render correctly
 
     func testSheetBuildsWithLabeledConnection() {
         let conn = makeConnection(name: "labeled", label: "My Anthropic")
-        mockClient.listResponse = [conn]
-        let sheet = makeSheet()
-        XCTAssertNotNil(sheet.body)
-    }
-
-    // MARK: - Connections with disabled status
-
-    func testSheetBuildsWithDisabledConnection() {
-        let conn = makeConnection(name: "disabled-conn", status: .disabled)
         mockClient.listResponse = [conn]
         let sheet = makeSheet()
         XCTAssertNotNil(sheet.body)
@@ -198,7 +177,6 @@ final class ProvidersSheetTests: XCTestCase {
             name: name,
             provider: provider,
             auth: ProviderConnectionAuth(type: "platform", credential: nil),
-            status: .active,
             label: label,
             createdAt: 0,
             updatedAt: 0,
@@ -255,7 +233,6 @@ final class ProvidersSheetTests: XCTestCase {
             provider: "anthropic",
             auth: ProviderConnectionAuth(type: "api_key", credential: "credential/anthropic/api_key"),
             label: "Anthropic",
-            status: .active,
             baseUrl: nil,
             models: nil
         )

--- a/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
@@ -37,18 +37,16 @@ final class MockProviderConnectionClient: ProviderConnectionClientProtocol {
     var createProviderArg: String?
     var createAuthArg: ProviderConnectionAuth?
     var createLabelArg: String?
-    var createStatusArg: ConnectionStatus?
     var createBaseUrlArg: String?
     var createModelsArg: [ConnectionModel]?
     var createResponse: ProviderConnectionCreateResult = .error
 
-    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult {
+    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult {
         createCallCount += 1
         createNameArg = name
         createProviderArg = provider
         createAuthArg = auth
         createLabelArg = label
-        createStatusArg = status
         createBaseUrlArg = baseUrl
         createModelsArg = models
         return createResponse
@@ -58,17 +56,15 @@ final class MockProviderConnectionClient: ProviderConnectionClientProtocol {
     var updateCallCount = 0
     var updateNameArg: String?
     var updateAuthArg: ProviderConnectionAuth?
-    var updateStatusArg: ConnectionStatus?
     var updateLabelArg: String??
     var updateBaseUrlArg: String??
     var updateModelsArg: [ConnectionModel]??
     var updateResponse: ProviderConnection? = nil
 
-    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection? {
+    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection? {
         updateCallCount += 1
         updateNameArg = name
         updateAuthArg = auth
-        updateStatusArg = status
         updateLabelArg = label
         updateBaseUrlArg = baseUrl
         updateModelsArg = models
@@ -115,14 +111,12 @@ private func makeConnection(
     provider: String = "anthropic",
     authType: String = "api_key",
     credential: String? = "sk-test",
-    status: ConnectionStatus = .active,
     label: String? = nil
 ) -> ProviderConnection {
     ProviderConnection(
         name: name,
         provider: provider,
         auth: ProviderConnectionAuth(type: authType, credential: credential),
-        status: status,
         label: label,
         createdAt: 0,
         updatedAt: 0
@@ -132,55 +126,14 @@ private func makeConnection(
 // MARK: - Tests
 
 /// Verifies the generated `ProviderConnection` Codable conformance keeps the
-/// macOS app working against daemons that predate the `status` field. Mixed-
-/// version setups must default missing `status` to `.active` rather than
-/// throwing `keyNotFound` and stranding the Providers UI.
+/// macOS app working against daemons that predate the `isManaged` field.
+/// Mixed-version setups must default missing `isManaged` to `false` rather
+/// than throwing `keyNotFound` and stranding the Providers UI.
 final class ProviderConnectionDecodingTests: XCTestCase {
 
     private func decode(_ jsonString: String) throws -> ProviderConnection {
         let data = jsonString.data(using: .utf8)!
         return try JSONDecoder().decode(ProviderConnection.self, from: data)
-    }
-
-    func testDecodesStatusWhenPresent() throws {
-        let conn = try decode("""
-        {
-          "name": "my-conn",
-          "provider": "anthropic",
-          "auth": { "type": "api_key", "credential": "credential/anthropic/api_key" },
-          "status": "disabled",
-          "createdAt": 1,
-          "updatedAt": 2
-        }
-        """)
-        XCTAssertEqual(conn.status, .disabled)
-    }
-
-    func testDefaultsToActiveWhenStatusKeyMissing() throws {
-        let conn = try decode("""
-        {
-          "name": "my-conn",
-          "provider": "anthropic",
-          "auth": { "type": "api_key", "credential": "credential/anthropic/api_key" },
-          "createdAt": 1,
-          "updatedAt": 2
-        }
-        """)
-        XCTAssertEqual(conn.status, .active)
-    }
-
-    func testDefaultsToActiveWhenStatusIsExplicitNull() throws {
-        let conn = try decode("""
-        {
-          "name": "my-conn",
-          "provider": "anthropic",
-          "auth": { "type": "api_key", "credential": "credential/anthropic/api_key" },
-          "status": null,
-          "createdAt": 1,
-          "updatedAt": 2
-        }
-        """)
-        XCTAssertEqual(conn.status, .active)
     }
 
     func testDecodesIsManagedWhenPresent() throws {
@@ -278,7 +231,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         let conn = makeConnection(name: "new-conn")
         mock.createResponse = .created(conn)
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "new-conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
+        let result = await mock.createProviderConnection(name: "new-conn", provider: "anthropic", auth: auth, label: nil, baseUrl: nil, models: nil)
         guard case .created(let created) = result else {
             XCTFail("Expected .created result, got \(result)")
             return
@@ -296,7 +249,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // instead of a generic "please try again."
         mock.createResponse = .duplicate
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "existing", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
+        let result = await mock.createProviderConnection(name: "existing", provider: "anthropic", auth: auth, label: nil, baseUrl: nil, models: nil)
         guard case .duplicate = result else {
             XCTFail("Expected .duplicate result, got \(result)")
             return
@@ -308,7 +261,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // sheet can echo it verbatim (e.g. `Invalid provider "x". Valid: ...`).
         mock.createResponse = .invalid(message: "Invalid auth configuration.")
         let auth = ProviderConnectionAuth(type: "api_key", credential: "")
-        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
+        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, baseUrl: nil, models: nil)
         guard case .invalid(let message) = result else {
             XCTFail("Expected .invalid result, got \(result)")
             return
@@ -320,7 +273,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // Catch-all for network errors, 5xx, decode failures, etc.
         mock.createResponse = .error
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
+        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, baseUrl: nil, models: nil)
         guard case .error = result else {
             XCTFail("Expected .error result, got \(result)")
             return
@@ -333,7 +286,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         let conn = makeConnection(name: "conn")
         mock.updateResponse = conn
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-new")
-        let result = await mock.updateProviderConnection(name: "conn", auth: auth, status: nil, label: nil, baseUrl: nil, models: nil)
+        let result = await mock.updateProviderConnection(name: "conn", auth: auth, label: nil, baseUrl: nil, models: nil)
         XCTAssertEqual(result?.name, "conn")
         XCTAssertEqual(mock.updateNameArg, "conn")
         XCTAssertEqual(mock.updateAuthArg?.credential, "sk-new")
@@ -342,7 +295,7 @@ final class ProviderConnectionClientTests: XCTestCase {
     func testUpdateReturnsNilOn404() async {
         mock.updateResponse = nil
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-x")
-        let result = await mock.updateProviderConnection(name: "missing", auth: auth, status: nil, label: nil, baseUrl: nil, models: nil)
+        let result = await mock.updateProviderConnection(name: "missing", auth: auth, label: nil, baseUrl: nil, models: nil)
         XCTAssertNil(result)
     }
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -6061,14 +6061,6 @@ public struct ProviderConnectionAuth: Codable, Sendable {
     }
 }
 
-/// Status of a provider connection. `active` (default) means the connection
-/// is offered in picker UIs. `disabled` hides it from pickers but keeps it
-/// visible in the settings sheet so the user can re-enable it.
-public enum ConnectionStatus: String, Codable, Sendable {
-    case active
-    case disabled
-}
-
 /// A model entry exposed by an openai-compatible provider connection.
 public struct ConnectionModel: Codable, Sendable {
     public let id: String
@@ -6086,7 +6078,6 @@ public struct ProviderConnection: Codable, Sendable {
     /// One of: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter`.
     public let provider: String
     public let auth: ProviderConnectionAuth
-    public let status: ConnectionStatus
     public let label: String?
     public let createdAt: Int
     public let updatedAt: Int
@@ -6101,11 +6092,10 @@ public struct ProviderConnection: Codable, Sendable {
     /// Model entries exposed by an openai-compatible provider connection.
     public let models: [ConnectionModel]?
 
-    public init(name: String, provider: String, auth: ProviderConnectionAuth, status: ConnectionStatus = .active, label: String? = nil, createdAt: Int, updatedAt: Int, isManaged: Bool = false, baseUrl: String? = nil, models: [ConnectionModel]? = nil) {
+    public init(name: String, provider: String, auth: ProviderConnectionAuth, label: String? = nil, createdAt: Int, updatedAt: Int, isManaged: Bool = false, baseUrl: String? = nil, models: [ConnectionModel]? = nil) {
         self.name = name
         self.provider = provider
         self.auth = auth
-        self.status = status
         self.label = label
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -6114,17 +6104,15 @@ public struct ProviderConnection: Codable, Sendable {
         self.models = models
     }
 
-    /// Decodes responses from daemons that predate the `status` or `isManaged`
-    /// fields. `status` defaults to `.active`; `isManaged` defaults to `false`.
-    /// Mixed-version setups (the app explicitly supports them via
-    /// version-mismatch handling) would otherwise throw `keyNotFound` and
-    /// silently strand the Providers UI.
+    /// Decodes responses from daemons that predate the `isManaged` field.
+    /// `isManaged` defaults to `false`. Mixed-version setups (the app
+    /// explicitly supports them via version-mismatch handling) would otherwise
+    /// throw `keyNotFound` and silently strand the Providers UI.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.provider = try container.decode(String.self, forKey: .provider)
         self.auth = try container.decode(ProviderConnectionAuth.self, forKey: .auth)
-        self.status = try container.decodeIfPresent(ConnectionStatus.self, forKey: .status) ?? .active
         self.label = try container.decodeIfPresent(String.self, forKey: .label)
         self.createdAt = try container.decode(Int.self, forKey: .createdAt)
         self.updatedAt = try container.decode(Int.self, forKey: .updatedAt)
@@ -6149,26 +6137,22 @@ public struct CreateProviderConnectionRequest: Codable, Sendable {
     public let provider: String
     public let auth: ProviderConnectionAuth
     public let label: String?
-    public let status: ConnectionStatus?
 
-    public init(name: String, provider: String, auth: ProviderConnectionAuth, label: String? = nil, status: ConnectionStatus? = nil) {
+    public init(name: String, provider: String, auth: ProviderConnectionAuth, label: String? = nil) {
         self.name = name
         self.provider = provider
         self.auth = auth
         self.label = label
-        self.status = status
     }
 }
 
 /// Request body for `PATCH /v1/inference/provider-connections/:name`.
 public struct UpdateProviderConnectionRequest: Codable, Sendable {
     public let auth: ProviderConnectionAuth
-    public let status: ConnectionStatus?
     public let label: String?
 
-    public init(auth: ProviderConnectionAuth, status: ConnectionStatus? = nil, label: String? = nil) {
+    public init(auth: ProviderConnectionAuth, label: String? = nil) {
         self.auth = auth
-        self.status = status
         self.label = label
     }
 }

--- a/clients/shared/Network/ProviderConnectionClient.swift
+++ b/clients/shared/Network/ProviderConnectionClient.swift
@@ -39,10 +39,10 @@ public struct ChatgptAuthStartResult: Sendable {
 public protocol ProviderConnectionClientProtocol {
     func listProviderConnections(provider: String?) async -> [ProviderConnection]?
     func getProviderConnection(name: String) async -> ProviderConnection?
-    /// `label` and `status` are optional extras; pass `nil` to omit from the request body.
-    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult
-    /// `status`: nil = omit from body (no change). `label`: nil outer = omit; `.some(nil)` = send null (clear); `.some("v")` = set.
-    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection?
+    /// `label` is optional; pass `nil` to omit from the request body.
+    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult
+    /// `label`: nil outer = omit; `.some(nil)` = send null (clear); `.some("v")` = set.
+    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection?
     func deleteProviderConnection(name: String) async -> ProviderConnectionDeleteResult
     /// Start a ChatGPT subscription OAuth flow. Returns the authorize URL and state token.
     func startChatgptSubscriptionAuth() async -> ChatgptAuthStartResult?
@@ -110,7 +110,6 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         provider: String,
         auth: ProviderConnectionAuth,
         label: String? = nil,
-        status: ConnectionStatus? = nil,
         baseUrl: String? = nil,
         models: [ConnectionModel]? = nil
     ) async -> ProviderConnectionCreateResult {
@@ -120,7 +119,6 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
             "auth": Self.authDict(for: auth),
         ]
         if let label { body["label"] = label }
-        if let status { body["status"] = status.rawValue }
         if let baseUrl { body["base_url"] = baseUrl }
         if let models { body["models"] = models.map { model -> [String: Any] in var d: [String: Any] = ["id": model.id]; if let dn = model.displayName { d["displayName"] = dn }; return d } }
         do {
@@ -166,14 +164,12 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
     public func updateProviderConnection(
         name: String,
         auth: ProviderConnectionAuth,
-        status: ConnectionStatus? = nil,
         label: String?? = nil,
         baseUrl: String?? = nil,
         models: [ConnectionModel]?? = nil
     ) async -> ProviderConnection? {
         let encoded = Self.encodePath(name)
         var body: [String: Any] = ["auth": Self.authDict(for: auth)]
-        if let status { body["status"] = status.rawValue }
         if let outerLabel = label {
             body["label"] = outerLabel ?? NSNull()
         }
@@ -289,24 +285,3 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
     }
 }
 
-// MARK: - ProviderConnection helpers
-
-extension ProviderConnection {
-    /// Return a copy of this connection with `status` replaced. Used by the
-    /// inline list-row toggle for optimistic + rollback updates without
-    /// needing the auto-generated struct's properties to be mutable.
-    public func withStatus(_ newStatus: ConnectionStatus) -> ProviderConnection {
-        ProviderConnection(
-            name: name,
-            provider: provider,
-            auth: auth,
-            status: newStatus,
-            label: label,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            isManaged: isManaged,
-            baseUrl: baseUrl,
-            models: models
-        )
-    }
-}


### PR DESCRIPTION
## Summary

- Remove the `ConnectionStatus` enum and all status-related fields from `ProviderConnection`, `CreateProviderConnectionRequest`, and `UpdateProviderConnectionRequest`
- Remove the inline status toggle from provider connection list rows, the status field from the connection editor, and the `setStatus`/`withStatus` helpers
- Remove `.status == .active` filters in `InferenceProfileEditor` so all connections for a provider are shown regardless of former status

The daemon no longer supports the `status` field on provider connections -- connections either exist or they don't. The macOS toggle was a no-op since the daemon ignores status in PATCH requests.

## Test plan

- [x] `swift build` passes with no errors
- [x] No remaining `ConnectionStatus` references (provider-connection-specific; `ConnectionStatusSnapshot` for daemon status is unrelated)
- [x] No remaining `.status == .active` filters on connections
- [ ] Open Providers sheet -- no toggle column, no status field in editor
- [ ] Profile editor shows all connections for a provider (no active/disabled filtering)


🤖 Generated with [Claude Code](https://claude.com/claude-code)