### PR TITLE
feat(config): make heartbeats opt-in (disabled by default)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -132,6 +132,8 @@ describe("AssistantConfigSchema", () => {
       allowOneTimeSend: false,
     });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
+    // Heartbeats are opt-in: absent config resolves to disabled.
+    expect(result.heartbeat.enabled).toBe(false);
   });
 
   test("accepts Tavily as a web search provider", () => {
@@ -2291,6 +2293,19 @@ describe("loadConfig with schema validation", () => {
     expect(config.llm.default.maxTokens).toBe(4096);
     expect(config.heartbeat.activeHoursStart).toBe(8);
     expect(config.heartbeat.activeHoursEnd).toBe(22);
+  });
+
+  test("heartbeat is disabled by default when heartbeat.enabled is absent", () => {
+    // Heartbeats are opt-in. A config with no explicit heartbeat.enabled
+    // (including a config with no heartbeat block at all) resolves to off.
+    writeConfig({ heartbeat: { intervalMs: 6000 } });
+    expect(loadConfig().heartbeat.enabled).toBe(false);
+  });
+
+  test("explicit heartbeat.enabled: true on disk keeps heartbeats on", () => {
+    // The "user overrode config.json" case — an explicit true is preserved.
+    writeConfig({ heartbeat: { enabled: true } });
+    expect(loadConfig().heartbeat.enabled).toBe(true);
   });
 
   test("recovers from equal filing.activeHours without wiping unrelated fields", () => {

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -5,7 +5,7 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      .default(true)
+      .default(false)
       .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })

--- a/assistant/src/workspace/migrations/092-release-notes-heartbeat-opt-in.ts
+++ b/assistant/src/workspace/migrations/092-release-notes-heartbeat-opt-in.ts
@@ -1,0 +1,62 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-092-release-notes-heartbeat-opt-in");
+
+const MIGRATION_ID = "092-release-notes-heartbeat-opt-in";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Heartbeats are now opt-in
+
+Periodic heartbeat check-ins are now off by default. To turn them on, set
+\`heartbeat.enabled\` to \`true\` in your config.json, then restart the
+assistant. Configs that already set it to \`true\` are unchanged.
+`;
+
+export const releaseNotesHeartbeatOptInMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description:
+    "Append release notes for heartbeat opt-in default to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended heartbeat opt-in release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append heartbeat opt-in release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -89,6 +89,7 @@ import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecat
 import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { memoryRouterCostOptimizedProfileMigration } from "./090-memory-router-cost-optimized-profile.js";
 import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-migration-onboarding-thread.js";
+import { releaseNotesHeartbeatOptInMigration } from "./092-release-notes-heartbeat-opt-in.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -189,4 +190,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveMemoryTreeOutOfV3Migration,
   memoryRouterCostOptimizedProfileMigration,
   retightenMigrationOnboardingThreadMigration,
+  releaseNotesHeartbeatOptInMigration,
 ];


### PR DESCRIPTION
## Summary
- Flip the `heartbeat.enabled` schema default from `true` to `false`, making periodic heartbeat check-ins opt-in. New installs and any config without an explicit `heartbeat.enabled` now resolve to **off**; configs that already have `heartbeat.enabled: true` on disk are unchanged (the loader treats disk as user intent, applying schema defaults only to absent keys).
- Add workspace migration `092-release-notes-heartbeat-opt-in` to append a user-facing note to `UPDATES.md`.
- Add config-schema tests covering the new default and the explicit-`true` override.

## Original prompt
Make heartbeats disabled by default unless the user has overridden `config.json` to set `heartbeat.enabled = true`. The goal is to flip the periodic guardian heartbeat from on-by-default to opt-in, respecting existing on-disk overrides, and ship a user-facing release note announcing the change.