### PR TITLE
refactor(daemon): route avatar write + remove endpoints through atomic store

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -6,10 +6,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockGeminiKey: string | undefined = "test-gemini-key";
 
-const mkdirSyncFn = mock(() => {});
-const writeFileSyncFn = mock(() => {});
-const renameSyncFn = mock(() => {});
-
 let logInfoCalls: Array<[unknown, string]> = [];
 let logErrorCalls: Array<[unknown, string]> = [];
 
@@ -79,16 +75,6 @@ mock.module("pino-pretty", () => ({
   default: () => ({ write: () => true }),
 }));
 
-mock.module("node:fs", () => ({
-  mkdirSync: mkdirSyncFn,
-  writeFileSync: writeFileSyncFn,
-  renameSync: renameSyncFn,
-}));
-
-mock.module("node:crypto", () => ({
-  randomUUID: () => "00000000-0000-0000-0000-000000000000",
-}));
-
 mock.module("@google/genai", () => ({
   GoogleGenAI: class {
     models = {
@@ -105,14 +91,14 @@ mock.module("@google/genai", () => ({
 }));
 
 // Import after all mocks are set up
-import { generateAndSaveAvatar } from "../tools/system/avatar-generator.js";
+import { generateAvatarImage } from "../tools/system/avatar-generator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function executeAvatar(description: string) {
-  return generateAndSaveAvatar(description);
+  return generateAvatarImage(description);
 }
 
 /** Standard successful Gemini generateContent response. */
@@ -135,8 +121,6 @@ function geminiContentResponse() {
   };
 }
 
-const expectedAvatarPath = `${process.env.VELLUM_WORKSPACE_DIR}/data/avatar/avatar-image.png`;
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -147,9 +131,6 @@ describe("avatar E2E integration", () => {
 
   beforeEach(() => {
     mockGeminiKey = "test-gemini-key";
-    mkdirSyncFn.mockClear();
-    writeFileSyncFn.mockClear();
-    renameSyncFn.mockClear();
     geminiGenerateContentFn.mockClear();
 
     logInfoCalls = [];
@@ -174,29 +155,18 @@ describe("avatar E2E integration", () => {
   // 1. Local Gemini success
   // -----------------------------------------------------------------------
 
-  test("local Gemini success — file written, correct content, success message", async () => {
+  test("local Gemini success — returns PNG bytes and success message", async () => {
     const result = await executeAvatar("a friendly robot");
 
     // Verify success message
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Avatar updated");
 
-    // Verify file was written
-    expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn).toHaveBeenCalledTimes(1);
-
-    // Verify rename target is the expected avatar path
-    expect((renameSyncFn.mock.calls[0] as unknown[])[1]).toBe(
-      expectedAvatarPath,
-    );
-
-    // Verify the written buffer content matches the base64 data
-    const writtenBuffer = (
-      writeFileSyncFn.mock.calls[0] as unknown[]
-    )[1] as Buffer;
+    // Verify the returned buffer content matches the base64 data. Persistence
+    // is the caller's job (the route routes these bytes through the store).
     const expectedBuffer = Buffer.from("iVBORw0KGgoAAAANSUhEUg==", "base64");
-    expect(writtenBuffer.equals(expectedBuffer)).toBe(true);
+    expect(result.pngBuffer).not.toBeNull();
+    expect(result.pngBuffer?.equals(expectedBuffer)).toBe(true);
 
     // Verify Gemini was called
     expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -12,10 +12,6 @@ const generateAvatarFn = mock(async () => {
   return mockRouterResult;
 });
 
-const mkdirSyncFn = mock(() => {});
-const writeFileSyncFn = mock(() => {});
-const renameSyncFn = mock(() => {});
-
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
 // ---------------------------------------------------------------------------
@@ -33,56 +29,51 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
-mock.module("node:fs", () => ({
-  mkdirSync: mkdirSyncFn,
-  writeFileSync: writeFileSyncFn,
-  renameSync: renameSyncFn,
-}));
-
 // Import after mocking
-import { generateAndSaveAvatar } from "../tools/system/avatar-generator.js";
+import { generateAvatarImage } from "../tools/system/avatar-generator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUg==";
+
 function successResult() {
   return {
-    imageBase64: "iVBORw0KGgoAAAANSUhEUg==",
+    imageBase64: PNG_BASE64,
     mimeType: "image/png",
   };
 }
 
 function executeAvatar(description: string) {
-  return generateAndSaveAvatar(description);
+  return generateAvatarImage(description);
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("generateAndSaveAvatar", () => {
+describe("generateAvatarImage", () => {
   beforeEach(() => {
     mockRouterResult = successResult();
     mockRouterError = undefined;
     generateAvatarFn.mockClear();
-    mkdirSyncFn.mockClear();
-    writeFileSyncFn.mockClear();
-    renameSyncFn.mockClear();
   });
 
-  test("successful generation writes PNG and returns success message", async () => {
+  test("successful generation returns PNG bytes and success message", async () => {
     const result = await executeAvatar("a friendly purple cat");
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Avatar updated");
+    expect(result.pngBuffer).toEqual(Buffer.from(PNG_BASE64, "base64"));
     expect(generateAvatarFn).toHaveBeenCalledTimes(1);
   });
 
-  test("empty description returns error", async () => {
+  test("empty description returns error and no buffer", async () => {
     const result = await executeAvatar("");
 
     expect(result.isError).toBe(true);
+    expect(result.pngBuffer).toBeNull();
     expect(result.content).toContain("description is required");
     expect(generateAvatarFn).not.toHaveBeenCalled();
   });
@@ -93,6 +84,7 @@ describe("generateAndSaveAvatar", () => {
     const result = await executeAvatar("a cat");
 
     expect(result.isError).toBe(true);
+    expect(result.pngBuffer).toBeNull();
     expect(result.content).toContain("No image data returned");
   });
 
@@ -104,31 +96,9 @@ describe("generateAndSaveAvatar", () => {
     const result = await executeAvatar("a cat");
 
     expect(result.isError).toBe(true);
+    expect(result.pngBuffer).toBeNull();
     expect(result.content).toContain(
       "Image generation failed: Network timeout",
     );
-  });
-
-  test("atomic write — file is written to .tmp then renamed", async () => {
-    await executeAvatar("a friendly cat");
-
-    const expectedPath = `${process.env.VELLUM_WORKSPACE_DIR}/data/avatar/avatar-image.png`;
-
-    // Verify mkdirSync was called for the directory
-    expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
-    expect((mkdirSyncFn.mock.calls[0] as unknown[])[1]).toEqual({
-      recursive: true,
-    });
-
-    // Verify writeFileSync writes to a unique tmp path
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const tmpPath = (writeFileSyncFn.mock.calls[0] as unknown[])[0] as string;
-    expect(tmpPath).toStartWith(expectedPath + ".");
-    expect(tmpPath).toEndWith(".tmp");
-
-    // Verify renameSync moves tmp to final path
-    expect(renameSyncFn).toHaveBeenCalledTimes(1);
-    expect((renameSyncFn.mock.calls[0] as unknown[])[0]).toBe(tmpPath);
-    expect((renameSyncFn.mock.calls[0] as unknown[])[1]).toBe(expectedPath);
   });
 });

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -131,16 +131,18 @@ Examples:
 
       avatar
         .command("remove")
-        .description("Remove custom avatar and restore character default")
+        .description("Reset the avatar to none (clears image and character)")
         .addHelpText(
           "after",
           `
-Removes the custom avatar image. If a native character was previously
-configured (character-traits.json still exists), it will be automatically
-restored the next time the avatar is regenerated.
+Resets the avatar to its empty state. This deletes ALL avatar artifacts —
+the custom image (avatar-image.png) AND any configured native character
+(character-traits.json / character-ascii.txt) — and marks the avatar as
+"none".
 
-Does not delete character-traits.json — the native character is preserved
-so it can be restored without reconfiguration.
+This is destructive: a previously configured native character is NOT
+preserved and will not be restored. Rebuild the character (or set a new
+image) to configure an avatar again.
 
 Examples:
   $ assistant avatar remove`,

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -9,6 +16,20 @@ import { ROUTES } from "../avatar-routes.js";
 import type { RouteHandlerArgs } from "../types.js";
 
 const VALID_TRAITS = { bodyShape: "round", eyeStyle: "happy", color: "blue" };
+
+const IMAGE_FILENAME = "avatar-image.png";
+const TRAITS_FILENAME = "character-traits.json";
+const ASCII_FILENAME = "character-ascii.txt";
+const MANIFEST_FILENAME = "avatar.json";
+
+/** Resolve a handler from the route registry by operationId. */
+function getHandler(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`${operationId} route not registered`);
+  return route.handler as (
+    args: RouteHandlerArgs,
+  ) => unknown | Promise<unknown>;
+}
 
 /** Resolve the GET /avatar/state handler from the route registry. */
 function getStateHandler() {
@@ -88,6 +109,163 @@ describe("GET /avatar/state", () => {
       traits: null,
       source: null,
       image: null,
+    });
+  });
+});
+
+/**
+ * Write/remove handlers route through the avatar store, so each leaves
+ * `avatar.json` consistent with the on-disk artifacts. State is asserted by
+ * reading the manifest + artifact files directly via `node:fs` (the route test
+ * already imports `node:fs`; importing store internals is avoided).
+ */
+describe("avatar write/remove handlers", () => {
+  let workspaceDir: string;
+  let avatarDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "avatar-write-route-test-"));
+    avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  const path = (name: string) => join(avatarDir, name);
+
+  interface ManifestShape {
+    kind: string;
+    traits: Record<string, unknown> | null;
+    source: string | null;
+    image: { updatedAt: string; etag: string } | null;
+  }
+
+  const readManifestFile = (): ManifestShape | null => {
+    const manifestPath = path(MANIFEST_FILENAME);
+    if (!existsSync(manifestPath)) return null;
+    return JSON.parse(readFileSync(manifestPath, "utf-8")) as ManifestShape;
+  };
+
+  describe("POST /avatar/render-from-traits", () => {
+    test("rejects missing required fields without writing a manifest", () => {
+      const handler = getHandler("avatar_render_from_traits");
+      expect(() => handler({ body: { bodyShape: "round" } })).toThrow(
+        /Missing required fields/,
+      );
+      expect(readManifestFile()).toBeNull();
+    });
+
+    test("writes a character manifest when the native renderer is available", async () => {
+      const handler = getHandler("avatar_render_from_traits");
+      // The native @resvg/resvg-js binding may be absent here. When it is, the
+      // store returns native_unavailable → the handler throws 503 and writes
+      // nothing. We assert that contract instead so the suite is deterministic.
+      let threw = false;
+      try {
+        await handler({ body: VALID_TRAITS });
+      } catch {
+        threw = true;
+      }
+
+      if (threw) {
+        expect(readManifestFile()).toBeNull();
+        return;
+      }
+
+      const manifest = readManifestFile();
+      expect(manifest).not.toBeNull();
+      expect(manifest!.kind).toBe("character");
+      expect(manifest!.traits).toEqual(VALID_TRAITS);
+      expect(manifest!.source).toBe("builder");
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(true);
+    });
+  });
+
+  describe("POST /avatar/set", () => {
+    test("clears stale traits and writes an image manifest (no both-files)", async () => {
+      // Seed legacy character artifacts to prove they get removed.
+      writeFileSync(path(TRAITS_FILENAME), JSON.stringify(VALID_TRAITS));
+      writeFileSync(path(ASCII_FILENAME), "ascii art");
+
+      const srcPath = join(workspaceDir, "upload.png");
+      writeFileSync(srcPath, Buffer.from("uploaded png bytes"));
+
+      const handler = getHandler("avatar_set");
+      const result = (await handler({ body: { imagePath: srcPath } })) as {
+        ok: boolean;
+      };
+      expect(result.ok).toBe(true);
+
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
+      expect(readFileSync(path(IMAGE_FILENAME)).toString()).toBe(
+        "uploaded png bytes",
+      );
+      // The stale character sidecars must be gone — no more both-files state.
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+      expect(existsSync(path(ASCII_FILENAME))).toBe(false);
+
+      const manifest = readManifestFile();
+      expect(manifest!.kind).toBe("image");
+      expect(manifest!.traits).toBeNull();
+      expect(manifest!.source).toBe("upload");
+      expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    test("rejects an imagePath outside the workspace", () => {
+      const handler = getHandler("avatar_set");
+      expect(() => handler({ body: { imagePath: "/etc/passwd" } })).toThrow(
+        /must resolve inside the workspace/,
+      );
+    });
+  });
+
+  describe("POST /avatar/remove", () => {
+    test("clears everything to kind:none (revert-to-character branch gone)", async () => {
+      // Seed an image plus legacy character artifacts.
+      writeFileSync(path(IMAGE_FILENAME), Buffer.from("png"));
+      writeFileSync(path(TRAITS_FILENAME), JSON.stringify(VALID_TRAITS));
+      writeFileSync(path(ASCII_FILENAME), "ascii art");
+
+      const handler = getHandler("avatar_remove");
+      const result = (await handler({ body: {} })) as {
+        ok: boolean;
+        hadAvatar: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.hadAvatar).toBe(true);
+
+      // Nothing is reverted: the character sidecars are gone too.
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+      expect(existsSync(path(ASCII_FILENAME))).toBe(false);
+      expect(readManifestFile()).toEqual({
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+      });
+    });
+
+    test("reports hadAvatar:false and still writes kind:none when nothing exists", async () => {
+      const handler = getHandler("avatar_remove");
+      const result = (await handler({ body: {} })) as {
+        ok: boolean;
+        hadAvatar: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.hadAvatar).toBe(false);
+      expect(readManifestFile()!.kind).toBe("none");
     });
   });
 });

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -1,11 +1,5 @@
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-} from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import { z } from "zod";
 
@@ -14,6 +8,11 @@ import {
   deriveStateFromLegacyFiles,
   readManifest,
 } from "../../avatar/avatar-manifest.js";
+import {
+  clearAvatar,
+  setCharacter,
+  setImage,
+} from "../../avatar/avatar-store.js";
 import { getCharacterComponents } from "../../avatar/character-components.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
 import {
@@ -23,7 +22,7 @@ import {
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
-import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
+import { generateAvatarImage } from "../../tools/system/avatar-generator.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getAvatarDir,
@@ -76,7 +75,7 @@ function handleRenderFromTraits({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  const result = writeTraitsAndRenderAvatar(traits);
+  const result = setCharacter(traits);
 
   if (!result.ok) {
     switch (result.reason) {
@@ -113,21 +112,14 @@ async function handleGenerateAvatar({ body, headers }: RouteHandlerArgs) {
     // Non-fatal
   }
 
-  const result = await generateAndSaveAvatar(description);
-  if (result.isError) {
+  const result = await generateAvatarImage(description);
+  if (result.isError || !result.pngBuffer) {
     throw new ServiceUnavailableError(result.content);
   }
 
-  // Remove native character files since AI-generated image takes precedence
-  const avatarDir = getAvatarDir();
-  const traitsPath = join(avatarDir, "character-traits.json");
-  const asciiPath = join(avatarDir, "character-ascii.txt");
-  try {
-    if (existsSync(traitsPath)) unlinkSync(traitsPath);
-    if (existsSync(asciiPath)) unlinkSync(asciiPath);
-  } catch {
-    // Best-effort
-  }
+  // Route through the store: atomically writes the PNG, removes the now-stale
+  // character sidecars (traits + ASCII), and records an AI-sourced manifest.
+  setImage(result.pngBuffer, "ai");
 
   updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
@@ -158,9 +150,9 @@ function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
     throw new BadRequestError(`Image file not found: ${normalized}`);
   }
 
-  const avatarPath = getAvatarImagePath();
-  mkdirSync(dirname(avatarPath), { recursive: true });
-  copyFileSync(normalized, avatarPath);
+  // Route through the store so traits sidecars are cleared and the manifest is
+  // recorded as an uploaded image atomically (no more stale both-files state).
+  setImage(readFileSync(normalized), "upload");
 
   updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
@@ -168,33 +160,21 @@ function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
 }
 
 function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
-  const avatarPath = getAvatarImagePath();
+  const hadAvatar = existsSync(getAvatarImagePath());
 
-  if (!existsSync(avatarPath)) {
-    return { ok: true, hadAvatar: false };
-  }
-
-  unlinkSync(avatarPath);
-
-  // Regenerate character PNG from traits if available
-  const traitsPath = join(getAvatarDir(), "character-traits.json");
-  if (existsSync(traitsPath)) {
-    try {
-      const traits = JSON.parse(
-        readFileSync(traitsPath, "utf-8"),
-      ) as CharacterTraits;
-      writeTraitsAndRenderAvatar(traits);
-    } catch {
-      // Best-effort
-    }
-  }
+  // Clear everything to a manifest-consistent kind:"none". Semantic change
+  // (intentional): traits no longer persist alongside an image, so there is
+  // nothing to revert to — the legacy "re-render character from traits" branch
+  // has been removed. avatar/remove is now a plain clear, reachable only via
+  // CLI/host.
+  clearAvatar();
 
   updateIdentityAvatarSection(
     "Default character avatar (no custom image set)",
     log,
   );
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
-  return { ok: true, hadAvatar: true };
+  return { ok: true, hadAvatar };
 }
 
 function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -8,6 +8,7 @@ import { basename, join } from "node:path";
 
 import { z } from "zod";
 
+import { setImage } from "../../avatar/avatar-store.js";
 import {
   getPlatformBaseUrl,
   setIngressPublicBaseUrl,
@@ -45,7 +46,7 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../../tools/schema-transforms.js";
-import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
+import { generateAvatarImage } from "../../tools/system/avatar-generator.js";
 import { pathExists } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getAvatarImagePath, getWorkspaceDir } from "../../util/platform.js";
@@ -90,11 +91,15 @@ async function handleGenerateAvatar({
   log.info({ description }, "Generating avatar via HTTP request");
 
   try {
-    const result = await generateAndSaveAvatar(description);
+    const result = await generateAvatarImage(description);
 
-    if (result.isError) {
+    if (result.isError || !result.pngBuffer) {
       throw new InternalError(result.content);
     }
+
+    // Route through the store so traits sidecars are cleared and the manifest
+    // is recorded as an AI-sourced image atomically.
+    setImage(result.pngBuffer, "ai");
 
     const avatarPath = getAvatarImagePath();
 

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -1,34 +1,30 @@
-import { randomUUID } from "node:crypto";
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
-
 import { generateAvatar } from "../../media/avatar-router.js";
 import { getLogger } from "../../util/logger.js";
-import { getAvatarImagePath } from "../../util/platform.js";
 
 const log = getLogger("avatar-generator");
 
-/** Canonical path where the custom avatar PNG is stored. */
-function getAvatarPath(): string {
-  return getAvatarImagePath();
-}
-
 export interface AvatarGenerationResult {
+  /** On success, the generated PNG bytes. Null on error. */
+  pngBuffer: Buffer | null;
+  /** User-facing message describing success or the failure reason. */
   content: string;
   isError: boolean;
 }
 
 /**
- * Generate a custom avatar image from a text description and save it
- * as the assistant's avatar PNG.
+ * Generate a custom avatar image from a text description and return the PNG
+ * bytes. Persistence is the caller's responsibility — the route handler routes
+ * the bytes through the avatar store (`setImage`) so the manifest and artifacts
+ * stay consistent.
  *
  * Used by the HTTP route handler at POST /v1/settings/avatar/generate.
  */
-export async function generateAndSaveAvatar(
+export async function generateAvatarImage(
   description: string,
 ): Promise<AvatarGenerationResult> {
   if (typeof description !== "string" || description.trim() === "") {
     return {
+      pngBuffer: null,
       content: "Error: description is required and must be a non-empty string.",
       isError: true,
     };
@@ -47,23 +43,17 @@ export async function generateAndSaveAvatar(
     const result = await generateAvatar(prompt);
     if (!result.imageBase64) {
       return {
+        pngBuffer: null,
         content: "Error: No image data returned. Please try again.",
         isError: true,
       };
     }
     const pngBuffer = Buffer.from(result.imageBase64, "base64");
 
-    const avatarPath = getAvatarPath();
-    const avatarDir = dirname(avatarPath);
-
-    const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
-    mkdirSync(avatarDir, { recursive: true });
-    writeFileSync(tmpPath, pngBuffer);
-    renameSync(tmpPath, avatarPath);
-
-    log.info({ avatarPath }, "Avatar saved successfully");
+    log.info("Avatar generated successfully");
 
     return {
+      pngBuffer,
       content: "Avatar updated! Your new avatar will appear shortly.",
       isError: false,
     };
@@ -76,6 +66,7 @@ export async function generateAndSaveAvatar(
         : "An unexpected error occurred during image generation.";
     log.error({ error: message }, "Avatar generation failed");
     return {
+      pngBuffer: null,
       content: `Avatar generation failed: ${message}`,
       isError: true,
     };


### PR DESCRIPTION
## Summary
- Route handleRenderFromTraits/handleGenerateAvatar/handleSetAvatar/handleRemoveAvatar through setCharacter/setImage/clearAvatar
- handleSetAvatar now clears traits (no more stale both-files); avatar/remove clears to kind:none (revert-to-character branch removed)

Part of plan: avatar-state-manifest.md (PR 5 of 13)