### PR TITLE
[codex] Remove queued transcript marker

### DIFF
--- a/apps/web/src/domains/chat/transcript/build-items.test.ts
+++ b/apps/web/src/domains/chat/transcript/build-items.test.ts
@@ -414,12 +414,10 @@ describe("buildTranscriptItems", () => {
     expect((items[0] as MessageItem).message).toBe(slack);
   });
 
-  test("queued blank user rows are NOT dropped (queued marker handles them)", () => {
-    // A blank user row with queueStatus="queued" passes through the filter
-    // so the projection layer can collapse it into a single QueuedMarker
-    // entry — dropping would hide the user's pending intent. Optimistic
-    // queued user rows carry a client-generated `id` and `isOptimistic:
-    // true`.
+  test("queued user rows are omitted from the transcript", () => {
+    // The queue drawer is the only visible queue surface. Optimistic queued
+    // user rows remain in state so the drawer can render and manage them, but
+    // the transcript itself should not add a duplicate queued marker row.
     const queued = makeMessage({
       role: "user",
       content: "Send when ready",
@@ -434,9 +432,7 @@ describe("buildTranscriptItems", () => {
       messages: [queued],
     });
 
-    // Queued marker collapses queued rows into a single QueuedMarkerItem.
-    expect(items).toHaveLength(1);
-    expect(items[0]!.kind).toBe("queuedMarker");
+    expect(items).toEqual([]);
   });
 
   test("assistant blank rows are NOT dropped (filter is user-only)", () => {

--- a/apps/web/src/domains/chat/transcript/build-items.ts
+++ b/apps/web/src/domains/chat/transcript/build-items.ts
@@ -9,7 +9,6 @@ import { dedupeDisplayMessages, type DisplayMessage } from "@/domains/chat/utils
 import type {
   MessageItem,
   PendingContactRequestItem,
-  QueuedMarkerItem,
   TranscriptItem,
 } from "@/domains/chat/transcript/types";
 
@@ -68,12 +67,6 @@ export function buildTranscriptItems(
 
   const items: TranscriptItem[] = [];
 
-  // Count queued user messages so we can collapse them into a single marker.
-  const queuedCount = messages.filter(
-    (m) => m.role === "user" && m.queueStatus === "queued",
-  ).length;
-  let markerInserted = false;
-
   for (const message of dedupeDisplayMessages(messages)) {
     // Subagent notification messages are injected by the daemon as user-role
     // messages for state reconstruction (history.ts extracts them). They
@@ -85,16 +78,7 @@ export function buildTranscriptItems(
     const isQueuedUser =
       message.role === "user" && message.queueStatus === "queued";
 
-    if (isQueuedUser && queuedCount > 0) {
-      if (!markerInserted) {
-        const marker: QueuedMarkerItem = {
-          kind: "queuedMarker",
-          key: "queued-marker",
-          count: queuedCount,
-        };
-        items.push(marker);
-        markerInserted = true;
-      }
+    if (isQueuedUser) {
       continue;
     }
 

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -1,5 +1,4 @@
 
-import { Loader2 } from "lucide-react";
 import { memo, type ReactNode } from "react";
 
 import { Notice } from "@vellum/design-library";
@@ -207,16 +206,6 @@ export const TranscriptRow = memo(function TranscriptRow({
          
         <div className="rounded-lg border border-[var(--border-primary)] bg-[var(--surface-secondary)] p-4 text-sm text-[var(--content-secondary)]">
           {item.label ?? "Enter contact info"}
-        </div>
-      );
-
-    case "queuedMarker":
-      return (
-        <div className="flex items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-sunken)] px-3 py-2 text-body-small-default text-[var(--content-tertiary)]">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          {item.count === 1
-            ? "1 message queued"
-            : `${item.count} messages queued`}
         </div>
       );
 

--- a/apps/web/src/domains/chat/transcript/types.ts
+++ b/apps/web/src/domains/chat/transcript/types.ts
@@ -14,7 +14,6 @@ export type TranscriptItemKind =
   | "pendingConfirmation"
   | "pendingContactRequest"
   | "surface"
-  | "queuedMarker"
   | "error"
   | "onboardingChoice";
 
@@ -61,11 +60,6 @@ export interface SurfaceItem extends TranscriptItemBase {
   surface: Surface;
 }
 
-export interface QueuedMarkerItem extends TranscriptItemBase {
-  kind: "queuedMarker";
-  count: number;
-}
-
 export interface ErrorItem extends TranscriptItemBase {
   kind: "error";
   message: string;
@@ -88,7 +82,6 @@ export type TranscriptItem =
   | PendingConfirmationItem
   | PendingContactRequestItem
   | SurfaceItem
-  | QueuedMarkerItem
   | ErrorItem
   | OnboardingChoiceItem;
 

--- a/apps/web/src/domains/chat/utils/debug-api.test.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.test.ts
@@ -239,7 +239,7 @@ describe("createChatDebugApi.getTranscriptItems", () => {
         message: fakeDisplayMessage({ id: "msg-a" }),
       },
       { kind: "thinking", key: "thinking", label: "Processing" },
-      { kind: "queuedMarker", key: "queued", count: 2 },
+      { kind: "error", key: "error-notice", message: "Something failed" },
     ];
     const api = createChatDebugApi(
       makeRefs({
@@ -253,8 +253,8 @@ describe("createChatDebugApi.getTranscriptItems", () => {
 
   test("surfaces the full discriminated union — not just message rows", () => {
     // The whole point of getTranscriptItems(): inspect non-message rows
-    // (thinking, pending prompts, queued marker) which getClientMessages()
-    // doesn't carry.
+    // (thinking, pending prompts, errors) which getClientMessages() doesn't
+    // carry.
     const items: TranscriptItem[] = [
       {
         kind: "message",

--- a/apps/web/src/domains/chat/utils/debug-api.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.ts
@@ -226,14 +226,14 @@ export interface ChatDebugApi {
    * `transcript-message-body.tsx`).
    *
    * For the full virtualized row list — including non-message rows like
-   * the thinking indicator, pending prompts, and the queued-marker —
-   * use {@link getTranscriptItems}.
+   * the thinking indicator and pending prompts — use
+   * {@link getTranscriptItems}.
    */
   getClientMessages(limit?: number): DisplayMessage[];
   /**
    * Return the full transcript-item array the virtualized list iterates
-   * — messages, the thinking indicator, pending-interaction rows, the
-   * queued-marker, error notices, the onboarding-choice row.
+   * — messages, the thinking indicator, pending-interaction rows, error
+   * notices, the onboarding-choice row.
    *
    * `getClientMessages()` returns only the `DisplayMessage[]` slice;
    * `getTranscriptItems()` returns the discriminated union of every
@@ -657,7 +657,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       "window._vellumDebug.chat — surgical chat debug API",
       "",
       "  .getClientMessages(n?)     last N DisplayMessage[] the UI is rendering (post-sanitize)",
-      "  .getTranscriptItems()      full virtualized row list — messages + thinking + pending prompts + markers",
+      "  .getTranscriptItems()      full virtualized row list — messages + thinking + pending prompts",
       "  .thinkingIndicator()       live evaluation of the `...` predicate + done signal",
       "                              .visible / .failingConditions tell you why dots are or aren't showing",
       "                              .done.terminal / .done.lastTerminalReason tell you if the turn is finished",

--- a/apps/web/src/domains/chat/utils/sanitize-display-messages.ts
+++ b/apps/web/src/domains/chat/utils/sanitize-display-messages.ts
@@ -84,7 +84,7 @@ function removeInvalidMessages(messages: DisplayMessage[]): DisplayMessage[] {
 }
 
 function isInvalidMessage(message: DisplayMessage): boolean {
-  // Assistant rows always render; queued user rows collapse into a marker upstream.
+  // Assistant rows always render; queued user rows render in the queue drawer.
   if (message.role !== "user") return false;
   if (message.queueStatus === "queued") return false;
 


### PR DESCRIPTION
## Summary

- Remove the transcript-level queued marker that rendered the duplicate `1 message queued` bar above the chat.
- Keep queued user rows available for the bottom queue drawer, which remains the single visible queue surface.
- Drop the now-unused `queuedMarker` transcript union/render path and update debug API wording/tests.

## Validation

- `bun test src/domains/chat/transcript/build-items.test.ts src/domains/chat/utils/debug-api.test.ts`
- `bunx tsc --noEmit`
- `bun run lint src/domains/chat/transcript/build-items.ts src/domains/chat/transcript/build-items.test.ts src/domains/chat/transcript/transcript-row.tsx src/domains/chat/transcript/types.ts src/domains/chat/utils/debug-api.ts src/domains/chat/utils/debug-api.test.ts src/domains/chat/utils/sanitize-display-messages.ts`
- `git diff --check`