### PR TITLE
test(macos): unit test scaffolding for main-process modules (LUM-2023)

### DIFF
--- a/.github/workflows/ci-main-electron.yaml
+++ b/.github/workflows/ci-main-electron.yaml
@@ -54,9 +54,30 @@ jobs:
       - name: Build (main + preload)
         run: bun run build
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test:ci
+
   checks:
-    name: Type Check & Build
-    needs: [typecheck, build]
+    name: Type Check, Build & Test
+    needs: [typecheck, build, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -64,10 +85,12 @@ jobs:
         env:
           TYPECHECK: ${{ needs.typecheck.result }}
           BUILD: ${{ needs.build.result }}
+          TEST: ${{ needs.test.result }}
         run: |
           echo "Type Check: $TYPECHECK"
           echo "Build:      $BUILD"
-          for r in "$TYPECHECK" "$BUILD"; do
+          echo "Test:       $TEST"
+          for r in "$TYPECHECK" "$BUILD" "$TEST"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one electron CI job failed."
               exit 1

--- a/.github/workflows/pr-electron.yaml
+++ b/.github/workflows/pr-electron.yaml
@@ -54,9 +54,30 @@ jobs:
       - name: Build (main + preload)
         run: bun run build
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test:ci
+
   checks:
-    name: Type Check & Build
-    needs: [typecheck, build]
+    name: Type Check, Build & Test
+    needs: [typecheck, build, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -64,10 +85,12 @@ jobs:
         env:
           TYPECHECK: ${{ needs.typecheck.result }}
           BUILD: ${{ needs.build.result }}
+          TEST: ${{ needs.test.result }}
         run: |
           echo "Type Check: $TYPECHECK"
           echo "Build:      $BUILD"
-          for r in "$TYPECHECK" "$BUILD"; do
+          echo "Test:       $TEST"
+          for r in "$TYPECHECK" "$BUILD" "$TEST"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one electron CI job failed."
               exit 1

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -113,7 +113,29 @@ bun run dev:web            # apps/web Vite (port 5173, strict) — invoked by de
 bun run dev:electron       # wait-on :5173 then electron-vite dev — invoked by dev:standalone
 bun run build              # electron-vite build — bundles main + preload to out/
 bun run typecheck          # tsc --noEmit
+bun run test               # bun test — single Bun process (fastest for local iteration)
+bun run test:ci            # bun scripts/run-tests.ts — each file in its own subprocess (mock-safe; what CI runs)
 ```
+
+## Testing
+
+Pure functions under `src/main/` and `src/preload/` are unit-tested with
+[Bun's built-in test runner](https://bun.sh/docs/test/writing). Tests
+colocate next to source files (`commands.ts` → `commands.test.ts`).
+
+The real `electron` module isn't loadable off-Electron, so
+[`test-setup.ts`](./test-setup.ts) is preloaded by
+[`bunfig.toml`](./bunfig.toml) and mocks the surface every `src/main/`
+file imports at the top level. Tests that exercise a specific Electron
+API (e.g. `screen.getDisplayMatching`) re-mock it locally via
+`mock.module("electron", …)` inside the test file.
+
+`scripts/run-tests.ts` runs each test file in its own Bun subprocess —
+[`mock.module()` mutates a process-global registry](https://bun.sh/docs/test/mocking#mock-module),
+so mocks set in one file would leak into the next. Use `bun run test`
+for fast local iteration on a single file and `bun run test:ci` (or a
+single targeted file: `bun scripts/run-tests.ts src/main/foo.test.ts`)
+when running the full suite.
 
 ## Layout
 

--- a/apps/macos/bun.lock
+++ b/apps/macos/bun.lock
@@ -8,6 +8,7 @@
         "electron-store": "11.0.2",
       },
       "devDependencies": {
+        "@types/bun": "1.3.14",
         "@types/node": "22.10.5",
         "concurrently": "9.1.2",
         "electron": "42.2.0",
@@ -208,6 +209,8 @@
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
@@ -291,6 +294,8 @@
     "builder-util": ["builder-util@26.8.1", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.12", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "cross-spawn": "^7.0.6", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "js-yaml": "^4.1.0", "sanitize-filename": "^1.6.3", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0" } }, "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw=="],
 
     "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -804,6 +809,8 @@
 
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "bun-types/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -867,6 +874,8 @@
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 

--- a/apps/macos/bunfig.toml
+++ b/apps/macos/bunfig.toml
@@ -1,0 +1,9 @@
+[test]
+
+# Preloads the `electron` module mock so importing `src/main/` files in
+# tests doesn't crash. The Electron binary isn't available off-Electron
+# (CI runs `bun test` on plain Node Linux), and most main-process modules
+# `import { app, BrowserWindow, ipcMain, … } from "electron"` at top level.
+# The shim provides just enough surface that imports succeed; individual
+# tests still mock specific call sites they exercise.
+preload = ["./test-setup.ts"]

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -13,9 +13,12 @@
     "dev:web": "cd ../web && bun run dev -- --port 5173 --strictPort",
     "dev:electron": "wait-on --timeout 30000 http://localhost:5173 && electron-vite dev",
     "build": "electron-vite build",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test",
+    "test:ci": "bun scripts/run-tests.ts"
   },
   "devDependencies": {
+    "@types/bun": "1.3.14",
     "@types/node": "22.10.5",
     "concurrently": "9.1.2",
     "electron": "42.2.0",

--- a/apps/macos/scripts/run-tests.ts
+++ b/apps/macos/scripts/run-tests.ts
@@ -1,0 +1,77 @@
+/**
+ * Runs each test file in its own Bun subprocess to guarantee mock isolation.
+ *
+ * Bun's `mock.module()` mutates a process-global module registry, so mocks
+ * set in one test file leak into every subsequent file in the same process.
+ * Running each file in its own process is the only reliable workaround.
+ *
+ * Mirrors `apps/web/scripts/run-tests.ts` — kept as a per-package copy
+ * (rather than a shared workspace script) because each package's `src/`
+ * glob and `cwd` differ, and copy is cheaper than the abstraction today.
+ *
+ * Usage:
+ *   bun scripts/run-tests.ts                  # run all test files
+ *   bun scripts/run-tests.ts src/foo.test.ts  # run specific files
+ *
+ * Environment:
+ *   TEST_CONCURRENCY=N  — max parallel processes (default: 8)
+ *
+ * Reference: https://bun.sh/docs/test/mocking#mock-module
+ */
+
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const concurrency = Math.max(
+  1,
+  parseInt(process.env.TEST_CONCURRENCY ?? "8", 10) || 8,
+);
+
+const files =
+  args.length > 0
+    ? args
+    : [...new Glob("src/**/*.test.ts").scanSync(".")].sort();
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+async function runFile(file: string): Promise<boolean> {
+  const proc = Bun.spawn(["bun", "test", file], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: import.meta.dir + "/..",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    process.stderr.write(`\n✗ ${file}\n${stdout}${stderr}`);
+    return false;
+  }
+  return true;
+}
+
+for (let i = 0; i < files.length; i += concurrency) {
+  const batch = files.slice(i, i + concurrency);
+  await Promise.all(
+    batch.map(async (f) => {
+      if (await runFile(f)) {
+        passed++;
+      } else {
+        failed++;
+        failures.push(f);
+      }
+    }),
+  );
+}
+
+console.log(`\n${passed} passed, ${failed} failed (${files.length} test files)`);
+
+if (failures.length > 0) {
+  console.log("\nFailed:");
+  for (const f of failures) console.log(`  ${f}`);
+  process.exit(1);
+}

--- a/apps/macos/src/main/commands.test.ts
+++ b/apps/macos/src/main/commands.test.ts
@@ -2,6 +2,14 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 let mockHotkeys: unknown = null;
 
+// Order matters: `mock.module("./settings", …)` must run before any
+// `import` of `./commands`, because `./commands` imports `./settings` at
+// the top level. The static `import` form would resolve `./settings`
+// first — before this `mock.module` line runs — and bind the real
+// `readSetting`. Using `await import("./commands")` after the mock
+// ensures the mocked module graph is in place when `./commands` is
+// evaluated. Subsequent test files copying this template should
+// preserve the same ordering.
 mock.module("./settings", () => ({
   readSetting: (key: string) => (key === "hotkeys" ? mockHotkeys : null),
   writeSetting: () => undefined,

--- a/apps/macos/src/main/commands.test.ts
+++ b/apps/macos/src/main/commands.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let mockHotkeys: unknown = null;
+
+mock.module("./settings", () => ({
+  readSetting: (key: string) => (key === "hotkeys" ? mockHotkeys : null),
+  writeSetting: () => undefined,
+}));
+
+const { DEFAULT_ACCELERATORS, resolveAccelerator } = await import("./commands");
+
+afterEach(() => {
+  mockHotkeys = null;
+});
+
+describe("resolveAccelerator", () => {
+  test("returns the default when no override is set", () => {
+    mockHotkeys = {};
+    expect(resolveAccelerator("newConversation")).toBe(
+      DEFAULT_ACCELERATORS.newConversation,
+    );
+  });
+
+  test("returns the default when `hotkeys` is null", () => {
+    mockHotkeys = null;
+    expect(resolveAccelerator("currentConversation")).toBe(
+      DEFAULT_ACCELERATORS.currentConversation,
+    );
+  });
+
+  test("returns the user override when set to a non-empty string", () => {
+    mockHotkeys = { newConversation: "CmdOrCtrl+Alt+T" };
+    expect(resolveAccelerator("newConversation")).toBe("CmdOrCtrl+Alt+T");
+  });
+
+  test("falls back to the default for an empty-string override", () => {
+    mockHotkeys = { newConversation: "" };
+    expect(resolveAccelerator("newConversation")).toBe(
+      DEFAULT_ACCELERATORS.newConversation,
+    );
+  });
+
+  test("falls back to the default for a non-string override", () => {
+    mockHotkeys = { markCurrentUnread: 42 };
+    expect(resolveAccelerator("markCurrentUnread")).toBe(
+      DEFAULT_ACCELERATORS.markCurrentUnread,
+    );
+  });
+
+  test("ignores overrides for other commands", () => {
+    mockHotkeys = { newConversation: "CmdOrCtrl+Alt+T" };
+    expect(resolveAccelerator("markCurrentUnread")).toBe(
+      DEFAULT_ACCELERATORS.markCurrentUnread,
+    );
+  });
+});

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -66,6 +66,9 @@ mock.module("electron", () => ({
     },
   },
   net: {
+    // Import-time stub only — returns an empty Response so module-eval
+    // calls succeed. Tests that exercise response bodies should re-mock
+    // `net.fetch` locally with their own fixture.
     fetch: () => Promise.resolve(new Response("")),
   },
   screen: {

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -62,7 +62,11 @@ mock.module("electron", () => ({
   session: {
     defaultSession: {
       webRequest: { onHeadersReceived: () => undefined },
+      setPermissionRequestHandler: () => undefined,
     },
+  },
+  net: {
+    fetch: () => Promise.resolve(new Response("")),
   },
   screen: {
     getDisplayMatching: () => ({

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -1,0 +1,78 @@
+import { mock } from "bun:test";
+
+/**
+ * Mock surface for `electron`. The real module is a native binary that
+ * isn't loadable off-Electron, so `import { app, BrowserWindow, … } from
+ * "electron"` would throw the moment any `src/main/` file is imported.
+ *
+ * The shim provides empty / no-op stubs covering every symbol currently
+ * referenced under `src/main/`. Individual tests can re-mock specific
+ * methods (e.g. `screen.getDisplayMatching`) via their own
+ * `mock.module("electron", …)` call inside the test file.
+ */
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    requestSingleInstanceLock: () => true,
+    on: () => undefined,
+    whenReady: () => Promise.resolve(),
+    setName: () => undefined,
+    setAppUserModelId: () => undefined,
+    setActivationPolicy: () => undefined,
+    getPath: () => "/tmp",
+    quit: () => undefined,
+    dock: undefined,
+  },
+  BrowserWindow: class {
+    static getFocusedWindow() {
+      return null;
+    }
+    static getAllWindows() {
+      return [];
+    }
+    webContents = { send: () => undefined };
+    on() {
+      return this;
+    }
+    loadURL() {
+      return Promise.resolve();
+    }
+    isDestroyed() {
+      return false;
+    }
+    isFullScreen() {
+      return false;
+    }
+    getNormalBounds() {
+      return { x: 0, y: 0, width: 0, height: 0 };
+    }
+  },
+  ipcMain: {
+    handle: () => undefined,
+    on: () => undefined,
+  },
+  Menu: {
+    buildFromTemplate: () => ({ popup: () => undefined }),
+    setApplicationMenu: () => undefined,
+  },
+  protocol: {
+    handle: () => undefined,
+    registerSchemesAsPrivileged: () => undefined,
+  },
+  session: {
+    defaultSession: {
+      webRequest: { onHeadersReceived: () => undefined },
+    },
+  },
+  screen: {
+    getDisplayMatching: () => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    }),
+    getPrimaryDisplay: () => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    }),
+  },
+  shell: {
+    openExternal: () => Promise.resolve(),
+  },
+}));

--- a/apps/macos/tsconfig.json
+++ b/apps/macos/tsconfig.json
@@ -13,8 +13,13 @@
     "noEmit": true,
     "allowJs": false,
     "isolatedModules": true,
-    "types": ["node"]
+    "types": ["node", "bun"]
   },
-  "include": ["src/**/*.ts", "scripts/**/*.ts", "electron.vite.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "scripts/**/*.ts",
+    "electron.vite.config.ts",
+    "test-setup.ts"
+  ],
   "exclude": ["out/**", "dist/**", "node_modules/**"]
 }


### PR DESCRIPTION
## Summary

Stands up unit-test infrastructure for `apps/macos/src/main/` so pure functions can be verified in CI without launching Electron. There's no test harness in `apps/macos` today — Dock-badge formatting, window-state clamping, protocol guards, and the command-bus resolver are all unverified beyond manual exercise on a real Mac.

Mirrors the conventions in `apps/web/` (bun:test + a subprocess-isolated runner) so contributors switching between packages don't learn a new harness.

### Scaffolding

- **`apps/macos/bunfig.toml`** — preloads `test-setup.ts` for every test run.
- **`apps/macos/test-setup.ts`** — mocks the `electron` module. The real module is a native binary that can't load off-Electron (CI runs `bun test` on plain Linux), and most `src/main/*.ts` files import from `electron` at the top level. The shim covers every symbol referenced today (`app`, `BrowserWindow`, `ipcMain`, `Menu`, `protocol`, `session`, `screen`, `shell`). Tests that exercise a specific API re-mock it via `mock.module("electron", …)` locally.
- **`apps/macos/scripts/run-tests.ts`** — runs each test file in its own Bun subprocess so [`mock.module()` registry mutations don't leak between files](https://bun.sh/docs/test/mocking#mock-module). Near-copy of `apps/web/scripts/run-tests.ts`; kept as a per-package copy rather than a shared workspace script because each package's `cwd` and `src/` glob differ.
- **`@types/bun` + `tsconfig.types: ["node", "bun"]`** — so `bun:test` and `Bun.spawn` typecheck.
- **`package.json` scripts** — `test` (single Bun process, fastest for local iteration) and `test:ci` (subprocess-isolated, what CI runs).

### First test (proof of framework)

- **`src/main/commands.test.ts`** — covers `resolveAccelerator` across all override paths: default fallback, valid override, empty-string override, non-string override, unrelated-command override. Exists as the working template subsequent test files can copy.

### CI

- New **"Unit Tests"** job in `.github/workflows/pr-electron.yaml` and `.github/workflows/ci-main-electron.yaml`, rolled into the aggregate `checks` gate.

### Docs

- `apps/macos/README.md` gains a **Testing** section explaining the bunfig preload, the subprocess-isolated runner, when to use `test` vs `test:ci`, and how to target a single file.

## Follow-ups (out of scope for this PR)

These were called out in the ticket but each needs a small refactor or new module to be testable; landing them alongside the scaffolding would balloon this PR:

- **`dock.test.ts`** — `formatBadge` (0 → `""`, 1–99 pass-through, > 99 → `"99+"`) and `computePolicy` matrix. Both functions are currently module-private; needs `export`.
- **`window-state.test.ts`** — `restoreBounds` clamping under unplugged-monitor / shrunken-display / missing-state. Needs `screen.getDisplayMatching` re-mock per case.
- **`index-protocol.test.ts`** — path-traversal guard in `registerAppProtocol`. Needs the resolver factored into a pure helper first.

Each can land as part of touching the module it tests, now that the harness exists.

## Test plan

- [ ] `bun --cwd apps/macos run typecheck` passes locally.
- [ ] `bun --cwd apps/macos run test:ci` passes locally — single file (`src/main/commands.test.ts`), 6 cases.
- [ ] `bun --cwd apps/macos run build` passes locally.
- [ ] PR CI's new "Unit Tests" job passes; aggregate "Type Check, Build & Test" gate runs all three.
- [ ] No internal-issue references in `bunfig.toml`, `test-setup.ts`, `run-tests.ts`, or `commands.test.ts`.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_