### PR TITLE
fix(bootstrap): make VOICE.md voice-capture an explicit, anchored step

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -70,7 +70,7 @@ Treat every open comment as signal about their voice and preferences:
 - "Add a citation" — they anchor claims. Use evidence by default.
 - "This angle is tired" — they are angle-sensitive. Lead with contrast.
 
-Capturing this signal is a required step, not an afterthought — and it starts with the very first comment. The moment a comment reveals a voice or preference marker, append it to VOICE.md before you resolve the comment. Don't wait for a pattern to repeat (that gate is for skill edits, not voice notes), don't batch it for later, and don't skip it because the signal seems small. Use `file_edit` silently — never mention the file or the write.
+Writing this signal to VOICE.md is a required step, starting with the first comment. The moment a comment reveals a voice marker, append it (silently, via `file_edit`) before you resolve the comment. Don't wait for a repeat — that gate is for skill edits, not voice notes. Never mention the file or the write.
 
 ### Fallback: if they edit the doc directly
 If the user edits the document directly (you see a diff without comments), fall back to the diff-based loop: read the diff, learn from it, save to VOICE.md. The comment loop is preferred but not required.
@@ -124,7 +124,7 @@ On your first skill edit, append a `## Self-improvement` meta-section to the wor
 
 ## Voice notes destination
 
-VOICE.md is the file for voice markers learned from this user. Separate from SOUL.md and IDENTITY.md. Append to it with `file_edit` the moment you observe a marker — from samples, drafting, edit diffs, or comment feedback — starting with the first signal you get, not once a pattern accumulates. Never mention the file or the write.
+VOICE.md holds the voice markers learned from this user — distinct from SOUL.md and IDENTITY.md. Capture the same way from samples and edit diffs, not just comments.
 
 ## Constraints
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -70,7 +70,7 @@ Treat every open comment as signal about their voice and preferences:
 - "Add a citation" — they anchor claims. Use evidence by default.
 - "This angle is tired" — they are angle-sensitive. Lead with contrast.
 
-Save specific observations to VOICE.md as a byproduct of reading and acting on comments. Never mention the file or the write.
+Capturing this signal is a required step, not an afterthought — and it starts with the very first comment. The moment a comment reveals a voice or preference marker, append it to VOICE.md before you resolve the comment. Don't wait for a pattern to repeat (that gate is for skill edits, not voice notes), don't batch it for later, and don't skip it because the signal seems small. Use `file_edit` silently — never mention the file or the write.
 
 ### Fallback: if they edit the doc directly
 If the user edits the document directly (you see a diff without comments), fall back to the diff-based loop: read the diff, learn from it, save to VOICE.md. The comment loop is preferred but not required.
@@ -124,7 +124,7 @@ On your first skill edit, append a `## Self-improvement` meta-section to the wor
 
 ## Voice notes destination
 
-VOICE.md is the file for voice markers learned from this user. Separate from SOUL.md and IDENTITY.md. Append with file_edit as a byproduct of drafting and reading edit diffs or comment feedback. Never mention the file or the write.
+VOICE.md is the file for voice markers learned from this user. Separate from SOUL.md and IDENTITY.md. Append to it with `file_edit` the moment you observe a marker — from samples, drafting, edit diffs, or comment feedback — starting with the first signal you get, not once a pattern accumulates. Never mention the file or the write.
 
 ## Constraints
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -70,7 +70,7 @@ Treat every open comment as signal about their voice and preferences:
 - "Add a citation" — they anchor claims. Use evidence by default.
 - "This angle is tired" — they are angle-sensitive. Lead with contrast.
 
-Writing this signal to VOICE.md is a required step, starting with the first comment. The moment a comment reveals a voice marker, append it (silently, via `file_edit`) before you resolve the comment. Don't wait for a repeat — that gate is for skill edits, not voice notes. Never mention the file or the write.
+Writing this signal to VOICE.md is a required step, starting with the first comment. The moment a comment reveals a voice marker, write it silently before you resolve the comment — create VOICE.md with `file_write` if it doesn't exist yet, otherwise `file_edit` to append. Don't wait for a repeat — that gate is for skill edits, not voice notes. Never mention the file or the write.
 
 ### Fallback: if they edit the doc directly
 If the user edits the document directly (you see a diff without comments), fall back to the diff-based loop: read the diff, learn from it, save to VOICE.md. The comment loop is preferred but not required.


### PR DESCRIPTION
## Summary

- Promote VOICE.md voice-signal capture in the content-automation (GEO) bootstrap from a passive "byproduct" aside into an explicit, **required** step anchored to the first user comment. QA found assistants didn't reliably execute the old passive phrasing ("Save specific observations to VOICE.md as a byproduct…").
- Reconcile the "Voice notes destination" section to match, so there's one clear trigger: append the moment a marker is observed (from samples, drafts, edit diffs, or comments), starting with the first signal — not once a pattern accumulates.
- Preserves the silent-write convention (never mention the file/write) and explicitly distinguishes voice-note timing from the skill-edit "wait for article 2" gate. Leaves the already-shipped skill-editing / Self-improvement / lifecycle / workspace-fork sections (PR #31518) untouched.

## Original prompt

Re-scoped JARVIS-992 after triage: four of its five reported gaps were already fixed by PR #31518 (the QA pass ran against a stale deployed bootstrap, so they only appeared open). The one genuine remaining gap was that VOICE.md voice capture was buried as a passive "byproduct" line inside the *Learning from comments* subsection with no explicit trigger, so assistants skipped it. This change makes voice capture an explicit step anchored to the first comment and reconciles the destination section to agree.

Closes JARVIS-992