### PR TITLE
fix(web): update bottom sheet section label font and spacing to match Figma

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -439,7 +439,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 /** Bottom-sheet section label — small-caps style matching Menu.Label. */
 function SectionLabel({ children }: { children: ReactNode }) {
   return (
-    <div className="px-[8px] py-1 text-label-small-default text-[var(--content-tertiary)]">
+    <div className="px-4 pt-2.5 pb-2 text-body-small-default text-[var(--content-tertiary)]">
       {children}
     </div>
   );

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -239,7 +239,7 @@ function PanelItem({
     leadingSlot !== undefined
       ? leadingSlot
       : Icon
-        ? <Icon size={14} aria-hidden className={cn(LEADING_ICON_BASE_CLASSES, iconActiveClass)} />
+        ? <Icon size={14} aria-hidden className={cn("max-md:size-4", LEADING_ICON_BASE_CLASSES, iconActiveClass)} />
         : null;
 
   const labelNode = marqueeOnHover ? (


### PR DESCRIPTION
Updates the iOS bottom sheet "Assistant Access" and "Model Profile" section labels and icon sizing to match the Figma design spec (node 4462-116465, "Light 171"). Section labels were 10px with minimal padding; Figma spec calls for 12px with more generous spacing. PanelItem leading icons were 14px on all screen sizes but should be 16px on mobile to match the 16px body text.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ff7fe6262b5a4397b62b45d32a52e784
