### PR TITLE
feat(web): watch design-library source for Vite HMR

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,11 @@ import tailwindcss from "@tailwindcss/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { localModePlugin } from "./vite-plugin-local-mode";
 
+const DESIGN_LIBRARY_SRC = path.resolve(
+  import.meta.dirname,
+  "../../packages/design-library/src",
+);
+
 // Keep in sync with PLATFORM_MODE_TRUTHY in src/lib/local-mode.ts
 const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 function isPlatformMode(raw: string | undefined): boolean {
@@ -52,6 +57,14 @@ export default defineConfig(({ mode }) => {
         },
       }),
       isPlatformMode(env.VITE_PLATFORM_MODE) ? null : localModePlugin(env),
+      {
+        // Chokidar won't follow the file: symlink when preserveSymlinks
+        // is true, so manually add the design-library source tree.
+        name: "watch-design-library",
+        configureServer(server) {
+          server.watcher.add(DESIGN_LIBRARY_SRC);
+        },
+      },
     ].filter(Boolean),
     resolve: {
       alias: [
@@ -66,12 +79,6 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.PORT || "3000"),
       strictPort: true,
       host: true,
-      watch: {
-        // Include the design-library source so edits trigger HMR via the
-        // file: dependency link (chokidar won't follow it automatically
-        // when preserveSymlinks is true).
-        paths: [path.resolve(import.meta.dirname, "../../packages/design-library/src")],
-      },
       proxy: {
         "/v1": { target: apiProxyTarget, changeOrigin: true },
         "/_allauth": { target: apiProxyTarget, changeOrigin: true },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,6 +9,12 @@ const DESIGN_LIBRARY_SRC = path.resolve(
   import.meta.dirname,
   "../../packages/design-library/src",
 );
+// With preserveSymlinks, the module graph keys by the node_modules symlink
+// path, not the real source path. We need both to translate watcher events.
+const DESIGN_LIBRARY_SYMLINK = path.resolve(
+  import.meta.dirname,
+  "node_modules/@vellum/design-library/src",
+);
 
 // Keep in sync with PLATFORM_MODE_TRUTHY in src/lib/local-mode.ts
 const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
@@ -60,9 +66,18 @@ export default defineConfig(({ mode }) => {
       {
         // Chokidar won't follow the file: symlink when preserveSymlinks
         // is true, so manually add the design-library source tree.
+        // handleHotUpdate translates the real path to the symlink path
+        // so the module graph lookup finds the right modules.
         name: "watch-design-library",
         configureServer(server) {
           server.watcher.add(DESIGN_LIBRARY_SRC);
+        },
+        handleHotUpdate({ file, server }) {
+          if (!file.startsWith(DESIGN_LIBRARY_SRC)) return;
+          const rel = path.relative(DESIGN_LIBRARY_SRC, file);
+          const symlinkPath = path.resolve(DESIGN_LIBRARY_SYMLINK, rel);
+          const mods = server.moduleGraph.getModulesByFile(symlinkPath);
+          if (mods?.size) return [...mods];
         },
       },
     ].filter(Boolean),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,6 +66,12 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.PORT || "3000"),
       strictPort: true,
       host: true,
+      watch: {
+        // Include the design-library source so edits trigger HMR via the
+        // file: dependency link (chokidar won't follow it automatically
+        // when preserveSymlinks is true).
+        paths: [path.resolve(import.meta.dirname, "../../packages/design-library/src")],
+      },
       proxy: {
         "/v1": { target: apiProxyTarget, changeOrigin: true },
         "/_allauth": { target: apiProxyTarget, changeOrigin: true },


### PR DESCRIPTION
## Summary

- Add `server.watch.paths` to the web app's Vite config to include `packages/design-library/src`
- This enables hot-module replacement for design library changes during local dev (`vel up`)
- Fixes the issue where chokidar doesn't follow the `file:` dependency symlink when `preserveSymlinks: true` is set

## Original prompt

During local development with `vel up`, changes to the design library (`@vellum/design-library`) were not being hot-reloaded in the web app. The root cause is that Vite's file watcher (chokidar) doesn't follow the `file:` dependency symlink automatically when `preserveSymlinks` is enabled. The fix is to explicitly add the design library source directory to Vite's `server.watch.paths`, giving true HMR rather than requiring a service restart.