### PR TITLE
[codex] Fix ChatGPT subscription native web search

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1732,6 +1732,48 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
+  test("counts Codex Responses native web_search request tools", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_032,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Search the web when needed.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "What is the weather?" }],
+            type: "message",
+          },
+        ],
+        tools: [{ type: "web_search", external_web_access: false }],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [
+              { type: "output_text", text: "It is sunny in Boston today." },
+            ],
+          },
+        ],
+        usage: { input_tokens: 30, output_tokens: 15 },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary?.requestToolCount).toBe(1);
+    expect(normalized.requestSections).toContainEqual({
+      kind: "tool_definitions",
+      label: "Available tools",
+      data: {
+        tools: [{ type: "web_search", external_web_access: false }],
+      },
+      language: "json",
+    });
+  });
+
   test("normalizes Responses API response with only web_search_call (no message)", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_031,

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -1783,6 +1783,23 @@ describe("OpenAIResponsesProvider — Native Web Search", () => {
     ]);
   });
 
+  test("codexSubscription: maps web_search to the Codex native web_search tool", async () => {
+    const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
+      codexSubscription: true,
+      useNativeWebSearch: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await codexProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Search for cats" }] }],
+      [webSearchTool],
+    );
+
+    expect(lastStreamParams!.tools).toEqual([
+      { type: "web_search", external_web_access: false },
+    ]);
+  });
+
   test("codexSubscription: still sends model, input, and instructions", async () => {
     const codexProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.4", {
       codexSubscription: true,

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -219,9 +219,9 @@ export class OpenAIResponsesProvider implements Provider {
             parameters: t.input_schema,
             strict: null,
           }));
-          const webSearchTool = {
-            type: "web_search_preview" as const,
-          };
+          const webSearchTool = this.codexSubscription
+            ? { type: "web_search" as const, external_web_access: false }
+            : { type: "web_search_preview" as const };
           params.tools = [...mappedOther, webSearchTool];
         } else {
           params.tools = tools.map((t) => ({

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -1057,8 +1057,13 @@ function extractOpenAiResponsesRequestToolNames(tools: unknown): string[] {
       if (asString(tool.type) === "function" && asString(tool.name)) {
         return asString(tool.name);
       }
-      // Native web search tool: { type: "web_search_preview" }
-      if (asString(tool.type) === "web_search_preview") {
+      // Native web search tools:
+      // - OpenAI API: { type: "web_search_preview" }
+      // - Codex subscription endpoint: { type: "web_search" }
+      if (
+        asString(tool.type) === "web_search_preview" ||
+        asString(tool.type) === "web_search"
+      ) {
         return "web_search";
       }
       return undefined;


### PR DESCRIPTION
## Summary
- map `web_search` to the Codex subscription endpoint's supported native `{ type: "web_search", external_web_access: false }` shape
- keep standard OpenAI Responses native web search on `web_search_preview`
- add a regression test for `codexSubscription + useNativeWebSearch`

## Why
Follow-up to #32532. A production request using ChatGPT subscription auth failed with HTTP 400: `Unsupported tool type: web_search_preview`. A live reproduction through the actual `OpenAIResponsesProvider` confirmed the provider was serializing `web_search` as `web_search_preview` for the Codex endpoint.

The probe gap was that the optional web-search cases were not streaming, so `--include-web-search --stream-only` filtered them out. After fixing the local probe, the endpoint rejected `web_search_preview` but accepted `{ type: "web_search", external_web_access: false }` and emitted `response.web_search_call.*` events, which this provider already handles.

## Validation
- Live actual-provider reproduction with `example_raw_request.json`: before fix returned HTTP 400 `Unsupported tool type: web_search_preview`; after fix returned success and serialized native `web_search`
- `cd assistant && bun test src/__tests__/openai-responses-provider.test.ts --grep "codexSubscription: maps web_search"`
- `cd assistant && bun test src/__tests__/openai-responses-provider.test.ts src/__tests__/cross-provider-web-search.test.ts src/providers/__tests__/registry-native-web-search.test.ts`
- `cd assistant && bunx tsc --noEmit`
