### PR TITLE
feat(daemon): add GET /avatar/state returning authoritative avatar render mode

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -550,6 +550,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "settings/voice", scopes: ["settings.write"] },
   { endpoint: "settings/avatar/generate", scopes: ["settings.write"] },
   { endpoint: "avatar/character-components", scopes: ["settings.read"] },
+  { endpoint: "avatar/state", scopes: ["settings.read"] },
   { endpoint: "avatar/render-from-traits", scopes: ["settings.write"] },
   { endpoint: "avatar/generate", scopes: ["settings.write"] },
   { endpoint: "avatar/set", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AvatarState } from "../../../avatar/avatar-manifest.js";
+import { writeManifest } from "../../../avatar/avatar-manifest.js";
+import { ROUTES } from "../avatar-routes.js";
+import type { RouteHandlerArgs } from "../types.js";
+
+const VALID_TRAITS = { bodyShape: "round", eyeStyle: "happy", color: "blue" };
+
+/** Resolve the GET /avatar/state handler from the route registry. */
+function getStateHandler() {
+  const route = ROUTES.find((r) => r.operationId === "avatar_get_state");
+  if (!route) throw new Error("avatar_get_state route not registered");
+  expect(route.endpoint).toBe("avatar/state");
+  expect(route.method).toBe("GET");
+  return route.handler as (
+    args: RouteHandlerArgs,
+  ) => AvatarState | Promise<AvatarState>;
+}
+
+describe("GET /avatar/state", () => {
+  let workspaceDir: string;
+  let avatarDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "avatar-state-route-test-"));
+    avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  test("returns the manifest verbatim when present", async () => {
+    const state: AvatarState = {
+      kind: "character",
+      traits: VALID_TRAITS,
+      source: "builder",
+      image: null,
+    };
+    writeManifest(state, avatarDir);
+
+    const result = await getStateHandler()({});
+    expect(result).toEqual(state);
+  });
+
+  test("falls back to derived character state on manifest-miss (traits file)", async () => {
+    writeFileSync(
+      join(avatarDir, "character-traits.json"),
+      JSON.stringify(VALID_TRAITS),
+    );
+
+    const result = await getStateHandler()({});
+    expect(result.kind).toBe("character");
+    expect(result.traits).toEqual(VALID_TRAITS);
+    expect(result.image).toBeNull();
+  });
+
+  test("falls back to derived image state on manifest-miss (image file)", async () => {
+    writeFileSync(join(avatarDir, "avatar-image.png"), Buffer.from("fake png"));
+
+    const result = await getStateHandler()({});
+    expect(result.kind).toBe("image");
+    expect(result.traits).toBeNull();
+    expect(result.image).not.toBeNull();
+    expect(result.image?.etag).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("returns kind:none (no throw, no 404) for an empty workspace", async () => {
+    let result: AvatarState | undefined;
+    expect(() => {
+      result = getStateHandler()({}) as AvatarState;
+    }).not.toThrow();
+    expect(result).toEqual({
+      kind: "none",
+      traits: null,
+      source: null,
+      image: null,
+    });
+  });
+});

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -10,6 +10,10 @@ import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 
 import { renderCharacterAscii } from "../../avatar/ascii-renderer.js";
+import {
+  deriveStateFromLegacyFiles,
+  readManifest,
+} from "../../avatar/avatar-manifest.js";
 import { getCharacterComponents } from "../../avatar/character-components.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
 import {
@@ -38,6 +42,23 @@ const log = getLogger("avatar-routes");
 
 function handleGetCharacterComponents() {
   return getCharacterComponents();
+}
+
+/**
+ * Return the authoritative avatar render state.
+ *
+ * Reads the manifest (`avatar.json`) first. When the manifest is absent or
+ * invalid, `readManifest` returns null and we fall back to deriving state
+ * from the legacy sidecar files. Never 404s — an empty workspace yields
+ * `{ kind: "none", traits: null, source: null, image: null }`.
+ */
+function handleGetAvatarState() {
+  const manifest = readManifest();
+  if (manifest) {
+    return manifest;
+  }
+  // TODO(avatar-manifest): remove after migration ships + clients adopt (PR 13)
+  return deriveStateFromLegacyFiles();
 }
 
 function handleRenderFromTraits({ body, headers }: RouteHandlerArgs) {
@@ -266,6 +287,33 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["avatar"],
   },
   {
+    operationId: "avatar_get_state",
+    endpoint: "avatar/state",
+    method: "GET",
+    handler: handleGetAvatarState,
+    summary: "Get avatar state",
+    description:
+      "Return the authoritative avatar render mode (character, image, or none).",
+    tags: ["avatar"],
+    responseBody: z.object({
+      kind: z.enum(["character", "image", "none"]),
+      traits: z
+        .object({
+          bodyShape: z.string(),
+          eyeStyle: z.string(),
+          color: z.string(),
+        })
+        .nullable(),
+      source: z.enum(["builder", "upload", "ai"]).nullable(),
+      image: z
+        .object({
+          updatedAt: z.string(),
+          etag: z.string(),
+        })
+        .nullable(),
+    }),
+  },
+  {
     operationId: "avatar_render_from_traits",
     endpoint: "avatar/render-from-traits",
     method: "POST",
@@ -287,7 +335,9 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "avatar/notify-updated",
     method: "POST",
     handler: ({ headers }: RouteHandlerArgs) => {
-      publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
+      publishAvatarChanged(
+        headers?.["x-vellum-client-id"]?.trim() || undefined,
+      );
       return { ok: true };
     },
     summary: "Notify avatar updated",


### PR DESCRIPTION
## Summary
- Add handleGetAvatarState + GET /avatar/state route (always 200, kind:none for empty)
- Reads manifest first, temporary legacy-derivation fallback on manifest-miss
- route-policy grants settings.read

Part of plan: avatar-state-manifest.md (PR 3 of 13)