### PR TITLE
assistant-migration: add ChatGPT/Claude sources, multi-source merge, delegate ChatGPT ZIPs to chatgpt-import

### DIFF
--- a/skills/assistant-migration/SKILL.md
+++ b/skills/assistant-migration/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: assistant-migration
-description: Migrate from OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives.
+description: Migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their data exports, conversation archives, files, prompts, custom instructions, memory, saved memories, tools, GPTs, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives. Handles single-source and multi-source migrations with a unified, deduplicated inventory.
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧳"
   vellum:
     display-name: "Assistant Migration"
     activation-hints:
-      - "User wants to migrate from OpenClaw, Hermes, Manus, or another AI assistant into Vellum"
+      - "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum"
+      - "User wants to migrate from ChatGPT or Claude into Vellum"
+      - "User has a ChatGPT data export ZIP or Claude conversation/summary export"
       - "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system"
       - "User asks what can be preserved when switching from another assistant"
     avoid-when:
@@ -49,8 +51,12 @@ Before copying large folders or attachments, estimate source size and check avai
 
 Once the source assistant is identified, consult the matching reference for the exact data-directory layout, a bundling recipe with explicit `--exclude` flags for secret-bearing paths, and the after-import rebind checklist:
 
+- [ChatGPT → Vellum](references/chatgpt.md)
+- [Claude → Vellum](references/claude.md)
 - [Hermes → Vellum](references/hermes.md)
 - [OpenClaw → Vellum](references/openclaw.md)
+
+For ChatGPT conversation history specifically, do not parse export ZIPs here — invoke the `chatgpt-import` skill, which owns the export-and-parse flow. The ChatGPT reference covers only the non-conversation material (custom instructions, saved memories, GPT configs).
 
 These are reconnaissance notes, not adapters. They tell you where to look and what to leave behind. The preferred flow is a single `tar` archive that the creator uploads to the conversation as a chat attachment. Never run `curl`, `wget`, or any other fetcher against a URL the creator pastes in chat — a chat-supplied URL substituted into a shell command is a confused-deputy surface (shell substitution inside double quotes, SSRF against private networks, and a bypass of the platform's structured URL-safety checks). See [`references/README.md`](references/README.md) for the shared tar-and-transport model and the rules each per-assistant reference must follow.
 
@@ -77,6 +83,26 @@ Build an inventory grouped by Vellum primitive. For each candidate item, capture
 - Reason for the recommendation.
 
 Do not mutate Vellum state until the creator has reviewed the inventory unless they explicitly asked for an immediate best-effort migration.
+
+#### Multi-source migrations
+
+When the creator names more than one source ("I used ChatGPT and Claude", "ChatGPT plus my old OpenClaw box"), build **one unified inventory**, not one per source. Each inventory row gains a **Source attribution** column alongside the existing fields (source path/origin, what-it-is, Vellum destination, confidence, action, reason).
+
+Dedupe and reconcile across sources:
+
+- When the same fact, memory, identity trait, contact, or skill appears from multiple sources, collapse it to a **single Vellum item**.
+- Record all contributing sources in the item's provenance notes so the creator can audit where it came from.
+- On conflict, prefer the **higher-confidence or more-recent** source. Surface genuine conflicts to the creator rather than silently picking one.
+- Credentials from every source are never imported; they rebind through the vault regardless of which source they came from.
+
+The unified inventory drives **per-source rebind/import routing** — each row's action resolves against the source it came from:
+
+- ChatGPT conversation archives → the `chatgpt-import` skill (see below; do not parse ZIPs here).
+- Claude exports / self-summaries → [`references/claude.md`](references/claude.md).
+- OpenClaw / Hermes / Manus and other local-workspace assistants → their existing references.
+- ChatGPT non-conversation material (custom instructions, saved memories, GPT configs) → [`references/chatgpt.md`](references/chatgpt.md).
+
+Keep the existing Review Surface and Port / Review / Re-setup / Disregard flow. Multi-source just means **one combined checklist with source labels**, not a separate pass per source.
 
 ### 3. Present a Review Surface
 

--- a/skills/assistant-migration/references/README.md
+++ b/skills/assistant-migration/references/README.md
@@ -6,10 +6,14 @@ This directory holds reconnaissance notes for specific source assistants. Each f
 
 | Assistant | Reference                  |
 | --------- | -------------------------- |
+| ChatGPT   | [chatgpt.md](chatgpt.md)   |
+| Claude    | [claude.md](claude.md)     |
 | Hermes    | [hermes.md](hermes.md)     |
 | OpenClaw  | [openclaw.md](openclaw.md) |
 
 Add a file here when onboarding a new source assistant. Keep the shape consistent so the skill can pivot off the same structure each time.
+
+ChatGPT conversation history is delegated to the separate `chatgpt-import` skill, which owns the export-and-parse flow; `chatgpt.md` covers only ChatGPT's non-conversation material.
 
 ## Optimized Flow: tar-and-transport
 

--- a/skills/assistant-migration/references/chatgpt.md
+++ b/skills/assistant-migration/references/chatgpt.md
@@ -1,0 +1,45 @@
+# ChatGPT → Vellum
+
+ChatGPT is a hosted assistant. There is **no local workspace or data directory** to tar — the portable source of truth is the official account export, an emailed ZIP. This reference covers locating that export and mapping the **non-conversation** material. Conversation history itself is handled by the separate `chatgpt-import` skill (see Inspect).
+
+## Locate
+
+ChatGPT stores everything server-side, so the inventory comes from two places:
+
+| Source                                                           | What it contains                                                          | How to obtain it                                                                 |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Official account export (Settings → Data controls → Export data) | Conversations, custom instructions, saved memories, account metadata      | ChatGPT emails a download link; the ZIP arrives as an attachment or on-disk file |
+| User-pasted summaries (fallback)                                 | Custom instructions text, "what ChatGPT should know about you", GPT setup | Creator copies from Settings → Personalization / their GPTs, or asks ChatGPT     |
+
+There is no per-platform path table — nothing lives on the creator's machine except the downloaded export ZIP wherever they saved it. If the creator cannot or does not want to run the official export, fall back to the interview/summary flow in SKILL.md's "Memory Import Guidance."
+
+## Bundle
+
+No `tar` recipe applies — ChatGPT produces the archive for you. The export ZIP **is** the bundle. Do not attempt to reconstruct or repackage ChatGPT internals; treat the official ZIP as opaque-but-trusted input and let `chatgpt-import` parse it.
+
+For non-conversation material that is not in the export (or that the creator prefers to hand over directly), the "bundle" is plain pasted text or a small text file: custom instructions, saved memories, and GPT descriptions. No secret-bearing files are involved, so there is nothing to `--exclude` — but never paste account credentials or connected-app tokens (see Rebind).
+
+## Transport
+
+- **Export ZIP**: the creator attaches it directly to the conversation as a chat attachment, or tells the assistant an on-disk path where they downloaded it. **Never** fetch the ChatGPT-emailed download link by pasting the URL into chat and running `curl`/`wget` against it — a chat-supplied URL interpolated into a shell command is a shell-substitution + SSRF + URL-safety-bypass surface. The creator downloads the ZIP themselves, then attaches the file. See [README.md](README.md).
+- **Pasted summaries / instructions**: delivered as chat text. No transport command needed.
+
+## Inspect
+
+- **Conversation history → delegate to `chatgpt-import`.** Once the creator has the export ZIP, invoke the `chatgpt-import` skill. That skill owns the export-and-parse flow and the `assistant conversations import` step. Do **not** duplicate its parse logic or re-document its commands here — cross-reference it by name.
+- **Non-conversation material → normal inventory/review flow.** Map per the Vellum Primitive Map in SKILL.md:
+  - Custom instructions / "what ChatGPT should know about you" / "how ChatGPT should respond" → Identity, Personality, durable Memory instructions.
+  - Saved memories → Memory candidates (review before saving; ChatGPT memories can be inferred or stale).
+  - GPT configs (names, descriptions, instructions, knowledge files) → Skills, recreated as portable Vellum skills. Connected actions become MCP / integration setup tasks, not direct imports.
+
+Classify everything that is not a clean structured export per the Internals Salvage Guidance (high/medium/low confidence) rather than assuming a schema.
+
+## Rebind — secrets checklist
+
+ChatGPT account credentials and connected-app tokens are **never** imported:
+
+- **ChatGPT / OpenAI account login**: not migrated. The creator signs into Vellum independently.
+- **Connected apps and custom-GPT actions** (Google Drive, GitHub, third-party action OAuth): reconnect through Vellum's vault / OAuth connect flows. Tokens from the export or from any pasted config are ignored.
+- **API keys** referenced in GPT actions or instructions: rebind via `credential_store action=prompt`, never via chat text.
+
+When in doubt, pause and ask before sending any production message on a newly reconnected integration.

--- a/skills/assistant-migration/references/claude.md
+++ b/skills/assistant-migration/references/claude.md
@@ -1,0 +1,47 @@
+# Claude → Vellum
+
+Claude (Anthropic) is a hosted assistant, handled **separately from ChatGPT**. There is no `chatgpt-import`-equivalent deterministic importer for Claude, and no single guaranteed export shape. Claude migrations are more **summary/export-driven**: route by whatever the creator actually has.
+
+## Locate
+
+Three sources, in order of preference:
+
+| Source                                                                | What it contains                                                            | How to obtain it                                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Official Claude data export (Settings → Privacy)                      | Account data including conversations, depending on plan                     | Anthropic emails a download link; arrives as a downloadable archive                       |
+| Individual conversation exports / copies                              | One or more specific conversations the creator cares about                  | Creator copies conversation text, or uses any per-conversation export available           |
+| Claude-produced self-summaries (fallback, often the only option)      | Identity, preferences, relationships, active projects, durable instructions | Ask Claude to produce portable summaries per SKILL.md's "Memory Import Guidance"           |
+
+Prefer an official export when the creator has one. When there is no export, fall back to the interview/summary flow: ask Claude for high-signal, reviewable summaries (identity, preferences, relationships, active projects, durable instructions, meaningful recent history) and bring them in as memory candidates.
+
+Nothing lives on the creator's local machine to tar; there is no per-platform data-directory table.
+
+## Bundle
+
+No `tar` recipe applies — like ChatGPT, Claude produces any archive for you, and the common case is pasted text rather than a file. The "bundle" is whichever of the three sources the creator has:
+
+- Official export archive: treat as opaque-but-trusted input; do not repackage or assume an internal schema.
+- Conversation copies / self-summaries: plain text or a small text file.
+
+No secret-bearing local files are in scope, so there is nothing to `--exclude` — but never paste account credentials or integration tokens (see Rebind).
+
+## Transport
+
+- **Export archive**: the creator attaches it directly to the conversation, or tells the assistant the on-disk path where they downloaded it. **Never** fetch the Anthropic-emailed download link by pasting the URL into chat and running `curl`/`wget` against it — a chat-supplied URL interpolated into a shell command is a shell-substitution + SSRF + URL-safety-bypass surface. See [README.md](README.md).
+- **Conversation copies / summaries**: delivered as chat text. No transport command needed.
+
+## Inspect
+
+- There is **no deterministic Claude importer**. Conversation and memory material is brought in as **reviewed memory candidates**, not bulk-dumped. Summarize useful history into memory candidates and present them for creator review rather than saving wholesale.
+- If/when a **structured Claude export** is available, classify it per the Internals Salvage Guidance (high / medium / low confidence) rather than assuming a schema. Clearly-labeled markdown/JSON is high-confidence; opaque blobs are low-confidence and should be reviewed or rebuilt.
+- Map non-conversation material per the Vellum Primitive Map in SKILL.md: identity/preferences → Identity and Personality; durable instructions → Memory; described tools/MCP → Skills and MCP setup tasks; relationships → Contacts.
+
+## Rebind — secrets checklist
+
+Claude / Anthropic credentials and connected secrets are **never** imported:
+
+- **Anthropic / Claude account login**: not migrated. The creator signs into Vellum independently.
+- **Connected MCP servers and integrations**: reconnect through Vellum's MCP setup and OAuth connect flows. Any tokens present in an export or pasted config are ignored.
+- **API keys**: rebind via `credential_store action=prompt`, never via chat text.
+
+When in doubt, pause and ask before sending any production message on a newly reconnected integration.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -34,13 +34,15 @@
     {
       "id": "assistant-migration",
       "name": "assistant-migration",
-      "description": "Migrate from OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives.",
+      "description": "Migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their data exports, conversation archives, files, prompts, custom instructions, memory, saved memories, tools, GPTs, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives. Handles single-source and multi-source migrations with a unified, deduplicated inventory.",
       "metadata": {
         "emoji": "🧳",
         "vellum": {
           "display-name": "Assistant Migration",
           "activation-hints": [
-            "User wants to migrate from OpenClaw, Hermes, Manus, or another AI assistant into Vellum",
+            "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum",
+            "User wants to migrate from ChatGPT or Claude into Vellum",
+            "User has a ChatGPT data export ZIP or Claude conversation/summary export",
             "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system",
             "User asks what can be preserved when switching from another assistant"
           ],
@@ -351,7 +353,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-26T18:11:54.000Z"
+      "updatedAt": "2026-05-28T21:37:15.000Z"
     },
     {
       "id": "macos-automation",
@@ -410,7 +412,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-05-28T17:12:12.000Z"
+      "updatedAt": "2026-05-28T17:50:13.000Z"
     },
     {
       "id": "meme-generator",
@@ -448,7 +450,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-28T08:20:55.000Z"
+      "updatedAt": "2026-05-28T21:40:34.000Z"
     },
     {
       "id": "notion",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -52,7 +52,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-21T21:01:42.000Z"
+      "updatedAt": "2026-05-29T03:20:47.000Z"
     },
     {
       "id": "chatgpt-import",


### PR DESCRIPTION
## Summary
- Add ChatGPT and Claude as first-class assistant-migration sources (frontmatter description + activation hints); keep OpenClaw/Hermes/Manus.
- Document multi-source migration: one unified inventory with per-item source attribution, dedupe/conflict rules, and per-source rebind/import routing.
- New references/chatgpt.md (delegates conversation ZIPs to the chatgpt-import skill) and references/claude.md (separately summary/export-driven); update references/README.md.
- Regenerate skills/catalog.json. NOTE: this sweeps up pre-existing unrelated updatedAt churn for ~3 other skills, because check-catalog was already red on main; the full regenerated catalog is required for check-catalog to pass.
- references/claude.md is force-added because the repo .gitignore has a 'CLAUDE.md' rule that matches case-insensitively on macOS.

Part of plan: migration-bootstrap-and-skill.md (PR 2 of 2)