### PR TITLE
Add deterministic Slack mute fast path

### DIFF
--- a/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
+++ b/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
@@ -77,8 +77,37 @@ function activeThreadRows(): Array<{ threadTs: string; channelId: string }> {
   return new SlackStore(getGatewayDb()).listActiveThreadsWithChannel();
 }
 
+function rawActiveThreadRows(): Array<{
+  threadTs: string;
+  channelId: string | null;
+}> {
+  const rawDb = (getGatewayDb() as unknown as { $client: unknown }).$client as {
+    prepare: (sql: string) => {
+      all: () => Array<{ thread_ts: string; channel_id: string | null }>;
+    };
+  };
+  return rawDb
+    .prepare("SELECT thread_ts, channel_id FROM slack_active_threads")
+    .all()
+    .map((row) => ({
+      threadTs: row.thread_ts,
+      channelId: row.channel_id,
+    }));
+}
+
 function trackThread(): void {
   new SlackStore(getGatewayDb()).trackThread(THREAD_TS, CHANNEL_ID, 60_000);
+}
+
+function trackLegacyThreadWithoutChannel(): void {
+  const rawDb = (getGatewayDb() as unknown as { $client: unknown }).$client as {
+    prepare: (sql: string) => { run: (...params: unknown[]) => void };
+  };
+  rawDb
+    .prepare(
+      "INSERT INTO slack_active_threads (thread_ts, channel_id, tracked_at, expires_at) VALUES (?, NULL, ?, ?)",
+    )
+    .run(THREAD_TS, Date.now(), Date.now() + 60_000);
 }
 
 describe("IPC Slack thread routes", () => {
@@ -133,6 +162,24 @@ describe("IPC Slack thread routes", () => {
     expect(activeThreadRows()).toEqual([
       { threadTs: THREAD_TS, channelId: CHANNEL_ID },
     ]);
+  });
+
+  test("detach_slack_active_thread removes a legacy active thread without channel", async () => {
+    trackLegacyThreadWithoutChannel();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "detach_slack_active_thread", {
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      detached: true,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(rawActiveThreadRows()).toEqual([]);
   });
 
   test("detach_slack_active_thread does not remove channel mismatches", async () => {

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -6,6 +6,7 @@ import { SlackStore } from "../db/slack-store.js";
 import * as schema from "../db/schema.js";
 import type { RuntimeInboundPayload } from "../runtime/client.js";
 import type { NormalizedSlackEvent } from "../slack/normalize.js";
+import { SLACK_THREAD_MUTE_SUCCESS } from "../webhook-copy.js";
 
 type FetchFn = (
   input: string | URL | Request,
@@ -185,6 +186,89 @@ beforeEach(() => {
 });
 
 describe("SlackSocketModeClient thread tracking", () => {
+  test("handles app mention mute without forwarding or re-tracking the thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const threadTs = "1700000000.000000";
+    const postBodies: Array<Record<string, unknown>> = [];
+
+    fetchMock = mock(async (input, init) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/chat.postMessage")) {
+        postBodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          JSON.stringify({ ok: true, ts: "1700000000.000300" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      store.trackThread(threadTs, "C-thread", 60_000);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-mute",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-mute",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> mute",
+              ts: "1700000000.000100",
+              channel: "C-thread",
+              thread_ts: threadTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(threadTs)).toBe(false);
+      expect(postBodies).toEqual([
+        {
+          channel: "C-thread",
+          thread_ts: threadTs,
+          text: SLACK_THREAD_MUTE_SUCCESS,
+        },
+      ]);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-muted-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-muted-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up without mentioning the bot",
+              ts: "1700000000.000200",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: threadTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("accepts unmentioned thread replies immediately after an app mention", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -6,7 +6,10 @@ import { SlackStore } from "../db/slack-store.js";
 import * as schema from "../db/schema.js";
 import type { RuntimeInboundPayload } from "../runtime/client.js";
 import type { NormalizedSlackEvent } from "../slack/normalize.js";
-import { SLACK_THREAD_MUTE_SUCCESS } from "../webhook-copy.js";
+import {
+  SLACK_THREAD_ALREADY_MUTED,
+  SLACK_THREAD_MUTE_SUCCESS,
+} from "../webhook-copy.js";
 
 type FetchFn = (
   input: string | URL | Request,
@@ -30,6 +33,10 @@ let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () =>
   makeSlackUserResponse(),
 );
 const runtimePayloads: RuntimeInboundPayload[] = [];
+const warnLogs: Array<{
+  payload: unknown;
+  message: string | undefined;
+}> = [];
 
 mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
@@ -55,6 +62,17 @@ mock.module("../runtime/client.js", () => ({
       };
     },
   ),
+}));
+
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: (payload: unknown, message?: string) => {
+      warnLogs.push({ payload, message });
+    },
+  }),
 }));
 
 mock.module("../verification/text-verification.js", () => ({
@@ -180,6 +198,7 @@ function flushAsyncEventEmission(): Promise<void> {
 
 beforeEach(() => {
   runtimePayloads.length = 0;
+  warnLogs.length = 0;
   clearUserInfoCache();
   clearChannelInfoCache();
   fetchMock = mock(async () => makeSlackUserResponse());
@@ -264,6 +283,125 @@ describe("SlackSocketModeClient thread tracking", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("acknowledges mute commands for already untracked threads", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const threadTs = "1700000000.000010";
+    const postBodies: Array<Record<string, unknown>> = [];
+
+    fetchMock = mock(async (input, init) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/chat.postMessage")) {
+        postBodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          JSON.stringify({ ok: true, ts: "1700000000.000030" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-already-muted",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-already-muted",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> mute",
+              ts: "1700000000.000020",
+              channel: "C-thread",
+              thread_ts: threadTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(threadTs)).toBe(false);
+      expect(postBodies).toEqual([
+        {
+          channel: "C-thread",
+          thread_ts: threadTs,
+          text: SLACK_THREAD_ALREADY_MUTED,
+        },
+      ]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("logs Slack mute confirmation API failures", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const threadTs = "1700000000.000040";
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/chat.postMessage")) {
+        return new Response(
+          JSON.stringify({ ok: false, error: "channel_not_found" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      store.trackThread(threadTs, "C-thread", 60_000);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-confirmation-failure",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-confirmation-failure",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> mute",
+              ts: "1700000000.000050",
+              channel: "C-thread",
+              thread_ts: threadTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(threadTs)).toBe(false);
+      const warning = warnLogs.find(
+        (entry) =>
+          entry.message ===
+          "Slack thread muted, but confirmation message failed",
+      );
+      expect(warning).toBeDefined();
+      expect(
+        String((warning?.payload as { err?: Error })?.err?.message),
+      ).toContain("channel_not_found");
     } finally {
       rawDb.close();
     }

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -71,7 +71,7 @@ export class SlackStore {
     const raw = (this.db as unknown as { $client: Database }).$client;
     const changes = raw
       .prepare(
-        "DELETE FROM slack_active_threads WHERE thread_ts = ? AND channel_id = ?",
+        "DELETE FROM slack_active_threads WHERE thread_ts = ? AND (channel_id = ? OR channel_id IS NULL)",
       )
       .run(threadTs, channelId).changes;
     return changes > 0;

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -7,6 +7,7 @@ import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
 import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
+import { SLACK_THREAD_MUTE_SUCCESS } from "../webhook-copy.js";
 import {
   CatchupAbortSignal,
   fetchChannelHistorySince,
@@ -65,6 +66,7 @@ const CATCHUP_MAX_LOOKBACK_MS = 60 * 60 * 1_000;
 const CATCHUP_SAFETY_OVERLAP_MS = 60 * 1_000;
 const CATCHUP_HISTORY_LIMIT = 50;
 const CATCHUP_CONCURRENCY = 4;
+const SLACK_MUTE_COMMANDS = new Set(["detach", "mute"]);
 
 export type SlackSocketModeConfig = {
   appToken: string;
@@ -77,6 +79,31 @@ export type SlackSocketModeConfig = {
   /** Workspace/team name, resolved at startup via auth.test. */
   teamName?: string;
 };
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function removeLeadingBotMentions(text: string, botUserId?: string): string {
+  let remaining = text.trim();
+  if (!remaining) return "";
+
+  if (botUserId) {
+    const mentionPrefix = new RegExp(`^<@${escapeRegExp(botUserId)}>\\s*`);
+    while (mentionPrefix.test(remaining)) {
+      remaining = remaining.replace(mentionPrefix, "").trim();
+    }
+    return remaining;
+  }
+
+  return remaining.replace(/^<@[UW][A-Z0-9]+>\s*/, "").trim();
+}
+
+function isSlackMuteCommand(text: string, botUserId?: string): boolean {
+  return SLACK_MUTE_COMMANDS.has(
+    removeLeadingBotMentions(text, botUserId).toLowerCase(),
+  );
+}
 
 /**
  * Slack Socket Mode WebSocket client.
@@ -281,6 +308,57 @@ export class SlackSocketModeClient {
    */
   trackThread(threadTs: string, channelId: string): void {
     this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
+  }
+
+  private handleSlackMuteCommand(event: SlackAppMentionEvent): boolean {
+    if (!isSlackMuteCommand(event.text, this.config.botUserId)) {
+      return false;
+    }
+
+    const channelId = event.channel;
+    const threadTs = event.thread_ts ?? event.ts;
+    if (!channelId || !threadTs) {
+      log.warn(
+        { channelId, threadTs },
+        "Slack mute command missing channel or thread timestamp",
+      );
+      return true;
+    }
+
+    const detached = this.store.detachThread(threadTs, channelId);
+    log.info(
+      { channelId, threadTs, detached },
+      "Handled Slack mute command without runtime dispatch",
+    );
+
+    if (detached) {
+      this.sendSlackMuteConfirmation(channelId, threadTs).catch((err) => {
+        log.warn(
+          { err, channelId, threadTs },
+          "Slack thread muted, but confirmation message failed",
+        );
+      });
+    }
+
+    return true;
+  }
+
+  private async sendSlackMuteConfirmation(
+    channelId: string,
+    threadTs: string,
+  ): Promise<void> {
+    await fetchImpl("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.botToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: channelId,
+        text: SLACK_THREAD_MUTE_SUCCESS,
+        thread_ts: threadTs,
+      }),
+    });
   }
 
   /**
@@ -697,6 +775,13 @@ export class SlackSocketModeClient {
     const watermarkTs = extractEventWatermarkTs(event, eventPayload.event_time);
     if (watermarkTs) {
       this.store.setLastSeenTsIfGreater(watermarkTs);
+    }
+
+    if (
+      isAppMention &&
+      this.handleSlackMuteCommand(event as SlackAppMentionEvent)
+    ) {
+      return;
     }
 
     if (isAppMention) {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -7,7 +7,10 @@ import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
 import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
-import { SLACK_THREAD_MUTE_SUCCESS } from "../webhook-copy.js";
+import {
+  SLACK_THREAD_ALREADY_MUTED,
+  SLACK_THREAD_MUTE_SUCCESS,
+} from "../webhook-copy.js";
 import {
   CatchupAbortSignal,
   fetchChannelHistorySince,
@@ -331,14 +334,17 @@ export class SlackSocketModeClient {
       "Handled Slack mute command without runtime dispatch",
     );
 
-    if (detached) {
-      this.sendSlackMuteConfirmation(channelId, threadTs).catch((err) => {
+    const confirmationText = detached
+      ? SLACK_THREAD_MUTE_SUCCESS
+      : SLACK_THREAD_ALREADY_MUTED;
+    this.sendSlackMuteConfirmation(channelId, threadTs, confirmationText).catch(
+      (err) => {
         log.warn(
           { err, channelId, threadTs },
           "Slack thread muted, but confirmation message failed",
         );
-      });
-    }
+      },
+    );
 
     return true;
   }
@@ -346,8 +352,9 @@ export class SlackSocketModeClient {
   private async sendSlackMuteConfirmation(
     channelId: string,
     threadTs: string,
+    text: string,
   ): Promise<void> {
-    await fetchImpl("https://slack.com/api/chat.postMessage", {
+    const resp = await fetchImpl("https://slack.com/api/chat.postMessage", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.config.botToken}`,
@@ -355,10 +362,15 @@ export class SlackSocketModeClient {
       },
       body: JSON.stringify({
         channel: channelId,
-        text: SLACK_THREAD_MUTE_SUCCESS,
+        text,
         thread_ts: threadTs,
       }),
     });
+    const data = (await resp.json()) as { ok?: boolean; error?: string };
+    if (!resp.ok || data.ok === false) {
+      const reason = data.error ?? `HTTP ${resp.status}`;
+      throw new Error(`Slack chat.postMessage failed: ${reason}`);
+    }
   }
 
   /**

--- a/gateway/src/webhook-copy.ts
+++ b/gateway/src/webhook-copy.ts
@@ -6,4 +6,7 @@ export const NEW_COMMAND_SUCCESS = "Starting a new conversation!";
 export const NEW_COMMAND_ERROR =
   "Failed to reset conversation. Please try again.";
 
+export const SLACK_THREAD_MUTE_SUCCESS =
+  "Muted this Slack thread. I won't respond to further replies here unless you mention me again.";
+
 export const SERVICE_UNAVAILABLE_ERROR = "Service temporarily unavailable";

--- a/gateway/src/webhook-copy.ts
+++ b/gateway/src/webhook-copy.ts
@@ -9,4 +9,6 @@ export const NEW_COMMAND_ERROR =
 export const SLACK_THREAD_MUTE_SUCCESS =
   "Muted this Slack thread. I won't respond to further replies here unless you mention me again.";
 
+export const SLACK_THREAD_ALREADY_MUTED = "This thread is already muted.";
+
 export const SERVICE_UNAVAILABLE_ERROR = "Service temporarily unavailable";


### PR DESCRIPTION
## Summary
- Handle exact Slack app-mention mute/detach commands in the gateway before runtime dispatch.
- Detach active-thread listening and send the Slack mute confirmation from Socket Mode.
- Add regression coverage that verifies mute does not re-track the thread or admit later unmentioned replies.

## Original prompt
The user asked for `@assistant mute` in Slack to detach snappily without invoking the LLM/tool path, while preserving deterministic behavior.