### PR TITLE
refactor(macos): drive AvatarAppearanceManager from /avatar/state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -176,16 +176,75 @@ final class AvatarAppearanceManager {
         return statusCode == 404
     }
 
-    /// Fetches the avatar image via HTTP through the gateway. On transient
-    /// failure (401, 5xx, transport error) the existing cached image is
-    /// preserved and one retry is scheduled; only an authoritative 404 clears
-    /// it. Guarded by `avatarRetryInFlight` so repeated transient failures
-    /// don't stack retries.
-    private func fetchAvatarViaHTTP() async {
+    /// Authoritative render state returned by `GET /avatar/state`. `kind`
+    /// selects the render mode; `traits` is populated for `character`, and the
+    /// PNG bytes for `image` are fetched separately from the workspace.
+    struct AvatarState: Codable, Equatable {
+        enum Kind: String, Codable {
+            case character
+            case image
+            case none
+        }
+
+        struct Traits: Codable, Equatable {
+            let bodyShape: String
+            let eyeStyle: String
+            let color: String
+        }
+
+        struct ImageInfo: Codable, Equatable {
+            let updatedAt: String
+            let etag: String
+        }
+
+        let kind: Kind
+        let traits: Traits?
+        let source: String?
+        let image: ImageInfo?
+    }
+
+    /// The action implied by an `avatar/state` HTTP response, before any state
+    /// is mutated. Extracted as a pure function so the transient-vs-authoritative
+    /// policy can be unit-tested without a live gateway connection.
+    enum StateFetchAction: Equatable {
+        /// Apply the decoded authoritative state.
+        case apply(AvatarState)
+        /// Authoritative "no avatar" (404, or 2xx with empty/garbled body):
+        /// clear cached state.
+        case clear
+        /// Transient failure (401/403/5xx): preserve cached state and retry.
+        case retry
+    }
+
+    /// Classifies an `avatar/state` response into an action. Pure and
+    /// synchronous so the preserve-vs-clear policy is fully testable.
+    static func stateFetchAction(statusCode: Int, data: Data) -> StateFetchAction {
+        if (200..<300).contains(statusCode) {
+            guard !data.isEmpty,
+                  let state = try? JSONDecoder().decode(AvatarState.self, from: data) else {
+                // A 2xx with an empty/garbled body is treated as an
+                // authoritative "no avatar" signal, matching the daemon's
+                // `{ kind: "none" }` contract.
+                return .clear
+            }
+            return .apply(state)
+        }
+        if isAuthoritativeAbsence(statusCode: statusCode) {
+            return .clear
+        }
+        return .retry
+    }
+
+    /// Fetches the authoritative avatar render state via `GET /avatar/state`
+    /// and applies it in a single pass. On transient failure (401, 5xx,
+    /// transport error) the existing cached avatar is preserved and one retry
+    /// is scheduled; only an authoritative 404 — or an authoritative `none`
+    /// state — clears it. Guarded by `stateRetryInFlight` so repeated transient
+    /// failures don't stack retries.
+    private func fetchAvatarStateViaHTTP() async {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "workspace/file/content",
-                params: ["path": "data/avatar/avatar-image.png"],
+                path: "avatar/state",
                 timeout: 10
             )
             // Short-circuit state mutations if the task was cancelled while
@@ -193,122 +252,133 @@ final class AvatarAppearanceManager {
             // response from the previous assistant can stale-flash the
             // avatar after resetForDisconnect() has cleared state.
             guard !Task.isCancelled else { return }
-            if response.isSuccess, !response.data.isEmpty {
-                cachedChatAvatar = nil
-                customAvatarImage = NSImage(data: response.data)
-                AvatarCache.saveImage(response.data)
-                updateDockIcon()
-                return
+            switch Self.stateFetchAction(statusCode: response.statusCode, data: response.data) {
+            case .apply(let state):
+                await applyAvatarState(state)
+            case .clear:
+                applyNoneState()
+            case .retry:
+                log.warning("Transient avatar/state fetch failure (HTTP \(response.statusCode)) — preserving cached avatar and scheduling retry")
+                scheduleStateRetry()
             }
-            if Self.isAuthoritativeAbsence(statusCode: response.statusCode) {
-                if customAvatarImage != nil { customAvatarImage = nil }
-                cachedChatAvatar = nil
-                AvatarCache.clearImage()
-                updateDockIcon()
-                return
-            }
-            log.warning("Transient avatar fetch failure (HTTP \(response.statusCode)) — preserving cached image and scheduling retry")
-            scheduleAvatarRetry()
         } catch {
             guard !Task.isCancelled else { return }
-            log.warning("Transport failure fetching avatar — preserving cached image and scheduling retry: \(error.localizedDescription)")
-            scheduleAvatarRetry()
+            log.warning("Transport failure fetching avatar/state — preserving cached avatar and scheduling retry: \(error.localizedDescription)")
+            scheduleStateRetry()
         }
     }
 
-    /// Fetches character-traits.json via HTTP through the gateway. Same
-    /// transient-vs-authoritative policy as the avatar image: 404 clears the
-    /// cached traits, 401/5xx/transport errors preserve them and schedule one
-    /// retry.
-    private func fetchTraitsViaHTTP() async {
+    /// Applies a decoded `AvatarState` by switching on `kind`:
+    /// - `character`: render the animated character from traits, clear any image.
+    /// - `image`: fetch the PNG bytes and use the static custom-image path.
+    /// - `none`: clear both → default character / fallback.
+    private func applyAvatarState(_ state: AvatarState) async {
+        switch state.kind {
+        case .character:
+            applyCharacterState(state.traits)
+        case .image:
+            await applyImageState()
+        case .none:
+            applyNoneState()
+        }
+    }
+
+    /// Sets character traits from the authoritative state and clears the custom
+    /// image so the animated `AnimatedAvatarView` path is used.
+    func applyCharacterState(_ traits: AvatarState.Traits?) {
+        guard let traits,
+              let body = AvatarBodyShape(rawValue: traits.bodyShape),
+              let eyes = AvatarEyeStyle(rawValue: traits.eyeStyle),
+              let color = AvatarColor(rawValue: traits.color) else {
+            // Malformed traits for a "character" state: treat as no usable
+            // avatar rather than overwriting good cached state.
+            return
+        }
+        characterBodyShape = body
+        characterEyeStyle = eyes
+        characterColor = color
+        customAvatarImage = nil
+        cachedChatAvatar = nil
+        cachedFallbackAvatar = nil
+        cachedFullFallbackAvatar = nil
+        AvatarCache.saveTraits(bodyShape: body, eyeStyle: eyes, color: color)
+        AvatarCache.clearImage()
+        updateDockIcon()
+    }
+
+    /// Fetches the avatar PNG bytes from the workspace and uses them as the
+    /// custom (static) image, clearing character traits so the static
+    /// `VAvatarImage` path is used. A transient PNG fetch failure preserves the
+    /// existing cached image and schedules a retry of the whole state fetch.
+    private func applyImageState() async {
         do {
             let response = try await GatewayHTTPClient.get(
                 path: "workspace/file/content",
-                params: ["path": "data/avatar/character-traits.json"],
+                params: ["path": "data/avatar/avatar-image.png"],
                 timeout: 10
             )
-            // Short-circuit state mutations if the task was cancelled while
-            // the HTTP request was in flight — otherwise a late-arriving
-            // response from the previous assistant can stale-flash the
-            // traits after resetForDisconnect() has cleared state.
             guard !Task.isCancelled else { return }
             if response.isSuccess, !response.data.isEmpty {
-                guard let components = try? JSONDecoder().decode(AvatarComponents.self, from: response.data) else {
-                    return
-                }
-                characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
-                characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
-                characterColor = AvatarColor(rawValue: components.color)
-                // Character traits loaded — the PNG is just a daemon rendering
-                // of the character, not a user upload. Clear it so the animated
-                // path is used.
-                customAvatarImage = nil
+                customAvatarImage = NSImage(data: response.data)
+                characterBodyShape = nil
+                characterEyeStyle = nil
+                characterColor = nil
                 cachedChatAvatar = nil
-                cachedFallbackAvatar = nil
-                cachedFullFallbackAvatar = nil
-                if let body = characterBodyShape, let eyes = characterEyeStyle, let color = characterColor {
-                    AvatarCache.saveTraits(bodyShape: body, eyeStyle: eyes, color: color)
-                }
-                AvatarCache.clearImage()
-                updateDockIcon()
-                return
-            }
-            if Self.isAuthoritativeAbsence(statusCode: response.statusCode) {
-                if characterBodyShape != nil { characterBodyShape = nil }
-                if characterEyeStyle != nil { characterEyeStyle = nil }
-                if characterColor != nil { characterColor = nil }
-                cachedFallbackAvatar = nil
-                cachedFullFallbackAvatar = nil
+                AvatarCache.saveImage(response.data)
                 AvatarCache.clearTraits()
                 updateDockIcon()
                 return
             }
-            log.warning("Transient traits fetch failure (HTTP \(response.statusCode)) — preserving cached traits and scheduling retry")
-            scheduleTraitsRetry()
+            if Self.isAuthoritativeAbsence(statusCode: response.statusCode) {
+                applyNoneState()
+                return
+            }
+            log.warning("Transient avatar image fetch failure (HTTP \(response.statusCode)) — preserving cached image and scheduling retry")
+            scheduleStateRetry()
         } catch {
             guard !Task.isCancelled else { return }
-            log.warning("Transport failure fetching character traits — preserving cached traits and scheduling retry: \(error.localizedDescription)")
-            scheduleTraitsRetry()
+            log.warning("Transport failure fetching avatar image — preserving cached image and scheduling retry: \(error.localizedDescription)")
+            scheduleStateRetry()
         }
     }
 
+    /// Clears both the custom image and character traits so the default
+    /// character / bundled-logo / initial-letter fallback is used. Called for an
+    /// authoritative `none` state or 404.
+    func applyNoneState() {
+        if customAvatarImage != nil { customAvatarImage = nil }
+        if characterBodyShape != nil { characterBodyShape = nil }
+        if characterEyeStyle != nil { characterEyeStyle = nil }
+        if characterColor != nil { characterColor = nil }
+        cachedChatAvatar = nil
+        cachedFallbackAvatar = nil
+        cachedFullFallbackAvatar = nil
+        AvatarCache.clearAll()
+        updateDockIcon()
+    }
+
     /// Guards against stacking overlapping retries when repeated transient
-    /// failures arrive before the first retry has completed. Tracked as Task
-    /// handles so `resetForDisconnect()` can cancel a pending retry before it
+    /// failures arrive before the first retry has completed. Tracked as a Task
+    /// handle so `resetForDisconnect()` can cancel a pending retry before it
     /// writes into the next assistant's state.
-    @ObservationIgnored private var avatarRetryInFlight = false
-    @ObservationIgnored private var traitsRetryInFlight = false
-    @ObservationIgnored private var avatarRetryTask: Task<Void, Never>?
-    @ObservationIgnored private var traitsRetryTask: Task<Void, Never>?
+    @ObservationIgnored private var stateRetryInFlight = false
+    @ObservationIgnored private var stateRetryTask: Task<Void, Never>?
     /// Tracks the primary (non-retry) fetch Task spawned by `reloadAvatar()` so
     /// `resetForDisconnect()` can cancel a fetch in flight. Without cancellation,
     /// a late-arriving response from the previous assistant would bypass the
     /// `Task.isCancelled` guards in the fetch methods and stale-flash state.
     @ObservationIgnored private var avatarPrimaryTask: Task<Void, Never>?
 
-    private func scheduleAvatarRetry() {
-        guard !avatarRetryInFlight else { return }
-        avatarRetryInFlight = true
-        avatarRetryTask = Task { [weak self] in
+    private func scheduleStateRetry() {
+        guard !stateRetryInFlight else { return }
+        stateRetryInFlight = true
+        stateRetryTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
             guard !Task.isCancelled, let self else { return }
-            await self.fetchAvatarViaHTTP()
+            await self.fetchAvatarStateViaHTTP()
             guard !Task.isCancelled else { return }
-            self.avatarRetryInFlight = false
-            self.avatarRetryTask = nil
-        }
-    }
-
-    private func scheduleTraitsRetry() {
-        guard !traitsRetryInFlight else { return }
-        traitsRetryInFlight = true
-        traitsRetryTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
-            guard !Task.isCancelled, let self else { return }
-            await self.fetchTraitsViaHTTP()
-            guard !Task.isCancelled else { return }
-            self.traitsRetryInFlight = false
-            self.traitsRetryTask = nil
+            self.stateRetryInFlight = false
+            self.stateRetryTask = nil
         }
     }
 
@@ -406,8 +476,7 @@ final class AvatarAppearanceManager {
         avatarPrimaryTask?.cancel()
         avatarPrimaryTask = Task { [weak self] in
             await self?.fetchComponents()
-            await self?.fetchAvatarViaHTTP()
-            await self?.fetchTraitsViaHTTP()
+            await self?.fetchAvatarStateViaHTTP()
         }
     }
 
@@ -460,19 +529,16 @@ final class AvatarAppearanceManager {
     func resetForDisconnect() {
         identityLoadTask?.cancel()
         identityLoadTask = nil
-        // Cancel any pending retry Tasks and clear in-flight flags so a retry
+        // Cancel any pending retry Task and clear the in-flight flag so a retry
         // spawned against the previous assistant cannot fire after state has
         // been cleared, and so the next connection's legitimate retries are
         // not silently no-oped by a stale in-flight flag.
-        avatarRetryTask?.cancel()
-        avatarRetryTask = nil
-        avatarRetryInFlight = false
-        traitsRetryTask?.cancel()
-        traitsRetryTask = nil
-        traitsRetryInFlight = false
+        stateRetryTask?.cancel()
+        stateRetryTask = nil
+        stateRetryInFlight = false
         // Cancel the in-flight primary fetch too; the `Task.isCancelled` guards
-        // inside `fetchAvatarViaHTTP`/`fetchTraitsViaHTTP` suppress the state
-        // mutation once the surrounding Task is cancelled.
+        // inside `fetchAvatarStateViaHTTP` suppress the state mutation once the
+        // surrounding Task is cancelled.
         avatarPrimaryTask?.cancel()
         avatarPrimaryTask = nil
         customAvatarImage = nil

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerTransientFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerTransientFailureTests.swift
@@ -53,4 +53,165 @@ final class AvatarAppearanceManagerTransientFailureTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - AvatarState decoding
+
+    func testDecodesCharacterState() throws {
+        let json = """
+        {"kind":"character","traits":{"bodyShape":"round","eyeStyle":"dot","color":"forest"},"source":"builder","image":null}
+        """.data(using: .utf8)!
+        let state = try JSONDecoder().decode(AvatarAppearanceManager.AvatarState.self, from: json)
+        XCTAssertEqual(state.kind, .character)
+        XCTAssertEqual(state.traits, AvatarAppearanceManager.AvatarState.Traits(bodyShape: "round", eyeStyle: "dot", color: "forest"))
+        XCTAssertEqual(state.source, "builder")
+        XCTAssertNil(state.image)
+    }
+
+    func testDecodesImageState() throws {
+        let json = """
+        {"kind":"image","traits":null,"source":"upload","image":{"updatedAt":"2026-01-01T00:00:00Z","etag":"abc123"}}
+        """.data(using: .utf8)!
+        let state = try JSONDecoder().decode(AvatarAppearanceManager.AvatarState.self, from: json)
+        XCTAssertEqual(state.kind, .image)
+        XCTAssertNil(state.traits)
+        XCTAssertEqual(state.source, "upload")
+        XCTAssertEqual(state.image, AvatarAppearanceManager.AvatarState.ImageInfo(updatedAt: "2026-01-01T00:00:00Z", etag: "abc123"))
+    }
+
+    func testDecodesNoneState() throws {
+        let json = """
+        {"kind":"none","traits":null,"source":null,"image":null}
+        """.data(using: .utf8)!
+        let state = try JSONDecoder().decode(AvatarAppearanceManager.AvatarState.self, from: json)
+        XCTAssertEqual(state.kind, .none)
+        XCTAssertNil(state.traits)
+        XCTAssertNil(state.source)
+        XCTAssertNil(state.image)
+    }
+
+    // MARK: - stateFetchAction policy (transient vs authoritative)
+
+    func test2xxCharacterBodyProducesApply() {
+        let data = """
+        {"kind":"character","traits":{"bodyShape":"round","eyeStyle":"dot","color":"forest"},"source":"builder","image":null}
+        """.data(using: .utf8)!
+        let action = AvatarAppearanceManager.stateFetchAction(statusCode: 200, data: data)
+        guard case .apply(let state) = action else {
+            return XCTFail("Expected .apply for a valid 2xx character body, got \(action)")
+        }
+        XCTAssertEqual(state.kind, .character)
+    }
+
+    func test2xxImageBodyProducesApply() {
+        let data = """
+        {"kind":"image","traits":null,"source":"upload","image":{"updatedAt":"t","etag":"e"}}
+        """.data(using: .utf8)!
+        let action = AvatarAppearanceManager.stateFetchAction(statusCode: 200, data: data)
+        guard case .apply(let state) = action else {
+            return XCTFail("Expected .apply for a valid 2xx image body, got \(action)")
+        }
+        XCTAssertEqual(state.kind, .image)
+    }
+
+    func test2xxNoneBodyProducesApply() {
+        let data = """
+        {"kind":"none","traits":null,"source":null,"image":null}
+        """.data(using: .utf8)!
+        let action = AvatarAppearanceManager.stateFetchAction(statusCode: 200, data: data)
+        guard case .apply(let state) = action else {
+            return XCTFail("Expected .apply for a valid 2xx none body, got \(action)")
+        }
+        XCTAssertEqual(state.kind, .none)
+    }
+
+    func test2xxEmptyBodyClears() {
+        // A 2xx with no body is an authoritative "no avatar" signal.
+        XCTAssertEqual(AvatarAppearanceManager.stateFetchAction(statusCode: 200, data: Data()), .clear)
+    }
+
+    func test2xxGarbledBodyClears() {
+        let data = "not json".data(using: .utf8)!
+        XCTAssertEqual(AvatarAppearanceManager.stateFetchAction(statusCode: 200, data: data), .clear)
+    }
+
+    func test404Clears() {
+        // Authoritative absence clears cached state.
+        XCTAssertEqual(AvatarAppearanceManager.stateFetchAction(statusCode: 404, data: Data()), .clear)
+    }
+
+    func testTransientStatusesPreserveAndRetry() {
+        // 401 (auth race), 403, and 5xx must NOT clear cached state — they
+        // schedule a retry so a brief bootstrap hiccup doesn't wipe a good avatar.
+        for status in [401, 403, 500, 502, 503, 504] {
+            XCTAssertEqual(
+                AvatarAppearanceManager.stateFetchAction(statusCode: status, data: Data()),
+                .retry,
+                "HTTP \(status) should preserve cached state and retry"
+            )
+        }
+    }
+
+    func testNonAbsence4xxPreserveAndRetry() {
+        // Only 404 is authoritative absence; other 4xx are transient.
+        for status in [400, 402, 405, 410, 429] {
+            XCTAssertEqual(
+                AvatarAppearanceManager.stateFetchAction(statusCode: status, data: Data()),
+                .retry,
+                "HTTP \(status) should preserve cached state and retry"
+            )
+        }
+    }
+
+    // MARK: - apply* state branches
+
+    @MainActor
+    func testApplyCharacterStateSetsTraitsAndClearsImage() {
+        let manager = AvatarAppearanceManager()
+        let body = AvatarBodyShape.allCases.first!
+        let eyes = AvatarEyeStyle.allCases.first!
+        let color = AvatarColor.allCases.first!
+        manager.applyCharacterState(
+            AvatarAppearanceManager.AvatarState.Traits(
+                bodyShape: body.rawValue,
+                eyeStyle: eyes.rawValue,
+                color: color.rawValue
+            )
+        )
+        XCTAssertEqual(manager.characterBodyShape, body)
+        XCTAssertEqual(manager.characterEyeStyle, eyes)
+        XCTAssertEqual(manager.characterColor, color)
+        XCTAssertNil(manager.customAvatarImage, "character state must clear the custom image so the animated path is used")
+    }
+
+    @MainActor
+    func testApplyCharacterStateIgnoresMalformedTraits() {
+        let manager = AvatarAppearanceManager()
+        manager.applyCharacterState(
+            AvatarAppearanceManager.AvatarState.Traits(bodyShape: "??", eyeStyle: "??", color: "??")
+        )
+        // Malformed traits must not partially populate state.
+        XCTAssertNil(manager.characterBodyShape)
+        XCTAssertNil(manager.characterEyeStyle)
+        XCTAssertNil(manager.characterColor)
+    }
+
+    @MainActor
+    func testApplyNoneStateClearsBoth() {
+        let manager = AvatarAppearanceManager()
+        let body = AvatarBodyShape.allCases.first!
+        let eyes = AvatarEyeStyle.allCases.first!
+        let color = AvatarColor.allCases.first!
+        manager.applyCharacterState(
+            AvatarAppearanceManager.AvatarState.Traits(
+                bodyShape: body.rawValue,
+                eyeStyle: eyes.rawValue,
+                color: color.rawValue
+            )
+        )
+        manager.applyNoneState()
+        XCTAssertNil(manager.characterBodyShape)
+        XCTAssertNil(manager.characterEyeStyle)
+        XCTAssertNil(manager.characterColor)
+        XCTAssertNil(manager.customAvatarImage)
+    }
 }


### PR DESCRIPTION
## Summary
- Replace two-fetch avatar/traits reconcile with single GET /avatar/state switch on kind
- character→animated, image→custom image, none→fallback; transient failures preserve cache

Part of plan: avatar-state-manifest.md (PR 11 of 13)