### PR TITLE
fix(daemon): add warning-band disk-pressure hysteresis to stop in-chat banner flapping

### DIFF
--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -44,6 +44,8 @@ const {
   DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
   DISK_PRESSURE_THRESHOLD_PERCENT,
+  DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT,
+  DISK_PRESSURE_WARNING_THRESHOLD_PERCENT,
   __getDiskPressureGuardTimerForTests,
   __resetDiskPressureGuardForTests,
   acknowledgeDiskPressureLock,
@@ -316,5 +318,46 @@ describe("disk pressure guard", () => {
     expect(status.enabled).toBe(false);
     expect(status.locked).toBe(false);
     expect(__getDiskPressureGuardTimerForTests()).toBeNull();
+  });
+
+  test("does not enter warning until usage reaches the warning threshold", () => {
+    // Below 80% and never previously in a pressure state.
+    setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT - 2);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("ok");
+  });
+
+  test("holds the warning state across a dip within the warning clear deadband", () => {
+    setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT + 2);
+    expect(evaluateDiskPressureNow().state).toBe("warning");
+
+    // Below the 80% warning threshold but at/above the 77% clear threshold.
+    setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
+    expect(evaluateDiskPressureNow().state).toBe("warning");
+  });
+
+  test("clears the warning state once usage falls below the warning clear threshold", () => {
+    setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT + 2);
+    expect(evaluateDiskPressureNow().state).toBe("warning");
+
+    setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT - 1);
+    expect(evaluateDiskPressureNow().state).toBe("ok");
+  });
+
+  test("steps a critical lock down into a held warning state", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    expect(evaluateDiskPressureNow().state).toBe("critical");
+
+    // Below the 90% critical clear but above the 80% warning threshold.
+    setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT - 2);
+    const stepped = evaluateDiskPressureNow();
+    expect(stepped.state).toBe("warning");
+    expect(stepped.locked).toBe(false);
+
+    // Now within the warning clear deadband — warning must hold, not flap to ok.
+    setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
+    expect(evaluateDiskPressureNow().state).toBe("warning");
   });
 });

--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -360,4 +360,27 @@ describe("disk pressure guard", () => {
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
     expect(evaluateDiskPressureNow().state).toBe("warning");
   });
+
+  test("holds warning when a critical lock drops straight into the warning deadband", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    expect(evaluateDiskPressureNow().state).toBe("critical");
+
+    // A single large cleanup drops usage directly from critical to below the
+    // 80% warning threshold but still at/above the 77% clear threshold. The
+    // deadband must apply when stepping down out of critical too, so this holds
+    // as warning rather than flapping to ok (which would reopen the flap window).
+    setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
+    const stepped = evaluateDiskPressureNow();
+    expect(stepped.state).toBe("warning");
+    expect(stepped.locked).toBe(false);
+  });
+
+  test("clears straight to ok when a critical lock drops below the warning clear threshold", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
+    expect(evaluateDiskPressureNow().state).toBe("critical");
+
+    // A drop below even the warning-clear threshold is a genuine recovery.
+    setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT - 1);
+    expect(evaluateDiskPressureNow().state).toBe("ok");
+  });
 });

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -258,6 +258,16 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   // stepping down below its clear threshold lands here as a fresh warning
   // (state is still "critical" at this point, so the full 80% threshold
   // applies) and then holds with hysteresis on subsequent samples.
+  //
+  // Note on dismissal after a critical episode (intended behavior): the in-chat
+  // warning banner's dismissal is scoped to the live warning state, so a spike
+  // into critical clears it. When usage then steps back down into the warning
+  // band the banner re-shows and holds (down to the clear threshold) even
+  // though the user had dismissed an earlier warning. That is deliberate — the
+  // situation materially escalated (it reached the critical lock), so surfacing
+  // the warning again is correct, matching the client's existing
+  // escalation-resets-dismissal semantics. The hysteresis hold is what prevents
+  // the re-shown banner from flapping; the user can dismiss the current warning.
   const warningThreshold =
     state.status.state === "warning"
       ? DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -14,6 +14,13 @@ export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
 // 95% — otherwise clearing the lock immediately resumes background work,
 // which can refill the disk and re-trip the lock on the next sample.
 export const DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT = 90;
+// Warning-side hysteresis lower bound: once in the warning state, usage must
+// fall below this clear threshold before warning resolves. The deadband between
+// this and the warning threshold stops the in-chat disk-pressure banner from
+// flapping when usage hovers near 80% — without it, a brief dip below 80%
+// clears the warning state, which discards the banner's (state-scoped) dismissal
+// so it re-appears the moment usage ticks back up.
+export const DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT = 77;
 export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
 export const DISK_PRESSURE_OVERRIDE_CONFIRMATION = "I understand the risks";
 export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
@@ -246,8 +253,16 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
     ? DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT
     : DISK_PRESSURE_THRESHOLD_PERCENT;
   const isCritical = usagePercent >= criticalThreshold;
-  const isWarning =
-    !isCritical && usagePercent >= DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
+  // Mirror the critical deadband for the warning band: once warning, hold it
+  // until usage clears the lower warning-clear threshold. A critical lock
+  // stepping down below its clear threshold lands here as a fresh warning
+  // (state is still "critical" at this point, so the full 80% threshold
+  // applies) and then holds with hysteresis on subsequent samples.
+  const warningThreshold =
+    state.status.state === "warning"
+      ? DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT
+      : DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
+  const isWarning = !isCritical && usagePercent >= warningThreshold;
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical && !isWarning) {

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -253,25 +253,21 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
     ? DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT
     : DISK_PRESSURE_THRESHOLD_PERCENT;
   const isCritical = usagePercent >= criticalThreshold;
-  // Mirror the critical deadband for the warning band: once warning, hold it
-  // until usage clears the lower warning-clear threshold. A critical lock
-  // stepping down below its clear threshold lands here as a fresh warning
-  // (state is still "critical" at this point, so the full 80% threshold
-  // applies) and then holds with hysteresis on subsequent samples.
-  //
-  // Note on dismissal after a critical episode (intended behavior): the in-chat
-  // warning banner's dismissal is scoped to the live warning state, so a spike
-  // into critical clears it. When usage then steps back down into the warning
-  // band the banner re-shows and holds (down to the clear threshold) even
-  // though the user had dismissed an earlier warning. That is deliberate — the
-  // situation materially escalated (it reached the critical lock), so surfacing
-  // the warning again is correct, matching the client's existing
-  // escalation-resets-dismissal semantics. The hysteresis hold is what prevents
-  // the re-shown banner from flapping; the user can dismiss the current warning.
-  const warningThreshold =
-    state.status.state === "warning"
-      ? DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT
-      : DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
+  // Mirror the critical deadband for the warning band: once in an active
+  // pressure state (warning or critical), hold warning until usage clears the
+  // lower warning-clear threshold. Treating "critical" as active here matters
+  // for a direct step-down: when cleanup frees a lot of space in one sample,
+  // usage can drop straight from a critical lock to e.g. 78%, which is below
+  // the 80% warning trigger but above the 77% clear threshold. Using the full
+  // 80% threshold in that case would report "ok" and discard the warning/
+  // dismissal, reopening the flapping window on the next tick back up. The
+  // deadband must apply consistently whether we arrived in the warning band
+  // from below (rising past 80%) or from above (falling out of critical).
+  const inActivePressureState =
+    state.status.state === "warning" || state.status.state === "critical";
+  const warningThreshold = inActivePressureState
+    ? DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT
+    : DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
   const isWarning = !isCritical && usagePercent >= warningThreshold;
   const lastCheckedAt = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- Add `DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT = 77` and apply a warning-side deadband in `evaluateDiskPressureNow()`, mirroring the critical-lock deadband added in #32521. Once in the `warning` state, usage must fall below 77% before warning resolves (rather than clearing the instant a sample dips below the 80% trigger).
- Fixes the in-chat `DiskPressureBanner` re-appearing after a user dismisses it: the warning banner's dismissal is scoped to the live `warning` state, so a brief dip below 80% discarded the dismissal and the banner returned the moment usage ticked back up. The deadband keeps the state stable across normal disk churn near 80%.
- A critical lock stepping down below its 90% clear threshold now lands in a held warning state instead of flapping toward ok.

## Original prompt
While investigating why a dismissed storage-pressure message kept re-appearing in chat, we found the in-chat banner (assistant daemon, separate from the 90/80 email pipeline) recomputes warning/critical state from the live disk sample every 60s. #32521 added hysteresis to the critical (95%/90%) lock; this PR adds the matching warning-band (80%/77%) hysteresis, which is the boundary the reappearing banner actually flaps across.

## Test plan
- `bun test` disk-pressure-guard / lifecycle / routes / policy suites: all pass, 0 fail.
- New cases: no premature warning entry; warning held across a dip within the 77–80% deadband; warning cleared below 77%; critical lock stepping down into a held warning state.

## Notes / out of scope
- Acknowledgement/dismissal state remains in-memory (daemon) and client-localStorage respectively; durable persistence across daemon restarts is a separate, larger follow-up and intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)