### PR TITLE
fix(web): drive chat avatar from manifest kind so built characters animate

### DIFF
--- a/apps/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/apps/web/src/hooks/use-assistant-avatar.test.tsx
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import type {
+  AvatarState,
+  CharacterComponents,
+  CharacterTraits,
+} from "@/types/avatar";
 
 const components: CharacterComponents = {
   bodyShapes: [
@@ -32,13 +36,34 @@ const traits: CharacterTraits = {
   color: "cosmic-purple",
 };
 
+const characterState: AvatarState = {
+  kind: "character",
+  traits,
+  source: "builder",
+  image: { updatedAt: "2024-01-01T00:00:00Z", etag: "abc" },
+};
+
+const imageState: AvatarState = {
+  kind: "image",
+  traits: null,
+  source: "upload",
+  image: { updatedAt: "2024-01-01T00:00:00Z", etag: "def" },
+};
+
+const noneState: AvatarState = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+};
+
 const fetchCharacterComponents = mock(async () => components);
-const fetchCharacterTraits = mock(async () => traits);
+const fetchAvatarState = mock(async () => noneState as AvatarState | null);
 const fetchAvatarImageUrl = mock(async () => null as string | null);
 
 mock.module("@/assistant/avatar-api", () => ({
   fetchCharacterComponents,
-  fetchCharacterTraits,
+  fetchAvatarState,
   fetchAvatarImageUrl,
 }));
 
@@ -57,15 +82,35 @@ function createWrapper() {
 afterEach(() => {
   cleanup();
   fetchCharacterComponents.mockClear();
-  fetchCharacterTraits.mockClear();
+  fetchAvatarState.mockClear();
   fetchAvatarImageUrl.mockClear();
   fetchCharacterComponents.mockResolvedValue(components);
-  fetchCharacterTraits.mockResolvedValue(traits);
+  fetchAvatarState.mockResolvedValue(noneState);
   fetchAvatarImageUrl.mockResolvedValue(null);
 });
 
 describe("useAssistantAvatar", () => {
-  test("skips character traits when a custom avatar image is available", async () => {
+  test("character kind exposes manifest traits and skips the image fetch", async () => {
+    fetchAvatarState.mockResolvedValueOnce(characterState);
+
+    const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+
+    // traits present + no image ⇒ ChatAvatar renders AnimatedAvatar.
+    expect(result.current.components).toEqual(components);
+    expect(result.current.customImageUrl).toBeNull();
+    expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+  });
+
+  test("image kind fetches the static image and leaves traits null", async () => {
+    fetchAvatarState.mockResolvedValueOnce(imageState);
     fetchAvatarImageUrl.mockResolvedValueOnce("blob:avatar-image");
 
     const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
@@ -76,25 +121,28 @@ describe("useAssistantAvatar", () => {
       expect(result.current.customImageUrl).toBe("blob:avatar-image");
     });
 
+    // image present + no traits ⇒ ChatAvatar renders the static circle.
     expect(result.current.components).toEqual(components);
     expect(result.current.traits).toBeNull();
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
-    expect(fetchCharacterTraits).not.toHaveBeenCalled();
   });
 
-  test("fetches character traits when no avatar image is available", async () => {
+  test("none kind falls back with neither traits nor image", async () => {
     const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      expect(result.current.traits).toEqual(traits);
+      expect(result.current.components).toEqual(components);
     });
 
+    // both null ⇒ ChatAvatar falls back to default components / "V".
+    expect(result.current.traits).toBeNull();
     expect(result.current.customImageUrl).toBeNull();
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
-    expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/apps/web/src/hooks/use-assistant-avatar.test.tsx
@@ -8,6 +8,7 @@ import type {
   CharacterComponents,
   CharacterTraits,
 } from "@/types/avatar";
+import { avatarQueryKey } from "@/lib/sync/query-tags";
 
 const components: CharacterComponents = {
   bodyShapes: [
@@ -144,5 +145,39 @@ describe("useAssistantAvatar", () => {
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+  });
+
+  test("null state (transport failure) preserves the cached avatar instead of blanking", async () => {
+    // First render: a real character avatar is fetched and cached.
+    fetchAvatarState.mockResolvedValueOnce(characterState);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const first = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(first.result.current.traits).toEqual(traits);
+    });
+    first.unmount();
+
+    // Now the daemon goes away / version-skews: `/avatar/state` returns null.
+    // Refetching must NOT blank the avatar — the queryFn throws so React
+    // Query retains the previously cached data.
+    fetchAvatarState.mockResolvedValue(null);
+    await queryClient.invalidateQueries({ queryKey: avatarQueryKey("asst-1") });
+
+    const second = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(fetchAvatarState).toHaveBeenCalledTimes(2);
+    });
+
+    // Cached character avatar is preserved; it did not fall back to "V".
+    expect(second.result.current.traits).toEqual(traits);
+    expect(second.result.current.customImageUrl).toBeNull();
+    second.unmount();
   });
 });

--- a/apps/web/src/hooks/use-assistant-avatar.ts
+++ b/apps/web/src/hooks/use-assistant-avatar.ts
@@ -38,20 +38,33 @@ export function useAssistantAvatar(assistantId: string | null) {
         fetchAvatarState(id),
       ]);
 
+      if (state === null) {
+        // `fetchAvatarState` returns null only on transport failure or
+        // version-skew (e.g. an older daemon where `/avatar/state` 404s).
+        // Throw rather than resolve to an empty avatar: React Query keeps
+        // the previously cached avatar data on error (it does not overwrite
+        // `data`) and retries, so with `staleTime: Infinity` consumers keep
+        // showing the last good avatar instead of blanking out to the "V".
+        // We deliberately do NOT fall back to the old file-existence
+        // traits/image inference here — that heuristic is the bug this
+        // change removes.
+        throw new Error("Failed to fetch avatar state");
+      }
+
       let traits: CharacterTraits | null = null;
       let imageUrl: string | null = null;
 
-      if (state?.kind === "character") {
+      if (state.kind === "character") {
         // Built/AI character: render the animated SVG from traits. The
         // daemon also writes a derived avatar-image.png raster, but the
         // web never uses it, so we skip the image fetch entirely.
         traits = state.traits;
-      } else if (state?.kind === "image") {
+      } else if (state.kind === "image") {
         // Custom uploaded image: render the static circle.
         imageUrl = await fetchAvatarImageUrl(id);
       }
-      // kind === "none" (or null on transport failure): both stay null,
-      // and ChatAvatar falls back to default components / the "V".
+      // kind === "none": both stay null, and ChatAvatar falls back to
+      // default components / the "V".
 
       const prev = activeBlobUrls.get(id);
       if (prev && prev !== imageUrl) {
@@ -68,6 +81,9 @@ export function useAssistantAvatar(assistantId: string | null) {
     enabled: Boolean(assistantId),
     staleTime: Infinity,
     structuralSharing: false,
+    // Retry transient `/avatar/state` failures once so a flaky fetch or a
+    // briefly-unavailable daemon recovers without a manual invalidate.
+    retry: 1,
   });
 
   const invalidate = useCallback(() => {

--- a/apps/web/src/hooks/use-assistant-avatar.ts
+++ b/apps/web/src/hooks/use-assistant-avatar.ts
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   fetchCharacterComponents,
-  fetchCharacterTraits,
+  fetchAvatarState,
   fetchAvatarImageUrl,
 } from "@/assistant/avatar-api";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
@@ -30,16 +30,28 @@ export function useAssistantAvatar(assistantId: string | null) {
     queryKey: avatarQueryKey(assistantId ?? ""),
     queryFn: async () => {
       const id = assistantId!;
-      const [components, imageUrl] = await Promise.all([
+      // The manifest `kind` is authoritative for rendering. Fetch it
+      // alongside the SVG component set; only fetch the raster image
+      // when the manifest says this assistant uses an uploaded image.
+      const [components, state] = await Promise.all([
         fetchCharacterComponents(id),
-        fetchAvatarImageUrl(id),
+        fetchAvatarState(id),
       ]);
-      // Skip the traits fetch when a custom image exists — the traits
-      // file is intentionally deleted on the daemon side in that case,
-      // so requesting it just generates 404s on every SSE-driven
-      // reconnect invalidation. `AvatarRenderer` only reads `traits`
-      // when there is no `customImageUrl`.
-      const traits = imageUrl ? null : await fetchCharacterTraits(id);
+
+      let traits: CharacterTraits | null = null;
+      let imageUrl: string | null = null;
+
+      if (state?.kind === "character") {
+        // Built/AI character: render the animated SVG from traits. The
+        // daemon also writes a derived avatar-image.png raster, but the
+        // web never uses it, so we skip the image fetch entirely.
+        traits = state.traits;
+      } else if (state?.kind === "image") {
+        // Custom uploaded image: render the static circle.
+        imageUrl = await fetchAvatarImageUrl(id);
+      }
+      // kind === "none" (or null on transport failure): both stay null,
+      // and ChatAvatar falls back to default components / the "V".
 
       const prev = activeBlobUrls.get(id);
       if (prev && prev !== imageUrl) {


### PR DESCRIPTION
## Summary
- Rewire useAssistantAvatar to fetchAvatarState and derive traits/image from kind
- Built characters now render AnimatedAvatar (no traits 404); images render static circle; none falls back

Part of plan: avatar-state-manifest.md (PR 8 of 13)