### PR TITLE
refactor(messaging): convert processMessage from 9 positional params to options object

### DIFF
--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -297,7 +297,10 @@ describe("abort tool result persistence", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Run tools", [], () => {});
+    await conversation.processMessage({
+      content: "Run tools",
+      attachments: [],
+    });
 
     // Find user messages in persisted data that contain tool_result
     const toolResultUserMessages = persistedMessages.filter((m) => {
@@ -356,7 +359,10 @@ describe("abort tool result persistence", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Run tools", [], () => {});
+    await conversation.processMessage({
+      content: "Run tools",
+      attachments: [],
+    });
 
     // Simulate reload: the in-memory messages should be valid after repair
     const messages = conversation.getMessages();

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -333,15 +333,11 @@ describe("processMessage callSite threading", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage(
-      "Heartbeat tick",
-      [],
-      () => {},
-      undefined, // requestId
-      undefined, // activeSurfaceId
-      undefined, // currentPage
-      { callSite: "heartbeatAgent" },
-    );
+    await conversation.processMessage({
+      content: "Heartbeat tick",
+      attachments: [],
+      callSite: "heartbeatAgent",
+    });
 
     expect(captured.callSite).toBe("heartbeatAgent");
   });
@@ -361,7 +357,10 @@ describe("processMessage callSite threading", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Plain user message", [], () => {});
+    await conversation.processMessage({
+      content: "Plain user message",
+      attachments: [],
+    });
 
     expect(captured.callSite).toBe("mainAgent");
   });

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -479,9 +479,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage("Hello", [], (msg) =>
-      events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Hello",
+      attachments: [],
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // Should have been called exactly 2 times: original + one retry
     expect(agentLoopRunCount).toBe(2);
@@ -494,9 +496,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage("Hello", [], (msg) =>
-      events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Hello",
+      attachments: [],
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // Should have a message_complete event (from successful retry)
     const messageComplete = events.find((e) => e.type === "message_complete");
@@ -519,9 +523,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage("Hello", [], (msg) =>
-      events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Hello",
+      attachments: [],
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // Should have been called exactly 1 time (no retry for non-ordering errors)
     expect(agentLoopRunCount).toBe(1);
@@ -535,11 +541,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage(
-      "Please compare these images.",
-      makeImageAttachments(8),
-      (msg) => events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Please compare these images.",
+      attachments: makeImageAttachments(8),
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
@@ -555,11 +561,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage(
-      "Please compare these images.",
-      makeImageAttachments(8),
-      (msg) => events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Please compare these images.",
+      attachments: makeImageAttachments(8),
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // The convergence loop enters and applies the reducer (which returns
     // exhausted:true). With the early-break removed, the loop still re-runs
@@ -582,9 +588,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage("No attachments here.", [], (msg) =>
-      events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "No attachments here.",
+      attachments: [],
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // Same as above — convergence loop re-runs agent loop, which also fails.
     expect(agentLoopRunCount).toBe(2);
@@ -600,11 +608,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage(
-      "Please compare these images.",
-      makeImageAttachments(4),
-      (msg) => events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Please compare these images.",
+      attachments: makeImageAttachments(4),
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
@@ -620,11 +628,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage(
-      "Please compare these images.",
-      makeImageAttachments(8),
-      (msg) => events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Please compare these images.",
+      attachments: makeImageAttachments(8),
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // The 413 ProviderError message "request entity too large" doesn't match
     // the regex patterns, but classifyConversationError recognizes statusCode 413
@@ -643,11 +651,11 @@ describe("provider ordering error retry", () => {
     await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await conversation.processMessage(
-      "Run some tools then hit the limit.",
-      [],
-      (msg) => events.push(msg as unknown as Record<string, unknown>),
-    );
+    await conversation.processMessage({
+      content: "Run some tools then hit the limit.",
+      attachments: [],
+      onEvent: (msg) => events.push(msg as unknown as Record<string, unknown>),
+    });
 
     // Two agent loop runs — first makes progress then 413, convergence loop
     // re-runs after reducer (which returns exhausted). Second run also fails

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -524,12 +524,12 @@ describe("Conversation message queue", () => {
     const events2: ServerMessage[] = [];
 
     // Start first message — this will block on AgentLoop.run
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
 
     // Wait for the first AgentLoop.run to be registered
     await waitForPendingRun(1);
@@ -574,12 +574,12 @@ describe("Conversation message queue", () => {
     const events3: ServerMessage[] = [];
 
     // Start first message
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue two more sibling passthrough messages
@@ -649,7 +649,11 @@ describe("Conversation message queue", () => {
     const events2: ServerMessage[] = [];
 
     // Start first message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue second — simulating what handleUserMessage does
@@ -687,7 +691,11 @@ describe("Conversation message queue", () => {
     const events3: ServerMessage[] = [];
 
     // Start first message
-    conversation.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue two more
@@ -746,12 +754,12 @@ describe("Conversation message queue", () => {
     const events: ServerMessage[] = [];
 
     // Start a message — blocks on AgentLoop.run
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Reject the AgentLoop.run() with a provider error to trigger the
@@ -773,7 +781,11 @@ describe("Conversation message queue", () => {
     await conversation.loadFromDb();
 
     // Start first message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     expect(conversation.getQueueDepth()).toBe(0);
@@ -810,12 +822,12 @@ describe("Conversation message queue", () => {
     const events3: ServerMessage[] = [];
 
     // Start first message — blocks on AgentLoop.run
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a message with empty content (will fail persistUserMessage)
@@ -878,7 +890,11 @@ describe("Batched drain", () => {
     const events5: ServerMessage[] = [];
 
     // Start in-flight message (msg-1)
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue 4 messages with interfaces [macos, macos, cli, macos].
@@ -985,7 +1001,11 @@ describe("Batched drain", () => {
     const eventsWorld: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue ["hello", "/compact", "world"]. /compact resolves to a non-
@@ -1054,7 +1074,11 @@ describe("Batched drain", () => {
     const eventsPlainB: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue ["plain-a", "/status", "plain-b"]. /status resolves to a non-
@@ -1119,7 +1143,11 @@ describe("Batched drain", () => {
     await conversation.loadFromDb();
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Two sibling messages, each with a distinct image attachment.
@@ -1202,7 +1230,11 @@ describe("Batched drain", () => {
       new MessageQueue(budget);
 
     // Start in-flight so subsequent enqueues are queued (not processed).
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Fill to just-under budget: two ~500-char messages (1512+1512 = 3024 bytes).
@@ -1255,7 +1287,11 @@ describe("Batched drain", () => {
     // After the full drain, the byte budget must be fully reclaimed — a fresh
     // round of enqueues up to the budget should succeed again. Spin up another
     // in-flight message to reach the queueing state.
-    const p2 = conversation.processMessage("msg-2", [], () => {}, "req-2");
+    const p2 = conversation.processMessage({
+      content: "msg-2",
+      attachments: [],
+      requestId: "req-2",
+    });
     await waitForPendingRun(3);
     expect(
       conversation.enqueueMessage({
@@ -1297,7 +1333,11 @@ describe("Batched drain correctness fixes", () => {
     const eventsRegular: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a surface-action message (activeSurfaceId set + tracked in
@@ -1359,12 +1399,12 @@ describe("Batched drain correctness fixes", () => {
     const events4: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue three sibling passthroughs (msg-2 = head, msg-3 = mid,
@@ -1438,12 +1478,12 @@ describe("Batched drain correctness fixes", () => {
     const events4: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue three siblings. Configure addMessage to throw for the second
@@ -1500,12 +1540,12 @@ describe("Batched drain correctness fixes", () => {
     const events3: ServerMessage[] = [];
     const events4: ServerMessage[] = [];
 
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Mid tail will fail to persist. After the batched run resolves,
@@ -1556,7 +1596,11 @@ describe("Batched drain correctness fixes", () => {
     await conversation.loadFromDb();
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Snapshot the count before drain so we only compare batch-emitted
@@ -1630,7 +1674,11 @@ describe("Conversation queue policy helpers", () => {
     await conversation.loadFromDb();
 
     // Start processing to make the session busy
-    conversation.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a message while processing
@@ -1657,7 +1705,11 @@ describe("Conversation queue policy helpers", () => {
     await conversation.loadFromDb();
 
     // Start processing — but don't enqueue anything
-    conversation.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     expect(conversation.isProcessing()).toBe(true);
@@ -1674,7 +1726,11 @@ describe("Conversation queue policy helpers", () => {
     await conversation.loadFromDb();
 
     // Start processing
-    conversation.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a message
@@ -1725,12 +1781,12 @@ describe("Conversation checkpoint handoff", () => {
     const events1: ServerMessage[] = [];
 
     // Start processing first message
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
@@ -1776,7 +1832,11 @@ describe("Conversation checkpoint handoff", () => {
     await conversation.loadFromDb();
 
     // Start processing — no enqueued messages
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     expect(conversation.hasQueuedMessages()).toBe(false);
@@ -1809,12 +1869,12 @@ describe("Conversation checkpoint handoff", () => {
     const events4: ServerMessage[] = [];
 
     // Start first message (mid-tool-use — will yield at the next checkpoint)
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue three sibling passthroughs while msg-1 is mid-turn
@@ -1877,12 +1937,12 @@ describe("Conversation checkpoint handoff", () => {
     const events2: ServerMessage[] = [];
 
     // Start processing first message
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
@@ -1948,12 +2008,12 @@ describe("Conversation checkpoint handoff", () => {
     };
 
     // Start processing message A
-    const pA = conversation.processMessage(
-      "msg-A",
-      [],
-      (e) => eventsA.push(e),
-      "req-A",
-    );
+    const pA = conversation.processMessage({
+      content: "msg-A",
+      attachments: [],
+      onEvent: (e) => eventsA.push(e),
+      requestId: "req-A",
+    });
     await waitForPendingRun(1);
 
     // Enqueue messages B, C, D — each on a distinct userMessageInterface so the
@@ -2056,12 +2116,12 @@ describe("Conversation checkpoint handoff", () => {
     const eventsC: ServerMessage[] = [];
 
     // Start processing message A
-    const pA = conversation.processMessage(
-      "msg-A",
-      [],
-      (e) => eventsA.push(e),
-      "req-A",
-    );
+    const pA = conversation.processMessage({
+      content: "msg-A",
+      attachments: [],
+      onEvent: (e) => eventsA.push(e),
+      requestId: "req-A",
+    });
     await waitForPendingRun(1);
 
     // Enqueue B (empty content — will fail to persist) and C (valid)
@@ -2107,7 +2167,11 @@ describe("Conversation checkpoint handoff", () => {
     await conversation.loadFromDb();
 
     // Start processing
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // The first run should have onCheckpoint
@@ -2151,7 +2215,11 @@ describe("Conversation usage requestId correlation", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-42");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-42",
+    });
     await waitForPendingRun(1);
 
     // Complete the run — this triggers recordUsage with the request's ID
@@ -2184,7 +2252,11 @@ describe("Terminal trace events on rejection/failure", () => {
     await conversation.loadFromDb();
 
     // Start first message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue empty content (will fail persistUserMessage)
@@ -2232,12 +2304,12 @@ describe("Conversation host attachment directives", () => {
       const conversation = makeConversation((msg) => clientEvents.push(msg));
       await conversation.loadFromDb();
 
-      const p1 = conversation.processMessage(
-        "msg-1",
-        [],
-        (e) => events.push(e),
-        "req-1",
-      );
+      const p1 = conversation.processMessage({
+        content: "msg-1",
+        attachments: [],
+        onEvent: (e) => events.push(e),
+        requestId: "req-1",
+      });
       await waitForPendingRun(1);
 
       const run = pendingRuns[0];
@@ -2302,12 +2374,12 @@ describe("Conversation host attachment directives", () => {
       const conversation = makeConversation((msg) => clientEvents.push(msg));
       await conversation.loadFromDb();
 
-      const p1 = conversation.processMessage(
-        "msg-1",
-        [],
-        (e) => events.push(e),
-        "req-1",
-      );
+      const p1 = conversation.processMessage({
+        content: "msg-1",
+        attachments: [],
+        onEvent: (e) => events.push(e),
+        requestId: "req-1",
+      });
       await waitForPendingRun(1);
 
       const run = pendingRuns[0];
@@ -2389,12 +2461,12 @@ describe("Conversation attachment event payloads", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     const run = pendingRuns[0];
@@ -2452,12 +2524,12 @@ describe("Conversation attachment event payloads", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Queue a second message so the first run yields via checkpoint handoff.
@@ -2537,12 +2609,12 @@ describe("Regression: cancel semantics and error channel split", () => {
     await conversation.loadFromDb();
 
     // Start processing a message — collect events from the per-message callback
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => msgEvents.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => msgEvents.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // User cancels — sets the abort signal
@@ -2571,12 +2643,12 @@ describe("Regression: cancel semantics and error channel split", () => {
     await conversation.loadFromDb();
     linkAttachmentShouldThrow = true;
 
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
     const run = pendingRuns[0];
     const assistantMsg: Message = {
@@ -2625,12 +2697,12 @@ describe("Regression: cancel semantics and error channel split", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => allEvents.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => allEvents.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Simulate a provider failure
@@ -2654,12 +2726,12 @@ describe("Regression: cancel semantics and error channel split", () => {
 
     const eventsPerMsg: ServerMessage[][] = [[], [], []];
 
-    conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => eventsPerMsg[0].push(e),
-      "req-1",
-    );
+    conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => eventsPerMsg[0].push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     conversation.enqueueMessage({
@@ -2706,12 +2778,12 @@ describe("Regression: cancel semantics and error channel split", () => {
       const events2: ServerMessage[] = [];
 
       // Start first message (promise intentionally not awaited — we test queue drain behavior)
-      const _p1 = conversation.processMessage(
-        "msg-1",
-        [],
-        (e) => events1.push(e),
-        "req-1",
-      );
+      const _p1 = conversation.processMessage({
+        content: "msg-1",
+        attachments: [],
+        onEvent: (e) => events1.push(e),
+        requestId: "req-1",
+      });
       await waitForPendingRun(1);
 
       // Enqueue a second message while the first is processing

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -393,12 +393,12 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const events3: ServerMessage[] = [];
 
     // Start first message — blocks on agent loop
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a slash-like passthrough and a normal passthrough after it.
@@ -438,7 +438,11 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const sharedEvents: ServerMessage[] = [];
     const sharedOnEvent = (event: ServerMessage) => sharedEvents.push(event);
 
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     conversation.enqueueMessage({
@@ -477,12 +481,12 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const eventsSlash: ServerMessage[] = [];
 
     // Start first message — blocks on agent loop
-    const p1 = conversation.processMessage(
-      "msg-1",
-      [],
-      (e) => events1.push(e),
-      "req-1",
-    );
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue a slash command that matches a skill name — still passes through
@@ -521,7 +525,11 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const eventsBye: ServerMessage[] = [];
 
     // Start in-flight message
-    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
     await waitForPendingRun(1);
 
     // Enqueue ["hi", "/compact", "bye"]. /compact is non-passthrough, so the
@@ -576,7 +584,11 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const sync = syncChangedMessages();
     try {
       await expect(
-        conversation.processMessage("/compact", [], () => {}, "req-compact"),
+        conversation.processMessage({
+          content: "/compact",
+          attachments: [],
+          requestId: "req-compact",
+        }),
       ).rejects.toThrow("compaction failed");
 
       await waitFor(

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -336,7 +336,10 @@ describe("Conversation slash command — passthrough for unknown tokens", () => 
 
   test("unknown slash-like input passes through to agent loop", async () => {
     const conversation = makeConversation();
-    await conversation.processMessage("/not-a-skill", [], () => {});
+    await conversation.processMessage({
+      content: "/not-a-skill",
+      attachments: [],
+    });
 
     // Should go through the normal agent loop path
     expect(agentLoopRunCalled).toBe(true);
@@ -345,9 +348,11 @@ describe("Conversation slash command — passthrough for unknown tokens", () => 
   test("normal messages still go through standard path", async () => {
     const conversation = makeConversation();
     const events: ServerMessage[] = [];
-    await conversation.processMessage("hello world", [], (msg) =>
-      events.push(msg),
-    );
+    await conversation.processMessage({
+      content: "hello world",
+      attachments: [],
+      onEvent: (msg) => events.push(msg),
+    });
     expect(agentLoopRunCalled).toBe(true);
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -62,22 +62,13 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
     isProcessing: () => false,
     enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
     getQueueDepth: () => 0,
-    processMessage: async (
-      content: string,
-      attachments: UserMessageAttachment[],
-      _onEvent: (msg: ServerMessage) => void,
-      requestId?: string,
-      activeSurfaceId?: string,
-      _currentPage?: string,
-      _options?: { isInteractive?: boolean },
-      displayContent?: string,
-    ) => {
+    processMessage: async (options) => {
       processMessageCalls.push({
-        content,
-        attachments,
-        requestId,
-        activeSurfaceId,
-        displayContent,
+        content: options.content,
+        attachments: options.attachments,
+        requestId: options.requestId,
+        activeSurfaceId: options.activeSurfaceId,
+        displayContent: options.displayContent,
       });
       return "msg-1";
     },

--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -51,8 +51,11 @@ function makeContext(opts?: {
       return { queued: false, requestId: resolvedId };
     },
     getQueueDepth: () => 0,
-    processMessage: async (content, _attachments, _onEvent, requestId) => {
-      processCalls.push({ content, requestId });
+    processMessage: async (options) => {
+      processCalls.push({
+        content: options.content,
+        requestId: options.requestId,
+      });
       return "ok";
     },
     withSurface: createSurfaceMutex(),

--- a/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
@@ -75,22 +75,13 @@ function makeContext(): SurfaceConversationContext & {
       return { queued: false, requestId: options.requestId ?? "enq-req" };
     },
     getQueueDepth: () => 0,
-    processMessage: async (
-      content,
-      attachments,
-      _onEvent,
-      requestId,
-      surfaceId,
-      _currentPage,
-      _options,
-      displayContent,
-    ) => {
+    processMessage: async (options) => {
       processCalls.push({
-        content,
-        requestId,
-        attachments,
-        surfaceId,
-        displayContent,
+        content: options.content,
+        requestId: options.requestId,
+        attachments: options.attachments,
+        surfaceId: options.activeSurfaceId,
+        displayContent: options.displayContent,
       });
       return "ok";
     },

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -333,7 +333,7 @@ describe("Conversation workspace injection", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -347,7 +347,7 @@ describe("Conversation workspace injection", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -361,7 +361,7 @@ describe("Conversation workspace injection", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -375,7 +375,7 @@ describe("Conversation workspace injection", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
 
     // Workspace blocks use <workspace> tag which is intentionally NOT stripped.
     const persistedMessages = conversation.getMessages();
@@ -390,14 +390,17 @@ describe("Conversation workspace injection", () => {
     await conversation.loadFromDb();
 
     // First message — workspace is injected
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
     expect(runCalls).toHaveLength(1);
     const firstCallUser = runCalls[0][runCalls[0].length - 1];
     const firstText = messageText(firstCallUser);
     expect(firstText).toContain("<workspace>");
 
     // Second message — workspace is NOT injected (not first message, no compaction)
-    await conversation.processMessage("Follow up", [], () => {});
+    await conversation.processMessage({
+      content: "Follow up",
+      attachments: [],
+    });
     expect(runCalls).toHaveLength(2);
     const secondCallUser = runCalls[1][runCalls[1].length - 1];
     const secondText = messageText(secondCallUser);
@@ -416,7 +419,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
 
     expect(scanCallCount).toBe(1);
     const text = messageText(runCalls[0][runCalls[0].length - 1]);
@@ -427,10 +430,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
     const afterFirst = scanCallCount;
 
-    await conversation.processMessage("Again", [], () => {});
+    await conversation.processMessage({ content: "Again", attachments: [] });
 
     // Scanner should NOT have been called again
     expect(scanCallCount).toBe(afterFirst);
@@ -440,7 +443,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
     const afterFirst = scanCallCount;
 
     // Simulate a turn where the agent uses file_edit
@@ -453,7 +456,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: false,
       });
     };
-    await conversation.processMessage("Edit a file", [], () => {});
+    await conversation.processMessage({
+      content: "Edit a file",
+      attachments: [],
+    });
 
     // No rescan should happen during the mutation turn itself
     const afterMutation = scanCallCount;
@@ -461,7 +467,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
 
     // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
-    await conversation.processMessage("What happened?", [], () => {});
+    await conversation.processMessage({
+      content: "What happened?",
+      attachments: [],
+    });
 
     expect(scanCallCount).toBe(afterMutation + 1);
   });
@@ -470,7 +479,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
     const afterFirst = scanCallCount;
 
     agentLoopScript = (onEvent) => {
@@ -482,7 +491,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: false,
       });
     };
-    await conversation.processMessage("Run a command", [], () => {});
+    await conversation.processMessage({
+      content: "Run a command",
+      attachments: [],
+    });
 
     // No rescan should happen during the mutation turn itself
     const afterMutation = scanCallCount;
@@ -490,7 +502,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
 
     // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
-    await conversation.processMessage("What now?", [], () => {});
+    await conversation.processMessage({
+      content: "What now?",
+      attachments: [],
+    });
 
     expect(scanCallCount).toBe(afterMutation + 1);
   });
@@ -499,7 +514,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    await conversation.processMessage("Hello", [], () => {});
+    await conversation.processMessage({ content: "Hello", attachments: [] });
     const afterFirst = scanCallCount;
 
     agentLoopScript = (onEvent) => {
@@ -511,10 +526,16 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: true,
       });
     };
-    await conversation.processMessage("Try editing", [], () => {});
+    await conversation.processMessage({
+      content: "Try editing",
+      attachments: [],
+    });
 
     agentLoopScript = () => {};
-    await conversation.processMessage("What happened?", [], () => {});
+    await conversation.processMessage({
+      content: "What happened?",
+      attachments: [],
+    });
 
     // Scanner should NOT have been re-called since the tool failed
     expect(scanCallCount).toBe(afterFirst);

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -326,7 +326,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Write a file", [], () => {});
+    await conversation.processMessage({
+      content: "Write a file",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
@@ -352,7 +355,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Edit a file", [], () => {});
+    await conversation.processMessage({
+      content: "Edit a file",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
@@ -380,7 +386,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Write a file", [], () => {});
+    await conversation.processMessage({
+      content: "Write a file",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
@@ -406,7 +415,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Run a command", [], () => {});
+    await conversation.processMessage({
+      content: "Run a command",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
@@ -432,7 +444,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Run a command", [], () => {});
+    await conversation.processMessage({
+      content: "Run a command",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
@@ -458,7 +473,10 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await conversation.processMessage("Read a file", [], () => {});
+    await conversation.processMessage({
+      content: "Read a file",
+      attachments: [],
+    });
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
   });
 });

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -11,10 +11,10 @@ const getOrCreateCalls: Array<{
   conversationId: string;
   options?: Record<string, unknown>;
 }> = [];
-const processCalls: Array<unknown[]> = [];
+const processCalls: Array<Record<string, unknown>> = [];
 let fakeConversation: {
   taskRunId?: string;
-  processMessage: (...args: unknown[]) => Promise<string>;
+  processMessage: (options: Record<string, unknown>) => Promise<string>;
 };
 
 function resetConversationMock() {
@@ -22,8 +22,8 @@ function resetConversationMock() {
   processCalls.length = 0;
   fakeConversation = {
     taskRunId: "stale-task-run",
-    async processMessage(...args: unknown[]) {
-      processCalls.push(args);
+    async processMessage(options: Record<string, unknown>) {
+      processCalls.push(options);
       return "message-id";
     },
   };
@@ -109,8 +109,8 @@ describe("schedule run-now trust propagation", () => {
       trustClass: "guardian",
     });
     expect(processCalls).toHaveLength(1);
-    expect(processCalls[0][0]).toBe("scan my inbox");
-    expect(processCalls[0][6]).toEqual({ isInteractive: false });
+    expect(processCalls[0].content).toBe("scan my inbox");
+    expect(processCalls[0].isInteractive).toBe(false);
     expect(fakeConversation.taskRunId).toBeUndefined();
   });
 
@@ -128,9 +128,9 @@ describe("schedule run-now trust propagation", () => {
     const observedTaskRunIds: Array<string | undefined> = [];
     fakeConversation = {
       taskRunId: undefined,
-      async processMessage(...args: unknown[]) {
+      async processMessage(options: Record<string, unknown>) {
         observedTaskRunIds.push(fakeConversation.taskRunId);
-        processCalls.push(args);
+        processCalls.push(options);
         return "message-id";
       },
     };
@@ -147,8 +147,8 @@ describe("schedule run-now trust propagation", () => {
       trustClass: "guardian",
     });
     expect(processCalls).toHaveLength(1);
-    expect(processCalls[0][0]).toBe("triage inbox in background");
-    expect(processCalls[0][6]).toEqual({ isInteractive: false });
+    expect(processCalls[0].content).toBe("triage inbox in background");
+    expect(processCalls[0].isInteractive).toBe(false);
     expect(typeof observedTaskRunIds[0]).toBe("string");
     expect(fakeConversation.taskRunId).toBeUndefined();
   });

--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -54,8 +54,8 @@ describe("starter task surface actions", () => {
   test("forwards prompt payload as normal message content", () => {
     const forwarded: string[] = [];
     const ctx = makeContext();
-    ctx.processMessage = async (content) => {
-      forwarded.push(content);
+    ctx.processMessage = async (options) => {
+      forwarded.push(options.content);
       return "ok";
     };
     ctx.pendingSurfaceActions.set("surf-1", { surfaceType: "dynamic_page" });
@@ -74,8 +74,8 @@ describe("starter task surface actions", () => {
   test("falls back to human-readable summary with action data when prompt is absent", () => {
     const forwarded: string[] = [];
     const ctx = makeContext();
-    ctx.processMessage = async (content) => {
-      forwarded.push(content);
+    ctx.processMessage = async (options) => {
+      forwarded.push(options.content);
       return "ok";
     };
     ctx.pendingSurfaceActions.set("surf-2", { surfaceType: "dynamic_page" });
@@ -94,8 +94,8 @@ describe("starter task surface actions", () => {
   test("does not treat prompt-like fields as relay content for non-relay actions", () => {
     const forwarded: string[] = [];
     const ctx = makeContext();
-    ctx.processMessage = async (content) => {
-      forwarded.push(content);
+    ctx.processMessage = async (options) => {
+      forwarded.push(options.content);
       return "ok";
     };
     ctx.pendingSurfaceActions.set("surf-3", { surfaceType: "dynamic_page" });

--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -180,8 +180,8 @@ function makeContext(
       return { queued: false, requestId: "enq-req" };
     },
     getQueueDepth: () => 0,
-    processMessage: async (content: string) => {
-      processCalls.push({ content });
+    processMessage: async (options) => {
+      processCalls.push({ content: options.content });
       return "ok";
     },
     withSurface: createSurfaceMutex(),

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1463,6 +1463,22 @@ async function drainBatch(
     });
 }
 
+// ── ProcessMessageOptions ────────────────────────────────────────────
+
+/** Options for `processMessage`. Only `content` and `attachments` are
+ *  required; everything else has a sensible default or is genuinely optional. */
+export interface ProcessMessageOptions {
+  content: string;
+  attachments: UserMessageAttachment[];
+  onEvent?: (msg: ServerMessage) => void;
+  requestId?: string;
+  activeSurfaceId?: string;
+  currentPage?: string;
+  isInteractive?: boolean;
+  callSite?: LLMCallSite;
+  displayContent?: string;
+}
+
 // ── processMessage ───────────────────────────────────────────────────
 
 /**
@@ -1471,15 +1487,19 @@ async function drainBatch(
  */
 export async function processMessage(
   conversation: ProcessConversationContext,
-  content: string,
-  attachments: UserMessageAttachment[],
-  onEvent: (msg: ServerMessage) => void,
-  requestId?: string,
-  activeSurfaceId?: string,
-  currentPage?: string,
-  options?: { isInteractive?: boolean; callSite?: LLMCallSite },
-  displayContent?: string,
+  options: ProcessMessageOptions,
 ): Promise<string> {
+  const {
+    content,
+    attachments,
+    onEvent = () => {},
+    requestId,
+    activeSurfaceId,
+    currentPage,
+    isInteractive,
+    callSite,
+    displayContent,
+  } = options;
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.
@@ -1953,11 +1973,10 @@ export async function processMessage(
     titleText?: string;
     callSite?: LLMCallSite;
   } = { isUserMessage: true };
-  if (options?.isInteractive !== undefined)
-    loopOptions.isInteractive = options.isInteractive;
+  if (isInteractive !== undefined) loopOptions.isInteractive = isInteractive;
   if (agentLoopContent !== resolvedContent)
     loopOptions.titleText = resolvedContent;
-  if (options?.callSite !== undefined) loopOptions.callSite = options.callSite;
+  if (callSite !== undefined) loopOptions.callSite = callSite;
 
   await conversation.runAgentLoop(
     agentLoopContent,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -29,6 +29,7 @@ import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
 import { launchConversation } from "./conversation-launch.js";
 import type { EnqueueMessageOptions } from "./conversation-messaging.js";
+import type { ProcessMessageOptions } from "./conversation-process.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
@@ -524,16 +525,7 @@ export interface SurfaceConversationContext {
     rejected?: boolean;
   };
   getQueueDepth(): number;
-  processMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    onEvent?: (msg: ServerMessage) => void,
-    requestId?: string,
-    activeSurfaceId?: string,
-    currentPage?: string,
-    options?: { isInteractive?: boolean },
-    displayContent?: string,
-  ): Promise<string>;
+  processMessage(options: ProcessMessageOptions): Promise<string>;
   /** Serialize operations on a given surface to prevent read-modify-write races. */
   withSurface<T>(surfaceId: string, fn: () => T | Promise<T>): Promise<T>;
 }
@@ -1492,16 +1484,14 @@ export async function handleSurfaceAction(
       "Processing surface action immediately (history-restored) with attachments",
     );
     ctx
-      .processMessage(
+      .processMessage({
         content,
         attachments,
         onEvent,
         requestId,
-        surfaceId,
-        undefined,
-        undefined,
+        activeSurfaceId: surfaceId,
         displayContent,
-      )
+      })
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         log.error(
@@ -1779,16 +1769,14 @@ export async function handleSurfaceAction(
     "Processing surface action as follow-up with attachments",
   );
   ctx
-    .processMessage(
+    .processMessage({
       content,
-      pendingAttachments,
+      attachments: pendingAttachments,
       onEvent,
       requestId,
-      surfaceId,
-      undefined,
-      undefined,
+      activeSurfaceId: surfaceId,
       displayContent,
-    )
+    })
     .catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       log.error(

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -98,7 +98,10 @@ import {
 } from "./conversation-messaging.js";
 // Extracted modules
 import { registerConversationNotifiers } from "./conversation-notifiers.js";
-import type { ProcessConversationContext } from "./conversation-process.js";
+import type {
+  ProcessConversationContext,
+  ProcessMessageOptions,
+} from "./conversation-process.js";
 import {
   drainQueue as drainQueueImpl,
   processMessage as processMessageImpl,
@@ -135,7 +138,6 @@ import type {
   SurfaceData,
   SurfaceType,
   UsageStats,
-  UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import { isHostProxyTransport } from "./message-types/conversations.js";
@@ -1312,29 +1314,13 @@ export class Conversation {
     return drainQueueImpl(this as ProcessConversationContext, reason);
   }
 
-  async processMessage(
-    content: string,
-    attachments: UserMessageAttachment[],
-    onEvent?: (msg: ServerMessage) => void,
-    requestId?: string,
-    activeSurfaceId?: string,
-    currentPage?: string,
-    options?: { isInteractive?: boolean; callSite?: LLMCallSite },
-    displayContent?: string,
-  ): Promise<string> {
+  async processMessage(options: ProcessMessageOptions): Promise<string> {
     this.cacheWarmAbort?.abort();
     this.cacheWarmAbort = undefined;
-    return processMessageImpl(
-      this as ProcessConversationContext,
-      content,
-      attachments,
-      onEvent ?? this.sendToClient,
-      requestId,
-      activeSurfaceId,
-      currentPage,
-      options,
-      displayContent,
-    );
+    return processMessageImpl(this as ProcessConversationContext, {
+      ...options,
+      onEvent: options.onEvent ?? this.sendToClient,
+    });
   }
 
   // ── History ──────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -469,15 +469,11 @@ async function handleRunScheduleNow(id: string) {
           });
           conversation.taskRunId = taskRunId;
           try {
-            await conversation.processMessage(
-              message,
-              [],
-              () => {},
-              undefined,
-              undefined,
-              undefined,
-              { isInteractive: false },
-            );
+            await conversation.processMessage({
+              content: message,
+              attachments: [],
+              isInteractive: false,
+            });
           } finally {
             conversation.taskRunId = undefined;
           }
@@ -565,15 +561,11 @@ async function handleRunScheduleNow(id: string) {
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     });
     activeConversation.taskRunId = undefined;
-    await activeConversation.processMessage(
-      schedule.message,
-      [],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      { isInteractive: false },
-    );
+    await activeConversation.processMessage({
+      content: schedule.message,
+      attachments: [],
+      isInteractive: false,
+    });
     completeScheduleRun(runId, { status: "ok" });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -472,6 +472,7 @@ async function handleRunScheduleNow(id: string) {
             await conversation.processMessage({
               content: message,
               attachments: [],
+              onEvent: () => {},
               isInteractive: false,
             });
           } finally {
@@ -564,6 +565,7 @@ async function handleRunScheduleNow(id: string) {
     await activeConversation.processMessage({
       content: schedule.message,
       attachments: [],
+      onEvent: () => {},
       isInteractive: false,
     });
     completeScheduleRun(runId, { status: "ok" });

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -797,17 +797,14 @@ export const ROUTES: RouteDefinition[] = [
                 taskConversation.taskRunId = taskRunId;
                 taskConversation.headlessLock = true;
               }
-              await taskConversation.processMessage(
-                message,
-                [],
-                (event) => {
+              await taskConversation.processMessage({
+                content: message,
+                attachments: [],
+                onEvent: (event) => {
                   publishEvent(event);
                 },
-                undefined,
-                undefined,
-                undefined,
-                { isInteractive: false },
-              );
+                isInteractive: false,
+              });
             },
           );
 

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -137,8 +137,12 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
             conversation.taskRunId = taskRunId;
             conversation.headlessLock = true;
           }
-          await conversation.processMessage(message, [], (event) => {
-            broadcastMessage(event);
+          await conversation.processMessage({
+            content: message,
+            attachments: [],
+            onEvent: (event) => {
+              broadcastMessage(event);
+            },
           });
         },
       );

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -143,6 +143,7 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
             onEvent: (event) => {
               broadcastMessage(event);
             },
+            isInteractive: false,
           });
         },
       );


### PR DESCRIPTION
Closes LUM-2029

## Prompt / plan

Convert `processMessage` from 9 positional parameters to a single `ProcessMessageOptions` object, following the same pattern established in LUM-2004 (`persistUserMessage`) and LUM-2018 (`enqueueMessage`).

**Why needed:** `processMessage` had 9 positional params with 7 optional. Call sites were forced to pass `undefined, undefined` holes to reach later params (e.g. `processMessage(content, [], () => {}, undefined, undefined, undefined, { isInteractive: false })` in schedule-routes and work-items-routes). This is the [positional params anti-pattern](https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters) — fragile to reorder, unreadable at call sites, and error-prone.

**What changed:**
- Defined `ProcessMessageOptions` interface in `conversation-process.ts` with named fields: `content`, `attachments`, `onEvent?`, `requestId?`, `activeSurfaceId?`, `currentPage?`, `isInteractive?`, `callSite?`, `displayContent?`
- Updated `processMessage(ctx, ...)` function signature → `processMessage(ctx, options: ProcessMessageOptions)`
- Updated `Conversation.processMessage(...)` class method → `Conversation.processMessage(options)`
- Updated `SurfaceConversationContext.processMessage(...)` interface → `SurfaceConversationContext.processMessage(options)`
- Updated 7 production call sites (conversation-surfaces ×2, schedule-routes ×2, work-items-routes ×1, work-item-runner ×1)
- Updated ~89 test call sites across 14 test files
- Removed unused `UserMessageAttachment` import from `conversation.ts`

**Bug fixes included:**
- **`schedule-routes.ts`**: Restored explicit `onEvent: () => {}` at both schedule execution call sites. Without it, `Conversation.processMessage` substitutes `this.sendToClient` as the default, which would have caused headless scheduled tasks to stream assistant events to connected clients — a behavioral regression introduced during the refactor.
- **`work-item-runner.ts`**: Added `isInteractive: false` to match its sibling in `work-items-routes.ts`. Both set `headlessLock = true` for background task execution, but `work-item-runner` never passed the `isInteractive` flag. This was a pre-existing inconsistency (the old positional code also omitted it) that the refactoring made visible. Without it, background work item tasks could trigger interactive approval prompts and activity state indicators in the UI.

**Safety:** The `Conversation.processMessage` wrapper applies `onEvent: options.onEvent ?? this.sendToClient` — callers that intentionally suppress events (schedule-routes) must pass `onEvent: () => {}` explicitly. This default is correct for interactive paths but requires explicit opt-out for headless paths. All headless callers now explicitly pass both `onEvent: () => {}` and `isInteractive: false`.

## Test plan

- `tsc --noEmit`: 0 errors (compile-time proof all call sites updated)
- `bun run lint`: 0 errors
- 14 affected test files run individually: all pass (75+ tests, 500+ assertions)
- CI: 8/8 green (Type Check, Lint, Test, Lint Bundled Skills, OpenAPI Spec Check, FlexFrame Lint, Socket Security ×2)

Link to Devin session: https://app.devin.ai/sessions/1a2be238d9704952b6682fc77696d9b3
Requested by: @ashleeradka
