### PR TITLE
fix(daemon): avatar remove/set help + hadAvatar + TRAITS_FILENAME + self-heal robustness

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -84,7 +84,9 @@ Examples:
 
       avatar
         .command("set")
-        .description("Set the assistant's avatar from an image file")
+        .description(
+          "Set the assistant's avatar from an image file (removes any native character)",
+        )
         .requiredOption(
           "--image <path>",
           "Path to image file (absolute or relative to workspace)",
@@ -93,9 +95,11 @@ Examples:
           "after",
           `
 Sets the assistant's avatar by copying the provided image file to the
-canonical avatar location. This replaces any existing avatar image but
-preserves character-traits.json so the native character can be restored
-later with "assistant avatar remove".
+canonical avatar location. This REPLACES any existing avatar and removes
+any configured native character: character-traits.json (and character-ascii.txt)
+are deleted, so a previously configured character is NOT preserved and cannot
+be restored. Rebuild the character with "assistant avatar character update"
+to reconfigure one.
 
 The --image path can be absolute or relative to the workspace directory.
 

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -111,6 +112,32 @@ describe("GET /avatar/state", () => {
       readFileSync(join(avatarDir, MANIFEST_FILENAME), "utf-8"),
     ) as AvatarState;
     expect(persisted).toEqual(result);
+  });
+
+  test("still returns derived state when the self-heal persist fails (read-only workspace)", async () => {
+    // Seed a legacy traits file so derivation yields a character state, then make
+    // the avatar dir read-only so writeManifest() throws. The handler must
+    // swallow the persist failure and still return the derived state (no 500).
+    writeFileSync(
+      join(avatarDir, "character-traits.json"),
+      JSON.stringify(VALID_TRAITS),
+    );
+    expect(existsSync(join(avatarDir, MANIFEST_FILENAME))).toBe(false);
+
+    chmodSync(avatarDir, 0o555);
+    try {
+      let result: AvatarState | undefined;
+      expect(() => {
+        result = getStateHandler()({}) as AvatarState;
+      }).not.toThrow();
+      expect(result!.kind).toBe("character");
+      expect(result!.traits).toEqual(VALID_TRAITS);
+      // Persist failed, so no manifest was written.
+      expect(existsSync(join(avatarDir, MANIFEST_FILENAME))).toBe(false);
+    } finally {
+      // Restore write perms so afterEach can clean up the temp dir.
+      chmodSync(avatarDir, 0o755);
+    }
   });
 
   test("self-heals and persists kind:none (no throw, no 404) for an empty workspace", async () => {
@@ -342,6 +369,31 @@ describe("avatar write/remove handlers", () => {
         source: null,
         image: null,
       });
+    });
+
+    test("reports hadAvatar:true for a character-only workspace (traits, no PNG)", async () => {
+      // A configured native character with no rendered PNG is still an avatar.
+      // hadAvatar is derived from the manifest kind, not PNG existence, so the
+      // clear correctly reports that a configured character was removed.
+      const state: AvatarState = {
+        kind: "character",
+        traits: VALID_TRAITS,
+        source: "builder",
+        image: null,
+      };
+      writeManifest(state, avatarDir);
+      writeFileSync(path(TRAITS_FILENAME), JSON.stringify(VALID_TRAITS));
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
+
+      const handler = getHandler("avatar_remove");
+      const result = (await handler({ body: {} })) as {
+        ok: boolean;
+        hadAvatar: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.hadAvatar).toBe(true);
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+      expect(readManifestFile()!.kind).toBe("none");
     });
 
     test("reports hadAvatar:false and still writes kind:none when nothing exists", async () => {

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -19,6 +19,7 @@ import { getCharacterComponents } from "../../avatar/character-components.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
 import {
   type CharacterTraits,
+  TRAITS_FILENAME,
   writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { setPlatformBaseUrl } from "../../config/env.js";
@@ -61,7 +62,14 @@ function readManifestSelfHealing(): AvatarState {
     return manifest;
   }
   const derived = deriveStateFromLegacyFiles();
-  writeManifest(derived);
+  // Persist is best-effort: on a read-only / permission-restricted workspace the
+  // write can throw. Swallow it so a GET still returns the derived state instead
+  // of turning into a 500 — the next read simply self-heals again.
+  try {
+    writeManifest(derived);
+  } catch (err) {
+    log.warn({ err }, "Failed to persist self-healed avatar manifest");
+  }
   return derived;
 }
 
@@ -216,7 +224,12 @@ function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
 }
 
 function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
-  const hadAvatar = existsSync(getAvatarImagePath());
+  // `hadAvatar` must reflect whether *any* avatar was configured before the
+  // clear — not just a rendered PNG. A character-only workspace (traits present,
+  // no PNG) is still an avatar, and clearAvatar() deletes its traits/ascii too.
+  // Derive from the manifest (self-healing on a manifest-miss) and treat any
+  // non-"none" kind as hadAvatar.
+  const hadAvatar = readManifestSelfHealing().kind !== "none";
 
   // Clear everything to a manifest-consistent kind:"none". Semantic change
   // (intentional): traits no longer persist alongside an image, so there is
@@ -296,7 +309,7 @@ function handleCharacterAscii({ queryParams, body }: RouteHandlerArgs) {
     );
   }
 
-  const traitsPath = join(getAvatarDir(), "character-traits.json");
+  const traitsPath = join(getAvatarDir(), TRAITS_FILENAME);
   if (!existsSync(traitsPath)) {
     throw new BadRequestError(
       "No native character set. Use 'assistant avatar character update' first.",


### PR DESCRIPTION
## Summary
Review-remediation for the avatar-state-manifest plan:
- avatar set CLI help now reflects that it removes the native character
- hadAvatar for avatar/remove derived from manifest (not PNG-only)
- use TRAITS_FILENAME constant in handleCharacterAscii
- self-heal writeManifest is best-effort (no 500 on read-only workspace)

Part of plan: avatar-state-manifest.md (review remediation)