### PR TITLE
docs(web): point STATE_MANAGEMENT.md at canonical TanStack Query example + audit inline comments (LUM-2054)

### DIFF
--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -266,6 +266,18 @@ References:
 - [TkDodo — Working with Zustand](https://tkdodo.eu/blog/working-with-zustand) — React Query maintainer's guidance on the boundary between server state (RQ) and client/infrastructure state (Zustand)
 - [Zustand — Reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
 
+### Canonical migration example
+
+When migrating an imperative `setTimeout`-driven fetch loop to
+TanStack Query, the load-bearing patterns (mutation ref stability,
+explicit `staleTime: 0` on imperative re-checks, `setQueryData`
+post-mutation seeding, `setTimeout`-wrapped retry backoff) are
+demonstrated in [`src/assistant/queries.ts`](../src/assistant/queries.ts)
+and [`src/assistant/use-lifecycle.ts`](../src/assistant/use-lifecycle.ts).
+Each load-bearing call site has an inline comment explaining the
+invariant it preserves and the failure mode it prevents. Read those
+files as the source of truth — they update with the code.
+
 ## useReducer is not used for client state
 
 **Do not use `useReducer` in `apps/web/`.** All client state — including

--- a/apps/web/docs/STATE_MANAGEMENT.md
+++ b/apps/web/docs/STATE_MANAGEMENT.md
@@ -271,9 +271,11 @@ References:
 When migrating an imperative `setTimeout`-driven fetch loop to
 TanStack Query, the load-bearing patterns (mutation ref stability,
 explicit `staleTime: 0` on imperative re-checks, `setQueryData`
-post-mutation seeding, `setTimeout`-wrapped retry backoff) are
-demonstrated in [`src/assistant/queries.ts`](../src/assistant/queries.ts)
-and [`src/assistant/use-lifecycle.ts`](../src/assistant/use-lifecycle.ts).
+post-mutation seeding, `setTimeout`-wrapped retry backoff,
+`useEffect` on query data instead of the low-level
+`queryClient.getQueryCache().subscribe(...)`) are demonstrated in
+[`src/assistant/queries.ts`](../src/assistant/queries.ts) and
+[`src/assistant/use-lifecycle.ts`](../src/assistant/use-lifecycle.ts).
 Each load-bearing call site has an inline comment explaining the
 invariant it preserves and the failure mode it prevents. Read those
 files as the source of truth — they update with the code.

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -240,7 +240,7 @@ export function useAssistantLifecycle({
           // between hatch retries: rapid back-to-back invalidations
           // burn the `MAX_HATCH_RETRIES` budget in milliseconds and
           // hammer the server. The invalidation refetch lands the
-          // 404 in cache; the cache subscriber re-enters
+          // 404 in cache; the data-watcher effect below re-enters
           // `applyServerStateUpdate` → `auto_hatch` → `hatchAndCheck`
           // against the next retry slot.
           setTimeout(() => {
@@ -599,11 +599,12 @@ export function useAssistantLifecycle({
   // project each new query result into local state. The query polls
   // on the 3-second cadence defined by `pollIntervalFor`; `data`
   // updates as each successful poll (or hatch-time `setQueryData`
-  // seed, or `invalidateQueries` refetch) lands in cache. When the
-  // lifecycle is stable, the query stops polling, this effect's
-  // dependencies stop changing, and nothing projects — preserving
-  // the original "stop reacting once we land somewhere stable"
-  // contract that the old polling loop had via its early return.
+  // seed, or `invalidateQueries` refetch) lands in cache. Once the
+  // lifecycle reaches a stable phase (`active`, `self_hosted`,
+  // `error`, etc.), the kind-gate short-circuits and nothing
+  // projects — which is the right contract, because once we know
+  // where we landed the user shouldn't be silently re-routed by a
+  // late-arriving query result.
   useEffect(() => {
     if (
       assistantState.kind !== "initializing" &&


### PR DESCRIPTION
## Summary

Reframed [LUM-2054](https://linear.app/vellum/issue/LUM-2054). The original prescription — a 170-line "TanStack Query migration checklist" section in `STATE_MANAGEMENT.md` — was wrong, two ways:

1. **Category-conflation**: STATE_MANAGEMENT.md is a *conventions* doc ("server state lives in TanStack Query"), not a *framework mechanics* guide. Stuffing both into one dilutes both.
2. **Patterns belong where they're applied**: inline comments at the load-bearing call site stay maintained — they update with the code. A separate docs section silently rots, requires readers to know to look at it, and competes with the canonical example as the source of truth.

So instead this PR makes `src/assistant/queries.ts` and `src/assistant/use-lifecycle.ts` the canonical example and points STATE_MANAGEMENT.md at them.

## Changes

**`STATE_MANAGEMENT.md`** — new ~10-line "Canonical migration example" subsection under the React Query section. Points at the two files as the source of truth, names the five patterns that have inline anchors.

**`use-lifecycle.ts`** — two small comment fixes uncovered by the audit:

- Stale "cache subscriber re-enters" reference in the recoverable-failure backoff comment. We replaced the cache subscriber with `useEffect` on query data during the LUM-1814 cleanup pass; the comment now correctly says "the data-watcher effect."
- Refactor-history reference in the data-watcher's own comment ("the original polling loop had via its early return"). Rewritten to describe the kind-gate invariant in code terms.

## The five patterns and where they're documented

| Pattern | Inline anchor |
|---------|---------------|
| Mutation ref stability | `use-lifecycle.ts:141` |
| Imperative `staleTime: 0` on `fetchQuery` | `use-lifecycle.ts:436`, `:484` |
| `setQueryData` post-mutation seeding | `use-lifecycle.ts:204` |
| `setTimeout`-wrapped retry backoff | `use-lifecycle.ts:237`, `:270` |
| `useEffect` on query data (vs cache subscriber) | `use-lifecycle.ts:598` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `queries.test.ts` passing
- [x] STATE_MANAGEMENT.md internal links resolve

Closed PR: [#32628](https://github.com/vellum-ai/vellum-assistant/pull/32628) (the original 170-line approach)

Linear: [LUM-2054](https://linear.app/vellum/issue/LUM-2054)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_