### PR TITLE
[codex] Fix legacy computer use key alias

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -295,6 +295,36 @@ describe("session-tool-setup app refresh side effects", () => {
       });
     });
 
+    test("canonicalizes legacy computer_use_press_key skill_execute alias before dispatch", async () => {
+      const ctx = makeCtx({ allowedToolNames: new Set(["computer_use_key"]) });
+      const executor = makeFakeExecutor({ content: "ok", isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+      );
+
+      await toolFn("skill_execute", {
+        tool: "computer_use_press_key",
+        input: {
+          key: "Space",
+          modifiers: ["Command"],
+          reasoning: "Open Spotlight",
+        },
+        activity: "Opening Spotlight",
+      });
+
+      const calls = executor.execute.mock.calls as unknown[][];
+      expect(calls[0][0]).toBe("computer_use_key");
+      expect(calls[0][1]).toEqual({
+        key: "cmd+space",
+        reasoning: "Open Spotlight",
+      });
+    });
+
     test("preserves exact active create_app skill tool when app_create is also active", async () => {
       const ctx = makeCtx({
         allowedToolNames: new Set(["create_app", "app_create"]),

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -234,6 +234,28 @@ describe("ToolExecutor allowedToolNames gating", () => {
     expect(result.content).toBe("ok");
   });
 
+  test("canonicalizes legacy computer_use_press_key alias before active-tool gating", async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const allowed = new Set(["computer_use_key"]);
+    const result = await executor.execute(
+      "computer_use_press_key",
+      {
+        key: "Space",
+        modifiers: ["Command"],
+        reasoning: "Open Spotlight",
+      },
+      makeContext({ allowedToolNames: allowed }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("ok");
+    expect(lastCheckArgs?.toolName).toBe("computer_use_key");
+    expect(lastCheckArgs?.input).toEqual({
+      key: "cmd+space",
+      reasoning: "Open Spotlight",
+    });
+  });
+
   test("preserves exact active create_app tool before applying compatibility aliases", async () => {
     const executor = new ToolExecutor(makePrompter());
     const allowed = new Set(["create_app", "app_create"]);

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -256,6 +256,26 @@ describe("ToolExecutor allowedToolNames gating", () => {
     });
   });
 
+  test("lowercases legacy computer_use_press_key key-only input", async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const allowed = new Set(["computer_use_key"]);
+    const result = await executor.execute(
+      "computer_use_press_key",
+      {
+        key: "Space",
+        reasoning: "Pause media",
+      },
+      makeContext({ allowedToolNames: allowed }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(lastCheckArgs?.toolName).toBe("computer_use_key");
+    expect(lastCheckArgs?.input).toEqual({
+      key: "space",
+      reasoning: "Pause media",
+    });
+  });
+
   test("preserves exact active create_app tool before applying compatibility aliases", async () => {
     const executor = new ToolExecutor(makePrompter());
     const allowed = new Set(["create_app", "app_create"]);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -27,7 +27,7 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
-import { resolveToolNameAlias } from "../tools/tool-name-aliases.js";
+import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
 import {
   isDiskPressureCleanupToolName,
   type ProxyApprovalCallback,
@@ -111,10 +111,11 @@ export function createToolExecutor(
     toolUseId?: string,
     turnContext?: import("../plugins/types.js").TurnContext,
   ) => {
-    const executionName = resolveToolNameAlias(name, ctx.allowedToolNames);
+    const { name: executionName, input: executionInput } =
+      resolveToolInvocationAlias(name, input, ctx.allowedToolNames);
 
-    if (isDoordashCommand(executionName, input)) {
-      markDoordashStepInProgress(ctx, input);
+    if (isDoordashCommand(executionName, executionInput)) {
+      markDoordashStepInProgress(ctx, executionInput);
     }
 
     // Build the context object shared by both the skill_execute interception
@@ -200,7 +201,10 @@ export function createToolExecutor(
     // model self-select a different inference profile mid-turn. No permission
     // checks — this is a control-flow signal, not a user-visible tool.
     if (executionName === SWITCH_INFERENCE_PROFILE_TOOL_NAME) {
-      const profile = typeof input.profile === "string" ? input.profile : "";
+      const profile =
+        typeof executionInput.profile === "string"
+          ? executionInput.profile
+          : "";
       const config = getConfig();
       const profileEntry = config.llm.profiles?.[profile];
       if (!profileEntry) {
@@ -228,15 +232,19 @@ export function createToolExecutor(
     // risk level, permission checks, hooks, and lifecycle events all fire
     // with the real tool name.
     if (executionName === "skill_execute") {
-      const rawToolName = typeof input.tool === "string" ? input.tool : "";
-      const toolName = resolveToolNameAlias(rawToolName, ctx.allowedToolNames);
+      const rawToolName =
+        typeof executionInput.tool === "string" ? executionInput.tool : "";
       const rawToolInput =
-        input.input != null && typeof input.input === "object"
-          ? (input.input as Record<string, unknown>)
+        executionInput.input != null && typeof executionInput.input === "object"
+          ? (executionInput.input as Record<string, unknown>)
           : {};
 
       // Clone to avoid mutating shared input objects
-      const toolInput = { ...rawToolInput };
+      const { name: toolName, input: toolInput } = resolveToolInvocationAlias(
+        rawToolName,
+        { ...rawToolInput },
+        ctx.allowedToolNames,
+      );
 
       if (!toolName) {
         return {
@@ -263,7 +271,7 @@ export function createToolExecutor(
 
     const result = await executor.execute(
       executionName,
-      input,
+      executionInput,
       toolContext,
       turnContext,
     );
@@ -271,7 +279,7 @@ export function createToolExecutor(
       ctx.approvedViaPromptThisTurn = true;
     }
 
-    runPostExecutionSideEffects(executionName, input, result, { ctx });
+    runPostExecutionSideEffects(executionName, executionInput, result, { ctx });
 
     return result;
   };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -28,7 +28,7 @@ import { applyEdit } from "./shared/filesystem/edit-engine.js";
 import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
-import { resolveToolNameAlias } from "./tool-name-aliases.js";
+import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -78,10 +78,11 @@ export class ToolExecutor {
     };
 
     const middlewares = getMiddlewaresFor("toolExecute");
-    const executionName = resolveToolNameAlias(name, context.allowedToolNames);
+    const { name: executionName, input: executionInput } =
+      resolveToolInvocationAlias(name, input, context.allowedToolNames);
     const pipelineArgs: ToolExecuteArgs = {
       name: executionName,
-      input,
+      input: executionInput,
       context,
     };
 

--- a/assistant/src/tools/tool-name-aliases.ts
+++ b/assistant/src/tools/tool-name-aliases.ts
@@ -1,5 +1,19 @@
-const TOOL_NAME_ALIASES = new Map<string, string>([
-  ["create_app", "app_create"],
+type ToolInputNormalizer = (
+  input: Record<string, unknown>,
+) => Record<string, unknown>;
+
+const TOOL_NAME_ALIASES = new Map<
+  string,
+  { canonicalName: string; normalizeInput?: ToolInputNormalizer }
+>([
+  ["create_app", { canonicalName: "app_create" }],
+  [
+    "computer_use_press_key",
+    {
+      canonicalName: "computer_use_key",
+      normalizeInput: normalizeLegacyComputerUsePressKeyInput,
+    },
+  ],
 ]);
 
 /**
@@ -12,8 +26,67 @@ export function resolveToolNameAlias(
   allowedToolNames?: ReadonlySet<string>,
 ): string {
   if (allowedToolNames?.has(name)) return name;
-  const canonical = TOOL_NAME_ALIASES.get(name);
-  if (!canonical) return name;
-  if (allowedToolNames && !allowedToolNames.has(canonical)) return name;
-  return canonical;
+  const alias = TOOL_NAME_ALIASES.get(name);
+  if (!alias) return name;
+  if (allowedToolNames && !allowedToolNames.has(alias.canonicalName))
+    return name;
+  return alias.canonicalName;
+}
+
+export function resolveToolInvocationAlias(
+  name: string,
+  input: Record<string, unknown>,
+  allowedToolNames?: ReadonlySet<string>,
+): { name: string; input: Record<string, unknown> } {
+  if (allowedToolNames?.has(name)) return { name, input };
+  const alias = TOOL_NAME_ALIASES.get(name);
+  if (!alias) return { name, input };
+  if (allowedToolNames && !allowedToolNames.has(alias.canonicalName)) {
+    return { name, input };
+  }
+  return {
+    name: alias.canonicalName,
+    input: alias.normalizeInput ? alias.normalizeInput(input) : input,
+  };
+}
+
+function normalizeLegacyComputerUsePressKeyInput(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalized = { ...input };
+  const key = typeof normalized.key === "string" ? normalized.key.trim() : "";
+  const modifiers = Array.isArray(normalized.modifiers)
+    ? normalized.modifiers.flatMap((modifier) => {
+        if (typeof modifier !== "string") return [];
+        const normalizedModifier = normalizeKeyModifier(modifier);
+        return normalizedModifier ? [normalizedModifier] : [];
+      })
+    : [];
+
+  delete normalized.modifiers;
+
+  if (key && modifiers.length > 0 && !key.includes("+")) {
+    normalized.key = [...new Set(modifiers), key.toLowerCase()].join("+");
+  }
+
+  return normalized;
+}
+
+function normalizeKeyModifier(modifier: string): string | undefined {
+  switch (modifier.trim().toLowerCase()) {
+    case "cmd":
+    case "command":
+    case "meta":
+      return "cmd";
+    case "ctrl":
+    case "control":
+      return "ctrl";
+    case "option":
+    case "alt":
+      return "option";
+    case "shift":
+      return "shift";
+    default:
+      return undefined;
+  }
 }

--- a/assistant/src/tools/tool-name-aliases.ts
+++ b/assistant/src/tools/tool-name-aliases.ts
@@ -16,23 +16,6 @@ const TOOL_NAME_ALIASES = new Map<
   ],
 ]);
 
-/**
- * Resolve high-confidence compatibility aliases before active-tool gating.
- * Keep this list narrow: aliases should only cover observed model drift where
- * the canonical target is active for the turn.
- */
-export function resolveToolNameAlias(
-  name: string,
-  allowedToolNames?: ReadonlySet<string>,
-): string {
-  if (allowedToolNames?.has(name)) return name;
-  const alias = TOOL_NAME_ALIASES.get(name);
-  if (!alias) return name;
-  if (allowedToolNames && !allowedToolNames.has(alias.canonicalName))
-    return name;
-  return alias.canonicalName;
-}
-
 export function resolveToolInvocationAlias(
   name: string,
   input: Record<string, unknown>,
@@ -67,6 +50,8 @@ function normalizeLegacyComputerUsePressKeyInput(
 
   if (key && modifiers.length > 0 && !key.includes("+")) {
     normalized.key = [...new Set(modifiers), key.toLowerCase()].join("+");
+  } else if (key && !key.includes("+")) {
+    normalized.key = key.toLowerCase();
   }
 
   return normalized;


### PR DESCRIPTION
## Summary

- Add a compatibility alias from legacy `computer_use_press_key` invocations to the active `computer_use_key` tool.
- Normalize legacy `{ key, modifiers }` inputs into the canonical key chord format, such as `cmd+space`.
- Apply alias resolution both in direct tool execution and in `skill_execute` dispatch.
- Add regression coverage for both execution paths.

## Why

User feedback showed the assistant repeatedly calling `computer_use_press_key` even though the registered computer-use tool was `computer_use_key`. The active-tool gate rejected the legacy name before dispatch, causing the model to conclude that computer use was unavailable even though the desktop client and canonical computer-use tools were present.

## Validation

- `cd assistant && bun test src/__tests__/tool-executor.test.ts --grep "computer_use_press_key"`
- `cd assistant && bun test src/__tests__/conversation-tool-setup-app-refresh.test.ts --grep "computer_use_press_key"`
- `cd assistant && bunx tsc --noEmit`
- Pre-commit lint for the five changed assistant files passed.
- Pre-push assistant type-check and lint passed.