### PR TITLE
fix(web): add top padding above waveform when textarea is hidden on iOS

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -573,7 +573,7 @@ export function ChatComposer({
               // dictation cleanup are in flight — the visual signal that the
               // recording was captured and the transcript is on its way.
               <div
-                className="px-2"
+                className={hideTextareaForVoice ? "px-2 pt-3" : "px-2"}
                 aria-label={voicePhase === "processing" ? "Transcribing" : "Recording"}
                 aria-live="polite"
               >


### PR DESCRIPTION
Adds `pt-3` (12px) top padding to the waveform wrapper when the textarea is hidden during iOS voice recording, matching the textarea's own `pt-3` top padding so the waveform doesn't sit flush against the top of the composer.

Follow-up to #32603 which hid the textarea during recording on iOS but left the waveform without the corresponding top spacing.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/7fc9a912a6db4993bef99db5e7de97b2

## Prompt / plan
The waveform was too close to the top of the composer when the textarea was hidden on iOS. Added conditional `pt-3` padding to the waveform wrapper (matching the textarea's existing top padding) when `hideTextareaForVoice` is true.

## Test plan
- Lint and typecheck pass
- The padding is only applied when `hideTextareaForVoice` is true (iOS + voice active + not generating), so web is unaffected
- The `pt-3` value matches the textarea's existing `pt-3`, ensuring consistent vertical spacing