### PR TITLE
feat(first-greeting): self-intro first message behind `self-intro-greeting` flag

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -448,6 +448,14 @@
       "label": "Platform Features in Local Mode",
       "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
       "defaultEnabled": true
+    },
+    {
+      "id": "self-intro-greeting",
+      "scope": "assistant",
+      "key": "self-intro-greeting",
+      "label": "Self-intro first message",
+      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "defaultEnabled": false
     }
   ]
 }

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -8,6 +8,7 @@ const {
   isWakeUpGreeting,
   getCannedFirstGreeting,
   buildScanFirstMessage,
+  buildSelfIntroMessage,
   CANNED_FIRST_GREETING,
 } = await import("../daemon/first-greeting.js");
 import type { OnboardingGreetingContext } from "../daemon/first-greeting.js";
@@ -373,6 +374,46 @@ describe("first-greeting", () => {
       expect(greeting).not.toContain("Notion");
       expect(greeting).not.toContain("scheduling");
       expect(greeting).not.toContain("personal");
+    });
+  });
+
+  describe("buildSelfIntroMessage", () => {
+    const ctx = (
+      over: Partial<OnboardingGreetingContext> = {},
+    ): OnboardingGreetingContext => ({
+      tools: [],
+      tasks: [],
+      tone: "grounded",
+      ...over,
+    });
+
+    it("uses both names when present", () => {
+      expect(
+        buildSelfIntroMessage(ctx({ assistantName: "Vela", userName: "alex" })),
+      ).toBe("Hi Vela, I'm alex. Nice to meet you.");
+    });
+
+    it("drops the missing user name", () => {
+      expect(buildSelfIntroMessage(ctx({ assistantName: "Vela" }))).toBe(
+        "Hi Vela. Nice to meet you.",
+      );
+    });
+
+    it("drops the missing assistant name", () => {
+      expect(buildSelfIntroMessage(ctx({ userName: "alex" }))).toBe(
+        "Hi, I'm alex. Nice to meet you.",
+      );
+    });
+
+    it("treats whitespace-only names as missing", () => {
+      expect(
+        buildSelfIntroMessage(ctx({ assistantName: "  ", userName: "  " })),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when neither name is known (caller keeps canned greeting)", () => {
+      expect(buildSelfIntroMessage(ctx())).toBeUndefined();
+      expect(buildSelfIntroMessage(undefined)).toBeUndefined();
     });
   });
 });

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -43,6 +43,28 @@ export function getCannedFirstGreeting(
   return CANNED_FIRST_GREETING;
 }
 
+/**
+ * Builds a natural self-introduction to send *on behalf of the user* in place
+ * of the wake-up greeting, so the assistant generates a real response instead
+ * of replaying canned copy. Names come from the onboarding context; missing
+ * names are dropped so the line stays natural:
+ *   - both:           "Hi Vela, I'm alex. Nice to meet you."
+ *   - assistant only: "Hi Vela. Nice to meet you."
+ *   - user only:      "Hi, I'm alex. Nice to meet you."
+ * When neither name is known there is nothing personal to say, so this returns
+ * `undefined` and the caller falls back to the canned greeting.
+ */
+export function buildSelfIntroMessage(
+  onboarding?: OnboardingGreetingContext,
+): string | undefined {
+  const assistant = onboarding?.assistantName?.trim();
+  const user = onboarding?.userName?.trim();
+  if (!assistant && !user) return undefined;
+  const hi = assistant ? `Hi ${assistant}` : "Hi";
+  const intro = user ? `, I'm ${user}` : "";
+  return `${hi}${intro}. Nice to meet you.`;
+}
+
 const TONE_INTRO_CLOSE: Record<Tone, string> = {
   grounded: "",
   warm: "Good to meet you.",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -41,6 +41,7 @@ import { getOrCreateConversation as getOrCreateConversationInstance } from "../.
 import { canonicalizeTimeZone } from "../../daemon/date-context.js";
 import {
   buildScanFirstMessage,
+  buildSelfIntroMessage,
   getCannedFirstGreeting,
   isWakeUpGreeting,
 } from "../../daemon/first-greeting.js";
@@ -1392,6 +1393,12 @@ export async function handleSendMessage(
     conversation.getMessages().length,
   );
   const isScanPath = !!scanUrl && isWakeUp;
+  // Self-intro path: when we know a name, send a natural introduction on the
+  // user's behalf instead of the canned greeting, so the assistant generates a
+  // real first response. `undefined` (no names) falls back to the canned path.
+  const selfIntro = isWakeUp
+    ? buildSelfIntroMessage(body.onboarding ?? undefined)
+    : undefined;
 
   let effectiveContent: string | undefined;
   if (isScanPath) {
@@ -1402,6 +1409,10 @@ export async function handleSendMessage(
     // Fall through to normal inference path below
   } else if (isWakeUp && body.onboarding?.initialMessage) {
     effectiveContent = body.onboarding.initialMessage;
+  } else if (isWakeUp && selfIntro) {
+    // Rewrite to the self-introduction and fall through to real inference
+    // (mirrors the scan path above).
+    effectiveContent = selfIntro;
   } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -18,6 +18,7 @@ import {
   parseInterfaceId,
   supportsHostProxy,
 } from "../../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
@@ -140,6 +141,9 @@ const log = getLogger("conversation-routes");
 /** Matches the `<no_response/>` sentinel used by channel delivery suppression. */
 const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/g;
 const ATTACHMENT_ENTRY_RE = /^attachment:(\d+)$/;
+
+/** Feature flag gating the self-intro first message (see first-greeting.ts). */
+const SELF_INTRO_GREETING_FLAG = "self-intro-greeting" as const;
 
 const SUGGESTION_CACHE_MAX = 100;
 const VALID_RISK_THRESHOLDS = ["none", "low", "medium", "high"] as const;
@@ -1395,10 +1399,13 @@ export async function handleSendMessage(
   const isScanPath = !!scanUrl && isWakeUp;
   // Self-intro path: when we know a name, send a natural introduction on the
   // user's behalf instead of the canned greeting, so the assistant generates a
-  // real first response. `undefined` (no names) falls back to the canned path.
-  const selfIntro = isWakeUp
-    ? buildSelfIntroMessage(body.onboarding ?? undefined)
-    : undefined;
+  // real first response. Gated behind the `self-intro-greeting` flag (default
+  // off); `undefined` (flag off or no names) falls back to the canned path.
+  const selfIntro =
+    isWakeUp &&
+    isAssistantFeatureFlagEnabled(SELF_INTRO_GREETING_FLAG, getConfig())
+      ? buildSelfIntroMessage(body.onboarding ?? undefined)
+      : undefined;
 
   let effectiveContent: string | undefined;
   if (isScanPath) {

--- a/meta/feature-flags/PENDING_PLATFORM_PRS.md
+++ b/meta/feature-flags/PENDING_PLATFORM_PRS.md
@@ -15,3 +15,4 @@ Remove an entry from this file once its companion platform PR is merged.
 | Flag key | Registry declaration date | Owner | Status | Required platform work |
 |---|---|---|---|---|
 | `meet` | 2026-04-19 | sidd@vellum.ai | Platform PR not yet opened (as of 2026-04-19) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `skills/meet-join/SKILL.md`. |
+| `self-intro-greeting` | 2026-05-29 | alex@vellum.ai | Platform PR not yet opened (as of 2026-05-29) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `assistant/src/daemon/first-greeting.ts` (`buildSelfIntroMessage`). Needed so the flag can be toggled on in dev to test the self-intro first message. |

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -448,6 +448,14 @@
       "label": "Platform Features in Local Mode",
       "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
       "defaultEnabled": true
+    },
+    {
+      "id": "self-intro-greeting",
+      "scope": "assistant",
+      "key": "self-intro-greeting",
+      "label": "Self-intro first message",
+      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

On the first conversation, when a name is known, send a natural self-introduction *on the user's behalf* and route it through real LLM inference, instead of serving the canned greeting. Gated behind the `self-intro-greeting` assistant feature flag (**default off**), so merging is a no-op until flipped — gives us an A/B (self-intro vs. canned) and a kill switch.

Mirrors the existing scan-path rewrite in `conversation-routes.ts`.

### Changes
- **`assistant/src/daemon/first-greeting.ts`** — new `buildSelfIntroMessage(onboarding)`:
  - both names → `Hi Vela, I'm alex. Nice to meet you.`
  - assistant only → `Hi Vela. Nice to meet you.`
  - user only → `Hi, I'm alex. Nice to meet you.`
  - neither / whitespace-only → `undefined`
- **`assistant/src/runtime/routes/conversation-routes.ts`** — new `else if (isWakeUp && selfIntro)` branch sets `effectiveContent` and falls through to real inference. `selfIntro` is computed only when the flag is on **and** a name is known; otherwise the unchanged canned-greeting branch runs. Onboarding-artifact persistence still runs via the existing fall-through.
- **Feature flag** — declared `self-intro-greeting` (default off) in the canonical registry, synced to bundled copies, tracked the companion platform TF PR in `meta/feature-flags/PENDING_PLATFORM_PRS.md`.
- **`assistant/src/__tests__/first-greeting.test.ts`** — 5 new cases for `buildSelfIntroMessage`.

### Rollout
1. Merge this PR — zero behavior change (flag default off).
2. Companion **platform TF PR** in `vellum-assistant-platform` provisions the flag (tracked in `PENDING_PLATFORM_PRS.md`).
3. Flip on in **dev** to test the real first response; flip off if it looks off.
4. If it holds up, use the flag to A/B canned vs. self-intro before prod.

### Notes
- Response quality now depends on BOOTSTRAP.md producing a good reply to a bare self-intro — worth eyeballing the actual output in dev.

### Test
`bun test src/__tests__/first-greeting.test.ts` → 41 pass. `bootstrap-turn-cleanup` still green. Lint + typecheck clean. Codex review passed on the pre-flag revision.

JARVIS-988

🤖 Generated with [Claude Code](https://claude.com/claude-code)