### PR TITLE
fix(feature-flags): handle .both scope in macOS FeatureFlagsCard switches

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/FeatureFlagsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/FeatureFlagsCard.swift
@@ -158,7 +158,11 @@ struct FeatureFlagsCard: View {
         let flagBinding = Binding<Bool>(
             get: {
                 switch flag.scope {
-                case .assistant:
+                // `.both`-scoped flags are consumed by the assistant backend, which owns
+                // their persisted state, so they read/write through the assistant path.
+                // (In practice `buildUnifiedFlags` only tags entries `.assistant`/`.client`,
+                // so `.both` is unreachable here — this keeps the switch exhaustive.)
+                case .assistant, .both:
                     return assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
                 case .client:
                     return macOSFlagStates.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
@@ -166,7 +170,7 @@ struct FeatureFlagsCard: View {
             },
             set: { newValue in
                 switch flag.scope {
-                case .assistant:
+                case .assistant, .both:
                     setAssistantFlag(key: flag.key, enabled: newValue, flag: flag)
                 case .client:
                     setMacOSFlag(key: flag.key, enabled: newValue)


### PR DESCRIPTION
## Summary
- `FeatureFlagScope` gained a `.both` case in #32577, but the two `switch flag.scope` statements in the macOS `FeatureFlagsCard` were never updated — breaking the `macOS Build` CI job with `error: switch must be exhaustive`.
- Group `.both` with `.assistant` in both the getter and setter switches. A `.both`-scoped flag is consumed by the assistant backend (which owns its persisted state), so the assistant read/write path is correct. In practice `buildUnifiedFlags` only ever tags unified entries `.assistant`/`.client`, so `.both` is unreachable here; this restores exhaustiveness with no behavior change.

## Original prompt
Fix the specific failing `macOS Build` job from CI run 26654424940 on `main`, and that job only. The build broke after #32577 added a `.both` case to the shared `FeatureFlagScope` enum but left two non-exhaustive switches in `FeatureFlagsCard.swift`.