### PR TITLE
test(macos): dock + window-state + app-protocol tests, fix malformed-URL → 500 bug, scrub internal-tracker refs

### DIFF
--- a/apps/macos/src/main/app-protocol.test.ts
+++ b/apps/macos/src/main/app-protocol.test.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveAppProtocolPath } from "./app-protocol";
+
+// Use posix-style absolute roots in tests so assertions are
+// platform-stable; `app-protocol.ts` uses `node:path` which respects
+// `path.sep` at runtime. On Linux CI / dev macOS that's `/`.
+const ROOT = "/app/renderer";
+
+describe("resolveAppProtocolPath — allowed paths", () => {
+  test("resolves the empty pathname to the root itself", () => {
+    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/");
+    expect(result).toEqual({ kind: "ok", resolved: ROOT });
+  });
+
+  test("resolves a top-level file inside the root", () => {
+    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/index.html");
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "index.html"),
+    });
+  });
+
+  test("resolves nested asset paths inside the root", () => {
+    const result = resolveAppProtocolPath(
+      ROOT,
+      "app://vellum.ai/assets/app.css",
+    );
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "assets/app.css"),
+    });
+  });
+
+  test("strips leading slashes so the join doesn't escape the root", () => {
+    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai///index.html");
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "index.html"),
+    });
+  });
+});
+
+// The `URL` parser collapses `..` and `%2e%2e` segments while parsing
+// the pathname (RFC 3986 path normalization), so most "traversal-style"
+// inputs never reach `path.normalize` with any `..` left to escape.
+// That's the first line of defense; these tests document its behavior.
+// The `startsWith(rendererRoot + sep)` check in `resolveAppProtocolPath`
+// is defense-in-depth that catches any pathname that did slip past URL
+// normalization — important to keep, even if there's no known case in
+// practice today.
+describe("resolveAppProtocolPath — URL parser collapses `..` segments", () => {
+  test("literal `..` resolves to a safe in-root path", () => {
+    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/../etc/passwd");
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "etc/passwd"),
+    });
+  });
+
+  test("deeply nested `..` chains resolve to a safe in-root path", () => {
+    const result = resolveAppProtocolPath(
+      ROOT,
+      "app://vellum.ai/a/b/../../../etc/passwd",
+    );
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "etc/passwd"),
+    });
+  });
+
+  test("percent-encoded `..` (`%2e%2e`) resolves to a safe in-root path", () => {
+    const result = resolveAppProtocolPath(
+      ROOT,
+      "app://vellum.ai/%2e%2e/etc/passwd",
+    );
+    expect(result).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "etc/passwd"),
+    });
+  });
+});
+
+// Direct probe of the defense-in-depth guard. We can't easily smuggle a
+// `..` past URL normalization, but we can bypass URL entirely by
+// constructing a request URL whose pathname is a literal trailing
+// segment, then trusting `path.normalize` to do nothing surprising.
+// These cases pin the contract: if `URL` normalization ever regresses
+// or a future scheme exposes new traversal vectors, this guard fires.
+describe("resolveAppProtocolPath — startsWith guard", () => {
+  test("returns `ok` for the root itself (the `===` exemption)", () => {
+    expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/")).toEqual({
+      kind: "ok",
+      resolved: ROOT,
+    });
+  });
+
+  test("ROOT-prefixed siblings would be rejected if URL didn't normalize", () => {
+    // `/app/renderer-evil` shares the `/app/renderer` prefix as a
+    // string but isn't a child directory. The `+ path.sep` in the
+    // startsWith check is what rejects the false-positive prefix
+    // match. We verify this by asserting that `/app/renderer-evil` is
+    // NOT considered a child of `/app/renderer` — the function's
+    // internal predicate.
+    const sibling = "/app/renderer-evil";
+    expect(sibling.startsWith(ROOT + path.sep)).toBe(false);
+  });
+});

--- a/apps/macos/src/main/app-protocol.test.ts
+++ b/apps/macos/src/main/app-protocol.test.ts
@@ -2,7 +2,10 @@ import path from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { resolveAppProtocolPath } from "./app-protocol";
+import {
+  resolveAppProtocolPath,
+  resolveRelativePath,
+} from "./app-protocol";
 
 // Use posix-style absolute roots in tests so assertions are
 // platform-stable; `app-protocol.ts` uses `node:path` which respects
@@ -11,35 +14,29 @@ const ROOT = "/app/renderer";
 
 describe("resolveAppProtocolPath — allowed paths", () => {
   test("resolves the empty pathname to the root itself", () => {
-    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/");
-    expect(result).toEqual({ kind: "ok", resolved: ROOT });
+    expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/")).toEqual({
+      kind: "ok",
+      resolved: ROOT,
+    });
   });
 
   test("resolves a top-level file inside the root", () => {
-    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/index.html");
-    expect(result).toEqual({
+    expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/index.html")).toEqual({
       kind: "ok",
       resolved: path.join(ROOT, "index.html"),
     });
   });
 
   test("resolves nested asset paths inside the root", () => {
-    const result = resolveAppProtocolPath(
-      ROOT,
-      "app://vellum.ai/assets/app.css",
-    );
-    expect(result).toEqual({
-      kind: "ok",
-      resolved: path.join(ROOT, "assets/app.css"),
-    });
+    expect(
+      resolveAppProtocolPath(ROOT, "app://vellum.ai/assets/app.css"),
+    ).toEqual({ kind: "ok", resolved: path.join(ROOT, "assets/app.css") });
   });
 
   test("strips leading slashes so the join doesn't escape the root", () => {
-    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai///index.html");
-    expect(result).toEqual({
-      kind: "ok",
-      resolved: path.join(ROOT, "index.html"),
-    });
+    expect(
+      resolveAppProtocolPath(ROOT, "app://vellum.ai///index.html"),
+    ).toEqual({ kind: "ok", resolved: path.join(ROOT, "index.html") });
   });
 });
 
@@ -47,64 +44,81 @@ describe("resolveAppProtocolPath — allowed paths", () => {
 // the pathname (RFC 3986 path normalization), so most "traversal-style"
 // inputs never reach `path.normalize` with any `..` left to escape.
 // That's the first line of defense; these tests document its behavior.
-// The `startsWith(rendererRoot + sep)` check in `resolveAppProtocolPath`
-// is defense-in-depth that catches any pathname that did slip past URL
-// normalization — important to keep, even if there's no known case in
-// practice today.
+// The `startsWith(rendererRoot + sep)` check inside `resolveRelativePath`
+// is defense-in-depth — exercised directly below — that catches any
+// pathname that did slip past URL normalization.
 describe("resolveAppProtocolPath — URL parser collapses `..` segments", () => {
   test("literal `..` resolves to a safe in-root path", () => {
-    const result = resolveAppProtocolPath(ROOT, "app://vellum.ai/../etc/passwd");
-    expect(result).toEqual({
-      kind: "ok",
-      resolved: path.join(ROOT, "etc/passwd"),
-    });
+    expect(
+      resolveAppProtocolPath(ROOT, "app://vellum.ai/../etc/passwd"),
+    ).toEqual({ kind: "ok", resolved: path.join(ROOT, "etc/passwd") });
   });
 
   test("deeply nested `..` chains resolve to a safe in-root path", () => {
-    const result = resolveAppProtocolPath(
-      ROOT,
-      "app://vellum.ai/a/b/../../../etc/passwd",
-    );
-    expect(result).toEqual({
-      kind: "ok",
-      resolved: path.join(ROOT, "etc/passwd"),
-    });
+    expect(
+      resolveAppProtocolPath(
+        ROOT,
+        "app://vellum.ai/a/b/../../../etc/passwd",
+      ),
+    ).toEqual({ kind: "ok", resolved: path.join(ROOT, "etc/passwd") });
   });
 
   test("percent-encoded `..` (`%2e%2e`) resolves to a safe in-root path", () => {
-    const result = resolveAppProtocolPath(
-      ROOT,
-      "app://vellum.ai/%2e%2e/etc/passwd",
-    );
-    expect(result).toEqual({
-      kind: "ok",
-      resolved: path.join(ROOT, "etc/passwd"),
+    expect(
+      resolveAppProtocolPath(ROOT, "app://vellum.ai/%2e%2e/etc/passwd"),
+    ).toEqual({ kind: "ok", resolved: path.join(ROOT, "etc/passwd") });
+  });
+});
+
+describe("resolveAppProtocolPath — malformed input handling", () => {
+  test("invalid percent-encoding returns `forbidden` instead of throwing", () => {
+    // `decodeURIComponent("/%ZZ")` throws `URIError`. The wrapper
+    // converts that to a clean 403 so the protocol handler doesn't
+    // surface a 500 to the renderer.
+    expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/%ZZ")).toEqual({
+      kind: "forbidden",
     });
   });
 });
 
-// Direct probe of the defense-in-depth guard. We can't easily smuggle a
-// `..` past URL normalization, but we can bypass URL entirely by
-// constructing a request URL whose pathname is a literal trailing
-// segment, then trusting `path.normalize` to do nothing surprising.
-// These cases pin the contract: if `URL` normalization ever regresses
-// or a future scheme exposes new traversal vectors, this guard fires.
-describe("resolveAppProtocolPath — startsWith guard", () => {
-  test("returns `ok` for the root itself (the `===` exemption)", () => {
-    expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/")).toEqual({
+// Direct probes of `resolveRelativePath` — the pure guard the URL
+// wrapper delegates to. These bypass URL normalization to exercise the
+// `startsWith(rendererRoot + sep)` invariant for real, so a future
+// regression in either the guard or URL normalization is caught here.
+describe("resolveRelativePath — startsWith guard", () => {
+  test("the empty path resolves to the root itself", () => {
+    expect(resolveRelativePath(ROOT, "")).toEqual({
       kind: "ok",
       resolved: ROOT,
     });
   });
 
-  test("ROOT-prefixed siblings would be rejected if URL didn't normalize", () => {
-    // `/app/renderer-evil` shares the `/app/renderer` prefix as a
-    // string but isn't a child directory. The `+ path.sep` in the
-    // startsWith check is what rejects the false-positive prefix
-    // match. We verify this by asserting that `/app/renderer-evil` is
-    // NOT considered a child of `/app/renderer` — the function's
-    // internal predicate.
-    const sibling = "/app/renderer-evil";
-    expect(sibling.startsWith(ROOT + path.sep)).toBe(false);
+  test("nested in-root paths pass", () => {
+    expect(resolveRelativePath(ROOT, "assets/app.css")).toEqual({
+      kind: "ok",
+      resolved: path.join(ROOT, "assets/app.css"),
+    });
+  });
+
+  test("`..` segments surviving normalization are rejected", () => {
+    expect(resolveRelativePath(ROOT, "../etc/passwd")).toEqual({
+      kind: "forbidden",
+    });
+  });
+
+  test("deeply nested `..` that escape the root are rejected", () => {
+    expect(resolveRelativePath(ROOT, "a/../../etc/passwd")).toEqual({
+      kind: "forbidden",
+    });
+  });
+
+  test("ROOT-prefixed siblings are rejected (the `+ sep` is what protects)", () => {
+    // `path.join("/app/renderer", "../renderer-evil/x")` →
+    // `/app/renderer-evil/x`. That string starts with the literal
+    // `/app/renderer` prefix but is a sibling, not a child. Adding
+    // `+ path.sep` to the prefix is what keeps this out.
+    expect(resolveRelativePath(ROOT, "../renderer-evil/x")).toEqual({
+      kind: "forbidden",
+    });
   });
 });

--- a/apps/macos/src/main/app-protocol.ts
+++ b/apps/macos/src/main/app-protocol.ts
@@ -10,27 +10,38 @@ import path from "node:path";
  * (which evaluates the full lifecycle wiring at module load) just to
  * exercise URL parsing. Pure: no Electron, no filesystem, no I/O.
  *
- * Rules:
+ * Implementation is split in two so the guard itself is directly
+ * testable:
  *
- * - URL pathname is `decodeURIComponent`-ed once so `%2e%2e` -style
- *   bypasses get unescaped before normalization sees them.
- * - Leading slashes on the pathname are stripped so `path.join` doesn't
- *   treat the path as absolute and discard `rendererRoot`.
- * - After joining + normalizing, the resolved path must be exactly
- *   `rendererRoot` or sit inside it (`rendererRoot + sep`-prefixed).
- *   Anything else — `..` climbs, absolute-style overrides, sibling
+ *   - `resolveAppProtocolPath` is the public entry point. It parses
+ *     the URL, decodes the pathname, and delegates to
+ *     `resolveRelativePath` for the actual guard. Malformed
+ *     percent-encoding (e.g. `%ZZ`) throws `URIError` out of
+ *     `decodeURIComponent`; we catch and convert to `forbidden` so
+ *     `protocol.handle` returns a clean 403 instead of a 500.
+ *
+ *   - `resolveRelativePath` is the predicate the URL-agnostic guard
+ *     is built from. Exported so tests can probe the
+ *     `startsWith(rendererRoot + sep)` invariant directly with
+ *     synthetic inputs (e.g. `../renderer-evil/x`) the URL parser
+ *     would otherwise normalize away.
+ *
+ * Rules `resolveRelativePath` enforces:
+ *
+ * - The relative path is joined onto `rendererRoot` and normalized.
+ * - The resolved path must be exactly `rendererRoot` or sit inside it
+ *   (`rendererRoot + sep`-prefixed). Anything else — `..` climbs
+ *   surviving normalization, absolute-path overrides, sibling
  *   directories — returns `forbidden`.
  */
 export type ResolveResult =
   | { kind: "ok"; resolved: string }
   | { kind: "forbidden" };
 
-export const resolveAppProtocolPath = (
+export const resolveRelativePath = (
   rendererRoot: string,
-  requestUrl: string,
+  relativePath: string,
 ): ResolveResult => {
-  const url = new URL(requestUrl);
-  const relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
   const resolved = path.normalize(path.join(rendererRoot, relativePath));
   const rendererRootWithSep = rendererRoot + path.sep;
   if (
@@ -40,4 +51,21 @@ export const resolveAppProtocolPath = (
     return { kind: "forbidden" };
   }
   return { kind: "ok", resolved };
+};
+
+export const resolveAppProtocolPath = (
+  rendererRoot: string,
+  requestUrl: string,
+): ResolveResult => {
+  const url = new URL(requestUrl);
+  let relativePath: string;
+  try {
+    relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+  } catch {
+    // Malformed percent-encoding (e.g. `%ZZ`) throws `URIError`.
+    // Convert to `forbidden` so the protocol handler returns a clean
+    // 403 instead of a 500 from an uncaught error.
+    return { kind: "forbidden" };
+  }
+  return resolveRelativePath(rendererRoot, relativePath);
 };

--- a/apps/macos/src/main/app-protocol.ts
+++ b/apps/macos/src/main/app-protocol.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+
+/**
+ * Path-traversal guard for the `app://` protocol handler. Given the
+ * renderer-root directory and a request URL, returns either the
+ * normalized absolute path to serve, or a sentinel telling the caller
+ * to respond with 403.
+ *
+ * Lives in its own file so tests don't have to import `src/main/index.ts`
+ * (which evaluates the full lifecycle wiring at module load) just to
+ * exercise URL parsing. Pure: no Electron, no filesystem, no I/O.
+ *
+ * Rules:
+ *
+ * - URL pathname is `decodeURIComponent`-ed once so `%2e%2e` -style
+ *   bypasses get unescaped before normalization sees them.
+ * - Leading slashes on the pathname are stripped so `path.join` doesn't
+ *   treat the path as absolute and discard `rendererRoot`.
+ * - After joining + normalizing, the resolved path must be exactly
+ *   `rendererRoot` or sit inside it (`rendererRoot + sep`-prefixed).
+ *   Anything else — `..` climbs, absolute-style overrides, sibling
+ *   directories — returns `forbidden`.
+ */
+export type ResolveResult =
+  | { kind: "ok"; resolved: string }
+  | { kind: "forbidden" };
+
+export const resolveAppProtocolPath = (
+  rendererRoot: string,
+  requestUrl: string,
+): ResolveResult => {
+  const url = new URL(requestUrl);
+  const relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+  const resolved = path.normalize(path.join(rendererRoot, relativePath));
+  const rendererRootWithSep = rendererRoot + path.sep;
+  if (
+    resolved !== rendererRoot &&
+    !resolved.startsWith(rendererRootWithSep)
+  ) {
+    return { kind: "forbidden" };
+  }
+  return { kind: "ok", resolved };
+};

--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -23,7 +23,7 @@ export type VellumCommandKind = VellumCommand["kind"];
  *
  * Populated lazily at menu-build time by merging with `settings.hotkeys`
  * (rather than via the electron-store schema `default` block, which would
- * clobber user overrides on schema migration — see LUM-1962).
+ * clobber user overrides on schema migration).
  */
 export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   newConversation: "CmdOrCtrl+N",
@@ -53,7 +53,7 @@ export const resolveAccelerator = (kind: VellumCommandKind): string => {
  * back to the first window if none is focused (which happens when a menu
  * item is clicked from the menu bar while the app is in the background but
  * its window isn't the OS focus owner). Capturing a window reference at
- * menu-construction time would break thread pop-outs (LUM-1870) where the
+ * menu-construction time would break future thread pop-outs, where the
  * user expects Cmd+N to operate on the popped-out window they're in.
  */
 export const dispatchToFocused = (command: VellumCommand): void => {

--- a/apps/macos/src/main/dock.test.ts
+++ b/apps/macos/src/main/dock.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import { computePolicy, formatBadge } from "./dock";
+
+describe("formatBadge", () => {
+  test("returns empty string for zero", () => {
+    expect(formatBadge(0)).toBe("");
+  });
+
+  test("returns empty string for negatives", () => {
+    expect(formatBadge(-1)).toBe("");
+    expect(formatBadge(-99)).toBe("");
+  });
+
+  test("returns empty string for NaN and ±Infinity", () => {
+    expect(formatBadge(Number.NaN)).toBe("");
+    expect(formatBadge(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatBadge(Number.NEGATIVE_INFINITY)).toBe("");
+  });
+
+  test("passes through 1..99", () => {
+    expect(formatBadge(1)).toBe("1");
+    expect(formatBadge(42)).toBe("42");
+    expect(formatBadge(99)).toBe("99");
+  });
+
+  test("truncates anything beyond 99 to \"99+\"", () => {
+    expect(formatBadge(100)).toBe("99+");
+    expect(formatBadge(1_000_000)).toBe("99+");
+  });
+
+  test("floors fractional counts in the 1..99 range", () => {
+    expect(formatBadge(2.9)).toBe("2");
+    expect(formatBadge(98.7)).toBe("98");
+  });
+
+  test("anything strictly greater than 99 truncates to \"99+\" before flooring", () => {
+    // 99.0001 fails the `count > 99` check and bypasses `Math.floor`,
+    // landing on `"99+"`. This is intentional — Swift Vellum caps at 99
+    // and matching its cap avoids visual jitter at the boundary.
+    expect(formatBadge(99.0001)).toBe("99+");
+    expect(formatBadge(99.9)).toBe("99+");
+  });
+});
+
+describe("computePolicy", () => {
+  test("regular while any window is visible (signed out, gate off)", () => {
+    expect(computePolicy(1, false, false)).toBe("regular");
+    expect(computePolicy(3, false, false)).toBe("regular");
+  });
+
+  test("regular while signed in even with no visible windows", () => {
+    expect(computePolicy(0, true, false)).toBe("regular");
+    expect(computePolicy(0, true, true)).toBe("regular");
+  });
+
+  test("regular when signed out + no windows AND accessory gate off", () => {
+    expect(computePolicy(0, false, false)).toBe("regular");
+  });
+
+  test("accessory only when signed out + no windows + gate on", () => {
+    expect(computePolicy(0, false, true)).toBe("accessory");
+  });
+
+  test("visible windows override every other signal", () => {
+    expect(computePolicy(2, false, true)).toBe("regular");
+    expect(computePolicy(1, true, true)).toBe("regular");
+  });
+});

--- a/apps/macos/src/main/dock.ts
+++ b/apps/macos/src/main/dock.ts
@@ -37,7 +37,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 // `> 999 → "999+"` is what we'd want if we ever exposed a triple-digit
 // counter, but macOS truncates very long strings and Swift caps at 99
 // today; we match Swift.
-const formatBadge = (count: number): string => {
+export const formatBadge = (count: number): string => {
   if (!Number.isFinite(count) || count <= 0) return "";
   if (count > 99) return "99+";
   return String(Math.floor(count));
@@ -68,10 +68,19 @@ let refreshTimer: NodeJS.Timeout | null = null;
 const visibleWindowCount = (): number =>
   BrowserWindow.getAllWindows().filter((win) => !win.isDestroyed()).length;
 
-const computePolicy = (): DockState["policy"] => {
-  if (visibleWindowCount() > 0) return "regular";
-  if (state.signedIn) return "regular";
-  return ALLOW_ACCESSORY_MODE ? "accessory" : "regular";
+// Pure function of (visible window count, signed-in flag, accessory-mode
+// gate). Factored out of the caller so tests can exercise the matrix
+// without standing up a full Electron `BrowserWindow` registry — the
+// caller passes `visibleWindowCount()` + `state.signedIn` +
+// `ALLOW_ACCESSORY_MODE` at the seam.
+export const computePolicy = (
+  visibleWindows: number,
+  signedIn: boolean,
+  allowAccessoryMode: boolean,
+): DockState["policy"] => {
+  if (visibleWindows > 0) return "regular";
+  if (signedIn) return "regular";
+  return allowAccessoryMode ? "accessory" : "regular";
 };
 
 // `app.dock.show()` returns a Promise that resolves once the Dock has
@@ -96,7 +105,9 @@ const scheduleRefresh = (): void => {
   if (refreshTimer) clearTimeout(refreshTimer);
   refreshTimer = setTimeout(() => {
     refreshTimer = null;
-    void applyPolicy(computePolicy());
+    void applyPolicy(
+      computePolicy(visibleWindowCount(), state.signedIn, ALLOW_ACCESSORY_MODE),
+    );
   }, POLICY_DEBOUNCE_MS);
 };
 
@@ -165,6 +176,8 @@ export const installDock = (): void => {
   // fire-and-forget — its `dock.show()` Promise just sequences the
   // following `setActivationPolicy` call inside `applyPolicy`; the
   // caller has nothing to await on.
-  void applyPolicy(computePolicy());
+  void applyPolicy(
+    computePolicy(visibleWindowCount(), state.signedIn, ALLOW_ACCESSORY_MODE),
+  );
   applyBadge();
 };

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -50,9 +50,9 @@ const DEV_SERVER_ORIGIN = new URL(DEV_SERVER_URL).origin;
 // binary is `node_modules/electron/dist/Electron.app`, so the Dock
 // says "Electron". That's cosmetic and acceptable for dev runs; the
 // userData split is what actually prevents collision with Swift
-// installs. Packaged builds get a real `productName` via
-// electron-builder (LUM-1987), which writes CFBundleName, at which
-// point Dock / Cmd-Tab pick up the real name too.
+// installs. Packaged builds get a real `productName` from
+// electron-builder, which writes `CFBundleName`, at which point
+// Dock / Cmd-Tab pick up the real name too.
 //
 // Gated on `!app.isPackaged` so a packaged build keeps its
 // electron-builder-derived `CFBundleName` instead of being overridden

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -4,10 +4,11 @@ import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
+import { resolveAppProtocolPath } from "./app-protocol";
+import { installDock } from "./dock";
 import { installApplicationMenu } from "./menu";
 import { readSetting, writeSetting } from "./settings";
 import { restoreBounds, track as trackWindowState } from "./window-state";
-import { installDock } from "./dock";
 
 // Dev-mode renderer URL. Honors `VELLUM_DEV_URL` so the launcher can
 // point the BrowserWindow at whichever Vite-or-equivalent is actually
@@ -171,16 +172,14 @@ const registerAppProtocol = (): void => {
   // is built into an .asar/Resources/app/ tree, apps/web/dist/ is copied to
   // ../renderer relative to the main process bundle.
   const rendererRoot = path.join(__dirname, "../renderer");
-  const rendererRootWithSep = rendererRoot + path.sep;
   const indexHtml = path.join(rendererRoot, "index.html");
 
   protocol.handle(APP_PROTOCOL, async (request) => {
-    const url = new URL(request.url);
-    const relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
-    const resolved = path.normalize(path.join(rendererRoot, relativePath));
-    if (resolved !== rendererRoot && !resolved.startsWith(rendererRootWithSep)) {
+    const result = resolveAppProtocolPath(rendererRoot, request.url);
+    if (result.kind === "forbidden") {
       return new Response("Forbidden", { status: 403 });
     }
+    const { resolved } = result;
     if (await fileExists(resolved)) {
       return net.fetch(pathToFileURL(resolved).toString());
     }

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -3,7 +3,7 @@ import Store, { type Schema } from "electron-store";
 /**
  * Persisted user preferences shape. The schema below validates writes; reads
  * are returned as `null` when a key has never been written and no default
- * applies. Top-level keys are the renderer-facing categories from LUM-1846 —
+ * applies. Top-level keys are the renderer-facing categories;
  * additional categories get added here as future tickets need them, with a
  * matching schema entry to keep validation honest.
  *

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type SavedState = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  isFullScreen: boolean;
+};
+
+let savedWindows: Record<string, SavedState> = {};
+let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+
+// Mock `electron-store` so `restoreBounds` reads from `savedWindows`
+// without touching disk. The store wrapper in `window-state.ts` uses the
+// default export, so the mock returns a class.
+mock.module("electron-store", () => ({
+  default: class {
+    get(_key: string, _fallback: { windows: Record<string, SavedState> }) {
+      return savedWindows;
+    }
+    set() {
+      // no-op
+    }
+  },
+}));
+
+// Override the `screen` surface from `test-setup.ts` so each test can
+// shape the work-area to its scenario.
+mock.module("electron", () => ({
+  BrowserWindow: class {},
+  screen: {
+    getDisplayMatching: () => ({ workArea }),
+  },
+}));
+
+const { restoreBounds } = await import("./window-state");
+
+const DEFAULTS = { width: 800, height: 600 };
+
+beforeEach(() => {
+  savedWindows = {};
+  workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+});
+
+afterEach(() => {
+  savedWindows = {};
+});
+
+describe("restoreBounds", () => {
+  test("returns the supplied defaults when no state has been persisted", () => {
+    expect(restoreBounds("main", DEFAULTS)).toEqual(DEFAULTS);
+  });
+
+  test("returns the saved rectangle when it fits inside the work area", () => {
+    savedWindows.main = {
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 700,
+      isFullScreen: false,
+    };
+    expect(restoreBounds("main", DEFAULTS)).toEqual({
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 700,
+      fullscreen: false,
+    });
+  });
+
+  test("clamps width and height to the work area when the display shrunk", () => {
+    workArea = { x: 0, y: 0, width: 800, height: 600 };
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 1600,
+      height: 1200,
+      isFullScreen: false,
+    };
+    const result = restoreBounds("main", DEFAULTS);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(600);
+  });
+
+  test("clamps x and y into the work area when the window was off-screen", () => {
+    workArea = { x: 0, y: 0, width: 1024, height: 768 };
+    savedWindows.main = {
+      x: 5000,
+      y: 5000,
+      width: 400,
+      height: 300,
+      isFullScreen: false,
+    };
+    const result = restoreBounds("main", DEFAULTS);
+    expect(result.x).toBe(1024 - 400);
+    expect(result.y).toBe(768 - 300);
+  });
+
+  test("clamps negative origins into the work area's top-left", () => {
+    savedWindows.main = {
+      x: -500,
+      y: -500,
+      width: 400,
+      height: 300,
+      isFullScreen: false,
+    };
+    const result = restoreBounds("main", DEFAULTS);
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+
+  test("respects non-zero work-area origins (external monitor offset)", () => {
+    workArea = { x: 1920, y: 0, width: 1920, height: 1080 };
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+      isFullScreen: false,
+    };
+    const result = restoreBounds("main", DEFAULTS);
+    expect(result.x).toBe(1920);
+    expect(result.y).toBe(0);
+  });
+
+  test("forwards the fullscreen flag when saved", () => {
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+      isFullScreen: true,
+    };
+    expect(restoreBounds("main", DEFAULTS).fullscreen).toBe(true);
+  });
+
+  test("namespaces by key so windows don't clobber each other", () => {
+    savedWindows.main = {
+      x: 10,
+      y: 20,
+      width: 800,
+      height: 600,
+      isFullScreen: false,
+    };
+    savedWindows["thread.abc"] = {
+      x: 500,
+      y: 500,
+      width: 400,
+      height: 300,
+      isFullScreen: false,
+    };
+    expect(restoreBounds("main", DEFAULTS).x).toBe(10);
+    expect(restoreBounds("thread.abc", DEFAULTS).x).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

Fills out the unit tests the scaffolding PR (#32588) was built for. Each sub-change lands the smallest refactor needed to make the target function testable in isolation, plus the test file itself.

During review, vex-assistant-bot also caught a real production bug in the `app://` protocol handler and a fake-guard-test smell in my first version of the path-traversal coverage. Both are fixed here. The audit also surfaced four pre-existing internal-tracker references in `apps/macos/src/main/` comments, scrubbed in the same PR per the open-source-friendly-docs convention.

## What's in this PR

### 1) `dock.ts` — `formatBadge` + `computePolicy`

- **Export `formatBadge`** (no behavior change, was module-private).
- **Refactor `computePolicy`** to take `(visibleWindows, signedIn, allowAccessoryMode)` as arguments and export it. Internal callers pass `visibleWindowCount() / state.signedIn / ALLOW_ACCESSORY_MODE` at the seam. Lets tests exercise the policy matrix without standing up a `BrowserWindow` registry.
- **`dock.test.ts`**: badge cases (zero, negatives, NaN/Infinity, 1-99 pass-through, `>99 → "99+"` truncation, fractional flooring, the strict-`>` boundary) + the full `computePolicy` matrix.

### 2) `window-state.test.ts`

Mocks `electron-store` (the default-export class) and re-mocks `screen.getDisplayMatching` per-test so each clamping scenario gets its own work-area. Covers:

- Default fallback when no state is persisted.
- In-bounds passthrough.
- Shrunken display (width/height clamp).
- Off-screen origin (x/y clamped to right/bottom edge).
- Negative origin (clamped to work-area top-left).
- Non-zero work-area origin (external monitor offset preserved).
- Fullscreen flag forwarded.
- Key namespacing (windows don't clobber each other).

### 3) `app-protocol.ts` — extracted path resolver + tests + production bug fix

- **New file `app-protocol.ts`** — pure helper with a two-layer shape:
  - `resolveRelativePath(rendererRoot, relativePath)` — pure file-system guard, exported separately so the `startsWith(rendererRoot + sep)` invariant is testable in isolation with synthetic inputs.
  - `resolveAppProtocolPath(rendererRoot, requestUrl)` — URL parsing + decode + delegates to the guard, with `try/catch` around `decodeURIComponent`.
- **`index.ts`**: `registerAppProtocol` delegates to the helper. Lifecycle and signature unchanged.
- **`app-protocol.test.ts`**: allowed paths + URL-parser-handles-`..` documentation + direct probe of the guard with adversarial relative paths.

## Bugs and assumption-corrections this PR surfaced

### 🐛 Production bug — malformed percent-encoding → 500 (fixed)

The previous `protocol.handle` callback called `decodeURIComponent(url.pathname)` unguarded. Inputs like `app://vellum.ai/%ZZ` throw `URIError`, which leaked from the promise and surfaced to the renderer as a 500-ish failure instead of the documented 403. Fixed by wrapping `decodeURIComponent` in `try/catch` in `resolveAppProtocolPath`; malformed input now returns `{ kind: "forbidden" }` and the protocol handler stays on contract. Test pins the new behavior:

```ts
expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/%ZZ")).toEqual({ kind: "forbidden" });
```

### 🔍 Assumption correction — `startsWith` guard isn't doing what I assumed (documented, not "fixed")

While writing the traversal tests I discovered the WHATWG `URL` parser collapses `..` and `%2e%2e` segments during RFC 3986 path normalization, so by the time `path.normalize` runs there's nothing to escape with. The `startsWith(rendererRoot + sep)` guard in production rejects nothing in practice today — URL parsing is the real first line of defense. The guard stays as defense-in-depth (URL normalization could regress, future schemes could expose new vectors), but the tests now document this honestly rather than asserting fake confidence in attacks URL has already neutralized:

```ts
test("literal `..` resolves to a safe in-root path (URL parser collapses it)", () => {
  // not "forbidden" — URL ate the `..` at parse time
  expect(resolveAppProtocolPath(ROOT, "app://vellum.ai/../etc/passwd")).toEqual({
    kind: "ok",
    resolved: path.join(ROOT, "etc/passwd"),
  });
});
```

The pure `resolveRelativePath` is then exercised with synthetic inputs that bypass URL normalization (`../etc/passwd`, `../renderer-evil/x`) so the guard is verified for real.

### 🧪 Self-caught test bug — fake guard assertion

The first version of the traversal test asserted on a local string constant (`"/app/renderer-evil".startsWith(ROOT + path.sep)`) and never called the SUT. Caught in review by vex-assistant-bot. The fix was the two-layer split of `app-protocol.ts` above; the guard is now exercised by code that actually runs through `resolveRelativePath`.

### 📝 Pre-existing doc-convention scrub — internal-tracker refs

Four `LUM-` references in `apps/macos/src/main/` comments, surfaced during the audit. The open-source-friendly-docs convention prohibits internal-tracker pointers in code comments. Fixed in this PR rather than deferred, per "fix when you touch" + the consolidated cleanup:

- `index.ts:54` — `(LUM-1987)` parenthetical removed from the packaging comment.
- `settings.ts:6` — "from LUM-1846" dropped; sentence still identifies the keys as renderer-facing categories.
- `commands.ts:26` — "see LUM-1962" dropped from `DEFAULT_ACCELERATORS` JSDoc; the merge-vs-`default`-block rationale stays in plain English.
- `commands.ts:56` — "thread pop-outs (LUM-1870)" → "future thread pop-outs." Constraint named, tracker not.

## Test plan

- [x] `bun --cwd apps/macos run typecheck` — green.
- [x] `bun --cwd apps/macos run test:ci` — 4 test files, all green.
- [x] `bun --cwd apps/macos run build` — main + preload bundles build cleanly.
- [x] `grep -rE "LUM-[0-9]+" apps/macos/src apps/macos/scripts` returns nothing.
- [x] CI's "Unit Tests" job runs the full suite (6/6 green).

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe