### PR TITLE
fix(web): align iOS file picker popover with composer right edge

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -134,12 +134,12 @@ export const AttachFileButton: FC<AttachFileButtonProps> = ({
   );
 
   return (
-    <>
+    <div className="relative">
       <input
         ref={inputRef}
         type="file"
         multiple
-        className="hidden"
+        className="absolute inset-0 opacity-0 pointer-events-none"
         onChange={handleChange}
         aria-hidden="true"
         tabIndex={-1}
@@ -153,6 +153,6 @@ export const AttachFileButton: FC<AttachFileButtonProps> = ({
         title={title}
         className="[--vbtn-fg:var(--content-secondary)]"
       />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
On iOS WKWebView, the native file picker popover extends past the composer's right edge because the `<input type="file">` has `display: none` (Tailwind `hidden`), giving it a zero bounding rect. iOS uses this rect as the popover's anchor — with a zero rect, it falls back to a default position that doesn't align with the composer. Fixing this by overlaying the input on the button (`opacity-0`, `absolute inset-0`, `pointer-events-none`) so iOS has a valid anchor rect matching the button's position.

---

- Requested by: @Jasonnnz

Link to Devin session: https://app.devin.ai/sessions/cfd68de2b81f493d823a501be43c3c74