### PR TITLE
[codex] Avoid sidebar refetches for metadata sync

### DIFF
--- a/apps/web/src/lib/sync/web-sync-router.test.ts
+++ b/apps/web/src/lib/sync/web-sync-router.test.ts
@@ -127,6 +127,22 @@ describe("createWebSyncRouter — self-echo drop", () => {
     expect(calls.scheduleConversationListRefetch).toBe(1);
   });
 
+  test("metadata-only conversation tags do not refetch the full conversation list", async () => {
+    const { router, calls } = createHarness();
+    const tag = conversationMetadataSyncTag("conv-123");
+    const event: SyncChangedEvent = {
+      type: "sync_changed",
+      tags: [tag],
+    };
+
+    const result = await router.dispatchSyncChanged(event);
+
+    expect(result.handledTags).toEqual([tag]);
+    expect(result.unknownTags).toEqual([]);
+    expect(calls.scheduleConversationListRefetch).toBe(0);
+    expect(calls.refreshActiveConversationMessages).toBe(0);
+  });
+
   test("does not drop when originClientId is empty string", async () => {
     // An empty origin id should never have been emitted in the first
     // place — the daemon trims and only sets the field when truthy.

--- a/apps/web/src/lib/sync/web-sync-router.ts
+++ b/apps/web/src/lib/sync/web-sync-router.ts
@@ -73,7 +73,10 @@ export function createWebSyncRouter(
       options.scheduleConversationListRefetch,
     ),
     registry.registerPattern(isConversationMetadataSyncTag, () => {
-      options.scheduleConversationListRefetch();
+      // RootLayout's `useConversationSync` owns metadata tags and
+      // GET-and-patches the single cached row. Handling the tag here as a
+      // no-op keeps it out of unknown-tag telemetry without re-draining every
+      // paginated conversation list during active turns.
     }),
     registry.registerPattern(isConversationMessagesSyncTag, ({ tag }) => {
       // List-level refetch on `:messages` tags is deliberately omitted.

--- a/assistant/src/__tests__/conversation-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-sync-tags.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import {
@@ -118,6 +120,22 @@ describe("conversation sync tags", () => {
         (event) => event.message.type === "conversation_list_invalidated",
       ),
     ).toBe(false);
+  });
+
+  test("agent-loop title updates emit metadata-only sync tags (no list umbrella)", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "..", "daemon", "conversation-agent-loop.ts"),
+      "utf-8",
+    );
+    const titleUpdateBlocks =
+      source.match(
+        /type: "conversation_title_updated"[\s\S]{0,500}?type: "sync_changed"[\s\S]{0,250}?tags: \[[\s\S]*?\]/g,
+      ) ?? [];
+
+    expect(titleUpdateBlocks.length).toBeGreaterThanOrEqual(2);
+    for (const block of titleUpdateBlocks) {
+      expect(block).not.toContain("SYNC_TAGS.conversationsList");
+    }
   });
 
   test("create emits a sync_changed with the conversationsList umbrella tag", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -219,10 +219,7 @@ import type {
 } from "./message-protocol.js";
 import type { MemoryRecalled } from "./message-types/memory.js";
 import type { ConfirmationStateChanged } from "./message-types/messages.js";
-import {
-  conversationMetadataSyncTag,
-  SYNC_TAGS,
-} from "./message-types/sync.js";
+import { conversationMetadataSyncTag } from "./message-types/sync.js";
 import { parseActualTokensFromError } from "./parse-actual-tokens-from-error.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 import type { TrustContext } from "./trust-context.js";
@@ -1052,10 +1049,7 @@ export async function runAgentLoopImpl(
           });
           onEvent({
             type: "sync_changed",
-            tags: [
-              SYNC_TAGS.conversationsList,
-              conversationMetadataSyncTag(ctx.conversationId),
-            ],
+            tags: [conversationMetadataSyncTag(ctx.conversationId)],
           });
         },
       };
@@ -3517,10 +3511,7 @@ export async function runAgentLoopImpl(
           });
           onEvent({
             type: "sync_changed",
-            tags: [
-              SYNC_TAGS.conversationsList,
-              conversationMetadataSyncTag(ctx.conversationId),
-            ],
+            tags: [conversationMetadataSyncTag(ctx.conversationId)],
           });
         },
         signal: abortController.signal,


### PR DESCRIPTION
## Summary

- Treat `conversation:<id>:metadata` sync tags as handled no-ops in the chat-page sync router so they do not re-drain the full paginated sidebar list.
- Keep title-generation sync payloads metadata-only by removing the `conversations:list` umbrella tag from title update callbacks.
- Add regression coverage for both the web router and assistant title-update sync contract.

## Root Cause

During active streamed turns, metadata-only conversation sync events could still flow through the chat-page sync router. That router scheduled a full conversation-list refetch for every metadata tag, which caused repeated `GET /conversations?limit=50&offset=...&conversationType=background` page drains. Title-generation callbacks also emitted `conversations:list` for title-only updates, which widened a single-row metadata change into a full list invalidation.

## Validation

- `cd apps/web && bun test src/lib/sync/web-sync-router.test.ts`
- `cd assistant && bun test src/__tests__/conversation-sync-tags.test.ts`
- `cd apps/web && bunx tsc --noEmit`
- `cd assistant && bunx tsc --noEmit`
- Pre-push hook also passed assistant typecheck and targeted lint before pushing.