### PR TITLE
fix(macos): silence unused 'risk' binding warning in AssistantProgressView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1136,7 +1136,7 @@ struct ToolCallStepDetailRow: View {
     /// level; the rule editor still receives the original risk for correct rule creation.
     @ViewBuilder
     private var leadingAccessory: some View {
-        if let risk = toolCall.riskLevel {
+        if toolCall.riskLevel != nil {
             let effective = effectiveRiskDisplay(
                 approvalReason: toolCall.approvalReason,
                 riskLevel: toolCall.riskLevel


### PR DESCRIPTION
## Summary

- `leadingAccessory` in `AssistantProgressView.swift` bound `if let risk = toolCall.riskLevel` but never read `risk` — the block references `toolCall.riskLevel` directly — producing a `#no-usage` Swift compiler warning.
- Replaced the optional binding with a boolean nil test (`if toolCall.riskLevel != nil`), exactly as the compiler suggests. Behavior is unchanged.

## Original prompt

A macOS build surfaced a Swift compiler warning at `AssistantProgressView.swift:1139`: `value 'risk' was defined but never used; consider replacing with boolean test [#no-usage]`. The ask was to silence the warning by removing the dead optional binding while preserving the existing risk-badge rendering behavior.