### PR TITLE
feat(web): add fetchAvatarState API and AvatarState types

### DIFF
--- a/apps/web/src/assistant/avatar-api.test.ts
+++ b/apps/web/src/assistant/avatar-api.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for `fetchAvatarState` and the `isAvatarState` type guard.
+ *
+ * Spies on `client.get` rather than `mock.module`-ing the whole SDK,
+ * matching the pattern in `compaction-trail-fetch.test.ts` — keeps the
+ * module registry clean for sibling test files.
+ *
+ * What's pinned:
+ *   - The guard accepts every valid `kind` and rejects malformed payloads.
+ *   - A 200 `{ kind: "none" }` is a VALID state, not `null`.
+ *   - `fetchAvatarState` returns `null` only on transport failure (network
+ *     throw, non-2xx, or a payload that fails validation).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { client } from "@/generated/api/client.gen";
+import type { AvatarState } from "@/types/avatar";
+import { isAvatarState } from "@/types/avatar";
+
+import { fetchAvatarState } from "./avatar-api";
+
+const CHARACTER_STATE: AvatarState = {
+  kind: "character",
+  traits: { bodyShape: "round", eyeStyle: "happy", color: "#123456" },
+  source: "builder",
+  image: null,
+};
+
+const IMAGE_STATE: AvatarState = {
+  kind: "image",
+  traits: null,
+  source: "upload",
+  image: { updatedAt: "2026-05-29T00:00:00Z", etag: "abc123" },
+};
+
+const NONE_STATE: AvatarState = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+};
+
+describe("isAvatarState", () => {
+  test("accepts a character state", () => {
+    expect(isAvatarState(CHARACTER_STATE)).toBe(true);
+  });
+
+  test("accepts an image state", () => {
+    expect(isAvatarState(IMAGE_STATE)).toBe(true);
+  });
+
+  test("accepts a none state", () => {
+    expect(isAvatarState(NONE_STATE)).toBe(true);
+  });
+
+  test("rejects non-objects", () => {
+    expect(isAvatarState(null)).toBe(false);
+    expect(isAvatarState(undefined)).toBe(false);
+    expect(isAvatarState("none")).toBe(false);
+    expect(isAvatarState(42)).toBe(false);
+  });
+
+  test("rejects an unknown kind", () => {
+    expect(isAvatarState({ ...NONE_STATE, kind: "default" })).toBe(false);
+  });
+
+  test("rejects malformed traits", () => {
+    expect(
+      isAvatarState({ ...CHARACTER_STATE, traits: { bodyShape: "round" } }),
+    ).toBe(false);
+  });
+
+  test("rejects malformed image meta", () => {
+    expect(
+      isAvatarState({ ...IMAGE_STATE, image: { updatedAt: "now" } }),
+    ).toBe(false);
+  });
+
+  test("rejects an invalid source", () => {
+    expect(isAvatarState({ ...NONE_STATE, source: "magic" })).toBe(false);
+  });
+});
+
+type CapturedGetOptions = {
+  url: string;
+  path?: Record<string, unknown>;
+};
+
+let captured: CapturedGetOptions | null = null;
+const originalGet = client.get;
+
+function stubGet(result: {
+  data: unknown;
+  error: unknown;
+  response: Response;
+}): void {
+  captured = null;
+  client.get = mock(async (options: CapturedGetOptions) => {
+    captured = options;
+    return result;
+  }) as typeof client.get;
+}
+
+function okResponse(): Response {
+  return new Response(null, { status: 200 });
+}
+
+function errorResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+afterEach(() => {
+  client.get = originalGet;
+  captured = null;
+});
+
+describe("fetchAvatarState", () => {
+  test("requests the avatar/state endpoint with the assistant id", async () => {
+    stubGet({ data: NONE_STATE, error: undefined, response: okResponse() });
+
+    await fetchAvatarState("asst-1");
+
+    expect(captured?.url).toBe(
+      "/v1/assistants/{assistant_id}/avatar/state",
+    );
+    expect(captured?.path).toEqual({ assistant_id: "asst-1" });
+  });
+
+  test("returns a typed character state", async () => {
+    stubGet({
+      data: CHARACTER_STATE,
+      error: undefined,
+      response: okResponse(),
+    });
+
+    const result = await fetchAvatarState("asst-1");
+
+    expect(result).toEqual(CHARACTER_STATE);
+  });
+
+  test("returns kind:none as a valid state, not null", async () => {
+    stubGet({ data: NONE_STATE, error: undefined, response: okResponse() });
+
+    const result = await fetchAvatarState("asst-1");
+
+    expect(result).toEqual(NONE_STATE);
+  });
+
+  test("returns null on a non-2xx response", async () => {
+    stubGet({
+      data: undefined,
+      error: { detail: "boom" },
+      response: errorResponse(500),
+    });
+
+    expect(await fetchAvatarState("asst-1")).toBeNull();
+  });
+
+  test("returns null when the payload fails validation", async () => {
+    stubGet({
+      data: { kind: "bogus" },
+      error: undefined,
+      response: okResponse(),
+    });
+
+    expect(await fetchAvatarState("asst-1")).toBeNull();
+  });
+
+  test("returns null on a transport throw", async () => {
+    client.get = mock(() =>
+      Promise.reject(new Error("network down")),
+    ) as typeof client.get;
+
+    expect(await fetchAvatarState("asst-1")).toBeNull();
+  });
+});

--- a/apps/web/src/assistant/avatar-api.ts
+++ b/apps/web/src/assistant/avatar-api.ts
@@ -8,8 +8,35 @@
  */
 import { client } from "@/generated/api/client.gen";
 import { assertHasResponse } from "@/lib/api-errors";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
-import { isCharacterTraits } from "@/types/avatar";
+import type {
+  AvatarState,
+  CharacterComponents,
+  CharacterTraits,
+} from "@/types/avatar";
+import { isAvatarState, isCharacterTraits } from "@/types/avatar";
+
+/**
+ * Fetch the authoritative avatar render manifest from the daemon's
+ * `GET /avatar/state` endpoint.
+ *
+ * Returns `null` only on transport failure. A 200 response with
+ * `{ kind: "none" }` is a valid state (an empty avatar), not `null`.
+ */
+export async function fetchAvatarState(
+  assistantId: string,
+): Promise<AvatarState | null> {
+  try {
+    const { data, error, response } = await client.get({
+      url: "/v1/assistants/{assistant_id}/avatar/state",
+      path: { assistant_id: assistantId },
+    });
+    assertHasResponse(response, error, "Failed to fetch avatar state");
+    if (!response.ok || !isAvatarState(data)) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
 
 export async function fetchCharacterComponents(
   assistantId: string,

--- a/apps/web/src/types/avatar.ts
+++ b/apps/web/src/types/avatar.ts
@@ -50,3 +50,49 @@ export function isCharacterTraits(value: unknown): value is CharacterTraits {
     typeof obj.color === "string"
   );
 }
+
+export type AvatarKind = "character" | "image" | "none";
+
+export type AvatarSource = "builder" | "upload" | "ai";
+
+export interface AvatarImageMeta {
+  updatedAt: string;
+  etag: string;
+}
+
+/**
+ * Authoritative avatar render manifest served by the daemon's
+ * `GET /avatar/state` endpoint. `kind` drives rendering; `source` is
+ * metadata. Mirrors the daemon's `AvatarState` manifest shape.
+ */
+export interface AvatarState {
+  kind: AvatarKind;
+  traits: CharacterTraits | null;
+  source: AvatarSource | null;
+  image: AvatarImageMeta | null;
+}
+
+function isAvatarKind(value: unknown): value is AvatarKind {
+  return value === "character" || value === "image" || value === "none";
+}
+
+function isAvatarSource(value: unknown): value is AvatarSource {
+  return value === "builder" || value === "upload" || value === "ai";
+}
+
+function isAvatarImageMeta(value: unknown): value is AvatarImageMeta {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.updatedAt === "string" && typeof obj.etag === "string";
+}
+
+export function isAvatarState(value: unknown): value is AvatarState {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    isAvatarKind(obj.kind) &&
+    (obj.traits === null || isCharacterTraits(obj.traits)) &&
+    (obj.source === null || isAvatarSource(obj.source)) &&
+    (obj.image === null || isAvatarImageMeta(obj.image))
+  );
+}


### PR DESCRIPTION
## Summary
- Add AvatarKind/AvatarSource/AvatarImageMeta/AvatarState types + isAvatarState guard
- Add fetchAvatarState API client (returns typed state; null only on transport failure)

Part of plan: avatar-state-manifest.md (PR 7 of 13)