### PR TITLE
Make new assistants offer migration early without derailing the first task

### DIFF
--- a/assistant/src/__tests__/workspace-migration-091-retighten-migration-onboarding-thread.test.ts
+++ b/assistant/src/__tests__/workspace-migration-091-retighten-migration-onboarding-thread.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for workspace migration `091-retighten-migration-onboarding-thread`.
+ *
+ * The migration rewrites the assistant-migration onboarding bullet in
+ * `memory/threads.md` (seeded by 069) only for newly-created workspaces
+ * (`ctx.isNewWorkspace === true`) when the exact old bullet is present. It is a
+ * no-op on upgrade, when the old bullet is absent, and when the file is
+ * missing. It must be idempotent and compose with 069 (069 seeds the old
+ * bullets, then 091 retightens bullet 3).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedOnboardingThreadsMigration } from "../workspace/migrations/069-seed-onboarding-threads.js";
+import { retightenMigrationOnboardingThreadMigration } from "../workspace/migrations/091-retighten-migration-onboarding-thread.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+// Literal copy of the 4-bullet block 069 seeds into memory/threads.md. The
+// third bullet is the one 091 retightens.
+const ONBOARDING_THREADS = `- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.
+- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.
+- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.
+- Suggest connecting to available messaging services like Slack or Telegram
+`;
+
+const OLD_BULLET =
+  "- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-091-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function seedThreads(content: string): void {
+  mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+  writeFileSync(join(workspaceDir, "memory", "threads.md"), content, "utf-8");
+}
+
+function readThreads(): string {
+  return readFileSync(join(workspaceDir, "memory", "threads.md"), "utf-8");
+}
+
+describe("091-retighten-migration-onboarding-thread migration", () => {
+  test("has correct id and description", () => {
+    expect(retightenMigrationOnboardingThreadMigration.id).toBe(
+      "091-retighten-migration-onboarding-thread",
+    );
+    expect(retightenMigrationOnboardingThreadMigration.description).toContain(
+      "threads.md",
+    );
+  });
+
+  test("replaces the old bullet on a new workspace, preserving the others", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    const content = readThreads();
+    expect(content).not.toContain(OLD_BULLET);
+    expect(content).toContain("first real task");
+    expect(content).toContain("ChatGPT, Claude");
+    // The other three onboarding bullets are preserved verbatim.
+    expect(content).toContain("Figure out what kind of personality");
+    expect(content).toContain("data/avatar/avatar-image.png");
+    expect(content).toContain("Slack or Telegram");
+  });
+
+  test("no-op on upgrade even when the old bullet is present", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readThreads()).toBe(ONBOARDING_THREADS);
+  });
+
+  test("no-op when the old bullet is absent (user-edited content)", () => {
+    const edited = "- A bullet the user wrote themselves.\n";
+    seedThreads(edited);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readThreads()).toBe(edited);
+  });
+
+  test("no-op when memory/threads.md does not exist", () => {
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    expect(existsSync(join(workspaceDir, "memory", "threads.md"))).toBe(false);
+  });
+
+  test("idempotent — second run produces identical content", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const afterFirst = readThreads();
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const afterSecond = readThreads();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("composes 069 -> 091: fresh empty workspace ends with the new bullet", () => {
+    // Mirror how the 069 test sets up: create an empty threads.md first.
+    seedThreads("");
+
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    const content = readThreads();
+    expect(content).not.toContain(OLD_BULLET);
+    expect(content).toContain("first real task");
+    expect(content).toContain("ChatGPT, Claude");
+  });
+
+  test("down() is a no-op — rewritten content remains", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const rewritten = readThreads();
+
+    retightenMigrationOnboardingThreadMigration.down(workspaceDir);
+
+    expect(readThreads()).toBe(rewritten);
+  });
+});

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -118,7 +118,7 @@ If nothing comes up, don't force it.
 
 ## Assistant migration
 
-Assume early adopters may have context about themselves, prompts, memories, skills, workflows, tool configs, or integrations from another assistant or harness. Suggest porting early in the first conversation, after the canned greeting and once there is a natural opening. Frame it as a useful shortcut, not a push: "If you've already built context or workflows somewhere else, bring them over early and I can help port them." If they want to proceed, use the `assistant-migration` skill to inventory and port that context into their new assistant. Do not load or activate migration-related skills preemptively.
+Help first: do the user's actual first task before pivoting to this — the migration offer must never derail or precede real work. Then, at the first natural opening, offer it. This applies to every new assistant, whether onboarding was full, condensed, or absent: land it early in the first conversation, at the first lull or seam, even when the user came in task-first. Keep it to one light offer, a useful shortcut and not an upsell: "If you've already built context, prompts, skills, or workflows somewhere else, I can help port them over." Prior context may live in ChatGPT, Claude, OpenClaw, Hermes, or another assistant or harness — name those when it helps. If they decline, drop it and don't re-offer. Only if they opt in, use the `assistant-migration` skill to inventory and port that context; do not load or activate migration-related skills preemptively.
 
 ## Wrap up
 

--- a/assistant/src/workspace/migrations/091-retighten-migration-onboarding-thread.ts
+++ b/assistant/src/workspace/migrations/091-retighten-migration-onboarding-thread.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+// The exact onboarding bullet seeded by 069-seed-onboarding-threads for the
+// assistant-migration step. Inlined here (not imported) to keep this migration
+// self-contained and decoupled from 069.
+const OLD_BULLET =
+  "- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.";
+
+// The tightened replacement: help-first, an early light one-time offer, naming
+// the common prior assistants. Keeps the literal "ChatGPT, Claude" substring.
+const NEW_BULLET =
+  "- After helping with the user's first real task, offer early — at the first natural opening — to port their context, memories, prompts, skills, or workflows from a prior assistant (ChatGPT, Claude, OpenClaw, Hermes, or another tool). Keep it a light one-time offer, not a push; if they decline, drop it.";
+
+export const retightenMigrationOnboardingThreadMigration: WorkspaceMigration = {
+  id: "091-retighten-migration-onboarding-thread",
+  description:
+    "Retighten the assistant-migration onboarding bullet in memory/threads.md for brand new assistants",
+
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // Only rewrite onboarding tasks for newly-created workspaces. An existing
+    // assistant whose user has edited threads.md must not have its content
+    // rewritten on upgrade. When invoked without a context (e.g. from older
+    // callers), default to the safe path and skip — the runner always supplies
+    // one in production.
+    if (!ctx?.isNewWorkspace) return;
+    const filePath = join(workspaceDir, "memory", "threads.md");
+    if (!existsSync(filePath)) return;
+    const content = readFileSync(filePath, "utf-8");
+    // Idempotent: if the old bullet is absent (already replaced, or the user
+    // edited it away), there is nothing to do.
+    if (!content.includes(OLD_BULLET)) return;
+    writeFileSync(filePath, content.replace(OLD_BULLET, NEW_BULLET), "utf-8");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: never rewrite user-visible memory content on rollback.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -88,6 +88,7 @@ import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanc
 import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecate-background-conversation-override.js";
 import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { memoryRouterCostOptimizedProfileMigration } from "./090-memory-router-cost-optimized-profile.js";
+import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-migration-onboarding-thread.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -187,4 +188,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   deprecateBackgroundConversationOverrideMigration,
   moveMemoryTreeOutOfV3Migration,
   memoryRouterCostOptimizedProfileMigration,
+  retightenMigrationOnboardingThreadMigration,
 ];


### PR DESCRIPTION
## Summary
- Rework the BOOTSTRAP.md Assistant migration section: help first, then a light early offer at the first natural opening, naming ChatGPT/Claude/OpenClaw/Hermes, without preloading migration skills.
- Add append-only workspace migration 091 that idempotently retightens the onboarding-thread bullet seeded by 069 for new workspaces only; 069 left untouched.
- Add 091 migration test (replace/upgrade-no-op/absent/missing/idempotent/069-composition/down).

Part of plan: migration-bootstrap-and-skill.md (PR 1 of 2)