### PR TITLE
chore(flags): drop self-intro-greeting from pending platform PRs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5741,10 +5741,11 @@ paths:
       operationId: conversations_by_id_compaction_get
       summary: Get the compaction trail leading up to an LLM call
       description:
-        Return the chronological list of compaction events that ran in this conversation in the open window between
-        the previous non-`compactionAgent` LLM call and the call identified by `callId`. Projected from
-        `llm_request_logs` rows where `call_site = "compactionAgent"`. When the selected call is the first real call in
-        the conversation, every preceding compaction is in scope. Drives the Inspector's Compaction tab.
+        Return the chronological list of compaction events that ran in the same agent turn as the call identified
+        by `callId`. Turn bounds are walked from the `messages` table (real user messages — tool-result user messages
+        are not boundaries). Projected from `llm_request_logs` rows where `call_site = "compactionAgent"`. When the
+        conversation has no other messages around the selected call, every compaction strictly before the call's
+        `createdAt` is in scope. Drives the Inspector's Compaction tab.
       tags:
         - conversations
       responses:

--- a/meta/feature-flags/PENDING_PLATFORM_PRS.md
+++ b/meta/feature-flags/PENDING_PLATFORM_PRS.md
@@ -15,4 +15,3 @@ Remove an entry from this file once its companion platform PR is merged.
 | Flag key | Registry declaration date | Owner | Status | Required platform work |
 |---|---|---|---|---|
 | `meet` | 2026-04-19 | sidd@vellum.ai | Platform PR not yet opened (as of 2026-04-19) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `skills/meet-join/SKILL.md`. |
-| `self-intro-greeting` | 2026-05-29 | alex@vellum.ai | Platform PR not yet opened (as of 2026-05-29) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `assistant/src/daemon/first-greeting.ts` (`buildSelfIntroMessage`). Needed so the flag can be toggled on in dev to test the self-intro first message. |


### PR DESCRIPTION
## What

Removes the `self-intro-greeting` row from `meta/feature-flags/PENDING_PLATFORM_PRS.md`. Its companion platform PR (**vellum-assistant-platform#7968**) provisioning the LaunchDarkly flag has merged, so per the file's "remove once the companion platform PR is merged" rule, the tracking entry is no longer needed.

Pure docs cleanup — no code or flag changes.

JARVIS-988

🤖 Generated with [Claude Code](https://claude.com/claude-code)