### PR TITLE
streaming: generation guard against superseded message-loop subscribers

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -34,16 +34,25 @@ extension ChatViewModel {
     /// subscriber or an SSE reconnect can arrive after the turn has already ended,
     /// hit the lazy bubble-creation path with no `currentAssistantMessageId`, and
     /// fork a second copy of a message the daemon only persisted once (hence the
-    /// duplicate collapses on reload). We only suppress the narrow signature of
-    /// that bug: the turn is fully terminal (not sending, thinking, or cancelling)
-    /// *and* the previous bubble is already an assistant message — i.e. we'd be
-    /// appending a back-to-back duplicate. Legitimate new bubbles (first delta of
-    /// a turn, handoff to a queued turn, slash-command responses) all run while
-    /// `isSending`/`isThinking` is true, so they are never affected.
+    /// duplicate collapses on reload). We suppress only the narrow signature of
+    /// that bug: the assistant is fully quiescent *and* the previous bubble is
+    /// already an assistant message — i.e. we'd be appending a back-to-back
+    /// duplicate.
+    ///
+    /// Quiescence is keyed on `assistantActivityPhase == "idle"`, not just the
+    /// `isSending`/`isThinking` spinners. The daemon emits an `"idle"` activity
+    /// state at the end of every turn and a `"streaming"`/`"thinking"` state
+    /// before the first delta of any new turn — *including daemon-initiated
+    /// wakes and scheduled/background runs that never set `isSending`/
+    /// `isThinking`* (see `handleTextDelta` → `emitActivityState("streaming",
+    /// "first_text_delta")` in the daemon). Gating on the idle phase preserves
+    /// those live wake deltas — which legitimately fork a new bubble after a
+    /// prior assistant reply — while still catching post-completion replays.
     func shouldDropStrayStreamingDelta(_ count: Int, kind: String) -> Bool {
-        let turnIsTerminal = !isSending && !isThinking && !isCancelling
-        guard turnIsTerminal, messages.last?.role == .assistant else { return false }
-        log.warning("Dropping stray \(kind) delta (\(count) chars): turn already terminal with no active message — would fork a duplicate assistant bubble")
+        let assistantIsQuiescent = !isSending && !isThinking && !isCancelling
+            && assistantActivityPhase == "idle"
+        guard assistantIsQuiescent, messages.last?.role == .assistant else { return false }
+        log.warning("Dropping stray \(kind) delta (\(count) chars): assistant idle with no active message — would fork a duplicate assistant bubble")
         return true
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -27,6 +27,26 @@ extension ChatViewModel {
         appendThinkingToCurrentMessage(buffered)
     }
 
+    /// Decide whether a streaming delta that would fork a *brand-new* assistant
+    /// bubble is actually a stray replay/race artifact that should be dropped.
+    ///
+    /// Bandaid for the duplicate-streaming-message bug: a delta from a superseded
+    /// subscriber or an SSE reconnect can arrive after the turn has already ended,
+    /// hit the lazy bubble-creation path with no `currentAssistantMessageId`, and
+    /// fork a second copy of a message the daemon only persisted once (hence the
+    /// duplicate collapses on reload). We only suppress the narrow signature of
+    /// that bug: the turn is fully terminal (not sending, thinking, or cancelling)
+    /// *and* the previous bubble is already an assistant message — i.e. we'd be
+    /// appending a back-to-back duplicate. Legitimate new bubbles (first delta of
+    /// a turn, handoff to a queued turn, slash-command responses) all run while
+    /// `isSending`/`isThinking` is true, so they are never affected.
+    func shouldDropStrayStreamingDelta(_ count: Int, kind: String) -> Bool {
+        let turnIsTerminal = !isSending && !isThinking && !isCancelling
+        guard turnIsTerminal, messages.last?.role == .assistant else { return false }
+        log.warning("Dropping stray \(kind) delta (\(count) chars): turn already terminal with no active message — would fork a duplicate assistant bubble")
+        return true
+    }
+
     /// Append a chunk of thinking text to the current assistant message.
     func appendThinkingToCurrentMessage(_ text: String) {
         guard !text.isEmpty else { return }
@@ -43,6 +63,7 @@ extension ChatViewModel {
                 messages[index].contentOrder.append(.thinking(segIdx))
             }
         } else {
+            if shouldDropStrayStreamingDelta(text.count, kind: "thinking") { return }
             if let staleId = currentAssistantMessageId {
                 log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) thinking chars to new message")
                 currentAssistantMessageId = nil
@@ -109,6 +130,7 @@ extension ChatViewModel {
                 messages[index].textSegments[messages[index].textSegments.count - 1] += text
             }
         } else {
+            if shouldDropStrayStreamingDelta(text.count, kind: "text") { return }
             if let staleId = currentAssistantMessageId {
                 log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) chars to new message")
                 currentAssistantMessageId = nil

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -27,35 +27,6 @@ extension ChatViewModel {
         appendThinkingToCurrentMessage(buffered)
     }
 
-    /// Decide whether a streaming delta that would fork a *brand-new* assistant
-    /// bubble is actually a stray replay/race artifact that should be dropped.
-    ///
-    /// Bandaid for the duplicate-streaming-message bug: a delta from a superseded
-    /// subscriber or an SSE reconnect can arrive after the turn has already ended,
-    /// hit the lazy bubble-creation path with no `currentAssistantMessageId`, and
-    /// fork a second copy of a message the daemon only persisted once (hence the
-    /// duplicate collapses on reload). We suppress only the narrow signature of
-    /// that bug: the assistant is fully quiescent *and* the previous bubble is
-    /// already an assistant message — i.e. we'd be appending a back-to-back
-    /// duplicate.
-    ///
-    /// Quiescence is keyed on `assistantActivityPhase == "idle"`, not just the
-    /// `isSending`/`isThinking` spinners. The daemon emits an `"idle"` activity
-    /// state at the end of every turn and a `"streaming"`/`"thinking"` state
-    /// before the first delta of any new turn — *including daemon-initiated
-    /// wakes and scheduled/background runs that never set `isSending`/
-    /// `isThinking`* (see `handleTextDelta` → `emitActivityState("streaming",
-    /// "first_text_delta")` in the daemon). Gating on the idle phase preserves
-    /// those live wake deltas — which legitimately fork a new bubble after a
-    /// prior assistant reply — while still catching post-completion replays.
-    func shouldDropStrayStreamingDelta(_ count: Int, kind: String) -> Bool {
-        let assistantIsQuiescent = !isSending && !isThinking && !isCancelling
-            && assistantActivityPhase == "idle"
-        guard assistantIsQuiescent, messages.last?.role == .assistant else { return false }
-        log.warning("Dropping stray \(kind) delta (\(count) chars): assistant idle with no active message — would fork a duplicate assistant bubble")
-        return true
-    }
-
     /// Append a chunk of thinking text to the current assistant message.
     func appendThinkingToCurrentMessage(_ text: String) {
         guard !text.isEmpty else { return }
@@ -72,7 +43,6 @@ extension ChatViewModel {
                 messages[index].contentOrder.append(.thinking(segIdx))
             }
         } else {
-            if shouldDropStrayStreamingDelta(text.count, kind: "thinking") { return }
             if let staleId = currentAssistantMessageId {
                 log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) thinking chars to new message")
                 currentAssistantMessageId = nil
@@ -139,7 +109,6 @@ extension ChatViewModel {
                 messages[index].textSegments[messages[index].textSegments.count - 1] += text
             }
         } else {
-            if shouldDropStrayStreamingDelta(text.count, kind: "text") { return }
             if let staleId = currentAssistantMessageId {
                 log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) chars to new message")
                 currentAssistantMessageId = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1513,6 +1513,13 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         messageLoopTask = Task { @MainActor [weak self] in
             for await message in messageStream {
                 guard let self, !Task.isCancelled else { break }
+                // A cancelled-but-still-draining subscriber must not mutate the
+                // shared `messages` array. `Task.cancel()` is cooperative, so a
+                // superseded loop can still resume with a buffered event before
+                // it observes cancellation. Gate on the generation so only the
+                // current subscriber dispatches — this closes the double-subscriber
+                // window that lets a pre-`complete` delta fork a duplicate bubble.
+                guard self.messageLoopGeneration == generation else { break }
                 self.handleServerMessage(message)
             }
             // Stream ended (e.g. daemon disconnected) — clear the task reference


### PR DESCRIPTION
## What this is

A small, **defensive** frontend hardening for the duplicate-streaming-message bug (transient duplicate assistant bubble during an in-flight turn that collapses on reload). Frontend-only; no daemon or protocol changes.

## Change (7 lines, 1 file)

`ChatViewModel.startMessageLoop` — gate each dispatched event on the loop generation:
```swift
guard self.messageLoopGeneration == generation else { break }
```
A superseded/cancelled subscriber that resumes with a buffered event no longer mutates the shared `messages` array. This is belt-and-suspenders alongside the existing `!Task.isCancelled` break.

## Honest scope note

This started as a larger "Bandaid B" (generation guard **+** a terminal-state stray-delta drop). The stray-drop was removed during local QA because it **swallowed legitimate live messages** — deltas arriving when this client isn't the sender (observed/channel turns, background/wake turns), compounded by the `activityVersion` gate leaving `assistantActivityPhase` stuck at `"idle"`. See commit history (`cb1feef4` → `0743c208` → `482972a2`).

What remains is the generation guard alone. It is **safe and zero-regression**, but it is largely redundant with the existing cancellation check, so it is **unlikely to fully eliminate** the duplicate on its own. The real duplicate is most likely a stale-id fork after `generation_handoff` or an SSE reconnect replay — neither addressed here. A properly-targeted fix (or the `message_id`/`seq` identity from the full streaming-architecture branch) is the durable answer.

## Testing
- ✅ Builds + links clean (debug `.app`).
- Local QA: live messages render correctly (the regression from the removed stray-drop is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)