### PR TITLE
feat(design-library): replace native title tooltips with Radix UI Tooltip for faster display

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -26,6 +26,7 @@
         "@radix-ui/react-slider": "1.3.6",
         "@radix-ui/react-slot": "1.2.4",
         "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-tooltip": "1.2.7",
         "@sentry/browser": "10.53.1",
         "@sentry/react": "10.53.1",
         "@stripe/react-stripe-js": "6.4.0",
@@ -462,6 +463,8 @@
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.7", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -477,6 +480,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
@@ -1765,6 +1770,16 @@
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-slider": "1.3.6",
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-tabs": "1.1.13",
+    "@radix-ui/react-tooltip": "1.2.7",
     "@sentry/browser": "10.53.1",
     "@sentry/react": "10.53.1",
     "@stripe/react-stripe-js": "6.4.0",

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -5,12 +5,13 @@
  * switching users or orgs yields a fresh React Query cache instead of
  * leaking stale data.
  *
- * Only third-party library providers (React Query) belong here.
- * App state uses Zustand stores — see `src/stores/`.
+ * Only third-party library providers (React Query, Radix Tooltip) belong
+ * here. App state uses Zustand stores — see `src/stores/`.
  *
  * Reference: https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@vellum/design-library";
 import { useState, type ReactNode } from "react";
 
 import { useAuthStore } from "@/stores/auth-store";
@@ -76,10 +77,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
     : "anonymous";
 
   return (
-    <AuthScopedQueryClientProvider key={authScopeKey}>
-      <ScopeKeyedQueryClientProvider>
-        {children}
-      </ScopeKeyedQueryClientProvider>
-    </AuthScopedQueryClientProvider>
+    <TooltipProvider delayDuration={200} skipDelayDuration={300}>
+      <AuthScopedQueryClientProvider key={authScopeKey}>
+        <ScopeKeyedQueryClientProvider>
+          {children}
+        </ScopeKeyedQueryClientProvider>
+      </AuthScopedQueryClientProvider>
+    </TooltipProvider>
   );
 }

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -106,7 +106,7 @@ export function ChatLayoutHeader({
                 variant="ghost"
                 iconOnly={<Search />}
                 aria-label="Search (Ctrl+K)"
-                title="Search (Ctrl+K)"
+                tooltip="Search (Ctrl+K)"
                 onClick={onSearchClick}
               />
             ) : null}
@@ -114,7 +114,7 @@ export function ChatLayoutHeader({
               variant="ghost"
               iconOnly={<ChevronLeft />}
               aria-label="Back (Ctrl+[)"
-              title="Back (Ctrl+[)"
+              tooltip="Back (Ctrl+[)"
               disabled={!canGoBack}
               className={!canGoBack ? "opacity-35" : undefined}
               onClick={onGoBack}
@@ -123,7 +123,7 @@ export function ChatLayoutHeader({
               variant="ghost"
               iconOnly={<ChevronRight />}
               aria-label="Forward (Ctrl+])"
-              title="Forward (Ctrl+])"
+              tooltip="Forward (Ctrl+])"
               disabled={!canGoForward}
               className={!canGoForward ? "opacity-35" : undefined}
               onClick={onGoForward}
@@ -142,7 +142,7 @@ export function ChatLayoutHeader({
             variant="ghost"
             iconOnly={<Search />}
             aria-label="Search (Ctrl+K)"
-            title="Search (Ctrl+K)"
+            tooltip="Search (Ctrl+K)"
             onClick={onSearchClick}
           />
         ) : null}

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -277,6 +277,7 @@ export function AssistantSideMenu({
       size="compact"
       iconOnly={<SquarePen />}
       aria-label="New conversation"
+      tooltip="New conversation"
       onClick={() => { onStartNewConversation(); onClose?.(); }}
     />
   ) : null;

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -1,46 +1,39 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
-import { cn } from "@vellum/design-library";
+import { cn, Tooltip } from "@vellum/design-library";
 import { formatRelativeDate } from "@/utils/format-date";
 import { CATEGORY_STYLES } from "./home-feed-filter-bar";
 import type { FeedItem, FeedItemCategory, FeedItemStatus } from "./types";
 
 function HoverIconButton({
-  title,
+  label,
   onClick,
   className,
   children,
 }: {
-  title: string;
+  label: string;
   onClick: () => void;
   className?: string;
   children: ReactNode;
 }) {
   return (
-    <span
-      role="button"
-      tabIndex={0}
-      title={title}
-      aria-label={title}
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick();
-      }}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
+    <Tooltip content={label}>
+      <button
+        type="button"
+        aria-label={label}
+        onClick={(e) => {
           e.stopPropagation();
-          e.preventDefault();
           onClick();
-        }
-      }}
-      className={cn(
-        "cursor-pointer text-[var(--content-disabled)] transition-colors hover:text-[var(--content-secondary)]",
-        className,
-      )}
-    >
-      {children}
-    </span>
+        }}
+        className={cn(
+          "cursor-pointer text-[var(--content-disabled)] transition-colors hover:text-[var(--content-secondary)]",
+          className,
+        )}
+      >
+        {children}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -127,7 +120,7 @@ export function HomeRecapRow({
         <span className="flex shrink-0 items-center gap-[var(--app-spacing-sm)]">
           {onToggleRead && (
             <HoverIconButton
-              title={isUnread ? "Mark as read" : "Mark as unread"}
+              label={isUnread ? "Mark as read" : "Mark as unread"}
               onClick={() => onToggleRead(item.id, isUnread ? "seen" : "new")}
             >
               {isUnread ? <MailOpen width={14} height={14} /> : <Mail width={14} height={14} />}
@@ -135,7 +128,7 @@ export function HomeRecapRow({
           )}
           {onGoToThread && item.conversationId && (!validConversationIds || validConversationIds.has(item.conversationId)) && (
             <HoverIconButton
-              title="Go to thread"
+              label="Go to thread"
               onClick={() => {
                 if (isUnread && onToggleRead) {
                   onToggleRead(item.id, "seen");
@@ -147,7 +140,7 @@ export function HomeRecapRow({
             </HoverIconButton>
           )}
           <HoverIconButton
-            title="Dismiss"
+            label="Dismiss"
             onClick={() => onDismiss(item.id)}
           >
             <Trash2 width={14} height={14} />
@@ -155,7 +148,7 @@ export function HomeRecapRow({
         </span>
       ) : isHovering && isRestore ? (
         <HoverIconButton
-          title="Restore"
+          label="Restore"
           onClick={() => onDismiss(item.id)}
           className="flex shrink-0 items-center gap-[var(--app-spacing-xs)]"
         >

--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -6,8 +6,6 @@
       "name": "@vellum/design-library",
       "dependencies": {
         "katex": "0.17.0",
-        "rehype-katex": "7.0.1",
-        "remark-math": "6.0.0",
       },
       "devDependencies": {
         "@playwright/browser-chromium": "1.60.0",
@@ -21,6 +19,7 @@
         "@radix-ui/react-slider": "1.3.6",
         "@radix-ui/react-slot": "1.2.4",
         "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-tooltip": "1.2.7",
         "@storybook/addon-a11y": "10.4.0",
         "@storybook/addon-docs": "10.4.0",
         "@storybook/addon-mcp": "0.6.0",
@@ -41,7 +40,9 @@
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-markdown": "10.1.0",
+        "rehype-katex": "7.0.1",
         "remark-gfm": "4.0.1",
+        "remark-math": "6.0.0",
         "sonner": "2.0.7",
         "storybook": "10.4.0",
         "tailwind-merge": "3.6.0",
@@ -66,7 +67,9 @@
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",
         "react-markdown": ">=10.1.0",
+        "rehype-katex": ">=7.0.0",
         "remark-gfm": ">=4.0.0",
+        "remark-math": ">=6.0.0",
         "sonner": ">=2.0.0",
         "tailwind-merge": ">=3.6.0",
         "tailwindcss": ">=4.0.0",
@@ -341,6 +344,8 @@
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.7", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -356,6 +361,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
@@ -1098,6 +1105,16 @@
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-slider": ">=1.3.0",
     "@radix-ui/react-slot": ">=1.2.0",
     "@radix-ui/react-tabs": ">=1.1.0",
+    "@radix-ui/react-tooltip": ">=1.2.0",
     "class-variance-authority": ">=0.7.0",
     "clsx": ">=2.1.0",
     "lucide-react": ">=1.16.0",
@@ -47,6 +48,7 @@
     "tailwindcss": ">=4.0.0"
   },
   "devDependencies": {
+    "@playwright/browser-chromium": "1.60.0",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-checkbox": "1.3.3",
     "@radix-ui/react-context-menu": "2.2.16",
@@ -57,6 +59,7 @@
     "@radix-ui/react-slider": "1.3.6",
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-tabs": "1.1.13",
+    "@radix-ui/react-tooltip": "1.2.7",
     "@storybook/addon-a11y": "10.4.0",
     "@storybook/addon-docs": "10.4.0",
     "@storybook/addon-mcp": "0.6.0",
@@ -69,7 +72,6 @@
     "@vitest/browser": "4.1.6",
     "@vitest/browser-playwright": "4.1.6",
     "@vitest/coverage-v8": "4.1.6",
-    "@playwright/browser-chromium": "1.60.0",
     "@vitest/runner": "4.1.6",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import { cn } from "../utils/cn";
+import { Tooltip } from "./tooltip";
 
 /**
  * Standardized button for the web platform. Visual parity with the macOS
@@ -262,7 +263,7 @@ export function Button({
     event.stopPropagation();
   };
 
-  return (
+  const buttonElement = (
     <Comp
       {...rest}
       ref={ref}
@@ -273,7 +274,7 @@ export function Button({
       data-slot="button"
       tabIndex={isSlotDisabled ? -1 : rest.tabIndex}
       onClick={isSlotDisabled ? handleBlockedClick : onClick}
-      title={title ?? tooltip}
+      title={title}
       className={cn(
         buttonVariants({ variant, size, iconOnly: isIconOnly, fullWidth, active }),
         className,
@@ -311,4 +312,10 @@ export function Button({
       )}
     </Comp>
   );
+
+  if (tooltip) {
+    return <Tooltip content={tooltip}>{buttonElement}</Tooltip>;
+  }
+
+  return buttonElement;
 }

--- a/packages/design-library/src/components/tooltip.tsx
+++ b/packages/design-library/src/components/tooltip.tsx
@@ -1,0 +1,112 @@
+import * as RadixTooltip from "@radix-ui/react-tooltip";
+import { type ComponentProps, type ReactNode } from "react";
+
+import { cn } from "../utils/cn";
+import { usePortalContainer } from "../utils/portal-container";
+
+/**
+ * Tooltip primitive built on `@radix-ui/react-tooltip`.
+ *
+ * Renders a styled overlay label when the user hovers or focuses the trigger
+ * element. Content is portaled into the nearest `<PortalContainerProvider>`
+ * so design tokens resolve correctly.
+ *
+ * **Requires `<TooltipProvider>`** at the application root to configure
+ * global delay behaviour (`delayDuration`, `skipDelayDuration`).
+ *
+ * Quick usage (string label wrapping a single trigger):
+ *
+ * ```tsx
+ * <Tooltip content="Deploy">
+ *   <Button iconOnly={<Globe />} />
+ * </Tooltip>
+ * ```
+ *
+ * Compound usage (custom content or positioning):
+ *
+ * ```tsx
+ * <Tooltip.Root>
+ *   <Tooltip.Trigger asChild>
+ *     <Button>Hover me</Button>
+ *   </Tooltip.Trigger>
+ *   <Tooltip.Content side="right">Rich content here</Tooltip.Content>
+ * </Tooltip.Root>
+ * ```
+ *
+ * @see https://www.radix-ui.com/primitives/docs/components/tooltip
+ */
+
+type TooltipProviderProps = ComponentProps<typeof RadixTooltip.Provider>;
+
+function TooltipProvider(props: TooltipProviderProps) {
+  return <RadixTooltip.Provider data-slot="tooltip-provider" {...props} />;
+}
+
+const Root = RadixTooltip.Root;
+
+type TriggerProps = ComponentProps<typeof RadixTooltip.Trigger>;
+
+function Trigger(props: TriggerProps) {
+  return <RadixTooltip.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+export type TooltipContentProps = ComponentProps<typeof RadixTooltip.Content>;
+
+function Content({
+  className,
+  children,
+  sideOffset = 6,
+  ref,
+  ...rest
+}: TooltipContentProps) {
+  const portalContainer = usePortalContainer();
+  return (
+    <RadixTooltip.Portal container={portalContainer ?? undefined}>
+      <RadixTooltip.Content
+        ref={ref}
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 rounded-md bg-[var(--primary-base)] px-2 py-1 shadow-[var(--shadow-popover)]",
+          "text-body-small-default text-[color:var(--content-inset)]",
+          "data-[state=delayed-open]:animate-[popoverIn_120ms_ease-out]",
+          "data-[state=instant-open]:animate-[popoverIn_60ms_ease-out]",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </RadixTooltip.Content>
+    </RadixTooltip.Portal>
+  );
+}
+
+export interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+  side?: TooltipContentProps["side"];
+  align?: TooltipContentProps["align"];
+  delayDuration?: number;
+}
+
+/**
+ * Convenience wrapper that pairs a trigger element with a text tooltip.
+ * Wraps the child with `asChild` so the trigger's DOM element is the
+ * child itself (no extra wrapper `<button>`).
+ */
+function Tooltip({ content, children, side, align, delayDuration }: TooltipProps) {
+  return (
+    <Root delayDuration={delayDuration}>
+      <Trigger asChild>{children}</Trigger>
+      <Content side={side} align={align}>
+        {content}
+      </Content>
+    </Root>
+  );
+}
+
+Tooltip.Root = Root;
+Tooltip.Trigger = Trigger;
+Tooltip.Content = Content;
+
+export { Tooltip, TooltipProvider, type TooltipProviderProps };

--- a/packages/design-library/src/components/tooltip.tsx
+++ b/packages/design-library/src/components/tooltip.tsx
@@ -11,8 +11,9 @@ import { usePortalContainer } from "../utils/portal-container";
  * element. Content is portaled into the nearest `<PortalContainerProvider>`
  * so design tokens resolve correctly.
  *
- * **Requires `<TooltipProvider>`** at the application root to configure
- * global delay behaviour (`delayDuration`, `skipDelayDuration`).
+ * The convenience `Tooltip` wrapper embeds its own `TooltipProvider` so
+ * it works standalone. For compound usage, wrap the tree in a
+ * `<TooltipProvider>` to configure global delay behaviour.
  *
  * Quick usage (string label wrapping a single trigger):
  *
@@ -93,15 +94,22 @@ export interface TooltipProps {
  * Convenience wrapper that pairs a trigger element with a text tooltip.
  * Wraps the child with `asChild` so the trigger's DOM element is the
  * child itself (no extra wrapper `<button>`).
+ *
+ * Embeds its own `TooltipProvider` so it works standalone (tests,
+ * storybooks) without requiring a provider ancestor. When an app-level
+ * `TooltipProvider` exists, the inner provider scopes its own subtree
+ * with matching defaults so behaviour is consistent.
  */
 function Tooltip({ content, children, side, align, delayDuration }: TooltipProps) {
   return (
-    <Root delayDuration={delayDuration}>
-      <Trigger asChild>{children}</Trigger>
-      <Content side={side} align={align}>
-        {content}
-      </Content>
-    </Root>
+    <RadixTooltip.Provider delayDuration={200} skipDelayDuration={300}>
+      <Root delayDuration={delayDuration}>
+        <Trigger asChild>{children}</Trigger>
+        <Content side={side} align={align}>
+          {content}
+        </Content>
+      </Root>
+    </RadixTooltip.Provider>
   );
 }
 

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -53,6 +53,13 @@ export {
   type ToggleProps,
 } from "./components/toggle";
 export {
+  Tooltip,
+  TooltipProvider,
+  type TooltipProps,
+  type TooltipProviderProps,
+  type TooltipContentProps,
+} from "./components/tooltip";
+export {
   Checkbox,
   type CheckboxProps,
   type CheckboxState,


### PR DESCRIPTION
Replaces the native HTML `title` attribute on buttons with a Radix UI Tooltip component (`@radix-ui/react-tooltip`) that shows in ~200ms instead of the browser-controlled ~500-1000ms delay. Also fixes the notification row action icons which used `<span role="button">` with native `title` — now proper `<button>` elements wrapped in `Tooltip`.

## Prompt / plan

The `Button` component's `tooltip` prop mapped directly to the native HTML `title` attribute, which has an unconfigurable ~500-1000ms browser delay. This PR:
1. Adds `@radix-ui/react-tooltip` (already used pattern — ~10 Radix primitives in the project)
2. Creates a `Tooltip` component in the design library with embedded `TooltipProvider` for standalone usage
3. Updates `Button` to conditionally wrap with `Tooltip` when the `tooltip` prop is provided
4. Adds app-level `TooltipProvider` with `delayDuration={200}` and `skipDelayDuration={300}`
5. Converts header search/back/forward buttons from `title` to `tooltip`
6. Replaces `HoverIconButton` `<span role="button">` with semantic `<button>` + `Tooltip`

## Test plan

- Local: `bun run lint`, `bunx tsc --noEmit`, and full test suite (171 files, 0 failures) all pass
- CI: All checks green (lint, typecheck, build, tests)
- Manual: Hover over any icon-only button in the header or notification row action icons to verify fast tooltip display

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ea10a13d02034e12aa6ec68e7243a60d
