### PR TITLE
Assistant migration: early first-conversation offer + robust multi-source skill (JARVIS-986)

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -285,6 +285,45 @@ describe("first-greeting", () => {
     });
   });
 
+  describe("migration offer is present in every variant", () => {
+    const MIGRATION_MARKER = "bring them over early";
+
+    it("no-onboarding greeting includes the migration offer", () => {
+      expect(getCannedFirstGreeting(undefined)).toContain(MIGRATION_MARKER);
+      expect(CANNED_FIRST_GREETING).toContain(MIGRATION_MARKER);
+    });
+
+    it("minimal onboarding (falls back to CANNED) includes the migration offer", () => {
+      expect(
+        getCannedFirstGreeting({ tools: [], tasks: [], tone: "" }),
+      ).toContain(MIGRATION_MARKER);
+    });
+
+    it("every tone variant includes the migration offer", () => {
+      for (const tone of ["grounded", "warm", "energetic", "poetic"]) {
+        const greeting = getCannedFirstGreeting({
+          tools: [],
+          tasks: [],
+          tone,
+          userName: "Alice",
+          assistantName: "Pax",
+        });
+        expect(greeting).toContain(MIGRATION_MARKER);
+        expect(greeting).toContain("port them");
+      }
+    });
+
+    it("google-connected greeting still includes the migration offer", () => {
+      const greeting = getCannedFirstGreeting({
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      });
+      expect(greeting).toContain(MIGRATION_MARKER);
+    });
+  });
+
   describe("buildScanFirstMessage", () => {
     it("website variant includes 'my website' and the URL", () => {
       const msg = buildScanFirstMessage("https://acme.com", "website");

--- a/assistant/src/__tests__/workspace-migration-091-retighten-migration-onboarding-thread.test.ts
+++ b/assistant/src/__tests__/workspace-migration-091-retighten-migration-onboarding-thread.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for workspace migration `091-retighten-migration-onboarding-thread`.
+ *
+ * The migration rewrites the assistant-migration onboarding bullet in
+ * `memory/threads.md` (seeded by 069) only for newly-created workspaces
+ * (`ctx.isNewWorkspace === true`) when the exact old bullet is present. It is a
+ * no-op on upgrade, when the old bullet is absent, and when the file is
+ * missing. It must be idempotent and compose with 069 (069 seeds the old
+ * bullets, then 091 retightens bullet 3).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedOnboardingThreadsMigration } from "../workspace/migrations/069-seed-onboarding-threads.js";
+import { retightenMigrationOnboardingThreadMigration } from "../workspace/migrations/091-retighten-migration-onboarding-thread.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+// Literal copy of the 4-bullet block 069 seeds into memory/threads.md. The
+// third bullet is the one 091 retightens.
+const ONBOARDING_THREADS = `- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.
+- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.
+- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.
+- Suggest connecting to available messaging services like Slack or Telegram
+`;
+
+const OLD_BULLET =
+  "- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-091-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function seedThreads(content: string): void {
+  mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+  writeFileSync(join(workspaceDir, "memory", "threads.md"), content, "utf-8");
+}
+
+function readThreads(): string {
+  return readFileSync(join(workspaceDir, "memory", "threads.md"), "utf-8");
+}
+
+describe("091-retighten-migration-onboarding-thread migration", () => {
+  test("has correct id and description", () => {
+    expect(retightenMigrationOnboardingThreadMigration.id).toBe(
+      "091-retighten-migration-onboarding-thread",
+    );
+    expect(retightenMigrationOnboardingThreadMigration.description).toContain(
+      "threads.md",
+    );
+  });
+
+  test("replaces the old bullet on a new workspace, preserving the others", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    const content = readThreads();
+    expect(content).not.toContain(OLD_BULLET);
+    expect(content).toContain("first real task");
+    expect(content).toContain("ChatGPT, Claude");
+    // The other three onboarding bullets are preserved verbatim.
+    expect(content).toContain("Figure out what kind of personality");
+    expect(content).toContain("data/avatar/avatar-image.png");
+    expect(content).toContain("Slack or Telegram");
+  });
+
+  test("no-op on upgrade even when the old bullet is present", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readThreads()).toBe(ONBOARDING_THREADS);
+  });
+
+  test("no-op when the old bullet is absent (user-edited content)", () => {
+    const edited = "- A bullet the user wrote themselves.\n";
+    seedThreads(edited);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readThreads()).toBe(edited);
+  });
+
+  test("no-op when memory/threads.md does not exist", () => {
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    expect(existsSync(join(workspaceDir, "memory", "threads.md"))).toBe(false);
+  });
+
+  test("idempotent — second run produces identical content", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const afterFirst = readThreads();
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const afterSecond = readThreads();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("composes 069 -> 091: fresh empty workspace ends with the new bullet", () => {
+    // Mirror how the 069 test sets up: create an empty threads.md first.
+    seedThreads("");
+
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    const content = readThreads();
+    expect(content).not.toContain(OLD_BULLET);
+    expect(content).toContain("first real task");
+    expect(content).toContain("ChatGPT, Claude");
+  });
+
+  test("down() is a no-op — rewritten content remains", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const rewritten = readThreads();
+
+    retightenMigrationOnboardingThreadMigration.down(workspaceDir);
+
+    expect(readThreads()).toBe(rewritten);
+  });
+});

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -14,12 +14,6 @@ export interface OnboardingGreetingContext {
   googleConnected?: boolean;
 }
 
-export const CANNED_FIRST_GREETING = [
-  "Hey,",
-  "",
-  "We can get into whatever you've got, or just talk first — that tends to go better. Up to you. If you have context or workflows from another assistant or harness, bring them over early and I'll help port them.",
-].join("\n");
-
 /**
  * Returns `true` when all of the following are true:
  * - `conversationMessageCount === 0` (no prior messages in this conversation)
@@ -67,14 +61,30 @@ function buildIntroLine(
   return [greeting, who, close].filter(Boolean).join(" ");
 }
 
-const TONE_INVITE: Record<Tone, string> = {
+// Every greeting variant — the no-onboarding CANNED greeting and all four
+// personalized tones — ends with a migration offer. The opener (task-vs-talk)
+// and the migration offer are kept as separate per-tone maps and composed in
+// `buildInvite`, rather than inlined as one full sentence per variant, so the
+// offer cannot be silently dropped from a variant when the opener copy is
+// edited. The first-greeting test asserts every variant still includes it.
+const TONE_INVITE_OPENER: Record<Tone, string> = {
   grounded:
-    "We can get into whatever you've got, or just talk first — that tends to go better. Up to you. If you have context or workflows from another assistant or harness, bring them over early and I'll help port them.",
-  warm: "We can start on something specific, or just talk for a bit first — honestly that tends to work out better. Either way, I'm here. If you have context or workflows from another assistant or harness, bring them over early and I can help port them.",
+    "We can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
+  warm: "We can start on something specific, or just talk for a bit first — honestly that tends to work out better. Either way, I'm here.",
   energetic:
-    "We can jump straight into whatever you've got, or take a few minutes to just talk first. If you've got context or workflows from another assistant or harness, bring them over early and I'll port them with you. What sounds right?",
+    "We can jump straight into whatever you've got, or take a few minutes to just talk first.",
   poetic:
-    "We can start with whatever's in front of you, or just talk for a bit first. Either way. If there's old context or workflows from another assistant or harness, bring them over early and I'll help port them.",
+    "We can start with whatever's in front of you, or just talk for a bit first. Either way.",
+};
+
+const TONE_MIGRATION_OFFER: Record<Tone, string> = {
+  grounded:
+    "If you have context or workflows from another assistant or harness, bring them over early and I'll help port them.",
+  warm: "If you have context or workflows from another assistant or harness, bring them over early and I can help port them.",
+  energetic:
+    "If you've got context or workflows from another assistant or harness, bring them over early and I'll port them with you. What sounds right?",
+  poetic:
+    "If there's old context or workflows from another assistant or harness, bring them over early and I'll help port them.",
 };
 
 const TONE_GOOGLE_SCAN: Record<Tone, string> = {
@@ -88,8 +98,16 @@ const TONE_GOOGLE_SCAN: Record<Tone, string> = {
 };
 
 function buildInvite(tone: Tone = "grounded"): string {
-  return TONE_INVITE[tone];
+  return `${TONE_INVITE_OPENER[tone]} ${TONE_MIGRATION_OFFER[tone]}`;
 }
+
+// Composed from the grounded opener + migration offer so the no-onboarding
+// greeting reuses the same source as the personalized grounded greeting rather
+// than duplicating the copy. Defined after the tone maps so they are
+// initialized before this module-level evaluation runs.
+export const CANNED_FIRST_GREETING = ["Hey,", "", buildInvite("grounded")].join(
+  "\n",
+);
 
 const VALID_TONES = new Set<string>([
   "grounded",

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -118,7 +118,7 @@ If nothing comes up, don't force it.
 
 ## Assistant migration
 
-Assume early adopters may have context about themselves, prompts, memories, skills, workflows, tool configs, or integrations from another assistant or harness. Suggest porting early in the first conversation, after the canned greeting and once there is a natural opening. Frame it as a useful shortcut, not a push: "If you've already built context or workflows somewhere else, bring them over early and I can help port them." If they want to proceed, use the `assistant-migration` skill to inventory and port that context into their new assistant. Do not load or activate migration-related skills preemptively.
+Help first: do the user's actual first task before pivoting to this — the migration offer must never derail or precede real work. Then, at the first natural opening, offer it. This applies to every new assistant, whether onboarding was full, condensed, or absent: land it early in the first conversation, at the first lull or seam, even when the user came in task-first. Keep it to one light offer, a useful shortcut and not an upsell: "If you've already built context, prompts, skills, or workflows somewhere else, I can help port them over." Prior context may live in ChatGPT, Claude, OpenClaw, Hermes, or another assistant or harness — name those when it helps. If they decline, drop it and don't re-offer. Only if they opt in, use the `assistant-migration` skill to inventory and port that context; do not load or activate migration-related skills preemptively.
 
 ## Wrap up
 

--- a/assistant/src/workspace/migrations/091-retighten-migration-onboarding-thread.ts
+++ b/assistant/src/workspace/migrations/091-retighten-migration-onboarding-thread.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+// The exact onboarding bullet seeded by 069-seed-onboarding-threads for the
+// assistant-migration step. Inlined here (not imported) to keep this migration
+// self-contained and decoupled from 069.
+const OLD_BULLET =
+  "- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.";
+
+// The tightened replacement: help-first, an early light one-time offer, naming
+// the common prior assistants. Keeps the literal "ChatGPT, Claude" substring.
+const NEW_BULLET =
+  "- After helping with the user's first real task, offer early — at the first natural opening — to port their context, memories, prompts, skills, or workflows from a prior assistant (ChatGPT, Claude, OpenClaw, Hermes, or another tool). Keep it a light one-time offer, not a push; if they decline, drop it.";
+
+export const retightenMigrationOnboardingThreadMigration: WorkspaceMigration = {
+  id: "091-retighten-migration-onboarding-thread",
+  description:
+    "Retighten the assistant-migration onboarding bullet in memory/threads.md for brand new assistants",
+
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // Only rewrite onboarding tasks for newly-created workspaces. An existing
+    // assistant whose user has edited threads.md must not have its content
+    // rewritten on upgrade. When invoked without a context (e.g. from older
+    // callers), default to the safe path and skip — the runner always supplies
+    // one in production.
+    if (!ctx?.isNewWorkspace) return;
+    const filePath = join(workspaceDir, "memory", "threads.md");
+    if (!existsSync(filePath)) return;
+    const content = readFileSync(filePath, "utf-8");
+    // Idempotent: if the old bullet is absent (already replaced, or the user
+    // edited it away), there is nothing to do.
+    if (!content.includes(OLD_BULLET)) return;
+    writeFileSync(filePath, content.replace(OLD_BULLET, NEW_BULLET), "utf-8");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: never rewrite user-visible memory content on rollback.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -88,6 +88,7 @@ import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanc
 import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecate-background-conversation-override.js";
 import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { memoryRouterCostOptimizedProfileMigration } from "./090-memory-router-cost-optimized-profile.js";
+import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-migration-onboarding-thread.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -187,4 +188,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   deprecateBackgroundConversationOverrideMigration,
   moveMemoryTreeOutOfV3Migration,
   memoryRouterCostOptimizedProfileMigration,
+  retightenMigrationOnboardingThreadMigration,
 ];

--- a/skills/assistant-migration/SKILL.md
+++ b/skills/assistant-migration/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🧳"
   vellum:
     display-name: "Assistant Migration"
+    includes: ["chatgpt-import"]
     activation-hints:
       - "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum"
       - "User wants to migrate from ChatGPT or Claude into Vellum"

--- a/skills/assistant-migration/SKILL.md
+++ b/skills/assistant-migration/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: assistant-migration
-description: Migrate from OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives.
+description: Migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their data exports, conversation archives, files, prompts, custom instructions, memory, saved memories, tools, GPTs, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives. Handles single-source and multi-source migrations with a unified, deduplicated inventory.
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧳"
   vellum:
     display-name: "Assistant Migration"
     activation-hints:
-      - "User wants to migrate from OpenClaw, Hermes, Manus, or another AI assistant into Vellum"
+      - "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum"
+      - "User wants to migrate from ChatGPT or Claude into Vellum"
+      - "User has a ChatGPT data export ZIP or Claude conversation/summary export"
       - "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system"
       - "User asks what can be preserved when switching from another assistant"
     avoid-when:
@@ -49,8 +51,12 @@ Before copying large folders or attachments, estimate source size and check avai
 
 Once the source assistant is identified, consult the matching reference for the exact data-directory layout, a bundling recipe with explicit `--exclude` flags for secret-bearing paths, and the after-import rebind checklist:
 
+- [ChatGPT → Vellum](references/chatgpt.md)
+- [Claude → Vellum](references/claude.md)
 - [Hermes → Vellum](references/hermes.md)
 - [OpenClaw → Vellum](references/openclaw.md)
+
+For ChatGPT conversation history specifically, do not parse export ZIPs here — invoke the `chatgpt-import` skill, which owns the export-and-parse flow. The ChatGPT reference covers only the non-conversation material (custom instructions, saved memories, GPT configs).
 
 These are reconnaissance notes, not adapters. They tell you where to look and what to leave behind. The preferred flow is a single `tar` archive that the creator uploads to the conversation as a chat attachment. Never run `curl`, `wget`, or any other fetcher against a URL the creator pastes in chat — a chat-supplied URL substituted into a shell command is a confused-deputy surface (shell substitution inside double quotes, SSRF against private networks, and a bypass of the platform's structured URL-safety checks). See [`references/README.md`](references/README.md) for the shared tar-and-transport model and the rules each per-assistant reference must follow.
 
@@ -77,6 +83,26 @@ Build an inventory grouped by Vellum primitive. For each candidate item, capture
 - Reason for the recommendation.
 
 Do not mutate Vellum state until the creator has reviewed the inventory unless they explicitly asked for an immediate best-effort migration.
+
+#### Multi-source migrations
+
+When the creator names more than one source ("I used ChatGPT and Claude", "ChatGPT plus my old OpenClaw box"), build **one unified inventory**, not one per source. Each inventory row gains a **Source attribution** column alongside the existing fields (source path/origin, what-it-is, Vellum destination, confidence, action, reason).
+
+Dedupe and reconcile across sources:
+
+- When the same fact, memory, identity trait, contact, or skill appears from multiple sources, collapse it to a **single Vellum item**.
+- Record all contributing sources in the item's provenance notes so the creator can audit where it came from.
+- On conflict, prefer the **higher-confidence or more-recent** source. Surface genuine conflicts to the creator rather than silently picking one.
+- Credentials from every source are never imported; they rebind through the vault regardless of which source they came from.
+
+The unified inventory drives **per-source rebind/import routing** — each row's action resolves against the source it came from:
+
+- ChatGPT conversation archives → the `chatgpt-import` skill (see below; do not parse ZIPs here).
+- Claude exports / self-summaries → [`references/claude.md`](references/claude.md).
+- OpenClaw / Hermes / Manus and other local-workspace assistants → their existing references.
+- ChatGPT non-conversation material (custom instructions, saved memories, GPT configs) → [`references/chatgpt.md`](references/chatgpt.md).
+
+Keep the existing Review Surface and Port / Review / Re-setup / Disregard flow. Multi-source just means **one combined checklist with source labels**, not a separate pass per source.
 
 ### 3. Present a Review Surface
 

--- a/skills/assistant-migration/references/README.md
+++ b/skills/assistant-migration/references/README.md
@@ -6,10 +6,14 @@ This directory holds reconnaissance notes for specific source assistants. Each f
 
 | Assistant | Reference                  |
 | --------- | -------------------------- |
+| ChatGPT   | [chatgpt.md](chatgpt.md)   |
+| Claude    | [claude.md](claude.md)     |
 | Hermes    | [hermes.md](hermes.md)     |
 | OpenClaw  | [openclaw.md](openclaw.md) |
 
 Add a file here when onboarding a new source assistant. Keep the shape consistent so the skill can pivot off the same structure each time.
+
+ChatGPT conversation history is delegated to the separate `chatgpt-import` skill, which owns the export-and-parse flow; `chatgpt.md` covers only ChatGPT's non-conversation material.
 
 ## Optimized Flow: tar-and-transport
 

--- a/skills/assistant-migration/references/chatgpt.md
+++ b/skills/assistant-migration/references/chatgpt.md
@@ -1,0 +1,45 @@
+# ChatGPT → Vellum
+
+ChatGPT is a hosted assistant. There is **no local workspace or data directory** to tar — the portable source of truth is the official account export, an emailed ZIP. This reference covers locating that export and mapping the **non-conversation** material. Conversation history itself is handled by the separate `chatgpt-import` skill (see Inspect).
+
+## Locate
+
+ChatGPT stores everything server-side, so the inventory comes from two places:
+
+| Source                                                           | What it contains                                                          | How to obtain it                                                                 |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Official account export (Settings → Data controls → Export data) | Conversations, custom instructions, saved memories, account metadata      | ChatGPT emails a download link; the ZIP arrives as an attachment or on-disk file |
+| User-pasted summaries (fallback)                                 | Custom instructions text, "what ChatGPT should know about you", GPT setup | Creator copies from Settings → Personalization / their GPTs, or asks ChatGPT     |
+
+There is no per-platform path table — nothing lives on the creator's machine except the downloaded export ZIP wherever they saved it. If the creator cannot or does not want to run the official export, fall back to the interview/summary flow in SKILL.md's "Memory Import Guidance."
+
+## Bundle
+
+No `tar` recipe applies — ChatGPT produces the archive for you. The export ZIP **is** the bundle. Do not attempt to reconstruct or repackage ChatGPT internals; treat the official ZIP as opaque-but-trusted input and let `chatgpt-import` parse it.
+
+For non-conversation material that is not in the export (or that the creator prefers to hand over directly), the "bundle" is plain pasted text or a small text file: custom instructions, saved memories, and GPT descriptions. No secret-bearing files are involved, so there is nothing to `--exclude` — but never paste account credentials or connected-app tokens (see Rebind).
+
+## Transport
+
+- **Export ZIP**: the creator attaches it directly to the conversation as a chat attachment, or tells the assistant an on-disk path where they downloaded it. **Never** fetch the ChatGPT-emailed download link by pasting the URL into chat and running `curl`/`wget` against it — a chat-supplied URL interpolated into a shell command is a shell-substitution + SSRF + URL-safety-bypass surface. The creator downloads the ZIP themselves, then attaches the file. See [README.md](README.md).
+- **Pasted summaries / instructions**: delivered as chat text. No transport command needed.
+
+## Inspect
+
+- **Conversation history → delegate to `chatgpt-import`.** Once the creator has the export ZIP, invoke the `chatgpt-import` skill. That skill owns the export-and-parse flow and the `assistant conversations import` step. Do **not** duplicate its parse logic or re-document its commands here — cross-reference it by name.
+- **Non-conversation material → normal inventory/review flow.** Map per the Vellum Primitive Map in SKILL.md:
+  - Custom instructions / "what ChatGPT should know about you" / "how ChatGPT should respond" → Identity, Personality, durable Memory instructions.
+  - Saved memories → Memory candidates (review before saving; ChatGPT memories can be inferred or stale).
+  - GPT configs (names, descriptions, instructions, knowledge files) → Skills, recreated as portable Vellum skills. Connected actions become MCP / integration setup tasks, not direct imports.
+
+Classify everything that is not a clean structured export per the Internals Salvage Guidance (high/medium/low confidence) rather than assuming a schema.
+
+## Rebind — secrets checklist
+
+ChatGPT account credentials and connected-app tokens are **never** imported:
+
+- **ChatGPT / OpenAI account login**: not migrated. The creator signs into Vellum independently.
+- **Connected apps and custom-GPT actions** (Google Drive, GitHub, third-party action OAuth): reconnect through Vellum's vault / OAuth connect flows. Tokens from the export or from any pasted config are ignored.
+- **API keys** referenced in GPT actions or instructions: rebind via `credential_store action=prompt`, never via chat text.
+
+When in doubt, pause and ask before sending any production message on a newly reconnected integration.

--- a/skills/assistant-migration/references/chatgpt.md
+++ b/skills/assistant-migration/references/chatgpt.md
@@ -27,7 +27,7 @@ For non-conversation material that is not in the export (or that the creator pre
 ## Inspect
 
 - **Conversation history → delegate to `chatgpt-import`.** Once the creator has the export ZIP, invoke the `chatgpt-import` skill. That skill owns the export-and-parse flow and the `assistant conversations import` step. Do **not** duplicate its parse logic or re-document its commands here — cross-reference it by name.
-- **Non-conversation material → normal inventory/review flow.** Map per the Vellum Primitive Map in SKILL.md:
+- **Non-conversation material → normal inventory/review flow.** The official export ZIP also contains custom instructions and saved memories that `chatgpt-import` does not consume — unzip the export and read those files directly into the inventory rather than relying on the creator to re-paste them. Map per the Vellum Primitive Map in SKILL.md:
   - Custom instructions / "what ChatGPT should know about you" / "how ChatGPT should respond" → Identity, Personality, durable Memory instructions.
   - Saved memories → Memory candidates (review before saving; ChatGPT memories can be inferred or stale).
   - GPT configs (names, descriptions, instructions, knowledge files) → Skills, recreated as portable Vellum skills. Connected actions become MCP / integration setup tasks, not direct imports.

--- a/skills/assistant-migration/references/claude.md
+++ b/skills/assistant-migration/references/claude.md
@@ -1,0 +1,47 @@
+# Claude → Vellum
+
+Claude (Anthropic) is a hosted assistant, handled **separately from ChatGPT**. There is no `chatgpt-import`-equivalent deterministic importer for Claude, and no single guaranteed export shape. Claude migrations are more **summary/export-driven**: route by whatever the creator actually has.
+
+## Locate
+
+Three sources, in order of preference:
+
+| Source                                                                | What it contains                                                            | How to obtain it                                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Official Claude data export (Settings → Privacy)                      | Account data including conversations, depending on plan                     | Anthropic emails a download link; arrives as a downloadable archive                       |
+| Individual conversation exports / copies                              | One or more specific conversations the creator cares about                  | Creator copies conversation text, or uses any per-conversation export available           |
+| Claude-produced self-summaries (fallback, often the only option)      | Identity, preferences, relationships, active projects, durable instructions | Ask Claude to produce portable summaries per SKILL.md's "Memory Import Guidance"           |
+
+Prefer an official export when the creator has one. When there is no export, fall back to the interview/summary flow: ask Claude for high-signal, reviewable summaries (identity, preferences, relationships, active projects, durable instructions, meaningful recent history) and bring them in as memory candidates.
+
+Nothing lives on the creator's local machine to tar; there is no per-platform data-directory table.
+
+## Bundle
+
+No `tar` recipe applies — like ChatGPT, Claude produces any archive for you, and the common case is pasted text rather than a file. The "bundle" is whichever of the three sources the creator has:
+
+- Official export archive: treat as opaque-but-trusted input; do not repackage or assume an internal schema.
+- Conversation copies / self-summaries: plain text or a small text file.
+
+No secret-bearing local files are in scope, so there is nothing to `--exclude` — but never paste account credentials or integration tokens (see Rebind).
+
+## Transport
+
+- **Export archive**: the creator attaches it directly to the conversation, or tells the assistant the on-disk path where they downloaded it. **Never** fetch the Anthropic-emailed download link by pasting the URL into chat and running `curl`/`wget` against it — a chat-supplied URL interpolated into a shell command is a shell-substitution + SSRF + URL-safety-bypass surface. See [README.md](README.md).
+- **Conversation copies / summaries**: delivered as chat text. No transport command needed.
+
+## Inspect
+
+- There is **no deterministic Claude importer**. Conversation and memory material is brought in as **reviewed memory candidates**, not bulk-dumped. Summarize useful history into memory candidates and present them for creator review rather than saving wholesale.
+- If/when a **structured Claude export** is available, classify it per the Internals Salvage Guidance (high / medium / low confidence) rather than assuming a schema. Clearly-labeled markdown/JSON is high-confidence; opaque blobs are low-confidence and should be reviewed or rebuilt.
+- Map non-conversation material per the Vellum Primitive Map in SKILL.md: identity/preferences → Identity and Personality; durable instructions → Memory; described tools/MCP → Skills and MCP setup tasks; relationships → Contacts.
+
+## Rebind — secrets checklist
+
+Claude / Anthropic credentials and connected secrets are **never** imported:
+
+- **Anthropic / Claude account login**: not migrated. The creator signs into Vellum independently.
+- **Connected MCP servers and integrations**: reconnect through Vellum's MCP setup and OAuth connect flows. Any tokens present in an export or pasted config are ignored.
+- **API keys**: rebind via `credential_store action=prompt`, never via chat text.
+
+When in doubt, pause and ask before sending any production message on a newly reconnected integration.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -52,7 +52,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-29T03:20:47.000Z"
+      "updatedAt": "2026-05-29T03:39:03.000Z"
     },
     {
       "id": "chatgpt-import",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -34,13 +34,15 @@
     {
       "id": "assistant-migration",
       "name": "assistant-migration",
-      "description": "Migrate from OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives.",
+      "description": "Migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, and other AI assistants into Vellum by inspecting their data exports, conversation archives, files, prompts, custom instructions, memory, saved memories, tools, GPTs, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives. Handles single-source and multi-source migrations with a unified, deduplicated inventory.",
       "metadata": {
         "emoji": "🧳",
         "vellum": {
           "display-name": "Assistant Migration",
           "activation-hints": [
-            "User wants to migrate from OpenClaw, Hermes, Manus, or another AI assistant into Vellum",
+            "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum",
+            "User wants to migrate from ChatGPT or Claude into Vellum",
+            "User has a ChatGPT data export ZIP or Claude conversation/summary export",
             "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system",
             "User asks what can be preserved when switching from another assistant"
           ],
@@ -50,7 +52,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-21T21:01:42.000Z"
+      "updatedAt": "2026-05-29T03:20:47.000Z"
     },
     {
       "id": "chatgpt-import",
@@ -351,7 +353,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-26T18:11:54.000Z"
+      "updatedAt": "2026-05-28T21:37:15.000Z"
     },
     {
       "id": "macos-automation",
@@ -410,7 +412,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-05-28T17:12:12.000Z"
+      "updatedAt": "2026-05-28T17:50:13.000Z"
     },
     {
       "id": "meme-generator",
@@ -448,7 +450,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-28T08:20:55.000Z"
+      "updatedAt": "2026-05-28T21:40:34.000Z"
     },
     {
       "id": "notion",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -39,6 +39,9 @@
         "emoji": "🧳",
         "vellum": {
           "display-name": "Assistant Migration",
+          "includes": [
+            "chatgpt-import"
+          ],
           "activation-hints": [
             "User wants to migrate from ChatGPT, Claude, OpenClaw, Hermes, Manus, or another AI assistant into Vellum",
             "User wants to migrate from ChatGPT or Claude into Vellum",
@@ -52,7 +55,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-29T03:39:03.000Z"
+      "updatedAt": "2026-05-29T03:45:08.000Z"
     },
     {
       "id": "chatgpt-import",


### PR DESCRIPTION
## Summary
Improves how a brand-new Vellum assistant helps users port context from prior AI assistants. Tightens the first-conversation migration offer (help-first, then an early light offer) and hardens the `assistant-migration` skill to treat ChatGPT and Claude as first-class sources with explicit multi-source merge semantics, delegating ChatGPT conversation ZIPs to the existing `chatgpt-import` skill.

Closes JARVIS-986.

## Self-review result
PASS — 1 blocking gap fixed (catalog `updatedAt` self-staleness after squash-merge → catalog regenerated as a final catalog-only commit; `check-catalog` green), 1 optional doc clarification applied (chatgpt.md: read non-conversation files from the unzipped export). 1 Codex P2 (091 test importing 069) evaluated and declined with rationale: it mirrors the existing 069→060 composition-test precedent, the test-isolation rule targets shared-state coupling not pure migration fns on a tmpdir, and the real call preserves drift-detection.

## PRs merged into feature branch
- #32525: Make new assistants offer migration early without derailing the first task (BOOTSTRAP.md + append-only migration 091 + test)
- #32526: assistant-migration: add ChatGPT/Claude sources, multi-source merge, delegate ChatGPT ZIPs to chatgpt-import

## Notes
- Migration 069 left untouched (write-once rule); new append-only `091-retighten-migration-onboarding-thread` retightens the seeded onboarding bullet for new workspaces only.
- `skills/catalog.json` regeneration also swept up pre-existing unrelated `updatedAt` drift for ~3 other skills (catalog was already red on main); this is expected.

Part of plan: migration-bootstrap-and-skill.md