### PR TITLE
[EPD-2808] fix(web): enable vertical scrolling on onboarding screens for small viewports

### DIFF
--- a/apps/web/src/domains/onboarding/components/onboarding-layout.tsx
+++ b/apps/web/src/domains/onboarding/components/onboarding-layout.tsx
@@ -6,11 +6,19 @@ import { CreatureFooter } from "./creature-footer";
  * Shared chrome for the onboarding screens: a full-height dark surface with
  * the decorative creature footer pinned to the bottom. Caller owns the inner
  * column's layout and padding.
+ *
+ * The outer div fills the RootLayout's fixed-height (100dvh) shell. Children
+ * render inside a flex-1 scroll container so screens whose content exceeds
+ * the viewport (e.g. ToolSelectionScreen on iPhone 13 mini) become scrollable
+ * instead of clipping the Continue button off-screen. The CreatureFooter sits
+ * outside the scroll container so it stays at the viewport bottom.
  */
 export function OnboardingLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[var(--surface-base)]">
-      {children}
+    <div className="relative flex h-full flex-col bg-[var(--surface-base)]">
+      <div className="flex-1 overflow-y-auto">
+        {children}
+      </div>
       <CreatureFooter />
     </div>
   );


### PR DESCRIPTION
OnboardingLayout's `overflow-hidden` on a `min-h-screen` container prevented scrolling when content exceeded the viewport. On iPhone 13 mini (~731px effective viewport), screens like TaskToneSelectionScreen and ToolSelectionScreen had their Continue buttons clipped off-screen, blocking signup completion.

Restructures OnboardingLayout as a flex column (`h-full flex flex-col`) with a scrollable inner wrapper (`flex-1 overflow-y-auto`). The CreatureFooter stays outside the scroll container so it remains fixed at the viewport bottom. Screens' existing `pb-40` clearance is preserved — no changes needed to individual screen components.

---

## Prompt / plan

Investigated EPD-2808: two nested `overflow-hidden` containers (RootLayout's fixed `100dvh` shell + OnboardingLayout's `min-h-screen overflow-hidden`) made it impossible to scroll onboarding screens on small viewports. The fix wraps children in a scrollable flex container while keeping the decorative footer anchored at the bottom.

## Test plan

- Lint and typecheck pass locally (pre-existing design-library `@types/react` errors only)
- Single-file change scoped to `OnboardingLayout` — only affects onboarding routes
- Chat, settings, and all non-onboarding routes are unaffected (they don't use `OnboardingLayout`)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/1bf77a541d6b4fba99bdd070beb871b4