### PR TITLE
Show ChatGPT sign-in instructions before the button click

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -902,9 +902,14 @@ export function ProviderEditorContent({
                   <Typography
                     variant="body-small-default"
                     as="p"
-                    className="text-[var(--content-secondary)]"
+                    className={
+                      chatgptOAuthState === "paste_url"
+                        ? "text-[var(--content-tertiary)] line-through"
+                        : "text-[var(--content-secondary)]"
+                    }
                   >
-                    1. Click &ldquo;Sign in with ChatGPT&rdquo; below to open a
+                    1. Click &ldquo;Sign in with ChatGPT&rdquo;
+                    {chatgptOAuthState === "idle" ? " below" : null} to open a
                     popup
                   </Typography>
                   <Typography
@@ -921,7 +926,7 @@ export function ProviderEditorContent({
                     className="text-[var(--content-secondary)]"
                   >
                     3. Copy the full URL from that page&apos;s address bar and
-                    paste it back here
+                    paste it below
                   </Typography>
                 </div>
 

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -896,14 +896,67 @@ export function ProviderEditorContent({
               API key.
             </Typography>
 
-            {chatgptOAuthState === "idle" ? (
-              <Button
-                variant="outlined"
-                size="compact"
-                onClick={() => void handleChatgptSignIn()}
-              >
-                Sign in with ChatGPT
-              </Button>
+            {chatgptOAuthState === "idle" || chatgptOAuthState === "paste_url" ? (
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    1. Click &ldquo;Sign in with ChatGPT&rdquo; below to open a
+                    popup
+                  </Typography>
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    2. Sign in, then you&apos;ll land on an error page &mdash;
+                    that&apos;s expected
+                  </Typography>
+                  <Typography
+                    variant="body-small-default"
+                    as="p"
+                    className="text-[var(--content-secondary)]"
+                  >
+                    3. Copy the full URL from that page&apos;s address bar and
+                    paste it back here
+                  </Typography>
+                </div>
+
+                {chatgptOAuthState === "idle" ? (
+                  <Button
+                    variant="outlined"
+                    size="compact"
+                    onClick={() => void handleChatgptSignIn()}
+                  >
+                    Sign in with ChatGPT
+                  </Button>
+                ) : (
+                  <>
+                    <Input
+                      value={chatgptPastedUrl}
+                      onChange={(e) => {
+                        setChatgptPastedUrl(e.target.value);
+                        setChatgptOAuthError(null);
+                      }}
+                      placeholder="Paste callback URL here..."
+                      fullWidth
+                    />
+                    <div className="flex justify-end">
+                      <Button
+                        variant="primary"
+                        size="compact"
+                        disabled={!chatgptPastedUrl.trim()}
+                        onClick={() => void handleChatgptUrlSubmit()}
+                      >
+                        Complete Sign In
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </div>
             ) : null}
 
             {chatgptOAuthState === "starting" ? (
@@ -915,53 +968,6 @@ export function ProviderEditorContent({
                 >
                   Starting sign-in...
                 </Typography>
-              </div>
-            ) : null}
-
-            {chatgptOAuthState === "paste_url" ? (
-              <div className="space-y-3">
-                <div className="space-y-1">
-                  <Typography
-                    variant="body-small-default"
-                    as="p"
-                    className="text-[var(--content-secondary)]"
-                  >
-                    1. Sign in with ChatGPT in the popup
-                  </Typography>
-                  <Typography
-                    variant="body-small-default"
-                    as="p"
-                    className="text-[var(--content-secondary)]"
-                  >
-                    2. After sign-in, you&apos;ll see an error page
-                  </Typography>
-                  <Typography
-                    variant="body-small-default"
-                    as="p"
-                    className="text-[var(--content-secondary)]"
-                  >
-                    3. Copy the URL from the address bar and paste it below
-                  </Typography>
-                </div>
-                <Input
-                  value={chatgptPastedUrl}
-                  onChange={(e) => {
-                    setChatgptPastedUrl(e.target.value);
-                    setChatgptOAuthError(null);
-                  }}
-                  placeholder="Paste callback URL here..."
-                  fullWidth
-                />
-                <div className="flex justify-end">
-                  <Button
-                    variant="primary"
-                    size="compact"
-                    disabled={!chatgptPastedUrl.trim()}
-                    onClick={() => void handleChatgptUrlSubmit()}
-                  >
-                    Complete Sign In
-                  </Button>
-                </div>
               </div>
             ) : null}
 


### PR DESCRIPTION
## Summary

- Move the 3-step sign-in instructions from the `paste_url` state to render in both `idle` and `paste_url` states, so users read them **before** clicking "Sign in with ChatGPT"
- Reword the steps for clarity: explicitly mention the popup, clarify the error page is expected, and tell users to paste the URL "back here"
- The button and URL input field swap in/out below the instructions depending on the current state

## Original prompt

Improve the "Sign in with ChatGPT" OAuth flow UX. The current design shows instructions about copying the callback URL only after the user clicks "Sign in with ChatGPT", but that button immediately opens a new tab — so users never see the instructions before navigating away. The fix moves the step-by-step instructions above the button so users understand the copy/paste flow before they click.