### PR TITLE
fix(notifications): only suppress passive-notification conversations when home-page is enabled

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -379,7 +379,7 @@
     },
     {
       "id": "home-page",
-      "scope": "client",
+      "scope": "both",
       "key": "home-page",
       "label": "Home Page",
       "description": "Enable the Home page as the default landing view.",

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -104,6 +104,7 @@ import type {
   NotificationChannel,
   RenderedChannelCopy,
 } from "../notifications/types.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
 // ── Test helpers ────────────────────────────────────────────────────────
 
@@ -155,6 +156,10 @@ describe("pairDeliveryWithConversation", () => {
     addMessageShouldThrow = false;
     mockExistingConversations = {};
     mockBindings = {};
+    // The passive-suppression gate requires the home-page flag; default it on
+    // so the existing creation/suppression expectations hold. The dedicated
+    // flag-off test below overrides this to assert the create fallback.
+    setOverridesForTesting({ "home-page": true });
   });
 
   // ── start_new_conversation (vellum) ─────────────────────────────────
@@ -840,6 +845,29 @@ describe("pairDeliveryWithConversation", () => {
     expect(result.conversationFallbackUsed).toBe(false);
     expect(createConversationMock).not.toHaveBeenCalled();
     expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("passive vellum signal creates a conversation when home-page flag is off", async () => {
+    // Without the home feed there is no surface for passive notifications, so
+    // the suppression is gated off and pairing falls back to creating a
+    // conversation (the pre-home-feed behavior).
+    setOverridesForTesting({ "home-page": false });
+    const signal = makeSignal({ requiresConversation: undefined });
+    const copy = makeCopy();
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.messageId).toBe("msg-001");
+    expect(result.strategy).toBe("start_new_conversation");
+    expect(result.createdNewConversation).toBe(true);
+    expect(result.conversationFallbackUsed).toBe(false);
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
   });
 
   test("passive vellum signal still honors explicit reuse_existing action", async () => {

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -89,7 +89,7 @@ function loadDefaultsRegistry(): FeatureFlagDefaultsRegistry {
 
 /**
  * Parse the unified registry JSON into a flat key -> default map,
- * filtering to assistant-scope flags only.
+ * filtering to flags the backend consumes (`assistant`- and `both`-scope).
  */
 function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
@@ -101,7 +101,7 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
   for (const flag of registry.flags) {
     if (!flag || typeof flag !== "object" || Array.isArray(flag)) continue;
     const entry = flag as Record<string, unknown>;
-    if (entry.scope !== "assistant") continue;
+    if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
     if (typeof entry.defaultEnabled !== "boolean") continue;
 

--- a/assistant/src/home/feature-gate.ts
+++ b/assistant/src/home/feature-gate.ts
@@ -1,0 +1,22 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+const HOME_PAGE_FLAG_KEY = "home-page" as const;
+
+/**
+ * Whether the home page / home feed surface is enabled for this install.
+ *
+ * `home-page` is a `"both"`-scope flag: the client renders the home feed as the
+ * landing view, and the notification pipeline uses it to decide whether passive
+ * notifications have a home-feed surface to land on (when off, they fall back to
+ * materializing a conversation instead of being suppressed).
+ *
+ * `config` is accepted for parity with the other gate modules but is unused —
+ * the value resolves from the gateway override cache / registry default.
+ */
+export function isHomePageEnabled(config?: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(
+    HOME_PAGE_FLAG_KEY,
+    (config ?? {}) as AssistantConfig,
+  );
+}

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -21,6 +21,7 @@
 import type { ConversationStrategy } from "../channels/config.js";
 import { getConversationStrategy } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
+import { isHomePageEnabled } from "../home/feature-gate.js";
 import {
   addMessage,
   createConversation,
@@ -122,10 +123,16 @@ export async function pairDeliveryWithConversation(
     // seed message leaves a graveyard entry in the sidebar; skip it unless
     // the producer opted in via `requiresConversation` or the decision engine
     // requested explicit reuse of a target conversation.
+    //
+    // Gated on `home-page`: the home feed is the surface that hosts passive
+    // notifications, so when the flag is off there is nowhere for them to
+    // land — fall through and create a conversation (the pre-home-feed
+    // behavior) to preserve the notification's only surface.
     if (
       strategy === "start_new_conversation" &&
       !signal.requiresConversation &&
-      conversationAction?.action !== "reuse_existing"
+      conversationAction?.action !== "reuse_existing" &&
+      isHomePageEnabled()
     ) {
       return {
         conversationId: null,

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -71,7 +71,7 @@ function getRegistryCandidates(): string[] {
 
 /**
  * Parse the unified registry JSON into a flat key -> default map,
- * filtering to assistant-scope flags only.
+ * filtering to flags the backend consumes (`assistant`- and `both`-scope).
  */
 function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
@@ -83,7 +83,7 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
   for (const flag of registry.flags) {
     if (!flag || typeof flag !== "object" || Array.isArray(flag)) continue;
     const entry = flag as Record<string, unknown>;
-    if (entry.scope !== "assistant") continue;
+    if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
     if (typeof entry.defaultEnabled !== "boolean") continue;
     if (typeof entry.description !== "string") {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -379,7 +379,7 @@
     },
     {
       "id": "home-page",
-      "scope": "client",
+      "scope": "both",
       "key": "home-page",
       "label": "Home Page",
       "description": "Enable the Home page as the default landing view.",

--- a/meta/feature-flags/loader.ts
+++ b/meta/feature-flags/loader.ts
@@ -14,7 +14,7 @@ import { join } from 'path';
 // Types
 // ---------------------------------------------------------------------------
 
-export type FeatureFlagScope = 'assistant' | 'client';
+export type FeatureFlagScope = 'assistant' | 'client' | 'both';
 
 export interface FeatureFlagDefinition {
   id: string;
@@ -50,12 +50,12 @@ export async function loadFeatureFlagRegistry(): Promise<FeatureFlagRegistry> {
 // Scope filters
 // ---------------------------------------------------------------------------
 
-/** Return only flags with `scope === 'assistant'`. */
+/** Return flags consumed by the assistant backend (`scope === 'assistant'` or `'both'`). */
 export function getAssistantScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
-  return registry.flags.filter((f) => f.scope === 'assistant');
+  return registry.flags.filter((f) => f.scope === 'assistant' || f.scope === 'both');
 }
 
-/** Return only flags with `scope === 'client'`. */
+/** Return flags consumed by clients (`scope === 'client'` or `'both'`). */
 export function getClientScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
-  return registry.flags.filter((f) => f.scope === 'client');
+  return registry.flags.filter((f) => f.scope === 'client' || f.scope === 'both');
 }


### PR DESCRIPTION
## Summary
- PR #32478 stopped creating per-notification conversations for passive vellum notifications ("they surface via the home feed alone") — but that premise only holds for users who actually have the home feed. This gates that suppression on the `home-page` flag, so users without it keep getting a conversation (the pre-#32478 behavior).
- `home-page` was **client-scope** and therefore structurally unreadable by the daemon — both the gateway IPC merge (`feature-flag-defaults.ts`) and the assistant resolver (`assistant-feature-flags.ts`) filter the registry to `assistant`-scope. Promoted it to a new `"both"` scope so the single flag is readable by both the client (renders the feed) and the backend (gates suppression); added `"both"` to the loader union/filters and both backend registry parsers. The web catalog already supported `"both"` via `scopeIncludes`.
- Added `isHomePageEnabled()` (`assistant/src/home/feature-gate.ts`) and a fourth condition to the suppression check in `conversation-pairing.ts`, plus a regression test asserting a conversation is created when the flag is off. Re-ran the registry sync so the tracked bundled copy stays in step.

## Original prompt
Yesterday's merge (#32478) suppressed new-conversation creation for passive notifications but didn't account for users who don't have the homepage feature flag enabled. The ask: make that suppression apply only when the user has `home-page` on, otherwise fall back to the prior conversation-creating behavior. Investigation showed `home-page` is client-scope and structurally invisible to the daemon, so the agreed approach was to promote it to a `"both"`-scope flag readable by both client and backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)