### PR TITLE
feat(daemon): add workspace migration seeding avatar.json from legacy files

### DIFF
--- a/assistant/src/workspace/migrations/092-seed-avatar-manifest.ts
+++ b/assistant/src/workspace/migrations/092-seed-avatar-manifest.ts
@@ -1,0 +1,148 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("092-seed-avatar-manifest");
+
+// Filenames are inlined to keep this migration self-contained (see AGENTS.md).
+// They mirror the canonical constants in util/platform.ts and avatar-manifest.ts.
+const TRAITS_FILENAME = "character-traits.json";
+const AVATAR_IMAGE_FILENAME = "avatar-image.png";
+const AVATAR_MANIFEST_FILENAME = "avatar.json";
+
+type AvatarKind = "character" | "image" | "none";
+type AvatarSource = "builder" | "upload" | "ai";
+
+interface AvatarImageMeta {
+  updatedAt: string;
+  etag: string;
+}
+
+interface CharacterTraits {
+  bodyShape: string;
+  eyeStyle: string;
+  color: string;
+}
+
+interface AvatarState {
+  kind: AvatarKind;
+  traits: CharacterTraits | null;
+  source: AvatarSource | null;
+  image: AvatarImageMeta | null;
+}
+
+/** Narrows an unknown value to valid CharacterTraits (presence check only). */
+function isValidTraits(value: unknown): value is CharacterTraits {
+  if (!value || typeof value !== "object") return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.bodyShape === "string" &&
+    !!t.bodyShape &&
+    typeof t.eyeStyle === "string" &&
+    !!t.eyeStyle &&
+    typeof t.color === "string" &&
+    !!t.color
+  );
+}
+
+/** Computes a stable etag for the avatar image from its size and mtime. */
+function computeImageEtag(sizeBytes: number, mtimeMs: number): string {
+  return createHash("sha256")
+    .update(`${sizeBytes}:${mtimeMs}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/**
+ * Derives avatar state from the legacy sidecar files (traits JSON + PNG).
+ *
+ * Inference is **traits-first**: whenever a valid `character-traits.json`
+ * exists, the result is `character` regardless of whether a PNG is also
+ * present. We deliberately do NOT compare mtimes to break the both-present
+ * tie, because the builder writes the rendered PNG *after* the traits file, so
+ * the PNG is always newer even when the character is the source of truth.
+ *
+ * Inlined from avatar-manifest.ts to keep this migration self-contained.
+ */
+function deriveStateFromLegacyFiles(avatarDir: string): AvatarState {
+  const traitsPath = join(avatarDir, TRAITS_FILENAME);
+  if (existsSync(traitsPath)) {
+    try {
+      const traits = JSON.parse(readFileSync(traitsPath, "utf-8")) as unknown;
+      if (isValidTraits(traits)) {
+        return { kind: "character", traits, source: null, image: null };
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "Corrupt character-traits.json — falling back to image/none",
+      );
+    }
+  }
+
+  const imagePath = join(avatarDir, AVATAR_IMAGE_FILENAME);
+  if (existsSync(imagePath)) {
+    const stats = statSync(imagePath);
+    return {
+      kind: "image",
+      traits: null,
+      source: null,
+      image: {
+        updatedAt: new Date(stats.mtimeMs).toISOString(),
+        etag: computeImageEtag(stats.size, stats.mtimeMs),
+      },
+    };
+  }
+
+  return { kind: "none", traits: null, source: null, image: null };
+}
+
+/**
+ * Writes the avatar manifest atomically (tmp-write + rename), mirroring the
+ * write pattern in avatar-manifest.ts. Inlined to keep this migration
+ * self-contained.
+ */
+function writeManifest(state: AvatarState, avatarDir: string): void {
+  mkdirSync(avatarDir, { recursive: true });
+  const manifestPath = join(avatarDir, AVATAR_MANIFEST_FILENAME);
+  const tmp = `${manifestPath}.${randomUUID()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2));
+  renameSync(tmp, manifestPath);
+}
+
+export const seedAvatarManifestMigration: WorkspaceMigration = {
+  id: "092-seed-avatar-manifest",
+  description:
+    "Seed avatar.json from legacy sidecar files (traits-first), backfilling existing workspaces",
+  run(workspaceDir: string): void {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    const manifestPath = join(avatarDir, AVATAR_MANIFEST_FILENAME);
+
+    // Idempotent: if a manifest already exists, leave it untouched.
+    if (existsSync(manifestPath)) return;
+
+    // For a brand-new workspace (no legacy files) this naturally derives
+    // { kind: "none" }, so we don't need to branch on ctx.isNewWorkspace.
+    const state = deriveStateFromLegacyFiles(avatarDir);
+    writeManifest(state, avatarDir);
+  },
+  down(workspaceDir: string): void {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    const manifestPath = join(avatarDir, AVATAR_MANIFEST_FILENAME);
+    // Remove only the manifest; leave legacy files intact so the old
+    // heuristic/fallback still works on rollback. `force` makes this
+    // idempotent (no-op when the manifest is already gone).
+    rmSync(manifestPath, { force: true });
+  },
+};

--- a/assistant/src/workspace/migrations/__tests__/092-seed-avatar-manifest.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/092-seed-avatar-manifest.test.ts
@@ -1,0 +1,138 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedAvatarManifestMigration } from "../092-seed-avatar-manifest.js";
+
+const VALID_TRAITS = {
+  bodyShape: "round",
+  eyeStyle: "wide",
+  color: "#123456",
+};
+
+let workspaceDir: string;
+let avatarDir: string;
+let manifestPath: string;
+
+function readManifest(): Record<string, unknown> {
+  return JSON.parse(readFileSync(manifestPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "seed-avatar-manifest-"));
+  avatarDir = join(workspaceDir, "data", "avatar");
+  mkdirSync(avatarDir, { recursive: true });
+  manifestPath = join(avatarDir, "avatar.json");
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("092-seed-avatar-manifest", () => {
+  test("has a unique, expected id", () => {
+    expect(seedAvatarManifestMigration.id).toBe("092-seed-avatar-manifest");
+  });
+
+  test("traits only → character", () => {
+    writeFileSync(
+      join(avatarDir, "character-traits.json"),
+      JSON.stringify(VALID_TRAITS),
+    );
+
+    seedAvatarManifestMigration.run(workspaceDir);
+
+    const manifest = readManifest();
+    expect(manifest.kind).toBe("character");
+    expect(manifest.traits).toEqual(VALID_TRAITS);
+    expect(manifest.image).toBeNull();
+  });
+
+  test("image only → image", () => {
+    writeFileSync(join(avatarDir, "avatar-image.png"), "fake-png-bytes");
+
+    seedAvatarManifestMigration.run(workspaceDir);
+
+    const manifest = readManifest();
+    expect(manifest.kind).toBe("image");
+    expect(manifest.traits).toBeNull();
+    const image = manifest.image as Record<string, unknown>;
+    expect(typeof image.updatedAt).toBe("string");
+    expect(typeof image.etag).toBe("string");
+  });
+
+  test("both present → character (traits-first)", () => {
+    writeFileSync(
+      join(avatarDir, "character-traits.json"),
+      JSON.stringify(VALID_TRAITS),
+    );
+    writeFileSync(join(avatarDir, "avatar-image.png"), "fake-png-bytes");
+
+    seedAvatarManifestMigration.run(workspaceDir);
+
+    const manifest = readManifest();
+    expect(manifest.kind).toBe("character");
+    expect(manifest.traits).toEqual(VALID_TRAITS);
+    expect(manifest.image).toBeNull();
+  });
+
+  test("neither present → none", () => {
+    seedAvatarManifestMigration.run(workspaceDir);
+
+    const manifest = readManifest();
+    expect(manifest.kind).toBe("none");
+    expect(manifest.traits).toBeNull();
+    expect(manifest.image).toBeNull();
+    expect(manifest.source).toBeNull();
+  });
+
+  test("re-run is a no-op (does not overwrite an existing manifest)", () => {
+    // Seed an image-derived manifest first.
+    writeFileSync(join(avatarDir, "avatar-image.png"), "fake-png-bytes");
+    seedAvatarManifestMigration.run(workspaceDir);
+    const first = readFileSync(manifestPath, "utf-8");
+
+    // Now add traits — a fresh derivation would flip to character, but the
+    // migration must leave the existing manifest untouched.
+    writeFileSync(
+      join(avatarDir, "character-traits.json"),
+      JSON.stringify(VALID_TRAITS),
+    );
+    seedAvatarManifestMigration.run(workspaceDir);
+
+    expect(readFileSync(manifestPath, "utf-8")).toBe(first);
+    expect((JSON.parse(first) as Record<string, unknown>).kind).toBe("image");
+  });
+
+  test("down() removes only avatar.json (legacy files remain)", () => {
+    const traitsPath = join(avatarDir, "character-traits.json");
+    const imagePath = join(avatarDir, "avatar-image.png");
+    writeFileSync(traitsPath, JSON.stringify(VALID_TRAITS));
+    writeFileSync(imagePath, "fake-png-bytes");
+
+    seedAvatarManifestMigration.run(workspaceDir);
+    expect(existsSync(manifestPath)).toBe(true);
+
+    seedAvatarManifestMigration.down(workspaceDir);
+
+    expect(existsSync(manifestPath)).toBe(false);
+    expect(existsSync(traitsPath)).toBe(true);
+    expect(existsSync(imagePath)).toBe(true);
+  });
+
+  test("down() is idempotent when no manifest exists", () => {
+    expect(() => seedAvatarManifestMigration.down(workspaceDir)).not.toThrow();
+    expect(existsSync(manifestPath)).toBe(false);
+  });
+});

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -89,6 +89,7 @@ import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecat
 import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { memoryRouterCostOptimizedProfileMigration } from "./090-memory-router-cost-optimized-profile.js";
 import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-migration-onboarding-thread.js";
+import { seedAvatarManifestMigration } from "./092-seed-avatar-manifest.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -189,4 +190,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveMemoryTreeOutOfV3Migration,
   memoryRouterCostOptimizedProfileMigration,
   retightenMigrationOnboardingThreadMigration,
+  seedAvatarManifestMigration,
 ];


### PR DESCRIPTION
## Summary
- Add migration 092-seed-avatar-manifest: seeds avatar.json from legacy files (traits-first)
- Idempotent, checkpointed, down() removes only avatar.json
- Registered in migrations registry

Part of plan: avatar-state-manifest.md (PR 4 of 13)