### PR TITLE
feat(config): add weighted "mix" LLM profile mode for per-conversation A/B routing

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -812,6 +812,299 @@ describe("resolveCallSiteConfig", () => {
   });
 });
 
+describe("mix profiles", () => {
+  // A mix that routes 80% to `a` (model-a) and 20% to `b` (model-b).
+  const mixLlm = LLMSchema.parse({
+    default: fullDefault,
+    profiles: {
+      a: { model: "model-a", effort: "low" },
+      b: { model: "model-b", effort: "high" },
+      ab: {
+        mix: [
+          { profile: "a", weight: 80 },
+          { profile: "b", weight: 20 },
+        ],
+      },
+    },
+    activeProfile: "ab",
+  });
+
+  test("same seed resolves to the same arm (stable across calls)", () => {
+    const first = resolveCallSiteConfig("mainAgent", mixLlm, {
+      selectionSeed: "conv-1",
+    });
+    const second = resolveCallSiteConfig("mainAgent", mixLlm, {
+      selectionSeed: "conv-1",
+    });
+    expect(first.model).toBe(second.model);
+    expect(["model-a", "model-b"]).toContain(first.model);
+    // The chosen arm's other fields flow through; the other arm's don't.
+    if (first.model === "model-a") expect(first.effort).toBe("low");
+    else expect(first.effort).toBe("high");
+  });
+
+  test("all dereference spots in a turn agree for the same seed", () => {
+    // mainAgent (mix layered as activeProfile) and a non-main call site
+    // resolving the same mix as activeProfile must pick the same arm when
+    // given the same conversation seed — guards the invariant that every
+    // resolver call within a conversation lands on one arm.
+    const main = resolveCallSiteConfig("mainAgent", mixLlm, {
+      selectionSeed: "conv-xyz",
+    });
+    const other = resolveCallSiteConfig("memoryExtraction", mixLlm, {
+      selectionSeed: "conv-xyz",
+    });
+    expect(other.model).toBe(main.model);
+  });
+
+  test("different seeds split across both arms by weight", () => {
+    let aCount = 0;
+    let bCount = 0;
+    for (let i = 0; i < 400; i++) {
+      const resolved = resolveCallSiteConfig("mainAgent", mixLlm, {
+        selectionSeed: `conv-${i}`,
+      });
+      if (resolved.model === "model-a") aCount++;
+      else if (resolved.model === "model-b") bCount++;
+    }
+    // Both arms must be reachable, and the 80/20 weighting must skew toward
+    // `a`. Wide band so the assertion locks weighting without coupling to the
+    // exact hash output (deterministic, so never flaky).
+    expect(aCount).toBeGreaterThan(bCount);
+    expect(bCount).toBeGreaterThan(0);
+    expect(aCount).toBeGreaterThan(240); // ~80% of 400 = 320
+    expect(aCount).toBeLessThan(390);
+  });
+
+  test("relative weights are normalized by their sum ([80,20] ≡ [4,1])", () => {
+    const llm2 = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        a: { model: "model-a" },
+        b: { model: "model-b" },
+        ab: {
+          mix: [
+            { profile: "a", weight: 4 },
+            { profile: "b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "ab",
+    });
+    for (let i = 0; i < 200; i++) {
+      const seed = `conv-${i}`;
+      expect(
+        resolveCallSiteConfig("mainAgent", llm2, { selectionSeed: seed }).model,
+      ).toBe(
+        resolveCallSiteConfig("mainAgent", mixLlm, { selectionSeed: seed })
+          .model,
+      );
+    }
+  });
+
+  test("mix works as overrideProfile", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        a: { model: "model-a" },
+        b: { model: "model-b" },
+        ab: {
+          mix: [
+            { profile: "a", weight: 50 },
+            { profile: "b", weight: 50 },
+          ],
+        },
+      },
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "ab",
+      selectionSeed: "conv-1",
+    });
+    expect(["model-a", "model-b"]).toContain(resolved.model);
+  });
+
+  test("mix works as a call-site profile (non-mainAgent and mainAgent)", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        a: { model: "model-a" },
+        b: { model: "model-b" },
+        ab: {
+          mix: [
+            { profile: "a", weight: 50 },
+            { profile: "b", weight: 50 },
+          ],
+        },
+      },
+      callSites: {
+        memoryExtraction: { profile: "ab" },
+        mainAgent: { profile: "ab" },
+      },
+    });
+    expect(["model-a", "model-b"]).toContain(
+      resolveCallSiteConfig("memoryExtraction", llm, { selectionSeed: "c1" })
+        .model,
+    );
+    expect(["model-a", "model-b"]).toContain(
+      resolveCallSiteConfig("mainAgent", llm, { selectionSeed: "c1" }).model,
+    );
+  });
+
+  test("onMixSelected reports the mix name and the chosen arm matching the resolved model", () => {
+    const calls: Array<{ mixProfile: string; chosenProfile: string }> = [];
+    const resolved = resolveCallSiteConfig("mainAgent", mixLlm, {
+      selectionSeed: "conv-1",
+      onMixSelected: (info) => calls.push(info),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].mixProfile).toBe("ab");
+    expect(["a", "b"]).toContain(calls[0].chosenProfile);
+    expect(resolved.model).toBe(
+      calls[0].chosenProfile === "a" ? "model-a" : "model-b",
+    );
+  });
+
+  test("no seed falls back to random selection without throwing (both arms reachable)", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      seen.add(resolveCallSiteConfig("mainAgent", mixLlm).model);
+    }
+    expect(seen.has("model-a")).toBe(true);
+    expect(seen.has("model-b")).toBe(true);
+  });
+});
+
+describe("mix validation (LLMSchema.superRefine)", () => {
+  const base = {
+    default: fullDefault,
+    profiles: {
+      a: { model: "model-a" },
+      b: { model: "model-b" },
+    },
+  };
+
+  test("valid mix parses cleanly", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            mix: [
+              { profile: "a", weight: 80 },
+              { profile: "b", weight: 20 },
+            ],
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects a mix referencing an undefined profile", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            mix: [
+              { profile: "a", weight: 1 },
+              { profile: "ghost", weight: 1 },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/not defined in llm\.profiles/);
+  });
+
+  test("rejects a nested mix (arm references another mix)", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            mix: [
+              { profile: "a", weight: 1 },
+              { profile: "b", weight: 1 },
+            ],
+          },
+          outer: {
+            mix: [
+              { profile: "ab", weight: 1 },
+              { profile: "a", weight: 1 },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/cannot be nested/);
+  });
+
+  test("rejects a self-referencing mix", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            mix: [
+              { profile: "ab", weight: 1 },
+              { profile: "a", weight: 1 },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/cannot reference itself/);
+  });
+
+  test("rejects a mix that also sets a config field", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            model: "model-c",
+            mix: [
+              { profile: "a", weight: 1 },
+              { profile: "b", weight: 1 },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/cannot also set/);
+  });
+
+  test("rejects a mix with fewer than two arms", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: { mix: [{ profile: "a", weight: 1 }] },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a non-positive arm weight", () => {
+    expect(() =>
+      LLMSchema.parse({
+        ...base,
+        profiles: {
+          ...base.profiles,
+          ab: {
+            mix: [
+              { profile: "a", weight: 0 },
+              { profile: "b", weight: 1 },
+            ],
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("resolveDefaultProfileKey", () => {
   test("mainAgent returns activeProfile when set and enabled", () => {
     const llm = LLMSchema.parse({
@@ -893,6 +1186,44 @@ describe("resolveDefaultProfileKey", () => {
     expect(resolveDefaultProfileKey("filingAgent", llm)).toBe(
       "custom-cost-optimized",
     );
+  });
+
+  test("mainAgent returns the mix key (not an arm) when activeProfile is a mix", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        a: { model: "model-a" },
+        b: { model: "model-b" },
+        ab: {
+          mix: [
+            { profile: "a", weight: 1 },
+            { profile: "b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "ab",
+    });
+    expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("ab");
+  });
+
+  test("mainAgent falls back to catalog default when the mix activeProfile is disabled", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        balanced: { provider: "anthropic", model: "claude-sonnet-4-7" },
+        a: { model: "model-a" },
+        b: { model: "model-b" },
+        ab: {
+          status: "disabled",
+          mix: [
+            { profile: "a", weight: 1 },
+            { profile: "b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "ab",
+    });
+    expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("balanced");
   });
 });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -618,6 +618,16 @@ export class AgentLoop {
         if (callSite) {
           providerConfig.callSite = callSite;
           providerConfig.usageTracking = "manual";
+          // Per-conversation seed for deterministic `mix`-profile expansion.
+          // Sourced from the orchestrator-supplied turn context's
+          // conversationId so every LLM call in a conversation resolves the
+          // same mix arm (stable across turns and retries, and across daemon
+          // restarts since the seed is the durable conversation id). Absent
+          // for standalone `AgentLoop` instances (unit tests / no turnContext)
+          // — those fall back to per-call random mix selection.
+          if (turnContext?.conversationId) {
+            providerConfig.selectionSeed = turnContext.conversationId;
+          }
         }
 
         // Per-call inference-profile override. The resolver layers

--- a/assistant/src/config/llm-context-resolution.ts
+++ b/assistant/src/config/llm-context-resolution.ts
@@ -27,12 +27,21 @@ export function resolveEffectiveContextWindow({
   llm,
   callSite,
   overrideProfile,
+  selectionSeed,
 }: {
   llm: LLMConfig;
   callSite: LLMCallSite;
   overrideProfile?: string;
+  /**
+   * Per-conversation mix seed (the conversation id). Threaded so context-window
+   * sizing for a mix profile reflects the same arm the dispatch path picks.
+   */
+  selectionSeed?: string;
 }): EffectiveContextWindow {
-  const resolved = resolveCallSiteConfig(callSite, llm, { overrideProfile });
+  const resolved = resolveCallSiteConfig(callSite, llm, {
+    overrideProfile,
+    selectionSeed,
+  });
   const catalogModel = PROVIDER_CATALOG.find(
     (provider) => provider.id === resolved.provider,
   )?.models.find((model) => model.id === resolved.model);

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -42,33 +42,60 @@ import {
  * resolver stays pure; schema validation in `LLMSchema.superRefine` catches
  * unknown `activeProfile` references at config-load time.
  *
- * Pure & synchronous: no I/O, no async work.
+ * A profile reference that points at a "mix" profile is expanded to one of its
+ * constituent profiles by a seeded weighted pick (see `resolveProfileFragment`
+ * and `opts.selectionSeed`). Expansion happens uniformly at every dereference
+ * spot, so a mix works as `activeProfile`, `overrideProfile`, or a call-site
+ * `profile`.
+ *
+ * Pure & synchronous: no I/O, no async work. (Random selection only occurs for
+ * mix profiles when no `selectionSeed` is supplied; with a seed the pick is
+ * deterministic.)
  */
+export interface ResolveCallSiteOpts {
+  overrideProfile?: string;
+  /**
+   * Per-conversation seed for expanding `mix` profiles. The chosen constituent
+   * is a deterministic function of `selectionSeed` + the mix profile's own
+   * name, so every `resolveCallSiteConfig` call for the same conversation picks
+   * the SAME arm (stable across turns, retries, and restarts). Pass the
+   * conversation id. When absent, the resolver falls back to a fresh random
+   * pick per call — acceptable only for one-shot/background call sites that
+   * resolve config exactly once per invocation.
+   */
+  selectionSeed?: string;
+  /**
+   * Invoked once for each mix profile the resolver expands, reporting which
+   * constituent was chosen. Used by A/B-eval recording (usage attribution).
+   */
+  onMixSelected?: (info: { mixProfile: string; chosenProfile: string }) => void;
+}
+
 export function resolveCallSiteConfig(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
-  opts: { overrideProfile?: string } = {},
+  opts: ResolveCallSiteOpts = {},
 ): z.infer<typeof LLMConfigBase> {
   const layers: Mergeable[] = [llm.default as Mergeable];
 
-  const activeFragment =
-    llm.activeProfile != null ? llm.profiles?.[llm.activeProfile] : undefined;
-  const overrideFragment =
-    opts.overrideProfile != null
-      ? llm.profiles?.[opts.overrideProfile]
-      : undefined;
+  const activeFragment = resolveProfileFragment(llm.activeProfile, llm, opts);
+  const overrideFragment = resolveProfileFragment(
+    opts.overrideProfile,
+    llm,
+    opts,
+  );
   const site =
     llm.callSites?.[callSite] ??
     effectiveDefault(callSite, llm, opts.overrideProfile != null);
 
   if (callSite === "mainAgent") {
-    appendCallSiteLayers(layers, callSite, llm, site);
+    appendCallSiteLayers(layers, callSite, llm, site, opts);
     appendProfileLayer(layers, activeFragment);
     appendProfileLayer(layers, overrideFragment);
   } else {
     appendProfileLayer(layers, activeFragment);
     appendProfileLayer(layers, overrideFragment);
-    appendCallSiteLayers(layers, callSite, llm, site);
+    appendCallSiteLayers(layers, callSite, llm, site, opts);
   }
 
   return finalize(deepMerge(...layers.map(withImpliedProviderForKnownModel)));
@@ -79,6 +106,81 @@ export function resolveCallSiteConfig(
 // ---------------------------------------------------------------------------
 
 type Mergeable = Record<string, unknown>;
+
+/**
+ * FNV-1a 32-bit string hash → unit float in [0, 1). Deterministic and stable
+ * across runtimes — the mix-pick contract depends on identical output for
+ * identical input forever, so the constants must never change. (Mirrors the
+ * private hash in `memory/v2/page-index.ts`; intentionally re-declared here so
+ * the resolver's determinism contract is self-contained and cannot be broken
+ * by an unrelated edit to that module.)
+ */
+function seededUnitFloat(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  // `>>> 0` → unsigned 32-bit; divide by 2^32 to land in [0, 1).
+  return (h >>> 0) / 0x100000000;
+}
+
+/**
+ * Pick one entry from a weighted list given a unit float in [0, 1). Weights
+ * are relative and normalized by their sum. Assumes `entries` is non-empty
+ * with positive weights (guaranteed by `MixSchema`: `.min(2)` + positive).
+ */
+function weightedPick<T extends { weight: number }>(
+  entries: readonly T[],
+  unit: number,
+): T {
+  const total = entries.reduce((sum, e) => sum + e.weight, 0);
+  // Defensive: a degenerate total (unreachable post-schema) → first arm.
+  if (!(total > 0)) return entries[0];
+  let threshold = unit * total;
+  for (const entry of entries) {
+    threshold -= entry.weight;
+    if (threshold < 0) return entry;
+  }
+  // Floating-point fall-through (unit ≈ 1): return the last arm.
+  return entries[entries.length - 1];
+}
+
+/**
+ * Dereference a profile name to its concrete `ProfileEntry`, expanding a mix
+ * profile by a seeded weighted pick. Returns `undefined` when the name is
+ * unknown (parity with the silent fall-through callers already rely on).
+ *
+ * Mix expansion is one level only — `LLMSchema.superRefine` guarantees arms
+ * are standard (non-mix) profiles, so this never recurses unboundedly. A
+ * chosen arm pointing at a missing profile (only reachable in hand-crafted,
+ * unparsed configs) falls through to `undefined`.
+ *
+ * Pure & synchronous (the only impurity is `Math.random()` in the no-seed
+ * fallback path).
+ */
+function resolveProfileFragment(
+  name: string | undefined,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts,
+): ProfileEntry | undefined {
+  if (name == null) return undefined;
+  const entry = llm.profiles?.[name];
+  if (entry?.mix == null) return entry;
+
+  // Mix: pick one constituent. Seed by per-conversation seed + the mix's own
+  // name so two different mixes in the same conversation pick independently,
+  // but the same mix always resolves to the same arm within the conversation.
+  const unit =
+    opts.selectionSeed != null
+      ? seededUnitFloat(`${opts.selectionSeed}\u0000${name}`)
+      : Math.random();
+  const chosen = weightedPick(entry.mix, unit);
+  opts.onMixSelected?.({ mixProfile: name, chosenProfile: chosen.profile });
+
+  // The chosen arm must be a standard profile (enforced by superRefine).
+  return llm.profiles?.[chosen.profile];
+}
 
 /**
  * Returns the effective default profile key the resolver would actually
@@ -170,16 +272,16 @@ function appendCallSiteLayers(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
   site: z.infer<typeof LLMSchema>["callSites"][LLMCallSite] | undefined,
+  opts: ResolveCallSiteOpts,
 ): void {
   if (site != null) {
     if (site.profile != null) {
-      const profileFragment: ProfileEntry | undefined =
-        llm.profiles?.[site.profile];
+      const profileFragment = resolveProfileFragment(site.profile, llm, opts);
       if (profileFragment == null) {
         // Defensive: `LLMSchema.superRefine` already rejects unknown profile
-        // references at config load, so this branch is unreachable for any
-        // config that survived schema validation. Throw a clear error in case
-        // a hand-crafted (un-parsed) config slips through.
+        // references (and unknown mix arms) at config load, so this branch is
+        // unreachable for any config that survived schema validation. Throw a
+        // clear error in case a hand-crafted (un-parsed) config slips through.
         throw new Error(
           `LLM call site "${callSite}" references undefined profile "${site.profile}"`,
         );
@@ -198,6 +300,10 @@ function profileConfigFragment(profile: ProfileEntry): Mergeable {
     source: _source,
     label: _label,
     description: _description,
+    // `mix` never reaches here in practice (a mix expands to a standard
+    // profile before this point), but strip it defensively so it can never
+    // leak into the merged `LLMConfigBase`.
+    mix: _mix,
     ...config
   } = profile;
   return config as Mergeable;

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -344,6 +344,27 @@ type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
 export const ProfileStatusSchema = z.enum(["active", "disabled"]);
 export type ProfileStatus = z.infer<typeof ProfileStatusSchema>;
 
+// ---------------------------------------------------------------------------
+// Mix profiles
+//
+// A "mix" profile carries no model config of its own. Instead it references a
+// weighted list of other (standard) profiles; at resolve time exactly one
+// constituent is chosen by weight. The pick is a deterministic function of a
+// per-conversation seed (the conversation id — see `resolveCallSiteConfig`'s
+// `selectionSeed`), so a conversation always lands on the same arm across all
+// its turns, retries, and even daemon restarts, while different conversations
+// split according to the weights — and the chosen arm is recordable for A/B
+// evaluation. Weights are relative (normalized by their sum at pick time), so
+// `[{weight:80},{weight:20}]` and `[{weight:4},{weight:1}]` are equivalent.
+// ---------------------------------------------------------------------------
+const MixArmSchema = z.object({
+  profile: z.string().min(1),
+  weight: z.number().finite().positive(),
+});
+export type MixArm = z.infer<typeof MixArmSchema>;
+
+const MixSchema = z.array(MixArmSchema).min(2);
+
 /**
  * A named profile entry: an `LLMConfigFragment` augmented with
  * presentation/ownership metadata. These fields are intentionally kept off
@@ -379,6 +400,17 @@ export const ProfileEntry = LLMConfigFragment.extend({
    * #30362 even though the schema didn't accept it until now.
    */
   status: ProfileStatusSchema.nullable().optional(),
+  /**
+   * When present, this profile is a "mix": it carries no model config and
+   * instead references a weighted list of standard profiles. The resolver
+   * expands a mix by a seeded weighted pick (see `resolveCallSiteConfig`).
+   * `LLMSchema.superRefine` enforces that (a) every referenced profile exists,
+   * (b) no referenced profile is itself a mix (no nesting), (c) no arm
+   * references the mix itself, and (d) a mix carries no `LLMConfigFragment`
+   * config field — only metadata (`label`, `description`, `status`, `source`)
+   * may accompany `mix`.
+   */
+  mix: MixSchema.optional(),
 });
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
@@ -443,6 +475,63 @@ export const LLMSchema = z
         path: ["activeProfile"],
         message: `Profile "${config.activeProfile}" referenced by llm.activeProfile is not defined in llm.profiles`,
       });
+    }
+
+    // --- Mix profile validation --------------------------------------------
+    // Config keys a mix profile must NOT also set (a mix only references other
+    // profiles + metadata). Derived from the fragment shape plus the
+    // ProfileEntry-only `provider_connection` so it can't drift if a new config
+    // field is added to `LLMConfigFragment`.
+    const MIX_DISALLOWED_CONFIG_KEYS = [
+      ...Object.keys(LLMConfigFragment.shape),
+      "provider_connection",
+    ];
+    const mixProfileNames = new Set(
+      Object.entries(config.profiles ?? {})
+        .filter(([, profile]) => profile?.mix != null)
+        .map(([name]) => name),
+    );
+    for (const [name, profile] of Object.entries(config.profiles ?? {})) {
+      if (profile?.mix == null) continue;
+      // (d) A mix must not also carry model config — the resolved config comes
+      // entirely from the chosen constituent.
+      for (const key of MIX_DISALLOWED_CONFIG_KEYS) {
+        if ((profile as Record<string, unknown>)[key] !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["profiles", name, key],
+            message: `Mix profile "${name}" cannot also set "${key}" — a mix only references other profiles plus metadata (label, description, status).`,
+          });
+        }
+      }
+      for (const [index, arm] of profile.mix.entries()) {
+        // (c) No self-reference.
+        if (arm.profile === name) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["profiles", name, "mix", index, "profile"],
+            message: `Mix profile "${name}" cannot reference itself.`,
+          });
+          continue;
+        }
+        // (a) Referenced profile must exist.
+        if (!profileNames.has(arm.profile)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["profiles", name, "mix", index, "profile"],
+            message: `Mix profile "${name}" references profile "${arm.profile}" which is not defined in llm.profiles.`,
+          });
+          continue;
+        }
+        // (b) No nesting — a mix arm must be a standard (non-mix) profile.
+        if (mixProfileNames.has(arm.profile)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["profiles", name, "mix", index, "profile"],
+            message: `Mix profile "${name}" references another mix profile "${arm.profile}" — mixes cannot be nested; constituents must be standard profiles.`,
+          });
+        }
+      }
     }
   });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -770,12 +770,14 @@ export async function runAgentLoopImpl(
     llm: config.llm,
     callSite: turnCallSite,
     overrideProfile: turnOverrideProfile ?? undefined,
+    selectionSeed: ctx.conversationId,
   });
   let currentEffectiveContextWindow: EffectiveContextWindow =
     effectiveContextWindow;
   let currentContextWindowConfig = contextWindowConfigFromEffective(
     resolveCallSiteConfig(turnCallSite, config.llm, {
       overrideProfile: turnOverrideProfile ?? undefined,
+      selectionSeed: ctx.conversationId,
     }).contextWindow,
     currentEffectiveContextWindow,
   );
@@ -794,10 +796,12 @@ export async function runAgentLoopImpl(
         llm: config.llm,
         callSite: turnCallSite,
         overrideProfile: currentOverrideProfile,
+        selectionSeed: ctx.conversationId,
       });
       currentContextWindowConfig = contextWindowConfigFromEffective(
         resolveCallSiteConfig(turnCallSite, config.llm, {
           overrideProfile: currentOverrideProfile,
+          selectionSeed: ctx.conversationId,
         }).contextWindow,
         currentEffectiveContextWindow,
       );

--- a/assistant/src/daemon/switch-inference-profile-tool.ts
+++ b/assistant/src/daemon/switch-inference-profile-tool.ts
@@ -17,7 +17,13 @@ export function buildSwitchInferenceProfileToolDef(
   currentProfile?: string,
 ): ToolDefinition | null {
   const entries = Object.entries(profiles).filter(
-    ([key, entry]) => entry.status !== "disabled" && key !== AUTO_PROFILE_KEY,
+    ([key, entry]) =>
+      entry.status !== "disabled" &&
+      key !== AUTO_PROFILE_KEY &&
+      // Mix profiles are A/B-routing buckets, not concrete targets the model
+      // should self-select into — exclude them so the picker only offers real
+      // profiles.
+      entry.mix == null,
   );
   if (entries.length < 2) return null;
 

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -149,8 +149,14 @@ export class CallSiteRoutingProvider implements Provider {
     if (!callSite) return this.defaultProvider;
 
     const overrideProfile = options?.config?.overrideProfile;
+    // Forward the per-conversation mix seed so transport selection picks the
+    // same mix arm as wire-param normalization in `retry.ts` — otherwise a mix
+    // spanning providers could route the transport to a different arm than the
+    // request params.
+    const selectionSeed = options?.config?.selectionSeed;
     const resolved = resolveCallSiteConfig(callSite, getConfig().llm, {
       overrideProfile,
+      selectionSeed,
     });
 
     let connectionName = resolved.provider_connection;
@@ -159,7 +165,9 @@ export class CallSiteRoutingProvider implements Provider {
     // auto-resolve a connection for the provider (handles the case where the
     // profile set provider but not provider_connection, and the merge didn't
     // inherit one).
-    let autoResolveCandidates: import("./inference/auth.js").ProviderConnection[] | undefined;
+    let autoResolveCandidates:
+      | import("./inference/auth.js").ProviderConnection[]
+      | undefined;
     if (!connectionName && resolved.provider !== this.defaultProvider.name) {
       try {
         autoResolveCandidates = listConnections(getDb(), {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -34,6 +34,7 @@ const USAGE_ATTRIBUTION_HEADER_NAMES = {
   inferenceProfileSource: "X-Vellum-Inference-Profile-Source",
   resolvedProvider: "X-Vellum-Resolved-Provider",
   resolvedModel: "X-Vellum-Resolved-Model",
+  resolvedMixArm: "X-Vellum-Resolved-Mix-Arm",
 } as const;
 
 /** Providers that support the `effort` config (extended thinking / reasoning). */
@@ -195,19 +196,23 @@ function normalizeSendMessageOptions(
   delete nextConfig.usageAttributionHeaders;
   delete nextConfig.usageTracking;
 
-  // `overrideProfile` is a routing/resolution-time concern (consumed by the
-  // resolver below and `CallSiteRoutingProvider`'s provider selection); it is
-  // not a wire-format field. Strip unconditionally so it never leaks into
-  // provider request bodies even when callers set it without a `callSite`.
+  // `overrideProfile` and `selectionSeed` are routing/resolution-time concerns
+  // (consumed by the resolver below and `CallSiteRoutingProvider`'s provider
+  // selection); neither is a wire-format field. Strip unconditionally so they
+  // never leak into provider request bodies even when callers set them without
+  // a `callSite`.
   delete nextConfig.overrideProfile;
+  delete nextConfig.selectionSeed;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
       overrideProfile: config.overrideProfile,
+      selectionSeed: config.selectionSeed,
     });
     const attribution = resolveUsageAttribution({
       callSite: config.callSite,
       overrideProfile: config.overrideProfile,
+      selectionSeed: config.selectionSeed,
     });
 
     const explicitModel =
@@ -225,6 +230,7 @@ function normalizeSendMessageOptions(
         profileSource: attribution.profileSource,
         resolvedProvider: attribution.resolvedProvider,
         resolvedModel: attribution.resolvedModel,
+        resolvedMixArm: attribution.resolvedMixArm,
       });
       if (Object.keys(usageAttributionHeaders).length > 0) {
         nextConfig.usageAttributionHeaders = usageAttributionHeaders;
@@ -446,6 +452,7 @@ function buildUsageAttributionHeaders(input: {
   profileSource: string;
   resolvedProvider: string;
   resolvedModel: string;
+  resolvedMixArm: string | null;
 }): Record<string, string> {
   const headers: Record<string, string> = {};
   addSanitizedHeader(
@@ -474,6 +481,11 @@ function buildUsageAttributionHeaders(input: {
     headers,
     USAGE_ATTRIBUTION_HEADER_NAMES.resolvedModel,
     input.resolvedModel,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.resolvedMixArm,
+    input.resolvedMixArm,
   );
   return headers;
 }

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -183,6 +183,15 @@ export interface SendMessageConfig {
    */
   overrideProfile?: string;
   /**
+   * Per-conversation seed for deterministic `mix`-profile expansion. The agent
+   * loop sets this to the conversation id so every resolver call this send
+   * triggers — provider/transport selection, wire-param normalization, usage
+   * attribution — picks the same mix constituent, stable across the
+   * conversation's turns and retries. A resolution/routing-time concern only;
+   * stripped before any provider wire request.
+   */
+  selectionSeed?: string;
+  /**
    * Internal per-request HTTP headers for managed-proxy usage attribution.
    * Provider clients may pass these through SDK request options only when the
    * transport is Vellum-managed, and must never include this object in provider

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -258,7 +258,10 @@ function normalizeLlmContextLog(log: LogRow): LlmContextRouteResult & {
     responsePayload,
     createdAt: log.createdAt,
   });
-  const result = applyStoredProviderToLlmContextResult(normalized, log.provider);
+  const result = applyStoredProviderToLlmContextResult(
+    normalized,
+    log.provider,
+  );
   return {
     id: log.id,
     requestPayload: null,
@@ -707,6 +710,49 @@ async function handleReplaceInferenceProfile({
       );
     }
   }
+  // Mix profiles reference other profiles by name. `ProfileEntry.safeParse`
+  // above validates the fragment in isolation, so the cross-profile integrity
+  // rules `LLMSchema.superRefine` enforces on full-config load (every arm
+  // exists, no nesting, no self-reference, no config fields) must be checked
+  // here against the live profile set — otherwise an invalid mix would persist
+  // and break the next full config reparse.
+  if (parsed.data.mix != null) {
+    const MIX_ALLOWED_KEYS = new Set([
+      "mix",
+      "label",
+      "description",
+      "status",
+      "source",
+    ]);
+    const extraneous = Object.keys(parsed.data).filter(
+      (k) => !MIX_ALLOWED_KEYS.has(k),
+    );
+    if (extraneous.length > 0) {
+      throw new BadRequestError(
+        `Mix profile "${name}" cannot also set [${extraneous.join(", ")}] — a mix only references other profiles plus metadata (label, description, status).`,
+      );
+    }
+    const existingProfiles = getConfig().llm.profiles ?? {};
+    parsed.data.mix.forEach((arm, index) => {
+      if (arm.profile === name) {
+        throw new BadRequestError(
+          `Mix profile "${name}" cannot reference itself (arm ${index}).`,
+        );
+      }
+      const target = existingProfiles[arm.profile];
+      if (target == null) {
+        throw new BadRequestError(
+          `Mix profile "${name}" references profile "${arm.profile}" which is not defined.`,
+        );
+      }
+      if (target.mix != null) {
+        throw new BadRequestError(
+          `Mix profile "${name}" references another mix profile "${arm.profile}" — mixes cannot be nested; constituents must be standard profiles.`,
+        );
+      }
+    });
+  }
+
   // When the UI sends provider but no provider_connection, derive the connection
   // now so the config deep-merge doesn't inherit a stale connection from the
   // default layer.
@@ -1008,9 +1054,7 @@ function handleSteerToMessage({
       ? (body as Record<string, unknown>).conversationId
       : undefined);
   if (!conversationId || typeof conversationId !== "string") {
-    throw new BadRequestError(
-      "Missing required parameter: conversationId",
-    );
+    throw new BadRequestError("Missing required parameter: conversationId");
   }
   const result = steerToMessage(conversationId, pathParams.id ?? "");
   if (result.steered) {

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -15,6 +15,14 @@ export type UsageAttributionProfileSource =
 export interface UsageAttributionInput {
   callSite: LLMCallSite | null;
   overrideProfile?: string | null;
+  /**
+   * Per-conversation seed for `mix`-profile expansion (the conversation id).
+   * When the applied profile is a mix, threading the same seed the dispatch
+   * path uses ensures `resolvedModel`/`resolvedMixArm` reflect the arm the
+   * request actually ran on. Omitted by one-shot callers (the snapshot's
+   * `resolvedMixArm` is then null even if a mix was involved).
+   */
+  selectionSeed?: string;
 }
 
 export interface UsageAttributionSnapshot {
@@ -26,6 +34,12 @@ export interface UsageAttributionSnapshot {
   profileSource: UsageAttributionProfileSource;
   resolvedProvider: string;
   resolvedModel: string;
+  /**
+   * When `appliedProfile` is a mix profile, the constituent arm chosen for
+   * this request; null otherwise. Lets A/B analysis attribute usage to the
+   * specific arm (mix name lives in `appliedProfile`).
+   */
+  resolvedMixArm: string | null;
 }
 
 /**
@@ -51,7 +65,11 @@ export function resolveUsageAttribution(
   const overrideProfile = normalizeProfileId(input.overrideProfile);
 
   if (callSite == null) {
-    const resolvedMainAgent = resolveCallSiteConfig("mainAgent", llm);
+    const resolvedMainAgent = resolveCallSiteConfig("mainAgent", llm, {
+      ...(input.selectionSeed != null
+        ? { selectionSeed: input.selectionSeed }
+        : {}),
+    });
     return {
       callSite: null,
       activeProfile: normalizeProfileId(llm.activeProfile),
@@ -61,11 +79,20 @@ export function resolveUsageAttribution(
       profileSource: "unknown",
       resolvedProvider: resolvedMainAgent.provider,
       resolvedModel: resolvedMainAgent.model,
+      resolvedMixArm: null,
     };
   }
 
+  // Capture which arm each expanded mix resolved to so we can attribute usage
+  // to the arm behind the applied (mix) profile below.
+  const mixSelections = new Map<string, string>();
   const resolved = resolveCallSiteConfig(callSite, llm, {
     ...(overrideProfile != null ? { overrideProfile } : {}),
+    ...(input.selectionSeed != null
+      ? { selectionSeed: input.selectionSeed }
+      : {}),
+    onMixSelected: ({ mixProfile, chosenProfile }) =>
+      mixSelections.set(mixProfile, chosenProfile),
   });
   const activeProfile = normalizeProfileId(llm.activeProfile);
   const callSiteProfile = normalizeProfileId(
@@ -88,6 +115,10 @@ export function resolveUsageAttribution(
     profileSource: profile.profileSource,
     resolvedProvider: resolved.provider,
     resolvedModel: resolved.model,
+    resolvedMixArm:
+      profile.appliedProfile != null
+        ? (mixSelections.get(profile.appliedProfile) ?? null)
+        : null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds a **"mix" profile kind**: `llm.profiles.<name>.mix` references a weighted list of other profiles (e.g. 80% A / 20% B). The resolver expands a mix to one constituent per request via a deterministic, **conversation-seeded** weighted pick (`hash(conversationId + mixName)`), so a conversation stays on one arm across all its turns, retries, and daemon restarts while different conversations split by the weights — preserving prompt caching.
- **Records the chosen arm for A/B analysis**: `resolvedMixArm` on the usage-attribution snapshot plus a new `X-Vellum-Resolved-Mix-Arm` attribution header.
- **Validates mix integrity** (every arm exists, no nesting, no self-reference, no config fields) in both `LLMSchema.superRefine` and the profile `PUT` route, and excludes mixes from the model self-switch tool. A mix works anywhere a profile does (active / per-conversation override / call-site).

## Original prompt
Add a new model-profile mode that randomly selects between several other profiles according to a per-profile mix ratio (e.g. 80% profile A, 20% profile B). We decided the selection should be sticky **per conversation** — so the model stays consistent within a chat and prompt caching survives — and that the primary use case is **A/B testing / evaluation**, so the chosen arm is recorded per request for later analysis.

## Implementation notes
- Plumbing reuses the existing `overrideProfile` path: `selectionSeed` (= conversation id) threads through `SendMessageConfig` → `resolveCallSiteConfig`, and is stripped before any provider wire request. The same seed reaches transport selection (`call-site-routing`) and wire-param normalization (`retry`) so a cross-provider mix can't route the transport and params to different arms.
- The pick is a pure function of the seed, so it requires **no persisted state** and is stable across restarts. With no seed (background/global call sites) it falls back to per-call random — acceptable for same-provider A/B mixes.
- Mixes carry only metadata + the `mix` list (no model config); the resolved config comes entirely from the chosen arm. Nesting is disallowed in v1.

## Verification
- `bun test src/__tests__/llm-resolver.test.ts` — 55 pass (new `mix profiles` + `mix validation` suites: determinism, stability, weighting distribution, normalization, placement, `onMixSelected`, random fallback, and all validation rejections).
- `bun test src/__tests__/usage-attribution.test.ts` — 8 pass (new `resolvedMixArm` field is compatible).
- `bunx tsc --noEmit` — no errors in any changed file (remaining errors are pre-existing unbuilt-workspace-package resolution, unrelated to this change).

## Where to focus review
- `assistant/src/config/llm-resolver.ts` — `resolveProfileFragment` / `seededUnitFloat` / `weightedPick` and the determinism contract (the FNV-1a constants must never change).
- `assistant/src/agent/loop.ts` — `selectionSeed` is sourced from `turnContext.conversationId`; standalone `AgentLoop` instances (no turn context) fall back to random.

🤖 Generated with [Claude Code](https://claude.com/claude-code)