### PR TITLE
refactor(web): remove avatar Reset to default action

### DIFF
--- a/apps/web/src/assistant/avatar-api.ts
+++ b/apps/web/src/assistant/avatar-api.ts
@@ -134,28 +134,6 @@ export async function uploadAvatarImage(
   }
 }
 
-export async function deleteAvatar(assistantId: string): Promise<boolean> {
-  try {
-    const [imageResult, traitsResult] = await Promise.all([
-      client.post({
-        url: "/v1/assistants/{assistant_id}/workspace/delete/",
-        path: { assistant_id: assistantId },
-        body: { path: "data/avatar/avatar-image.png" },
-        headers: { "Content-Type": "application/json" },
-      }),
-      client.post({
-        url: "/v1/assistants/{assistant_id}/workspace/delete/",
-        path: { assistant_id: assistantId },
-        body: { path: "data/avatar/character-traits.json" },
-        headers: { "Content-Type": "application/json" },
-      }),
-    ]);
-    return (imageResult.response?.ok ?? false) || (traitsResult.response?.ok ?? false);
-  } catch {
-    return false;
-  }
-}
-
 export async function fetchAvatarImageUrl(
   assistantId: string,
 ): Promise<string | null> {

--- a/apps/web/src/components/avatar/avatar-management-modal.tsx
+++ b/apps/web/src/components/avatar/avatar-management-modal.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Image as ImageIcon, Sparkles, Trash2, Wrench, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Image as ImageIcon, Sparkles, Wrench, X } from "lucide-react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -28,7 +28,6 @@ interface AvatarManagementModalProps {
   onSaveCharacter: (traits: CharacterTraits) => void;
   onUploadImage: () => void;
   onGenerateWithAI?: () => void;
-  onDeleteAvatar?: () => void;
 }
 
 export function AvatarManagementModal({
@@ -41,7 +40,6 @@ export function AvatarManagementModal({
   onSaveCharacter,
   onUploadImage,
   onGenerateWithAI,
-  onDeleteAvatar,
 }: AvatarManagementModalProps) {
   const titleId = useId();
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -132,11 +130,6 @@ export function AvatarManagementModal({
     handleClose();
     onGenerateWithAI?.();
   }, [handleClose, onGenerateWithAI]);
-
-  const handleDeleteAvatar = useCallback(() => {
-    handleClose();
-    onDeleteAvatar?.();
-  }, [handleClose, onDeleteAvatar]);
 
   const handleCharacterSave = useCallback(
     (savedTraits: CharacterTraits) => {
@@ -313,18 +306,6 @@ export function AvatarManagementModal({
                   </button>
                 )}
               </div>
-
-              {onDeleteAvatar && (
-                <button
-                  type="button"
-                  onClick={handleDeleteAvatar}
-                  className="flex items-center gap-1.5 text-body-small-default transition-colors hover:opacity-70"
-                  style={{ color: "var(--content-tertiary)" }}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Reset to default
-                </button>
-              )}
             </div>
           ) : (
             <AvatarCustomizationPanel

--- a/apps/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/identity-tab.tsx
@@ -7,7 +7,6 @@ import { ConstellationView } from "@/domains/intelligence/components/constellati
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
 import { AvatarManagementModal } from "@/components/avatar/avatar-management-modal";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import { deleteAvatar } from "@/assistant/avatar-api";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { fetchSkills, installSkill, uninstallSkill } from "@/domains/intelligence/skills/api";
@@ -235,13 +234,6 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
     onOpenThread?.("I'd like to create a custom AI-generated avatar.");
   }, [onOpenThread]);
 
-  const handleDeleteAvatar = useCallback(async () => {
-    const ok = await deleteAvatar(assistantId);
-    if (ok) {
-      invalidateAvatar();
-    }
-  }, [assistantId, invalidateAvatar]);
-
   const invalidateSkills = useCallback(() => {
     void queryClient.invalidateQueries({
       queryKey: ["assistantSkills", assistantId],
@@ -393,7 +385,6 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
         onSaveCharacter={handleAvatarChange}
         onUploadImage={handleAvatarChange}
         onGenerateWithAI={onOpenThread ? handleGenerateWithAI : undefined}
-        onDeleteAvatar={handleDeleteAvatar}
       />
       {removalDialog}
     </div>


### PR DESCRIPTION
## Summary
- Remove 'Reset to default' UI from avatar modal + identity tab; delete deleteAvatar API
- clearAvatar/avatar/remove remain daemon-side for CLI/host only

Part of plan: avatar-state-manifest.md (PR 10 of 13)