### PR TITLE
fix(feature-flags): propagate 'both' scope to registry guard and Swift loader

### DIFF
--- a/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
+++ b/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
@@ -31,7 +31,7 @@ function loadRegistry(): Record<string, unknown> {
   return JSON.parse(raw);
 }
 
-const VALID_SCOPES = new Set(["assistant", "client"]);
+const VALID_SCOPES = new Set(["assistant", "client", "both"]);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -169,7 +169,7 @@ describe("unified feature flag registry guard", () => {
       const scope = flag.scope as string;
       if (!VALID_SCOPES.has(scope)) {
         violations.push(
-          `flag '${flag.id}' has invalid scope '${scope}' (expected 'assistant' or 'client')`,
+          `flag '${flag.id}' has invalid scope '${scope}' (expected 'assistant', 'client', or 'both')`,
         );
       }
     }

--- a/clients/shared/Utilities/FeatureFlagRegistry.swift
+++ b/clients/shared/Utilities/FeatureFlagRegistry.swift
@@ -3,9 +3,11 @@ import Foundation
 // MARK: - Types
 
 /// Scope of a feature flag — determines which platform consumes it.
+/// `both` is read by both the assistant backend and clients.
 public enum FeatureFlagScope: String, Decodable {
     case assistant
     case client
+    case both
 }
 
 /// A single entry in the unified feature flag registry.
@@ -25,14 +27,14 @@ public struct FeatureFlagRegistry: Decodable {
 
     // MARK: - Scope filters
 
-    /// Return only flags with `scope == .client`.
+    /// Return flags consumed by clients (`scope == .client` or `.both`).
     public func clientScopeFlags() -> [FeatureFlagDefinition] {
-        flags.filter { $0.scope == .client }
+        flags.filter { $0.scope == .client || $0.scope == .both }
     }
 
-    /// Return only flags with `scope == .assistant`.
+    /// Return flags consumed by the assistant backend (`scope == .assistant` or `.both`).
     public func assistantScopeFlags() -> [FeatureFlagDefinition] {
-        flags.filter { $0.scope == .assistant }
+        flags.filter { $0.scope == .assistant || $0.scope == .both }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `both` to the assistant `feature-flag-registry-guard.test.ts` `VALID_SCOPES`, fixing the failing **Test** job on `main` CI (the guard rejected the `home-page` flag's new `both` scope introduced in b32f801b55).
- Add a `both` case to the Swift `FeatureFlagScope` enum and extend `clientScopeFlags()` / `assistantScopeFlags()` to include it — mirroring the TS `loader.ts` filters that b32f801b55 already updated.

## Why the Swift change is part of this fix
The guard test's contract is that *both* the TS and Swift loaders can consume every scope in the registry. Commit b32f801b55 added the `both` scope and updated the TS loader, but not the Swift enum. The Swift registry is decoded with `try? JSONDecoder().decode(...)`, so an unknown `both` value fails the whole decode and returns `nil` — silently disabling the *entire* client feature-flag registry at runtime. Whitelisting `both` in the guard without fixing the Swift enum would make the test assert a falsehood. (The macOS CI job is green only because no Swift test decodes the real bundled registry.)

## Original prompt
Fix the specific CI failure in the **Test** job of `CI Main Assistant Checks` run 26653407221 — `feature-flag-registry-guard.test.ts` failing with "flag 'home-page' has invalid scope 'both'". Root cause: the most recent commit on main introduced the `both` scope but left two registry consumers (this guard test and the Swift loader) un-updated.