### PR TITLE
fix(web): align bottom sheet section labels with PanelItem icons

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -439,7 +439,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 /** Bottom-sheet section label — small-caps style matching Menu.Label. */
 function SectionLabel({ children }: { children: ReactNode }) {
   return (
-    <div className="px-4 pt-2.5 pb-2 text-body-small-default text-[var(--content-tertiary)]">
+    <div className="px-[8px] pt-2.5 pb-2 text-body-small-default text-[var(--content-tertiary)]">
       {children}
     </div>
   );


### PR DESCRIPTION
Fixes horizontal alignment of "Assistant Access" and "Model Profile" section labels in the composer settings bottom sheet. The `BottomSheet.Content` wrapper already provides `px-4` (16px) horizontal padding; the previous PR (#32597) set `SectionLabel` to `px-4` as well, creating 32px total indent — 8px more than PanelItem rows (which only add 8px via `p-[8px]`). This reverts the horizontal padding to `px-[8px]` so labels align flush with the leading icons.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/ff7fe6262b5a4397b62b45d32a52e784
