### PR TITLE
feat(web): add timestamp badge to home detail panel header

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -9,7 +9,8 @@ import {
   X,
 } from "lucide-react";
 
-import { Button, Menu, Typography } from "@vellum/design-library";
+import { Button, Menu, Tag, Typography } from "@vellum/design-library";
+import { formatRelativeDate } from "@/utils/format-date";
 import { CATEGORY_STYLES } from "../home-feed-filter-bar";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
@@ -124,6 +125,9 @@ export function HomeDetailPanel({
           >
             {item.title ?? item.summary}
           </Typography>
+          <Tag tone="neutral" className="shrink-0">
+            · {formatRelativeDate(item.timestamp)}
+          </Tag>
         </div>
 
         {/* Divider */}
@@ -180,6 +184,10 @@ export function HomeDetailPanel({
         >
           {item.title ?? item.summary}
         </Typography>
+
+        <Tag tone="neutral" className="shrink-0">
+          · {formatRelativeDate(item.timestamp)}
+        </Tag>
 
         {hasValidConversation ? (
           <Button

--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 
 import { Button, Menu, Tag, Typography } from "@vellum/design-library";
-import { formatRelativeDate } from "@/utils/format-date";
+import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
 import { CATEGORY_STYLES } from "../home-feed-filter-bar";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
@@ -125,8 +125,8 @@ export function HomeDetailPanel({
           >
             {item.title ?? item.summary}
           </Typography>
-          <Tag tone="neutral" className="shrink-0">
-            · {formatRelativeDate(item.timestamp)}
+          <Tag tone="neutral" className="shrink-0" title={formatFullLocalDate(item.timestamp)}>
+            {formatRelativeDate(item.timestamp)}
           </Tag>
         </div>
 
@@ -185,8 +185,8 @@ export function HomeDetailPanel({
           {item.title ?? item.summary}
         </Typography>
 
-        <Tag tone="neutral" className="shrink-0">
-          · {formatRelativeDate(item.timestamp)}
+        <Tag tone="neutral" className="shrink-0" title={formatFullLocalDate(item.timestamp)}>
+          {formatRelativeDate(item.timestamp)}
         </Tag>
 
         {hasValidConversation ? (

--- a/apps/web/src/utils/format-date.ts
+++ b/apps/web/src/utils/format-date.ts
@@ -70,3 +70,23 @@ export function formatRelativeDate(
   }
   return date.toLocaleDateString();
 }
+
+/**
+ * Full local timestamp with timezone abbreviation for tooltip display.
+ * e.g. "May 29, 2026, 10:36 AM EDT"
+ */
+export function formatFullLocalDate(
+  dateStr: string | null | undefined,
+): string {
+  if (!dateStr) {
+    return "";
+  }
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}


### PR DESCRIPTION
Adds a relative timestamp badge (using the `Tag` component from the design library) inline with the title in both desktop and mobile detail panel headers. This provides consistent temporal context alongside the feed row timestamps added in #32485, so users can see when a notification event occurred without returning to the feed list.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/54fc47db011843dabcb15a64b64747c4