### PR TITLE
refactor(skills): remove dead workspace skill source code

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -235,7 +235,7 @@ describe("buildSkillMarkdown", () => {
       "---\nname: 'path\\\\name'\ndescription: 'has \\n in it'\n---\n\nBody.\n",
     );
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     const skill = catalog.find((s) => s.id === "single-quote-test");
     expect(skill).toBeDefined();
     // Backslashes should be preserved literally, not interpreted as escape sequences
@@ -345,7 +345,7 @@ describe("createManagedSkill", () => {
 
     expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     const skill = catalog.find((s) => s.id === "discovered-skill");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Discovered");
@@ -456,7 +456,7 @@ describe("deleteManagedSkill", () => {
     expect(result.deleted).toBe(true);
     expect(existsSync(join(TEST_DIR, "skills", "to-delete"))).toBe(false);
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     expect(catalog.find((s) => s.id === "to-delete")).toBeUndefined();
   });
 
@@ -494,7 +494,7 @@ describe("deleteManagedSkill", () => {
     expect(indexContent).toContain("- keep-index");
     expect(indexContent).toContain("- survivor");
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     expect(catalog.find((s) => s.id === "keep-index")).toBeUndefined();
   });
 
@@ -683,7 +683,7 @@ describe("YAML metadata round-trip", () => {
     });
 
     // Load it back via loadSkillCatalog
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     const skill = catalog.find((s) => s.id === "yaml-roundtrip-all");
     expect(skill).toBeDefined();
 
@@ -722,7 +722,7 @@ describe("YAML metadata round-trip", () => {
       ].join("\n"),
     );
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog([join(TEST_DIR, "skills")]);
     const skill = catalog.find((s) => s.id === "yaml-nested-test");
     expect(skill).toBeDefined();
 

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -256,7 +256,7 @@ describe("skill_load inline command expansion", () => {
   // We verify the rejection logic exists by importing the tool class directly
   // and confirming the code path rejects extra sources when inline commands
   // are present. The actual source-level guard is tested by checking that
-  // workspace-source skills *do* expand (above) while the code explicitly
+  // managed-source skills *do* expand (above) while the code explicitly
   // gates on INLINE_COMMAND_ELIGIBLE_SOURCES which excludes "extra".
 
   describe("extra source rejection (code-level verification)", () => {
@@ -274,10 +274,10 @@ describe("skill_load inline command expansion", () => {
         ),
         "utf-8",
       );
-      // The eligible sources set must include bundled, managed, workspace but NOT extra
+      // The eligible sources set must include bundled and managed but NOT extra
       expect(loadSrc).toContain('"bundled"');
       expect(loadSrc).toContain('"managed"');
-      expect(loadSrc).toContain('"workspace"');
+      expect(loadSrc).not.toContain('"workspace"');
       expect(loadSrc).toContain('skill.source === "extra"');
     });
   });

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -316,7 +316,7 @@ function installedSkill(id: string, directoryPath: string) {
       description: id,
       directoryPath,
       skillFilePath: join(directoryPath, "SKILL.md"),
-      source: "workspace" as const,
+      source: "managed" as const,
     },
     state: "enabled" as const,
   };

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -246,7 +246,7 @@ function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
     skillFilePath:
       overrides.skillFilePath ??
       join(overrides.directoryPath ?? "/tmp/nonexistent-skill-dir", "SKILL.md"),
-    source: overrides.source ?? "workspace",
+    source: overrides.source ?? "managed",
     bundled: overrides.bundled,
     icon: overrides.icon,
     emoji: overrides.emoji,
@@ -389,7 +389,7 @@ describe("getSkillFiles — provider chain fallback", () => {
             displayName: "Installed Skill",
             description: "A pre-installed skill",
             directoryPath: installedDir,
-            source: "workspace",
+            source: "managed",
           }),
           state: "enabled",
         },
@@ -428,7 +428,7 @@ describe("getSkillFiles — provider chain fallback", () => {
           displayName: "Ghost Installed",
           description: "Installed in resolver but directory is gone",
           directoryPath: "/tmp/definitely-does-not-exist-" + Date.now(),
-          source: "workspace",
+          source: "managed",
         }),
         state: "enabled",
       },

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -7,7 +7,6 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -34,8 +33,7 @@ mock.module("../util/logger.js", () => ({
   pruneOldLogFiles: () => 0,
 }));
 
-const { loadSkillCatalog, loadSkillBySelector, resolveSkillSelector } =
-  await import("../config/skills.js");
+const { loadSkillCatalog } = await import("../config/skills.js");
 
 /** Return only user-installed skills (filters out bundled skills that ship with the source tree). */
 function loadUserSkillCatalog() {
@@ -152,103 +150,6 @@ describe("skills catalog loading", () => {
 
     const catalog = loadUserSkillCatalog();
     expect(catalog).toHaveLength(0);
-  });
-});
-
-describe("workspace skills", () => {
-  const WORKSPACE_DIR = join(
-    tmpdir(),
-    `vellum-workspace-test-${crypto.randomUUID()}`,
-  );
-  const workspaceSkillsDir = join(WORKSPACE_DIR, ".vellum", "skills");
-
-  function writeWorkspaceSkill(
-    skillId: string,
-    name: string,
-    description: string,
-    body: string = "Workspace skill body",
-  ): void {
-    const skillDir = join(workspaceSkillsDir, skillId);
-    mkdirSync(skillDir, { recursive: true });
-    writeFileSync(
-      join(skillDir, "SKILL.md"),
-      `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
-    );
-  }
-
-  beforeEach(() => {
-    mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
-    mkdirSync(workspaceSkillsDir, { recursive: true });
-  });
-
-  afterEach(() => {
-    const skillsDir = join(TEST_DIR, "skills");
-    if (existsSync(skillsDir))
-      rmSync(skillsDir, { recursive: true, force: true });
-    const outsideDir = join(TEST_DIR, "outside");
-    if (existsSync(outsideDir))
-      rmSync(outsideDir, { recursive: true, force: true });
-    if (existsSync(WORKSPACE_DIR)) {
-      rmSync(WORKSPACE_DIR, { recursive: true, force: true });
-    }
-  });
-
-  test("workspace skills appear in catalog when workspaceSkillsDir is provided", () => {
-    writeWorkspaceSkill("ws-skill", "Workspace Skill", "A workspace skill");
-
-    const catalog = loadSkillCatalog(workspaceSkillsDir);
-    const wsSkills = catalog.filter((s) => s.source === "workspace");
-    expect(wsSkills).toHaveLength(1);
-    expect(wsSkills[0].id).toBe("ws-skill");
-  });
-
-  test("resolveSkillSelector finds workspace skills when workspaceSkillsDir is provided", () => {
-    writeWorkspaceSkill(
-      "ws-resolve",
-      "Workspace Resolve",
-      "Resolvable workspace skill",
-    );
-
-    const result = resolveSkillSelector("ws-resolve", workspaceSkillsDir);
-    expect(result.skill).toBeDefined();
-    expect(result.skill!.id).toBe("ws-resolve");
-    expect(result.skill!.source).toBe("workspace");
-  });
-
-  test("resolveSkillSelector does not find workspace skills without workspaceSkillsDir", () => {
-    writeWorkspaceSkill("ws-hidden", "Hidden Workspace", "Should not be found");
-
-    const result = resolveSkillSelector("ws-hidden");
-    expect(result.skill).toBeUndefined();
-    expect(result.error).toBeDefined();
-  });
-
-  test("loadSkillBySelector loads workspace skill body without isOutsideSkillsRoot rejection", () => {
-    writeWorkspaceSkill(
-      "ws-load",
-      "Loadable Workspace",
-      "Can be loaded",
-      "Full workspace body here",
-    );
-
-    const result = loadSkillBySelector("ws-load", workspaceSkillsDir);
-    expect(result.error).toBeUndefined();
-    expect(result.skill).toBeDefined();
-    expect(result.skill!.id).toBe("ws-load");
-    expect(result.skill!.body).toBe("Full workspace body here");
-    expect(result.skill!.source).toBe("workspace");
-  });
-
-  test("workspace skill overrides managed skill with the same id", () => {
-    writeSkill("shared-id", "Managed Shared", "Managed version");
-    writeWorkspaceSkill("shared-id", "Workspace Shared", "Workspace version");
-
-    const skill = loadSkillCatalog(workspaceSkillsDir).find(
-      (s) => s.id === "shared-id",
-    );
-    expect(skill).toBeDefined();
-    expect(skill!.source).toBe("workspace");
-    expect(skill!.name).toBe("Workspace Shared");
   });
 });
 

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -55,7 +55,7 @@ export function resolveSkillStates(
       isEnabled = entry.enabled;
     } else {
       // Default: bundled, managed (user-installed), and plugin-contributed
-      // skills are enabled. Others (workspace, extra) are disabled by default.
+      // skills are enabled. Extra skills are disabled by default.
       isEnabled =
         skill.source === "bundled" ||
         skill.source === "managed" ||

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -62,19 +62,13 @@ const SkillMetadataSchema = z
  *
  * - `bundled`: ships inside the assistant binary under `bundled-skills/`.
  * - `managed`: installed into `~/.vellum/workspace/skills/` from our catalog.
- * - `workspace`: user-authored skill living in a conversation's working dir.
  * - `extra`: third-party directory roots passed via `loadSkillCatalog`'s
  *   `extraDirs` argument (primarily for tests).
  * - `plugin`: contributed at runtime by a loaded plugin via
  *   `PluginSkillRegistration`. Body is held in-memory by
  *   `plugins/plugin-skill-contributions.ts`, not on disk.
  */
-export type SkillSource =
-  | "bundled"
-  | "managed"
-  | "workspace"
-  | "extra"
-  | "plugin";
+export type SkillSource = "bundled" | "managed" | "extra" | "plugin";
 
 // ─── Core interfaces ─────────────────────────────────────────────────────────
 
@@ -660,10 +654,7 @@ function skillSummaryFromDefinition(
   };
 }
 
-export function loadSkillCatalog(
-  workspaceSkillsDir?: string,
-  extraDirs?: string[],
-): SkillSummary[] {
+export function loadSkillCatalog(extraDirs?: string[]): SkillSummary[] {
   const catalog: SkillSummary[] = [];
   const seenIds = new Set<string>();
 
@@ -743,8 +734,8 @@ export function loadSkillCatalog(
   }
 
   // Load plugin-contributed skills. They sit above bundled/extra but below
-  // managed and workspace so that user-authored filesystem skills can
-  // override a plugin-provided skill by declaring the same id under
+  // managed so that user-authored filesystem skills can override a
+  // plugin-provided skill by declaring the same id under
   // `~/.vellum/workspace/skills/`. Registration is owned by the plugin
   // bootstrap — this call is a pure read against the in-memory registry.
   const pluginSkills = getPluginContributedSkillSummaries();
@@ -783,9 +774,8 @@ export function loadSkillCatalog(
 
     if (seenIds.has(skill.id)) {
       // If the existing entry is bundled, extra, or plugin-contributed, the
-      // user skill overrides it. Only another `managed` or `workspace` entry
-      // (already at or above managed precedence) is treated as a true
-      // duplicate.
+      // user skill overrides it. Only another `managed` entry (already at
+      // managed precedence) is treated as a true duplicate.
       const existingIndex = catalog.findIndex((s) => s.id === skill.id);
       if (
         existingIndex !== -1 &&
@@ -810,62 +800,6 @@ export function loadSkillCatalog(
 
     seenIds.add(skill.id);
     catalog.push(skillSummaryFromDefinition(skill, "managed"));
-  }
-
-  // Load workspace skills with highest precedence
-  if (workspaceSkillsDir && existsSync(workspaceSkillsDir)) {
-    const workspaceDirs = discoverSkillDirectories(workspaceSkillsDir);
-
-    for (const directory of workspaceDirs) {
-      const skillFilePath = join(directory, "SKILL.md");
-      if (!existsSync(skillFilePath)) continue;
-
-      try {
-        const stat = statSync(skillFilePath);
-        if (!stat.isFile()) continue;
-
-        const content = readFileSync(skillFilePath, "utf-8");
-        const parsed = parseFrontmatter(content, skillFilePath);
-        if (!parsed) continue;
-
-        const id = basename(directory);
-        const workspaceSkill: SkillSummary = {
-          id,
-          name: parsed.name,
-          displayName: parsed.displayName ?? parsed.name,
-          description: parsed.description,
-          directoryPath: directory,
-          skillFilePath,
-          emoji: parsed.emoji,
-
-          source: "workspace",
-          toolManifest: detectToolManifest(directory),
-          includes: parsed.includes,
-          featureFlag: parsed.featureFlag,
-          activationHints: parsed.activationHints,
-          avoidWhen: parsed.avoidWhen,
-          inlineCommandExpansions: parsed.inlineCommandExpansions,
-        };
-
-        if (seenIds.has(id)) {
-          // Workspace skills override any existing skill
-          const existingIndex = catalog.findIndex((s) => s.id === id);
-          if (existingIndex !== -1) {
-            log.info(
-              { id, directory },
-              "Workspace skill overrides existing skill",
-            );
-            catalog[existingIndex] = workspaceSkill;
-            continue;
-          }
-        }
-
-        seenIds.add(id);
-        catalog.push(workspaceSkill);
-      } catch (err) {
-        log.warn({ err, directory }, "Failed to read workspace skill");
-      }
-    }
   }
 
   return catalog;
@@ -1011,14 +945,6 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   let loaded: SkillDefinition | null;
   if (skill.bundled) {
     loaded = readBundledSkillFromDirectory(skill.directoryPath);
-  } else if (skill.source === "workspace") {
-    // Workspace skills live outside ~/.vellum/workspace/skills, so use their parent
-    // directory as the root to avoid the isOutsideSkillsRoot rejection.
-    loaded = readSkillFromDirectory(
-      skill.directoryPath,
-      dirname(skill.directoryPath),
-      skill.source,
-    );
   } else {
     loaded = readSkillFromDirectory(
       skill.directoryPath,
@@ -1056,10 +982,7 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   return { skill: loaded };
 }
 
-export function resolveSkillSelector(
-  selector: string,
-  workspaceSkillsDir?: string,
-): SkillSelectorResult {
+export function resolveSkillSelector(selector: string): SkillSelectorResult {
   const needle = selector.trim();
   if (!needle) {
     return {
@@ -1068,7 +991,7 @@ export function resolveSkillSelector(
     };
   }
 
-  const catalog = loadSkillCatalog(workspaceSkillsDir);
+  const catalog = loadSkillCatalog();
   if (catalog.length === 0) {
     return {
       error: `No skills are available. Add skill directories under ${getWorkspaceDirDisplay()}/skills/.`,
@@ -1118,11 +1041,8 @@ export function resolveSkillSelector(
   };
 }
 
-export function loadSkillBySelector(
-  selector: string,
-  workspaceSkillsDir?: string,
-): SkillLookupResult {
-  const resolved = resolveSkillSelector(selector, workspaceSkillsDir);
+export function loadSkillBySelector(selector: string): SkillLookupResult {
+  const resolved = resolveSkillSelector(selector);
   if (!resolved.skill) {
     return {
       error: resolved.error ?? "Failed to resolve skill selector.",

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -29,11 +29,7 @@ import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 /** Skill sources eligible for inline command expansion in v1. */
-const INLINE_COMMAND_ELIGIBLE_SOURCES = new Set([
-  "bundled",
-  "managed",
-  "workspace",
-]);
+const INLINE_COMMAND_ELIGIBLE_SOURCES = new Set(["bundled", "managed"]);
 
 const log = getLogger("skill-load");
 
@@ -129,15 +125,15 @@ export class SkillLoadTool implements Tool {
   defaultRiskLevel = RiskLevel.Low;
 
   input_schema = {
-        type: "object",
-        properties: {
-          skill: {
-            type: "string",
-            description: "The skill id or skill name to load.",
-          },
-        },
-        required: ["skill"],
-      };
+    type: "object",
+    properties: {
+      skill: {
+        type: "string",
+        description: "The skill id or skill name to load.",
+      },
+    },
+    required: ["skill"],
+  };
 
   async execute(
     input: Record<string, unknown>,

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -33,7 +33,7 @@
   - Place documentation examples of the syntax inside fenced code blocks (`` ``` `` or `~~~`) — the parser skips tokens inside fences, so examples will not accidentally execute
   - Never use empty commands (`` !`` ``), whitespace-only commands, or unmatched backticks — these are rejected by the parser as malformed
   - The `inline-skill-commands` feature flag must be enabled for inline expansions to work. When the flag is off, skills containing expansion tokens fail closed at load time
-  - Inline command expansions are only supported for `bundled`, `managed`, and `workspace` skill sources. Skills distributed as `extra` sources cannot use this syntax
+  - Inline command expansions are only supported for `bundled` and `managed` skill sources. Skills distributed as `extra` sources cannot use this syntax
 
 - **User-gated actions (interactive confirmation/input)**
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -55,7 +55,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-29T03:45:08.000Z"
+      "updatedAt": "2026-05-29T12:58:30.000Z"
     },
     {
       "id": "chatgpt-import",


### PR DESCRIPTION
Closes LUM-2049 (sub-issue of [LUM-2040](https://linear.app/vellum/issue/LUM-2040))

## Prompt / plan

The `"workspace"` skill source — per-conversation skills loaded via a `workspaceSkillsDir` parameter — was unreachable in production. This PR removes the dead code.

### Why the code was dead

Three independent gates prevented workspace skills from ever loading:

1. **No caller supplied the parameter.** `SkillLoadTool.execute()` calls `loadSkillBySelector(selector)` without `workspaceSkillsDir`. All 20+ other `loadSkillCatalog()` callers also pass no args.
2. **`resolveSkillStates` disabled workspace skills by default.** Even if the catalog loaded them, they'd be excluded from the active skill set unless explicitly enabled in config.
3. **No per-conversation working directory exists.** `context.workingDir` always resolves to `~/.vellum/workspace` (the shared workspace), so wiring the parameter would point workspace skill discovery at `~/.vellum/workspace/.vellum/skills/` — a path that doesn't exist and would conflict with the managed directory at `~/.vellum/workspace/skills/`.

### What's removed

- `"workspace"` from the `SkillSource` type union and its doc comment
- `workspaceSkillsDir` parameter from `loadSkillCatalog`, `resolveSkillSelector`, `loadSkillBySelector`
- Workspace block in `loadSkillCatalog` (~53 lines) that scanned the workspace dir
- Workspace branch in `loadSkillDefinition` that bypassed `isOutsideSkillsRoot`
- Workspace test suite in `skills.test.ts` (5 tests)
- `"workspace"` from `INLINE_COMMAND_ELIGIBLE_SOURCES` in `load.ts`
- Inline command test assertion updated to assert `"workspace"` is NOT in eligible sources
- `"workspace"` references in `skills/AGENTS.md` and `skill-state.ts` comments
- Test fixtures in 3 other test files that used `source: "workspace"` (changed to `"managed"`)

### Why this is safe

- **No production caller** ever passed `workspaceSkillsDir`. The parameter was plumbed but never connected. Removing it cannot change runtime behavior.
- **No wire/protocol impact.** `SkillSource` is an internal TypeScript type, not serialized over IPC or HTTP. No backwards compatibility concern.
- **Tests for the remaining sources** (bundled, managed, extra, plugin) are unchanged and pass.

### Alternatives not taken

- **Wire the parameter instead of removing it**: Investigated in [LUM-2040](https://linear.app/vellum/issue/LUM-2040). The per-conversation working directory concept doesn't exist in the runtime, so there's nothing to wire to. If per-project skills become a real requirement, it should be designed from scratch.

## Test plan

- All 31 remaining tests in `skills.test.ts` pass
- All tests in `managed-store.test.ts`, `skills-file-content-endpoint.test.ts`, `skills-files-catalog-fallback.test.ts`, `skill-load-inline-command.test.ts` pass
- `bunx tsc --noEmit` passes
- `bun run lint` passes
- CI green

Link to Devin session: https://app.devin.ai/sessions/348d4a4009e74664982f5cfb2a08ac8d
Requested by: @ashleeradka