### PR TITLE
Change default heartbeat interval from 30 to 60 minutes

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -11,7 +11,7 @@ export const HeartbeatConfigSchema = z
       .number({ error: "heartbeat.intervalMs must be a number" })
       .int("heartbeat.intervalMs must be an integer")
       .positive("heartbeat.intervalMs must be a positive integer")
-      .default(30 * 60_000)
+      .default(60 * 60_000)
       .describe("Time between heartbeat checks in milliseconds"),
     cronExpression: z
       .string()


### PR DESCRIPTION
## Summary
- Update the default `heartbeat.intervalMs` from 30 minutes to 60 minutes
- Users who have explicitly configured their interval are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)