### PR TITLE
docs(macos): scrub internal-tracker references from main-process comments

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -23,7 +23,7 @@ export type VellumCommandKind = VellumCommand["kind"];
  *
  * Populated lazily at menu-build time by merging with `settings.hotkeys`
  * (rather than via the electron-store schema `default` block, which would
- * clobber user overrides on schema migration — see LUM-1962).
+ * clobber user overrides on schema migration).
  */
 export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   newConversation: "CmdOrCtrl+N",
@@ -53,7 +53,7 @@ export const resolveAccelerator = (kind: VellumCommandKind): string => {
  * back to the first window if none is focused (which happens when a menu
  * item is clicked from the menu bar while the app is in the background but
  * its window isn't the OS focus owner). Capturing a window reference at
- * menu-construction time would break thread pop-outs (LUM-1870) where the
+ * menu-construction time would break future thread pop-outs, where the
  * user expects Cmd+N to operate on the popped-out window they're in.
  */
 export const dispatchToFocused = (command: VellumCommand): void => {

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -3,7 +3,7 @@ import Store, { type Schema } from "electron-store";
 /**
  * Persisted user preferences shape. The schema below validates writes; reads
  * are returned as `null` when a key has never been written and no default
- * applies. Top-level keys are the renderer-facing categories from LUM-1846 —
+ * applies. Top-level keys are the renderer-facing categories;
  * additional categories get added here as future tickets need them, with a
  * matching schema entry to keep validation honest.
  *


### PR DESCRIPTION
## Summary

Scrubs three remaining `LUM-` references in `apps/macos/src/main/` comments. Surfaced during an audit of #32614 — the fourth one (in `index.ts`) is fixed in that PR because that's a file it touches; per the STYLE_GUIDE rule "unrelated dead code spotted during a PR gets its own separate PR opened at the same time", the other three land here.

Per the earlier mandate that "docs should be open-source friendly — no references to internal dev tools, issue trackers, or internal URLs."

### Changes

- **`settings.ts`** — drop "from LUM-1846" from the schema comment. The surrounding prose already documents the renderer-facing-categories rationale.
- **`commands.ts:DEFAULT_ACCELERATORS`** — drop the "see LUM-1962" pointer. The comment already explains why merging at menu-build beats the `default` block.
- **`commands.ts:dispatchToFocused`** — rephrase "thread pop-outs (LUM-1870)" as "future thread pop-outs" so the constraint is named without the tracker reference.

No behavior changes; comments only.

## Test plan

- [x] `bun --cwd apps/macos run typecheck` — green.
- [x] `bun --cwd apps/macos run test:ci` — green.
- [x] `grep -rE "LUM-[0-9]+" apps/macos/src apps/macos/scripts` returns nothing.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_