### PR TITLE
fix(web): match context window bottom sheet styling to Figma design

### DIFF
--- a/apps/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/apps/web/src/domains/chat/components/context-window-indicator.tsx
@@ -31,7 +31,7 @@ function resolveRingColor(ratio: number): string {
   if (ratio >= 0.6) {
     return "var(--system-mid-strong)";
   }
-  return "var(--content-tertiary)";
+  return "var(--system-positive-strong)";
 }
 
 function formatTokens(count: number): string {
@@ -141,10 +141,10 @@ function MobileSheetContent({
 }) {
   return (
     <>
-      <div className="flex flex-col items-center gap-4">
+      <div className="flex flex-col items-center gap-5">
         <span
           aria-hidden="true"
-          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full"
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl"
           style={{
             backgroundColor:
               "color-mix(in oklab, var(--primary-base) 16%, transparent)",
@@ -155,8 +155,8 @@ function MobileSheetContent({
 
         <BottomSheet.Title className="justify-center">Context Window</BottomSheet.Title>
 
-        <div className="w-full px-4">
-          <div className="relative h-2 w-full overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]">
+        <div className="w-full px-2">
+          <div className="relative h-3 w-full overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]">
             <div
               className="h-full rounded-full transition-[width] duration-250 ease-out"
               style={{
@@ -167,18 +167,18 @@ function MobileSheetContent({
           </div>
         </div>
 
-        <div className="flex flex-col items-center gap-1">
-          <span className="text-body-medium-emphasised text-[var(--content-default)]">
+        <div className="flex flex-col items-center gap-1.5">
+          <span className="text-body-large-default text-[var(--content-default)]">
             {percentage}% full
             {maxTokens != null && (
               <>
                 {" "}
-                <span className="text-[var(--content-secondary)]">•</span>{" "}
+                <span className="text-[var(--content-tertiary)]">•</span>{" "}
                 {formatTokens(tokens)} / {formatTokens(maxTokens)} tokens used
               </>
             )}
           </span>
-          <span className="text-body-small-default text-[var(--content-tertiary)]">
+          <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
             Vellum automatically compacts its context
           </span>
         </div>


### PR DESCRIPTION
Aligns the mobile context window bottom sheet with the Figma target design (#32594 landed the feature but had visual discrepancies). Changes: icon container from circle to rounded square, progress bar color to green (`--system-positive-strong`) for healthy usage, thicker bar (`h-3`), increased spacing between elements, and corrected typography tokens to use existing design system utilities (`text-body-large-default`, `text-body-medium-lighter`) instead of non-existent `text-body-medium-emphasised`.

## Prompt / plan

User-reported visual discrepancies vs Figma target (node `4499-117435`): icon background shape, progress bar color/thickness, spacing, and font sizes.

## Test plan

- Lint (`bun run lint`) and typecheck (`bunx tsc --noEmit`) both pass
- Visual comparison against Figma target image

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ec2e9157e66a438f9318f0daafef84d1