### PR TITLE
feat(web): improve iOS voice recording UI — larger stop button and waveform-only composer

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useAudioAmplitude } from "@/domains/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/voice/voice-recording-store";
@@ -281,6 +282,7 @@ export function ChatComposer({
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
+  const isNative = useIsNativePlatform();
 
   // Stable ref so handleSlashCommandSelect's autoSend path always calls the
   // latest onSubmit even after flushSync triggers a synchronous re-render.
@@ -351,6 +353,7 @@ export function ChatComposer({
   const phase: TurnPhase = useTurnStore.use.phase();
   const isGenerating =
     phase === "queued" || phase === "thinking" || phase === "streaming";
+  const hideTextareaForVoice = isNative && isVoiceActive && !isGenerating;
 
   const ghostSuffix = useMemo(
     () =>
@@ -385,7 +388,7 @@ export function ChatComposer({
             This avoids the iOS WKWebView re-dispatch bug entirely: no DOM
             geometry mutation means no re-fired input events.
             Reference: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */}
-            <div className="grid">
+            <div className={hideTextareaForVoice ? "hidden" : "grid"}>
               <div
                 aria-hidden
                 className="pointer-events-none col-start-1 row-start-1 overflow-hidden whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat"

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -9,11 +9,12 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import { Button } from "@vellum/design-library";
+import { Button, cn } from "@vellum/design-library";
 import {
   postSttTranscribe,
   type SttFailureReason,
 } from "@/domains/voice/stt-api";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useVoiceRecordingStore } from "@/domains/voice/voice-recording-store";
 
 // ---------------------------------------------------------------------------
@@ -569,6 +570,8 @@ export const VoiceInputButton = forwardRef<
     [assistantId, disabled, startRecording, stopRecording],
   );
 
+  const isNative = useIsNativePlatform();
+
   if (!supported || !assistantId) return null;
 
   // The button has three visible states:
@@ -611,7 +614,10 @@ export const VoiceInputButton = forwardRef<
       aria-pressed={recording}
       aria-busy={processing}
       title={label}
-      className="[--vbtn-fg:var(--content-secondary)]"
+      className={cn(
+        "[--vbtn-fg:var(--content-secondary)]",
+        isNative && recording && "h-12 w-12 max-md:h-12 max-md:w-12",
+      )}
     />
   );
 });


### PR DESCRIPTION
Improves the iOS voice recording experience in the Capacitor shell by making the stop recording button larger (48×48px, up from the default 40×40px mobile size) and hiding the textarea during active recording so the waveform takes the full composer content area.

These changes are scoped to native iOS via `useIsNativePlatform()` — the web experience is unchanged. The stop button's enlarged touch target aligns with [Apple HIG's 44pt minimum recommendation](https://developer.apple.com/design/human-interface-guidelines/layout#Ergonomics), and the waveform-only view matches the target Figma design for a cleaner recording UI on mobile.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/7fc9a912a6db4993bef99db5e7de97b2

## Prompt / plan
Update the iOS voice recording UI to match the Figma target designs (nodes 5283-6605 → 5283-6606):
1. Increase the stop recording button size on iOS
2. Hide the textarea and show only the waveform when recording on iOS

## Test plan
- Lint and typecheck pass (`bun run lint`, `bunx tsc --noEmit`)
- Changes are iOS-only (gated behind `useIsNativePlatform()`) — no web regression
- Button size override uses `cn()` to compose with existing Tailwind classes; `max-md:h-12 max-md:w-12` overrides the default `max-md:h-10 max-md:w-10` compound variant
- Textarea hiding uses `className` toggle (`hidden` vs `grid`) — the waveform section below is already conditionally rendered for `isVoiceActive && !isGenerating`

### Manual UI testing (iOS Capacitor):
1. Open chat, tap the mic button to start recording
2. Verify the stop button is visibly larger than other toolbar buttons
3. Verify the textarea/placeholder is hidden and only the waveform is shown
4. Tap stop, verify the textarea reappears after transcription completes