### PR TITLE
fix(daemon): add disk-pressure lock hysteresis to prevent flapping near 95%

### DIFF
--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -38,10 +38,10 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   },
 }));
 
-const { setOverridesForTesting } = await import(
-  "./feature-flag-test-helpers.js"
-);
+const { setOverridesForTesting } =
+  await import("./feature-flag-test-helpers.js");
 const {
+  DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
   DISK_PRESSURE_THRESHOLD_PERCENT,
   __getDiskPressureGuardTimerForTests,
@@ -154,6 +154,63 @@ describe("disk pressure guard", () => {
     expect(status.locked).toBe(false);
     expect(status.acknowledged).toBe(false);
     expect(status.overrideActive).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+    expect(status.lockId).toBeNull();
+    expect(status.blockedCapabilities).toEqual([]);
+  });
+
+  test("does not lock within the deadband until usage reaches the critical threshold", () => {
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("warning");
+    expect(status.locked).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+  });
+
+  test("stays locked while usage stays within the hysteresis deadband", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    const locked = evaluateDiskPressureNow();
+    expect(locked.locked).toBe(true);
+    const { lockId } = locked;
+
+    // Below critical (95) but above clear (90): must hold, not flap.
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("critical");
+    expect(status.locked).toBe(true);
+    expect(status.effectivelyLocked).toBe(true);
+    // Same lock id — the dip did not mint a fresh lock.
+    expect(status.lockId).toBe(lockId);
+  });
+
+  test("preserves acknowledgement across a dip within the deadband", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    evaluateDiskPressureNow();
+    acknowledgeDiskPressureLock();
+
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
+    const status = evaluateDiskPressureNow();
+
+    expect(status.locked).toBe(true);
+    expect(status.acknowledged).toBe(true);
+  });
+
+  test("clears the lock only once usage falls below the clear threshold", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    evaluateDiskPressureNow();
+
+    // Still within the deadband: locked.
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
+    expect(evaluateDiskPressureNow().locked).toBe(true);
+
+    // Below the clear threshold: released.
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT - 2);
+    const status = evaluateDiskPressureNow();
+
+    expect(status.locked).toBe(false);
     expect(status.effectivelyLocked).toBe(false);
     expect(status.lockId).toBeNull();
     expect(status.blockedCapabilities).toEqual([]);

--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -73,13 +73,13 @@ describe("disk-pressure-warning injector", () => {
       DEFAULT_INJECTOR_ORDER.diskPressureWarning,
     );
     expect(DISK_PRESSURE_WARNING_PROMPT).toBe(`<disk_pressure_warning>
-Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is at least 95% full.
+Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is critically full.
 
 In your first paragraph, warn the user that storage is critically low and that normal work is suspended until space is freed.
 
 Then help the user clean up storage. Prefer safe inspection steps first, such as checking available space and finding large directories. Ask before deleting files or caches unless the user has already clearly approved the specific cleanup action.
 
-Do not work on unrelated tasks until disk usage drops below the critical threshold or the user explicitly overrides the lock. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
+Do not work on unrelated tasks until enough space is freed to clear the lock or the user explicitly overrides it. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
 </disk_pressure_warning>`);
   });
 

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -8,6 +8,12 @@ import { getLogger } from "../util/logger.js";
 
 export const DISK_PRESSURE_WARNING_THRESHOLD_PERCENT = 80;
 export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
+// Hysteresis lower bound: once locked, the guard stays locked until usage
+// falls below this clear threshold. The deadband between this and the
+// critical threshold stops the lock from flapping when usage hovers near
+// 95% — otherwise clearing the lock immediately resumes background work,
+// which can refill the disk and re-trip the lock on the next sample.
+export const DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT = 90;
 export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
 export const DISK_PRESSURE_OVERRIDE_CONFIRMATION = "I understand the risks";
 export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
@@ -16,7 +22,12 @@ export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
   "remote-ingress",
 ] as const;
 
-export type DiskPressureState = "disabled" | "ok" | "warning" | "critical" | "unknown";
+export type DiskPressureState =
+  | "disabled"
+  | "ok"
+  | "warning"
+  | "critical"
+  | "unknown";
 
 export type DiskPressureBlockedCapability =
   (typeof DISK_PRESSURE_BLOCKED_CAPABILITIES)[number];
@@ -229,8 +240,14 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   const usagePercent = roundPercent(
     (usageInfo.usedMb / usageInfo.totalMb) * 100,
   );
-  const isCritical = usagePercent >= DISK_PRESSURE_THRESHOLD_PERCENT;
-  const isWarning = !isCritical && usagePercent >= DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
+  // Hysteresis: while locked, hold until usage drops below the lower clear
+  // threshold; otherwise lock at the critical threshold.
+  const criticalThreshold = state.status.locked
+    ? DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT
+    : DISK_PRESSURE_THRESHOLD_PERCENT;
+  const isCritical = usagePercent >= criticalThreshold;
+  const isWarning =
+    !isCritical && usagePercent >= DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical && !isWarning) {

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -107,13 +107,13 @@ function readInjectionInputs(ctx: TurnContext): TurnInjectionInputs {
 }
 
 export const DISK_PRESSURE_WARNING_PROMPT = `<disk_pressure_warning>
-Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is at least 95% full.
+Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is critically full.
 
 In your first paragraph, warn the user that storage is critically low and that normal work is suspended until space is freed.
 
 Then help the user clean up storage. Prefer safe inspection steps first, such as checking available space and finding large directories. Ask before deleting files or caches unless the user has already clearly approved the specific cleanup action.
 
-Do not work on unrelated tasks until disk usage drops below the critical threshold or the user explicitly overrides the lock. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
+Do not work on unrelated tasks until enough space is freed to clear the lock or the user explicitly overrides it. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
 </disk_pressure_warning>`;
 
 function isSafeStorageLimitsEnabled(): boolean {


### PR DESCRIPTION
## Summary
- Add a lower `DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT` (90%): once the disk-pressure guard locks at ≥95%, it stays locked until usage drops below 90%, rather than releasing the instant usage dips below 95%.
- Fixes lock flapping near the threshold. Without the deadband, clearing the lock immediately re-enables background work (heartbeat, scheduler, memory jobs, filing), which can refill the disk and re-trip the lock on the next 60s sample — each cycle mints a new lockId, resets the user's acknowledge/override, and re-cancels in-flight background cleanup tools. This specifically harms the guardian mid-cleanup.
- Adds tests covering the deadband: no early lock between 90–95%, lock holds on a dip within the band (same lockId), acknowledgement preserved across a dip, and release only once usage falls below the clear threshold.

## Original prompt
Resuming a pre-GA review of the `safe-storage-limits` feature flag (the 95% disk-pressure guard that blocks message sends and halts heartbeats/scheduled jobs). The audit surfaced that lock and unlock both pivot on the single 95% line, so usage hovering near the threshold flaps the lock. We chose Option A — add hysteresis via a separate lower clear threshold — to break the refill→re-lock feedback loop before turning the flag on in production.