### PR TITLE
refactor(agent-loop): convert run() from 11 positional params to options object

### DIFF
--- a/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
+++ b/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
@@ -105,14 +105,7 @@ describe("AgentLoop — call-site precedence", () => {
     const { provider, lastConfig } = makePipeline("anthropic");
     const loop = new AgentLoop(provider, "system", { maxTokens: 64000 });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     expect(lastConfig()!.max_tokens).toBe(4096);
   });
@@ -133,14 +126,7 @@ describe("AgentLoop — call-site precedence", () => {
       effort: "high",
     });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     expect(lastConfig()!.effort).toBe("low");
   });
@@ -164,14 +150,7 @@ describe("AgentLoop — call-site precedence", () => {
       speed: "fast",
     });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     expect(lastConfig()!.speed).toBe("fast");
   });
@@ -200,14 +179,7 @@ describe("AgentLoop — call-site precedence", () => {
       thinking: { enabled: true },
     });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     // Call-site override resolves `thinking.enabled: false`, so the
     // RetryProvider normalizer must send Anthropic's explicit disabled shape.
@@ -227,14 +199,7 @@ describe("AgentLoop — call-site precedence", () => {
     const { provider, lastConfig } = makePipeline("anthropic");
     const loop = new AgentLoop(provider, "system", { maxTokens: 64000 });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     // Must be wire-format `{ type: "adaptive" }` so the Anthropic SDK's
     // `ThinkingConfigParam` accepts it. The schema-shape `{ enabled,
@@ -262,7 +227,7 @@ describe("AgentLoop — call-site precedence", () => {
       thinking: { enabled: true },
     });
 
-    await loop.run([userMessage], () => {}, undefined, undefined, undefined);
+    await loop.run([userMessage], () => {});
 
     const config = lastConfig()!;
     expect(config.max_tokens).toBe(64000);
@@ -298,14 +263,7 @@ describe("AgentLoop — call-site precedence", () => {
       resolveSystemPrompt,
     );
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "mainAgent" });
 
     // Per-turn explicit value beats both the call-site (4096) and the
     // default (64000).

--- a/assistant/src/__tests__/agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/agent-loop-exit-reason.test.ts
@@ -221,7 +221,7 @@ describe("AgentLoop exit-reason instrumentation", () => {
       (e) => {
         events.push(e);
       },
-      controller.signal,
+      { signal: controller.signal },
     );
 
     expect(countExitEvents(events)).toBe(1);
@@ -276,9 +276,7 @@ describe("AgentLoop exit-reason instrumentation", () => {
       (e) => {
         events.push(e);
       },
-      undefined,
-      undefined,
-      onCheckpoint,
+      { onCheckpoint },
     );
 
     expect(countExitEvents(events)).toBe(0);
@@ -355,7 +353,7 @@ describe("AgentLoop exit-reason instrumentation", () => {
       (e) => {
         events.push(e);
       },
-      controller.signal,
+      { signal: controller.signal },
     );
 
     expect(countExitEvents(events)).toBe(1);

--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -120,16 +120,10 @@ describe("AgentLoop.run — overrideProfile plumbing", () => {
       toolExecutor,
     );
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined, // signal
-      undefined, // requestId
-      undefined, // onCheckpoint
-      "mainAgent", // callSite
-      undefined, // turnContext
-      "fast", // overrideProfile
-    );
+    await loop.run([userMessage], () => {}, {
+      callSite: "mainAgent",
+      overrideProfile: "fast",
+    });
 
     // Three sends — initial + two tool round-trips.
     expect(configs()).toHaveLength(3);
@@ -158,16 +152,10 @@ describe("AgentLoop.run — overrideProfile plumbing", () => {
     const { provider, configs } = makeRecordingProvider([textResponse("hi")]);
     const loop = new AgentLoop(provider, "system", { maxTokens: 1024 });
 
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      undefined,
-      "mainAgent",
-      undefined,
-      "does-not-exist",
-    );
+    await loop.run([userMessage], () => {}, {
+      callSite: "mainAgent",
+      overrideProfile: "does-not-exist",
+    });
 
     expect(configs()[0]?.overrideProfile).toBe("does-not-exist");
   });

--- a/assistant/src/__tests__/agent-loop-provider-error-recording.test.ts
+++ b/assistant/src/__tests__/agent-loop-provider-error-recording.test.ts
@@ -184,7 +184,7 @@ describe("AgentLoop provider_error event emission", () => {
       (e) => {
         events.push(e);
       },
-      controller.signal,
+      { signal: controller.signal },
     );
 
     const providerErrorEvent = events.find((e) => e.type === "provider_error");

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -201,18 +201,11 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
 
-    await loop.run(
-      [userMessage],
-      collectEvents([]),
-      undefined,
-      "req-1",
-      undefined,
-      "mainAgent",
-      undefined,
-      undefined,
-      undefined,
-      () => overrideProfile,
-    );
+    await loop.run([userMessage], collectEvents([]), {
+      requestId: "req-1",
+      callSite: "mainAgent",
+      resolveOverrideProfile: () => overrideProfile,
+    });
 
     expect(calls).toHaveLength(2);
     expect(calls[0].options?.config?.overrideProfile).toBeUndefined();
@@ -240,19 +233,12 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
 
-    await loop.run(
-      [userMessage],
-      collectEvents([]),
-      undefined,
-      "req-1",
-      undefined,
-      "mainAgent",
-      undefined,
-      undefined,
-      1_000,
-      undefined,
-      () => maxInputTokens,
-    );
+    await loop.run([userMessage], collectEvents([]), {
+      requestId: "req-1",
+      callSite: "mainAgent",
+      effectiveMaxInputTokens: 1_000,
+      resolveEffectiveMaxInputTokens: () => maxInputTokens,
+    });
 
     const secondCallMessages = calls[1].messages;
     const lastMsg = secondCallMessages[secondCallMessages.length - 1];
@@ -347,7 +333,9 @@ describe("AgentLoop", () => {
 
     const { provider } = createMockProvider([textResponse("Should not reach")]);
     const loop = new AgentLoop(provider, "system");
-    const history = await loop.run([userMessage], () => {}, controller.signal);
+    const history = await loop.run([userMessage], () => {}, {
+      signal: controller.signal,
+    });
 
     // Loop should exit immediately, returning only original messages
     expect(history).toHaveLength(1);
@@ -379,7 +367,9 @@ describe("AgentLoop", () => {
       dummyTools,
       toolExecutor,
     );
-    const history = await loop.run([userMessage], () => {}, controller.signal);
+    const history = await loop.run([userMessage], () => {}, {
+      signal: controller.signal,
+    });
 
     // After the first tool turn, abort fires. The while loop checks signal at the
     // top and breaks. History: user, assistant(t1), user(result1)
@@ -427,7 +417,9 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const start = Date.now();
-    const history = await loop.run([userMessage], () => {}, controller.signal);
+    const history = await loop.run([userMessage], () => {}, {
+      signal: controller.signal,
+    });
     const elapsed = Date.now() - start;
 
     // The loop should exit quickly (~50ms for abort), not wait 10s for the tool
@@ -797,11 +789,9 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run(
-      [userMessage],
-      collectEvents(events),
-      controller.signal,
-    );
+    const history = await loop.run([userMessage], collectEvents(events), {
+      signal: controller.signal,
+    });
 
     // No tools should have been executed
     expect(toolCalls).toHaveLength(0);
@@ -917,7 +907,7 @@ describe("AgentLoop", () => {
       return "continue";
     };
 
-    await loop.run([userMessage], () => {}, undefined, undefined, onCheckpoint);
+    await loop.run([userMessage], () => {}, { onCheckpoint });
 
     expect(checkpoints).toHaveLength(1);
     expect(checkpoints[0]).toMatchObject({
@@ -948,13 +938,7 @@ describe("AgentLoop", () => {
 
     const onCheckpoint = (): CheckpointDecision => "continue";
 
-    const history = await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      onCheckpoint,
-    );
+    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
 
     // All 3 provider calls should happen (2 tool turns + final text)
     expect(calls).toHaveLength(3);
@@ -982,13 +966,7 @@ describe("AgentLoop", () => {
 
     const onCheckpoint = (): CheckpointDecision => "yield";
 
-    const history = await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      onCheckpoint,
-    );
+    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
 
     // Only 1 provider call should happen — loop yields after first tool turn
     expect(calls).toHaveLength(1);
@@ -1046,7 +1024,7 @@ describe("AgentLoop", () => {
       return "continue";
     };
 
-    await loop.run([userMessage], () => {}, undefined, undefined, onCheckpoint);
+    await loop.run([userMessage], () => {}, { onCheckpoint });
 
     expect(checkpoints).toHaveLength(3);
     expect(checkpoints[0].turnIndex).toBe(0);
@@ -1067,13 +1045,7 @@ describe("AgentLoop", () => {
       return "continue";
     };
 
-    const history = await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      onCheckpoint,
-    );
+    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
 
     // Checkpoint should never be called for a text-only response
     expect(checkpoints).toHaveLength(0);
@@ -1130,7 +1102,7 @@ describe("AgentLoop", () => {
       return "continue";
     };
 
-    await loop.run([userMessage], () => {}, undefined, undefined, onCheckpoint);
+    await loop.run([userMessage], () => {}, { onCheckpoint });
 
     expect(checkpoints).toHaveLength(1);
     expect(checkpoints[0].toolCount).toBe(3);
@@ -1166,13 +1138,9 @@ describe("AgentLoop", () => {
     };
 
     const events: AgentEvent[] = [];
-    const history = await loop.run(
-      [userMessage],
-      collectEvents(events),
-      undefined,
-      undefined,
+    const history = await loop.run([userMessage], collectEvents(events), {
       onCheckpoint,
-    );
+    });
 
     // Turns 0, 1, 2, 3 execute (4 provider calls). Turn 3 yields, so turns 4+ never execute.
     expect(calls).toHaveLength(4);
@@ -1239,13 +1207,7 @@ describe("AgentLoop", () => {
       return checkpoint.turnIndex === 1 ? "yield" : "continue";
     };
 
-    const history = await loop.run(
-      [userMessage],
-      () => {},
-      undefined,
-      undefined,
-      onCheckpoint,
-    );
+    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
 
     // 2 provider calls: first tool turn + second tool turn (yield after second)
     expect(calls).toHaveLength(2);
@@ -2005,14 +1967,7 @@ describe("AgentLoop", () => {
     const { provider, calls } = createMockProvider([textResponse("ok")]);
 
     const loop = new AgentLoop(provider, "system");
-    await loop.run(
-      [userMessage],
-      () => {},
-      undefined, // signal
-      undefined, // requestId
-      undefined, // onCheckpoint
-      "heartbeatAgent",
-    );
+    await loop.run([userMessage], () => {}, { callSite: "heartbeatAgent" });
 
     expect(calls).toHaveLength(1);
     expect(calls[0].options?.config?.callSite).toBe("heartbeatAgent");

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -48,7 +48,7 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-import type { AgentEvent } from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 import { RetryProvider } from "../providers/retry.js";
 import type {
@@ -65,13 +65,7 @@ import {
 
 interface RunArgs {
   messages: Message[];
-  signal: AbortSignal | undefined;
-  requestId: string | undefined;
-  onCheckpoint: unknown;
-  callSite: unknown;
-  turnContext: unknown;
-  overrideProfile: string | undefined;
-  effectiveMaxInputTokens: number | undefined;
+  options: AgentLoopRunOptions | undefined;
 }
 
 function makeTarget(): {
@@ -90,23 +84,11 @@ function makeTarget(): {
       run: (async (
         messages: Message[],
         _onEvent: (event: AgentEvent) => void | Promise<void>,
-        signal?: AbortSignal,
-        requestId?: string,
-        onCheckpoint?: unknown,
-        callSite?: unknown,
-        turnContext?: unknown,
-        overrideProfile?: string,
-        effectiveMaxInputTokens?: number,
+        options?: AgentLoopRunOptions,
       ) => {
         runArgs.push({
           messages: [...messages],
-          signal,
-          requestId,
-          onCheckpoint,
-          callSite,
-          turnContext,
-          overrideProfile,
-          effectiveMaxInputTokens,
+          options,
         });
         // Return the input verbatim → silent no-op (no assistant tail).
         return messages;
@@ -167,18 +149,15 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
 
     expect(result.invoked).toBe(true);
     expect(runArgs).toHaveLength(1);
-    // The 8th positional argument (after messages, onEvent, signal,
-    // requestId, onCheckpoint, callSite, turnContext) is overrideProfile.
-    expect(runArgs[0]!.overrideProfile).toBe("frontier");
-    // The 6th positional argument is callSite. Wakes resume a user-facing
-    // conversation, so route through the same `mainAgent` call site as a
-    // normal user turn — without it the resolver and routing layers would
-    // short-circuit and silently drop both the call-site config and the
-    // pinned override profile.
-    expect(runArgs[0]!.callSite).toBe("mainAgent");
-    expect(runArgs[0]!.effectiveMaxInputTokens).toBe(150000);
+    expect(runArgs[0]!.options?.overrideProfile).toBe("frontier");
+    // Wakes resume a user-facing conversation, so route through the same
+    // `mainAgent` call site as a normal user turn — without it the resolver
+    // and routing layers would short-circuit and silently drop both the
+    // call-site config and the pinned override profile.
+    expect(runArgs[0]!.options?.callSite).toBe("mainAgent");
+    expect(runArgs[0]!.options?.effectiveMaxInputTokens).toBe(150000);
     // Sanity: the wake-source tag still propagates as requestId.
-    expect(runArgs[0]!.requestId).toBe("wake:scheduler");
+    expect(runArgs[0]!.options?.requestId).toBe("wake:scheduler");
   });
 
   test("passes undefined overrideProfile when the conversation has no pinned profile, but still forwards mainAgent callSite", async () => {
@@ -195,13 +174,13 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
     );
 
     expect(runArgs).toHaveLength(1);
-    expect(runArgs[0]!.overrideProfile).toBeUndefined();
+    expect(runArgs[0]!.options?.overrideProfile).toBeUndefined();
     // Even without an override profile, we still need callSite="mainAgent"
     // so the resolver picks up `llm.callSites.mainAgent` config (model,
     // maxTokens, effort, etc.). Otherwise the wake silently runs under
     // workspace defaults regardless of any per-call-site configuration.
-    expect(runArgs[0]!.callSite).toBe("mainAgent");
-    expect(runArgs[0]!.effectiveMaxInputTokens).toBeGreaterThan(0);
+    expect(runArgs[0]!.options?.callSite).toBe("mainAgent");
+    expect(runArgs[0]!.options?.effectiveMaxInputTokens).toBeGreaterThan(0);
   });
 });
 

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -8,11 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Minimatch } from "minimatch";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { ConfirmationStateChanged } from "../daemon/message-types/messages.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -213,11 +209,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -10,12 +10,7 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  AgentLoopConfig,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent, AgentLoopConfig } from "../agent/loop.js";
 import type { ContextWindowResult } from "../context/window-manager.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -238,11 +233,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -192,7 +192,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
     ): Promise<Message[]> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -14,11 +14,7 @@
 import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
@@ -354,10 +350,7 @@ import {
 
 // ── Test helpers ─────────────────────────────────────────────────────
 
-// Captures every positional argument the loop passes to `agentLoop.run`.
-// The 8th positional argument is the per-turn `overrideProfile`, which is
-// what most tests assert on. The 10th and 11th positional arguments re-resolve
-// that profile and its max-token budget between provider calls.
+/** Captures the options the orchestrator passes to `agentLoop.run`. */
 interface CapturedAgentLoopRun {
   callSite: LLMCallSite | undefined;
   overrideProfile: string | undefined;
@@ -374,24 +367,15 @@ function makeCtx(
   const agentLoopRun = async (
     messages: Message[],
     _onEvent: (event: AgentEvent) => void,
-    _signal?: AbortSignal,
-    _requestId?: string,
-    _onCheckpoint?: (
-      checkpoint: CheckpointInfo,
-    ) => CheckpointDecision | Promise<CheckpointDecision>,
-    callSite?: LLMCallSite,
-    _turnContext?: unknown,
-    overrideProfile?: string,
-    _effectiveMaxInputTokens?: number,
-    resolveOverrideProfile?: () => string | undefined,
-    resolveEffectiveMaxInputTokens?: () => number | undefined,
+    options?: AgentLoopRunOptions,
   ): Promise<Message[]> => {
     mutateBeforeResolveOverrideProfile?.();
     captured.push({
-      callSite,
-      overrideProfile,
-      resolvedOverrideProfile: resolveOverrideProfile?.(),
-      resolvedEffectiveMaxInputTokens: resolveEffectiveMaxInputTokens?.(),
+      callSite: options?.callSite,
+      overrideProfile: options?.overrideProfile,
+      resolvedOverrideProfile: options?.resolveOverrideProfile?.(),
+      resolvedEffectiveMaxInputTokens:
+        options?.resolveEffectiveMaxInputTokens?.(),
     });
     return [
       ...messages,

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -14,11 +14,7 @@
 import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
 import type { LLMConfig } from "../config/schemas/llm.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
@@ -435,11 +431,7 @@ import {
 type AgentLoopRun = (
   messages: Message[],
   onEvent: (event: AgentEvent) => void,
-  signal?: AbortSignal,
-  requestId?: string,
-  onCheckpoint?: (
-    checkpoint: CheckpointInfo,
-  ) => CheckpointDecision | Promise<CheckpointDecision>,
+  options?: AgentLoopRunOptions,
 ) => Promise<Message[]>;
 
 function makeCtx(
@@ -1449,13 +1441,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       };
 
       let agentLoopCallCount = 0;
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _requestId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         // Prime the assistant row anchor — production code emits this from
         // `AgentLoop.run` just before `provider.sendMessage`.
         await onEvent({ type: "llm_call_started" });
@@ -1515,8 +1501,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
           // Call onCheckpoint — this should trigger the mid-loop budget check
           // which sees 170_000 > 161_500 and returns "yield"
-          if (onCheckpoint) {
-            const decision = await onCheckpoint({
+          if (options?.onCheckpoint) {
+            const decision = await options.onCheckpoint({
               turnIndex: 0,
               toolCount: 1,
               hasToolUse: true,
@@ -1637,13 +1623,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       let agentLoopCallCount = 0;
       let contextTooLargeEmitted = false;
 
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _requestId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         // Prime the assistant row anchor — production code emits this from
         // `AgentLoop.run` just before `provider.sendMessage`.
         await onEvent({ type: "llm_call_started" });
@@ -1692,8 +1672,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
               providerDurationMs: 100,
             });
 
-            if (onCheckpoint) {
-              const decision = await onCheckpoint({
+            if (options?.onCheckpoint) {
+              const decision = await options.onCheckpoint({
                 turnIndex: i,
                 toolCount: 1,
                 hasToolUse: true,
@@ -1815,13 +1795,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
     };
 
     let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (
-      messages,
-      onEvent,
-      _signal,
-      _requestId,
-      onCheckpoint,
-    ) => {
+    const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -1879,8 +1853,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       });
 
       // Always yield at checkpoint — simulates compaction not helping
-      if (onCheckpoint) {
-        const decision = await onCheckpoint({
+      if (options?.onCheckpoint) {
+        const decision = await options.onCheckpoint({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,
@@ -1979,13 +1953,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
     };
 
     let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (
-      messages,
-      onEvent,
-      _signal,
-      _requestId,
-      onCheckpoint,
-    ) => {
+    const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -2042,8 +2010,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       });
 
       // Always yield at checkpoint — simulates reduction not helping enough
-      if (onCheckpoint) {
-        const decision = await onCheckpoint({
+      if (options?.onCheckpoint) {
+        const decision = await options.onCheckpoint({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,
@@ -2320,13 +2288,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
     mockOverflowAction = "auto_compress_latest_turn";
 
     let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (
-      messages,
-      onEvent,
-      _signal,
-      _requestId,
-      onCheckpoint,
-    ) => {
+    const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -2383,8 +2345,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       });
 
       // Every checkpoint yields — including the final auto_compress rerun.
-      if (onCheckpoint) {
-        const decision = await onCheckpoint({
+      if (options?.onCheckpoint) {
+        const decision = await options.onCheckpoint({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1,11 +1,7 @@
 import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -548,11 +544,7 @@ import {
 type AgentLoopRun = (
   messages: Message[],
   onEvent: (event: AgentEvent) => void | Promise<void>,
-  signal?: AbortSignal,
-  requestId?: string,
-  onCheckpoint?: (
-    checkpoint: CheckpointInfo,
-  ) => CheckpointDecision | Promise<CheckpointDecision>,
+  options?: AgentLoopRunOptions,
 ) => Promise<Message[]>;
 
 function makeCtx(
@@ -819,13 +811,7 @@ describe("session-agent-loop", () => {
       mockHasProactiveArtifactCompleted = false;
       mockTryClaimProactiveArtifactTrigger = true;
 
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _requestId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         // Prime the assistant row anchor for LLM call 1 — production code
         // emits this from `AgentLoop.run` just before `provider.sendMessage`.
         await onEvent({ type: "llm_call_started" });
@@ -848,7 +834,7 @@ describe("session-agent-loop", () => {
           content: "{}",
           isError: false,
         });
-        await onCheckpoint?.({
+        await options?.onCheckpoint?.({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,
@@ -2150,13 +2136,7 @@ describe("session-agent-loop", () => {
       // call). 90k satisfies both so the path reaches call 3.
       mockEstimateTokens = 90_000;
 
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _reqId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         callCount++;
         if (callCount <= 2) {
           // Calls 1 (initial) and 2 (convergence rerun): error so
@@ -2180,8 +2160,8 @@ describe("session-agent-loop", () => {
         // flips `yieldedForBudget` to true, then return without
         // finishing — mirroring what AgentLoop.run does when its
         // checkpoint returns "yield".
-        if (onCheckpoint) {
-          await onCheckpoint({
+        if (options?.onCheckpoint) {
+          await options.onCheckpoint({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,
@@ -2461,13 +2441,7 @@ describe("session-agent-loop", () => {
     test("yields at checkpoint when canHandoffAtCheckpoint returns true", async () => {
       const events: ServerMessage[] = [];
 
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _reqId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         // Prime the assistant row anchor — production code emits this from
         // `AgentLoop.run` just before `provider.sendMessage`. Retry branches
         // need this on every invocation: each agent-loop iteration reserves
@@ -2495,8 +2469,8 @@ describe("session-agent-loop", () => {
           model: "test-model",
           providerDurationMs: 100,
         });
-        if (onCheckpoint) {
-          const decision = await onCheckpoint({
+        if (options?.onCheckpoint) {
+          const decision = await options.onCheckpoint({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,
@@ -2539,13 +2513,7 @@ describe("session-agent-loop", () => {
     test("continues when canHandoffAtCheckpoint returns false", async () => {
       const events: ServerMessage[] = [];
 
-      const agentLoopRun: AgentLoopRun = async (
-        messages,
-        onEvent,
-        _signal,
-        _reqId,
-        onCheckpoint,
-      ) => {
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
         // Prime the assistant row anchor — production code emits this from
         // `AgentLoop.run` just before `provider.sendMessage`. Retry branches
         // need this on every invocation: each agent-loop iteration reserves
@@ -2572,8 +2540,8 @@ describe("session-agent-loop", () => {
           model: "test-model",
           providerDurationMs: 100,
         });
-        if (onCheckpoint) {
-          await onCheckpoint({
+        if (options?.onCheckpoint) {
+          await options.onCheckpoint({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,
@@ -3939,14 +3907,12 @@ describe("session-agent-loop", () => {
       const agentLoopRun: AgentLoopRun = async (
         messages,
         _onEvent,
-        _signal,
-        _reqId,
-        onCheckpoint,
+        options,
       ) => {
         runCount++;
         if (runCount === 1) {
           mockEstimateTokens = 90_000;
-          const decision = await onCheckpoint?.({
+          const decision = await options?.onCheckpoint?.({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -11,11 +11,7 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
@@ -204,11 +200,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -4,11 +4,11 @@
  * user-initiated turns default to `'mainAgent'` when no caller-supplied
  * `callSite` is set.
  *
- * The test mocks `AgentLoop.run()` so it can capture the `callSite` parameter
- * the conversation passes after `processMessage` runs the slash-resolver and
- * runtime-injection pipeline. Adapter callers (heartbeat, filing, scheduler)
- * pass an explicit `callSite` so `RetryProvider` resolves their per-call
- * config from `llm.callSites.<id>`.
+ * The test mocks `AgentLoop.run()` so it can capture the `callSite` option
+ * the conversation passes via `AgentLoopRunOptions` after `processMessage`
+ * runs the slash-resolver and runtime-injection pipeline. Adapter callers
+ * (heartbeat, filing, scheduler) pass an explicit `callSite` so
+ * `RetryProvider` resolves their per-call config from `llm.callSites.<id>`.
  */
 import { describe, expect, mock, test } from "bun:test";
 

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -202,8 +202,8 @@ mock.module("../memory/retriever.js", () => ({
   injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
-// Mock AgentLoop to capture the callSite argument that runAgentLoopImpl passes.
-// The 6th positional parameter is `callSite` (see assistant/src/agent/loop.ts).
+// Mock AgentLoop to capture the callSite argument that runAgentLoopImpl passes
+// via the options object (see assistant/src/agent/loop.ts → AgentLoopRunOptions).
 mock.module("../agent/loop.js", () => ({
   AgentLoop: class {
     constructor(
@@ -231,12 +231,9 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: Record<string, unknown>) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: unknown,
-      callSite?: string,
+      options?: { callSite?: string },
     ): Promise<Message[]> {
-      captured.callSite = callSite;
+      captured.callSite = options?.callSite;
       onEvent({
         type: "usage",
         inputTokens: 0,

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -277,7 +277,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
     ): Promise<Message[]> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -345,14 +345,20 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void | Promise<void>,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
+      options?: {
+        onCheckpoint?: (
+          checkpoint: CheckpointInfo,
+        ) => CheckpointDecision | Promise<CheckpointDecision>;
+      },
     ): Promise<Message[]> {
       return new Promise<Message[]>((resolve, reject) => {
-        pendingRuns.push({ resolve, reject, messages, onEvent, onCheckpoint });
+        pendingRuns.push({
+          resolve,
+          reject,
+          messages,
+          onEvent,
+          onCheckpoint: options?.onCheckpoint,
+        });
       });
     }
   },

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import {
   conversationMessagesSyncTag,
@@ -226,11 +222,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void | Promise<void>,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return new Promise<Message[]>((resolve) => {
         pendingRuns.push({ resolve, messages, onEvent });

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
@@ -250,11 +246,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -7,12 +7,7 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 
-import type {
-  AgentEvent,
-  AgentLoopConfig,
-  CheckpointDecision,
-  CheckpointInfo,
-} from "../agent/loop.js";
+import type { AgentEvent, AgentLoopConfig } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
@@ -220,11 +215,6 @@ mock.module("../agent/loop.js", () => ({
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,
-      _signal?: AbortSignal,
-      _requestId?: string,
-      _onCheckpoint?: (
-        checkpoint: CheckpointInfo,
-      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/parallel-tool.benchmark.test.ts
+++ b/assistant/src/__tests__/parallel-tool.benchmark.test.ts
@@ -304,11 +304,9 @@ describe("Parallel tool execution benchmarks", () => {
         toolExecutor,
       );
       const start = Date.now();
-      const history = await loop.run(
-        [userMessage],
-        () => {},
-        controller.signal,
-      );
+      const history = await loop.run([userMessage], () => {}, {
+        signal: controller.signal,
+      });
       const elapsed = Date.now() - start;
 
       // Should exit quickly after the 50ms abort, not wait 500ms

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -378,6 +378,35 @@ export interface ResolvedSystemPrompt {
   model?: string;
 }
 
+export interface AgentLoopRunOptions {
+  signal?: AbortSignal;
+  requestId?: string;
+  onCheckpoint?: (
+    checkpoint: CheckpointInfo,
+  ) => CheckpointDecision | Promise<CheckpointDecision>;
+  callSite?: LLMCallSite;
+  /**
+   * Per-turn context supplied by the orchestrator. Every pipeline
+   * invocation inside the loop clones from this value (overwriting only
+   * `turnIndex`/`requestId`) so middleware sees the real conversation
+   * identity, trust class, and `contextWindowManager` rather than the
+   * `"agent-loop"` sentinel used when the loop is instantiated standalone
+   * in unit tests.
+   */
+  turnContext?: TurnContext;
+  /**
+   * Ad-hoc inference-profile override applied to every LLM call the loop
+   * issues. When set, each `SendMessageOptions.config` carries
+   * `overrideProfile = <name>` so the provider's resolver layers
+   * `llm.profiles[<name>]` between the workspace `activeProfile` and any
+   * call-site named profile. Missing profile names silently fall through.
+   */
+  overrideProfile?: string;
+  effectiveMaxInputTokens?: number;
+  resolveOverrideProfile?: () => string | undefined;
+  resolveEffectiveMaxInputTokens?: () => number | undefined;
+}
+
 /**
  * Callback shape the loop uses to execute a tool invocation.
  *
@@ -484,35 +513,19 @@ export class AgentLoop {
   async run(
     messages: Message[],
     onEvent: (event: AgentEvent) => void | Promise<void>,
-    signal?: AbortSignal,
-    requestId?: string,
-    onCheckpoint?: (
-      checkpoint: CheckpointInfo,
-    ) => CheckpointDecision | Promise<CheckpointDecision>,
-    callSite?: LLMCallSite,
-    /**
-     * Optional per-turn context supplied by the orchestrator. Every pipeline
-     * invocation inside the loop clones from this value (overwriting only
-     * `turnIndex`/`requestId`) so middleware sees the real conversation
-     * identity, trust class, and `contextWindowManager` rather than the
-     * `"agent-loop"` sentinel used when the loop is instantiated standalone
-     * in unit tests.
-     */
-    turnContext?: TurnContext,
-    /**
-     * Optional ad-hoc inference-profile override applied to every LLM call
-     * the loop issues. When set, each `SendMessageOptions.config` carries
-     * `overrideProfile = <name>` so the provider's resolver layers
-     * `llm.profiles[<name>]` between the workspace `activeProfile` and any
-     * call-site named profile. Missing profile names silently fall through.
-     * Used by per-conversation pinned profiles to override the workspace
-     * default for the lifetime of an agent loop run.
-     */
-    overrideProfile?: string,
-    effectiveMaxInputTokens?: number,
-    resolveOverrideProfile?: () => string | undefined,
-    resolveEffectiveMaxInputTokens?: () => number | undefined,
+    options?: AgentLoopRunOptions,
   ): Promise<Message[]> {
+    const {
+      signal,
+      requestId,
+      onCheckpoint,
+      callSite,
+      turnContext,
+      overrideProfile,
+      effectiveMaxInputTokens,
+      resolveOverrideProfile,
+      resolveEffectiveMaxInputTokens,
+    } = options ?? {};
     const history = [...messages];
     const initialHistoryLength = messages.length;
     let toolUseTurns = 0;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2284,19 +2284,21 @@ export async function runAgentLoopImpl(
     // and overwrites `turnIndex` with its own tool-use iteration counter.
     const loopTurnCtx = buildPluginTurnContext(ctx, reqId);
 
-    let updatedHistory = await ctx.agentLoop.run(
-      runMessages,
-      eventHandler,
-      abortController.signal,
-      reqId,
-      onCheckpoint,
-      turnCallSite,
-      loopTurnCtx,
-      turnOverrideProfile,
-      resolveCurrentMaxInputTokens(),
-      resolveCurrentOverrideProfile,
-      resolveCurrentMaxInputTokens,
-    );
+    /** Shared closure: runs the agent loop with the orchestrator's turn context. */
+    const runAgentLoop = (msgs: Message[]) =>
+      ctx.agentLoop.run(msgs, eventHandler, {
+        signal: abortController.signal,
+        requestId: reqId,
+        onCheckpoint,
+        callSite: turnCallSite,
+        turnContext: loopTurnCtx,
+        overrideProfile: turnOverrideProfile,
+        effectiveMaxInputTokens: resolveCurrentMaxInputTokens(),
+        resolveOverrideProfile: resolveCurrentOverrideProfile,
+        resolveEffectiveMaxInputTokens: resolveCurrentMaxInputTokens,
+      });
+
+    let updatedHistory = await runAgentLoop(runMessages);
 
     rlog.info(
       { resultMessageCount: updatedHistory.length },
@@ -2440,19 +2442,7 @@ export async function runAgentLoopImpl(
       preRepairMessages = runMessages;
       preRunHistoryLength = runMessages.length;
 
-      updatedHistory = await ctx.agentLoop.run(
-        runMessages,
-        eventHandler,
-        abortController.signal,
-        reqId,
-        onCheckpoint,
-        turnCallSite,
-        loopTurnCtx,
-        turnOverrideProfile,
-        resolveCurrentMaxInputTokens(),
-        resolveCurrentOverrideProfile,
-        resolveCurrentMaxInputTokens,
-      );
+      updatedHistory = await runAgentLoop(runMessages);
     }
 
     // If mid-loop compaction exhausted all attempts but the agent loop
@@ -2500,19 +2490,7 @@ export async function runAgentLoopImpl(
       state.orderingErrorDetected = false;
       state.deferredOrderingError = null;
 
-      updatedHistory = await ctx.agentLoop.run(
-        runMessages,
-        eventHandler,
-        abortController.signal,
-        reqId,
-        onCheckpoint,
-        turnCallSite,
-        loopTurnCtx,
-        turnOverrideProfile,
-        resolveCurrentMaxInputTokens(),
-        resolveCurrentOverrideProfile,
-        resolveCurrentMaxInputTokens,
-      );
+      updatedHistory = await runAgentLoop(runMessages);
 
       if (state.orderingErrorDetected) {
         rlog.error(
@@ -2571,19 +2549,7 @@ export async function runAgentLoopImpl(
         };
       });
       runMessages = ctx.messages;
-      updatedHistory = await ctx.agentLoop.run(
-        runMessages,
-        eventHandler,
-        abortController.signal,
-        reqId,
-        onCheckpoint,
-        turnCallSite,
-        loopTurnCtx,
-        turnOverrideProfile,
-        resolveCurrentMaxInputTokens(),
-        resolveCurrentOverrideProfile,
-        resolveCurrentMaxInputTokens,
-      );
+      updatedHistory = await runAgentLoop(runMessages);
       if (state.imageTooLargeDetected) {
         rlog.error(
           { phase: "image-recovery" },
@@ -2831,19 +2797,7 @@ export async function runAgentLoopImpl(
         state.contextTooLargeDetected = false;
         yieldedForBudget = false;
 
-        updatedHistory = await ctx.agentLoop.run(
-          runMessages,
-          eventHandler,
-          abortController.signal,
-          reqId,
-          onCheckpoint,
-          turnCallSite,
-          loopTurnCtx,
-          turnOverrideProfile,
-          resolveCurrentMaxInputTokens(),
-          resolveCurrentOverrideProfile,
-          resolveCurrentMaxInputTokens,
-        );
+        updatedHistory = await runAgentLoop(runMessages);
 
         // If the rerun still yields at checkpoint, the turn is still
         // incomplete — continue reducing through the remaining tiers
@@ -2987,19 +2941,7 @@ export async function runAgentLoopImpl(
           preRunHistoryLength = runMessages.length;
           state.contextTooLargeDetected = false;
 
-          updatedHistory = await ctx.agentLoop.run(
-            runMessages,
-            eventHandler,
-            abortController.signal,
-            reqId,
-            onCheckpoint,
-            turnCallSite,
-            loopTurnCtx,
-            turnOverrideProfile,
-            resolveCurrentMaxInputTokens(),
-            resolveCurrentOverrideProfile,
-            resolveCurrentMaxInputTokens,
-          );
+          updatedHistory = await runAgentLoop(runMessages);
         }
         // action === "fail_gracefully" falls through to the final error below
       }

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -117,7 +117,7 @@ mock.module("../../memory/llm-request-log-store.js", () => ({
   backfillMessageIdOnLogs: () => {},
 }));
 
-import type { AgentEvent } from "../../agent/loop.js";
+import type { AgentEvent, AgentLoopRunOptions } from "../../agent/loop.js";
 import type { Message } from "../../providers/types.js";
 import {
   __resetWakeChainForTests,
@@ -196,13 +196,13 @@ function makeTarget(options: {
       run: async (
         input: Message[],
         onEvent: (event: AgentEvent) => void | Promise<void>,
-        _signal?: AbortSignal,
-        requestId?: string,
-        _onCheckpoint?: unknown,
-        _callSite?: unknown,
-        turnContext?: unknown,
+        runOptions?: AgentLoopRunOptions,
       ) => {
-        runCalls.push({ input: [...input], requestId, turnContext });
+        runCalls.push({
+          input: [...input],
+          requestId: runOptions?.requestId,
+          turnContext: runOptions?.turnContext,
+        });
         // Emit any scripted events the test wanted us to produce.
         for (const ev of options.scriptedEvents ?? []) {
           await onEvent(ev);
@@ -605,9 +605,13 @@ describe("wakeAgentForOpportunity", () => {
     // hold the processing flag while agentLoop.run executes.
     const observedDuringRun: boolean[] = [];
     const originalRun = target.agentLoop.run;
-    target.agentLoop.run = async (input, onEvent, signal, requestId) => {
+    target.agentLoop.run = async (
+      input: Message[],
+      onEvent: (event: AgentEvent) => void | Promise<void>,
+      runOptions?: AgentLoopRunOptions,
+    ) => {
       observedDuringRun.push(target.isProcessing());
-      return originalRun(input, onEvent, signal, requestId);
+      return originalRun(input, onEvent, runOptions);
     };
 
     await wakeAgentForOpportunity(
@@ -1296,7 +1300,7 @@ describe("wakeAgentForOpportunity", () => {
       const target: WakeTarget = {
         conversationId: "conv-stream",
         agentLoop: {
-          run: async (_input, onEvent, _signal, _requestId, onCheckpoint) => {
+          run: async (_input, onEvent, runOptions) => {
             // Preamble + assistant hint + postamble (mirrors what the
             // wake injects). The agent-wake helper expects these three
             // hint messages in the input it hands to run().
@@ -1311,7 +1315,7 @@ describe("wakeAgentForOpportunity", () => {
               message: turn1Assistant,
             });
             runHistory.push(turn1ToolResult);
-            const dec1 = await onCheckpoint!({
+            const dec1 = await runOptions!.onCheckpoint!({
               turnIndex: 0,
               toolCount: 1,
               hasToolUse: true,
@@ -1328,7 +1332,7 @@ describe("wakeAgentForOpportunity", () => {
               message: turn2Assistant,
             });
             runHistory.push(turn2ToolResult);
-            const dec2 = await onCheckpoint!({
+            const dec2 = await runOptions!.onCheckpoint!({
               turnIndex: 1,
               toolCount: 1,
               hasToolUse: true,
@@ -1432,11 +1436,11 @@ describe("wakeAgentForOpportunity", () => {
       const target: WakeTarget = {
         conversationId: "conv-card",
         agentLoop: {
-          run: async (_input, _onEvent, _signal, _requestId, onCheckpoint) => {
+          run: async (_input, _onEvent, runOptions) => {
             const runHistory: Message[] = [..._input];
             runHistory.push(firstAssistant);
             runHistory.push(toolResult);
-            await onCheckpoint!({
+            await runOptions!.onCheckpoint!({
               turnIndex: 0,
               toolCount: 1,
               hasToolUse: true,
@@ -1704,11 +1708,11 @@ describe("wakeAgentForOpportunity", () => {
       const target: WakeTarget = {
         conversationId: "conv-suppress-surface",
         agentLoop: {
-          run: async (_input, _onEvent, _signal, _requestId, onCheckpoint) => {
+          run: async (_input, _onEvent, runOptions) => {
             const runHistory: Message[] = [..._input];
             runHistory.push(firstAssistant);
             runHistory.push(toolResult);
-            await onCheckpoint!({
+            await runOptions!.onCheckpoint!({
               turnIndex: 0,
               toolCount: 1,
               hasToolUse: true,

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -862,11 +862,8 @@ export async function wakeAgentForOpportunity(
     try {
       let updatedHistory: Message[];
       try {
-        updatedHistory = await target.agentLoop.run(
-          runInput,
-          onEvent,
-          undefined, // no external abort signal
-          `wake:${source}`,
+        updatedHistory = await target.agentLoop.run(runInput, onEvent, {
+          requestId: `wake:${source}`,
           onCheckpoint,
           // Route through the caller-supplied call site (defaults to
           // `mainAgent` so a normal user-turn wake shares the user's chat
@@ -875,10 +872,10 @@ export async function wakeAgentForOpportunity(
           // short-circuit and silently drop both per-callsite config and the
           // pinned `overrideProfile` below.
           callSite,
-          wakeTurnContext,
+          turnContext: wakeTurnContext,
           overrideProfile,
-          effectiveContextWindow.maxInputTokens,
-        );
+          effectiveMaxInputTokens: effectiveContextWindow.maxInputTokens,
+        });
       } catch (err) {
         // Capture the error for post-finally logging, then short-circuit
         // the rest of the try body — no tail to push/persist when the


### PR DESCRIPTION
## Prompt / plan

Closes LUM-2031

Convert `AgentLoop.run` from 11 positional parameters (9 optional) to a 3-parameter signature with an options object, and DRY up the 6 identical call sites in `conversation-agent-loop.ts`.

## Why needed

`AgentLoop.run` had 11 positional params — `messages`, `onEvent`, then 9 optional ones (`signal`, `requestId`, `onCheckpoint`, `callSite`, `turnContext`, `overrideProfile`, `effectiveMaxInputTokens`, `resolveOverrideProfile`, `resolveEffectiveMaxInputTokens`). Test call sites were riddled with `undefined` holes:

```typescript
loop.run([msg], () => {}, undefined, undefined, onCheckpoint)
```

Additionally, `conversation-agent-loop.ts` called `run()` 6 times with the exact same 10 arguments — only `runMessages` varied. This is both a positional-param antipattern and a DRY violation.

## What changed

**Production code (3 files):**
- `agent/loop.ts`: Define `AgentLoopRunOptions` interface with docstrings, convert `run(messages, onEvent, signal?, requestId?, ...)` → `run(messages, onEvent, options?)`
- `daemon/conversation-agent-loop.ts`: Extract `runAgentLoop(runMessages)` closure that captures shared turn context, replacing 6 identical 12-line call blocks with one-liners
- `runtime/agent-wake.ts`: Update 1 call site — also removes stale `undefined, // no external abort signal` comment

**Test files (21 files):**
- 12 files with direct `loop.run()` call sites: updated from positional args to options object
- 9 files with `mock.module("../agent/loop.js")` mock classes:
  - 2 that actively read positional params (`conversation-process-callsite.test.ts` captures `callSite`, `conversation-queue.test.ts` captures `onCheckpoint`): updated to read from `options?.field`
  - 7 that had stale positional signatures with unused `_`-prefixed params: simplified to `(messages, onEvent)` and removed dead `CheckpointInfo`/`CheckpointDecision` imports

## First-principles audit

Audited against CLAUDE.md, AGENTS.md, and the 20-item review checklist:

**5. DRY** — The 6→1 `runAgentLoop` extraction is the core DRY fix. The helper captures the shared closure (`eventHandler`, `abortController`, `reqId`, `onCheckpoint`, etc.) once — each call site becomes a single `await runAgentLoop(runMessages)`. No remaining repetition.

**8. Dead code** — Removed unused `CheckpointInfo`/`CheckpointDecision` imports from 6 test files where the stale positional signature was the only consumer. Removed stale `undefined, // no external abort signal` comment from `agent-wake.ts`.

**9. Behavioral preservation** — Traced all 3 production code paths:
- `conversation-agent-loop.ts`: The `runAgentLoop` closure captures the same variables that were inline at each call site. The options object destructures to identical locals.
- `agent-wake.ts`: `requestId: \`wake:${source}\`` replaces positional 4th arg, `turnContext: wakeTurnContext` replaces positional 8th arg — same values, named fields.
- `loop.ts`: Method body unchanged; `const { signal, requestId, ... } = options ?? {}` produces identical locals to the old positional params.

**10. Tests** — All 21 test files updated. The 2 files with functional regressions (mock reading from wrong positional index) are fixed. The 7 with stale-but-harmless signatures are cleaned up to document the correct contract — "what would we want the next person to copy."

**11. Tech debt** — `mock.module` bypasses TypeScript type checking (duck-typed mocks), which is why `tsc --noEmit` didn't catch the stale mock signatures. This is a known limitation documented in the `testing-assistant-db` skill. No fix available — just awareness that mock signatures must be updated manually alongside production signature changes.

**17. File size** — `conversation-agent-loop.ts` is ~3300 lines (pre-existing). This PR reduces it by ~80 lines via the DRY extraction. Splitting is out of scope for a signature refactor.

**19. Documentation** — `AgentLoopRunOptions` interface has docstrings on `turnContext` and `overrideProfile` explaining their orchestrator-facing semantics. These were moved verbatim from the old inline parameter JSDoc. Updated stale docstring in `conversation-process-callsite.test.ts` to reference "options object" instead of "6th positional parameter."

**Items not applicable** — 1-4, 6-7, 12-16 are frontend-specific (React/Zustand/domains/barrel files/components). Item 18 (security) — no internal URLs, credentials, or OpenAPI specs.

## Why safe

- **Pure signature refactor** — function body is unchanged; all existing behavior is preserved
- **TypeScript catches missed sites** — `tsc --noEmit` passes with 0 errors
- **`messages` and `onEvent` stay positional** — always required, no ergonomic loss
- **No wire contract changes** — internal method signatures only, no IPC/SSE/HTTP surface affected
- **Pre-push hook**: all tests pass, lint + typecheck clean

## Alternatives considered

- **Keep positional params, just DRY the call sites**: Would reduce the 6x repetition but leave the `undefined` hole problem in tests and other callers. The options object solves both problems.
- **Also refactor the constructor**: The constructor has 7 params (5 optional) but only 1 production call site and no `undefined` holes in tests. Separate scope — recommend a follow-up ticket if desired.

Link to Devin session: https://app.devin.ai/sessions/1a2be238d9704952b6682fc77696d9b3
Requested by: @ashleeradka
