### PR TITLE
fix(daemon): respect shouldProtect in config-reload eviction (LUM-2039)

### DIFF
--- a/assistant/src/__tests__/conversation-evictor.test.ts
+++ b/assistant/src/__tests__/conversation-evictor.test.ts
@@ -197,6 +197,51 @@ describe("ConversationEvictor", () => {
     });
   });
 
+  describe("shouldProtect", () => {
+    test("TTL eviction skips protected sessions", () => {
+      const s1 = createMockSession();
+      const s2 = createMockSession();
+      sessions.set("protected", s1);
+      sessions.set("unprotected", s2);
+
+      evictor.shouldProtect = (id) => id === "protected";
+
+      const result = evictor.sweep();
+
+      expect(result.ttlEvicted).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(sessions.has("protected")).toBe(true);
+      expect(sessions.has("unprotected")).toBe(false);
+      expect(s1.disposed).toBe(false);
+      expect(s2.disposed).toBe(true);
+    });
+
+    test("LRU eviction skips protected sessions", () => {
+      // maxConversations = 3, add 5 sessions, protect one
+      for (let i = 0; i < 5; i++) {
+        sessions.set(`s${i}`, createMockSession());
+        evictor.touch(`s${i}`);
+      }
+
+      const now = Date.now();
+      const lastAccess = (
+        evictor as unknown as { lastAccess: Map<string, number> }
+      ).lastAccess;
+      // Make s0 the oldest but protected
+      lastAccess.set("s0", now - 100);
+      lastAccess.set("s1", now - 90);
+      lastAccess.set("s2", now - 80);
+
+      evictor.shouldProtect = (id) => id === "s0";
+
+      const result = evictor.sweep();
+
+      // s0 is protected despite being oldest — s1 and s2 are evicted instead
+      expect(sessions.has("s0")).toBe(true);
+      expect(result.lruEvicted).toBe(2);
+    });
+  });
+
   describe("start/stop", () => {
     test("stop clears tracking state", () => {
       evictor.touch("a");

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -8,6 +8,10 @@
  *
  * Regression guard for LUM-2039: subagent spawn silent death caused by
  * config-reload eviction bypassing the shouldProtect callback.
+ *
+ * KEEP IN SYNC with `DaemonServer.evictConversationsForReload` in
+ * `src/daemon/server.ts`. If the production logic changes, update
+ * `evictConversationsForReload` below to match.
  */
 import { describe, expect, test } from "bun:test";
 

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Contract test for `DaemonServer.evictConversationsForReload`.
+ *
+ * Standing up a full DaemonServer is impractical (heavy collaborator graph),
+ * so this test mirrors the eviction logic from server.ts and verifies that
+ * `shouldProtect` is respected — conversations with active subagents are
+ * marked stale instead of evicted.
+ *
+ * Regression guard for LUM-2039: subagent spawn silent death caused by
+ * config-reload eviction bypassing the shouldProtect callback.
+ */
+import { describe, expect, test } from "bun:test";
+
+interface MockConversation {
+  processing: boolean;
+  stale: boolean;
+  disposed: boolean;
+  isProcessing(): boolean;
+  markStale(): void;
+  dispose(): void;
+}
+
+function createMockConversation(processing = false): MockConversation {
+  return {
+    processing,
+    stale: false,
+    disposed: false,
+    isProcessing() {
+      return this.processing;
+    },
+    markStale() {
+      this.stale = true;
+    },
+    dispose() {
+      this.disposed = true;
+    },
+  };
+}
+
+/**
+ * Mirrors the eviction logic from `DaemonServer.evictConversationsForReload`
+ * in server.ts. The production code iterates conversations and checks both
+ * `isProcessing()` and `shouldProtect()` before evicting.
+ */
+function evictConversationsForReload(
+  conversations: Map<string, MockConversation>,
+  shouldProtect: (id: string) => boolean,
+): { evicted: string[]; staled: string[] } {
+  const evicted: string[] = [];
+  const staled: string[] = [];
+
+  for (const [id, conversation] of conversations) {
+    if (!conversation.isProcessing() && !shouldProtect(id)) {
+      conversation.dispose();
+      conversations.delete(id);
+      evicted.push(id);
+    } else {
+      conversation.markStale();
+      staled.push(id);
+    }
+  }
+
+  return { evicted, staled };
+}
+
+describe("evictConversationsForReload — shouldProtect contract", () => {
+  test("evicts idle conversations without active subagents", () => {
+    const conversations = new Map<string, MockConversation>();
+    conversations.set("idle-1", createMockConversation());
+    conversations.set("idle-2", createMockConversation());
+
+    const { evicted, staled } = evictConversationsForReload(
+      conversations,
+      () => false,
+    );
+
+    expect(evicted).toEqual(["idle-1", "idle-2"]);
+    expect(staled).toEqual([]);
+    expect(conversations.size).toBe(0);
+  });
+
+  test("marks stale instead of evicting when shouldProtect returns true", () => {
+    const conversations = new Map<string, MockConversation>();
+    const parentConv = createMockConversation();
+    const idleConv = createMockConversation();
+    conversations.set("parent-with-subagent", parentConv);
+    conversations.set("idle-no-children", idleConv);
+
+    const { evicted, staled } = evictConversationsForReload(
+      conversations,
+      (id) => id === "parent-with-subagent",
+    );
+
+    expect(evicted).toEqual(["idle-no-children"]);
+    expect(staled).toEqual(["parent-with-subagent"]);
+    expect(parentConv.disposed).toBe(false);
+    expect(parentConv.stale).toBe(true);
+    expect(idleConv.disposed).toBe(true);
+    expect(conversations.has("parent-with-subagent")).toBe(true);
+    expect(conversations.has("idle-no-children")).toBe(false);
+  });
+
+  test("marks stale when conversation is processing (regardless of protection)", () => {
+    const conversations = new Map<string, MockConversation>();
+    const processing = createMockConversation(true);
+    conversations.set("busy", processing);
+
+    const { evicted, staled } = evictConversationsForReload(
+      conversations,
+      () => false,
+    );
+
+    expect(evicted).toEqual([]);
+    expect(staled).toEqual(["busy"]);
+    expect(processing.disposed).toBe(false);
+    expect(processing.stale).toBe(true);
+  });
+
+  test("marks stale when both processing and protected", () => {
+    const conversations = new Map<string, MockConversation>();
+    const conv = createMockConversation(true);
+    conversations.set("busy-parent", conv);
+
+    const { evicted, staled } = evictConversationsForReload(
+      conversations,
+      () => true,
+    );
+
+    expect(evicted).toEqual([]);
+    expect(staled).toEqual(["busy-parent"]);
+    expect(conv.disposed).toBe(false);
+  });
+});

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -381,7 +381,7 @@ export class DaemonServer {
   private evictConversationsForReload(): void {
     const subagentManager = getSubagentManager();
     for (const [id, conversation] of conversationEntries()) {
-      if (!conversation.isProcessing()) {
+      if (!conversation.isProcessing() && !this.evictor.shouldProtect?.(id)) {
         subagentManager.abortAllForParent(id);
         conversation.dispose();
         deleteConversation(id);


### PR DESCRIPTION
## Prompt / plan

Closes LUM-2039.

### Problem

`evictConversationsForReload()` bypasses the `shouldProtect` callback when evicting conversations during config/credential changes. The evictor's periodic sweep (TTL, LRU, memory pressure) correctly respects `shouldProtect` — but the config-reload path has its own inline eviction loop that only checks `isProcessing()`.

This means any workspace file change (config.json, SOUL.md, IDENTITY.md, skills, credentials) while a subagent is running will:
1. Find the parent conversation is not processing (the spawn call returned, subagent runs independently)
2. Call `abortAllForParent()` — aborting and disposing all subagents
3. Dispose and delete the parent conversation

When the user later queries `subagent_status`, the parent is recreated from DB but the SubagentManager (purely in-memory) is empty → "No subagents found."

### Fix

Add the `shouldProtect` check to `evictConversationsForReload`, unifying it with the evictor's own sweep behavior. Protected conversations are marked stale instead of evicted — the same treatment processing conversations already receive.

### Why this is the right fix (and not a deeper change)

- The `shouldProtect` callback was introduced specifically to prevent eviction of conversations with active subagents. The evictor respects it in all three sweep phases. The config-reload path bypassing it was an oversight, not a design choice.
- `markStale()` is correct here: the stale conversation can still receive subagent completion notifications. When the next user message arrives, `getOrCreateConversation` sees `isStale() && !isProcessing()` and recreates with fresh config/provider — by which point the subagent has either completed (notification delivered) or the stale recreation's `abortAllForParent` handles cleanup.
- Persisting SubagentManager state to the DB (the "durable fix") would eliminate the class of problem entirely, but it's a larger change requiring a migration and lifecycle rework — appropriate as a follow-up, not bundled here.

### Alternatives not taken

- **Guard with `hasActiveChildren()` instead of `shouldProtect`**: Would duplicate the protection logic already expressed in `shouldProtect`. The callback exists as the single source of truth for "should this conversation be protected from eviction" — config-reload should use it, not reimplement it.
- **Persist SubagentManager state to DB**: Correct long-term direction (matches the rehydration pattern used for surfaces in [#32231](https://github.com/vellum-ai/vellum-assistant/pull/32231)), but scope is too large for this bug fix. Filed separately.

### Root cause analysis

1. **How did the code get into this state?** `evictConversationsForReload` was written before subagent support existed. When `shouldProtect` was added (to the evictor's sweep), the config-reload path wasn't updated to use it.
2. **What led to it?** The eviction system has two separate code paths — the evictor's periodic sweep and the config-reload wipe — that should share the same protection logic but don't. The config-reload path is in `DaemonServer`, not in `ConversationEvictor`, so the `shouldProtect` addition to the evictor didn't naturally reach it.
3. **Warning signs?** The config-reload path's inline eviction loop is a code smell — it reimplements eviction logic that the evictor already owns. The split makes it easy to miss protection checks in one path when they're added to the other.
4. **Prevention?** Consider moving the "evict for reload" logic into `ConversationEvictor` as a method (e.g., `evictAll()`) so all eviction paths go through one class. For now, the one-line `shouldProtect` guard is sufficient and low-risk.

## Test plan

- Added `shouldProtect` tests to `conversation-evictor.test.ts` covering TTL and LRU eviction paths
- Added `evict-conversations-for-reload.test.ts` — contract-mirroring test for the `evictConversationsForReload` logic, verifying that protected conversations are marked stale instead of evicted
- All 15 tests pass
- `bunx tsc --noEmit` passes
- `bun run lint` passes

Link to Devin session: https://app.devin.ai/sessions/7e1160a21072461f9de852734950c6d0
Requested by: @ashleeradka