### PR TITLE
[codex] fix queued stream event duplication

### DIFF
--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -427,6 +427,44 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     await new Promise((r) => setTimeout(r, 50));
   });
 
+  test("batched queued messages with the same event sink do not duplicate assistant stream events", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const sharedEvents: ServerMessage[] = [];
+    const sharedOnEvent = (event: ServerMessage) => sharedEvents.push(event);
+
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: sharedOnEvent,
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: sharedOnEvent,
+      requestId: "req-3",
+    });
+
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    expect(
+      sharedEvents.filter((event) => event.type === "message_dequeued"),
+    ).toHaveLength(2);
+
+    sharedEvents.length = 0;
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(
+      sharedEvents.filter((event) => event.type === "message_complete"),
+    ).toHaveLength(1);
+  });
+
   test("queued skill-name slash passes through as-is", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1406,12 +1406,19 @@ async function drainBatch(
   conversation.currentActiveSurfaceId = lastSuccessfulActiveSurfaceId;
   conversation.currentPage = lastSuccessfulCurrentPage;
 
-  // Broadcast agent-loop events only to members whose persist succeeded.
-  // Members whose persist failed already received an error event in the
-  // catch block above; sending them the assistant's streaming response
-  // would surface a reply for a user message that isn't in their DB.
+  // Broadcast agent-loop events only to unique sinks whose persist succeeded.
+  // Multiple web-queued messages share the same broadcastMessage callback; if
+  // we call it once per queued message, every text delta is published N times
+  // to the same SSE stream and the client renders duplicated text.
+  //
+  // Members whose persist failed already received an error event in the catch
+  // block above; sending them the assistant's streaming response would surface
+  // a reply for a user message that isn't in their DB.
+  const successfulEventSinks = Array.from(
+    new Set(successfulBatch.map((qm) => qm.onEvent)),
+  );
   const fanOutOnEvent = (msg: ServerMessage) => {
-    for (const qm of successfulBatch) qm.onEvent(msg);
+    for (const onEvent of successfulEventSinks) onEvent(msg);
   };
 
   const drainLoopOptions: {


### PR DESCRIPTION
## Summary

Fix duplicate assistant streaming events when multiple queued web messages are drained as one batch.

## Root Cause

Batched queued web messages share the same `broadcastMessage` event sink. The batch drain logic fanned each agent-loop event out once per queued message, so each streamed delta was published multiple times to the same SSE stream and rendered as duplicated/interleaved text.

## Changes

- Deduplicate successful event sinks before forwarding batched agent-loop stream events.
- Add a regression test covering two queued messages with the same event sink.

## Validation

- `cd assistant && bun test src/__tests__/conversation-slash-queue.test.ts --grep "same event sink"`
- `cd assistant && bun test src/__tests__/conversation-slash-queue.test.ts`
- `cd assistant && bunx tsc --noEmit`
- Pre-push hook: assistant typecheck and lint passed.