### PR TITLE
feat(daemon): add POST /avatar/image for base64 image uploads via store

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -554,6 +554,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "avatar/render-from-traits", scopes: ["settings.write"] },
   { endpoint: "avatar/generate", scopes: ["settings.write"] },
   { endpoint: "avatar/set", scopes: ["settings.write"] },
+  { endpoint: "avatar/image", scopes: ["settings.write"] },
   { endpoint: "avatar/remove", scopes: ["settings.write"] },
   { endpoint: "avatar/get", scopes: ["settings.read"] },
   { endpoint: "avatar/character/ascii", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -230,6 +230,74 @@ describe("avatar write/remove handlers", () => {
     });
   });
 
+  describe("POST /avatar/image", () => {
+    // Minimal valid PNG signature followed by enough bytes to clear the
+    // 12-byte sniff floor. The handler only checks the magic bytes.
+    const PNG_BYTES = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    ]);
+
+    test("writes an image manifest and clears stale traits from base64", async () => {
+      // Seed legacy character artifacts to prove they get removed.
+      writeFileSync(path(TRAITS_FILENAME), JSON.stringify(VALID_TRAITS));
+      writeFileSync(path(ASCII_FILENAME), "ascii art");
+
+      const handler = getHandler("avatar_upload_image");
+      const result = (await handler({
+        body: { content: PNG_BYTES.toString("base64"), encoding: "base64" },
+      })) as { ok: boolean };
+      expect(result.ok).toBe(true);
+
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
+      expect(readFileSync(path(IMAGE_FILENAME))).toEqual(PNG_BYTES);
+      // The stale character sidecars must be gone — no both-files state.
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+      expect(existsSync(path(ASCII_FILENAME))).toBe(false);
+
+      const manifest = readManifestFile();
+      expect(manifest!.kind).toBe("image");
+      expect(manifest!.traits).toBeNull();
+      expect(manifest!.source).toBe("upload");
+      expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    test("accepts a base64 payload without an explicit encoding field", async () => {
+      const handler = getHandler("avatar_upload_image");
+      const result = (await handler({
+        body: { content: PNG_BYTES.toString("base64") },
+      })) as { ok: boolean };
+      expect(result.ok).toBe(true);
+      expect(readManifestFile()!.kind).toBe("image");
+    });
+
+    test("rejects a missing content field with 400 and writes no manifest", () => {
+      const handler = getHandler("avatar_upload_image");
+      expect(() => handler({ body: {} })).toThrow(/content/);
+      expect(readManifestFile()).toBeNull();
+    });
+
+    test("rejects a non-base64 / non-image payload with 400", () => {
+      const handler = getHandler("avatar_upload_image");
+      // Valid base64 but decodes to plain text — not a supported image.
+      expect(() =>
+        handler({
+          body: { content: Buffer.from("not an image").toString("base64") },
+        }),
+      ).toThrow(/PNG|JPEG|GIF|WEBP|image/);
+      expect(readManifestFile()).toBeNull();
+    });
+
+    test("rejects an unsupported encoding with 400", () => {
+      const handler = getHandler("avatar_upload_image");
+      expect(() =>
+        handler({
+          body: { content: PNG_BYTES.toString("base64"), encoding: "hex" },
+        }),
+      ).toThrow(/encoding/);
+      expect(readManifestFile()).toBeNull();
+    });
+  });
+
   describe("POST /avatar/remove", () => {
     test("clears everything to kind:none (revert-to-character branch gone)", async () => {
       // Seed an image plus legacy character artifacts.

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -22,6 +22,7 @@ import {
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { detectMediaType } from "../../tools/shared/filesystem/image-read.js";
 import { generateAvatarImage } from "../../tools/system/avatar-generator.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -124,6 +125,45 @@ async function handleGenerateAvatar({ body, headers }: RouteHandlerArgs) {
   updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
   return { ok: true, message: result.content };
+}
+
+/**
+ * Accept a base64-encoded image and set it as the avatar. Replaces the web
+ * client's prior two-call `workspace/write` + `workspace/delete` dance with a
+ * single server-authoritative endpoint: the store atomically writes the PNG,
+ * clears the character sidecars, and records an `image` manifest.
+ */
+function handleUploadAvatarImage({ body, headers }: RouteHandlerArgs) {
+  const payload = body as Record<string, unknown> | undefined;
+  const content = payload?.content;
+  const encoding = payload?.encoding;
+
+  if (typeof content !== "string" || content.length === 0) {
+    throw new BadRequestError("content (base64 string) is required");
+  }
+  if (encoding !== undefined && encoding !== "base64") {
+    throw new BadRequestError('encoding must be "base64"');
+  }
+
+  const buffer = Buffer.from(content, "base64");
+  // Buffer.from silently drops invalid characters, so guard against an empty
+  // decode (e.g. whitespace-only / non-base64 input).
+  if (buffer.length === 0) {
+    throw new BadRequestError("content is not valid base64-encoded image data");
+  }
+  if (detectMediaType(buffer) === null) {
+    throw new BadRequestError(
+      "content must be a PNG, JPEG, GIF, or WEBP image",
+    );
+  }
+
+  // Route through the store: atomically writes the PNG, removes the now-stale
+  // character sidecars (traits + ASCII), and records an uploaded-image manifest.
+  setImage(buffer, "upload");
+
+  updateIdentityAvatarSection(null, log);
+  publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
+  return { ok: true };
 }
 
 function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
@@ -347,6 +387,21 @@ export const ROUTES: RouteDefinition[] = [
     description: "Copy an image file to the avatar location.",
     tags: ["avatar"],
     requestBody: z.object({ imagePath: z.string() }),
+    responseBody: z.object({ ok: z.boolean() }),
+  },
+  {
+    operationId: "avatar_upload_image",
+    endpoint: "avatar/image",
+    method: "POST",
+    handler: handleUploadAvatarImage,
+    summary: "Upload avatar image",
+    description:
+      "Upload a base64-encoded image as the avatar; writes the PNG and clears character traits atomically.",
+    tags: ["avatar"],
+    requestBody: z.object({
+      content: z.string(),
+      encoding: z.literal("base64").optional(),
+    }),
     responseBody: z.object({ ok: z.boolean() }),
   },
   {

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -19,7 +19,7 @@ const MAX_SOURCE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB — pre-optimization 
  * Detect the actual image format from the first bytes of the buffer.
  * Returns the MIME type, or null if unrecognised.
  */
-function detectMediaType(buf: Buffer): string | null {
+export function detectMediaType(buf: Buffer): string | null {
   if (buf.length < 12) return null;
 
   // JPEG: FF D8 FF

--- a/gateway/src/auth/ipc-route-policy.ts
+++ b/gateway/src/auth/ipc-route-policy.ts
@@ -310,6 +310,9 @@ const POLICY_TABLE: PolicyEntry[] = [
   ["recordings_status_post", ["settings.write"]],
   ["recordings_stop", ["settings.write"]],
 
+  // Avatar
+  ["avatar_upload_image", ["settings.write"]],
+
   // Settings
   ["settings_avatar_generate_post", ["settings.write"]],
   ["settings_client_put", ["settings.write"]],


### PR DESCRIPTION
## Summary
- Add handleUploadAvatarImage + POST /avatar/image (base64) routed through setImage(buf, "upload")
- Clears traits + writes manifest atomically; route-policy grants settings.write

Part of plan: avatar-state-manifest.md (PR 6 of 13)