### PR TITLE
feat(billing): hide Remove PM button for Pro subscribers

### DIFF
--- a/apps/web/openapi-schemas/platform.yaml
+++ b/apps/web/openapi-schemas/platform.yaml
@@ -4847,8 +4847,6 @@ components:
           nullable: true
         has_payment_method:
           type: boolean
-        can_delete_payment_method:
-          type: boolean
         payment_method_brand:
           type: string
           nullable: true
@@ -4885,7 +4883,6 @@ components:
           type: boolean
       required:
       - amount_usd
-      - can_delete_payment_method
       - current_month_charged_usd
       - current_month_credits_purchased_usd
       - enabled

--- a/apps/web/openapi-schemas/platform.yaml
+++ b/apps/web/openapi-schemas/platform.yaml
@@ -3406,6 +3406,14 @@ paths:
         Callers that need to fully remove the card from Stripe can use
         ``PaymentMethodViewSet.destroy`` separately.
 
+        Rejected with ``409`` while the organization is on the Pro plan:
+        Pro subscribers must always have a saved PM on file because the
+        same card funds both recurring subscription renewals and
+        off-session auto top-ups. From the UI's perspective this is the
+        endpoint behind the "Remove" button on the payment-method card,
+        so blocking it here is what makes the rule "Pro users cannot
+        delete their payment method" actually hold end-to-end.
+
         No-op (returns the same disabled payload) when no config row exists or
         the config already has no PM saved.
       parameters:
@@ -3428,6 +3436,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AutoTopUpDisableResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
           description: ''
       x-vellum-api-clients:
       - platform
@@ -4833,6 +4847,8 @@ components:
           nullable: true
         has_payment_method:
           type: boolean
+        can_delete_payment_method:
+          type: boolean
         payment_method_brand:
           type: string
           nullable: true
@@ -4869,6 +4885,7 @@ components:
           type: boolean
       required:
       - amount_usd
+      - can_delete_payment_method
       - current_month_charged_usd
       - current_month_credits_purchased_usd
       - enabled

--- a/apps/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -11,7 +11,10 @@ import {
   organizationsBillingAutoTopUpUpdateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
-import { brandLabel, formatBrandLast4 } from "@/domains/settings/utils/payment-method-brand";
+import {
+  brandLabel,
+  formatBrandLast4,
+} from "@/domains/settings/utils/payment-method-brand";
 
 import {
   AutoTopUpForm,
@@ -62,9 +65,6 @@ export const DISABLED_CONFIG: AutoTopUpConfigResponse = {
   amount_usd: null,
   monthly_cap_usd: null,
   has_payment_method: false,
-  // No saved PM means no Remove button anyway; default True matches what
-  // the backend serializer returns for `_serialize_config(None)`.
-  can_delete_payment_method: true,
   payment_method_brand: null,
   payment_method_last4: null,
   stripe_payment_method_updated_at: null,
@@ -83,10 +83,14 @@ export const DISABLED_CONFIG: AutoTopUpConfigResponse = {
  * per field. Exported so unit tests can exercise the parsing without
  * rendering the card.
  */
-export function extractAutoTopUpServerErrors(err: unknown): Record<string, string> {
+export function extractAutoTopUpServerErrors(
+  err: unknown,
+): Record<string, string> {
   if (!err || typeof err !== "object") return {};
   const out: Record<string, string> = {};
-  for (const [key, messages] of Object.entries(err as Record<string, unknown>)) {
+  for (const [key, messages] of Object.entries(
+    err as Record<string, unknown>,
+  )) {
     if (Array.isArray(messages) && typeof messages[0] === "string") {
       out[key] = messages[0];
     }
@@ -131,7 +135,9 @@ export function formatSavedPaymentMethodLine(args: {
 export function AutoTopUpCard() {
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
-  const updateMutation = useMutation(organizationsBillingAutoTopUpUpdateMutation());
+  const updateMutation = useMutation(
+    organizationsBillingAutoTopUpUpdateMutation(),
+  );
   const disableMutation = useMutation(
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
@@ -369,8 +375,8 @@ export function AutoTopUpCard() {
                   className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]"
                   data-testid="auto-top-up-cap-progress"
                 >
-                  {formatUsdShort(config.current_month_credits_purchased_usd)} of{" "}
-                  {formatUsdShort(config.monthly_cap_usd)} this month
+                  {formatUsdShort(config.current_month_credits_purchased_usd)}{" "}
+                  of {formatUsdShort(config.monthly_cap_usd)} this month
                 </p>
               )}
             </div>

--- a/apps/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -62,6 +62,9 @@ export const DISABLED_CONFIG: AutoTopUpConfigResponse = {
   amount_usd: null,
   monthly_cap_usd: null,
   has_payment_method: false,
+  // No saved PM means no Remove button anyway; default True matches what
+  // the backend serializer returns for `_serialize_config(None)`.
+  can_delete_payment_method: true,
   payment_method_brand: null,
   payment_method_last4: null,
   stripe_payment_method_updated_at: null,

--- a/apps/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/apps/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -1,25 +1,35 @@
 /**
  * Render gate test for the saved-card row's **Remove** button.
  *
- * The button visibility is driven by `config.can_delete_payment_method` on
- * the AutoTopUpConfig response — a server-authored boolean that's `false`
- * for Pro accounts and `true` for Base. The UI rule has a single source of
- * truth on the backend; this test pins the client-side gate so a refactor
- * can't silently re-derive the rule locally (e.g. via `plan_id === "pro"`)
- * or drop the conditional render altogether.
+ * The button visibility is driven by `subscription.plan_id` — hidden for
+ * Pro accounts, shown for everyone else. This is the local-derivation
+ * version of the rule (Carson review on platform PR #7781 dropped the
+ * server-authored `can_delete_payment_method` flag as redundant: "if the
+ * rule reduces to plan_id == PRO the field is redundant").
+ *
+ * The test pins the gate at the render level so a future refactor can't
+ * silently drop the conditional and let the button leak back in for Pro
+ * users.
  *
  * Strategy mirrors `ai-page.test.tsx`: pre-populate the React Query cache
- * via the generated query-key helper so `renderToStaticMarkup` (single-pass,
- * never resolves a pending queryFn) renders the loaded state directly. No
- * happy-dom interaction, no mutation firing — pure render assertion.
+ * via the generated query-key helpers so `renderToStaticMarkup` (single-
+ * pass, never resolves a pending queryFn) renders the loaded state
+ * directly. No happy-dom interaction, no mutation firing — pure render
+ * assertion.
  */
 
 import { describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
-import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  AutoTopUpConfigResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+import {
+  organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
 
 // Mirror the toast stub from ai-page.test.tsx — the component's onError
 // path imports the toast module via the design-library barrel, which can
@@ -41,9 +51,8 @@ mock.module(
   }),
 );
 
-const { PaymentMethodsCard } = await import(
-  "@/domains/settings/components/payment-methods-card"
-);
+const { PaymentMethodsCard } =
+  await import("@/domains/settings/components/payment-methods-card");
 
 function makeConfig(
   overrides: Partial<AutoTopUpConfigResponse> = {},
@@ -54,7 +63,6 @@ function makeConfig(
     amount_usd: null,
     monthly_cap_usd: null,
     has_payment_method: true,
-    can_delete_payment_method: true,
     payment_method_brand: "visa",
     payment_method_last4: "4242",
     stripe_payment_method_updated_at: null,
@@ -70,13 +78,31 @@ function makeConfig(
   };
 }
 
-function renderCard(config: AutoTopUpConfigResponse): string {
+function makeSubscription(
+  planId: SubscriptionResponse["plan_id"] = "base",
+): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function renderCard(
+  config: AutoTopUpConfigResponse,
+  subscription: SubscriptionResponse,
+): string {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), config);
   client.setQueryData(
-    organizationsBillingAutoTopUpRetrieveQueryKey(),
-    config,
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
   );
   return renderToStaticMarkup(
     <QueryClientProvider client={client}>
@@ -86,16 +112,16 @@ function renderCard(config: AutoTopUpConfigResponse): string {
 }
 
 describe("PaymentMethodsCard Remove-button gate", () => {
-  test("renders Remove when can_delete_payment_method is true (Base account)", () => {
-    const html = renderCard(makeConfig({ can_delete_payment_method: true }));
+  test("renders Remove when account is not Pro (Base)", () => {
+    const html = renderCard(makeConfig(), makeSubscription("base"));
     // The Change button is always present on the saved-card row — pin it
     // so a regression that nukes the entire button group is also caught.
     expect(html).toContain("Change");
     expect(html).toContain("Remove");
   });
 
-  test("hides Remove when can_delete_payment_method is false (Pro account)", () => {
-    const html = renderCard(makeConfig({ can_delete_payment_method: false }));
+  test("hides Remove when account is Pro", () => {
+    const html = renderCard(makeConfig(), makeSubscription("pro"));
     // Change must stay — it's the path forward for Pro users (add a new
     // card, which the unified-PM webhook flow promotes to the
     // subscription's default_payment_method, replacing the previous one).
@@ -105,15 +131,13 @@ describe("PaymentMethodsCard Remove-button gate", () => {
 
   test("does not render any PM action buttons when no card is on file", () => {
     // No saved PM → the Add Card CTA renders instead of the saved-card row.
-    // can_delete_payment_method defaults to true here from the backend
-    // (no PM to gate against) but is unused in this branch.
     const html = renderCard(
       makeConfig({
         has_payment_method: false,
         payment_method_brand: null,
         payment_method_last4: null,
-        can_delete_payment_method: true,
       }),
+      makeSubscription("base"),
     );
     expect(html).toContain("Add Card");
     expect(html).not.toContain("Change");

--- a/apps/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/apps/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Render gate test for the saved-card row's **Remove** button.
+ *
+ * The button visibility is driven by `config.can_delete_payment_method` on
+ * the AutoTopUpConfig response — a server-authored boolean that's `false`
+ * for Pro accounts and `true` for Base. The UI rule has a single source of
+ * truth on the backend; this test pins the client-side gate so a refactor
+ * can't silently re-derive the rule locally (e.g. via `plan_id === "pro"`)
+ * or drop the conditional render altogether.
+ *
+ * Strategy mirrors `ai-page.test.tsx`: pre-populate the React Query cache
+ * via the generated query-key helper so `renderToStaticMarkup` (single-pass,
+ * never resolves a pending queryFn) renders the loaded state directly. No
+ * happy-dom interaction, no mutation firing — pure render assertion.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+
+// Mirror the toast stub from ai-page.test.tsx — the component's onError
+// path imports the toast module via the design-library barrel, which can
+// pull a real surface during static render and break the test.
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+// AutoTopUpPaymentMethodModal opens its own pricing/SetupIntent flow and
+// pulls in extra hooks we don't want to bootstrap for a static render.
+// It's closed in our render path (pmModalOpen=false initial state), so
+// stubbing the import is safe and keeps the test focused on the gate.
+mock.module(
+  "@/domains/settings/components/auto-top-up-payment-method-modal",
+  () => ({
+    AutoTopUpPaymentMethodModal: () => null,
+  }),
+);
+
+const { PaymentMethodsCard } = await import(
+  "@/domains/settings/components/payment-methods-card"
+);
+
+function makeConfig(
+  overrides: Partial<AutoTopUpConfigResponse> = {},
+): AutoTopUpConfigResponse {
+  return {
+    enabled: false,
+    threshold_usd: null,
+    amount_usd: null,
+    monthly_cap_usd: null,
+    has_payment_method: true,
+    can_delete_payment_method: true,
+    payment_method_brand: "visa",
+    payment_method_last4: "4242",
+    stripe_payment_method_updated_at: null,
+    last_charge_at: null,
+    last_failure_at: null,
+    last_failure_reason: null,
+    paused_until: null,
+    current_month_credits_purchased_usd: "0.00",
+    current_month_charged_usd: "0.00",
+    next_trigger_amount_usd: null,
+    stubbed: false,
+    ...overrides,
+  };
+}
+
+function renderCard(config: AutoTopUpConfigResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingAutoTopUpRetrieveQueryKey(),
+    config,
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <PaymentMethodsCard />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PaymentMethodsCard Remove-button gate", () => {
+  test("renders Remove when can_delete_payment_method is true (Base account)", () => {
+    const html = renderCard(makeConfig({ can_delete_payment_method: true }));
+    // The Change button is always present on the saved-card row — pin it
+    // so a regression that nukes the entire button group is also caught.
+    expect(html).toContain("Change");
+    expect(html).toContain("Remove");
+  });
+
+  test("hides Remove when can_delete_payment_method is false (Pro account)", () => {
+    const html = renderCard(makeConfig({ can_delete_payment_method: false }));
+    // Change must stay — it's the path forward for Pro users (add a new
+    // card, which the unified-PM webhook flow promotes to the
+    // subscription's default_payment_method, replacing the previous one).
+    expect(html).toContain("Change");
+    expect(html).not.toContain("Remove");
+  });
+
+  test("does not render any PM action buttons when no card is on file", () => {
+    // No saved PM → the Add Card CTA renders instead of the saved-card row.
+    // can_delete_payment_method defaults to true here from the backend
+    // (no PM to gate against) but is unused in this branch.
+    const html = renderCard(
+      makeConfig({
+        has_payment_method: false,
+        payment_method_brand: null,
+        payment_method_last4: null,
+        can_delete_payment_method: true,
+      }),
+    );
+    expect(html).toContain("Add Card");
+    expect(html).not.toContain("Change");
+    expect(html).not.toContain("Remove");
+  });
+});

--- a/apps/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/apps/web/src/domains/settings/components/payment-methods-card.tsx
@@ -38,7 +38,8 @@ function PaymentMethodHeading() {
         variant="body-small-default"
         className="mt-2 text-[var(--content-tertiary)]"
       >
-        This is the payment method that will be used for automated credit reloads.
+        This is the payment method that will be used for automated credit
+        reloads.
       </Typography>
     </div>
   );
@@ -145,6 +146,62 @@ export function PaymentMethodsCard() {
   const config = configQuery.data;
   const brand = brandLabel(config.payment_method_brand ?? "card");
   const last4 = config.payment_method_last4;
+  const isAutoTopUpEnabled = config.enabled;
+  // Backend gates the Remove action via this flag (False for Pro
+  // subscribers — they must replace the card instead so the Pro plan
+  // never has an empty default-PM slot). We hide the button entirely
+  // rather than disabling it so Pro users don't see a dead control;
+  // the Change button next to it is the path forward. Backend also
+  // returns 409 on the corresponding endpoints
+  // (AutoTopUpViewSet.remove_payment_method and
+  // PaymentMethodViewSet.destroy) as the authoritative guard.
+  const canDeletePaymentMethod = config.can_delete_payment_method;
+
+  // Two confirm-modal variants for the Remove click:
+  // 1. Auto-top-up ON → warn that removing the PM disables auto-top-up.
+  // 2. Auto-top-up OFF → neutral "remove the saved card" confirm; no
+  //    auto-top-up language because none applies.
+  //
+  // The shared remove-mutation handlers below are reused by both so the
+  // success/error/optimistic-cache behavior stays in one place.
+  const handleConfirmRemoveMutation = () => {
+    if (removePmMutation.isPending) return;
+    removePmMutation.mutate(
+      {},
+      {
+        onSuccess: () => {
+          // The remove endpoint clears `stripe_payment_method_id` and
+          // flips `enabled=False` but intentionally preserves the
+          // saved thresholds (`threshold_usd`, `amount_usd`,
+          // `monthly_cap_usd`) so the user can re-enable later
+          // without re-entering them. Merge from the prior cache so
+          // the AutoTopUpCard sibling (same query key) doesn't render
+          // an empty config until the next refetch lands.
+          queryClient.setQueryData<AutoTopUpConfigResponse | undefined>(
+            organizationsBillingAutoTopUpRetrieveQueryKey(),
+            (prior) =>
+              prior
+                ? {
+                    ...prior,
+                    enabled: false,
+                    has_payment_method: false,
+                    payment_method_brand: null,
+                    payment_method_last4: null,
+                  }
+                : DISABLED_CONFIG,
+          );
+          setConfirmRemovePm(false);
+        },
+        onError: () => {
+          toast.error("Failed to remove payment method. Please try again.");
+          setConfirmRemovePm(false);
+        },
+      },
+    );
+  };
+  const handleCancelRemove = () => {
+    if (!removePmMutation.isPending) setConfirmRemovePm(false);
+  };
 
   return (
     <>
@@ -168,80 +225,58 @@ export function PaymentMethodsCard() {
                   {brand}
                 </Typography>
                 {last4 ? (
-                  <Typography variant="body-small-default" as="div" className="text-[var(--content-tertiary)]">
+                  <Typography
+                    variant="body-small-default"
+                    as="div"
+                    className="text-[var(--content-tertiary)]"
+                  >
                     Ending in {last4}
                   </Typography>
                 ) : null}
               </div>
               <div className="flex shrink-0 items-center gap-1">
-                <Button
-                  variant="ghost"
-                  onClick={() => setPmModalOpen(true)}
-                >
+                <Button variant="ghost" onClick={() => setPmModalOpen(true)}>
                   Change
                 </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => setConfirmRemovePm(true)}
-                  disabled={confirmRemovePm || removePmMutation.isPending}
-                  leftIcon={<Trash2 className="h-3.5 w-3.5" />}
-                >
-                  Remove
-                </Button>
+                {canDeletePaymentMethod ? (
+                  <Button
+                    variant="ghost"
+                    onClick={() => setConfirmRemovePm(true)}
+                    disabled={confirmRemovePm || removePmMutation.isPending}
+                    leftIcon={<Trash2 className="h-3.5 w-3.5" />}
+                  >
+                    Remove
+                  </Button>
+                ) : null}
               </div>
             </div>
           )}
         </div>
       </Card>
 
-      <ConfirmDialog
-        open={confirmRemovePm}
-        title="Remove payment method?"
-        message="Removing your payment method will disable automatic top-ups. You can re-enable them after adding a new payment method."
-        confirmLabel={removePmMutation.isPending ? "Removing…" : "Remove"}
-        cancelLabel="Keep"
-        destructive
-        onConfirm={() => {
-          if (removePmMutation.isPending) return;
-          removePmMutation.mutate(
-            {},
-            {
-              onSuccess: () => {
-                // The remove endpoint clears `stripe_payment_method_id` and
-                // flips `enabled=False` but intentionally preserves the
-                // saved thresholds (`threshold_usd`, `amount_usd`,
-                // `monthly_cap_usd`) so the user can re-enable later
-                // without re-entering them. Merge from the prior cache so
-                // the AutoTopUpCard sibling (same query key) doesn't render
-                // an empty config until the next refetch lands.
-                queryClient.setQueryData<AutoTopUpConfigResponse | undefined>(
-                  organizationsBillingAutoTopUpRetrieveQueryKey(),
-                  (prior) =>
-                    prior
-                      ? {
-                          ...prior,
-                          enabled: false,
-                          has_payment_method: false,
-                          payment_method_brand: null,
-                          payment_method_last4: null,
-                        }
-                      : DISABLED_CONFIG,
-                );
-                setConfirmRemovePm(false);
-              },
-              onError: () => {
-                toast.error(
-                  "Failed to remove payment method. Please try again.",
-                );
-                setConfirmRemovePm(false);
-              },
-            },
-          );
-        }}
-        onCancel={() => {
-          if (!removePmMutation.isPending) setConfirmRemovePm(false);
-        }}
-      />
+      {isAutoTopUpEnabled ? (
+        <ConfirmDialog
+          open={confirmRemovePm}
+          title="Remove payment method?"
+          message="Removing your payment method will disable automatic top-ups. You can re-enable them after adding a new payment method."
+          confirmLabel={removePmMutation.isPending ? "Removing…" : "Remove"}
+          cancelLabel="Keep"
+          destructive
+          onConfirm={handleConfirmRemoveMutation}
+          onCancel={handleCancelRemove}
+        />
+      ) : (
+        <ConfirmDialog
+          open={confirmRemovePm}
+          title="Remove payment method?"
+          message="The saved card will be removed from your account."
+          confirmLabel={removePmMutation.isPending ? "Removing…" : "Remove"}
+          cancelLabel="Cancel"
+          destructive
+          onConfirm={handleConfirmRemoveMutation}
+          onCancel={handleCancelRemove}
+        />
+      )}
 
       <AutoTopUpPaymentMethodModal
         open={pmModalOpen}

--- a/apps/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/apps/web/src/domains/settings/components/payment-methods-card.tsx
@@ -12,6 +12,7 @@ import {
   organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation,
   organizationsBillingAutoTopUpRetrieveOptions,
   organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
@@ -48,6 +49,21 @@ function PaymentMethodHeading() {
 export function PaymentMethodsCard() {
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
+  // Pro subscribers can't remove their PM — the Pro plan requires a
+  // payment method on file. Hide the Remove button entirely so they
+  // see only the Change button (which is the path forward). Backend
+  // 409 guards on AutoTopUpViewSet.remove_payment_method and
+  // PaymentMethodViewSet.destroy are the authoritative enforcement;
+  // this is the UX layer.
+  //
+  // Reads plan_id directly from the subscription rather than a
+  // server-authored boolean on the AutoTopUp response — the rule is
+  // pure plan_id == "pro", so a separate field was redundant (Carson
+  // review on platform PR #7781).
+  const subscriptionQuery = useQuery(
+    organizationsBillingSubscriptionRetrieveOptions(),
+  );
+  const isPro = subscriptionQuery.data?.plan_id === "pro";
 
   const [pmModalOpen, setPmModalOpen] = useState(false);
   const [confirmRemovePm, setConfirmRemovePm] = useState(false);
@@ -147,15 +163,6 @@ export function PaymentMethodsCard() {
   const brand = brandLabel(config.payment_method_brand ?? "card");
   const last4 = config.payment_method_last4;
   const isAutoTopUpEnabled = config.enabled;
-  // Backend gates the Remove action via this flag (False for Pro
-  // subscribers — they must replace the card instead so the Pro plan
-  // never has an empty default-PM slot). We hide the button entirely
-  // rather than disabling it so Pro users don't see a dead control;
-  // the Change button next to it is the path forward. Backend also
-  // returns 409 on the corresponding endpoints
-  // (AutoTopUpViewSet.remove_payment_method and
-  // PaymentMethodViewSet.destroy) as the authoritative guard.
-  const canDeletePaymentMethod = config.can_delete_payment_method;
 
   // Two confirm-modal variants for the Remove click:
   // 1. Auto-top-up ON → warn that removing the PM disables auto-top-up.
@@ -238,7 +245,7 @@ export function PaymentMethodsCard() {
                 <Button variant="ghost" onClick={() => setPmModalOpen(true)}>
                   Change
                 </Button>
-                {canDeletePaymentMethod ? (
+                {isPro ? null : (
                   <Button
                     variant="ghost"
                     onClick={() => setConfirmRemovePm(true)}
@@ -247,7 +254,7 @@ export function PaymentMethodsCard() {
                   >
                     Remove
                   </Button>
-                ) : null}
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

Hides the **Remove** action on the saved payment-method card for Pro subscribers. The Pro plan requires a payment method on file at all times, so the only valid action for a Pro user is **Change** (which adds a new card and lets the unified-PM webhook flow promote it to the subscription's `default_payment_method`).

The Pro check reads `subscription.plan_id` directly. **Updated per [Carson's review](https://github.com/vellum-ai/vellum-assistant-platform/pull/7781#discussion_r2326896165) on the platform PR** — the originally proposed `can_delete_payment_method` server-authored boolean was redundant because the rule reduces to `plan_id === "pro"`, so the rule lives client-side.

Companion to platform PR [vellum-ai/vellum-assistant-platform#7781](https://github.com/vellum-ai/vellum-assistant-platform/pull/7781), specifically commit [`6aa58423e`](https://github.com/vellum-ai/vellum-assistant-platform/pull/7781/commits/6aa58423e) which removes the (now-redundant) `can_delete_payment_method` field from `AutoTopUpConfigResponse`.

## Changes

| File | Change |
| --- | --- |
| `apps/web/src/domains/settings/components/payment-methods-card.tsx` | `useQuery(organizationsBillingSubscriptionRetrieveOptions())` + `isPro = subscription?.plan_id === "pro"`. Conditionally render the Remove button (`{isPro ? null : <Button …Remove…/>}`). Both non-Pro `ConfirmDialog` variants (auto-top-up on vs off) unchanged. |
| `apps/web/src/domains/settings/components/payment-methods-card.test.tsx` | **New.** 3 happy-dom-style render tests pinning the gate behavior — see *Automated checks* below. |
| `apps/web/src/domains/settings/components/auto-top-up-card.tsx` | Removed the `can_delete_payment_method: true` line from `DISABLED_CONFIG` since the field no longer exists on the regenerated `AutoTopUpConfigResponse`. |
| `apps/web/openapi-schemas/platform.yaml` | Re-synced from the platform repo's post-Carson-fix schema. |

Backend enforcement (`AutoTopUpViewSet.remove_payment_method` + `PaymentMethodViewSet.destroy` both return `409` for Pro plans) stays in place as the authoritative safety net — see platform PR.

## How to test locally

Per [`apps/web/README.md`](apps/web/README.md):

```bash
cd apps/web
bun install
bun run openapi-ts          # regenerate the (gitignored) generated client
bun run typecheck           # bunx tsc --noEmit
bun run lint                # eslint
bun run dev                 # Vite at http://localhost:3000
```

The Vite dev server proxies `/v1/*`, `/_allauth/*`, `/accounts/*` to Django on `localhost:8000` (override via `API_PROXY_TARGET`). For the full stack including the Django backend you'll want the platform repo's `vel up` workflow — the platform PR has the matching backend changes.

### Functional verification

Log in as an account whose `plan_id` you can flip locally (via Django shell or seed data). Navigate to **Settings → Billing → Payment Method**:

1. **Pro account, saved card present** → expect **only the Change button** to render on the saved-card row. No Remove button, no trash icon. Inspect element to confirm the button isn't just visually hidden.
2. **Base account, saved card present, auto-top-up enabled** → Remove button renders. Clicking it opens the existing modal:
   > *"Removing your payment method will disable automatic top-ups. You can re-enable them after adding a new payment method."*
   With **Remove** / **Keep** buttons. Clicking Remove fires the existing mutation and optimistically clears the card from the UI.
3. **Base account, saved card present, auto-top-up disabled** → Remove button renders. Clicking it opens the new neutral modal:
   > *"Remove payment method? — The saved card will be removed from your account."*
   With **Remove** / **Cancel** buttons. Clicking Remove fires the same mutation.
4. **No saved card on file** → "Add Card" button renders, no Remove path exists.

### Backend safety net (covered by the platform PR, listed here for completeness)

Even if the frontend somehow tries to call the remove endpoint as a Pro user (e.g. stale cache, malicious request), the backend returns `409` with:

> *"You cannot remove a payment method with a Pro subscription. You can only replace it with a new card."*

### Automated checks

```bash
cd apps/web
bun run typecheck                                                              # passes
bun run lint                                                                   # passes
bun test src/domains/settings/components/payment-methods-card.test.tsx         # 3 pass
```

The test file pins the Remove-button gate at the render level so a future refactor can't silently:

- Drop the conditional render and let the button leak back in for Pro users.
- Re-derive the rule incorrectly.

Strategy mirrors `ai-page.test.tsx` already in the repo: pre-populate the React Query cache via the generated query-key helpers (one for the AutoTopUp config, one for the subscription), single-pass `renderToStaticMarkup`, no interaction. Cases covered:

| Setup | Expected render |
| --- | --- |
| `subscription.plan_id: "base"`, saved card present | Change ✓ + Remove ✓ |
| `subscription.plan_id: "pro"`, saved card present | Change ✓ + Remove ✗ |
| `has_payment_method: false` | Add Card ✓, no row, no Remove |

The middle row is the load-bearing one — that's the regression this PR is meant to prevent.

## Merge order (matters)

1. **Platform PR [#7781](https://github.com/vellum-ai/vellum-assistant-platform/pull/7781) merges first.** It removes the `can_delete_payment_method` field from `AutoTopUpConfigResponse` (after Carson's review).
2. **This PR merges second.** The `openapi-schemas/platform.yaml` snapshot here is in sync with what the platform serves post-merge; the regenerated TS client (gitignored, produced by `bun run openapi-ts` on `predev`) will type-check against the live API.

Reverse order risks: this PR would ship a frontend reading a field the deployed backend still returns — type would still match but the behavior would race the deploy. Low blast radius (just an unused field) but ordering this way avoids that entirely.

## Out of scope / follow-ups

- The error message returned by the backend on `409` is currently a single shared string for both remove endpoints. If future product copy needs to vary by endpoint, the toast/error handler in `payment-methods-card.tsx` can read `err.response.data.detail` and render verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
