### PR TITLE
fix(test): update heartbeat test to match 60-minute default interval

### DIFF
--- a/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
@@ -90,7 +90,7 @@ describe("setHeartbeatConfig handler", () => {
     // invalidation + getConfig() read picked up the new on-disk state.
     expect(result.success).toBe(true);
     expect(result.enabled).toBe(true);
-    expect(result.intervalMs).toBe(30 * 60_000);
+    expect(result.intervalMs).toBe(60 * 60_000);
     expect(result.activeHoursStart).toBe(8);
     expect(result.activeHoursEnd).toBe(22);
   });

--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -61,6 +61,7 @@
         "@radix-ui/react-slider": ">=1.3.0",
         "@radix-ui/react-slot": ">=1.2.0",
         "@radix-ui/react-tabs": ">=1.1.0",
+        "@radix-ui/react-tooltip": ">=1.2.0",
         "class-variance-authority": ">=0.7.0",
         "clsx": ">=2.1.0",
         "lucide-react": ">=1.16.0",


### PR DESCRIPTION
## Summary
- The heartbeat default interval was changed from 30 to 60 minutes in #32601, but the test in `heartbeat-routes.test.ts` still expected the old 30-minute default
- Updated the test assertion to expect `60 * 60_000` instead of `30 * 60_000`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)