### PR TITLE
chore(daemon): remove temporary legacy-derivation fallback from avatar reads

### DIFF
--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -152,7 +152,8 @@ export function computeImageMeta(imagePath: string): AvatarImageMeta {
 
 /**
  * Derives avatar state from the legacy sidecar files (traits JSON + PNG).
- * Used both by the one-time migration and as a temporary read fallback.
+ * Used by the read handlers to self-heal once on a manifest-miss: the derived
+ * state is persisted via `writeManifest` so subsequent reads are manifest-only.
  *
  * Inference is **traits-first**: whenever a valid `character-traits.json`
  * exists, the result is `character` regardless of whether a PNG is also

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -77,29 +77,43 @@ describe("GET /avatar/state", () => {
     expect(result).toEqual(state);
   });
 
-  test("falls back to derived character state on manifest-miss (traits file)", async () => {
+  test("self-heals derived character state on manifest-miss (traits file) and persists it", async () => {
     writeFileSync(
       join(avatarDir, "character-traits.json"),
       JSON.stringify(VALID_TRAITS),
     );
+    expect(existsSync(join(avatarDir, MANIFEST_FILENAME))).toBe(false);
 
     const result = await getStateHandler()({});
     expect(result.kind).toBe("character");
     expect(result.traits).toEqual(VALID_TRAITS);
     expect(result.image).toBeNull();
+
+    // Self-heal: the derived state is now persisted so subsequent reads hit
+    // the manifest directly rather than re-inferring from legacy files.
+    const persisted = JSON.parse(
+      readFileSync(join(avatarDir, MANIFEST_FILENAME), "utf-8"),
+    ) as AvatarState;
+    expect(persisted).toEqual(result);
   });
 
-  test("falls back to derived image state on manifest-miss (image file)", async () => {
+  test("self-heals derived image state on manifest-miss (image file) and persists it", async () => {
     writeFileSync(join(avatarDir, "avatar-image.png"), Buffer.from("fake png"));
+    expect(existsSync(join(avatarDir, MANIFEST_FILENAME))).toBe(false);
 
     const result = await getStateHandler()({});
     expect(result.kind).toBe("image");
     expect(result.traits).toBeNull();
     expect(result.image).not.toBeNull();
     expect(result.image?.etag).toMatch(/^[0-9a-f]{16}$/);
+
+    const persisted = JSON.parse(
+      readFileSync(join(avatarDir, MANIFEST_FILENAME), "utf-8"),
+    ) as AvatarState;
+    expect(persisted).toEqual(result);
   });
 
-  test("returns kind:none (no throw, no 404) for an empty workspace", async () => {
+  test("self-heals and persists kind:none (no throw, no 404) for an empty workspace", async () => {
     let result: AvatarState | undefined;
     expect(() => {
       result = getStateHandler()({}) as AvatarState;
@@ -110,6 +124,11 @@ describe("GET /avatar/state", () => {
       source: null,
       image: null,
     });
+
+    const persisted = JSON.parse(
+      readFileSync(join(avatarDir, MANIFEST_FILENAME), "utf-8"),
+    ) as AvatarState;
+    expect(persisted).toEqual(result!);
   });
 });
 
@@ -453,12 +472,19 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     expect(result.path).toBeUndefined();
   });
 
-  test("falls back to legacy derivation when no manifest exists (image file)", () => {
+  test("self-heals from legacy files when no manifest exists (image file) and persists the manifest", () => {
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("png bytes"));
+    expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
 
     const result = getHandler("avatar_get")({}) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.path).toBe(path(IMAGE_FILENAME));
+
+    // Self-heal: the manifest is now written so the next read is manifest-only.
+    const persisted = JSON.parse(
+      readFileSync(path(MANIFEST_FILENAME), "utf-8"),
+    ) as AvatarState;
+    expect(persisted.kind).toBe("image");
   });
 
   test("returns exists:false for an empty workspace (no manifest, no files)", () => {

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -5,8 +5,10 @@ import { z } from "zod";
 
 import { renderCharacterAscii } from "../../avatar/ascii-renderer.js";
 import {
+  type AvatarState,
   deriveStateFromLegacyFiles,
   readManifest,
+  writeManifest,
 } from "../../avatar/avatar-manifest.js";
 import {
   clearAvatar,
@@ -45,20 +47,34 @@ function handleGetCharacterComponents() {
 }
 
 /**
- * Return the authoritative avatar render state.
+ * Reads the manifest, self-healing once if it is absent.
  *
- * Reads the manifest (`avatar.json`) first. When the manifest is absent or
- * invalid, `readManifest` returns null and we fall back to deriving state
- * from the legacy sidecar files. Never 404s — an empty workspace yields
- * `{ kind: "none", traits: null, source: null, image: null }`.
+ * The migration (092) seeds `avatar.json` for every workspace, so the manifest
+ * is normally present. If it is somehow missing (e.g. a workspace that predates
+ * the manifest and skipped the migration), we derive state from the legacy
+ * sidecar files *once* and persist it via `writeManifest` so subsequent reads
+ * hit the manifest directly — no per-request legacy inference.
  */
-function handleGetAvatarState() {
+function readManifestSelfHealing(): AvatarState {
   const manifest = readManifest();
   if (manifest) {
     return manifest;
   }
-  // TODO(avatar-manifest): remove after migration ships + clients adopt (PR 13)
-  return deriveStateFromLegacyFiles();
+  const derived = deriveStateFromLegacyFiles();
+  writeManifest(derived);
+  return derived;
+}
+
+/**
+ * Return the authoritative avatar render state.
+ *
+ * Reads the manifest (`avatar.json`). When the manifest is absent it is
+ * self-healed once from the legacy sidecar files and persisted. Never 404s —
+ * an empty workspace yields `{ kind: "none", traits: null, source: null,
+ * image: null }`.
+ */
+function handleGetAvatarState() {
+  return readManifestSelfHealing();
 }
 
 function handleRenderFromTraits({ body, headers }: RouteHandlerArgs) {
@@ -231,11 +247,9 @@ function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
   // Resolve precedence from the manifest so this raster accessor (CLI / dock /
   // notifications) agrees with macOS/web rather than picking image-first off
   // file existence. For both `character` and `image` the derived raster is the
-  // same on-disk PNG; only the precedence is manifest-driven.
-  const state =
-    readManifest() ??
-    // TODO(avatar-manifest): remove after migration ships + clients adopt (PR 13)
-    deriveStateFromLegacyFiles();
+  // same on-disk PNG; only the precedence is manifest-driven. Self-heals once
+  // on manifest-miss so we never re-infer from legacy files per request.
+  const state = readManifestSelfHealing();
 
   if (state.kind === "none") {
     return { exists: false };


### PR DESCRIPTION
## Summary
- Remove per-request deriveStateFromLegacyFiles fallback from handleGetAvatarState + handleGetAvatar
- Self-heal on manifest-miss: derive once + writeManifest, then read manifest only thereafter

Part of plan: avatar-state-manifest.md (PR 13 of 13)