### PR TITLE
fix(web): close gap between billing banner and composer on iOS

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -212,6 +212,11 @@ export interface ChatComposerProps {
   // notices and the live voice-interim preview. The app-editing variant omits it.
   noticesAboveFormSlot?: ReactNode;
 
+  // When true, the form's top border-radius is removed so the billing banner
+  // (which has only top corners rounded) sits flush against the form,
+  // forming a single continuous card.
+  hasBillingBanner?: boolean;
+
   // Cap for the textarea's auto-grow height in pixels. The empty state passes a
   // larger value so the user can compose long first messages without the box
   // clipping.
@@ -254,6 +259,7 @@ export function ChatComposer({
   thresholdPickerSlot,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
+  hasBillingBanner = false,
   textareaMaxHeightPx = 240,
   cmdEnterMode = false,
   suggestion,
@@ -364,7 +370,9 @@ export function ChatComposer({
         <Popover.Anchor asChild>
           <form
             onSubmit={onSubmit}
-            className="overflow-hidden rounded-[10px] bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)]"
+            className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
+              hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
+            }`}
           >
             <ChatAttachmentsStrip
               attachments={chatAttachments}

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1055,24 +1055,21 @@ export function ChatRouteContent({
   // Billing composer banner
   // -------------------------------------------------------------------------
 
+  const billingBannerDecision = getChatBillingBannerDecision(error);
+
   const renderBillingComposerBanner = (): ReactNode => {
-    const decision = getChatBillingBannerDecision(error);
-    if (decision === "managed_credits") {
+    if (billingBannerDecision === "managed_credits") {
       return (
-        <div className="mb-2">
-          <CreditsExhaustedBanner
-            onAddFunds={() => setShowAddCreditsModal(true)}
-          />
-        </div>
+        <CreditsExhaustedBanner
+          onAddFunds={() => setShowAddCreditsModal(true)}
+        />
       );
     }
-    if (decision === "provider_billing") {
+    if (billingBannerDecision === "provider_billing") {
       return (
-        <div className="mb-2">
-          <ProviderBillingBanner
-            onOpenSettings={pushToAiSettings}
-          />
-        </div>
+        <ProviderBillingBanner
+          onOpenSettings={pushToAiSettings}
+        />
       );
     }
     return null;
@@ -1324,6 +1321,7 @@ export function ChatRouteContent({
       />
     ),
     suggestion,
+    hasBillingBanner: billingBannerDecision !== null,
   };
 
   const chatBodyScrollAreaPropsBase = {


### PR DESCRIPTION
The credits-exhausted and provider-billing banners had an 8px gap (`mb-2`) separating them from the composer form, despite being designed for flush placement (`borderRadius: 10px 10px 0 0` — only top corners rounded). This removes the gap and flattens the form's top border-radius when a billing banner is visible, so the two elements form a single continuous card matching the Figma spec.

---

## Root cause analysis

The `mb-2` wrapper divs in `renderBillingComposerBanner()` were carried over from the spacing pattern used by other `ComposerNotices` items (attachment errors, voice errors, disk pressure, etc.), which correctly use `mb-2` for visual separation. The billing banners are different — their `borderRadius: "10px 10px 0 0"` was always intended for flush placement, but no one noticed the gap since the banners only appear when credits run out.

Additionally, the composer form kept its full `rounded-[10px]` (all corners) regardless of whether a banner sat above it. With the gap removed, the form's top corners would peek out below the banner's flat bottom edge without also flattening them.

**What changed:**
- Removed the `<div className="mb-2">` wrappers around both `CreditsExhaustedBanner` and `ProviderBillingBanner` in `renderBillingComposerBanner()`
- Added a `hasBillingBanner` prop to `ChatComposer` — when `true`, changes the form from `rounded-[10px]` to `rounded-b-[10px]` (flat top, rounded bottom)
- Derived `hasBillingBanner` from `getChatBillingBannerDecision(error) !== null` in the shared composer props

**What was NOT done and why:**
- CSS sibling selectors to auto-flatten the form radius — rejected because the form is nested inside `Popover.Root > Popover.Anchor`, not a direct sibling of the notices slot
- Removing `mb-2` without adjusting border-radius — rejected because the form's 10px top corners would create a visible artifact below the banner's flat bottom edge

**Prevention:** Billing banners are visually distinct from other notices (they use `BillingErrorBanner` with flush-placement styling). Future contributors should note the intentional absence of `mb-2` and the `hasBillingBanner` prop coupling.

## Prompt / plan
Figma references:
- Issue: https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=5277-6599
- Target: https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=4451-115909

## Test plan
- `bunx tsc --noEmit` passes
- `bun run lint` passes
- Pre-commit hooks pass
- Visual verification: billing banner now sits flush against the composer form with no gap, matching the Figma design

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/de412cba2dc9444ca0291ba95b6b62aa