### PR TITLE
feat(daemon): add avatar state manifest schema and read/derive/write helpers

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-manifest.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-manifest.test.ts
@@ -72,6 +72,98 @@ describe("avatar-manifest", () => {
       writeFileSync(join(dir, "avatar.json"), JSON.stringify({ traits: null }));
       expect(readManifest(dir)).toBeNull();
     });
+
+    test("returns null when kind is character but traits are null", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "character",
+          traits: null,
+          source: null,
+          image: null,
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is character but traits are missing", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({ kind: "character" }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is character but traits are incomplete", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "character",
+          traits: { bodyShape: "round" },
+          source: null,
+          image: null,
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is image but image meta is null", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "image",
+          traits: null,
+          source: null,
+          image: null,
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is image but image meta is missing", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({ kind: "image" }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is image but etag is empty", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "image",
+          traits: null,
+          source: null,
+          image: { updatedAt: "2024-01-01T00:00:00.000Z", etag: "" },
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is image but updatedAt is missing", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "image",
+          traits: null,
+          source: null,
+          image: { etag: "abc123" },
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns the manifest when kind is none (no payload required)", () => {
+      const state: AvatarState = {
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+      };
+      writeFileSync(join(dir, "avatar.json"), JSON.stringify({ kind: "none" }));
+      expect(readManifest(dir)).toEqual(state);
+    });
   });
 
   describe("deriveStateFromLegacyFiles", () => {

--- a/assistant/src/avatar/__tests__/avatar-manifest.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-manifest.test.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type AvatarState,
+  deriveStateFromLegacyFiles,
+  readManifest,
+  writeManifest,
+} from "../avatar-manifest.js";
+
+const VALID_TRAITS = { bodyShape: "round", eyeStyle: "happy", color: "blue" };
+
+describe("avatar-manifest", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "avatar-manifest-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("readManifest / writeManifest", () => {
+    test("round-trips a written manifest", () => {
+      const state: AvatarState = {
+        kind: "character",
+        traits: VALID_TRAITS,
+        source: "builder",
+        image: null,
+      };
+      writeManifest(state, dir);
+      expect(readManifest(dir)).toEqual(state);
+    });
+
+    test("round-trips an image manifest", () => {
+      const state: AvatarState = {
+        kind: "image",
+        traits: null,
+        source: "upload",
+        image: { updatedAt: "2024-01-01T00:00:00.000Z", etag: "abc123" },
+      };
+      writeManifest(state, dir);
+      expect(readManifest(dir)).toEqual(state);
+    });
+
+    test("returns null when manifest is missing", () => {
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when manifest is corrupt JSON", () => {
+      writeFileSync(join(dir, "avatar.json"), "{ not json");
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is invalid", () => {
+      writeFileSync(
+        join(dir, "avatar.json"),
+        JSON.stringify({
+          kind: "bogus",
+          traits: null,
+          source: null,
+          image: null,
+        }),
+      );
+      expect(readManifest(dir)).toBeNull();
+    });
+
+    test("returns null when kind is missing", () => {
+      writeFileSync(join(dir, "avatar.json"), JSON.stringify({ traits: null }));
+      expect(readManifest(dir)).toBeNull();
+    });
+  });
+
+  describe("deriveStateFromLegacyFiles", () => {
+    test("traits-only → character", () => {
+      writeFileSync(
+        join(dir, "character-traits.json"),
+        JSON.stringify(VALID_TRAITS),
+      );
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state.kind).toBe("character");
+      expect(state.traits).toEqual(VALID_TRAITS);
+      expect(state.source).toBeNull();
+      expect(state.image).toBeNull();
+    });
+
+    test("image-only → image with computed etag and updatedAt", () => {
+      writeFileSync(join(dir, "avatar-image.png"), Buffer.from("fake png"));
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state.kind).toBe("image");
+      expect(state.traits).toBeNull();
+      expect(state.source).toBeNull();
+      expect(state.image?.etag).toMatch(/^[0-9a-f]{16}$/);
+      expect(state.image?.updatedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
+    test("both present → character (traits-first, ignores PNG mtime)", () => {
+      // Write traits first, then PNG so the PNG is strictly newer — mirrors
+      // how the builder writes files. Traits-first must still win.
+      writeFileSync(
+        join(dir, "character-traits.json"),
+        JSON.stringify(VALID_TRAITS),
+      );
+      writeFileSync(join(dir, "avatar-image.png"), Buffer.from("fake png"));
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state.kind).toBe("character");
+      expect(state.traits).toEqual(VALID_TRAITS);
+      expect(state.image).toBeNull();
+    });
+
+    test("corrupt traits json + image present → image", () => {
+      writeFileSync(join(dir, "character-traits.json"), "{ broken");
+      writeFileSync(join(dir, "avatar-image.png"), Buffer.from("fake png"));
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state.kind).toBe("image");
+      expect(state.image).not.toBeNull();
+    });
+
+    test("incomplete traits (missing fields) + image present → image", () => {
+      writeFileSync(
+        join(dir, "character-traits.json"),
+        JSON.stringify({ bodyShape: "round" }),
+      );
+      writeFileSync(join(dir, "avatar-image.png"), Buffer.from("fake png"));
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state.kind).toBe("image");
+    });
+
+    test("neither → none", () => {
+      const state = deriveStateFromLegacyFiles(dir);
+      expect(state).toEqual({
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+      });
+    });
+  });
+});

--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -65,10 +65,23 @@ function isValidTraits(value: unknown): value is CharacterTraits {
   );
 }
 
+/** Narrows an unknown value to valid AvatarImageMeta (presence check only). */
+function isValidImageMeta(value: unknown): value is AvatarImageMeta {
+  if (!value || typeof value !== "object") return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.updatedAt === "string" &&
+    !!m.updatedAt &&
+    typeof m.etag === "string" &&
+    !!m.etag
+  );
+}
+
 /**
  * Reads and validates the avatar manifest. Returns `null` when the manifest is
- * missing, unreadable, unparseable, or has an invalid `kind` so callers can
- * fall back to legacy derivation.
+ * missing, unreadable, unparseable, has an invalid `kind`, or carries a
+ * partial/malformed per-kind payload so callers can fall back to legacy
+ * derivation rather than surfacing an avatar with null traits/image.
  */
 export function readManifest(
   avatarDir: string = getAvatarDir(),
@@ -83,8 +96,16 @@ export function readManifest(
     if (typeof obj.kind !== "string" || !AVATAR_KINDS.has(obj.kind)) {
       return null;
     }
+    const kind = obj.kind as AvatarKind;
+
+    // Reject partial manifests: a valid `kind` with a missing/malformed payload
+    // would otherwise short-circuit the legacy fallback and surface an avatar
+    // with null traits/image.
+    if (kind === "character" && !isValidTraits(obj.traits)) return null;
+    if (kind === "image" && !isValidImageMeta(obj.image)) return null;
+
     return {
-      kind: obj.kind as AvatarKind,
+      kind,
       traits: (obj.traits as CharacterTraits | null) ?? null,
       source: (obj.source as AvatarSource | null) ?? null,
       image: (obj.image as AvatarImageMeta | null) ?? null,

--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -1,0 +1,166 @@
+/**
+ * Avatar state manifest — schema + pure filesystem helpers.
+ *
+ * The manifest (`avatar.json`) is the canonical record of the user's avatar
+ * configuration. This module is intentionally pure: it only reads/writes the
+ * filesystem and derives state from legacy sidecar files. It must not import
+ * route or handler code.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import {
+  AVATAR_IMAGE_FILENAME,
+  AVATAR_MANIFEST_FILENAME,
+  getAvatarDir,
+} from "../util/platform.js";
+import type { CharacterTraits } from "./traits-png-sync.js";
+
+const log = getLogger("avatar-manifest");
+
+/** Legacy traits sidecar filename, mirrored from traits-png-sync.ts writes. */
+const TRAITS_FILENAME = "character-traits.json";
+
+export type AvatarKind = "character" | "image" | "none";
+export type AvatarSource = "builder" | "upload" | "ai";
+
+export interface AvatarImageMeta {
+  updatedAt: string;
+  etag: string;
+}
+
+export interface AvatarState {
+  kind: AvatarKind;
+  traits: CharacterTraits | null;
+  source: AvatarSource | null;
+  image: AvatarImageMeta | null;
+}
+
+const AVATAR_KINDS: ReadonlySet<string> = new Set<AvatarKind>([
+  "character",
+  "image",
+  "none",
+]);
+
+/** Narrows an unknown value to valid CharacterTraits (presence check only). */
+function isValidTraits(value: unknown): value is CharacterTraits {
+  if (!value || typeof value !== "object") return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.bodyShape === "string" &&
+    !!t.bodyShape &&
+    typeof t.eyeStyle === "string" &&
+    !!t.eyeStyle &&
+    typeof t.color === "string" &&
+    !!t.color
+  );
+}
+
+/**
+ * Reads and validates the avatar manifest. Returns `null` when the manifest is
+ * missing, unreadable, unparseable, or has an invalid `kind` so callers can
+ * fall back to legacy derivation.
+ */
+export function readManifest(
+  avatarDir: string = getAvatarDir(),
+): AvatarState | null {
+  const manifestPath = join(avatarDir, AVATAR_MANIFEST_FILENAME);
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.kind !== "string" || !AVATAR_KINDS.has(obj.kind)) {
+      return null;
+    }
+    return {
+      kind: obj.kind as AvatarKind,
+      traits: (obj.traits as CharacterTraits | null) ?? null,
+      source: (obj.source as AvatarSource | null) ?? null,
+      image: (obj.image as AvatarImageMeta | null) ?? null,
+    };
+  } catch (err) {
+    log.warn({ err }, "Failed to read avatar manifest — treating as absent");
+    return null;
+  }
+}
+
+/**
+ * Writes the avatar manifest atomically (tmp-write + rename), mirroring the
+ * write pattern in traits-png-sync.ts.
+ */
+export function writeManifest(
+  state: AvatarState,
+  avatarDir: string = getAvatarDir(),
+): void {
+  mkdirSync(avatarDir, { recursive: true });
+  const manifestPath = join(avatarDir, AVATAR_MANIFEST_FILENAME);
+  const tmp = `${manifestPath}.${randomUUID()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2));
+  renameSync(tmp, manifestPath);
+}
+
+/** Computes a stable etag for the avatar image from its size and mtime. */
+function computeImageEtag(sizeBytes: number, mtimeMs: number): string {
+  return createHash("sha256")
+    .update(`${sizeBytes}:${mtimeMs}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/**
+ * Derives avatar state from the legacy sidecar files (traits JSON + PNG).
+ * Used both by the one-time migration and as a temporary read fallback.
+ *
+ * Inference is **traits-first**: whenever a valid `character-traits.json`
+ * exists, the result is `character` regardless of whether a PNG is also
+ * present. We deliberately do NOT compare mtimes to break the both-present
+ * tie, because the builder writes the rendered PNG *after* the traits file
+ * (see traits-png-sync.ts), so the PNG is always newer even when the
+ * character is the source of truth. Comparing mtimes would misclassify a
+ * builder-generated character as an uploaded image.
+ */
+export function deriveStateFromLegacyFiles(
+  avatarDir: string = getAvatarDir(),
+): AvatarState {
+  const traitsPath = join(avatarDir, TRAITS_FILENAME);
+  if (existsSync(traitsPath)) {
+    try {
+      const traits = JSON.parse(readFileSync(traitsPath, "utf-8")) as unknown;
+      if (isValidTraits(traits)) {
+        return { kind: "character", traits, source: null, image: null };
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "Corrupt character-traits.json — falling back to image/none",
+      );
+    }
+  }
+
+  const imagePath = join(avatarDir, AVATAR_IMAGE_FILENAME);
+  if (existsSync(imagePath)) {
+    const stats = statSync(imagePath);
+    return {
+      kind: "image",
+      traits: null,
+      source: null,
+      image: {
+        updatedAt: new Date(stats.mtimeMs).toISOString(),
+        etag: computeImageEtag(stats.size, stats.mtimeMs),
+      },
+    };
+  }
+
+  return { kind: "none", traits: null, source: null, image: null };
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -124,6 +124,14 @@ export function getAvatarImagePath(): string {
   return join(getAvatarDir(), AVATAR_IMAGE_FILENAME);
 }
 
+/** Canonical filename for the avatar state manifest. */
+export const AVATAR_MANIFEST_FILENAME = "avatar.json";
+
+/** Returns the canonical avatar manifest path (~/.vellum/workspace/data/avatar/avatar.json). */
+export function getAvatarManifestPath(): string {
+  return join(getAvatarDir(), AVATAR_MANIFEST_FILENAME);
+}
+
 // Kept in sync with `cli/src/lib/environments/seeds.ts`. Drift between
 // these two sites is caught at test time by
 // `cli/src/__tests__/env-drift.test.ts`. Fast follow: hoist the shared


### PR DESCRIPTION
## Summary
- Add AvatarState manifest schema + read/write/derive helpers (traits-first legacy inference)
- Add AVATAR_MANIFEST_FILENAME + getAvatarManifestPath to platform.ts
- Unit tests for round-trip + all derivation cases

Part of plan: avatar-state-manifest.md (PR 1 of 13)