### PR TITLE
Real-Time Voice (Live Voice Channel) — Web SPA Revival (JARVIS-982)

### DIFF
--- a/apps/web/public/worklets/pcm16k-capture-processor.js
+++ b/apps/web/public/worklets/pcm16k-capture-processor.js
@@ -1,0 +1,157 @@
+/**
+ * AudioWorklet processor that captures microphone audio at the input
+ * AudioContext sample rate (typically 48 kHz), downmixes to mono,
+ * decimates to 16 kHz, batches into ~20 ms PCM16 LE chunks (320 samples),
+ * and posts each chunk to the main thread.
+ *
+ * This is the web port of the macOS `LiveVoicePCM16kMonoConverter`
+ * (see clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift).
+ *
+ * Loaded at runtime by `LiveVoicePcmCapture` via
+ * `audioContext.audioWorklet.addModule("/worklets/pcm16k-capture-processor.js")`.
+ *
+ * Plain JS (no TypeScript compile) because it runs in the audio-rendering
+ * worklet global scope, which has its own module loader.
+ */
+
+/* global AudioWorkletProcessor, registerProcessor, sampleRate */
+
+const TARGET_SAMPLE_RATE = 16000;
+/** 20 ms at 16 kHz = 320 samples. */
+const CHUNK_SAMPLES = 320;
+/** Post amplitude updates at ~20 Hz (every 50 ms of input audio). */
+const AMPLITUDE_INTERVAL_SECONDS = 0.05;
+
+class Pcm16kCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Decimation ratio from the AudioContext sample rate (set by the host,
+    // usually 48000) down to 16 kHz. Fractional positions are accumulated
+    // across `process()` calls so we don't drift.
+    this.decimationRatio = sampleRate / TARGET_SAMPLE_RATE;
+    this.nextSourcePosition = 0;
+
+    // Ring/append buffer of decimated mono samples. We flush 320-sample
+    // chunks as PCM16 LE.
+    this.pendingSamples = new Float32Array(CHUNK_SAMPLES * 4);
+    this.pendingCount = 0;
+
+    // Amplitude meter: peak absolute value over a ~50 ms window.
+    this.amplitudePeak = 0;
+    this.amplitudeFramesAccumulated = 0;
+    this.amplitudeWindowFrames = Math.max(
+      1,
+      Math.round(sampleRate * AMPLITUDE_INTERVAL_SECONDS),
+    );
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) {
+      return true;
+    }
+
+    const channelCount = input.length;
+    const frameCount = input[0]?.length ?? 0;
+    if (frameCount === 0) {
+      return true;
+    }
+
+    // Track peak amplitude on the input (pre-decimation) signal so the
+    // meter responds to the raw mic loudness.
+    for (let i = 0; i < frameCount; i++) {
+      let monoSample = 0;
+      for (let c = 0; c < channelCount; c++) {
+        monoSample += input[c][i];
+      }
+      monoSample /= channelCount;
+
+      const abs = monoSample >= 0 ? monoSample : -monoSample;
+      if (abs > this.amplitudePeak) {
+        this.amplitudePeak = abs;
+      }
+    }
+
+    this.amplitudeFramesAccumulated += frameCount;
+    if (this.amplitudeFramesAccumulated >= this.amplitudeWindowFrames) {
+      const amplitude = this.amplitudePeak > 1 ? 1 : this.amplitudePeak;
+      this.port.postMessage({ type: "amplitude", amplitude });
+      this.amplitudePeak = 0;
+      this.amplitudeFramesAccumulated = 0;
+    }
+
+    // Decimate by linear interpolation between adjacent mono samples.
+    // `nextSourcePosition` is a fractional index into the current input
+    // buffer; after the loop we subtract `frameCount` so the remainder
+    // carries into the next callback.
+    while (this.nextSourcePosition < frameCount) {
+      const lowerFrame = Math.min(
+        Math.floor(this.nextSourcePosition),
+        frameCount - 1,
+      );
+      const upperFrame = Math.min(lowerFrame + 1, frameCount - 1);
+      const fraction = this.nextSourcePosition - lowerFrame;
+
+      const lowerSample = monoAt(input, lowerFrame, channelCount);
+      const upperSample = monoAt(input, upperFrame, channelCount);
+      const sample = lowerSample + (upperSample - lowerSample) * fraction;
+
+      this.appendSample(sample);
+      this.nextSourcePosition += this.decimationRatio;
+    }
+    this.nextSourcePosition -= frameCount;
+    if (this.nextSourcePosition < 0) {
+      this.nextSourcePosition = 0;
+    }
+
+    // Flush full 320-sample chunks. Multiple may be ready if the
+    // sample rate is low enough relative to the input quantum.
+    while (this.pendingCount >= CHUNK_SAMPLES) {
+      const pcm16 = new Int16Array(CHUNK_SAMPLES);
+      let peakAbs = 0;
+      for (let i = 0; i < CHUNK_SAMPLES; i++) {
+        const f = this.pendingSamples[i];
+        const clamped = f < -1 ? -1 : f > 1 ? 1 : f;
+        const abs = clamped >= 0 ? clamped : -clamped;
+        if (abs > peakAbs) peakAbs = abs;
+        const scale = clamped < 0 ? 32768 : 32767;
+        pcm16[i] = Math.trunc(clamped * scale);
+      }
+
+      this.port.postMessage(
+        { type: "chunk", pcm16, frameCount: CHUNK_SAMPLES, amplitude: peakAbs },
+        [pcm16.buffer],
+      );
+
+      // Shift remaining samples down.
+      const remaining = this.pendingCount - CHUNK_SAMPLES;
+      this.pendingSamples.copyWithin(0, CHUNK_SAMPLES, this.pendingCount);
+      this.pendingCount = remaining;
+    }
+
+    return true;
+  }
+
+  appendSample(sample) {
+    if (this.pendingCount >= this.pendingSamples.length) {
+      // Grow the buffer in chunks to avoid frequent reallocations. This
+      // shouldn't normally happen at the input rates we expect, but it
+      // keeps the worklet correct under bursty schedulers.
+      const grown = new Float32Array(this.pendingSamples.length * 2);
+      grown.set(this.pendingSamples);
+      this.pendingSamples = grown;
+    }
+    this.pendingSamples[this.pendingCount++] = sample;
+  }
+}
+
+function monoAt(input, frame, channelCount) {
+  let sum = 0;
+  for (let c = 0; c < channelCount; c++) {
+    sum += input[c][frame];
+  }
+  return sum / channelCount;
+}
+
+registerProcessor("pcm16k-capture-processor", Pcm16kCaptureProcessor);

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -11,10 +11,11 @@
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 
 import type { ChatAttachment } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
 import { INITIAL_TURN_STATE, type TurnState, useTurnStore } from "@/domains/chat/turn-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import { ChatComposer, computeGhostSuffix, shouldSubmitOnEnter } from "@/domains/chat/components/chat-composer/chat-composer";
 
@@ -472,6 +473,63 @@ describe("ChatComposer — optional slots", () => {
     // VoiceInputButton renders aria-label="Start voice input" / "Stop voice input".
     expect(html).not.toContain("Start voice input");
     expect(html).not.toContain("Stop voice input");
+  });
+
+  test("showLiveVoiceOverlay mounts the overlay slot ABOVE the form (off by default)", () => {
+    // Off: the overlay's `data-slot="live-voice-overlay"` is absent.
+    // The overlay itself renders `null` when `state === "off"`, but the
+    // gate around `<LiveVoiceOverlay />` is what we assert here, so we
+    // toggle it via the `showLiveVoiceOverlay` prop.
+    const offHtml = renderComposer({ showLiveVoiceOverlay: false });
+    expect(offHtml).not.toContain('data-slot="live-voice-overlay"');
+    // On: the live voice store's default state is `off`, so the
+    // overlay still renders `null` — but we can assert the surrounding
+    // `relative` wrapper still sits ABOVE the form to keep the
+    // structural contract intact.
+    const onHtml = renderComposer({ showLiveVoiceOverlay: true });
+    const wrapperIdx = onHtml.indexOf('class="relative"');
+    const formIdx = onHtml.indexOf("<form");
+    expect(wrapperIdx).toBeGreaterThan(-1);
+    expect(formIdx).toBeGreaterThan(-1);
+    expect(wrapperIdx).toBeLessThan(formIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTML rendering — LiveVoiceButton mount
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer — LiveVoiceButton mount", () => {
+  test("LiveVoiceButton renders in the toolbar when voice-mode flag is on + assistantId is set", () => {
+    // The button gates itself on `voiceMode` + `assistantId`. With the flag
+    // off (default), it short-circuits to null. Flip the flag on and assert
+    // the button surface lands in the rendered HTML. `act` wraps the
+    // store mutation so React's gate-close `useEffect` (which fires the
+    // manager `end()` cleanup) flushes inside the test boundary.
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: true });
+    });
+    const html = renderComposer({
+      assistantId: "asst_test",
+      conversationId: "conv_test",
+    });
+    // LiveVoiceButton uses aria-label "Start voice conversation" in the
+    // initial `off` state — that's the unambiguous signal it mounted.
+    expect(html).toContain("Start voice conversation");
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+  });
+
+  test("LiveVoiceButton is omitted when voice-mode flag is off (gate closed)", () => {
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+    const html = renderComposer({
+      assistantId: "asst_test",
+      conversationId: "conv_test",
+    });
+    expect(html).not.toContain("Start voice conversation");
   });
 });
 

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -9,7 +9,7 @@
  *   2. `@testing-library/react` `render` for HTML surface checks (placeholder,
  *      send/stop button, disabled attribute).
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 
@@ -277,7 +277,23 @@ describe("computeGhostSuffix", () => {
 // HTML rendering — placeholder and send/stop button surface
 // ---------------------------------------------------------------------------
 
-afterEach(cleanup);
+// Snapshot the `voiceMode` flag before each test and restore it in
+// `afterEach`. The flag store is a module-scoped Zustand singleton, so
+// without this guard a mid-test failure in any voice-mode-on case
+// (`setState({ voiceMode: true })` ... assertion throws ... restore
+// `false` never runs) leaves the flag set for every subsequent test in
+// the file. Mirrors the explicit reset pattern from
+// `live-voice-button.test.tsx`.
+let voiceModeSnapshot = false;
+beforeEach(() => {
+  voiceModeSnapshot = useAssistantFeatureFlagStore.getState().voiceMode;
+  useAssistantFeatureFlagStore.setState({ voiceMode: false });
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantFeatureFlagStore.setState({ voiceMode: voiceModeSnapshot });
+});
 
 function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
   const { container } = render(
@@ -501,11 +517,13 @@ describe("ChatComposer — optional slots", () => {
 
 describe("ChatComposer — LiveVoiceButton mount", () => {
   test("LiveVoiceButton renders in the toolbar when voice-mode flag is on + assistantId is set", () => {
-    // The button gates itself on `voiceMode` + `assistantId`. With the flag
-    // off (default), it short-circuits to null. Flip the flag on and assert
-    // the button surface lands in the rendered HTML. `act` wraps the
-    // store mutation so React's gate-close `useEffect` (which fires the
-    // manager `end()` cleanup) flushes inside the test boundary.
+    // The button gates itself on `voiceMode` + `assistantId`. The shared
+    // `beforeEach` already reset the flag to `false`; flip it on and
+    // assert the button surface lands in the rendered HTML. `act` wraps
+    // the store mutation so React's gate-close `useEffect` (which fires
+    // the manager `end()` cleanup) flushes inside the test boundary.
+    // The shared `afterEach` restores the snapshot so a thrown assertion
+    // here can't leak `voiceMode: true` into subsequent tests.
     act(() => {
       useAssistantFeatureFlagStore.setState({ voiceMode: true });
     });
@@ -516,15 +534,11 @@ describe("ChatComposer — LiveVoiceButton mount", () => {
     // LiveVoiceButton uses aria-label "Start voice conversation" in the
     // initial `off` state — that's the unambiguous signal it mounted.
     expect(html).toContain("Start voice conversation");
-    act(() => {
-      useAssistantFeatureFlagStore.setState({ voiceMode: false });
-    });
   });
 
   test("LiveVoiceButton is omitted when voice-mode flag is off (gate closed)", () => {
-    act(() => {
-      useAssistantFeatureFlagStore.setState({ voiceMode: false });
-    });
+    // `beforeEach` already set the flag to `false`; no explicit
+    // mutation needed here.
     const html = renderComposer({
       assistantId: "asst_test",
       conversationId: "conv_test",

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -396,17 +396,23 @@ export function ChatComposer({
 
   return (
     <Popover.Root open={emoji.show || slash.show}>
-      <Popover.Anchor asChild>
-        {/* `relative` wrapper anchors the live voice overlay's
-            `absolute bottom-full` directly above the composer's notices
-            + form stack. Because `noticesAboveFormSlot` is rendered as
-            an in-flow sibling of the form inside this wrapper, the
-            overlay's `bottom: 100%` clears both notices and form rather
-            than clipping into the notices region (billing banner,
-            maintenance banner, voice errors, etc.). */}
-        <div className="relative">
-          {showLiveVoiceOverlay && <LiveVoiceOverlay />}
-          {noticesAboveFormSlot}
+      {/* `relative` wrapper anchors the live voice overlay's
+          `absolute bottom-full` directly above the composer's notices
+          + form stack. Because `noticesAboveFormSlot` is rendered as
+          an in-flow sibling of the form inside this wrapper, the
+          overlay's `bottom: 100%` clears both notices and form rather
+          than clipping into the notices region (billing banner,
+          maintenance banner, voice errors, etc.).
+
+          `Popover.Anchor` is scoped to the form only — not the whole
+          wrapper — so the slash/emoji popup's `side="top"` positioning
+          stays anchored at the textarea instead of floating above any
+          visible notice banner with the banner sandwiched between the
+          popup and the textarea. */}
+      <div className="relative">
+        {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+        {noticesAboveFormSlot}
+        <Popover.Anchor asChild>
           <form
             onSubmit={onSubmit}
             className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
@@ -740,8 +746,8 @@ export function ChatComposer({
               </div>
             </div>
           </form>
-        </div>
-      </Popover.Anchor>
+        </Popover.Anchor>
+      </div>
       <Popover.Content
         side="top"
         align="start"

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -23,6 +23,8 @@ import {
   VoiceInputButton,
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
+import { LiveVoiceButton } from "@/domains/voice/live-voice/live-voice-button";
+import { LiveVoiceOverlay } from "@/domains/voice/live-voice/live-voice-overlay";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -195,6 +197,30 @@ export interface ChatComposerProps {
   assistantId: string | null;
 
   /**
+   * Active conversation id. Required for `LiveVoiceButton` to bind the
+   * live voice session to a specific chat; the button reads its own
+   * gating (voice-mode flag + assistantId) internally, so passing
+   * `null`/`undefined` simply disables the button.
+   */
+  conversationId?: string | null;
+
+  /**
+   * Mounts `<LiveVoiceOverlay />` above the composer form when `true`.
+   * The form is wrapped in a `relative` container so the overlay's
+   * `absolute bottom-full` anchors directly above the composer rather
+   * than the surrounding page. The main chat sets this to `true`; the
+   * app-editing variant leaves it `false` so the overlay doesn't bleed
+   * into the chat-on-the-side surface.
+   *
+   * Defined here (not in `chat-route-content.tsx`) because the chat
+   * domain isn't permitted to import from `domains/voice` — the
+   * composer already owns voice-domain wiring (live + dictation), so
+   * rendering the overlay alongside the button keeps the cross-domain
+   * import contained.
+   */
+  showLiveVoiceOverlay?: boolean;
+
+  /**
    * Whether the currently-active inference model accepts image input.
    * When `false`, the AttachFileButton is disabled so users can't pick a
    * file that the provider would reject downstream (MiniMax, Fireworks
@@ -257,6 +283,8 @@ export function ChatComposer({
   onVoiceBeforeStart,
   onStopGenerating,
   assistantId,
+  conversationId,
+  showLiveVoiceOverlay = false,
   thresholdPickerSlot,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
@@ -371,12 +399,20 @@ export function ChatComposer({
       {noticesAboveFormSlot}
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
-          <form
-            onSubmit={onSubmit}
-            className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
-              hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
-            }`}
-          >
+          {/* `relative` wrapper anchors the live voice overlay's
+              `absolute bottom-full` directly above the composer form —
+              since the overlay is out of flow, the wrapper's content
+              height collapses to the form's height, so `bottom: 100%`
+              of the wrapper sits flush against the top of the form. */}
+          <div className="relative">
+            {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+            <form
+              onSubmit={onSubmit}
+              className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
+                hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
+              }`}
+            >
+
             <ChatAttachmentsStrip
               attachments={chatAttachments}
               onRemove={onRemoveAttachment}
@@ -663,6 +699,16 @@ export function ChatComposer({
                         }}
                       />
                     )}
+                    {/* Live voice (always-on) sits next to the batch
+                    dictation button. The button gates itself internally
+                    on the `voice-mode` flag + `assistantId`, so it's
+                    cheap to render unconditionally — it short-circuits
+                    to `null` when either is falsy. */}
+                    <LiveVoiceButton
+                      assistantId={assistantId}
+                      conversationId={conversationId ?? null}
+                      disabled={typingDisabled}
+                    />
                     {/* macOS parity: the send button is hidden during recording
                     and while transcription is being processed. Only the voice
                     button (mic / stop / spinner) is shown. */}
@@ -692,7 +738,8 @@ export function ChatComposer({
                 )}
               </div>
             </div>
-          </form>
+            </form>
+          </div>
         </Popover.Anchor>
         <Popover.Content
           side="top"

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -395,23 +395,24 @@ export function ChatComposer({
   );
 
   return (
-    <>
-      {noticesAboveFormSlot}
-      <Popover.Root open={emoji.show || slash.show}>
-        <Popover.Anchor asChild>
-          {/* `relative` wrapper anchors the live voice overlay's
-              `absolute bottom-full` directly above the composer form —
-              since the overlay is out of flow, the wrapper's content
-              height collapses to the form's height, so `bottom: 100%`
-              of the wrapper sits flush against the top of the form. */}
-          <div className="relative">
-            {showLiveVoiceOverlay && <LiveVoiceOverlay />}
-            <form
-              onSubmit={onSubmit}
-              className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
-                hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
-              }`}
-            >
+    <Popover.Root open={emoji.show || slash.show}>
+      <Popover.Anchor asChild>
+        {/* `relative` wrapper anchors the live voice overlay's
+            `absolute bottom-full` directly above the composer's notices
+            + form stack. Because `noticesAboveFormSlot` is rendered as
+            an in-flow sibling of the form inside this wrapper, the
+            overlay's `bottom: 100%` clears both notices and form rather
+            than clipping into the notices region (billing banner,
+            maintenance banner, voice errors, etc.). */}
+        <div className="relative">
+          {showLiveVoiceOverlay && <LiveVoiceOverlay />}
+          {noticesAboveFormSlot}
+          <form
+            onSubmit={onSubmit}
+            className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
+              hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
+            }`}
+          >
 
             <ChatAttachmentsStrip
               attachments={chatAttachments}
@@ -738,36 +739,35 @@ export function ChatComposer({
                 )}
               </div>
             </div>
-            </form>
-          </div>
-        </Popover.Anchor>
-        <Popover.Content
-          side="top"
-          align="start"
-          sideOffset={4}
-          className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
-          onOpenAutoFocus={(e: Event) => e.preventDefault()}
-          onCloseAutoFocus={(e: Event) => e.preventDefault()}
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: Event) => e.preventDefault()}
-          onPointerDownOutside={(e: Event) => e.preventDefault()}
-        >
-          {emoji.show && (
-            <EmojiPickerPopup
-              entries={emoji.items}
-              selectedIndex={emoji.selectedIndex}
-              onSelect={insertEmoji}
-            />
-          )}
-          {slash.show && (
-            <SlashCommandPopup
-              commands={slash.items}
-              selectedIndex={slash.selectedIndex}
-              onSelect={handleSlashCommandSelect}
-            />
-          )}
-        </Popover.Content>
-      </Popover.Root>
-    </>
+          </form>
+        </div>
+      </Popover.Anchor>
+      <Popover.Content
+        side="top"
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
+        onOpenAutoFocus={(e: Event) => e.preventDefault()}
+        onCloseAutoFocus={(e: Event) => e.preventDefault()}
+        onInteractOutside={(e: Event) => e.preventDefault()}
+        onEscapeKeyDown={(e: Event) => e.preventDefault()}
+        onPointerDownOutside={(e: Event) => e.preventDefault()}
+      >
+        {emoji.show && (
+          <EmojiPickerPopup
+            entries={emoji.items}
+            selectedIndex={emoji.selectedIndex}
+            onSelect={insertEmoji}
+          />
+        )}
+        {slash.show && (
+          <SlashCommandPopup
+            commands={slash.items}
+            selectedIndex={slash.selectedIndex}
+            onSelect={handleSlashCommandSelect}
+          />
+        )}
+      </Popover.Content>
+    </Popover.Root>
   );
 }

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1345,6 +1345,7 @@ export function ChatRouteContent({
     onVoiceBeforeStart: handleVoiceBeforeStart,
     onStopGenerating: handleStopGenerating,
     assistantId,
+    conversationId: activeConversationId,
     modelSupportsVision: activeModelSupportsVision,
     onRecallLastMessage: phase === "idle" ? () => {
       const content = startEditing();
@@ -1549,7 +1550,11 @@ export function ChatRouteContent({
     );
   }
 
-  // Default: main chat content (with optional document panel)
+  // Default: main chat content (with optional document panel).
+  // `showLiveVoiceOverlay: true` mounts `<LiveVoiceOverlay />` above
+  // the composer — only on the main chat. The app-editing side panel
+  // omits it so the overlay doesn't bleed into the chat-on-the-side
+  // experience.
   const chatContent = (
     <ChatBody
       variant="main"
@@ -1557,7 +1562,10 @@ export function ChatRouteContent({
         ...chatBodyScrollAreaPropsBase,
         showMaintenanceRecoveryCard: isInMaintenanceWithNoMessages,
       }}
-      composerProps={chatBodyComposerProps}
+      composerProps={{
+        ...chatBodyComposerProps,
+        showLiveVoiceOverlay: true,
+      }}
       dragHandlers={attachmentDropHandlers}
       isAttachmentDragOver={isAttachmentDragOver}
       showScrollToLatest={

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
@@ -318,4 +318,58 @@ describe("LiveVoiceButton — lifecycle", () => {
     );
     expect(stub.endCalls).toBe(1);
   });
+
+  test("switching conversationId mid-session ends the manager", () => {
+    // The composer is stable across conversation navigation — only the
+    // `conversationId` prop changes. Without the switch-detection effect
+    // the existing WebSocket would keep streaming against conversation A
+    // while the UI shows conversation B.
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-A"
+        managerFactory={() => stub}
+      />,
+    );
+    // Drive the store into `listening` so the conversation is meaningfully
+    // bound to a live session at the moment of navigation.
+    act(() => {
+      useLiveVoiceStore.setState({ state: "listening" });
+    });
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-B"
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
+
+  test("initial null→value conversationId binding does NOT end the manager", () => {
+    // Mounting with no conversation, then a conversation activates for
+    // the first time, is initial binding — not a switch. End() must not
+    // fire or we'd kill the session before it can begin.
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={null}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId="conv-A"
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+  });
 });

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-button.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * Tests for `LiveVoiceButton`.
+ *
+ * Exercises the render gating (feature flag + assistant id) and the
+ * state → method-call mapping. We inject a stub `managerFactory` so the
+ * real `LiveVoiceChannelManager` (and its WebSocket / mic / playback
+ * collaborators) never gets constructed in the test runner.
+ *
+ * The Zustand stores (`useAssistantFeatureFlagStore`, `useLiveVoiceStore`)
+ * are imported as-is so we can drive them with `.setState()` — they're
+ * module-scoped singletons but each test resets them in `beforeEach`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { LiveVoiceButtonManager } from "@/domains/voice/live-voice/live-voice-button";
+import { LiveVoiceButton } from "@/domains/voice/live-voice/live-voice-button";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/**
+ * Records every call the button forwards to the manager so each test
+ * can assert on (a) which method ran and (b) what payload it received.
+ * Mirrors the fake-collaborator pattern used in
+ * `live-voice-channel-manager.test.ts`.
+ */
+function createStubManager(): LiveVoiceButtonManager & {
+  startCalls: string[];
+  stopListeningCalls: number;
+  interruptCalls: string[];
+  endCalls: number;
+} {
+  const stub = {
+    startCalls: [] as string[],
+    stopListeningCalls: 0,
+    interruptCalls: [] as string[],
+    endCalls: 0,
+    async start(conversationId: string) {
+      stub.startCalls.push(conversationId);
+    },
+    async stopListening() {
+      stub.stopListeningCalls += 1;
+    },
+    async interruptSpeakingAndStartListening(conversationId: string) {
+      stub.interruptCalls.push(conversationId);
+    },
+    async end() {
+      stub.endCalls += 1;
+    },
+  };
+  return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// The Button component renders to a real `<button>` so the test's
+// `fireEvent.click` lands on the right handler — we mock it to a thin
+// shell that forwards the `iconOnly` slot and ARIA attributes. Avoids
+// pulling the design-library barrel (which imports Tailwind / radix
+// modules) into the test process.
+mock.module("@vellum/design-library", () => ({
+  Button: ({
+    iconOnly,
+    onClick,
+    disabled,
+    "aria-label": ariaLabel,
+    "aria-busy": ariaBusy,
+    title,
+  }: {
+    iconOnly?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    "aria-label"?: string;
+    "aria-busy"?: boolean;
+    title?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      aria-busy={ariaBusy}
+      title={title}
+    >
+      {iconOnly}
+    </button>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const CONVERSATION_ID = "conv-123";
+const ASSISTANT_ID = "asst-abc";
+
+beforeEach(() => {
+  // Reset Zustand singletons so each test starts from a clean slate.
+  // `setState` with the full snapshot avoids mutating the action
+  // closures the store holds onto.
+  useLiveVoiceStore.setState({
+    state: "off",
+    sessionId: null,
+    conversationId: null,
+    partialTranscript: "",
+    finalTranscript: "",
+    assistantTranscript: "",
+    inputAmplitude: 0,
+    errorMessage: "",
+  });
+  useAssistantFeatureFlagStore.setState({ voiceMode: true });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoiceButton — render gating", () => {
+  test("(a) returns null when the voice-mode flag is off", () => {
+    useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("(b) returns null when assistantId is null", () => {
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={null}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("(f) returns null even when assistantId is set if the flag is off", () => {
+    // The flag check must short-circuit before the assistantId check —
+    // a user without the flag should never see the button regardless of
+    // which assistant they're on.
+    useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    const stub = createStubManager();
+    const { container } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("LiveVoiceButton — state → click handler", () => {
+  test("(c) clicking the idle button calls manager.start(conversationId)", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    fireEvent.click(getByRole("button"));
+    expect(stub.startCalls).toEqual([CONVERSATION_ID]);
+    expect(stub.stopListeningCalls).toBe(0);
+    expect(stub.interruptCalls).toEqual([]);
+  });
+
+  test("(d) in `speaking` state, click calls interruptSpeakingAndStartListening", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    // Drive the store into `speaking` — the component subscribes via
+    // `useLiveVoiceStore.use.state()` so this triggers a re-render and
+    // re-binds the click handler to `interruptSpeakingAndStartListening`.
+    // Wrap in `act()` because the Zustand subscription schedules a React
+    // state update inside the component.
+    act(() => {
+      useLiveVoiceStore.setState({ state: "speaking" });
+    });
+    fireEvent.click(getByRole("button"));
+    expect(stub.interruptCalls).toEqual([CONVERSATION_ID]);
+    expect(stub.startCalls).toEqual([]);
+  });
+
+  test("in `listening` state, click calls stopListening", () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    act(() => {
+      useLiveVoiceStore.setState({ state: "listening" });
+    });
+    fireEvent.click(getByRole("button"));
+    expect(stub.stopListeningCalls).toBe(1);
+    expect(stub.startCalls).toEqual([]);
+  });
+
+  test("in `failed` state, click ends the session then starts a fresh one", async () => {
+    const stub = createStubManager();
+    const { getByRole } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    act(() => {
+      useLiveVoiceStore.setState({
+        state: "failed",
+        errorMessage: "connection lost",
+      });
+    });
+    fireEvent.click(getByRole("button"));
+    // Failed retry chains `end()` before `start()` so the next call
+    // has a clean manager — yield to microtasks twice (one for the
+    // awaited `end()`, one for the awaited `start()`) before asserting.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(stub.endCalls).toBeGreaterThanOrEqual(1);
+    expect(stub.startCalls).toEqual([CONVERSATION_ID]);
+  });
+});
+
+describe("LiveVoiceButton — lifecycle", () => {
+  test("(e) unmounting calls manager.end()", () => {
+    const stub = createStubManager();
+    const { unmount } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+    unmount();
+    expect(stub.endCalls).toBe(1);
+  });
+
+  test("flipping the voice-mode flag off mid-session ends the manager", () => {
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ voiceMode: false });
+    });
+    rerender(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
+
+  test("dropping assistantId mid-session ends the manager", () => {
+    const stub = createStubManager();
+    const { rerender } = render(
+      <LiveVoiceButton
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(0);
+
+    rerender(
+      <LiveVoiceButton
+        assistantId={null}
+        conversationId={CONVERSATION_ID}
+        managerFactory={() => stub}
+      />,
+    );
+    expect(stub.endCalls).toBe(1);
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
@@ -1,0 +1,501 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import {
+  buildLiveVoiceWebSocketUrl,
+  LiveVoiceChannelClient,
+  type LiveVoiceChannelEvent,
+  type LiveVoiceChannelFailure,
+  type LiveVoiceWebSocketLike,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import {
+  base64ToPcm16,
+  pcm16ToBase64,
+} from "@/domains/voice/live-voice/protocol";
+
+// Mock the gateway-session module so we never touch localStorage from
+// tests. Lint rule `no-restricted-syntax` blocks writing tokens to
+// localStorage, and mocking lets us drive `getGatewayToken()` directly.
+let mockToken: string | null = "test-token";
+mock.module("@/lib/auth/gateway-session", () => ({
+  getGatewayToken: () => mockToken,
+  clearGatewayToken: () => {
+    mockToken = null;
+  },
+  isGatewayAuthEnabled: () => true,
+  isGatewayAuthMode: () => mockToken !== null,
+  ensureGatewayToken: async () => mockToken ?? "",
+  getLocalTokenUrl: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+interface SentRecord {
+  data: string | ArrayBufferLike | ArrayBufferView | Blob;
+}
+
+class MockWebSocket implements LiveVoiceWebSocketLike {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  binaryType: BinaryType = "blob";
+  readyState: number = MockWebSocket.CONNECTING;
+
+  onopen: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null = null;
+  onclose:
+    | ((this: LiveVoiceWebSocketLike, ev: CloseEvent) => unknown)
+    | null = null;
+  onerror: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null = null;
+  onmessage:
+    | ((this: LiveVoiceWebSocketLike, ev: MessageEvent) => unknown)
+    | null = null;
+
+  readonly sent: SentRecord[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void {
+    this.sent.push({ data });
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  // -------- Test helpers --------
+
+  emitOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.call(this, new Event("open"));
+  }
+
+  emitText(payload: string): void {
+    this.onmessage?.call(this, new MessageEvent("message", { data: payload }));
+  }
+
+  emitJson(frame: Record<string, unknown>): void {
+    this.emitText(JSON.stringify(frame));
+  }
+
+  emitClose(code = 1000, reason = ""): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.call(
+      this,
+      new CloseEvent("close", { code, reason, wasClean: code === 1000 }),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let originalWebSocket: unknown;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  originalWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
+  (globalThis as { WebSocket?: unknown }).WebSocket = MockWebSocket;
+  mockToken = "test-token";
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket?: unknown }).WebSocket = originalWebSocket;
+  mockToken = null;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildLiveVoiceWebSocketUrl", () => {
+  test("uses window.origin and ws scheme for http origin", () => {
+    const url = buildLiveVoiceWebSocketUrl("abc");
+    expect(url.startsWith("ws://localhost:3000/v1/live-voice?token=abc")).toBe(
+      true,
+    );
+  });
+
+  test("url-encodes the token", () => {
+    const url = buildLiveVoiceWebSocketUrl("a/b+c=");
+    expect(url).toContain(`token=${encodeURIComponent("a/b+c=")}`);
+  });
+});
+
+describe("LiveVoiceChannelClient", () => {
+  test("start sends the encoded start frame after the WS opens", async () => {
+    const client = new LiveVoiceChannelClient();
+    const onEvent = mock((_e: LiveVoiceChannelEvent) => {});
+    const onFailure = mock((_f: LiveVoiceChannelFailure) => {});
+
+    await client.start({
+      conversationId: "conv-1",
+      onEvent,
+      onFailure,
+    });
+
+    const ws = MockWebSocket.instances[0];
+    expect(ws).toBeDefined();
+    expect(ws!.binaryType).toBe("arraybuffer");
+    expect(client.getState()).toBe("connecting");
+
+    ws!.emitOpen();
+
+    expect(ws!.sent.length).toBe(1);
+    expect(typeof ws!.sent[0]!.data).toBe("string");
+    const decoded = JSON.parse(ws!.sent[0]!.data as string) as Record<
+      string,
+      unknown
+    >;
+    expect(decoded).toEqual({
+      type: "start",
+      conversationId: "conv-1",
+      audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+    });
+
+    client.close();
+  });
+
+  test("ready server frame transitions state to active and fires onEvent", async () => {
+    const client = new LiveVoiceChannelClient();
+    const onEvent = mock((_e: LiveVoiceChannelEvent) => {});
+    const onFailure = mock((_f: LiveVoiceChannelFailure) => {});
+
+    await client.start({ onEvent, onFailure });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    expect(client.getState()).toBe("active");
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0]![0]).toEqual({
+      type: "ready",
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    expect(onFailure).not.toHaveBeenCalled();
+
+    client.close();
+  });
+
+  test("sendAudio writes binary while active and drops otherwise", async () => {
+    const client = new LiveVoiceChannelClient();
+    await client.start({ onEvent: () => {}, onFailure: () => {} });
+    const ws = MockWebSocket.instances[0]!;
+
+    const samples = new Int16Array([1, -2, 3, -4]);
+
+    // While connecting, sendAudio is dropped.
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(0);
+
+    ws.emitOpen();
+    // The start frame is now the first sent item.
+    expect(ws.sent.length).toBe(1);
+
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    expect(client.getState()).toBe("active");
+
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(2);
+    const binary = ws.sent[1]!.data;
+    expect(ArrayBuffer.isView(binary)).toBe(true);
+    expect((binary as ArrayBufferView).byteLength).toBe(samples.byteLength);
+
+    // Also accepts ArrayBuffer directly.
+    const buf = new ArrayBuffer(8);
+    client.sendAudio(buf);
+    expect(ws.sent.length).toBe(3);
+    expect(ws.sent[2]!.data).toBe(buf);
+
+    client.close();
+
+    // After close, sendAudio is a no-op.
+    client.sendAudio(samples);
+    expect(ws.sent.length).toBe(3);
+  });
+
+  test("connection timeout fires onFailure(timeout)", async () => {
+    // Capture timeout callbacks by intercepting setTimeout. We only
+    // trigger the *first* registered callback (the 10s connection
+    // timeout); other callbacks fall through to the real timer so
+    // `await client.start(...)` still resolves normally.
+    const realSetTimeout = globalThis.setTimeout;
+    const captured: Array<() => void> = [];
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && ms === 10_000) {
+        captured.push(handler as () => void);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      const failures: LiveVoiceChannelFailure[] = [];
+
+      await client.start({
+        onEvent: () => {},
+        onFailure: (f) => failures.push(f),
+      });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      // Do NOT emit `ready`; manually fire the captured 10s timeout.
+      expect(captured.length).toBe(1);
+      captured[0]!();
+
+      expect(failures.length).toBe(1);
+      expect(failures[0]).toEqual({
+        type: "timeout",
+        message: "ready frame not received",
+      });
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  test("protocol-error server frame fires onFailure(protocolError)", async () => {
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    ws.emitJson({
+      type: "error",
+      seq: 1,
+      code: "invalid_frame",
+      message: "oops",
+    });
+
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toEqual({
+      type: "protocolError",
+      code: "invalid_frame",
+      message: "oops",
+    });
+    expect(client.getState()).toBe("closed");
+  });
+
+  test("end then close are idempotent", async () => {
+    // Patch setTimeout so the 1s end-grace timer fires immediately and
+    // the connection-timeout (10s) registration becomes a no-op.
+    const realSetTimeout = globalThis.setTimeout;
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && (ms === 1_000 || ms === 10_000)) {
+        if (ms === 1_000) (handler as () => void)();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      await client.start({ onEvent: () => {}, onFailure: () => {} });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      ws.emitJson({
+        type: "ready",
+        seq: 0,
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+
+      const endPromise = client.end();
+      // The "end" control frame should have been sent.
+      const sentTypes = ws.sent.map((s) => {
+        try {
+          return JSON.parse(s.data as string).type as string;
+        } catch {
+          return null;
+        }
+      });
+      expect(sentTypes).toContain("end");
+
+      await endPromise;
+      expect(client.getState()).toBe("closed");
+      expect(ws.closeCalls.length).toBe(1);
+
+      // Subsequent end() and close() must be no-ops.
+      await client.end();
+      client.close();
+      expect(ws.closeCalls.length).toBe(1);
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  test("tts_audio frame decodes base64 and surfaces as ttsAudio with Uint8Array", async () => {
+    const client = new LiveVoiceChannelClient();
+    const events: LiveVoiceChannelEvent[] = [];
+
+    await client.start({
+      onEvent: (e) => events.push(e),
+      onFailure: () => {},
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({
+      type: "ready",
+      seq: 0,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    const pcm = new Int16Array([100, -200, 300, -400, 500, -600]);
+    const dataBase64 = pcm16ToBase64(pcm);
+
+    ws.emitJson({
+      type: "tts_audio",
+      seq: 1,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64,
+    });
+
+    const ttsEvent = events.find(
+      (e): e is Extract<LiveVoiceChannelEvent, { type: "ttsAudio" }> =>
+        e.type === "ttsAudio",
+    );
+    expect(ttsEvent).toBeDefined();
+    expect(ttsEvent!.mimeType).toBe("audio/pcm");
+    expect(ttsEvent!.sampleRate).toBe(24000);
+    expect(ttsEvent!.pcm).toBeInstanceOf(Uint8Array);
+    expect(ttsEvent!.pcm.byteLength).toBe(pcm.byteLength);
+
+    // Round-trip: decode the surfaced Uint8Array back into Int16 samples.
+    const roundTripped = new Int16Array(
+      ttsEvent!.pcm.buffer,
+      ttsEvent!.pcm.byteOffset,
+      ttsEvent!.pcm.byteLength / 2,
+    );
+    expect(Array.from(roundTripped)).toEqual(Array.from(pcm));
+    // Sanity-check the helper too.
+    expect(Array.from(base64ToPcm16(dataBase64))).toEqual(Array.from(pcm));
+
+    client.close();
+  });
+
+  test("missing gateway token fails fast", async () => {
+    mockToken = null;
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toEqual({
+      type: "connectionFailed",
+      message: "missing gateway token",
+    });
+    expect(client.getState()).toBe("closed");
+    expect(MockWebSocket.instances.length).toBe(0);
+  });
+
+  test("end() resolves even when teardown clears the grace timer first", async () => {
+    // Patch setTimeout so the 1 s end-grace timer never fires on its
+    // own (we want to drive teardown manually). The 10 s connection
+    // timeout is also a no-op so `start()` resolves cleanly.
+    const realSetTimeout = globalThis.setTimeout;
+    const stub = ((handler: TimerHandler, ms?: number) => {
+      if (typeof handler === "function" && (ms === 1_000 || ms === 10_000)) {
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, ms);
+    }) as typeof setTimeout;
+    globalThis.setTimeout = stub;
+
+    try {
+      const client = new LiveVoiceChannelClient();
+      await client.start({ onEvent: () => {}, onFailure: () => {} });
+      const ws = MockWebSocket.instances[0]!;
+      ws.emitOpen();
+      ws.emitJson({
+        type: "ready",
+        seq: 0,
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      expect(client.getState()).toBe("active");
+
+      // Kick off end() but don't await it — the grace timer is
+      // stubbed to never fire, so end() is parked on the Promise.
+      const endPromise = client.end();
+      expect(client.getState()).toBe("ending");
+
+      // Force teardown via a WS abnormal close before the grace timer
+      // fires. handleClose -> teardown clears the grace timer; before
+      // the fix this orphans the resolver and end() would hang.
+      ws.emitClose(1006, "abnormal");
+
+      // The awaited end() must now resolve rather than hang.
+      await endPromise;
+      expect(client.getState()).toBe("closed");
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  test("busy server frame fires onFailure(busy)", async () => {
+    const client = new LiveVoiceChannelClient();
+    const failures: LiveVoiceChannelFailure[] = [];
+
+    await client.start({
+      onEvent: () => {},
+      onFailure: (f) => failures.push(f),
+    });
+    const ws = MockWebSocket.instances[0]!;
+    ws.emitOpen();
+    ws.emitJson({ type: "busy", seq: 0, activeSessionId: "other-sess" });
+
+    expect(failures).toEqual([
+      { type: "busy", activeSessionId: "other-sess" },
+    ]);
+    expect(client.getState()).toBe("closed");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-client.test.ts
@@ -23,6 +23,9 @@ import {
 // tests. Lint rule `no-restricted-syntax` blocks writing tokens to
 // localStorage, and mocking lets us drive `getGatewayToken()` directly.
 let mockToken: string | null = "test-token";
+// Indirection so individual tests can override token acquisition (e.g.
+// simulate a refresh failure) without re-mocking the whole module.
+let ensureGatewayTokenImpl: () => Promise<string> = async () => mockToken ?? "";
 mock.module("@/lib/auth/gateway-session", () => ({
   getGatewayToken: () => mockToken,
   clearGatewayToken: () => {
@@ -30,7 +33,7 @@ mock.module("@/lib/auth/gateway-session", () => ({
   },
   isGatewayAuthEnabled: () => true,
   isGatewayAuthMode: () => mockToken !== null,
-  ensureGatewayToken: async () => mockToken ?? "",
+  ensureGatewayToken: () => ensureGatewayTokenImpl(),
   getLocalTokenUrl: () => undefined,
 }));
 
@@ -115,6 +118,7 @@ beforeEach(() => {
   originalWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
   (globalThis as { WebSocket?: unknown }).WebSocket = MockWebSocket;
   mockToken = "test-token";
+  ensureGatewayTokenImpl = async () => mockToken ?? "";
 });
 
 afterEach(() => {
@@ -418,23 +422,34 @@ describe("LiveVoiceChannelClient", () => {
     client.close();
   });
 
-  test("missing gateway token fails fast", async () => {
-    mockToken = null;
-    const client = new LiveVoiceChannelClient();
-    const failures: LiveVoiceChannelFailure[] = [];
+  test("gateway token acquisition failure fails fast", async () => {
+    // `ensureGatewayToken` rejecting models an expired/unprimed session
+    // that couldn't be refreshed — voice no longer reads a bare cached
+    // token, it acquires on demand like the rest of the app.
+    const restore = ensureGatewayTokenImpl;
+    ensureGatewayTokenImpl = async () => {
+      throw new Error("token request failed");
+    };
+    try {
+      const client = new LiveVoiceChannelClient();
+      const failures: LiveVoiceChannelFailure[] = [];
 
-    await client.start({
-      onEvent: () => {},
-      onFailure: (f) => failures.push(f),
-    });
+      await client.start({
+        onEvent: () => {},
+        onFailure: (f) => failures.push(f),
+      });
 
-    expect(failures.length).toBe(1);
-    expect(failures[0]).toEqual({
-      type: "connectionFailed",
-      message: "missing gateway token",
-    });
-    expect(client.getState()).toBe("closed");
-    expect(MockWebSocket.instances.length).toBe(0);
+      expect(failures.length).toBe(1);
+      expect(failures[0]).toEqual({
+        type: "connectionFailed",
+        message:
+          "Couldn't authenticate the voice session — refresh the page and try again.",
+      });
+      expect(client.getState()).toBe("closed");
+      expect(MockWebSocket.instances.length).toBe(0);
+    } finally {
+      ensureGatewayTokenImpl = restore;
+    }
   });
 
   test("end() resolves even when teardown clears the grace timer first", async () => {

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -1,0 +1,1048 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  LiveVoiceChannelClientLike,
+  LiveVoicePcmCaptureLike,
+  LiveVoicePcmPlaybackLike,
+  LiveVoiceStoreLike,
+} from "@/domains/voice/live-voice/live-voice-channel-manager";
+import { LiveVoiceChannelManager } from "@/domains/voice/live-voice/live-voice-channel-manager";
+import type {
+  LiveVoiceChannelEvent,
+  LiveVoiceChannelFailure,
+  LiveVoiceChannelStartOptions,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import type {
+  LiveVoiceStore,
+  LiveVoiceStoreState,
+} from "@/domains/voice/live-voice/live-voice-store";
+import type { LiveVoicePcmCaptureStartOptions } from "@/domains/voice/live-voice/pcm-capture";
+import type { LiveVoiceTtsChunk } from "@/domains/voice/live-voice/pcm-playback";
+
+// ---------------------------------------------------------------------------
+// Fake store
+//
+// The real `useLiveVoiceStore` is a Zustand singleton; touching it from
+// these tests would leak state across the test runner. We replicate the
+// store's mutating actions over a plain object so each test has its own
+// isolated snapshot.
+// ---------------------------------------------------------------------------
+
+const INITIAL_STORE_STATE: LiveVoiceStoreState = {
+  state: "off",
+  sessionId: null,
+  conversationId: null,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  errorMessage: "",
+};
+
+function createFakeStore(): LiveVoiceStoreLike {
+  const snapshot: LiveVoiceStoreState = { ...INITIAL_STORE_STATE };
+  const api: LiveVoiceStore = {
+    ...snapshot,
+    setState: (s) => {
+      api.state = s;
+    },
+    setSessionInfo: ({ sessionId, conversationId }) => {
+      api.sessionId = sessionId;
+      api.conversationId = conversationId;
+    },
+    setPartialTranscript: (text) => {
+      api.partialTranscript = text;
+    },
+    setFinalTranscript: (text) => {
+      api.finalTranscript = text;
+    },
+    appendAssistantTranscript: (delta) => {
+      api.assistantTranscript = api.assistantTranscript + delta;
+    },
+    clearAssistantTranscript: () => {
+      api.assistantTranscript = "";
+    },
+    setInputAmplitude: (amp) => {
+      api.inputAmplitude = amp;
+    },
+    setError: (msg) => {
+      api.errorMessage = msg;
+    },
+    reset: () => {
+      Object.assign(api, INITIAL_STORE_STATE);
+    },
+  };
+  return { getState: () => api };
+}
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures the `onEvent` / `onFailure` callbacks from `start()` so each
+ * test can drive event sequences synchronously. Records every method
+ * call so assertions can verify both the call ordering and the payloads
+ * the manager forwarded.
+ */
+class FakeClient implements LiveVoiceChannelClientLike {
+  startCalls: LiveVoiceChannelStartOptions[] = [];
+  sendAudioCalls: Array<ArrayBuffer | Int16Array> = [];
+  releasePushToTalkCalls = 0;
+  interruptCalls = 0;
+  endCalls = 0;
+  closeCalls = 0;
+
+  /** Most recent `onEvent` callback captured from `start()`. */
+  onEvent: ((event: LiveVoiceChannelEvent) => void) | null = null;
+  /** Most recent `onFailure` callback captured from `start()`. */
+  onFailure: ((failure: LiveVoiceChannelFailure) => void) | null = null;
+
+  async start(options: LiveVoiceChannelStartOptions): Promise<void> {
+    this.startCalls.push(options);
+    this.onEvent = options.onEvent;
+    this.onFailure = options.onFailure;
+  }
+
+  sendAudio(data: ArrayBuffer | Int16Array): void {
+    this.sendAudioCalls.push(data);
+  }
+
+  releasePushToTalk(): void {
+    this.releasePushToTalkCalls += 1;
+  }
+
+  interrupt(): void {
+    this.interruptCalls += 1;
+  }
+
+  async end(): Promise<void> {
+    this.endCalls += 1;
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+  }
+
+  /** Drive an event through the manager. */
+  emit(event: LiveVoiceChannelEvent): void {
+    if (!this.onEvent) {
+      throw new Error("FakeClient.start has not been called");
+    }
+    this.onEvent(event);
+  }
+
+  /** Drive a failure through the manager. */
+  fail(failure: LiveVoiceChannelFailure): void {
+    if (!this.onFailure) {
+      throw new Error("FakeClient.start has not been called");
+    }
+    this.onFailure(failure);
+  }
+}
+
+class FakeCapture implements LiveVoicePcmCaptureLike {
+  startCalls: LiveVoicePcmCaptureStartOptions[] = [];
+  stopCalls = 0;
+  shutdownCalls = 0;
+  /** Return value for the next `start()` call. Defaults to true. */
+  startResult = true;
+
+  async start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean> {
+    this.startCalls.push(options);
+    return this.startResult;
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+  }
+
+  shutdown(): void {
+    this.shutdownCalls += 1;
+  }
+}
+
+class FakePlayback implements LiveVoicePcmPlaybackLike {
+  isPlaying = false;
+  /**
+   * Ordered call log used to assert call sequencing (e.g. that
+   * `resetForNextResponse` ran BEFORE the first `enqueueTtsAudio` for a
+   * new turn).
+   */
+  callLog: string[] = [];
+  enqueueCalls: LiveVoiceTtsChunk[] = [];
+  handleInterruptCalls = 0;
+  handleEndCalls = 0;
+  handleSessionErrorCalls = 0;
+  resetCalls = 0;
+  waitCalls = 0;
+
+  /**
+   * Controls whether `waitUntilPlaybackFinishes()` resolves synchronously
+   * (default) or returns a manually controlled promise. Tests that need
+   * to race teardown against the `ttsDone` continuation flip this to a
+   * deferred promise and resolve it after driving the teardown.
+   */
+  private pendingWait: { promise: Promise<void>; resolve: () => void } | null =
+    null;
+
+  enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+    this.callLog.push("enqueueTtsAudio");
+    this.enqueueCalls.push(chunk);
+  }
+
+  handleInterrupt(): void {
+    this.callLog.push("handleInterrupt");
+    this.handleInterruptCalls += 1;
+  }
+
+  handleEnd(): void {
+    this.callLog.push("handleEnd");
+    this.handleEndCalls += 1;
+  }
+
+  handleSessionError(): void {
+    this.callLog.push("handleSessionError");
+    this.handleSessionErrorCalls += 1;
+  }
+
+  resetForNextResponse(): void {
+    this.callLog.push("resetForNextResponse");
+    this.resetCalls += 1;
+  }
+
+  async waitUntilPlaybackFinishes(): Promise<void> {
+    this.callLog.push("waitUntilPlaybackFinishes");
+    this.waitCalls += 1;
+    if (this.pendingWait) {
+      await this.pendingWait.promise;
+    }
+  }
+
+  /**
+   * Make the next `waitUntilPlaybackFinishes()` call hang until the
+   * returned `resolve` is invoked. Used to simulate the race where
+   * teardown happens between `ttsDone` and playback drain finishing.
+   */
+  deferNextWait(): () => void {
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    this.pendingWait = { promise, resolve: resolveFn };
+    return () => {
+      resolveFn();
+      this.pendingWait = null;
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  manager: LiveVoiceChannelManager;
+  /**
+   * Returns the most-recently-built fake client. The manager
+   * constructs a fresh client via the factory in every `start()` call,
+   * so tests resolve the client lazily (after calling `start`) rather
+   * than destructuring it up front. Tests that want to inspect a
+   * prior session's client should snapshot the returned reference
+   * before driving the next `start()`.
+   */
+  client(): FakeClient;
+  /** Every client the factory has handed out, oldest-first. */
+  clients: FakeClient[];
+  /**
+   * Returns the most-recently-built fake capture. Like the client,
+   * capture is built lazily inside `start()` via the factory, so tests
+   * must resolve it after `start()`. Snapshot the returned reference
+   * before driving another `start()` if you need to inspect the prior
+   * session's capture.
+   */
+  capture(): FakeCapture;
+  /** Every capture the factory has handed out, oldest-first. */
+  captures: FakeCapture[];
+  /**
+   * Returns the most-recently-built fake playback. Same lazy semantics
+   * as `capture()` — playback is built per `start()`.
+   */
+  playback(): FakePlayback;
+  /** Every playback the factory has handed out, oldest-first. */
+  playbacks: FakePlayback[];
+  store: LiveVoiceStoreLike;
+}
+
+function makeHarness(): Harness {
+  const clients: FakeClient[] = [];
+  const captures: FakeCapture[] = [];
+  const playbacks: FakePlayback[] = [];
+  const store = createFakeStore();
+  const manager = new LiveVoiceChannelManager({
+    clientFactory: () => {
+      const next = new FakeClient();
+      clients.push(next);
+      return next;
+    },
+    captureFactory: () => {
+      const next = new FakeCapture();
+      captures.push(next);
+      return next;
+    },
+    playbackFactory: () => {
+      const next = new FakePlayback();
+      playbacks.push(next);
+      return next;
+    },
+    store,
+  });
+  return {
+    manager,
+    clients,
+    captures,
+    playbacks,
+    store,
+    client: () => {
+      const latest = clients[clients.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakeClient factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+    capture: () => {
+      const latest = captures[captures.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakeCapture factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+    playback: () => {
+      const latest = playbacks[playbacks.length - 1];
+      if (!latest) {
+        throw new Error(
+          "FakePlayback factory has not been invoked yet — call manager.start first",
+        );
+      }
+      return latest;
+    },
+  };
+}
+
+/**
+ * Yield to the microtask queue. `startCapture()` runs synchronously
+ * inside an `onEvent` handler but its `await capture.start(...)`
+ * resolves on a microtask, so tests await an already-resolved promise
+ * to let those continuations land before asserting.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoiceChannelManager", () => {
+  describe("happy path", () => {
+    test("walks the macOS state machine through a full turn", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      expect(store.getState().state).toBe("connecting");
+      expect(client.startCalls.length).toBe(1);
+      expect(client.startCalls[0]!.conversationId).toBe("conv-1");
+
+      // ready → store session info + start capture → listening.
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      expect(store.getState().sessionId).toBe("sess-1");
+      expect(store.getState().conversationId).toBe("conv-1");
+      expect(capture.startCalls.length).toBe(1);
+      expect(store.getState().state).toBe("listening");
+
+      // Mic chunks forward to client.sendAudio; amplitude lands in store.
+      const pcm = new Int16Array([1, 2, 3, 4]);
+      capture.startCalls[0]!.onChunk({
+        pcm16: pcm,
+        frameCount: pcm.length,
+        amplitude: 0.42,
+      });
+      capture.startCalls[0]!.onAmplitude?.(0.42);
+      expect(client.sendAudioCalls).toEqual([pcm]);
+      expect(store.getState().inputAmplitude).toBe(0.42);
+
+      // sttPartial → transcribing + partial transcript recorded.
+      client.emit({ type: "sttPartial", text: "hello", seq: 1 });
+      expect(store.getState().state).toBe("transcribing");
+      expect(store.getState().partialTranscript).toBe("hello");
+
+      // sttFinal → final transcript stored, partial cleared.
+      client.emit({ type: "sttFinal", text: "hello world", seq: 2 });
+      expect(store.getState().finalTranscript).toBe("hello world");
+      expect(store.getState().partialTranscript).toBe("");
+
+      // thinking → state moves to thinking; assistant transcript cleared.
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      expect(store.getState().state).toBe("thinking");
+
+      // assistantTextDelta → speaking + appended.
+      client.emit({ type: "assistantTextDelta", text: "Hi ", seq: 3 });
+      expect(store.getState().state).toBe("speaking");
+      expect(store.getState().assistantTranscript).toBe("Hi ");
+
+      client.emit({ type: "assistantTextDelta", text: "there!", seq: 4 });
+      expect(store.getState().assistantTranscript).toBe("Hi there!");
+      // Second delta does not re-enter `speaking`.
+      expect(store.getState().state).toBe("speaking");
+
+      // ttsAudio → first chunk re-opens the playback gate, then enqueues.
+      const ttsPcm = new Uint8Array([0, 1, 2, 3]);
+      client.emit({
+        type: "ttsAudio",
+        pcm: ttsPcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 5,
+      });
+      expect(playback.enqueueCalls.length).toBe(1);
+      expect(playback.enqueueCalls[0]).toEqual({
+        pcm: ttsPcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      });
+      // First chunk of the response: reset must come BEFORE enqueue so
+      // the playback gate is open.
+      expect(playback.callLog).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
+
+      // ttsDone → waitUntilPlaybackFinishes runs, transcript reset,
+      // state back to listening. The reset count picks up a second call
+      // from the `completeAssistantTurn` continuation.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(playback.waitCalls).toBe(1);
+      expect(playback.resetCalls).toBe(2);
+      expect(store.getState().assistantTranscript).toBe("");
+      expect(store.getState().state).toBe("listening");
+    });
+  });
+
+  describe("interrupt path", () => {
+    test("interruptSpeakingAndStartListening interrupts client + playback and restarts capture", async () => {
+      const harness = makeHarness();
+      const { manager } = harness;
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      const captureStartsBefore = capture.startCalls.length;
+
+      await manager.interruptSpeakingAndStartListening("conv-1");
+      await flushMicrotasks();
+
+      expect(client.interruptCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      expect(capture.startCalls.length).toBe(captureStartsBefore + 1);
+    });
+  });
+
+  describe("end path", () => {
+    test("end shuts down capture, drains playback, ends client, resets store", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Seed some store state to confirm reset clears it.
+      store.getState().setFinalTranscript("dirty");
+
+      await manager.end();
+
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleEndCalls).toBe(1);
+      expect(client.endCalls).toBe(1);
+      // The protocol-level `end` frame is sent — `close()` is not.
+      expect(client.closeCalls).toBe(0);
+
+      const state = store.getState();
+      expect(state.state).toBe("off");
+      expect(state.sessionId).toBeNull();
+      expect(state.conversationId).toBeNull();
+      expect(state.finalTranscript).toBe("");
+      expect(state.errorMessage).toBe("");
+    });
+  });
+
+  describe("early failure path", () => {
+    test("busy failure tears down capture+playback and surfaces error state", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      expect(store.getState().state).toBe("connecting");
+
+      // No `ready` yet — server reports another session is already active.
+      client.fail({ type: "busy", activeSessionId: "sess-other" });
+
+      expect(store.getState().state).toBe("failed");
+      expect(store.getState().errorMessage.length).toBeGreaterThan(0);
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      // No protocol `end` frame; we tear down via `close()`.
+      expect(client.endCalls).toBe(0);
+      expect(client.closeCalls).toBe(1);
+    });
+
+    test("failure with explicit message stores that message verbatim", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+      await manager.start("conv-1");
+      const client = harness.client();
+
+      client.fail({
+        type: "connectionFailed",
+        message: "WebSocket error",
+      });
+
+      expect(store.getState().errorMessage).toBe("WebSocket error");
+      expect(store.getState().state).toBe("failed");
+    });
+  });
+
+  describe("stopListening", () => {
+    test("releases push-to-talk and stops capture, keeps channel open", async () => {
+      const harness = makeHarness();
+      const { manager } = harness;
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.stopListening();
+
+      expect(client.releasePushToTalkCalls).toBe(1);
+      expect(capture.stopCalls).toBe(1);
+      expect(client.endCalls).toBe(0);
+      expect(client.closeCalls).toBe(0);
+    });
+  });
+
+  describe("barge-in playback gate", () => {
+    test("re-opens playback gate before the first ttsAudio of a new turn after interrupt", async () => {
+      const harness = makeHarness();
+      const { manager } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // ---- Turn 1: assistant speaks. ----
+      client.emit({ type: "sttFinal", text: "first", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      const turn1Pcm = new Uint8Array([1, 2]);
+      client.emit({
+        type: "ttsAudio",
+        pcm: turn1Pcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+
+      // First chunk of turn 1 must reset BEFORE enqueueing.
+      const turn1Calls = playback.callLog.filter(
+        (call) =>
+          call === "resetForNextResponse" || call === "enqueueTtsAudio",
+      );
+      expect(turn1Calls).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
+      const turn1ResetCount = playback.resetCalls;
+
+      // ---- User barges in: interrupt slams the playback gate shut. ----
+      await manager.interruptSpeakingAndStartListening("conv-1");
+      await flushMicrotasks();
+      expect(playback.handleInterruptCalls).toBe(1);
+      // Capture restarts after the interrupt.
+      expect(capture.startCalls.length).toBeGreaterThan(1);
+
+      // ---- Turn 2: new utterance produces TTS. The first chunk of
+      //      turn 2 must re-open the gate before enqueueing, otherwise
+      //      `acceptsAudio === false` silently drops the audio. ----
+      client.emit({ type: "sttFinal", text: "second", seq: 4 });
+      client.emit({ type: "thinking", turnId: "turn-2" });
+      client.emit({ type: "assistantTextDelta", text: "again", seq: 5 });
+
+      const turn2Pcm = new Uint8Array([3, 4]);
+      const callsBeforeTurn2 = playback.callLog.length;
+      client.emit({
+        type: "ttsAudio",
+        pcm: turn2Pcm,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 6,
+      });
+
+      // The next two calls (after the snapshot) must be reset → enqueue,
+      // in that order — the new turn's first chunk re-opens the gate
+      // before it tries to enqueue.
+      expect(playback.callLog.slice(callsBeforeTurn2)).toEqual([
+        "resetForNextResponse",
+        "enqueueTtsAudio",
+      ]);
+      expect(playback.resetCalls).toBe(turn1ResetCount + 1);
+    });
+
+    test("subsequent ttsAudio chunks in the same turn do not call resetForNextResponse again", async () => {
+      const harness = makeHarness();
+      const { manager } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "sttFinal", text: "hi", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+      expect(playback.resetCalls).toBe(1);
+
+      // Second chunk in the same response should NOT call reset again —
+      // the gate is already open.
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([2]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 4,
+      });
+      expect(playback.resetCalls).toBe(1);
+      expect(playback.enqueueCalls.length).toBe(2);
+    });
+  });
+
+  describe("ttsDone teardown race", () => {
+    test("ttsDone continuation bails after end() arrives during the playback drain", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "sttFinal", text: "hi", seq: 1 });
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 2 });
+
+      // First chunk enqueues and opens the gate (resetCalls = 1).
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+      expect(playback.resetCalls).toBe(1);
+
+      // Make the upcoming drain hang so we can teardown mid-await.
+      const resolveDrain = playback.deferNextWait();
+
+      // ttsDone kicks off completeAssistantTurn, which awaits
+      // waitUntilPlaybackFinishes — but we haven't resolved yet.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(playback.waitCalls).toBe(1);
+      // No post-await mutations yet — still in `speaking`.
+      expect(store.getState().state).toBe("speaking");
+
+      // User ends the session BEFORE the drain finishes. This bumps the
+      // session generation, so the in-flight continuation must bail.
+      await manager.end();
+      expect(store.getState().state).toBe("off");
+      const resetCallsAtTeardown = playback.resetCalls;
+
+      // Now resolve the drain — the continuation resumes but should
+      // detect the generation mismatch and return without touching the
+      // store or calling resetForNextResponse.
+      resolveDrain();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(store.getState().state).toBe("off");
+      // No extra reset call from the cancelled continuation.
+      expect(playback.resetCalls).toBe(resetCallsAtTeardown);
+    });
+
+    test("ttsDone continuation bails after a failure arrives during the playback drain", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+
+      const resolveDrain = playback.deferNextWait();
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+
+      // Failure arrives mid-await — bumps the generation.
+      client.fail({ type: "abnormalClosure", code: 1006, reason: "boom" });
+      expect(store.getState().state).toBe("failed");
+      const resetCallsAtFailure = playback.resetCalls;
+
+      resolveDrain();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // State stays `failed` — not clobbered back to `listening`.
+      expect(store.getState().state).toBe("failed");
+      expect(playback.resetCalls).toBe(resetCallsAtFailure);
+    });
+  });
+
+  describe("client factory", () => {
+    test("start → end → start uses a fresh client each time", async () => {
+      const { manager, clients, store } = makeHarness();
+
+      // ---- Session 1: start then end. ----
+      await manager.start("conv-1");
+      expect(clients.length).toBe(1);
+      const firstClient = clients[0]!;
+      expect(firstClient.startCalls.length).toBe(1);
+
+      firstClient.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.end();
+      expect(firstClient.endCalls).toBe(1);
+      expect(store.getState().state).toBe("off");
+
+      // ---- Session 2: a brand-new client must be built. ----
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      expect(secondClient.startCalls.length).toBe(1);
+      expect(secondClient.startCalls[0]!.conversationId).toBe("conv-2");
+      // The old (closed) client must not be touched again.
+      expect(firstClient.startCalls.length).toBe(1);
+
+      // The second client's `ready` event drives the second session
+      // through the same listening transition as the first.
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+      expect(store.getState().sessionId).toBe("sess-2");
+    });
+
+    test("failure path discards the client so the next start gets a fresh one", async () => {
+      const { manager, clients } = makeHarness();
+
+      await manager.start("conv-1");
+      const firstClient = clients[0]!;
+      firstClient.fail({ type: "connectionFailed", message: "boom" });
+      expect(firstClient.closeCalls).toBe(1);
+
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      expect(secondClient.startCalls.length).toBe(1);
+    });
+  });
+
+  describe("capture + playback factories", () => {
+    test("start → end → start rebuilds capture and playback so the new session can listen", async () => {
+      const harness = makeHarness();
+      const { manager, captures, playbacks, store } = harness;
+
+      // ---- Session 1: start, ready, end. ----
+      await manager.start("conv-1");
+      expect(captures.length).toBe(1);
+      expect(playbacks.length).toBe(1);
+      const firstCapture = captures[0]!;
+      const firstPlayback = playbacks[0]!;
+
+      // `end()` calls shutdown — for the real `LiveVoicePcmCapture`,
+      // this would set `isShutdown = true` and any subsequent `start()`
+      // would return false, leaving the next session stuck in
+      // `connecting`. We must therefore build a fresh capture/playback.
+      await manager.end();
+      expect(firstCapture.shutdownCalls).toBe(1);
+      expect(firstPlayback.handleEndCalls).toBe(1);
+
+      // ---- Session 2: a brand-new capture and playback must be built. ----
+      await manager.start("conv-2");
+      expect(captures.length).toBe(2);
+      expect(playbacks.length).toBe(2);
+      const secondCapture = captures[1]!;
+      const secondPlayback = playbacks[1]!;
+      expect(secondCapture).not.toBe(firstCapture);
+      expect(secondPlayback).not.toBe(firstPlayback);
+      // The new capture has not been shut down — start() can transition
+      // the second session past `connecting`.
+      expect(secondCapture.shutdownCalls).toBe(0);
+      expect(secondPlayback.handleEndCalls).toBe(0);
+
+      // Drive the second session through `ready` to confirm the new
+      // capture actually starts (it would not on a recycled-and-shutdown
+      // instance — the second session would be stuck in `connecting`).
+      const secondClient = harness.client();
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+      expect(secondCapture.startCalls.length).toBe(1);
+      expect(store.getState().state).toBe("listening");
+    });
+
+    test("failure path discards capture and playback so the next start gets fresh ones", async () => {
+      const harness = makeHarness();
+      const { manager, captures, playbacks } = harness;
+
+      await manager.start("conv-1");
+      const firstCapture = captures[0]!;
+      const firstPlayback = playbacks[0]!;
+      const firstClient = harness.client();
+
+      // Failure tears down capture (shutdown) and playback (interrupt),
+      // and must drop both references so the next start builds fresh
+      // ones.
+      firstClient.fail({ type: "connectionFailed", message: "boom" });
+      expect(firstCapture.shutdownCalls).toBe(1);
+      expect(firstPlayback.handleInterruptCalls).toBe(1);
+
+      await manager.start("conv-2");
+      expect(captures.length).toBe(2);
+      expect(playbacks.length).toBe(2);
+      expect(captures[1]).not.toBe(firstCapture);
+      expect(playbacks[1]).not.toBe(firstPlayback);
+    });
+  });
+
+  describe("muted ttsDone ends the session", () => {
+    test("ttsDone after stopListening tears down the session instead of staying half-alive", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Run a normal turn so we're in `speaking` when ttsDone arrives.
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      expect(store.getState().state).toBe("speaking");
+
+      // User releases PTT — `ptt_release` is terminal on the server, so
+      // the session is logically done once `ttsDone` lands.
+      await manager.stopListening();
+      expect(client.releasePushToTalkCalls).toBe(1);
+
+      // ttsDone fires after the mute. The continuation must end the
+      // session instead of dangling in a half-alive state — otherwise
+      // the user's next utterance hits a server-side closed session.
+      client.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // Full teardown ran: store reset, client.end + capture.shutdown
+      // both invoked exactly once.
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().sessionId).toBeNull();
+      expect(store.getState().assistantTranscript).toBe("");
+      expect(client.endCalls).toBe(1);
+      expect(capture.shutdownCalls).toBe(1);
+    });
+
+    test("post-mute teardown lets the next start() build a fresh session", async () => {
+      const harness = makeHarness();
+      const { manager, store, clients } = harness;
+
+      await manager.start("conv-1");
+      const firstClient = harness.client();
+      firstClient.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // Run a turn that ends with stopListening + ttsDone — the session
+      // is now fully torn down.
+      firstClient.emit({ type: "thinking", turnId: "turn-1" });
+      firstClient.emit({ type: "assistantTextDelta", text: "ok", seq: 1 });
+      firstClient.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      await manager.stopListening();
+      firstClient.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("off");
+
+      // Next start() builds a brand-new client/capture/playback and
+      // walks the new session through `listening` as usual.
+      await manager.start("conv-2");
+      expect(clients.length).toBe(2);
+      const secondClient = clients[1]!;
+      expect(secondClient).not.toBe(firstClient);
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+      expect(store.getState().sessionId).toBe("sess-2");
+    });
+
+    test("start() resets isUserMuted so a new session is not stuck muted", async () => {
+      const { manager, clients, store } = makeHarness();
+
+      // Session 1: mute then end without un-muting.
+      await manager.start("conv-1");
+      clients[0]!.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      await manager.stopListening();
+      await manager.end();
+
+      // Session 2: start fresh — the mute flag must be cleared.
+      await manager.start("conv-2");
+      const secondClient = clients[1]!;
+      secondClient.emit({
+        type: "ready",
+        sessionId: "sess-2",
+        conversationId: "conv-2",
+      });
+      await flushMicrotasks();
+
+      secondClient.emit({ type: "thinking", turnId: "turn-1" });
+      secondClient.emit({ type: "assistantTextDelta", text: "hi", seq: 1 });
+      secondClient.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([1]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 2,
+      });
+      secondClient.emit({ type: "ttsDone", turnId: "turn-1" });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+    });
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -607,6 +607,46 @@ describe("LiveVoiceChannelManager", () => {
       expect(client.endCalls).toBe(0);
       expect(client.closeCalls).toBe(0);
     });
+
+    test("ends the session if ready arrives after stopListening fired during connecting", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      // Begin connecting. The user has not received a `ready` frame yet,
+      // so the client cannot send `ptt_release` and the capture has not
+      // started — `stopListening()` is essentially a "cancel" press.
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      expect(store.getState().state).toBe("connecting");
+
+      await manager.stopListening();
+      // Both calls are no-ops on the wire (client connecting, capture
+      // not started) but they DO flip `isUserMuted` on the manager.
+      expect(client.releasePushToTalkCalls).toBe(1);
+      expect(capture.stopCalls).toBe(1);
+
+      // Ready finally arrives. The manager must NOT open the mic — the
+      // user already asked to cancel. Instead it tears the session down.
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // The cancellation path runs `end()`: capture shutdown, playback
+      // end, client end, store reset.
+      expect(capture.startCalls.length).toBe(0);
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleEndCalls).toBe(1);
+      expect(client.endCalls).toBe(1);
+      expect(store.getState().state).toBe("off");
+      // Session info from the ready frame must not leak into the store
+      // since the user already cancelled.
+      expect(store.getState().sessionId).toBe(null);
+    });
   });
 
   describe("barge-in playback gate", () => {

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -608,6 +608,41 @@ describe("LiveVoiceChannelManager", () => {
       expect(client.closeCalls).toBe(0);
     });
 
+    test("ends the session if capture returns false because stopListening fired during capture start", async () => {
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      // The real `LiveVoicePcmCapture.start()` returns false if `stop()`
+      // races it (e.g. user pressed cancel while the mic permission
+      // prompt was still up). Simulate that here.
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      capture.startResult = false;
+
+      // ready → manager begins capture.start(); we model the race by
+      // calling stopListening before letting the start() microtask
+      // resolve, then yielding so the false continuation runs.
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await manager.stopListening();
+      await flushMicrotasks();
+
+      // The cancellation path must run `end()`, not `handleFailure()`.
+      // The store should NOT surface the "Microphone permission denied"
+      // message and the state should not be `failed`.
+      expect(client.endCalls).toBe(1);
+      expect(client.closeCalls).toBe(0);
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleEndCalls).toBe(1);
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().errorMessage).toBe("");
+    });
+
     test("ends the session if ready arrives after stopListening fired during connecting", async () => {
       const harness = makeHarness();
       const { manager, store } = harness;

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type {
   LiveVoiceChannelClientLike,
+  LiveVoiceManagerScheduler,
   LiveVoicePcmCaptureLike,
   LiveVoicePcmPlaybackLike,
   LiveVoiceStoreLike,
@@ -241,6 +242,33 @@ class FakePlayback implements LiveVoicePcmPlaybackLike {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Records `setTimeout`/`clearTimeout` calls so tests can fire pending
+ * timers deterministically. bun:test does not ship a fake-timer
+ * implementation, so the manager exposes the scheduler boundary as a
+ * dependency that tests can replace with this fake.
+ */
+class FakeScheduler implements LiveVoiceManagerScheduler {
+  private nextHandle = 0;
+  pending = new Map<number, () => void>();
+
+  setTimeout(handler: () => void): unknown {
+    this.nextHandle += 1;
+    this.pending.set(this.nextHandle, handler);
+    return this.nextHandle;
+  }
+
+  clearTimeout(handle: unknown): void {
+    if (typeof handle === "number") this.pending.delete(handle);
+  }
+
+  /** Fire every currently pending timer (FIFO). */
+  fireAll(): void {
+    for (const handler of [...this.pending.values()]) handler();
+    this.pending.clear();
+  }
+}
+
 interface Harness {
   manager: LiveVoiceChannelManager;
   /**
@@ -272,6 +300,7 @@ interface Harness {
   /** Every playback the factory has handed out, oldest-first. */
   playbacks: FakePlayback[];
   store: LiveVoiceStoreLike;
+  scheduler: FakeScheduler;
 }
 
 function makeHarness(): Harness {
@@ -279,6 +308,7 @@ function makeHarness(): Harness {
   const captures: FakeCapture[] = [];
   const playbacks: FakePlayback[] = [];
   const store = createFakeStore();
+  const scheduler = new FakeScheduler();
   const manager = new LiveVoiceChannelManager({
     clientFactory: () => {
       const next = new FakeClient();
@@ -296,6 +326,7 @@ function makeHarness(): Harness {
       return next;
     },
     store,
+    scheduler,
   });
   return {
     manager,
@@ -303,6 +334,7 @@ function makeHarness(): Harness {
     captures,
     playbacks,
     store,
+    scheduler,
     client: () => {
       const latest = clients[clients.length - 1];
       if (!latest) {
@@ -643,7 +675,71 @@ describe("LiveVoiceChannelManager", () => {
       expect(store.getState().errorMessage).toBe("");
     });
 
-    test("ends the session if ready arrives after stopListening fired during connecting", async () => {
+    test("fires the no-response watchdog if the server stays silent after stopListening", async () => {
+      const harness = makeHarness();
+      const { manager, store, scheduler } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      expect(store.getState().state).toBe("listening");
+
+      // User releases PTT after silence: ptt_release is sent but the
+      // server never produces a response (empty STT). The watchdog
+      // should be armed.
+      await manager.stopListening();
+      expect(client.releasePushToTalkCalls).toBe(1);
+      expect(scheduler.pending.size).toBe(1);
+
+      // Fire the watchdog — manager should tear the session down.
+      scheduler.fireAll();
+      await flushMicrotasks();
+
+      expect(client.endCalls).toBe(1);
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleEndCalls).toBe(1);
+      expect(store.getState().state).toBe("off");
+    });
+
+    test("server activity disarms the watchdog so a normal response is not interrupted", async () => {
+      const harness = makeHarness();
+      const { manager, scheduler } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      // STT events stream in BEFORE stopListening — user spoke, then
+      // released PTT. Watchdog should arm on stopListening, then
+      // disarm as soon as the server emits `thinking`.
+      client.emit({ type: "sttPartial", text: "hi", seq: 1 });
+      await manager.stopListening();
+      expect(scheduler.pending.size).toBe(1);
+
+      client.emit({ type: "sttFinal", text: "hi", seq: 2 });
+      // sttFinal alone does not disarm — STT can finalize even when
+      // the server decides not to respond.
+      expect(scheduler.pending.size).toBe(1);
+
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      // `thinking` means the server is producing a response — disarm.
+      expect(scheduler.pending.size).toBe(0);
+      expect(client.endCalls).toBe(0);
+    });
+
+    test("ends the session if capture returns false because stopListening fired during capture start", async () => {
       const harness = makeHarness();
       const { manager, store } = harness;
 

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -826,6 +826,92 @@ describe("LiveVoiceChannelManager", () => {
     });
   });
 
+  describe("stale frame guard after end", () => {
+    test("late server frames after end() do not mutate playback or store", async () => {
+      // Repro of the conversation-switch leak: `end()` is graceful — it
+      // sends the protocol `end` frame and waits up to 1s for the server
+      // to close. During that grace window the WebSocket can still
+      // dispatch frames (sttFinal, assistantTextDelta, ttsAudio, etc.)
+      // and without the generation guard each one would mutate the
+      // global store / playback, leaking the old session's STT and
+      // assistant audio into the new conversation's UI.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const playback = harness.playback();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      client.emit({ type: "thinking", turnId: "turn-1" });
+      client.emit({ type: "assistantTextDelta", text: "hello", seq: 1 });
+      expect(store.getState().state).toBe("speaking");
+
+      const enqueueCallsBeforeEnd = playback.enqueueCalls.length;
+
+      // Kick off end() (don't await) — the manager bumps the generation
+      // synchronously inside end() before awaiting `client.end()`, so by
+      // the time we emit the late frame the guard is already in effect.
+      const endPromise = manager.end();
+
+      // Server frames slip in during the grace window. With the guard
+      // in place the dispatcher bails before `handleEvent` runs, so
+      // `playback.enqueueTtsAudio` and `actions.appendAssistantTranscript`
+      // are never called.
+      client.emit({
+        type: "assistantTextDelta",
+        text: " from-old-session",
+        seq: 2,
+      });
+      client.emit({
+        type: "ttsAudio",
+        pcm: new Uint8Array([9, 9, 9]),
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        seq: 3,
+      });
+
+      await endPromise;
+      await flushMicrotasks();
+
+      expect(playback.enqueueCalls.length).toBe(enqueueCallsBeforeEnd);
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().assistantTranscript).toBe("");
+    });
+
+    test("late failure callback after end() does not flip state to failed", async () => {
+      // Same race on the failure callback: if the server closes
+      // abnormally during the grace window, the late `onFailure`
+      // dispatch would otherwise clobber the `off` state with `failed`
+      // and surface a confusing error message in the new conversation.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+
+      await manager.end();
+      expect(store.getState().state).toBe("off");
+
+      // Late failure callback from the still-open fake — the guard at
+      // the dispatch boundary drops it.
+      client.fail({ type: "abnormalClosure", code: 1006, reason: "boom" });
+
+      expect(store.getState().state).toBe("off");
+      expect(store.getState().errorMessage).toBe("");
+    });
+  });
+
   describe("client factory", () => {
     test("start → end → start uses a fresh client each time", async () => {
       const { manager, clients, store } = makeHarness();

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-channel-manager.test.ts
@@ -543,6 +543,49 @@ describe("LiveVoiceChannelManager", () => {
     });
   });
 
+  describe("capture failure after ready", () => {
+    test("capture.start() returning false transitions to failed and tears down", async () => {
+      // Regression: previously the manager silently dropped a `false`
+      // return from `capture.start()` (mic permission denied / no
+      // AudioContext / etc.), leaving the store stuck in `connecting`
+      // and the UI showing "Connecting voice conversation" forever.
+      // After the ready frame the WS-side connection timeout has already
+      // been cancelled, so there is no other recovery path.
+      const harness = makeHarness();
+      const { manager, store } = harness;
+
+      await manager.start("conv-1");
+      const client = harness.client();
+      const capture = harness.capture();
+      const playback = harness.playback();
+      expect(store.getState().state).toBe("connecting");
+
+      // Mic will fail to start once `ready` triggers `startCapture()`.
+      capture.startResult = false;
+
+      client.emit({
+        type: "ready",
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+      });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // Manager transitioned the session to `failed` via the same path
+      // as a server-driven failure, surfacing an error message to the
+      // overlay.
+      expect(store.getState().state).toBe("failed");
+      expect(store.getState().errorMessage.length).toBeGreaterThan(0);
+
+      // Same teardown shape as `handleFailure`: capture shutdown,
+      // playback interrupt, client closed (not `end()`).
+      expect(capture.shutdownCalls).toBe(1);
+      expect(playback.handleInterruptCalls).toBe(1);
+      expect(client.closeCalls).toBe(1);
+      expect(client.endCalls).toBe(0);
+    });
+  });
+
   describe("stopListening", () => {
     test("releases push-to-talk and stops capture, keeps channel open", async () => {
       const harness = makeHarness();

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-overlay.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for `LiveVoiceOverlay`.
+ *
+ * Verifies the overlay's lifecycle contract:
+ *   - Renders `null` when state is `off` (no DOM presence).
+ *   - Renders a non-empty status label for every other state.
+ *   - Renders the error message in the `failed` state.
+ *   - Re-renders partial / final / assistant transcript text when the
+ *     store mutates.
+ *
+ * Uses `@testing-library/react` against happy-dom (registered via
+ * `apps/web/test-setup.ts`). The store is mutated via `act()` so React
+ * flushes the resulting re-render before assertions.
+ */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { LiveVoiceOverlay } from "@/domains/voice/live-voice/live-voice-overlay";
+import {
+  type LiveVoiceState,
+  useLiveVoiceStore,
+} from "@/domains/voice/live-voice/live-voice-store";
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+});
+
+describe("LiveVoiceOverlay", () => {
+  test("renders null when state is off", () => {
+    const { container } = render(<LiveVoiceOverlay />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders a status label for each non-off state", () => {
+    const cases: ReadonlyArray<{ state: LiveVoiceState; label: string }> = [
+      { state: "connecting", label: "Connecting…" },
+      { state: "listening", label: "Listening…" },
+      { state: "transcribing", label: "Listening…" },
+      { state: "thinking", label: "Thinking…" },
+      { state: "speaking", label: "Speaking…" },
+      { state: "ending", label: "Ending…" },
+      { state: "failed", label: "Connection failed" },
+    ];
+
+    for (const { state, label } of cases) {
+      act(() => {
+        useLiveVoiceStore.getState().setState(state);
+      });
+
+      const { unmount } = render(<LiveVoiceOverlay />);
+      const status = screen.getByRole("status");
+      expect(status.textContent ?? "").toContain(label);
+      unmount();
+
+      act(() => {
+        useLiveVoiceStore.getState().reset();
+      });
+    }
+  });
+
+  test("renders the error message when state is failed", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("failed");
+      useLiveVoiceStore.getState().setError("mic permission denied");
+    });
+
+    render(<LiveVoiceOverlay />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("mic permission denied");
+  });
+
+  test("does not render the error region in non-failed states", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+      // Even if an old error message is hanging around in the store, a
+      // non-failed state must not surface it — error display is gated
+      // on state, not on the presence of an errorMessage.
+      useLiveVoiceStore.getState().setError("stale error");
+    });
+
+    render(<LiveVoiceOverlay />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("re-renders partial, final, and assistant transcripts when the store updates", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    render(<LiveVoiceOverlay />);
+
+    act(() => {
+      useLiveVoiceStore.getState().setFinalTranscript("hello");
+    });
+    expect(screen.getByRole("status").textContent).toContain("hello");
+
+    act(() => {
+      useLiveVoiceStore.getState().setPartialTranscript("world");
+    });
+    expect(screen.getByRole("status").textContent).toContain("hello");
+    expect(screen.getByRole("status").textContent).toContain("world");
+
+    act(() => {
+      useLiveVoiceStore.getState().appendAssistantTranscript("sure thing");
+    });
+    expect(screen.getByRole("status").textContent).toContain("sure thing");
+  });
+
+  test("amplitude bar width tracks the input amplitude (clamped to [0, 1])", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+      useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    });
+
+    const { container } = render(<LiveVoiceOverlay />);
+    const fill = container.querySelector(
+      '[data-slot="live-voice-overlay-amplitude-fill"]',
+    ) as HTMLElement | null;
+    expect(fill).not.toBeNull();
+    expect(fill?.style.width).toBe("42%");
+
+    // Out-of-range values must clamp rather than overflow the bar.
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(2);
+    });
+    expect(fill?.style.width).toBe("100%");
+
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(-1);
+    });
+    expect(fill?.style.width).toBe("0%");
+  });
+
+  test("root does not disable pointer events so scrollable transcripts work", () => {
+    // Regression: previously the root applied `pointer-events-none`, which is
+    // inherited and made the overflow-y-auto transcript regions unscrollable.
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    const { container } = render(<LiveVoiceOverlay />);
+    const root = container.querySelector(
+      '[data-slot="live-voice-overlay"]',
+    ) as HTMLElement | null;
+    expect(root).not.toBeNull();
+    expect(root?.className).not.toContain("pointer-events-none");
+  });
+
+  test("forwards className overrides onto the overlay root", () => {
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    const { container } = render(<LiveVoiceOverlay className="custom-layout" />);
+    const root = container.querySelector(
+      '[data-slot="live-voice-overlay"]',
+    ) as HTMLElement | null;
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain("custom-layout");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { LiveVoiceStoreState } from "@/domains/voice/live-voice/live-voice-store";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+
+function resetStore() {
+  useLiveVoiceStore.getState().reset();
+}
+
+afterEach(() => {
+  resetStore();
+});
+
+describe("LiveVoiceStore", () => {
+  test("defaults to the off state with empty session info", () => {
+    const state = useLiveVoiceStore.getState();
+    expect(state.state).toBe("off");
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+    expect(state.partialTranscript).toBe("");
+    expect(state.finalTranscript).toBe("");
+    expect(state.assistantTranscript).toBe("");
+    expect(state.inputAmplitude).toBe(0);
+    expect(state.errorMessage).toBe("");
+  });
+
+  test("setState transitions through each lifecycle phase", () => {
+    const phases = [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+      "failed",
+      "off",
+    ] as const;
+
+    for (const phase of phases) {
+      useLiveVoiceStore.getState().setState(phase);
+      expect(useLiveVoiceStore.getState().state).toBe(phase);
+    }
+  });
+
+  test("setSessionInfo updates both session and conversation ids", () => {
+    useLiveVoiceStore.getState().setSessionInfo({
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    let state = useLiveVoiceStore.getState();
+    expect(state.sessionId).toBe("sess-1");
+    expect(state.conversationId).toBe("conv-1");
+
+    useLiveVoiceStore.getState().setSessionInfo({
+      sessionId: null,
+      conversationId: null,
+    });
+
+    state = useLiveVoiceStore.getState();
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+  });
+
+  test("setPartialTranscript replaces the partial transcript", () => {
+    useLiveVoiceStore.getState().setPartialTranscript("hello");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello");
+
+    useLiveVoiceStore.getState().setPartialTranscript("hello world");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello world");
+
+    useLiveVoiceStore.getState().setPartialTranscript("");
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("");
+  });
+
+  test("setFinalTranscript replaces the final transcript", () => {
+    useLiveVoiceStore.getState().setFinalTranscript("done");
+    expect(useLiveVoiceStore.getState().finalTranscript).toBe("done");
+
+    useLiveVoiceStore.getState().setFinalTranscript("done again");
+    expect(useLiveVoiceStore.getState().finalTranscript).toBe("done again");
+  });
+
+  test("appendAssistantTranscript concatenates streamed deltas", () => {
+    useLiveVoiceStore.getState().appendAssistantTranscript("hello");
+    useLiveVoiceStore.getState().appendAssistantTranscript(" ");
+    useLiveVoiceStore.getState().appendAssistantTranscript("world");
+
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe(
+      "hello world",
+    );
+  });
+
+  test("setInputAmplitude updates the amplitude", () => {
+    useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.42);
+
+    useLiveVoiceStore.getState().setInputAmplitude(0);
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0);
+  });
+
+  test("setError records the error message", () => {
+    useLiveVoiceStore.getState().setError("mic permission denied");
+    expect(useLiveVoiceStore.getState().errorMessage).toBe(
+      "mic permission denied",
+    );
+
+    useLiveVoiceStore.getState().setError("");
+    expect(useLiveVoiceStore.getState().errorMessage).toBe("");
+  });
+
+  test("reset returns the store to its initial state", () => {
+    const actions = useLiveVoiceStore.getState();
+    actions.setState("listening");
+    actions.setSessionInfo({
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+    actions.setPartialTranscript("partial");
+    actions.setFinalTranscript("final");
+    actions.appendAssistantTranscript("assistant");
+    actions.setInputAmplitude(0.5);
+    actions.setError("boom");
+
+    actions.reset();
+
+    const state = useLiveVoiceStore.getState();
+    expect(state.state).toBe("off");
+    expect(state.sessionId).toBeNull();
+    expect(state.conversationId).toBeNull();
+    expect(state.partialTranscript).toBe("");
+    expect(state.finalTranscript).toBe("");
+    expect(state.assistantTranscript).toBe("");
+    expect(state.inputAmplitude).toBe(0);
+    expect(state.errorMessage).toBe("");
+  });
+
+  test("createSelectors exposes a per-field hook for every state field", () => {
+    // The atomic-selector contract: every state field gets its own
+    // `use.<field>()` hook, so consumers can subscribe to one slice
+    // without re-rendering on unrelated mutations.
+    const expectedFields: ReadonlyArray<keyof typeof useLiveVoiceStore.use> = [
+      "state",
+      "sessionId",
+      "conversationId",
+      "partialTranscript",
+      "finalTranscript",
+      "assistantTranscript",
+      "inputAmplitude",
+      "errorMessage",
+    ];
+
+    for (const field of expectedFields) {
+      expect(typeof useLiveVoiceStore.use[field]).toBe("function");
+    }
+  });
+
+  test("state shape uses only primitive fields (no nested objects)", () => {
+    // createSelectors compares field references with ===; nested
+    // objects would break that contract by producing new references
+    // on every set(). This guard ensures we keep state flat.
+    const state = useLiveVoiceStore.getState();
+    const stateFields: ReadonlyArray<keyof LiveVoiceStoreState> = [
+      "state",
+      "sessionId",
+      "conversationId",
+      "partialTranscript",
+      "finalTranscript",
+      "assistantTranscript",
+      "inputAmplitude",
+      "errorMessage",
+    ];
+
+    for (const field of stateFields) {
+      const value = state[field];
+      const isPrimitive =
+        value === null ||
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean";
+      expect(isPrimitive).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/live-voice-store.test.ts
@@ -91,6 +91,14 @@ describe("LiveVoiceStore", () => {
     );
   });
 
+  test("clearAssistantTranscript wipes the accumulated transcript", () => {
+    useLiveVoiceStore.getState().appendAssistantTranscript("hello");
+    useLiveVoiceStore.getState().appendAssistantTranscript(" world");
+    useLiveVoiceStore.getState().clearAssistantTranscript();
+
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe("");
+  });
+
   test("setInputAmplitude updates the amplitude", () => {
     useLiveVoiceStore.getState().setInputAmplitude(0.42);
     expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.42);

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Unit tests for `LiveVoicePcmCapture` — verifies the lifecycle and
+ * message routing without spinning up a real `AudioContext` or
+ * microphone.
+ *
+ * Covers:
+ *  (a) `start()` returns `false` when `getUserMedia` rejects
+ *  (b) `start()` returns `true` and forwards chunks/amplitude from the
+ *      mock worklet to the supplied callbacks
+ *  (c) `stop()` is idempotent
+ *  (d) `shutdown()` releases MediaStream tracks and closes the
+ *      AudioContext, and is idempotent
+ *  (e) `stop()` issued before `getUserMedia` resolves cancels the
+ *      pending start and releases the late-arriving stream
+ *  (f) Two overlapping `start()` calls cooperate — only the latest
+ *      wins; the earlier one releases its stream
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { LiveVoicePcmCapture } from "../pcm-capture";
+
+// ---------------------------------------------------------------------------
+// Mock primitives
+// ---------------------------------------------------------------------------
+
+class MockMediaStreamTrack {
+  kind = "audio";
+  readyState: "live" | "ended" = "live";
+  stop() {
+    this.readyState = "ended";
+  }
+}
+
+class MockMediaStream {
+  private tracks: MockMediaStreamTrack[];
+  constructor() {
+    this.tracks = [new MockMediaStreamTrack()];
+  }
+  getTracks(): MockMediaStreamTrack[] {
+    return this.tracks;
+  }
+}
+
+class MockMessagePort {
+  onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  /** Test helper: simulate the worklet posting to the main thread. */
+  emit(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent<unknown>);
+  }
+}
+
+class MockAudioWorkletNode {
+  port = new MockMessagePort();
+  disconnectCount = 0;
+  connectedTo: unknown[] = [];
+  constructor(public context: MockAudioContext, public name: string) {
+    context.lastWorkletNode = this;
+  }
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
+  }
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
+class MockMediaStreamAudioSourceNode {
+  disconnectCount = 0;
+  connectedTo: unknown[] = [];
+  constructor(public context: MockAudioContext, public stream: MockMediaStream) {}
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
+  }
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
+class MockAudioWorklet {
+  loadedModules: string[] = [];
+  addModule(url: string): Promise<void> {
+    this.loadedModules.push(url);
+    return Promise.resolve();
+  }
+}
+
+class MockAudioDestinationNode {}
+
+class MockGainNode {
+  gain = { value: 1 };
+  disconnectCount = 0;
+  connectedTo: unknown[] = [];
+  constructor(public context: MockAudioContext) {}
+  connect(destination: unknown): void {
+    this.connectedTo.push(destination);
+  }
+  disconnect() {
+    this.disconnectCount += 1;
+  }
+}
+
+class MockAudioContext {
+  audioWorklet = new MockAudioWorklet();
+  destination = new MockAudioDestinationNode();
+  closed = false;
+  lastWorkletNode: MockAudioWorkletNode | null = null;
+  lastSourceNode: MockMediaStreamAudioSourceNode | null = null;
+  lastGainNode: MockGainNode | null = null;
+  createMediaStreamSource(stream: MockMediaStream): MockMediaStreamAudioSourceNode {
+    const node = new MockMediaStreamAudioSourceNode(this, stream);
+    this.lastSourceNode = node;
+    return node;
+  }
+  createGain(): MockGainNode {
+    const node = new MockGainNode(this);
+    this.lastGainNode = node;
+    return node;
+  }
+  close(): Promise<void> {
+    this.closed = true;
+    return Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global wiring
+// ---------------------------------------------------------------------------
+
+interface TestGlobals {
+  AudioContext: typeof MockAudioContext;
+  AudioWorkletNode: typeof MockAudioWorkletNode;
+  navigator: {
+    mediaDevices: {
+      getUserMedia: (constraints: unknown) => Promise<MockMediaStream>;
+    };
+  };
+}
+
+const originals = {
+  AudioContext: (globalThis as unknown as { AudioContext?: unknown })
+    .AudioContext,
+  AudioWorkletNode: (globalThis as unknown as { AudioWorkletNode?: unknown })
+    .AudioWorkletNode,
+  mediaDevices: (
+    globalThis as unknown as { navigator?: { mediaDevices?: unknown } }
+  ).navigator?.mediaDevices,
+};
+
+let mockStream: MockMediaStream | null = null;
+let getUserMediaImpl: (constraints: unknown) => Promise<MockMediaStream> = () =>
+  Promise.reject(new Error("getUserMedia not configured"));
+
+function installMocks() {
+  const g = globalThis as unknown as TestGlobals;
+  g.AudioContext = MockAudioContext;
+  g.AudioWorkletNode = MockAudioWorkletNode;
+
+  // Bun's happy-dom registrator sets `navigator`, so we patch
+  // `mediaDevices` rather than replacing the whole navigator object.
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      getUserMedia: (constraints: unknown) => getUserMediaImpl(constraints),
+    },
+  });
+}
+
+function restoreMocks() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (originals.AudioContext === undefined) {
+    delete g.AudioContext;
+  } else {
+    g.AudioContext = originals.AudioContext;
+  }
+  if (originals.AudioWorkletNode === undefined) {
+    delete g.AudioWorkletNode;
+  } else {
+    g.AudioWorkletNode = originals.AudioWorkletNode;
+  }
+  if (originals.mediaDevices === undefined) {
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: undefined,
+    });
+  } else {
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: originals.mediaDevices,
+    });
+  }
+}
+
+beforeEach(() => {
+  mockStream = null;
+  getUserMediaImpl = () =>
+    Promise.reject(new Error("getUserMedia not configured"));
+  installMocks();
+});
+
+afterEach(() => {
+  restoreMocks();
+});
+
+/**
+ * Test-only escape hatch for reading the capture's internal AudioContext.
+ * Keeps the public API surface clean while still letting tests drive the
+ * worklet port directly.
+ */
+function getInternalContext(capture: LiveVoicePcmCapture): MockAudioContext {
+  const ctx = (capture as unknown as { audioContext: MockAudioContext })
+    .audioContext;
+  expect(ctx).toBeInstanceOf(MockAudioContext);
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveVoicePcmCapture", () => {
+  it("returns false when getUserMedia rejects", async () => {
+    getUserMediaImpl = () => Promise.reject(new Error("denied"));
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(false);
+  });
+
+  it("returns true and forwards chunks/amplitude when worklet posts", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const chunks: { pcm16: Int16Array; frameCount: number; amplitude: number }[] = [];
+    const amplitudes: number[] = [];
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({
+      onChunk: (chunk) => chunks.push(chunk),
+      onAmplitude: (a) => amplitudes.push(a),
+    });
+    expect(ok).toBe(true);
+
+    // The most recently constructed worklet node lives on the
+    // AudioContext the capture is using. Reach in and simulate the
+    // audio-thread posting messages.
+    const lastContext = getInternalContext(capture);
+    const lastWorklet = lastContext.lastWorkletNode;
+    expect(lastWorklet).not.toBeNull();
+
+    const pcm = new Int16Array([1, 2, 3]);
+    lastWorklet!.port.emit({
+      type: "chunk",
+      pcm16: pcm,
+      frameCount: 3,
+      amplitude: 0.42,
+    });
+    lastWorklet!.port.emit({ type: "amplitude", amplitude: 0.75 });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.frameCount).toBe(3);
+    expect(chunks[0]!.amplitude).toBe(0.42);
+    expect(Array.from(chunks[0]!.pcm16)).toEqual([1, 2, 3]);
+    expect(amplitudes).toEqual([0.75]);
+
+    // Verify worklet module was registered at the expected static path.
+    expect(lastContext.audioWorklet.loadedModules).toEqual([
+      "/worklets/pcm16k-capture-processor.js",
+    ]);
+  });
+
+  it("connects the worklet through a muted GainNode to the destination", async () => {
+    // Regression: Web Audio only pulls render quanta along edges that
+    // terminate at `audioContext.destination`. Without the muted sink
+    // the AudioWorklet's `process()` never runs and live voice gets
+    // zero PCM chunks.
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+    expect(ok).toBe(true);
+
+    const lastContext = getInternalContext(capture);
+    const worklet = lastContext.lastWorkletNode!;
+    const gain = lastContext.lastGainNode!;
+    expect(gain).not.toBeNull();
+
+    // Worklet feeds into the GainNode, which feeds into destination.
+    expect(worklet.connectedTo).toContain(gain);
+    expect(gain.gain.value).toBe(0);
+    expect(gain.connectedTo).toContain(lastContext.destination);
+  });
+
+  it("stop() is idempotent", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    await capture.start({ onChunk: () => undefined });
+    const lastContext = getInternalContext(capture);
+    const worklet = lastContext.lastWorkletNode!;
+    const source = lastContext.lastSourceNode!;
+    const gain = lastContext.lastGainNode!;
+
+    capture.stop();
+    expect(worklet.disconnectCount).toBe(1);
+    expect(source.disconnectCount).toBe(1);
+    expect(gain.disconnectCount).toBe(1);
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
+
+    // Second stop is a no-op and does not throw.
+    expect(() => capture.stop()).not.toThrow();
+    expect(worklet.disconnectCount).toBe(1);
+    expect(source.disconnectCount).toBe(1);
+    expect(gain.disconnectCount).toBe(1);
+
+    // AudioContext stays warm after stop().
+    expect(lastContext.closed).toBe(false);
+  });
+
+  it("start() called while already active releases the previous MediaStream", async () => {
+    // Regression: previously `start()` only called `stopInternal()` when
+    // restarting, leaving the old MediaStream alive and leaking the mic.
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const s = new MockMediaStream();
+      streams.push(s);
+      return Promise.resolve(s);
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const ok1 = await capture.start({ onChunk: () => undefined });
+    expect(ok1).toBe(true);
+    const ok2 = await capture.start({ onChunk: () => undefined });
+    expect(ok2).toBe(true);
+
+    // Two distinct streams were opened; the first one must have been
+    // released so the OS-level mic indicator can clear.
+    expect(streams).toHaveLength(2);
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+  });
+
+  it("shutdown() releases MediaStream tracks, closes AudioContext, and is idempotent", async () => {
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+
+    const capture = new LiveVoicePcmCapture();
+    await capture.start({ onChunk: () => undefined });
+    const lastContext = getInternalContext(capture);
+    const gain = lastContext.lastGainNode!;
+
+    capture.shutdown();
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
+    expect(lastContext.closed).toBe(true);
+    expect(gain.disconnectCount).toBe(1);
+
+    // Second shutdown is a no-op.
+    expect(() => capture.shutdown()).not.toThrow();
+    expect(lastContext.closed).toBe(true);
+    expect(gain.disconnectCount).toBe(1);
+
+    // start() after shutdown returns false.
+    const ok = await capture.start({ onChunk: () => undefined });
+    expect(ok).toBe(false);
+  });
+
+  it("stop() during a pending start() cancels it and releases the late stream", async () => {
+    // Regression: in a push-to-talk flow, the user can release the key
+    // before `getUserMedia()` resolves. The pending start must observe
+    // the cancellation, release the stream that does eventually arrive,
+    // and return false rather than wiring up a phantom mic.
+    let resolveGetUserMedia: ((stream: MockMediaStream) => void) | null = null;
+    const pendingStream = new MockMediaStream();
+    getUserMediaImpl = () =>
+      new Promise<MockMediaStream>((resolve) => {
+        resolveGetUserMedia = resolve;
+      });
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise = capture.start({ onChunk: () => undefined });
+
+    // User releases PTT key before `getUserMedia` resolves.
+    capture.stop();
+
+    // Now permission grant resolves, late — pending start should
+    // release the stream and bail.
+    expect(resolveGetUserMedia).not.toBeNull();
+    resolveGetUserMedia!(pendingStream);
+
+    const ok = await startPromise;
+    expect(ok).toBe(false);
+    expect(pendingStream.getTracks()[0]!.readyState).toBe("ended");
+
+    // No nodes should have been wired up.
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    const internalWorklet = (
+      capture as unknown as { workletNode: MockAudioWorkletNode | null }
+    ).workletNode;
+    expect(internalStream).toBeNull();
+    expect(internalWorklet).toBeNull();
+  });
+
+  it("two overlapping start() calls cancel the earlier one and only the latest wins", async () => {
+    // Regression: prior to the generation counter, both starts would
+    // race past the synchronous guard and the slower one would
+    // overwrite the stored nodes, leaving the earlier capture's
+    // MediaStream dangling.
+    const resolvers: ((stream: MockMediaStream) => void)[] = [];
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const stream = new MockMediaStream();
+      streams.push(stream);
+      return new Promise<MockMediaStream>((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise1 = capture.start({ onChunk: () => undefined });
+    const startPromise2 = capture.start({ onChunk: () => undefined });
+
+    // Both starts are pending on getUserMedia; the second one bumped
+    // the generation past the first.
+    expect(resolvers).toHaveLength(2);
+    expect(streams).toHaveLength(2);
+
+    // Resolve the FIRST start last to exercise the "earlier resolves
+    // last" ordering too. Actually we want the first to resolve first
+    // to mirror the bug scenario where the slower second overwrites
+    // the first's nodes. With the generation counter both orderings
+    // are correct — the first call always loses regardless of order.
+    resolvers[0]!(streams[0]!);
+    resolvers[1]!(streams[1]!);
+
+    const [ok1, ok2] = await Promise.all([startPromise1, startPromise2]);
+
+    expect(ok1).toBe(false);
+    expect(ok2).toBe(true);
+
+    // The first call's stream must be released; the second's must be
+    // live and wired up.
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    expect(internalStream).toBe(streams[1]!);
+  });
+
+  it("two overlapping start() calls — earlier resolves last, latest still wins", async () => {
+    // Same as above but with the resolution order swapped: the second
+    // (winning) start resolves first, then the stale first one
+    // resolves. The first must still release its stream and not
+    // clobber the second's nodes.
+    const resolvers: ((stream: MockMediaStream) => void)[] = [];
+    const streams: MockMediaStream[] = [];
+    getUserMediaImpl = () => {
+      const stream = new MockMediaStream();
+      streams.push(stream);
+      return new Promise<MockMediaStream>((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const capture = new LiveVoicePcmCapture();
+    const startPromise1 = capture.start({ onChunk: () => undefined });
+    const startPromise2 = capture.start({ onChunk: () => undefined });
+
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[1]!(streams[1]!);
+    resolvers[0]!(streams[0]!);
+
+    const [ok1, ok2] = await Promise.all([startPromise1, startPromise2]);
+    expect(ok1).toBe(false);
+    expect(ok2).toBe(true);
+    expect(streams[0]!.getTracks()[0]!.readyState).toBe("ended");
+    expect(streams[1]!.getTracks()[0]!.readyState).toBe("live");
+
+    const internalStream = (
+      capture as unknown as { stream: MockMediaStream | null }
+    ).stream;
+    expect(internalStream).toBe(streams[1]!);
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-capture.test.ts
@@ -101,9 +101,56 @@ class MockGainNode {
 }
 
 class MockAudioContext {
+  /**
+   * Initial `state` for the next-constructed `MockAudioContext`. The
+   * capture instantiates its context internally, so tests use this
+   * static hook to drive the suspended-context branch without reaching
+   * into private state.
+   */
+  static nextInitialState: "suspended" | "running" | "closed" | null = null;
+  /**
+   * Override `resume()` impl for the next-constructed context. Lets
+   * tests simulate a resume rejection without prototype patching.
+   */
+  static nextResumeImpl: (() => Promise<void>) | null = null;
+  static lastInstance: MockAudioContext | null = null;
   audioWorklet = new MockAudioWorklet();
   destination = new MockAudioDestinationNode();
   closed = false;
+  /**
+   * Mirrors the real `AudioContext.state` so the capture's
+   * suspended-context branch can be exercised. Defaults to `"running"`;
+   * tests that need to drive the suspended path set
+   * `MockAudioContext.nextInitialState = "suspended"` before invoking
+   * `start()` and supply a `resumeImpl` via `MockAudioContext.lastInstance`.
+   */
+  state: "suspended" | "running" | "closed" = "running";
+
+  constructor() {
+    if (MockAudioContext.nextInitialState !== null) {
+      this.state = MockAudioContext.nextInitialState;
+      MockAudioContext.nextInitialState = null;
+    }
+    if (MockAudioContext.nextResumeImpl !== null) {
+      this.resumeImpl = MockAudioContext.nextResumeImpl;
+      MockAudioContext.nextResumeImpl = null;
+    }
+    MockAudioContext.lastInstance = this;
+  }
+  /**
+   * Number of times `resume()` has been called. Tests assert this
+   * to verify the suspended-context branch ran.
+   */
+  resumeCalls = 0;
+  /**
+   * Override hook for `resume()` — by default it flips `state` to
+   * `"running"` and resolves. Tests that need to simulate a rejection
+   * (e.g. user-gesture missing) overwrite this with a rejecting impl.
+   */
+  resumeImpl: () => Promise<void> = () => {
+    this.state = "running";
+    return Promise.resolve();
+  };
   lastWorkletNode: MockAudioWorkletNode | null = null;
   lastSourceNode: MockMediaStreamAudioSourceNode | null = null;
   lastGainNode: MockGainNode | null = null;
@@ -116,6 +163,10 @@ class MockAudioContext {
     const node = new MockGainNode(this);
     this.lastGainNode = node;
     return node;
+  }
+  resume(): Promise<void> {
+    this.resumeCalls += 1;
+    return this.resumeImpl();
   }
   close(): Promise<void> {
     this.closed = true;
@@ -195,6 +246,9 @@ beforeEach(() => {
   mockStream = null;
   getUserMediaImpl = () =>
     Promise.reject(new Error("getUserMedia not configured"));
+  MockAudioContext.nextInitialState = null;
+  MockAudioContext.nextResumeImpl = null;
+  MockAudioContext.lastInstance = null;
   installMocks();
 });
 
@@ -451,6 +505,48 @@ describe("LiveVoicePcmCapture", () => {
       capture as unknown as { stream: MockMediaStream | null }
     ).stream;
     expect(internalStream).toBe(streams[1]!);
+  });
+
+  it("resumes a suspended AudioContext before reporting capture started", async () => {
+    // Regression: Chrome's autoplay policy and mobile Safari's tab
+    // lifecycle can leave the AudioContext in `"suspended"` immediately
+    // after construction. Without an explicit `resume()`, the worklet's
+    // `process()` never runs and live voice gets zero PCM chunks while
+    // the UI silently reports "Listening…".
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+    MockAudioContext.nextInitialState = "suspended";
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(true);
+    const ctx = getInternalContext(capture);
+    expect(ctx.resumeCalls).toBe(1);
+    expect(ctx.state).toBe("running");
+  });
+
+  it("returns false when resuming a suspended AudioContext rejects", async () => {
+    // Regression companion to the suspended-resume test: if the browser
+    // refuses to resume (e.g. no preceding user gesture on Safari),
+    // returning `true` would leave the manager reporting "Listening…"
+    // with no audio flowing. Treat the rejection as a start failure so
+    // the manager can transition the UI to `failed` and offer retry.
+    mockStream = new MockMediaStream();
+    getUserMediaImpl = () => Promise.resolve(mockStream as MockMediaStream);
+    MockAudioContext.nextInitialState = "suspended";
+    MockAudioContext.nextResumeImpl = () =>
+      Promise.reject(new Error("blocked"));
+
+    const capture = new LiveVoicePcmCapture();
+    const ok = await capture.start({ onChunk: () => undefined });
+
+    expect(ok).toBe(false);
+    const ctx = MockAudioContext.lastInstance;
+    expect(ctx).not.toBeNull();
+    expect(ctx!.resumeCalls).toBe(1);
+    // Stream must be released on the failure path.
+    expect(mockStream!.getTracks()[0]!.readyState).toBe("ended");
   });
 
   it("two overlapping start() calls — earlier resolves last, latest still wins", async () => {

--- a/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/pcm-playback.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import {
+    LiveVoicePcmPlayback,
+    type AudioBufferLike,
+    type AudioBufferSourceNodeLike,
+    type AudioDestinationNodeLike,
+    type PcmAudioContextLike,
+} from "@/domains/voice/live-voice/pcm-playback";
+
+interface ScheduledNode {
+    node: AudioBufferSourceNodeLike;
+    startedAt: number | undefined;
+    stoppedAt: number | undefined;
+    buffer: AudioBufferLike | null;
+}
+
+class MockAudioBuffer implements AudioBufferLike {
+    readonly duration: number;
+    private readonly channels: Float32Array[];
+
+    constructor(channelCount: number, frameCount: number, sampleRate: number) {
+        this.duration = frameCount / sampleRate;
+        this.channels = Array.from({ length: channelCount }, () => new Float32Array(frameCount));
+    }
+
+    getChannelData(channel: number): Float32Array {
+        const data = this.channels[channel];
+        if (!data) throw new Error(`channel ${channel} out of range`);
+        return data;
+    }
+
+    copyToChannel(source: Float32Array, channel: number): void {
+        this.getChannelData(channel).set(source);
+    }
+}
+
+class MockAudioContext implements PcmAudioContextLike {
+    currentTime = 0;
+    readonly destination: AudioDestinationNodeLike = {};
+    readonly scheduled: ScheduledNode[] = [];
+
+    createBuffer(channels: number, frameCount: number, sampleRate: number): AudioBufferLike {
+        return new MockAudioBuffer(channels, frameCount, sampleRate);
+    }
+
+    createBufferSource(): AudioBufferSourceNodeLike {
+        const tracked: ScheduledNode = {
+            node: undefined as unknown as AudioBufferSourceNodeLike,
+            startedAt: undefined,
+            stoppedAt: undefined,
+            buffer: null,
+        };
+        const node: AudioBufferSourceNodeLike = {
+            buffer: null,
+            onended: null,
+            connect: () => {},
+            start: (when?: number) => {
+                tracked.startedAt = when;
+                tracked.buffer = node.buffer;
+            },
+            stop: (when?: number) => {
+                tracked.stoppedAt = when;
+            },
+        };
+        tracked.node = node;
+        this.scheduled.push(tracked);
+        return node;
+    }
+
+    advanceTo(seconds: number): void {
+        this.currentTime = seconds;
+    }
+}
+
+function pcmChunk(samples: number[], sampleRate = 24000, channels = 1) {
+    const bytes = new Uint8Array(samples.length * 2);
+    const view = new DataView(bytes.buffer);
+    for (let i = 0; i < samples.length; i += 1) {
+        view.setInt16(i * 2, samples[i] ?? 0, true);
+    }
+    return {
+        pcm: bytes,
+        mimeType: "audio/pcm",
+        sampleRate,
+        channels,
+    };
+}
+
+describe("LiveVoicePcmPlayback", () => {
+    it("schedules consecutive PCM chunks back-to-back without gaps", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        const samplesA = new Array(2400).fill(100); // 0.1s @ 24kHz
+        const samplesB = new Array(4800).fill(200); // 0.2s @ 24kHz
+        playback.enqueueTtsAudio(pcmChunk(samplesA));
+        playback.enqueueTtsAudio(pcmChunk(samplesB));
+
+        expect(ctx.scheduled).toHaveLength(2);
+        const first = ctx.scheduled[0];
+        const second = ctx.scheduled[1];
+        expect(first?.startedAt).toBe(0);
+        expect(first?.buffer?.duration).toBeCloseTo(0.1, 5);
+        // Second start time must equal the first's end time — gapless.
+        expect(second?.startedAt).toBeCloseTo(0.1, 5);
+        expect(second?.buffer?.duration).toBeCloseTo(0.2, 5);
+    });
+
+    it("handleInterrupt() stops all scheduled nodes and resets the cursor", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(playback.isPlaying).toBe(true);
+
+        playback.handleInterrupt();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBe(0);
+        }
+
+        // Cursor reset — current time is still 0, so isPlaying is false.
+        expect(playback.isPlaying).toBe(false);
+
+        // After interrupt + reset, a fresh enqueue starts at currentTime (0),
+        // not accumulated on top of the prior cursor.
+        playback.resetForNextResponse();
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        const fresh = ctx.scheduled[ctx.scheduled.length - 1];
+        expect(fresh?.startedAt).toBe(0);
+    });
+
+    it("waitUntilPlaybackFinishes() resolves only after the cursor is reached", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // 0.05s @ 24kHz = 1200 samples
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // Synchronously, the promise hasn't resolved yet.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Advance the mock clock past the cursor; the scheduled setTimeout
+        // (50ms) will fire after that real-time delay.
+        ctx.advanceTo(0.05);
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("waitUntilPlaybackFinishes() resolves immediately when no audio is queued", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // Never called the factory — should resolve without scheduling work.
+        await playback.waitUntilPlaybackFinishes();
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+        ctx.advanceTo(1);
+        // After advancing past the cursor, the promise resolves synchronously.
+        await playback.waitUntilPlaybackFinishes();
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("drops non-PCM chunks with a warning and does not throw", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        expect(() => {
+            playback.enqueueTtsAudio({
+                pcm: new Uint8Array([0xff, 0xfb, 0x00, 0x00]),
+                mimeType: "audio/mpeg",
+                sampleRate: 24000,
+                channels: 1,
+            });
+        }).not.toThrow();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("drops PCM chunks whose byte length isn't aligned to Int16", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x01, 0x02, 0x03]), // odd length
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("decodes PCM16 LE samples to normalized Float32 values", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // -32768, 0, 32767 — covers min, mid, near-max
+        const chunk = pcmChunk([-32768, 0, 32767]);
+        playback.enqueueTtsAudio(chunk);
+
+        const buffer = ctx.scheduled[0]?.buffer;
+        expect(buffer).not.toBeNull();
+        const data = buffer!.getChannelData(0);
+        expect(data[0]).toBeCloseTo(-1, 5);
+        expect(data[1]).toBe(0);
+        expect(data[2]).toBeCloseTo(32767 / 32768, 5);
+    });
+
+    it("resetForNextResponse() preserves the cursor between back-to-back responses", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0))); // 0.1s
+        playback.resetForNextResponse();
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+
+        const first = ctx.scheduled[0];
+        const second = ctx.scheduled[1];
+        expect(first?.startedAt).toBe(0);
+        // Cursor still in effect — second chunk schedules after the first.
+        expect(second?.startedAt).toBeCloseTo(0.1, 5);
+    });
+
+    it("handleSessionError() stops scheduled nodes like an interrupt", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleSessionError();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBe(0);
+        }
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleSessionError() drops late TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleSessionError();
+
+        const scheduledCount = ctx.scheduled.length;
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        // No new node was scheduled — `acceptsAudio` gate dropped the chunk.
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("handleEnd() stops scheduled nodes and resets the cursor", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+
+        for (const entry of ctx.scheduled) {
+            expect(entry.stoppedAt).toBe(0);
+        }
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleInterrupt() drops late TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleInterrupt();
+
+        const scheduledCount = ctx.scheduled.length;
+        // A delayed TTS chunk arriving after the interrupt must be dropped —
+        // mirrors `LiveVoiceAudioPlayer.stop(reason: .interrupt)` behaviour.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("handleEnd() drops subsequent TTS chunks until resetForNextResponse()", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+
+        const scheduledCount = ctx.scheduled.length;
+        // Once the user ends the live voice session, TTS must not resume —
+        // any chunks that race the session-end must be dropped.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(scheduledCount);
+    });
+
+    it("resetForNextResponse() re-enables enqueue after an interrupt", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleInterrupt();
+
+        const beforeReset = ctx.scheduled.length;
+        // Sanity: gate is closed after the interrupt.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(beforeReset);
+
+        playback.resetForNextResponse();
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        // After reset, the next assistant turn can play again.
+        expect(ctx.scheduled).toHaveLength(beforeReset + 1);
+        const fresh = ctx.scheduled[ctx.scheduled.length - 1];
+        expect(fresh?.startedAt).toBe(0);
+    });
+
+    it("handleInterrupt() resolves a pending waitUntilPlaybackFinishes() promise without waiting for the original cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // 0.5s @ 24kHz = 12000 samples — long enough that a real setTimeout
+        // would visibly stall the test if the waiter weren't resolved early.
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // Synchronously, the waiter hasn't fired.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Interrupt before the cursor (0.5s) is reached. The waiter should
+        // resolve promptly rather than waiting for the original duration.
+        playback.handleInterrupt();
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleEnd() resolves a pending waitUntilPlaybackFinishes() promise without waiting for the original cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0))); // 0.5s
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        playback.handleEnd();
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+
+    it("handleSessionError() resolves a pending waitUntilPlaybackFinishes() promise", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(12000).fill(0))); // 0.5s
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        playback.handleSessionError();
+        await wait;
+        expect(resolved).toBe(true);
+    });
+
+    it("resetForNextResponse() re-enables enqueue after handleEnd", () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        playback.handleEnd();
+        playback.resetForNextResponse();
+
+        const beforeEnqueue = ctx.scheduled.length;
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0)));
+        expect(ctx.scheduled).toHaveLength(beforeEnqueue + 1);
+    });
+
+    it("accepts audio/pcm with no parameters", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("accepts audio/pcm with parameters", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcm;rate=16000",
+            sampleRate: 16000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("accepts audio/PCM case-insensitively", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/PCM",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(0);
+        expect(ctx.scheduled).toHaveLength(1);
+    });
+
+    it("rejects audio/pcma (G.711 A-law)", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcma",
+            sampleRate: 8000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("rejects audio/pcmu (G.711 mu-law)", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/pcmu",
+            sampleRate: 8000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("rejects audio/wav", () => {
+        const ctx = new MockAudioContext();
+        const warn = mock(() => {});
+        const playback = new LiveVoicePcmPlayback({
+            audioContextFactory: () => ctx,
+            logger: { warn },
+        });
+
+        playback.enqueueTtsAudio({
+            pcm: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            mimeType: "audio/wav",
+            sampleRate: 24000,
+            channels: 1,
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(ctx.scheduled).toHaveLength(0);
+    });
+
+    it("waitUntilPlaybackFinishes() keeps waiting when a new chunk extends the cursor", async () => {
+        const ctx = new MockAudioContext();
+        const playback = new LiveVoicePcmPlayback({ audioContextFactory: () => ctx });
+
+        // First chunk: 0.05s
+        playback.enqueueTtsAudio(pcmChunk(new Array(1200).fill(0)));
+
+        let resolved = false;
+        const wait = playback.waitUntilPlaybackFinishes().then(() => {
+            resolved = true;
+        });
+
+        // The waiter is pending against the 0.05s cursor.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Enqueue a second chunk before the first finishes — extends the
+        // cursor from 0.05s to 0.15s.
+        playback.enqueueTtsAudio(pcmChunk(new Array(2400).fill(0))); // 0.1s
+
+        // Advance past where the FIRST chunk ended. The waiter must NOT
+        // resolve here — buffered audio still extends to 0.15s.
+        ctx.advanceTo(0.05);
+        // Give the rescheduled timer enough wall time to fire if it were
+        // pointed at the old cursor (~50ms is what the original waiter delay
+        // was). After this, the still-pending timer should be a ~100ms one
+        // counting toward the extended cursor.
+        await new Promise((r) => setTimeout(r, 60));
+        expect(resolved).toBe(false);
+
+        // Advance past the extended cursor — the rescheduled timer fires
+        // shortly after, resolving the waiter.
+        ctx.advanceTo(0.2);
+        await wait;
+        expect(resolved).toBe(true);
+        expect(playback.isPlaying).toBe(false);
+    });
+});

--- a/apps/web/src/domains/voice/live-voice/__tests__/protocol.test.ts
+++ b/apps/web/src/domains/voice/live-voice/__tests__/protocol.test.ts
@@ -1,0 +1,618 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  base64ToPcm16,
+  encodeClientControlFrame,
+  encodeClientStartFrame,
+  LIVE_VOICE_AUDIO_PCM16K_MONO,
+  type LiveVoiceServerFrame,
+  parseServerBinaryFrame,
+  parseServerTextFrame,
+  pcm16ToBase64,
+} from "../protocol";
+
+// ---------------------------------------------------------------------------
+// Client frame encoders
+// ---------------------------------------------------------------------------
+
+describe("encodeClientStartFrame", () => {
+  test("encodes a start frame with conversationId", () => {
+    const json = encodeClientStartFrame({
+      conversationId: "conv-123",
+      audio: LIVE_VOICE_AUDIO_PCM16K_MONO,
+    });
+
+    expect(JSON.parse(json)).toEqual({
+      type: "start",
+      conversationId: "conv-123",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 16000,
+        channels: 1,
+      },
+    });
+  });
+
+  test("omits conversationId when not provided", () => {
+    const json = encodeClientStartFrame({
+      audio: LIVE_VOICE_AUDIO_PCM16K_MONO,
+    });
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toEqual({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 16000,
+        channels: 1,
+      },
+    });
+    expect("conversationId" in parsed).toBe(false);
+  });
+
+  test("LIVE_VOICE_AUDIO_PCM16K_MONO matches the Swift reference", () => {
+    expect(LIVE_VOICE_AUDIO_PCM16K_MONO).toEqual({
+      mimeType: "audio/pcm",
+      sampleRate: 16000,
+      channels: 1,
+    });
+  });
+});
+
+describe("encodeClientControlFrame", () => {
+  test("encodes each control frame type", () => {
+    for (const type of ["ptt_release", "interrupt", "end"] as const) {
+      expect(JSON.parse(encodeClientControlFrame(type))).toEqual({ type });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server text frame parsing — round-trip per type
+// ---------------------------------------------------------------------------
+
+function roundTripServerFrame(frame: LiveVoiceServerFrame): void {
+  const result = parseServerTextFrame(JSON.stringify(frame));
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;
+  expect(result.frame).toEqual(frame);
+}
+
+describe("parseServerTextFrame", () => {
+  test("round-trips ready frames", () => {
+    roundTripServerFrame({
+      type: "ready",
+      seq: 1,
+      sessionId: "session-abc",
+      conversationId: "conv-123",
+    });
+  });
+
+  test("round-trips busy frames", () => {
+    roundTripServerFrame({
+      type: "busy",
+      seq: 1,
+      activeSessionId: "session-def",
+    });
+  });
+
+  test("round-trips stt_partial and stt_final frames", () => {
+    roundTripServerFrame({ type: "stt_partial", seq: 2, text: "hel" });
+    roundTripServerFrame({ type: "stt_final", seq: 3, text: "hello" });
+  });
+
+  test("round-trips thinking frames", () => {
+    roundTripServerFrame({ type: "thinking", seq: 4, turnId: "turn-1" });
+  });
+
+  test("round-trips assistant_text_delta frames", () => {
+    roundTripServerFrame({
+      type: "assistant_text_delta",
+      seq: 5,
+      text: "hi",
+    });
+  });
+
+  test("round-trips tts_audio frames", () => {
+    roundTripServerFrame({
+      type: "tts_audio",
+      seq: 6,
+      mimeType: "audio/wav",
+      sampleRate: 24000,
+      dataBase64: "AQIDBA==",
+    });
+  });
+
+  test("round-trips tts_done frames", () => {
+    roundTripServerFrame({ type: "tts_done", seq: 7, turnId: "turn-1" });
+  });
+
+  test("round-trips metrics frames with all-nullable timings", () => {
+    roundTripServerFrame({
+      type: "metrics",
+      seq: 8,
+      turnId: "turn-1",
+      sttMs: 25,
+      llmFirstDeltaMs: null,
+      ttsFirstAudioMs: 100,
+      totalMs: null,
+    });
+  });
+
+  test("round-trips metrics frames with optional fields", () => {
+    roundTripServerFrame({
+      type: "metrics",
+      seq: 9,
+      event: "turn_complete",
+      sessionId: "session-1",
+      conversationId: "conv-1",
+      turnId: "turn-1",
+      metrics: { extra: "data" },
+      sttMs: 10,
+      llmFirstDeltaMs: 20,
+      ttsFirstAudioMs: 30,
+      totalMs: 60,
+    });
+  });
+
+  test("round-trips archived frames (minimal and full)", () => {
+    roundTripServerFrame({
+      type: "archived",
+      seq: 10,
+      conversationId: "conv-1",
+      sessionId: "session-1",
+    });
+
+    roundTripServerFrame({
+      type: "archived",
+      seq: 11,
+      conversationId: "conv-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+      role: "assistant",
+      attachmentId: "att-1",
+      attachmentIds: ["att-1", "att-2"],
+      warning: { code: "partial", message: "missing audio" },
+    });
+  });
+
+  test("round-trips error frames", () => {
+    roundTripServerFrame({
+      type: "error",
+      seq: 12,
+      code: "invalid_frame",
+      message: "bad",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server text frame parsing — negative cases
+// ---------------------------------------------------------------------------
+
+describe("parseServerTextFrame error branches", () => {
+  test("invalid JSON", () => {
+    const result = parseServerTextFrame("{");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("invalid_json");
+  });
+
+  test("non-object JSON", () => {
+    const result = parseServerTextFrame("[]");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("invalid_frame");
+  });
+
+  test("missing type field", () => {
+    const result = parseServerTextFrame(JSON.stringify({ seq: 1 }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "type",
+    });
+  });
+
+  test("non-string type field", () => {
+    const result = parseServerTextFrame(JSON.stringify({ type: 5, seq: 1 }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({ code: "invalid_field", field: "type" });
+  });
+
+  test("unknown type", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "pause", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "unknown_type",
+      frameType: "pause",
+    });
+  });
+
+  test("missing seq", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "ready", sessionId: "s", conversationId: "c" }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "seq",
+    });
+  });
+
+  test("non-integer seq", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "ready",
+        seq: -1,
+        sessionId: "s",
+        conversationId: "c",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({ code: "invalid_field", field: "seq" });
+  });
+
+  test("ready frame missing sessionId", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "ready", seq: 1, conversationId: "c" }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "sessionId",
+      frameType: "ready",
+    });
+  });
+
+  test("busy frame missing activeSessionId", () => {
+    const result = parseServerTextFrame(JSON.stringify({ type: "busy", seq: 1 }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "activeSessionId",
+      frameType: "busy",
+    });
+  });
+
+  test("stt_partial frame missing text", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "stt_partial", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "text",
+      frameType: "stt_partial",
+    });
+  });
+
+  test("stt_final frame missing text", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "stt_final", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "text",
+      frameType: "stt_final",
+    });
+  });
+
+  test("thinking frame missing turnId", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "thinking", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "turnId",
+      frameType: "thinking",
+    });
+  });
+
+  test("assistant_text_delta frame missing text", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "assistant_text_delta", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "text",
+      frameType: "assistant_text_delta",
+    });
+  });
+
+  test("tts_audio frame missing mimeType", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "tts_audio",
+        seq: 1,
+        sampleRate: 24000,
+        dataBase64: "AQIDBA==",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "mimeType",
+    });
+  });
+
+  test("tts_audio frame with malformed base64", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "tts_audio",
+        seq: 1,
+        mimeType: "audio/wav",
+        sampleRate: 24000,
+        dataBase64: "not base64",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("invalid_audio_payload");
+  });
+
+  test("tts_audio frame with invalid sampleRate", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "tts_audio",
+        seq: 1,
+        mimeType: "audio/wav",
+        sampleRate: 0,
+        dataBase64: "AQIDBA==",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "sampleRate",
+    });
+  });
+
+  test("tts_done frame missing turnId", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "tts_done", seq: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "turnId",
+      frameType: "tts_done",
+    });
+  });
+
+  test("metrics frame with non-integer timing", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "metrics",
+        seq: 1,
+        turnId: "turn-1",
+        sttMs: "fast",
+        llmFirstDeltaMs: null,
+        ttsFirstAudioMs: null,
+        totalMs: null,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "sttMs",
+    });
+  });
+
+  test("archived frame missing conversationId", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "archived", seq: 1, sessionId: "s" }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "conversationId",
+      frameType: "archived",
+    });
+  });
+
+  test("archived frame with invalid role", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "archived",
+        seq: 1,
+        conversationId: "c",
+        sessionId: "s",
+        role: "system",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "role",
+    });
+  });
+
+  test("archived frame with bad attachmentIds", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "archived",
+        seq: 1,
+        conversationId: "c",
+        sessionId: "s",
+        attachmentIds: [1, 2],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "attachmentIds",
+    });
+  });
+
+  test("archived frame with malformed warning", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "archived",
+        seq: 1,
+        conversationId: "c",
+        sessionId: "s",
+        warning: "uh oh",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "warning",
+    });
+  });
+
+  test("error frame with unknown code", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({
+        type: "error",
+        seq: 1,
+        code: "totally_made_up",
+        message: "bad",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "code",
+    });
+  });
+
+  test("error frame missing message", () => {
+    const result = parseServerTextFrame(
+      JSON.stringify({ type: "error", seq: 1, code: "invalid_frame" }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "message",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server binary frame parsing
+// ---------------------------------------------------------------------------
+
+describe("parseServerBinaryFrame", () => {
+  test("wraps ArrayBuffer payloads", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const result = parseServerBinaryFrame(bytes.buffer);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frame.type).toBe("binary_audio");
+    expect(Array.from(result.frame.data)).toEqual([1, 2, 3]);
+  });
+
+  test("wraps ArrayBufferView payloads", () => {
+    const source = new Uint8Array([9, 8, 7, 6]);
+    const result = parseServerBinaryFrame(source.subarray(1, 3));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Array.from(result.frame.data)).toEqual([8, 7]);
+  });
+
+  test("rejects empty ArrayBuffer", () => {
+    const result = parseServerBinaryFrame(new ArrayBuffer(0));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_audio_payload",
+      field: "data",
+      frameType: "binary_audio",
+    });
+  });
+
+  test("rejects empty ArrayBufferView", () => {
+    const result = parseServerBinaryFrame(new Uint8Array(0));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("invalid_audio_payload");
+  });
+
+  test("rejects non-binary payloads", () => {
+    const result = parseServerBinaryFrame("AQIDBA==");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("invalid_audio_payload");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Base64 PCM helpers
+// ---------------------------------------------------------------------------
+
+describe("pcm16ToBase64 / base64ToPcm16", () => {
+  test("round-trips an empty buffer", () => {
+    const encoded = pcm16ToBase64(new Int16Array(0));
+    expect(encoded).toBe("");
+    expect(base64ToPcm16(encoded).length).toBe(0);
+  });
+
+  test("round-trips a small buffer", () => {
+    const samples = new Int16Array([0, 1, -1, 32767, -32768, 1234, -5678]);
+    const encoded = pcm16ToBase64(samples);
+    const decoded = base64ToPcm16(encoded);
+    expect(Array.from(decoded)).toEqual(Array.from(samples));
+  });
+
+  test("round-trips a buffer > 100 kB without stack overflow", () => {
+    // 65,536 samples = 128 KiB of PCM16 data, well past the chunk
+    // size (32 KiB) so we exercise the chunked-encode path.
+    const samples = new Int16Array(65_536);
+    for (let i = 0; i < samples.length; i++) {
+      samples[i] = ((i * 7919) % 65_536) - 32_768;
+    }
+    const encoded = pcm16ToBase64(samples);
+    expect(encoded.length).toBeGreaterThan(100_000);
+    const decoded = base64ToPcm16(encoded);
+    expect(decoded.length).toBe(samples.length);
+    expect(decoded[0]).toBe(samples[0]);
+    expect(decoded[decoded.length - 1]).toBe(samples[samples.length - 1]);
+    expect(decoded[12_345]).toBe(samples[12_345]);
+  });
+
+  test("base64ToPcm16 throws on odd byte length", () => {
+    // 3 bytes of base64 -> invalid for PCM16
+    const oddBase64 = btoa("abc");
+    expect(() => base64ToPcm16(oddBase64)).toThrow();
+  });
+
+  test("base64ToPcm16 throws on malformed base64", () => {
+    expect(() => base64ToPcm16("@@@@")).toThrow();
+  });
+
+  test("pcm16ToBase64 handles a buffer view that is a subarray", () => {
+    const backing = new Int16Array([1, 2, 3, 4, 5, 6]);
+    const view = backing.subarray(1, 5);
+    const encoded = pcm16ToBase64(view);
+    const decoded = base64ToPcm16(encoded);
+    expect(Array.from(decoded)).toEqual([2, 3, 4, 5]);
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -75,11 +75,17 @@ export function LiveVoiceButton({
   const state = useLiveVoiceStore.use.state();
   const errorMessage = useLiveVoiceStore.use.errorMessage();
 
+  const gateOpen = voiceModeEnabled && assistantId !== null;
+
   // `useRef` (not `useState`) so React strict-mode's double-invoke of
   // render doesn't build two managers and leak the first one's
-  // WebSocket / mic handles.
+  // WebSocket / mic handles. We only construct the manager once the
+  // gate is open — for flag-off or assistantId-null mounts, leaving the
+  // ref null keeps the unmount + gate-close `end()` calls no-ops so we
+  // don't churn `useLiveVoiceStore` (which the manager's `end()` resets
+  // via `actions().reset()`) on every disabled render.
   const managerRef = useRef<LiveVoiceButtonManager | null>(null);
-  if (managerRef.current === null) {
+  if (managerRef.current === null && gateOpen) {
     managerRef.current = managerFactory
       ? managerFactory()
       : new LiveVoiceChannelManager();
@@ -87,11 +93,12 @@ export function LiveVoiceButton({
 
   // Fire-and-forget: React's cleanup is sync, the manager's `end()` is
   // async. Dropping the promise is safe — the component has already
-  // left the tree, so there's nothing to surface failures to.
+  // left the tree, so there's nothing to surface failures to. When the
+  // gate was closed for the lifetime of this mount, `managerRef.current`
+  // stays null and the cleanup is a no-op.
   useEffect(() => {
-    const manager = managerRef.current;
     return () => {
-      void manager?.end();
+      void managerRef.current?.end();
     };
   }, []);
 
@@ -100,7 +107,6 @@ export function LiveVoiceButton({
   // underlying manager would silently keep the WebSocket and mic open
   // with no visible control to stop it. Tear it down on every gate
   // transition to closed so the session ends with the affordance.
-  const gateOpen = voiceModeEnabled && assistantId !== null;
   useEffect(() => {
     if (!gateOpen) {
       void managerRef.current?.end();

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -107,6 +107,27 @@ export function LiveVoiceButton({
     }
   }, [gateOpen]);
 
+  // The composer is stable across conversation navigation — only
+  // `conversationId` changes as a prop. Without this effect, an active
+  // WebSocket would keep streaming audio/STT/LLM/TTS frames against the
+  // previous conversation's session while the UI shows the new one.
+  // Tear down the manager when the user navigates between two real
+  // conversations. Skip the initial mount (no previous id) and the
+  // null→value transition (a new conversation activating for the first
+  // time, not a switch).
+  const previousConversationIdRef = useRef<string | null>(conversationId);
+  useEffect(() => {
+    const previous = previousConversationIdRef.current;
+    previousConversationIdRef.current = conversationId;
+    if (
+      previous !== null &&
+      conversationId !== null &&
+      previous !== conversationId
+    ) {
+      void managerRef.current?.end();
+    }
+  }, [conversationId]);
+
   if (!voiceModeEnabled || !assistantId) return null;
 
   const manager = managerRef.current;

--- a/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-button.tsx
@@ -1,0 +1,191 @@
+/**
+ * LiveVoiceButton — composer affordance that drives a live voice
+ * conversation backed by `LiveVoiceChannelManager`.
+ *
+ * Renders alongside the existing `VoiceInputButton` (batch dictation):
+ * both are siblings in the chat composer's icon row so users on the
+ * `voice-mode` feature flag get the always-on live channel in addition
+ * to push-to-talk dictation.
+ *
+ * The button is a thin React shell around a per-mount
+ * `LiveVoiceChannelManager` instance. The manager owns the WebSocket,
+ * mic capture, and PCM playback — this component just maps the current
+ * `useLiveVoiceStore` state to the right icon + click handler and
+ * forwards user intent to the manager. State is mirrored from the
+ * `LiveVoiceChannelManager.State` enum in
+ * `clients/macos/.../Features/Voice/VoiceModeManager.swift` so the web
+ * and macOS surfaces stay in lockstep.
+ *
+ * The render is gated on the `voice-mode` assistant feature flag (auto
+ * derived from the `voice-mode` registry entry) AND a non-null
+ * `assistantId`. Either falsy short-circuits to `null`.
+ */
+
+import { Loader2, Mic, Phone } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+import { Button } from "@vellum/design-library";
+
+import { LiveVoiceChannelManager } from "@/domains/voice/live-voice/live-voice-channel-manager";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `LiveVoiceChannelManager` the button drives. Pulled out so
+ * tests can inject a stub without instantiating the real manager (which
+ * would touch the WebSocket, mic, and Web Audio APIs at construction
+ * time via its default factories).
+ */
+export interface LiveVoiceButtonManager {
+  start(conversationId: string): Promise<void>;
+  stopListening(): Promise<void>;
+  interruptSpeakingAndStartListening(conversationId: string): Promise<void>;
+  end(): Promise<void>;
+}
+
+export interface LiveVoiceButtonProps {
+  assistantId: string | null;
+  conversationId: string | null;
+  disabled?: boolean;
+  /**
+   * Optional factory for the per-mount manager — defaults to a real
+   * `LiveVoiceChannelManager`. Tests inject a stub here so they can
+   * assert on the method calls without spinning up the WebSocket /
+   * mic / playback stack the real manager wires up on construction.
+   */
+  managerFactory?: () => LiveVoiceButtonManager;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LiveVoiceButton({
+  assistantId,
+  conversationId,
+  disabled = false,
+  managerFactory,
+}: LiveVoiceButtonProps) {
+  const voiceModeEnabled = useAssistantFeatureFlagStore.use.voiceMode();
+  const state = useLiveVoiceStore.use.state();
+  const errorMessage = useLiveVoiceStore.use.errorMessage();
+
+  // `useRef` (not `useState`) so React strict-mode's double-invoke of
+  // render doesn't build two managers and leak the first one's
+  // WebSocket / mic handles.
+  const managerRef = useRef<LiveVoiceButtonManager | null>(null);
+  if (managerRef.current === null) {
+    managerRef.current = managerFactory
+      ? managerFactory()
+      : new LiveVoiceChannelManager();
+  }
+
+  // Fire-and-forget: React's cleanup is sync, the manager's `end()` is
+  // async. Dropping the promise is safe — the component has already
+  // left the tree, so there's nothing to surface failures to.
+  useEffect(() => {
+    const manager = managerRef.current;
+    return () => {
+      void manager?.end();
+    };
+  }, []);
+
+  // If the gate closes mid-session (flag flips off, assistant switches
+  // and assistantId goes null), the button stops rendering — but the
+  // underlying manager would silently keep the WebSocket and mic open
+  // with no visible control to stop it. Tear it down on every gate
+  // transition to closed so the session ends with the affordance.
+  const gateOpen = voiceModeEnabled && assistantId !== null;
+  useEffect(() => {
+    if (!gateOpen) {
+      void managerRef.current?.end();
+    }
+  }, [gateOpen]);
+
+  if (!voiceModeEnabled || !assistantId) return null;
+
+  const manager = managerRef.current;
+
+  // Map the live-voice state machine to (icon, click handler, label).
+  // Mirrors `VoiceModeManager.stateLabel` in the macOS client so the
+  // two surfaces share a vocabulary.
+  let icon: ReactNode;
+  let label: string;
+  let onClick: () => void;
+  let isBusy = false;
+  let isFailed = false;
+
+  switch (state) {
+    case "off":
+    case "ending":
+      icon = <Phone strokeWidth={2} />;
+      label = "Start voice conversation";
+      onClick = () => {
+        if (conversationId) {
+          void manager?.start(conversationId);
+        }
+      };
+      break;
+    case "connecting":
+    case "listening":
+    case "transcribing":
+      icon = <Mic strokeWidth={2} />;
+      label =
+        state === "connecting"
+          ? "Connecting voice conversation"
+          : "Stop voice listening";
+      isBusy = state === "connecting";
+      onClick = () => {
+        void manager?.stopListening();
+      };
+      break;
+    case "thinking":
+    case "speaking":
+      icon = <Loader2 className="animate-spin" strokeWidth={2} />;
+      label = "Interrupt and resume listening";
+      isBusy = true;
+      onClick = () => {
+        if (conversationId) {
+          void manager?.interruptSpeakingAndStartListening(conversationId);
+        }
+      };
+      break;
+    case "failed":
+      icon = <Phone strokeWidth={2} />;
+      label = errorMessage || "Voice conversation failed — tap to retry";
+      isFailed = true;
+      onClick = () => {
+        if (!conversationId) return;
+        // Chain `end → start` so the second call lands after teardown;
+        // the manager builds fresh collaborators on each `start()` so
+        // they don't fight over the failed session's stale WebSocket.
+        void (async () => {
+          await manager?.end();
+          await manager?.start(conversationId);
+        })();
+      };
+      break;
+  }
+
+  return (
+    <Button
+      // `dangerGhost` paints the negative tokens across light/dark/velvet
+      // themes — needed for the failed-state red icon.
+      variant={isFailed ? "dangerGhost" : "ghost"}
+      iconOnly={icon}
+      onClick={onClick}
+      disabled={disabled || !conversationId}
+      aria-label={label}
+      aria-busy={isBusy}
+      title={label}
+      // Match `VoiceInputButton`'s secondary tint so the two composer
+      // icons sit at the same visual weight.
+      className={isFailed ? undefined : "[--vbtn-fg:var(--content-secondary)]"}
+    />
+  );
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
@@ -1,0 +1,564 @@
+/**
+ * LiveVoiceChannelClient — WebSocket transport + frame dispatch for the
+ * live voice channel.
+ *
+ * TypeScript port of
+ * `clients/shared/Network/LiveVoiceChannelClient.swift`.
+ *
+ * Owns a single `WebSocket` to `/v1/live-voice`, authenticated via the
+ * gateway edge JWT (`getGatewayToken()` from
+ * `apps/web/src/lib/auth/gateway-session.ts`). Sends the JSON `start`
+ * frame after `open`, arms a 10 s ready-handshake timeout, normalizes
+ * incoming text/binary frames into a `LiveVoiceChannelEvent`
+ * discriminated union, and surfaces failures via
+ * `LiveVoiceChannelFailure`.
+ *
+ * Create a new instance for each session — `end()` and `close()` both
+ * transition state to `closed` and are idempotent.
+ */
+
+import {
+  base64ToPcm16,
+  encodeClientControlFrame,
+  encodeClientStartFrame,
+  LIVE_VOICE_AUDIO_PCM16K_MONO,
+  parseServerBinaryFrame,
+  parseServerTextFrame,
+  type LiveVoiceAudioConfig,
+  type LiveVoiceMetricsServerFrame,
+  type LiveVoiceServerFrame,
+} from "@/domains/voice/live-voice/protocol";
+import { getGatewayToken } from "@/lib/auth/gateway-session";
+import { getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Internal lifecycle state. Mirrors `LiveVoiceChannelSessionState`. */
+export type LiveVoiceChannelSessionState =
+  | "idle"
+  | "connecting"
+  | "active"
+  | "ending"
+  | "closed";
+
+/** Normalized server events. Mirrors the Swift `LiveVoiceChannelEvent` enum. */
+export type LiveVoiceChannelEvent =
+  | { type: "ready"; sessionId: string; conversationId: string }
+  | { type: "sttPartial"; text: string; seq: number }
+  | { type: "sttFinal"; text: string; seq: number }
+  | { type: "thinking"; turnId: string }
+  | { type: "assistantTextDelta"; text: string; seq: number }
+  | {
+      type: "ttsAudio";
+      pcm: Uint8Array;
+      mimeType: string;
+      sampleRate: number;
+      seq: number;
+    }
+  | { type: "ttsDone"; turnId: string }
+  | { type: "metrics"; metrics: LiveVoiceChannelMetrics }
+  | { type: "archived"; conversationId: string; sessionId: string };
+
+/** Turn-level latency metrics. Mirrors the Swift `LiveVoiceChannelMetrics`. */
+export interface LiveVoiceChannelMetrics {
+  readonly turnId: string;
+  readonly sttMs: number | null;
+  readonly llmFirstDeltaMs: number | null;
+  readonly ttsFirstAudioMs: number | null;
+  readonly totalMs: number | null;
+}
+
+/** Failure modes surfaced via `onFailure`. Mirrors `LiveVoiceChannelFailure`. */
+export type LiveVoiceChannelFailure =
+  | { type: "connectionFailed"; message: string }
+  | { type: "connectionRejected"; statusCode: number | null }
+  | { type: "protocolError"; code: string; message: string }
+  | { type: "busy"; activeSessionId: string }
+  | { type: "timeout"; message: string }
+  | { type: "abnormalClosure"; code: number; reason: string | null };
+
+export interface LiveVoiceChannelStartOptions {
+  conversationId?: string;
+  audioFormat?: LiveVoiceAudioConfig;
+  onEvent: (event: LiveVoiceChannelEvent) => void;
+  onFailure: (failure: LiveVoiceChannelFailure) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal WebSocket surface (for DI in tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of the DOM `WebSocket` interface the client depends on. Tests
+ * supply a mock via `globalThis.WebSocket = MockWebSocket`.
+ */
+export interface LiveVoiceWebSocketLike {
+  binaryType: BinaryType;
+  readonly readyState: number;
+  onopen: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null;
+  onclose:
+    | ((this: LiveVoiceWebSocketLike, ev: CloseEvent) => unknown)
+    | null;
+  onerror: ((this: LiveVoiceWebSocketLike, ev: Event) => unknown) | null;
+  onmessage:
+    | ((this: LiveVoiceWebSocketLike, ev: MessageEvent) => unknown)
+    | null;
+  send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void;
+  close(code?: number, reason?: string): void;
+}
+
+type WebSocketCtor = new (url: string) => LiveVoiceWebSocketLike;
+
+const CONNECTION_TIMEOUT_MS = 10_000;
+const END_GRACE_MS = 1_000;
+const NORMAL_CLOSURE = 1000;
+
+// ---------------------------------------------------------------------------
+// LiveVoiceChannelClient
+// ---------------------------------------------------------------------------
+
+export class LiveVoiceChannelClient {
+  private state: LiveVoiceChannelSessionState = "idle";
+  private ws: LiveVoiceWebSocketLike | null = null;
+  private connectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private endGraceTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Resolver for the Promise returned by `end()` while the 1 s grace
+   * timer is pending. Tracked separately from the timer so that
+   * `teardown()` (called by `close()`, `handleError()`, or a server
+   * failure) can resolve any awaited `end()` before clearing the
+   * timer — otherwise the caller hangs indefinitely.
+   */
+  private pendingEndResolver: (() => void) | null = null;
+  private onEvent: ((event: LiveVoiceChannelEvent) => void) | null = null;
+  private onFailure:
+    | ((failure: LiveVoiceChannelFailure) => void)
+    | null = null;
+
+  /** Current state. Exposed for tests. */
+  getState(): LiveVoiceChannelSessionState {
+    return this.state;
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(options: LiveVoiceChannelStartOptions): Promise<void> {
+    if (this.state !== "idle") return;
+
+    const audio = options.audioFormat ?? LIVE_VOICE_AUDIO_PCM16K_MONO;
+    this.onEvent = options.onEvent;
+    this.onFailure = options.onFailure;
+    this.state = "connecting";
+
+    const token = getGatewayToken();
+    if (!token) {
+      this.fail({
+        type: "connectionFailed",
+        message: "missing gateway token",
+      });
+      return;
+    }
+
+    const url = buildLiveVoiceWebSocketUrl(token);
+    const Ctor = resolveWebSocketCtor();
+    if (!Ctor) {
+      this.fail({
+        type: "connectionFailed",
+        message: "WebSocket is not available in this environment",
+      });
+      return;
+    }
+
+    let ws: LiveVoiceWebSocketLike;
+    try {
+      ws = new Ctor(url);
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+    this.ws = ws;
+
+    ws.onopen = () => this.handleOpen(options.conversationId, audio);
+    ws.onmessage = (event: MessageEvent) => this.handleMessage(event);
+    ws.onerror = () => this.handleError();
+    ws.onclose = (event: CloseEvent) => this.handleClose(event);
+
+    this.connectionTimeoutId = setTimeout(() => {
+      this.connectionTimeoutId = null;
+      if (this.state === "connecting") {
+        this.fail({
+          type: "timeout",
+          message: "ready frame not received",
+        });
+      }
+    }, CONNECTION_TIMEOUT_MS);
+  }
+
+  sendAudio(data: ArrayBuffer | Int16Array): void {
+    if (this.state !== "active" || !this.ws) return;
+    const payload: ArrayBuffer | ArrayBufferView =
+      data instanceof Int16Array
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : data;
+    try {
+      this.ws.send(payload);
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  releasePushToTalk(): void {
+    this.sendControlFrame("ptt_release", ["active"]);
+  }
+
+  interrupt(): void {
+    this.sendControlFrame("interrupt", ["active"]);
+  }
+
+  async end(): Promise<void> {
+    if (this.state !== "connecting" && this.state !== "active") return;
+    this.state = "ending";
+    this.sendControlFrame("end", ["ending"]);
+
+    await new Promise<void>((resolve) => {
+      // Track the resolver alongside the timer so `teardown()` can
+      // resolve this Promise even if it cancels the grace timer first
+      // (e.g. a concurrent `close()` or a WS error during the grace
+      // window). Without this, `await client.end()` would hang.
+      this.pendingEndResolver = resolve;
+      this.endGraceTimeoutId = setTimeout(() => {
+        this.endGraceTimeoutId = null;
+        this.pendingEndResolver = null;
+        resolve();
+      }, END_GRACE_MS);
+    });
+
+    this.teardown(null, NORMAL_CLOSURE);
+  }
+
+  close(): void {
+    if (this.state === "closed") return;
+    this.teardown(null, NORMAL_CLOSURE);
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket event handlers
+  // -------------------------------------------------------------------------
+
+  private handleOpen(
+    conversationId: string | undefined,
+    audioFormat: LiveVoiceAudioConfig,
+  ): void {
+    if (!this.ws || this.state !== "connecting") return;
+    try {
+      this.ws.send(encodeClientStartFrame({ conversationId, audio: audioFormat }));
+    } catch (err) {
+      this.fail({
+        type: "connectionFailed",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    if (this.state === "closed") return;
+    const data: unknown = event.data;
+
+    if (typeof data === "string") {
+      const result = parseServerTextFrame(data);
+      if (!result.ok) {
+        this.fail({
+          type: "protocolError",
+          code: result.error.code,
+          message: result.error.message,
+        });
+        return;
+      }
+      this.dispatchServerFrame(result.frame);
+      return;
+    }
+
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      const result = parseServerBinaryFrame(data);
+      if (!result.ok) {
+        this.fail({
+          type: "protocolError",
+          code: result.error.code,
+          message: result.error.message,
+        });
+        return;
+      }
+      // Binary frames are not part of the current server protocol surface;
+      // we accept them silently to stay forwards-compatible.
+      return;
+    }
+
+    // Blob fallback: browsers normally honor `binaryType = "arraybuffer"`,
+    // but treat any other payload shape as a protocol violation.
+    this.fail({
+      type: "protocolError",
+      code: "invalid_frame",
+      message: "Unsupported WebSocket frame payload",
+    });
+  }
+
+  private handleError(): void {
+    if (this.state === "closed" || this.state === "ending") return;
+    this.fail({
+      type: "connectionFailed",
+      message: "WebSocket error",
+    });
+  }
+
+  private handleClose(event: CloseEvent): void {
+    if (this.state === "closed") return;
+    if (event.code === NORMAL_CLOSURE || event.code === 0) {
+      this.teardown(null, NORMAL_CLOSURE);
+      return;
+    }
+    this.teardown(
+      {
+        type: "abnormalClosure",
+        code: event.code,
+        reason: event.reason ? event.reason : null,
+      },
+      NORMAL_CLOSURE,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Server frame dispatch
+  // -------------------------------------------------------------------------
+
+  private dispatchServerFrame(frame: LiveVoiceServerFrame): void {
+    switch (frame.type) {
+      case "ready":
+        if (this.state !== "connecting") return;
+        this.cancelConnectionTimeout();
+        this.state = "active";
+        this.onEvent?.({
+          type: "ready",
+          sessionId: frame.sessionId,
+          conversationId: frame.conversationId,
+        });
+        return;
+      case "busy":
+        this.fail({
+          type: "busy",
+          activeSessionId: frame.activeSessionId,
+        });
+        return;
+      case "stt_partial":
+        this.onEvent?.({ type: "sttPartial", text: frame.text, seq: frame.seq });
+        return;
+      case "stt_final":
+        this.onEvent?.({ type: "sttFinal", text: frame.text, seq: frame.seq });
+        return;
+      case "thinking":
+        this.onEvent?.({ type: "thinking", turnId: frame.turnId });
+        return;
+      case "assistant_text_delta":
+        this.onEvent?.({
+          type: "assistantTextDelta",
+          text: frame.text,
+          seq: frame.seq,
+        });
+        return;
+      case "tts_audio": {
+        let pcm: Uint8Array;
+        try {
+          const samples = base64ToPcm16(frame.dataBase64);
+          pcm = new Uint8Array(
+            samples.buffer,
+            samples.byteOffset,
+            samples.byteLength,
+          );
+        } catch (err) {
+          this.fail({
+            type: "protocolError",
+            code: "invalid_audio_payload",
+            message: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
+        this.onEvent?.({
+          type: "ttsAudio",
+          pcm,
+          mimeType: frame.mimeType,
+          sampleRate: frame.sampleRate,
+          seq: frame.seq,
+        });
+        return;
+      }
+      case "tts_done":
+        this.onEvent?.({ type: "ttsDone", turnId: frame.turnId });
+        return;
+      case "metrics":
+        this.onEvent?.({
+          type: "metrics",
+          metrics: toMetrics(frame),
+        });
+        return;
+      case "archived":
+        this.onEvent?.({
+          type: "archived",
+          conversationId: frame.conversationId,
+          sessionId: frame.sessionId,
+        });
+        return;
+      case "error":
+        this.fail({
+          type: "protocolError",
+          code: frame.code,
+          message: frame.message,
+        });
+        return;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private sendControlFrame(
+    type: "ptt_release" | "interrupt" | "end",
+    allowedStates: ReadonlyArray<LiveVoiceChannelSessionState>,
+  ): void {
+    if (!allowedStates.includes(this.state) || !this.ws) return;
+    try {
+      this.ws.send(encodeClientControlFrame(type));
+    } catch (err) {
+      if (this.state !== "closed") {
+        this.fail({
+          type: "connectionFailed",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  private fail(failure: LiveVoiceChannelFailure): void {
+    this.teardown(failure, NORMAL_CLOSURE);
+  }
+
+  private teardown(
+    failure: LiveVoiceChannelFailure | null,
+    closeCode: number,
+  ): void {
+    if (this.state === "closed") return;
+    this.state = "closed";
+
+    this.cancelConnectionTimeout();
+    // If `end()` is currently awaiting the 1 s grace timer, resolve
+    // its Promise *before* clearing the timer. Otherwise the awaited
+    // `client.end()` would hang when a concurrent `close()` or error
+    // path tears the client down during the grace window.
+    if (this.pendingEndResolver !== null) {
+      const resolve = this.pendingEndResolver;
+      this.pendingEndResolver = null;
+      resolve();
+    }
+    if (this.endGraceTimeoutId !== null) {
+      clearTimeout(this.endGraceTimeoutId);
+      this.endGraceTimeoutId = null;
+    }
+
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      try {
+        ws.close(closeCode);
+      } catch {
+        // ignore — close is best-effort
+      }
+    }
+
+    const failureCallback = this.onFailure;
+    this.onEvent = null;
+    this.onFailure = null;
+    if (failure) failureCallback?.(failure);
+  }
+
+  private cancelConnectionTimeout(): void {
+    if (this.connectionTimeoutId !== null) {
+      clearTimeout(this.connectionTimeoutId);
+      this.connectionTimeoutId = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the live voice WebSocket URL with the gateway edge JWT
+ * embedded as a `token` query parameter. Mirrors
+ * `GatewayHTTPClient.buildWebSocketRequest` in the Swift client:
+ * converts `http(s)://` to `ws(s)://`.
+ *
+ * In local mode, the proxy URL from `getLocalGatewayUrl()` is a
+ * relative path (e.g. `/assistant/__gateway/7830`) — we resolve it
+ * against `window.location.origin` before swapping schemes. In
+ * platform mode, the SPA is served from the same origin as the
+ * gateway, so we use `window.location.origin` directly.
+ *
+ * Exported for tests.
+ */
+export function buildLiveVoiceWebSocketUrl(token: string): string {
+  const base = resolveGatewayBaseUrl();
+  const path = "/v1/live-voice";
+  const query = `?token=${encodeURIComponent(token)}`;
+  const url = new URL(`${base}${path}${query}`);
+  if (url.protocol === "https:") url.protocol = "wss:";
+  else if (url.protocol === "http:") url.protocol = "ws:";
+  return url.toString();
+}
+
+function resolveGatewayBaseUrl(): string {
+  if (isLocalMode()) {
+    const localGateway = getLocalGatewayUrl();
+    if (localGateway) {
+      // The local proxy URL is a relative path served by the Vite dev
+      // middleware on the same origin as the SPA. Resolve it against
+      // window.location.origin so the URL parser can swap http→ws.
+      if (localGateway.startsWith("http://") || localGateway.startsWith("https://")) {
+        return localGateway;
+      }
+      return `${window.location.origin}${localGateway}`;
+    }
+  }
+  return window.location.origin;
+}
+
+function resolveWebSocketCtor(): WebSocketCtor | null {
+  const ctor = (globalThis as { WebSocket?: WebSocketCtor }).WebSocket;
+  return typeof ctor === "function" ? ctor : null;
+}
+
+function toMetrics(
+  frame: LiveVoiceMetricsServerFrame,
+): LiveVoiceChannelMetrics {
+  return {
+    turnId: frame.turnId,
+    sttMs: frame.sttMs,
+    llmFirstDeltaMs: frame.llmFirstDeltaMs,
+    ttsFirstAudioMs: frame.ttsFirstAudioMs,
+    totalMs: frame.totalMs,
+  };
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-client.ts
@@ -6,8 +6,8 @@
  * `clients/shared/Network/LiveVoiceChannelClient.swift`.
  *
  * Owns a single `WebSocket` to `/v1/live-voice`, authenticated via the
- * gateway edge JWT (`getGatewayToken()` from
- * `apps/web/src/lib/auth/gateway-session.ts`). Sends the JSON `start`
+ * gateway edge JWT (acquired/refreshed through `ensureGatewayToken()`
+ * from `apps/web/src/lib/auth/gateway-session.ts`). Sends the JSON `start`
  * frame after `open`, arms a 10 s ready-handshake timeout, normalizes
  * incoming text/binary frames into a `LiveVoiceChannelEvent`
  * discriminated union, and surfaces failures via
@@ -28,7 +28,7 @@ import {
   type LiveVoiceMetricsServerFrame,
   type LiveVoiceServerFrame,
 } from "@/domains/voice/live-voice/protocol";
-import { getGatewayToken } from "@/lib/auth/gateway-session";
+import { ensureGatewayToken, getLocalTokenUrl } from "@/lib/auth/gateway-session";
 import { getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
 
 // ---------------------------------------------------------------------------
@@ -115,6 +115,15 @@ const CONNECTION_TIMEOUT_MS = 10_000;
 const END_GRACE_MS = 1_000;
 const NORMAL_CLOSURE = 1000;
 
+/**
+ * User-facing message when the gateway edge JWT can't be acquired or
+ * refreshed (e.g. the session lapsed and re-acquisition failed). Shown
+ * under the overlay's "Connection failed" heading — actionable, unlike
+ * the previous raw internal "missing gateway token".
+ */
+const GATEWAY_AUTH_FAILED_MESSAGE =
+  "Couldn't authenticate the voice session — refresh the page and try again.";
+
 // ---------------------------------------------------------------------------
 // LiveVoiceChannelClient
 // ---------------------------------------------------------------------------
@@ -154,11 +163,30 @@ export class LiveVoiceChannelClient {
     this.onFailure = options.onFailure;
     this.state = "connecting";
 
-    const token = getGatewayToken();
+    // Acquire (or refresh) the gateway edge JWT on demand. Mirrors the
+    // rest of the app's auth path (`ensureGatewayToken` in auth-store /
+    // `primeLocalGatewayConnection`): a valid cached token is returned
+    // as-is, otherwise a fresh one is fetched from the gateway. Voice
+    // previously only *read* the cached token via `getGatewayToken()`
+    // and hard-failed with "missing gateway token" when it was expired
+    // or not yet primed — the one surface that didn't self-heal.
+    let token: string;
+    try {
+      token = await ensureGatewayToken(getLocalTokenUrl());
+    } catch {
+      this.fail({
+        type: "connectionFailed",
+        message: GATEWAY_AUTH_FAILED_MESSAGE,
+      });
+      return;
+    }
+    // `end()`/`close()` may have torn the session down while awaiting
+    // token acquisition — don't open a socket for a dead session.
+    if (this.state !== "connecting") return;
     if (!token) {
       this.fail({
         type: "connectionFailed",
-        message: "missing gateway token",
+        message: GATEWAY_AUTH_FAILED_MESSAGE,
       });
       return;
     }

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -82,6 +82,17 @@ export interface LiveVoiceStoreLike {
   getState(): LiveVoiceStore;
 }
 
+/**
+ * Wraps `setTimeout` / `clearTimeout` so tests can drive the
+ * no-response watchdog without `vi.useFakeTimers()` (unavailable in
+ * bun:test). The handle is intentionally opaque — production uses the
+ * value returned by `globalThis.setTimeout`, tests use a numeric id.
+ */
+export interface LiveVoiceManagerScheduler {
+  setTimeout(handler: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
 export interface LiveVoiceChannelManagerDeps {
   /**
    * Factory invoked once per `start()` to create a fresh
@@ -111,6 +122,12 @@ export interface LiveVoiceChannelManagerDeps {
    */
   playbackFactory?: () => LiveVoicePcmPlaybackLike;
   store?: LiveVoiceStoreLike;
+  /**
+   * Wrapper for the no-response watchdog timer. Defaults to the global
+   * `setTimeout` / `clearTimeout`. Tests inject a fake so they can
+   * trigger the timeout deterministically.
+   */
+  scheduler?: LiveVoiceManagerScheduler;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +135,23 @@ export interface LiveVoiceChannelManagerDeps {
 // ---------------------------------------------------------------------------
 
 const DEFAULT_FAILURE_MESSAGE = "Live voice session failed";
+
+/**
+ * After `stopListening()`, the server sometimes finalizes the turn
+ * silently — empty STT, only-noise audio — without emitting any
+ * `thinking` / `ttsAudio` / `ttsDone` frame. Without a fallback the
+ * session would dangle in `listening`/`transcribing` with the mic
+ * stopped and no recovery affordance. 10 s is long enough that a
+ * normal server response (thinking takes ~1 s in practice) is never
+ * starved, and short enough that the user is not stuck for long.
+ */
+const NO_RESPONSE_WATCHDOG_MS = 10_000;
+
+const DEFAULT_SCHEDULER: LiveVoiceManagerScheduler = {
+  setTimeout: (handler, ms) => globalThis.setTimeout(handler, ms),
+  clearTimeout: (handle) =>
+    globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
 
 export class LiveVoiceChannelManager {
   /**
@@ -177,6 +211,16 @@ export class LiveVoiceChannelManager {
    */
   private isUserMuted = false;
 
+  private readonly scheduler: LiveVoiceManagerScheduler;
+  /**
+   * Handle for the watchdog timer armed by `stopListening()`. The timer
+   * tears the session down via `end()` if no `thinking` / `ttsAudio` /
+   * `ttsDone` frame arrives within `NO_RESPONSE_WATCHDOG_MS` — the
+   * "released PTT after silence" case where the server finalizes the
+   * pending turn without emitting any terminal frame.
+   */
+  private noResponseWatchdogHandle: unknown = null;
+
   constructor(deps: LiveVoiceChannelManagerDeps = {}) {
     this.clientFactory =
       deps.clientFactory ?? (() => new LiveVoiceChannelClient());
@@ -185,6 +229,7 @@ export class LiveVoiceChannelManager {
     this.playbackFactory =
       deps.playbackFactory ?? (() => new LiveVoicePcmPlayback());
     this.store = deps.store ?? useLiveVoiceStore;
+    this.scheduler = deps.scheduler ?? DEFAULT_SCHEDULER;
   }
 
   // -------------------------------------------------------------------------
@@ -203,6 +248,7 @@ export class LiveVoiceChannelManager {
     const sessionGen = this.sessionGeneration;
     this.playbackReadyForResponse = false;
     this.isUserMuted = false;
+    this.clearNoResponseWatchdog();
 
     const actions = this.actions();
     actions.setState("connecting");
@@ -247,6 +293,14 @@ export class LiveVoiceChannelManager {
     this.isUserMuted = true;
     this.client?.releasePushToTalk();
     this.capture?.stop();
+    // Arm the no-response watchdog: if the server finalizes the turn
+    // silently (empty STT, only-noise audio) and never emits a
+    // `thinking` / `ttsAudio` / `ttsDone` frame, we'd otherwise be stuck
+    // with the mic stopped and the UI dangling in
+    // `listening`/`transcribing` with no recovery. The first sign of
+    // server activity disarms the watchdog; otherwise it tears the
+    // session down via `end()`.
+    this.armNoResponseWatchdog();
   }
 
   async end(): Promise<void> {
@@ -254,6 +308,7 @@ export class LiveVoiceChannelManager {
     // resumes after this teardown bails before touching state.
     this.sessionGeneration += 1;
     this.playbackReadyForResponse = false;
+    this.clearNoResponseWatchdog();
 
     this.capture?.shutdown();
     this.playback?.handleEnd();
@@ -301,6 +356,9 @@ export class LiveVoiceChannelManager {
         actions.setPartialTranscript("");
         return;
       case "thinking":
+        // The server is producing a response — disarm the post-stop
+        // watchdog (which only fires if the server falls silent).
+        this.clearNoResponseWatchdog();
         actions.setState("thinking");
         // Reset the rolling assistant transcript at the start of each
         // response — mirrors `prepareForAssistantResponse()` in
@@ -308,12 +366,14 @@ export class LiveVoiceChannelManager {
         actions.clearAssistantTranscript();
         return;
       case "assistantTextDelta":
+        this.clearNoResponseWatchdog();
         if (this.currentState() !== "speaking") {
           actions.setState("speaking");
         }
         actions.appendAssistantTranscript(event.text);
         return;
       case "ttsAudio":
+        this.clearNoResponseWatchdog();
         // The PCM playback's `acceptsAudio` gate is flipped closed by
         // any prior `handleInterrupt` / `handleEnd` / `ttsDone`. The
         // first audio chunk of a new response must re-open the gate
@@ -352,6 +412,7 @@ export class LiveVoiceChannelManager {
     // resumes after this teardown bails before touching state.
     this.sessionGeneration += 1;
     this.playbackReadyForResponse = false;
+    this.clearNoResponseWatchdog();
 
     const message = this.failureMessage(failure);
     const actions = this.actions();
@@ -448,6 +509,30 @@ export class LiveVoiceChannelManager {
     }
     if (this.currentState() !== "failed") {
       this.actions().setState("listening");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // No-response watchdog
+  // -------------------------------------------------------------------------
+
+  private armNoResponseWatchdog(): void {
+    this.clearNoResponseWatchdog();
+    const myGeneration = this.sessionGeneration;
+    this.noResponseWatchdogHandle = this.scheduler.setTimeout(() => {
+      // A concurrent `start()` / `end()` / failure may have moved on
+      // while the timer was pending. Bail without touching state.
+      if (myGeneration !== this.sessionGeneration) return;
+      // `end()` clears its own watchdog handle as part of teardown, so
+      // we don't need to null it out here.
+      void this.end();
+    }, NO_RESPONSE_WATCHDOG_MS);
+  }
+
+  private clearNoResponseWatchdog(): void {
+    if (this.noResponseWatchdogHandle !== null) {
+      this.scheduler.clearTimeout(this.noResponseWatchdogHandle);
+      this.noResponseWatchdogHandle = null;
     }
   }
 

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -381,7 +381,9 @@ export class LiveVoiceChannelManager {
   // -------------------------------------------------------------------------
 
   private async startCapture(): Promise<void> {
-    const started = await this.capture?.start({
+    const capture = this.capture;
+    if (!capture) return;
+    const started = await capture.start({
       onChunk: (chunk) => {
         this.client?.sendAudio(chunk.pcm16);
       },
@@ -389,7 +391,23 @@ export class LiveVoiceChannelManager {
         this.actions().setInputAmplitude(amplitude);
       },
     });
-    if (!started) return;
+    // A concurrent `end()` / failure may have nulled or replaced
+    // `this.capture` while we awaited start(). If so the session is
+    // gone and we must not clobber the resulting `off` / `failed` state.
+    if (this.capture !== capture) return;
+    if (!started) {
+      // Capture failed to start (mic permission denied, suspended-
+      // context resume rejection, worklet load failure, etc.).
+      // Without audio frames the WS would dangle in `connecting`
+      // forever — its 10s timeout was already cleared by the `ready`
+      // frame. Surface as a connection failure so the overlay shows the
+      // error and the button enters retry mode.
+      this.handleFailure({
+        type: "connectionFailed",
+        message: "Microphone permission denied or unavailable",
+      });
+      return;
+    }
     if (this.currentState() !== "failed") {
       this.actions().setState("listening");
     }

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -422,12 +422,24 @@ export class LiveVoiceChannelManager {
     // gone and we must not clobber the resulting `off` / `failed` state.
     if (this.capture !== capture) return;
     if (!started) {
-      // Capture failed to start (mic permission denied, suspended-
-      // context resume rejection, worklet load failure, etc.).
-      // Without audio frames the WS would dangle in `connecting`
-      // forever — its 10s timeout was already cleared by the `ready`
-      // frame. Surface as a connection failure so the overlay shows the
-      // error and the button enters retry mode.
+      // The user can press stop after `ready` but before `capture.start()`
+      // resolves (e.g. while the mic permission prompt or AudioWorklet
+      // load is still pending). `stopListening()` sets `isUserMuted` and
+      // calls `capture.stop()`, which bumps the capture's generation —
+      // the in-flight `start()` continuation then returns `false`. That
+      // is a cancellation, not a mic failure, so end the session cleanly
+      // instead of leaving the UI in `failed` with a misleading
+      // "Microphone permission denied" message.
+      if (this.isUserMuted) {
+        void this.end();
+        return;
+      }
+      // Real capture failure (mic permission denied, suspended-context
+      // resume rejection, worklet load failure, etc.). Without audio
+      // frames the WS would dangle in `connecting` forever — its 10s
+      // timeout was already cleared by the `ready` frame. Surface as a
+      // connection failure so the overlay shows the error and the
+      // button enters retry mode.
       this.handleFailure({
         type: "connectionFailed",
         message: "Microphone permission denied or unavailable",

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -1,0 +1,423 @@
+/**
+ * LiveVoiceChannelManager — orchestrates the live voice session lifecycle.
+ *
+ * TypeScript port of the public surface of
+ * `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`.
+ *
+ * Wires together three collaborators:
+ *
+ *   - `LiveVoiceChannelClient` — WebSocket transport (`/v1/live-voice`).
+ *   - `LiveVoicePcmCapture` — 16 kHz mono microphone capture.
+ *   - `LiveVoicePcmPlayback` — gapless TTS playback.
+ *
+ * State lives in the `useLiveVoiceStore` Zustand store; the manager is
+ * pure logic (no React) and mutates the store via `getState()`. The
+ * `state` field tracks the same machine as the macOS app:
+ * `off → connecting → listening → transcribing → thinking → speaking →
+ * ending`, with a `failed` branch on error.
+ *
+ * Collaborators are constructor-injected so tests can pass minimal fakes
+ * without touching the DOM, WebSocket, or Web Audio APIs.
+ */
+
+import type {
+  LiveVoiceChannelEvent,
+  LiveVoiceChannelFailure,
+  LiveVoiceChannelStartOptions,
+} from "@/domains/voice/live-voice/live-voice-channel-client";
+import { LiveVoiceChannelClient } from "@/domains/voice/live-voice/live-voice-channel-client";
+import type {
+  LiveVoiceStore,
+  LiveVoiceStoreActions,
+  LiveVoiceStoreState,
+} from "@/domains/voice/live-voice/live-voice-store";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
+import type { LiveVoicePcmCaptureStartOptions } from "@/domains/voice/live-voice/pcm-capture";
+import { LiveVoicePcmCapture } from "@/domains/voice/live-voice/pcm-capture";
+import type { LiveVoiceTtsChunk } from "@/domains/voice/live-voice/pcm-playback";
+import { LiveVoicePcmPlayback } from "@/domains/voice/live-voice/pcm-playback";
+
+// ---------------------------------------------------------------------------
+// Dependency contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `LiveVoiceChannelClient` the manager depends on. The fake
+ * used in tests captures the `onEvent` / `onFailure` callbacks from
+ * `start()` so the test can drive event sequences synchronously.
+ */
+export interface LiveVoiceChannelClientLike {
+  start(options: LiveVoiceChannelStartOptions): Promise<void>;
+  sendAudio(data: ArrayBuffer | Int16Array): void;
+  releasePushToTalk(): void;
+  interrupt(): void;
+  end(): Promise<void>;
+  close(): void;
+}
+
+/** Subset of `LiveVoicePcmCapture` the manager depends on. */
+export interface LiveVoicePcmCaptureLike {
+  start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean>;
+  stop(): void;
+  shutdown(): void;
+}
+
+/** Subset of `LiveVoicePcmPlayback` the manager depends on. */
+export interface LiveVoicePcmPlaybackLike {
+  readonly isPlaying: boolean;
+  enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void;
+  handleInterrupt(): void;
+  handleEnd(): void;
+  handleSessionError(): void;
+  resetForNextResponse(): void;
+  waitUntilPlaybackFinishes(): Promise<void>;
+}
+
+/**
+ * Minimal store surface the manager pokes from outside React. Matches
+ * the `getState()` shape of `useLiveVoiceStore`; tests pass a fake that
+ * records mutations without spinning up the real Zustand store.
+ */
+export interface LiveVoiceStoreLike {
+  getState(): LiveVoiceStore;
+}
+
+export interface LiveVoiceChannelManagerDeps {
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoiceChannelClient`. The underlying client is single-shot —
+   * after `end()` or a failure transitions it to `closed`, calling
+   * `start()` on the same instance is a no-op. We must instantiate a
+   * new client each time the manager starts a session.
+   */
+  clientFactory?: () => LiveVoiceChannelClientLike;
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoicePcmCapture`. Like the client, capture is single-shot:
+   * `shutdown()` (called by `end()` / failure paths) sets
+   * `isShutdown = true` and subsequent `start()` calls return `false`
+   * without ever restarting the microphone. We must instantiate a new
+   * capture each time the manager starts a session, otherwise the
+   * second session's `ready` event never transitions out of
+   * `connecting`.
+   */
+  captureFactory?: () => LiveVoicePcmCaptureLike;
+  /**
+   * Factory invoked once per `start()` to create a fresh
+   * `LiveVoicePcmPlayback`. Mirrors the capture factory rationale —
+   * playback teardown flips a one-shot disabled bit, so reusing the
+   * same instance across sessions leaves the next response unable to
+   * play any audio.
+   */
+  playbackFactory?: () => LiveVoicePcmPlaybackLike;
+  store?: LiveVoiceStoreLike;
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FAILURE_MESSAGE = "Live voice session failed";
+
+export class LiveVoiceChannelManager {
+  /**
+   * Per-session client factory. We construct a fresh client in `start()`
+   * because `LiveVoiceChannelClient` is single-shot: once `end()` /
+   * `close()` move it to the `closed` state, subsequent `start()`
+   * calls early-return without ever emitting a `ready` event.
+   */
+  private readonly clientFactory: () => LiveVoiceChannelClientLike;
+  private client: LiveVoiceChannelClientLike | null = null;
+  /**
+   * Per-session capture factory. We construct a fresh capture in
+   * `start()` because `LiveVoicePcmCapture.shutdown()` (called by
+   * `end()` / failure teardown) sets `isShutdown = true` and later
+   * `start()` returns `false`. Reusing the same instance across
+   * sessions left the next session's `ready` event unable to restart
+   * the microphone — the UI stayed stuck in `connecting` forever.
+   */
+  private readonly captureFactory: () => LiveVoicePcmCaptureLike;
+  private capture: LiveVoicePcmCaptureLike | null = null;
+  /**
+   * Per-session playback factory. Mirrors `captureFactory` — playback
+   * teardown is also one-shot disable, so a reused instance silently
+   * drops every subsequent response's audio.
+   */
+  private readonly playbackFactory: () => LiveVoicePcmPlaybackLike;
+  private playback: LiveVoicePcmPlaybackLike | null = null;
+  private readonly store: LiveVoiceStoreLike;
+
+  /**
+   * Monotonically incremented whenever the session boundary changes
+   * (`start`, `end`, failure). The `ttsDone` continuation captures this
+   * before awaiting `waitUntilPlaybackFinishes()` and bails after the
+   * await if it no longer matches — that race lets us avoid clobbering
+   * the `off`/`failed` state that teardown set while we were waiting,
+   * and prevents `resetForNextResponse()` from re-opening the playback
+   * gate after the session has gone away.
+   */
+  private sessionGeneration = 0;
+
+  /**
+   * Tracks whether `playback.resetForNextResponse()` has been called for
+   * the current assistant response. The PCM playback flips its
+   * `acceptsAudio` gate closed on `handleInterrupt` / `handleEnd`, so
+   * the first `ttsAudio` of every new response must re-open the gate
+   * before enqueueing — otherwise the chunk is silently dropped (e.g.
+   * the barge-in -> new utterance flow leaves the assistant mute).
+   */
+  private playbackReadyForResponse = false;
+
+  /**
+   * Set to `true` by `stopListening()` (user pressed PTT-release) and
+   * cleared by `start()` / `interruptSpeakingAndStartListening()`. When
+   * a `ttsDone` continuation lands after the user has muted, we skip
+   * the transition back to `listening` so the UI does not silently
+   * re-arm the mic against the user's wish.
+   */
+  private isUserMuted = false;
+
+  constructor(deps: LiveVoiceChannelManagerDeps = {}) {
+    this.clientFactory =
+      deps.clientFactory ?? (() => new LiveVoiceChannelClient());
+    this.captureFactory =
+      deps.captureFactory ?? (() => new LiveVoicePcmCapture());
+    this.playbackFactory =
+      deps.playbackFactory ?? (() => new LiveVoicePcmPlayback());
+    this.store = deps.store ?? useLiveVoiceStore;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API (mirrors `LiveVoiceChannelManaging` from VoiceModeManager.swift)
+  // -------------------------------------------------------------------------
+
+  async start(conversationId: string): Promise<void> {
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+    this.isUserMuted = false;
+
+    const actions = this.actions();
+    actions.setState("connecting");
+    actions.setError("");
+
+    // Build a fresh client/capture/playback for this session — see the
+    // field comments for why these must not be reused across sessions.
+    this.client = this.clientFactory();
+    this.capture = this.captureFactory();
+    this.playback = this.playbackFactory();
+    await this.client.start({
+      conversationId,
+      onEvent: (event) => this.handleEvent(event),
+      onFailure: (failure) => this.handleFailure(failure),
+    });
+  }
+
+  async interruptSpeakingAndStartListening(
+    // Conversation id is part of the macOS protocol surface so callers
+    // can swap conversations atomically. The current web manager
+    // assumes the existing channel matches and just resumes capture —
+    // future work can reopen the channel when the id changes.
+    _conversationId: string,
+  ): Promise<void> {
+    this.isUserMuted = false;
+    this.client?.interrupt();
+    this.playback?.handleInterrupt();
+    // The playback gate is now closed; the next assistant response's
+    // first `ttsAudio` must call `resetForNextResponse()` before
+    // enqueueing.
+    this.playbackReadyForResponse = false;
+    await this.startCapture();
+  }
+
+  async stopListening(): Promise<void> {
+    this.isUserMuted = true;
+    this.client?.releasePushToTalk();
+    this.capture?.stop();
+  }
+
+  async end(): Promise<void> {
+    // Bump the generation so any in-flight `ttsDone` continuation that
+    // resumes after this teardown bails before touching state.
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+
+    this.capture?.shutdown();
+    this.playback?.handleEnd();
+    await this.client?.end();
+    // Drop the closed collaborators so the next `start()` builds fresh
+    // ones — `shutdown()` permanently disables capture/playback.
+    this.client = null;
+    this.capture = null;
+    this.playback = null;
+    this.actions().reset();
+  }
+
+  // -------------------------------------------------------------------------
+  // Event mapping
+  // -------------------------------------------------------------------------
+
+  private handleEvent(event: LiveVoiceChannelEvent): void {
+    const actions = this.actions();
+    switch (event.type) {
+      case "ready":
+        actions.setSessionInfo({
+          sessionId: event.sessionId,
+          conversationId: event.conversationId,
+        });
+        void this.startCapture();
+        return;
+      case "sttPartial":
+        actions.setPartialTranscript(event.text);
+        actions.setState("transcribing");
+        return;
+      case "sttFinal":
+        actions.setFinalTranscript(event.text);
+        actions.setPartialTranscript("");
+        return;
+      case "thinking":
+        actions.setState("thinking");
+        // Reset the rolling assistant transcript at the start of each
+        // response — mirrors `prepareForAssistantResponse()` in
+        // `LiveVoiceChannelManager.swift`.
+        actions.clearAssistantTranscript();
+        return;
+      case "assistantTextDelta":
+        if (this.currentState() !== "speaking") {
+          actions.setState("speaking");
+        }
+        actions.appendAssistantTranscript(event.text);
+        return;
+      case "ttsAudio":
+        // The PCM playback's `acceptsAudio` gate is flipped closed by
+        // any prior `handleInterrupt` / `handleEnd` / `ttsDone`. The
+        // first audio chunk of a new response must re-open the gate
+        // before enqueueing so the assistant's reply is actually heard.
+        if (!this.playbackReadyForResponse) {
+          this.playback?.resetForNextResponse();
+          this.playbackReadyForResponse = true;
+        }
+        this.playback?.enqueueTtsAudio({
+          pcm: event.pcm,
+          mimeType: event.mimeType,
+          sampleRate: event.sampleRate,
+          channels: 1,
+        });
+        return;
+      case "ttsDone":
+        void this.completeAssistantTurn();
+        return;
+      case "metrics":
+        // Best-effort logging — metrics are diagnostic only.
+        console.debug("[LiveVoiceChannelManager] metrics", event.metrics);
+        return;
+      case "archived":
+        // No state change; just record the archival for diagnostics.
+        console.debug(
+          "[LiveVoiceChannelManager] archived",
+          event.conversationId,
+          event.sessionId,
+        );
+        return;
+    }
+  }
+
+  private handleFailure(failure: LiveVoiceChannelFailure): void {
+    // Bump the generation so any in-flight `ttsDone` continuation that
+    // resumes after this teardown bails before touching state.
+    this.sessionGeneration += 1;
+    this.playbackReadyForResponse = false;
+
+    const message = this.failureMessage(failure);
+    const actions = this.actions();
+    actions.setError(message);
+    actions.setState("failed");
+
+    // Same teardown as `end()` minus the protocol `end` frame — the
+    // channel is already gone, so we use `close()` instead.
+    this.capture?.shutdown();
+    this.playback?.handleInterrupt();
+    this.client?.close();
+    // Drop the closed collaborators so the next `start()` builds fresh
+    // ones — `shutdown()` permanently disables capture/playback.
+    this.client = null;
+    this.capture = null;
+    this.playback = null;
+  }
+
+  private async completeAssistantTurn(): Promise<void> {
+    // Capture the generation before awaiting playback so we can detect
+    // a teardown (`end()` / failure) that happens while we wait. Without
+    // this guard the post-await mutations would clobber `off` / `failed`
+    // with `listening` and re-open the playback gate for a session that
+    // no longer exists.
+    const myGeneration = this.sessionGeneration;
+    await this.playback?.waitUntilPlaybackFinishes();
+    if (myGeneration !== this.sessionGeneration) {
+      return;
+    }
+    // Re-arm the gate flag so the next response's first `ttsAudio`
+    // calls `resetForNextResponse()` again before enqueueing.
+    this.playbackReadyForResponse = false;
+    this.playback?.resetForNextResponse();
+    const actions = this.actions();
+    // Clear the rolling assistant transcript so the next turn starts
+    // from a clean buffer.
+    actions.clearAssistantTranscript();
+    // If the user has called `stopListening()` (i.e. PTT-released), the
+    // assistant server treats the `ptt_release` as terminal for this
+    // session — subsequent audio frames are rejected or ignored. The
+    // WebSocket is logically dead, so tear it down here instead of
+    // dangling in a half-alive state. The next user action will
+    // `start()` a fresh session.
+    if (this.isUserMuted) {
+      await this.end();
+      return;
+    }
+    actions.setState("listening");
+  }
+
+  // -------------------------------------------------------------------------
+  // Capture lifecycle
+  // -------------------------------------------------------------------------
+
+  private async startCapture(): Promise<void> {
+    const started = await this.capture?.start({
+      onChunk: (chunk) => {
+        this.client?.sendAudio(chunk.pcm16);
+      },
+      onAmplitude: (amplitude) => {
+        this.actions().setInputAmplitude(amplitude);
+      },
+    });
+    if (!started) return;
+    if (this.currentState() !== "failed") {
+      this.actions().setState("listening");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Store helpers
+  // -------------------------------------------------------------------------
+
+  private actions(): LiveVoiceStoreActions {
+    return this.store.getState();
+  }
+
+  private currentState(): LiveVoiceStoreState["state"] {
+    return this.store.getState().state;
+  }
+
+  private failureMessage(failure: LiveVoiceChannelFailure): string {
+    switch (failure.type) {
+      case "connectionFailed":
+      case "protocolError":
+      case "timeout":
+        return failure.message || DEFAULT_FAILURE_MESSAGE;
+      case "abnormalClosure":
+        return failure.reason || DEFAULT_FAILURE_MESSAGE;
+      case "busy":
+      case "connectionRejected":
+        return DEFAULT_FAILURE_MESSAGE;
+    }
+  }
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -274,6 +274,18 @@ export class LiveVoiceChannelManager {
     const actions = this.actions();
     switch (event.type) {
       case "ready":
+        // If the user tapped the button while the WebSocket was still
+        // connecting, `stopListening()` set `isUserMuted = true` but the
+        // `ptt_release` frame was dropped (client not yet ready) and the
+        // capture stop was a no-op (capture not yet started). Without
+        // this guard the ready handler would open the mic and the UI
+        // would snap to `listening` after the user explicitly asked to
+        // cancel. Honor the cancellation by ending the now-connected
+        // session instead.
+        if (this.isUserMuted) {
+          void this.end();
+          return;
+        }
         actions.setSessionInfo({
           sessionId: event.sessionId,
           conversationId: event.conversationId,

--- a/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-channel-manager.ts
@@ -193,6 +193,14 @@ export class LiveVoiceChannelManager {
 
   async start(conversationId: string): Promise<void> {
     this.sessionGeneration += 1;
+    // Snapshot the generation at handler-registration time. Server frames
+    // that arrive after `end()` / failure (which bump the generation) are
+    // dropped at the dispatch boundary so they cannot leak STT, assistant
+    // text, or TTS playback from a torn-down session into the global
+    // store — e.g. a conversation switch during the 1s `end()` grace
+    // window must not surface frames from the old conversation in the
+    // new conversation's UI.
+    const sessionGen = this.sessionGeneration;
     this.playbackReadyForResponse = false;
     this.isUserMuted = false;
 
@@ -207,8 +215,14 @@ export class LiveVoiceChannelManager {
     this.playback = this.playbackFactory();
     await this.client.start({
       conversationId,
-      onEvent: (event) => this.handleEvent(event),
-      onFailure: (failure) => this.handleFailure(failure),
+      onEvent: (event) => {
+        if (sessionGen !== this.sessionGeneration) return;
+        this.handleEvent(event);
+      },
+      onFailure: (failure) => {
+        if (sessionGen !== this.sessionGeneration) return;
+        this.handleFailure(failure);
+      },
     });
   }
 

--- a/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
+++ b/apps/web/src/domains/voice/live-voice/live-voice-overlay.tsx
@@ -1,0 +1,130 @@
+/**
+ * Live transcript and status surface for the live voice mode.
+ *
+ * Renders an absolute-positioned overlay above the composer while a
+ * live voice session is in progress. Mirrors the macOS
+ * `VoiceTranscriptionWindow` / `VoiceModeManager.stateLabel` surface
+ * (`clients/macos/.../Features/Voice/VoiceTranscriptionWindow.swift`)
+ * so the web and native clients show the same status, amplitude, and
+ * transcript hierarchy during a live session.
+ *
+ * State is read from `useLiveVoiceStore` via atomic per-field selectors
+ * so unrelated mutations (e.g. amplitude updates flowing at audio rate)
+ * don't re-render the entire overlay.
+ *
+ * Returns `null` when the live voice state is `off`.
+ *
+ * @see https://zustand.docs.pmnd.rs/guides/auto-generating-selectors
+ */
+
+import { cn } from "@vellum/design-library";
+
+import {
+  type LiveVoiceState,
+  useLiveVoiceStore,
+} from "@/domains/voice/live-voice/live-voice-store";
+
+/**
+ * User-facing label for each live voice lifecycle state. Mirrors the
+ * macOS `VoiceModeManager.stateLabel` switch. `off` is present so the
+ * lookup is total — callers gate rendering by checking `state === "off"`
+ * before selecting a label.
+ */
+const STATE_LABELS: Record<LiveVoiceState, string> = {
+  off: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Listening…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "Connection failed",
+};
+
+interface LiveVoiceOverlayProps {
+  className?: string;
+}
+
+export function LiveVoiceOverlay({ className }: LiveVoiceOverlayProps) {
+  const state = useLiveVoiceStore.use.state();
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
+  const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  const errorMessage = useLiveVoiceStore.use.errorMessage();
+
+  if (state === "off") return null;
+
+  // Defend against out-of-range amplitudes so the bar can't overflow.
+  const amplitudePct = Math.max(0, Math.min(1, inputAmplitude)) * 100;
+  const isFailed = state === "failed";
+
+  return (
+    <div
+      data-slot="live-voice-overlay"
+      data-state={state}
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "absolute inset-x-0 bottom-full mb-2 flex flex-col gap-2 rounded-lg border border-[var(--border-element)] bg-[var(--surface-overlay)] p-3 shadow-[var(--shadow-popover)]",
+        className,
+      )}
+    >
+      <div
+        data-slot="live-voice-overlay-status"
+        className="text-body-small-emphasised text-[var(--content-default)]"
+      >
+        {STATE_LABELS[state]}
+      </div>
+
+      <div
+        data-slot="live-voice-overlay-amplitude"
+        className="h-1 w-full overflow-hidden rounded-full bg-[var(--surface-active)]"
+        aria-hidden="true"
+      >
+        <div
+          data-slot="live-voice-overlay-amplitude-fill"
+          className="h-full bg-[var(--primary-base)] transition-[width] duration-75 ease-out"
+          style={{ width: `${amplitudePct}%` }}
+        />
+      </div>
+
+      {(partialTranscript || finalTranscript) && (
+        <div
+          data-slot="live-voice-overlay-transcript"
+          className="max-h-32 overflow-y-auto text-body-medium-default text-[var(--content-default)]"
+        >
+          {finalTranscript && <span>{finalTranscript}</span>}
+          {finalTranscript && partialTranscript ? " " : null}
+          {partialTranscript && (
+            <span
+              data-slot="live-voice-overlay-partial"
+              className="text-[var(--content-secondary)]"
+            >
+              {partialTranscript}
+            </span>
+          )}
+        </div>
+      )}
+
+      {assistantTranscript && (
+        <div
+          data-slot="live-voice-overlay-assistant"
+          className="max-h-32 overflow-y-auto text-body-medium-lighter italic text-[var(--content-tertiary)]"
+        >
+          {assistantTranscript}
+        </div>
+      )}
+
+      {isFailed && errorMessage && (
+        <div
+          data-slot="live-voice-overlay-error"
+          role="alert"
+          className="text-body-small-default text-[var(--system-negative-strong)]"
+        >
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-store.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-store.ts
@@ -1,0 +1,125 @@
+/**
+ * Zustand store for the live voice mode state machine.
+ *
+ * Mirrors the macOS `LiveVoiceChannelManager.State` enum
+ * (see `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`)
+ * so the web client tracks the same lifecycle:
+ * off → connecting → listening → transcribing → thinking → speaking →
+ * ending, with a `failed` branch for error states.
+ *
+ * Holds the session id, conversation id, rolling transcripts, current
+ * input amplitude, and the most recent error message. All fields are
+ * primitives so per-field selectors via `createSelectors` give minimal
+ * re-renders.
+ *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
+ *
+ * **Primary API** — per-field selectors:
+ * ```ts
+ * const state = useLiveVoiceStore.use.state();
+ * ```
+ *
+ * **Non-React code** — use `.getState()` in callbacks, effects, handlers:
+ * ```ts
+ * const { state } = useLiveVoiceStore.getState();
+ * ```
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/guides/auto-generating-selectors}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LiveVoiceState =
+  | "off"
+  | "connecting"
+  | "listening"
+  | "transcribing"
+  | "thinking"
+  | "speaking"
+  | "ending"
+  | "failed";
+
+export interface LiveVoiceStoreState {
+  /** Current phase of the live voice lifecycle. */
+  state: LiveVoiceState;
+  /** Server-assigned session id for the active live voice channel. */
+  sessionId: string | null;
+  /** Conversation id the session is currently attached to. */
+  conversationId: string | null;
+  /** In-progress user transcript from the STT stream. */
+  partialTranscript: string;
+  /** Finalized user transcript for the current turn. */
+  finalTranscript: string;
+  /** Rolling assistant transcript accumulated from streamed deltas. */
+  assistantTranscript: string;
+  /** Most recent microphone input amplitude in [0, 1]. */
+  inputAmplitude: number;
+  /** Most recent error message; empty string when there is no error. */
+  errorMessage: string;
+}
+
+export interface LiveVoiceStoreActions {
+  setState: (s: LiveVoiceState) => void;
+  setSessionInfo: (info: {
+    sessionId: string | null;
+    conversationId: string | null;
+  }) => void;
+  setPartialTranscript: (text: string) => void;
+  setFinalTranscript: (text: string) => void;
+  appendAssistantTranscript: (delta: string) => void;
+  setInputAmplitude: (amp: number) => void;
+  setError: (msg: string) => void;
+  reset: () => void;
+}
+
+export type LiveVoiceStore = LiveVoiceStoreState & LiveVoiceStoreActions;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: LiveVoiceStoreState = {
+  state: "off",
+  sessionId: null,
+  conversationId: null,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  errorMessage: "",
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
+  ...INITIAL_STATE,
+
+  setState: (s) => set({ state: s }),
+
+  setSessionInfo: ({ sessionId, conversationId }) =>
+    set({ sessionId, conversationId }),
+
+  setPartialTranscript: (text) => set({ partialTranscript: text }),
+
+  setFinalTranscript: (text) => set({ finalTranscript: text }),
+
+  appendAssistantTranscript: (delta) =>
+    set((prev) => ({ assistantTranscript: prev.assistantTranscript + delta })),
+
+  setInputAmplitude: (amp) => set({ inputAmplitude: amp }),
+
+  setError: (msg) => set({ errorMessage: msg }),
+
+  reset: () => set(INITIAL_STATE),
+}));
+
+export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);

--- a/apps/web/src/domains/voice/live-voice/live-voice-store.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-store.ts
@@ -74,6 +74,7 @@ export interface LiveVoiceStoreActions {
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   appendAssistantTranscript: (delta: string) => void;
+  clearAssistantTranscript: () => void;
   setInputAmplitude: (amp: number) => void;
   setError: (msg: string) => void;
   reset: () => void;
@@ -114,6 +115,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
 
   appendAssistantTranscript: (delta) =>
     set((prev) => ({ assistantTranscript: prev.assistantTranscript + delta })),
+
+  clearAssistantTranscript: () => set({ assistantTranscript: "" }),
 
   setInputAmplitude: (amp) => set({ inputAmplitude: amp }),
 

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -1,0 +1,307 @@
+/**
+ * Main-thread driver for the 16 kHz mono PCM AudioWorklet capture.
+ *
+ * Mirrors the macOS `LiveVoiceAudioCapture` surface so the rest of the
+ * live-voice manager (built in later PRs) can call into a familiar
+ * `start` / `stop` / `shutdown` lifecycle.
+ *
+ * Pipeline:
+ *
+ *   getUserMedia → MediaStreamAudioSourceNode → AudioWorkletNode
+ *   ("pcm16k-capture-processor" — see public/worklets/) → onChunk callback
+ *
+ * The worklet posts two message types: `chunk` (PCM16 LE Int16Array, 320
+ * samples = 20 ms at 16 kHz) and `amplitude` (peak abs in [0, 1] at ~20 Hz).
+ *
+ * Web Audio only pulls render quanta along graph edges that terminate at
+ * `audioContext.destination`. With no downstream consumer the worklet's
+ * `process()` never runs, so we also connect the worklet through a muted
+ * `GainNode` (gain = 0) to the destination. This keeps the graph
+ * renderable without producing any audible output.
+ *
+ * `stop()` tears down the active capture but keeps the `AudioContext` warm
+ * so the next `start()` can resume without paying for context creation
+ * again. `shutdown()` fully releases everything (tracks, context).
+ *
+ * Both methods are idempotent — duplicate calls are safe and cheap.
+ */
+
+const WORKLET_MODULE_URL = "/worklets/pcm16k-capture-processor.js";
+const WORKLET_PROCESSOR_NAME = "pcm16k-capture-processor";
+
+type AudioContextCtor = new (
+  contextOptions?: AudioContextOptions,
+) => AudioContext;
+
+interface PcmCaptureChunk {
+  pcm16: Int16Array;
+  frameCount: number;
+  amplitude: number;
+}
+
+export interface LiveVoicePcmCaptureStartOptions {
+  /** Called once per 320-sample PCM16 LE chunk (~20 ms at 16 kHz). */
+  onChunk: (chunk: PcmCaptureChunk) => void;
+  /** Called at ~20 Hz with peak amplitude in [0, 1]. Optional UI meter. */
+  onAmplitude?: (amplitude: number) => void;
+}
+
+interface WorkletChunkMessage {
+  type: "chunk";
+  pcm16: Int16Array;
+  frameCount: number;
+  amplitude: number;
+}
+
+interface WorkletAmplitudeMessage {
+  type: "amplitude";
+  amplitude: number;
+}
+
+type WorkletMessage = WorkletChunkMessage | WorkletAmplitudeMessage;
+
+function getAudioContextCtor(): AudioContextCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as typeof window & { webkitAudioContext?: AudioContextCtor };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+export class LiveVoicePcmCapture {
+  private audioContext: AudioContext | null = null;
+  private stream: MediaStream | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  /**
+   * Muted sink that keeps the capture graph connected to
+   * `audioContext.destination` so the AudioWorklet's `process()` is
+   * actually scheduled. Gain is pinned to 0 — no audible output.
+   */
+  private muteNode: GainNode | null = null;
+  private moduleLoaded = false;
+  private isShutdown = false;
+  /**
+   * Monotonic counter bumped on every `start()`, `stop()`, and
+   * `shutdown()`. The async `start()` work captures its generation at
+   * entry and re-verifies it after each `await` (and before each
+   * mutation). If the counter has moved, a concurrent `stop()`,
+   * `shutdown()`, or newer `start()` has superseded this attempt, and
+   * the continuation releases any opened stream and bails. Mirrors the
+   * macOS `LiveVoiceAudioCapture` generation counter.
+   */
+  private startGeneration = 0;
+
+  async start(options: LiveVoicePcmCaptureStartOptions): Promise<boolean> {
+    if (this.isShutdown) return false;
+
+    // If a previous capture is already wired up synchronously, tear it
+    // down so the new start observes a clean slate. Pending async
+    // starts are handled by the generation bump below — their
+    // continuations will bail without touching `this.stream` etc.
+    if (this.workletNode || this.stream) {
+      this.stop();
+    }
+
+    // Bump the generation: this both cancels any in-flight `start()`
+    // continuation (it will observe a stale generation at its next
+    // checkpoint) AND captures the current generation for this call.
+    const myGen = ++this.startGeneration;
+
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.getUserMedia) return false;
+
+    let stream: MediaStream;
+    try {
+      stream = await mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+    } catch {
+      return false;
+    }
+
+    // A concurrent `stop()`, `shutdown()`, or newer `start()` may have
+    // run while we awaited permission. Release the tracks we just
+    // opened and bail.
+    if (myGen !== this.startGeneration || this.isShutdown) {
+      releaseStream(stream);
+      return false;
+    }
+
+    const AudioCtx = getAudioContextCtor();
+    if (!AudioCtx) {
+      releaseStream(stream);
+      return false;
+    }
+
+    try {
+      if (!this.audioContext) {
+        this.audioContext = new AudioCtx();
+      }
+      const audioContext = this.audioContext;
+
+      if (!this.moduleLoaded) {
+        await audioContext.audioWorklet.addModule(WORKLET_MODULE_URL);
+        // Re-check after the worklet module load — `stop()`,
+        // `shutdown()`, or a newer `start()` may have raced it.
+        if (myGen !== this.startGeneration || this.isShutdown) {
+          releaseStream(stream);
+          return false;
+        }
+        this.moduleLoaded = true;
+      } else if (myGen !== this.startGeneration || this.isShutdown) {
+        // Even when the module is already loaded we re-check, because
+        // a concurrent caller may have invalidated us between the
+        // permission await and here (e.g. another `start()` chained
+        // synchronously).
+        releaseStream(stream);
+        return false;
+      }
+
+      const sourceNode = audioContext.createMediaStreamSource(stream);
+      const workletNode = new AudioWorkletNode(
+        audioContext,
+        WORKLET_PROCESSOR_NAME,
+      );
+
+      workletNode.port.onmessage = (event: MessageEvent<WorkletMessage>) => {
+        const data = event.data;
+        if (data.type === "chunk") {
+          options.onChunk({
+            pcm16: data.pcm16,
+            frameCount: data.frameCount,
+            amplitude: data.amplitude,
+          });
+        } else if (data.type === "amplitude") {
+          options.onAmplitude?.(data.amplitude);
+        }
+      };
+
+      sourceNode.connect(workletNode);
+
+      // Web Audio only pulls render quanta along graph edges that
+      // terminate at `audioContext.destination`. Without a sink the
+      // worklet's `process()` is never called, so live voice would
+      // receive zero PCM chunks. Route the worklet through a muted
+      // GainNode (gain = 0) to the destination — keeps the graph
+      // renderable without producing audible output.
+      const muteNode = audioContext.createGain();
+      muteNode.gain.value = 0;
+      workletNode.connect(muteNode);
+      muteNode.connect(audioContext.destination);
+
+      // Final guard before publishing the new nodes — even node
+      // construction is synchronous, so this is mostly belt-and-
+      // suspenders, but cheap.
+      if (myGen !== this.startGeneration || this.isShutdown) {
+        try {
+          workletNode.port.onmessage = null;
+          workletNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
+        try {
+          sourceNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
+        try {
+          muteNode.disconnect();
+        } catch {
+          // Best-effort cleanup.
+        }
+        releaseStream(stream);
+        return false;
+      }
+
+      this.stream = stream;
+      this.sourceNode = sourceNode;
+      this.workletNode = workletNode;
+      this.muteNode = muteNode;
+      return true;
+    } catch {
+      releaseStream(stream);
+      return false;
+    }
+  }
+
+  /**
+   * Stop the current capture but keep the `AudioContext` warm — cheap
+   * to call again from `start()`. The MediaStream is also released so
+   * the OS-level mic indicator clears; `start()` opens a fresh stream.
+   *
+   * Also bumps `startGeneration` so any pending `start()` continuation
+   * (e.g. still awaiting `getUserMedia` after PTT release) observes a
+   * stale generation and releases the stream it opens.
+   */
+  stop(): void {
+    this.startGeneration++;
+    this.stopInternal();
+    if (this.stream) {
+      releaseStream(this.stream);
+      this.stream = null;
+    }
+  }
+
+  /**
+   * Release all resources. Idempotent. After `shutdown()`, `start()`
+   * returns `false`.
+   */
+  shutdown(): void {
+    if (this.isShutdown) return;
+    this.isShutdown = true;
+    // Bump for consistency with `stop()` — `isShutdown` already gates
+    // the continuation, but the generation check is the primary
+    // cancellation signal so we keep them in sync.
+    this.startGeneration++;
+
+    this.stopInternal();
+
+    if (this.stream) {
+      releaseStream(this.stream);
+      this.stream = null;
+    }
+
+    if (this.audioContext) {
+      void this.audioContext.close();
+      this.audioContext = null;
+    }
+  }
+
+  private stopInternal(): void {
+    if (this.workletNode) {
+      this.workletNode.port.onmessage = null;
+      try {
+        this.workletNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.workletNode = null;
+    }
+    if (this.sourceNode) {
+      try {
+        this.sourceNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.sourceNode = null;
+    }
+    if (this.muteNode) {
+      try {
+        this.muteNode.disconnect();
+      } catch {
+        // Already disconnected — safe to ignore.
+      }
+      this.muteNode = null;
+    }
+  }
+}
+
+function releaseStream(stream: MediaStream): void {
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -161,6 +161,26 @@ export class LiveVoicePcmCapture {
         return false;
       }
 
+      // Chrome's autoplay policy and Safari's tab lifecycle can leave
+      // the AudioContext in `"suspended"` after construction. A
+      // suspended context never schedules `process()` on the worklet —
+      // we'd report capture as started but deliver zero PCM chunks.
+      // Resume it before publishing the new graph; on rejection
+      // (no user gesture, etc.) bail so the manager surfaces an error.
+      if (audioContext.state === "suspended") {
+        try {
+          await audioContext.resume();
+        } catch {
+          releaseStream(stream);
+          return false;
+        }
+        // Re-check after the await — same race window as `addModule()`.
+        if (myGen !== this.startGeneration || this.isShutdown) {
+          releaseStream(stream);
+          return false;
+        }
+      }
+
       const sourceNode = audioContext.createMediaStreamSource(stream);
       const workletNode = new AudioWorkletNode(
         audioContext,

--- a/apps/web/src/domains/voice/live-voice/pcm-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-playback.ts
@@ -1,0 +1,316 @@
+/**
+ * LiveVoicePcmPlayback — gapless streaming playback for live voice TTS.
+ *
+ * Mirrors `clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift`
+ * (pipelined PCM chunk fix in commit 39cdb36bae) and conforms to the
+ * `LiveVoiceAudioPlaying` protocol in `LiveVoiceChannelManager.swift`.
+ *
+ * Gapless scheduling: each chunk is scheduled at
+ * `Math.max(currentTime, nextStartTime)` and the cursor advances by the
+ * buffer's duration. Awaiting `onended` between chunks would introduce
+ * audible gaps from event-loop latency.
+ *
+ * Non-PCM payloads are dropped: the web live-voice path is PCM only, so we
+ * keep the protocol surface but skip `<audio>`-element fallbacks.
+ */
+
+// Match only `audio/pcm` exactly (case-insensitive) or `audio/pcm;<parameters>`.
+// A raw prefix check would incorrectly accept G.711 codecs like `audio/pcma`
+// (A-law) and `audio/pcmu` (mu-law) — those bytes are NOT 16-bit LE PCM.
+const PCM_MIME_PATTERN = /^audio\/pcm(?:;|$)/i;
+const BYTES_PER_SAMPLE = 2; // 16-bit signed little-endian PCM
+const INT16_MAX = 32768;
+
+export interface LiveVoiceTtsChunk {
+    pcm: Uint8Array;
+    mimeType: string;
+    sampleRate: number;
+    channels: number;
+}
+
+/**
+ * Minimal slice of the Web Audio surface this module depends on. Tests use a
+ * stand-in implementation; production code receives a real `AudioContext`.
+ */
+export interface PcmAudioContextLike {
+    readonly currentTime: number;
+    readonly destination: AudioDestinationNodeLike;
+    createBuffer(channels: number, frameCount: number, sampleRate: number): AudioBufferLike;
+    createBufferSource(): AudioBufferSourceNodeLike;
+}
+
+export type AudioDestinationNodeLike = Record<never, never>;
+
+export interface AudioBufferLike {
+    readonly duration: number;
+    getChannelData(channel: number): Float32Array;
+    copyToChannel?(source: Float32Array, channel: number): void;
+}
+
+export interface AudioBufferSourceNodeLike {
+    buffer: AudioBufferLike | null;
+    onended: ((this: AudioBufferSourceNodeLike, ev: Event) => unknown) | null;
+    connect(destination: AudioDestinationNodeLike): void;
+    start(when?: number): void;
+    stop(when?: number): void;
+}
+
+export type AudioContextFactory = () => PcmAudioContextLike;
+
+export interface LiveVoicePcmPlaybackOptions {
+    /**
+     * Override for the `AudioContext` constructor. Defaults to
+     * `globalThis.AudioContext || globalThis.webkitAudioContext`. The factory
+     * is invoked lazily on the first `enqueueTtsAudio` call.
+     */
+    audioContextFactory?: AudioContextFactory;
+    /**
+     * Optional logger for diagnostics. Defaults to `console`.
+     */
+    logger?: Pick<Console, "warn">;
+}
+
+interface WindowWithWebkitAudio {
+    AudioContext?: new () => PcmAudioContextLike;
+    webkitAudioContext?: new () => PcmAudioContextLike;
+}
+
+function defaultAudioContextFactory(): PcmAudioContextLike {
+    const w = globalThis as unknown as WindowWithWebkitAudio;
+    const Ctor = w.AudioContext ?? w.webkitAudioContext;
+    if (!Ctor) {
+        throw new Error("AudioContext is not available in this environment");
+    }
+    return new Ctor();
+}
+
+interface PendingWaiter {
+    timer: ReturnType<typeof setTimeout>;
+    resolve: () => void;
+}
+
+export class LiveVoicePcmPlayback {
+    private readonly factory: AudioContextFactory;
+    private readonly logger: Pick<Console, "warn">;
+    private audioContext: PcmAudioContextLike | null = null;
+    private nextStartTime = 0;
+    private acceptsAudio = true;
+    private readonly scheduledNodes = new Set<AudioBufferSourceNodeLike>();
+    private readonly pendingWaiters = new Set<PendingWaiter>();
+
+    constructor(options: LiveVoicePcmPlaybackOptions = {}) {
+        this.factory = options.audioContextFactory ?? defaultAudioContextFactory;
+        this.logger = options.logger ?? console;
+    }
+
+    /**
+     * `true` while at least one scheduled node hasn't drained yet.
+     */
+    get isPlaying(): boolean {
+        if (!this.audioContext) return false;
+        return this.audioContext.currentTime < this.nextStartTime;
+    }
+
+    /**
+     * Schedule a PCM16 LE chunk to play gaplessly after any previously
+     * scheduled chunks. Non-PCM payloads are dropped with a warning.
+     */
+    enqueueTtsAudio(chunk: LiveVoiceTtsChunk): void {
+        if (!this.acceptsAudio) {
+            // Mirrors `LiveVoiceAudioPlayer.stop(reason:)`'s `acceptsAudio = false`
+            // gate: once the session has been interrupted or ended, drop any
+            // late TTS chunks that race the cancel until `resetForNextResponse()`.
+            return;
+        }
+        if (!PCM_MIME_PATTERN.test(chunk.mimeType.trim())) {
+            this.logger.warn(
+                `[LiveVoicePcmPlayback] dropping non-PCM chunk (mimeType=${chunk.mimeType})`,
+            );
+            return;
+        }
+        if (chunk.pcm.byteLength === 0) return;
+        if (chunk.pcm.byteLength % BYTES_PER_SAMPLE !== 0) {
+            this.logger.warn(
+                "[LiveVoicePcmPlayback] dropping malformed PCM chunk (byteLength not aligned to Int16)",
+            );
+            return;
+        }
+        if (chunk.channels < 1 || chunk.sampleRate <= 0) {
+            this.logger.warn(
+                `[LiveVoicePcmPlayback] dropping PCM chunk with invalid format (channels=${chunk.channels}, sampleRate=${chunk.sampleRate})`,
+            );
+            return;
+        }
+
+        const samples = decodePcm16LeToFloat32(chunk.pcm);
+        if (samples.length === 0) return;
+
+        const ctx = this.ensureAudioContext();
+        const frameCount = Math.floor(samples.length / chunk.channels);
+        if (frameCount === 0) return;
+
+        const buffer = ctx.createBuffer(chunk.channels, frameCount, chunk.sampleRate);
+        for (let channel = 0; channel < chunk.channels; channel += 1) {
+            const channelData = extractChannel(samples, chunk.channels, channel, frameCount);
+            if (buffer.copyToChannel) {
+                buffer.copyToChannel(channelData, channel);
+            } else {
+                const target = buffer.getChannelData(channel);
+                target.set(channelData);
+            }
+        }
+
+        const node = ctx.createBufferSource();
+        node.buffer = buffer;
+        node.connect(ctx.destination);
+        const scheduledAt = Math.max(ctx.currentTime, this.nextStartTime);
+        this.scheduledNodes.add(node);
+        node.onended = () => {
+            this.scheduledNodes.delete(node);
+        };
+        node.start(scheduledAt);
+        this.nextStartTime = scheduledAt + buffer.duration;
+        this.rescheduleWaitersForExtendedCursor();
+    }
+
+    /**
+     * Stop all scheduled playback immediately and clear the queue. Matches
+     * `LiveVoiceAudioPlayer.handleInterrupt()` → `stop(reason: .interrupt)`:
+     * any late chunks from the interrupted response are dropped via the
+     * `acceptsAudio` gate until the next `resetForNextResponse()`.
+     */
+    handleInterrupt(): void {
+        this.stopAllScheduledNodes();
+        this.nextStartTime = 0;
+        this.acceptsAudio = false;
+        this.resolvePendingWaiters();
+    }
+
+    /**
+     * Stop all scheduled playback and refuse further TTS chunks. Matches
+     * `LiveVoiceAudioPlayer.handleEnd()` → `stop(reason: .end)`: once the user
+     * has ended the session, TTS must not continue playing — late chunks are
+     * dropped via the `acceptsAudio` gate.
+     */
+    handleEnd(): void {
+        this.stopAllScheduledNodes();
+        this.nextStartTime = 0;
+        this.acceptsAudio = false;
+        this.resolvePendingWaiters();
+    }
+
+    handleSessionError(): void {
+        // Same playback effect as an interrupt; observers distinguish the
+        // two via the session state, not the player.
+        this.handleInterrupt();
+    }
+
+    resetForNextResponse(): void {
+        // Re-enable the `acceptsAudio` gate so the next assistant turn can
+        // play. Matches `LiveVoiceAudioPlayer.resetForNextResponse()`.
+        this.acceptsAudio = true;
+    }
+
+    /**
+     * Resolve once `audioContext.currentTime` catches up to `nextStartTime`.
+     * Uses a single `setTimeout` rounded to the residual gap rather than a
+     * polling loop, matching `LiveVoiceAudioPlayer.waitUntilPlaybackFinishes()`.
+     *
+     * If `handleInterrupt()` or `handleEnd()` runs while a waiter is pending,
+     * the waiter is resolved immediately so close/cleanup paths don't block on
+     * a stale cursor — mirrors `LiveVoiceAudioPlayer.stop(reason:)` resolving
+     * its own waiters on stop.
+     */
+    waitUntilPlaybackFinishes(): Promise<void> {
+        const ctx = this.audioContext;
+        if (!ctx) return Promise.resolve();
+        const remaining = this.nextStartTime - ctx.currentTime;
+        if (remaining <= 0) return Promise.resolve();
+        return new Promise((resolve) => {
+            const delayMs = Math.ceil(remaining * 1000);
+            const waiter: PendingWaiter = {
+                timer: setTimeout(() => {
+                    this.pendingWaiters.delete(waiter);
+                    resolve();
+                }, delayMs),
+                resolve,
+            };
+            this.pendingWaiters.add(waiter);
+        });
+    }
+
+    private ensureAudioContext(): PcmAudioContextLike {
+        if (!this.audioContext) {
+            this.audioContext = this.factory();
+            this.nextStartTime = 0;
+        }
+        return this.audioContext;
+    }
+
+    private stopAllScheduledNodes(): void {
+        for (const node of this.scheduledNodes) {
+            try {
+                node.stop(0);
+            } catch {
+                // Stopping an already-finished node throws InvalidStateError
+                // per the Web Audio spec.
+            }
+        }
+        this.scheduledNodes.clear();
+    }
+
+    private resolvePendingWaiters(): void {
+        for (const waiter of this.pendingWaiters) {
+            clearTimeout(waiter.timer);
+            waiter.resolve();
+        }
+        this.pendingWaiters.clear();
+    }
+
+    /**
+     * When `enqueueTtsAudio()` extends `nextStartTime`, any pending
+     * `waitUntilPlaybackFinishes()` timer was rounded to the old cursor and
+     * would resolve too early. Reschedule each pending waiter against the new
+     * cursor so callers wait for the actual end of buffered audio. The waiter
+     * itself stays pending — only its timer handle is replaced.
+     */
+    private rescheduleWaitersForExtendedCursor(): void {
+        const ctx = this.audioContext;
+        if (!ctx) return;
+        if (this.pendingWaiters.size === 0) return;
+        for (const waiter of this.pendingWaiters) {
+            clearTimeout(waiter.timer);
+            const remaining = this.nextStartTime - ctx.currentTime;
+            const delayMs = remaining > 0 ? Math.ceil(remaining * 1000) : 0;
+            waiter.timer = setTimeout(() => {
+                this.pendingWaiters.delete(waiter);
+                waiter.resolve();
+            }, delayMs);
+        }
+    }
+}
+
+function decodePcm16LeToFloat32(pcm: Uint8Array): Float32Array {
+    const sampleCount = Math.floor(pcm.byteLength / BYTES_PER_SAMPLE);
+    const out = new Float32Array(sampleCount);
+    // DataView (not Int16Array) so reads stay little-endian on big-endian hosts.
+    const view = new DataView(pcm.buffer, pcm.byteOffset, sampleCount * BYTES_PER_SAMPLE);
+    for (let i = 0; i < sampleCount; i += 1) {
+        out[i] = view.getInt16(i * BYTES_PER_SAMPLE, true) / INT16_MAX;
+    }
+    return out;
+}
+
+function extractChannel(
+    interleaved: Float32Array,
+    channelCount: number,
+    channel: number,
+    frameCount: number,
+): Float32Array {
+    if (channelCount === 1) return interleaved.subarray(0, frameCount);
+    const out = new Float32Array(frameCount);
+    for (let i = 0; i < frameCount; i += 1) {
+        out[i] = interleaved[i * channelCount + channel] ?? 0;
+    }
+    return out;
+}

--- a/apps/web/src/domains/voice/live-voice/protocol.ts
+++ b/apps/web/src/domains/voice/live-voice/protocol.ts
@@ -1,0 +1,873 @@
+/**
+ * Live voice WebSocket protocol — TypeScript types and frame codecs for
+ * the web client.
+ *
+ * Mirrors the public surface of `assistant/src/live-voice/protocol.ts`
+ * (the runtime) and the Swift reference at
+ * `clients/shared/Network/LiveVoiceChannelClient.swift`.
+ *
+ * The runtime parses *client* frames; the web client parses *server*
+ * frames — the validator shapes are structurally identical, the union
+ * direction is just inverted.
+ *
+ * Pure TypeScript: no DOM, no React, no Node-specific APIs. Uses
+ * `btoa` / `atob` and `Uint8Array` (not `Buffer`) so the module works
+ * in browsers, Capacitor WebViews, and Bun's test runner.
+ */
+
+// ---------------------------------------------------------------------------
+// Frame type tables
+// ---------------------------------------------------------------------------
+
+const LIVE_VOICE_SERVER_FRAME_TYPES = [
+  "ready",
+  "busy",
+  "stt_partial",
+  "stt_final",
+  "thinking",
+  "assistant_text_delta",
+  "tts_audio",
+  "tts_done",
+  "metrics",
+  "archived",
+  "error",
+] as const;
+
+type LiveVoiceServerFrameType =
+  (typeof LIVE_VOICE_SERVER_FRAME_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export const LiveVoiceProtocolErrorCode = {
+  InvalidJson: "invalid_json",
+  InvalidFrame: "invalid_frame",
+  UnknownType: "unknown_type",
+  MissingRequiredField: "missing_required_field",
+  InvalidField: "invalid_field",
+  InvalidAudioPayload: "invalid_audio_payload",
+} as const;
+
+export type LiveVoiceProtocolErrorCode =
+  (typeof LiveVoiceProtocolErrorCode)[keyof typeof LiveVoiceProtocolErrorCode];
+
+export interface LiveVoiceProtocolError {
+  readonly code: LiveVoiceProtocolErrorCode;
+  readonly message: string;
+  readonly field?: string;
+  readonly frameType?: string;
+}
+
+type LiveVoiceParseResult<T> =
+  | { ok: true; frame: T }
+  | { ok: false; error: LiveVoiceProtocolError };
+
+// ---------------------------------------------------------------------------
+// Audio config
+// ---------------------------------------------------------------------------
+
+export interface LiveVoiceAudioConfig {
+  readonly mimeType: "audio/pcm";
+  readonly sampleRate: number;
+  readonly channels: 1;
+}
+
+/**
+ * The canonical 16 kHz mono PCM config used by the web and macOS
+ * clients. Matches `LiveVoiceChannelAudioFormat.pcm16kMono` in
+ * `LiveVoiceChannelClient.swift`.
+ */
+export const LIVE_VOICE_AUDIO_PCM16K_MONO: LiveVoiceAudioConfig = {
+  mimeType: "audio/pcm",
+  sampleRate: 16000,
+  channels: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Client frames (web -> server)
+// ---------------------------------------------------------------------------
+
+export interface LiveVoiceClientStartFrame {
+  readonly type: "start";
+  readonly conversationId?: string;
+  readonly audio: LiveVoiceAudioConfig;
+}
+
+export interface LiveVoiceClientAudioFrame {
+  readonly type: "audio";
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceClientPttReleaseFrame {
+  readonly type: "ptt_release";
+}
+
+export interface LiveVoiceClientInterruptFrame {
+  readonly type: "interrupt";
+}
+
+export interface LiveVoiceClientEndFrame {
+  readonly type: "end";
+}
+
+export type LiveVoiceClientFrame =
+  | LiveVoiceClientStartFrame
+  | LiveVoiceClientAudioFrame
+  | LiveVoiceClientPttReleaseFrame
+  | LiveVoiceClientInterruptFrame
+  | LiveVoiceClientEndFrame;
+
+// ---------------------------------------------------------------------------
+// Server frames (server -> web)
+// ---------------------------------------------------------------------------
+
+interface LiveVoiceServerFrameBase {
+  readonly type: LiveVoiceServerFrameType;
+  readonly seq: number;
+}
+
+export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "ready";
+  readonly sessionId: string;
+  readonly conversationId: string;
+}
+
+export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "busy";
+  readonly activeSessionId: string;
+}
+
+export interface LiveVoiceSttPartialServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "stt_partial";
+  readonly text: string;
+}
+
+export interface LiveVoiceSttFinalServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "stt_final";
+  readonly text: string;
+}
+
+export interface LiveVoiceThinkingServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "thinking";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceAssistantTextDeltaServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "assistant_text_delta";
+  readonly text: string;
+}
+
+export interface LiveVoiceTtsAudioServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "tts_audio";
+  readonly mimeType: string;
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceTtsDoneServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceMetricsServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "metrics";
+  readonly event?: string;
+  readonly sessionId?: string;
+  readonly conversationId?: string;
+  readonly turnId: string;
+  readonly metrics?: unknown;
+  readonly sttMs: number | null;
+  readonly llmFirstDeltaMs: number | null;
+  readonly ttsFirstAudioMs: number | null;
+  readonly totalMs: number | null;
+}
+
+export interface LiveVoiceArchivedServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "archived";
+  readonly conversationId: string;
+  readonly sessionId: string;
+  readonly turnId?: string;
+  readonly role?: "user" | "assistant";
+  readonly attachmentId?: string;
+  readonly attachmentIds?: string[];
+  readonly warning?: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "error";
+  readonly code: LiveVoiceProtocolErrorCode;
+  readonly message: string;
+}
+
+export type LiveVoiceServerFrame =
+  | LiveVoiceReadyServerFrame
+  | LiveVoiceBusyServerFrame
+  | LiveVoiceSttPartialServerFrame
+  | LiveVoiceSttFinalServerFrame
+  | LiveVoiceThinkingServerFrame
+  | LiveVoiceAssistantTextDeltaServerFrame
+  | LiveVoiceTtsAudioServerFrame
+  | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceMetricsServerFrame
+  | LiveVoiceArchivedServerFrame
+  | LiveVoiceErrorServerFrame;
+
+// ---------------------------------------------------------------------------
+// Binary audio frame (TTS audio)
+// ---------------------------------------------------------------------------
+
+export interface LiveVoiceServerBinaryAudioFrame {
+  readonly type: "binary_audio";
+  readonly data: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Client frame encoders
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode the JSON `start` frame the web client sends after the
+ * WebSocket opens. Mirrors `LiveVoiceChannelClient.encodeStartFrame` in
+ * the Swift client.
+ */
+export function encodeClientStartFrame(opts: {
+  conversationId?: string;
+  audio: LiveVoiceAudioConfig;
+}): string {
+  const frame: LiveVoiceClientStartFrame = {
+    type: "start",
+    ...(opts.conversationId !== undefined
+      ? { conversationId: opts.conversationId }
+      : {}),
+    audio: opts.audio,
+  };
+  return JSON.stringify(frame);
+}
+
+/**
+ * Encode a JSON control frame (`ptt_release`, `interrupt`, `end`).
+ * Mirrors `LiveVoiceChannelClient.encodeControlFrame` in the Swift
+ * client.
+ */
+export function encodeClientControlFrame(
+  type: "ptt_release" | "interrupt" | "end",
+): string {
+  return JSON.stringify({ type });
+}
+
+// ---------------------------------------------------------------------------
+// Server frame parsers
+// ---------------------------------------------------------------------------
+
+export function parseServerTextFrame(
+  text: string,
+): LiveVoiceParseResult<LiveVoiceServerFrame> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return protocolError("invalid_json", "Live voice frame is not valid JSON");
+  }
+  return validateServerFrame(parsed);
+}
+
+export function parseServerBinaryFrame(
+  data: unknown,
+): LiveVoiceParseResult<LiveVoiceServerBinaryAudioFrame> {
+  if (data instanceof ArrayBuffer) {
+    if (data.byteLength === 0) {
+      return invalidAudioPayload(
+        "Binary audio frame is empty",
+        "data",
+        "binary_audio",
+      );
+    }
+    return {
+      ok: true,
+      frame: { type: "binary_audio", data: new Uint8Array(data) },
+    };
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    if (data.byteLength === 0) {
+      return invalidAudioPayload(
+        "Binary audio frame is empty",
+        "data",
+        "binary_audio",
+      );
+    }
+    return {
+      ok: true,
+      frame: {
+        type: "binary_audio",
+        data: new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+      },
+    };
+  }
+
+  return invalidAudioPayload(
+    "Binary audio frame must be ArrayBuffer data",
+    "data",
+    "binary_audio",
+  );
+}
+
+function validateServerFrame(
+  value: unknown,
+): LiveVoiceParseResult<LiveVoiceServerFrame> {
+  if (!isRecord(value)) {
+    return protocolError(
+      "invalid_frame",
+      "Live voice frame must be a JSON object",
+    );
+  }
+
+  if (!("type" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "Live voice frame is missing required field type",
+      "type",
+    );
+  }
+
+  if (typeof value.type !== "string") {
+    return protocolError(
+      "invalid_field",
+      "Live voice frame field type must be a string",
+      "type",
+    );
+  }
+
+  if (!isLiveVoiceServerFrameType(value.type)) {
+    return protocolError(
+      "unknown_type",
+      `Unknown live voice server frame type: ${value.type}`,
+      "type",
+      value.type,
+    );
+  }
+
+  const seqResult = validateSeq(value, value.type);
+  if (!seqResult.ok) return seqResult;
+  const seq = seqResult.value;
+
+  switch (value.type) {
+    case "ready":
+      return validateReadyFrame(value, seq);
+    case "busy":
+      return validateBusyFrame(value, seq);
+    case "stt_partial":
+      return validateTextFieldFrame(value, "stt_partial", seq);
+    case "stt_final":
+      return validateTextFieldFrame(value, "stt_final", seq);
+    case "thinking":
+      return validateTurnIdFrame(value, "thinking", seq);
+    case "assistant_text_delta":
+      return validateTextFieldFrame(value, "assistant_text_delta", seq);
+    case "tts_audio":
+      return validateTtsAudioFrame(value, seq);
+    case "tts_done":
+      return validateTurnIdFrame(value, "tts_done", seq);
+    case "metrics":
+      return validateMetricsFrame(value, seq);
+    case "archived":
+      return validateArchivedFrame(value, seq);
+    case "error":
+      return validateErrorFrame(value, seq);
+  }
+}
+
+function validateSeq(
+  value: Record<string, unknown>,
+  frameType: string,
+): { ok: true; value: number } | { ok: false; error: LiveVoiceProtocolError } {
+  if (!("seq" in value)) {
+    return {
+      ok: false,
+      error: {
+        code: "missing_required_field",
+        message: `${frameType} frame is missing required field seq`,
+        field: "seq",
+        frameType,
+      },
+    };
+  }
+  if (!isNonNegativeInteger(value.seq)) {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_field",
+        message: `${frameType} frame field seq must be a non-negative integer`,
+        field: "seq",
+        frameType,
+      },
+    };
+  }
+  return { ok: true, value: value.seq };
+}
+
+function validateReadyFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceReadyServerFrame> {
+  const sessionId = requireString(value, "sessionId", "ready");
+  if (!sessionId.ok) return sessionId;
+  const conversationId = requireString(value, "conversationId", "ready");
+  if (!conversationId.ok) return conversationId;
+  return {
+    ok: true,
+    frame: {
+      type: "ready",
+      seq,
+      sessionId: sessionId.value,
+      conversationId: conversationId.value,
+    },
+  };
+}
+
+function validateBusyFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceBusyServerFrame> {
+  const activeSessionId = requireString(value, "activeSessionId", "busy");
+  if (!activeSessionId.ok) return activeSessionId;
+  return {
+    ok: true,
+    frame: { type: "busy", seq, activeSessionId: activeSessionId.value },
+  };
+}
+
+function validateTextFieldFrame<
+  T extends "stt_partial" | "stt_final" | "assistant_text_delta",
+>(
+  value: Record<string, unknown>,
+  type: T,
+  seq: number,
+): LiveVoiceParseResult<
+  Extract<LiveVoiceServerFrame, { readonly type: T }>
+> {
+  const text = requireString(value, "text", type);
+  if (!text.ok) return text;
+  return {
+    ok: true,
+    frame: { type, seq, text: text.value } as Extract<
+      LiveVoiceServerFrame,
+      { readonly type: T }
+    >,
+  };
+}
+
+function validateTurnIdFrame<T extends "thinking" | "tts_done">(
+  value: Record<string, unknown>,
+  type: T,
+  seq: number,
+): LiveVoiceParseResult<
+  Extract<LiveVoiceServerFrame, { readonly type: T }>
+> {
+  const turnId = requireString(value, "turnId", type);
+  if (!turnId.ok) return turnId;
+  return {
+    ok: true,
+    frame: { type, seq, turnId: turnId.value } as Extract<
+      LiveVoiceServerFrame,
+      { readonly type: T }
+    >,
+  };
+}
+
+function validateTtsAudioFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceTtsAudioServerFrame> {
+  const mimeType = requireString(value, "mimeType", "tts_audio");
+  if (!mimeType.ok) return mimeType;
+  if (!("sampleRate" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "tts_audio frame is missing required field sampleRate",
+      "sampleRate",
+      "tts_audio",
+    );
+  }
+  if (!isPositiveInteger(value.sampleRate)) {
+    return protocolError(
+      "invalid_field",
+      "tts_audio frame field sampleRate must be a positive integer",
+      "sampleRate",
+      "tts_audio",
+    );
+  }
+  if (!("dataBase64" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "tts_audio frame is missing required field dataBase64",
+      "dataBase64",
+      "tts_audio",
+    );
+  }
+  if (typeof value.dataBase64 !== "string") {
+    return invalidAudioPayload(
+      "tts_audio frame dataBase64 must be a string",
+      "dataBase64",
+      "tts_audio",
+    );
+  }
+  if (!isValidBase64Payload(value.dataBase64)) {
+    return invalidAudioPayload(
+      "tts_audio frame dataBase64 is malformed",
+      "dataBase64",
+      "tts_audio",
+    );
+  }
+  return {
+    ok: true,
+    frame: {
+      type: "tts_audio",
+      seq,
+      mimeType: mimeType.value,
+      sampleRate: value.sampleRate,
+      dataBase64: value.dataBase64,
+    },
+  };
+}
+
+function validateMetricsFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceMetricsServerFrame> {
+  const turnId = requireString(value, "turnId", "metrics");
+  if (!turnId.ok) return turnId;
+  const sttMs = requireNullableInteger(value, "sttMs", "metrics");
+  if (!sttMs.ok) return sttMs;
+  const llmFirstDeltaMs = requireNullableInteger(
+    value,
+    "llmFirstDeltaMs",
+    "metrics",
+  );
+  if (!llmFirstDeltaMs.ok) return llmFirstDeltaMs;
+  const ttsFirstAudioMs = requireNullableInteger(
+    value,
+    "ttsFirstAudioMs",
+    "metrics",
+  );
+  if (!ttsFirstAudioMs.ok) return ttsFirstAudioMs;
+  const totalMs = requireNullableInteger(value, "totalMs", "metrics");
+  if (!totalMs.ok) return totalMs;
+
+  return {
+    ok: true,
+    frame: {
+      type: "metrics",
+      seq,
+      turnId: turnId.value,
+      sttMs: sttMs.value,
+      llmFirstDeltaMs: llmFirstDeltaMs.value,
+      ttsFirstAudioMs: ttsFirstAudioMs.value,
+      totalMs: totalMs.value,
+      ...(typeof value.event === "string" ? { event: value.event } : {}),
+      ...(typeof value.sessionId === "string"
+        ? { sessionId: value.sessionId }
+        : {}),
+      ...(typeof value.conversationId === "string"
+        ? { conversationId: value.conversationId }
+        : {}),
+      ...("metrics" in value ? { metrics: value.metrics } : {}),
+    },
+  };
+}
+
+function validateArchivedFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceArchivedServerFrame> {
+  const conversationId = requireString(value, "conversationId", "archived");
+  if (!conversationId.ok) return conversationId;
+  const sessionId = requireString(value, "sessionId", "archived");
+  if (!sessionId.ok) return sessionId;
+
+  let warning: LiveVoiceArchivedServerFrame["warning"];
+  if ("warning" in value && value.warning !== undefined) {
+    if (!isRecord(value.warning)) {
+      return protocolError(
+        "invalid_field",
+        "archived frame field warning must be an object",
+        "warning",
+        "archived",
+      );
+    }
+    const code = requireString(value.warning, "code", "archived.warning");
+    if (!code.ok) return code;
+    const message = requireString(
+      value.warning,
+      "message",
+      "archived.warning",
+    );
+    if (!message.ok) return message;
+    warning = { code: code.value, message: message.value };
+  }
+
+  let attachmentIds: string[] | undefined;
+  if ("attachmentIds" in value && value.attachmentIds !== undefined) {
+    if (
+      !Array.isArray(value.attachmentIds) ||
+      !value.attachmentIds.every((id): id is string => typeof id === "string")
+    ) {
+      return protocolError(
+        "invalid_field",
+        "archived frame field attachmentIds must be an array of strings",
+        "attachmentIds",
+        "archived",
+      );
+    }
+    attachmentIds = value.attachmentIds;
+  }
+
+  let role: "user" | "assistant" | undefined;
+  if ("role" in value && value.role !== undefined) {
+    if (value.role !== "user" && value.role !== "assistant") {
+      return protocolError(
+        "invalid_field",
+        "archived frame field role must be 'user' or 'assistant'",
+        "role",
+        "archived",
+      );
+    }
+    role = value.role;
+  }
+
+  return {
+    ok: true,
+    frame: {
+      type: "archived",
+      seq,
+      conversationId: conversationId.value,
+      sessionId: sessionId.value,
+      ...(typeof value.turnId === "string" ? { turnId: value.turnId } : {}),
+      ...(role !== undefined ? { role } : {}),
+      ...(typeof value.attachmentId === "string"
+        ? { attachmentId: value.attachmentId }
+        : {}),
+      ...(attachmentIds !== undefined ? { attachmentIds } : {}),
+      ...(warning !== undefined ? { warning } : {}),
+    },
+  };
+}
+
+function validateErrorFrame(
+  value: Record<string, unknown>,
+  seq: number,
+): LiveVoiceParseResult<LiveVoiceErrorServerFrame> {
+  const code = requireString(value, "code", "error");
+  if (!code.ok) return code;
+  if (!isLiveVoiceProtocolErrorCode(code.value)) {
+    return protocolError(
+      "invalid_field",
+      `error frame field code must be a known protocol error code`,
+      "code",
+      "error",
+    );
+  }
+  const message = requireString(value, "message", "error");
+  if (!message.ok) return message;
+  return {
+    ok: true,
+    frame: {
+      type: "error",
+      seq,
+      code: code.value,
+      message: message.value,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Base64 PCM helpers
+// ---------------------------------------------------------------------------
+
+// Process bytes in chunks to avoid `Maximum call stack size exceeded`
+// when spreading large arrays into String.fromCharCode. 32 KiB stays
+// well under all browser limits.
+const BASE64_CHUNK_BYTES = 0x8000;
+
+/**
+ * Encode a PCM16 audio buffer to base64.
+ *
+ * Operates on the underlying byte view (little-endian on every platform
+ * we target). The input is treated as a contiguous byte stream — the
+ * caller is responsible for sample-rate and channel layout metadata
+ * (which travels in the JSON `start` frame).
+ */
+export function pcm16ToBase64(view: Int16Array): string {
+  const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_BYTES) {
+    const chunk = bytes.subarray(offset, offset + BASE64_CHUNK_BYTES);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode a base64 PCM16 audio buffer into an `Int16Array`.
+ *
+ * Throws if the base64 string has an odd byte length (malformed PCM16
+ * data) so callers don't silently truncate samples.
+ */
+export function base64ToPcm16(b64: string): Int16Array {
+  if (b64.length === 0) return new Int16Array(0);
+  const binary = atob(b64);
+  const length = binary.length;
+  if (length % 2 !== 0) {
+    throw new Error("base64ToPcm16: payload byte length must be even");
+  }
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Int16Array(bytes.buffer, bytes.byteOffset, length / 2);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (validation primitives + error constructors)
+// ---------------------------------------------------------------------------
+
+function requireString(
+  value: Record<string, unknown>,
+  field: string,
+  frameType: string,
+):
+  | { ok: true; value: string }
+  | { ok: false; error: LiveVoiceProtocolError } {
+  if (!(field in value)) {
+    return {
+      ok: false,
+      error: {
+        code: "missing_required_field",
+        message: `${frameType} frame is missing required field ${field}`,
+        field,
+        frameType,
+      },
+    };
+  }
+  if (typeof value[field] !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_field",
+        message: `${frameType} frame field ${field} must be a string`,
+        field,
+        frameType,
+      },
+    };
+  }
+  return { ok: true, value: value[field] };
+}
+
+function requireNullableInteger(
+  value: Record<string, unknown>,
+  field: string,
+  frameType: string,
+):
+  | { ok: true; value: number | null }
+  | { ok: false; error: LiveVoiceProtocolError } {
+  if (!(field in value)) {
+    return {
+      ok: false,
+      error: {
+        code: "missing_required_field",
+        message: `${frameType} frame is missing required field ${field}`,
+        field,
+        frameType,
+      },
+    };
+  }
+  const v = value[field];
+  if (v === null) return { ok: true, value: null };
+  if (typeof v === "number" && Number.isSafeInteger(v)) {
+    return { ok: true, value: v };
+  }
+  return {
+    ok: false,
+    error: {
+      code: "invalid_field",
+      message: `${frameType} frame field ${field} must be an integer or null`,
+      field,
+      frameType,
+    },
+  };
+}
+
+function isLiveVoiceServerFrameType(
+  value: string,
+): value is LiveVoiceServerFrameType {
+  return (LIVE_VOICE_SERVER_FRAME_TYPES as readonly string[]).includes(value);
+}
+
+function isLiveVoiceProtocolErrorCode(
+  value: string,
+): value is LiveVoiceProtocolErrorCode {
+  return (
+    Object.values(LiveVoiceProtocolErrorCode) as readonly string[]
+  ).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isSafeInteger(value) && value > 0
+  );
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+  );
+}
+
+function isValidBase64Payload(value: string): boolean {
+  if (value.length === 0 || value.length % 4 !== 0) return false;
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+    value,
+  );
+}
+
+function invalidAudioPayload(
+  message: string,
+  field = "dataBase64",
+  frameType = "audio",
+): LiveVoiceParseResult<never> {
+  return protocolError("invalid_audio_payload", message, field, frameType);
+}
+
+function protocolError<T = never>(
+  code: LiveVoiceProtocolErrorCode,
+  message: string,
+  field?: string,
+  frameType?: string,
+): LiveVoiceParseResult<T> {
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      ...(field ? { field } : {}),
+      ...(frameType ? { frameType } : {}),
+    },
+  };
+}
+

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import type { Duplex } from "node:stream";
 import type { Plugin, Connect } from "vite";
 
 const PRODUCTION_ENVIRONMENT_NAME = "production";
@@ -123,6 +124,18 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(retireMiddleware());
       server.middlewares.use(guardianTokenMiddleware(env));
       server.middlewares.use(gatewayProxyMiddleware());
+
+      // Connect middleware only handles HTTP requests; WebSocket
+      // upgrades bypass the middleware pipeline entirely and are
+      // dispatched via the underlying httpServer's `'upgrade'` event.
+      // Without this listener Vite would handle (and reject) browser
+      // WS upgrades to `/assistant/__gateway/:port/...`, so the live
+      // voice client could never connect to the local Bun gateway in
+      // local mode. `server.httpServer` is null when Vite runs in
+      // middleware mode (we don't use that), but be defensive.
+      if (server.httpServer) {
+        server.httpServer.on("upgrade", gatewayUpgradeHandler);
+      }
     },
   };
 }
@@ -713,4 +726,89 @@ function gatewayProxyMiddleware(): Connect.NextHandleFunction {
     // Pipe the incoming request body to the proxy request (supports POST, etc.)
     req.pipe(proxyReq);
   };
+}
+
+/**
+ * `'upgrade'` listener that tunnels WebSocket upgrades for paths
+ * matching `/assistant/__gateway/:port/*` (or `/__gateway/:port/*`)
+ * to the local Bun gateway at `http://127.0.0.1:{port}{rest}`.
+ *
+ * Why this exists: Connect/Vite middleware only handles HTTP requests
+ * that arrive through `httpServer.on('request', ...)`. WebSocket
+ * upgrades are dispatched separately via `httpServer.on('upgrade', ...)`
+ * and bypass the middleware stack entirely. Without an upgrade
+ * listener that mirrors the HTTP proxy in `gatewayProxyMiddleware`,
+ * browser WS upgrades to `/assistant/__gateway/:port/v1/live-voice`
+ * (and any future gateway WS endpoints) would terminate at Vite
+ * instead of being forwarded to the local Bun gateway, so live voice
+ * sessions could never connect in local mode.
+ *
+ * Implementation note: we issue a fresh `http.request` to 127.0.0.1
+ * with the original `Upgrade` / `Connection` / `Sec-WebSocket-*`
+ * headers, listen for the upstream `'upgrade'` event, replay the
+ * upstream HTTP 101 response line + headers onto the client socket,
+ * and then bidirectionally pipe the two sockets. This matches the
+ * minimal-dependency approach used by the HTTP proxy and avoids
+ * adding an external WS-proxy library to dev tooling.
+ */
+function gatewayUpgradeHandler(
+  req: http.IncomingMessage,
+  clientSocket: Duplex,
+  head: Buffer,
+): void {
+  const match = req.url?.match(GATEWAY_PATTERN);
+  if (!match) return;
+
+  const port = parseInt(match[1]!, 10);
+  if (port < 1024 || port > 65535) {
+    clientSocket.destroy();
+    return;
+  }
+  const restPath = match[2] || "/";
+
+  const proxyReq = http.request({
+    hostname: "127.0.0.1",
+    port,
+    path: restPath,
+    method: req.method ?? "GET",
+    headers: { ...req.headers, host: `127.0.0.1:${port}` },
+  });
+
+  proxyReq.on(
+    "upgrade",
+    (proxyRes: http.IncomingMessage, upstreamSocket: Duplex, upstreamHead: Buffer) => {
+      // Replay the upstream 101 Switching Protocols response onto the
+      // browser socket: status line, headers, blank line, then any
+      // body bytes that came along with the upgrade ack.
+      const statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 101} ${proxyRes.statusMessage ?? "Switching Protocols"}\r\n`;
+      const headerLines: string[] = [];
+      for (const [key, value] of Object.entries(proxyRes.headers)) {
+        if (value === undefined) continue;
+        if (Array.isArray(value)) {
+          for (const v of value) headerLines.push(`${key}: ${v}`);
+        } else {
+          headerLines.push(`${key}: ${value}`);
+        }
+      }
+      const responseHead = `${statusLine}${headerLines.join("\r\n")}\r\n\r\n`;
+      clientSocket.write(responseHead);
+      if (upstreamHead.length > 0) clientSocket.write(upstreamHead);
+
+      // Bidirectional pipe. Once either side closes the underlying
+      // socket, the other end will see EOF and tear down naturally.
+      upstreamSocket.on("error", () => clientSocket.destroy());
+      clientSocket.on("error", () => upstreamSocket.destroy());
+      upstreamSocket.pipe(clientSocket);
+      clientSocket.pipe(upstreamSocket);
+    },
+  );
+
+  proxyReq.on("error", () => {
+    clientSocket.destroy();
+  });
+
+  // Forward any pre-upgrade bytes the client already sent, then end
+  // the request side of the proxy connection (upgrades have no body).
+  if (head.length > 0) proxyReq.write(head);
+  proxyReq.end();
 }


### PR DESCRIPTION
## Summary
Revives the `voice-mode` feature flag end-to-end on the web SPA: WebSocket client, AudioWorklet PCM capture, gapless PCM playback, state machine + orchestrator, composer button + overlay UI, all wired into the existing chat composer.

## Self-review result
PASS after 2 remediation rounds (5 gaps fixed across 4 fix PRs).

## Implementation PRs merged into this branch
- #32418: protocol module + frame codecs
- #32420: 16 kHz mono PCM AudioWorklet capture
- #32417: gapless PCM streaming playback
- #32415: Zustand store + state machine
- #32425: LiveVoiceChannelClient (WS transport)
- #32427: LiveVoiceChannelManager (orchestrator)
- #32432: LiveVoiceOverlay (status + transcript)
- #32433: LiveVoiceButton (composer affordance behind voice-mode flag)
- #32435: wire LiveVoice button + overlay into chat composer

## Fix PRs (self-review remediation)
- #32441: end session on conversation switch + notices/overlay layout
- #32442: resume suspended AudioContext + surface capture failures to UI
- #32443: only construct manager when gate is open + reset flag in tests
- #32444: drop stale server frames on end + restore popover anchor scope

Part of plan: realtime-voice-web.md

Closes JARVIS-982