### PR TITLE
[ATL-763] [LUM-1951] fix(ios): set max-age on session cookie so it survives cold reopen

### DIFF
--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -180,7 +180,10 @@ export async function waitForNativeSessionCookie(): Promise<void> {
  * same code works across environments without runtime host sniffing.
  */
 export function installSessionCookies(sessionToken: string): void {
-  const cookieAttrs = "path=/; domain=.vellum.ai; secure; samesite=lax";
+  // `max-age` makes the cookie persistent. If unspecified, the cookie
+  // expires at the end of the session, and users will be required to
+  // login again.
+  const cookieAttrs = "path=/; domain=.vellum.ai; secure; samesite=lax; max-age=1209600";
   document.cookie = `sessionid=${sessionToken}; ${cookieAttrs}`;
   document.cookie = `__Secure-sessionid=${sessionToken}; ${cookieAttrs}`;
 }


### PR DESCRIPTION
After completing auth exchange, the Capacitor shell installs a session cookie into `WKWebView`'s cookie jar via `document.cookie`. We're manually setting cookie attributes in an attempt to mirror the actual cookie generated by the server.
https://github.com/vellum-ai/vellum-assistant/blob/5567c70d6069d1fe582c98077c7f370630b84e65/apps/web/src/runtime/native-auth.ts#L182-L186

This cookie doesn't specify `max-age` or `expires`, so its lifetime is scoped to the client session. The cookie gets wiped if you quit the app, so users would have to log in again. Biometric recovery flow was a sort of bandaid over this.

As another bandaid, let's give the cookie a 2 week expiry so that it actually persists. I don't love the cookie dance we're doing here.

## Testing
Verified this on iphone with biometric recovery disabled:
- on simulator with dev SPA
- on production build of app