### PR TITLE
refactor(web): split event-parser.ts into focused sub-parser modules

### DIFF
--- a/apps/web/src/domains/chat/hooks/stream-message-updaters.ts
+++ b/apps/web/src/domains/chat/hooks/stream-message-updaters.ts
@@ -11,7 +11,7 @@
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 import type { Surface } from "@/domains/chat/types/types";
-import { toDisplayAttachments } from "@/lib/streaming/event-parser";
+import { toDisplayAttachments } from "@/utils/display-attachments";
 import type { AllowlistOption, DirectoryScopeOption, ScopeOption } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { MessageCompleteEvent } from "@vellumai/assistant-api";

--- a/apps/web/src/lib/streaming/event-parser.test.ts
+++ b/apps/web/src/lib/streaming/event-parser.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  parseAssistantEvent,
-  toDisplayAttachments,
-} from "@/lib/streaming/event-parser";
+import { parseAssistantEvent } from "@/lib/streaming/event-parser";
 import { SYNC_TAGS } from "@/lib/sync/types";
 
 describe("parseAssistantEvent", () => {
@@ -2062,83 +2059,4 @@ describe("RuntimeMessage metadata types", () => {
   });
 });
 
-describe("toDisplayAttachments", () => {
-  test("returns undefined for empty/missing input", () => {
-    expect(toDisplayAttachments(undefined)).toBeUndefined();
-    expect(toDisplayAttachments([])).toBeUndefined();
-  });
 
-  test("converts image attachment with data-URI previewUrl", () => {
-    const result = toDisplayAttachments([
-      {
-        id: "att-1",
-        filename: "photo.png",
-        mimeType: "image/png",
-        data: "iVBORw0KGgo=",
-      },
-    ]);
-    expect(result).toEqual([
-      {
-        id: "att-1",
-        filename: "photo.png",
-        mimeType: "image/png",
-        sizeBytes: expect.any(Number),
-        previewUrl: "data:image/png;base64,iVBORw0KGgo=",
-      },
-    ]);
-  });
-
-  test("creates data-URI previewUrl for non-image types with inline data", () => {
-    const result = toDisplayAttachments([
-      {
-        id: "att-2",
-        filename: "report.pdf",
-        mimeType: "application/pdf",
-        data: "JVBERi0xLjQ=",
-      },
-    ]);
-    expect(result).toEqual([
-      {
-        id: "att-2",
-        filename: "report.pdf",
-        mimeType: "application/pdf",
-        sizeBytes: expect.any(Number),
-        previewUrl: "data:application/pdf;base64,JVBERi0xLjQ=",
-      },
-    ]);
-  });
-
-  test("uses thumbnailData when data is empty", () => {
-    const result = toDisplayAttachments([
-      {
-        id: "att-3",
-        filename: "clip.mp4",
-        mimeType: "video/mp4",
-        data: "",
-        thumbnailData: "thumb123",
-        fileBacked: true,
-        sizeBytes: 1024,
-      },
-    ]);
-    expect(result).toEqual([
-      {
-        id: "att-3",
-        filename: "clip.mp4",
-        mimeType: "video/mp4",
-        sizeBytes: 1024,
-        previewUrl: "data:image/jpeg;base64,thumb123",
-      },
-    ]);
-  });
-
-  test("falls back to filename for id when id is missing", () => {
-    const result = toDisplayAttachments([
-      {
-        filename: "noId.txt",
-        mimeType: "text/plain",
-        data: "aGVsbG8=",
-      },
-    ]);
-    expect(result?.[0]?.id).toBe("noId.txt");
-  });
-});

--- a/apps/web/src/lib/streaming/event-parser.ts
+++ b/apps/web/src/lib/streaming/event-parser.ts
@@ -6,34 +6,59 @@
  * envelope/flat shape, tries the canonical `AssistantEventSchema`
  * from `@vellumai/assistant-api` first, and falls back to hand-rolled
  * coercion for legacy events not yet covered by a schema.
+ *
+ * Legacy coercion is split across focused sub-modules by event group:
+ *   - `parse-interaction-events` — user-facing prompts
+ *   - `parse-tool-events`        — tool execution lifecycle
+ *   - `parse-surface-events`     — daemon-driven UI surfaces
+ *   - `parse-subagent-events`    — subagent orchestration
+ *   - `parse-resource-events`    — cache invalidation / push signals
+ *
+ * Events that migrate to `@vellumai/assistant-api` Zod schemas bypass
+ * the legacy switch entirely — the canonical path takes precedence.
  */
 
-import type {
-  DiskPressureBlockedCapability,
-  DiskPressureStatus,
-} from "@/assistant/types";
 import type {
   AssistantActivityPhase,
   AssistantActivityReason,
   AssistantActivityStateEvent,
   AssistantEvent,
-  ConversationListInvalidatedReason,
-  UISurfaceShowEvent,
 } from "@/types/event-types";
-import type {
-  AllowlistOption,
-  DirectoryScopeOption,
-  QuestionEntry,
-  QuestionOption,
-  ScopeOption,
-  SubagentInnerEvent,
-  SubagentStatus,
-} from "@/types/interaction-ui-types";
-import type { AssistantOutboundAttachment } from "@vellumai/assistant-api";
 import { AssistantEventSchema } from "@vellumai/assistant-api";
-import type { DisplayAttachment } from "@/types/attachment-types";
-import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
-import type { SyncInvalidationTag } from "@/lib/sync/types";
+import { unknownEvent } from "@/lib/streaming/parse-helpers";
+
+import {
+  parseSecretRequest,
+  parseConfirmationRequest,
+  parseContactRequest,
+  parseQuestionRequest,
+} from "@/lib/streaming/parse-interaction-events";
+import {
+  parseToolUseStart,
+  parseToolResult,
+  parseToolProgress,
+} from "@/lib/streaming/parse-tool-events";
+import {
+  parseUISurfaceShow,
+  parseUISurfaceUpdate,
+  parseUISurfaceDismiss,
+  parseUISurfaceComplete,
+} from "@/lib/streaming/parse-surface-events";
+import {
+  parseSubagentSpawned,
+  parseSubagentStatusChanged,
+  parseSubagentEvent,
+} from "@/lib/streaming/parse-subagent-events";
+import {
+  parseSyncChanged,
+  parseIdentityChanged,
+  parseAvatarUpdated,
+  parseConversationTitleUpdated,
+  parseConversationListInvalidated,
+  parseNotificationIntent,
+  parseDiskPressureStatusChanged,
+  parseDocumentEditorUpdate,
+} from "@/lib/streaming/parse-resource-events";
 
 /**
  * Unwrap envelope-shape payloads `{ message: { type, ...fields }, conversationId }`
@@ -85,24 +110,6 @@ function mergeEnvelopeConversationId(
 }
 
 /**
- * Build the `unknown` fallback event, preserving the raw type, the
- * original payload, and any conversation scope so downstream filters
- * (e.g. per-conversation SSE subscribers) still route correctly.
- */
-function unknownEvent(
-  rawType: string,
-  data: Record<string, unknown>,
-): AssistantEvent {
-  return {
-    type: "unknown",
-    rawType,
-    data,
-    conversationId:
-      typeof data.conversationId === "string" ? data.conversationId : undefined,
-  };
-}
-
-/**
  * Parse a raw SSE payload into a typed `AssistantEvent`. Owns envelope
  * unwrap, canonical-schema dispatch, legacy-event coercion, and
  * envelope-conversationId stamping. Tolerant of unknown event types —
@@ -138,24 +145,61 @@ function parseLegacyEvent(data: Record<string, unknown>): AssistantEvent {
   const rawType = typeof data.type === "string" ? data.type : "";
 
   switch (rawType) {
-    case "sync_changed": {
-      const tags = data.tags;
-      if (
-        !Array.isArray(tags) ||
-        !tags.every((tag): tag is string => typeof tag === "string")
-      ) {
-        return unknownEvent(rawType, data);
-      }
-      const rawOriginClientId =
-        typeof data.originClientId === "string"
-          ? data.originClientId.trim()
-          : "";
-      return {
-        type: "sync_changed",
-        tags: tags as SyncInvalidationTag[],
-        ...(rawOriginClientId ? { originClientId: rawOriginClientId } : {}),
-      };
-    }
+    // --- Interaction prompts ---
+    case "secret_request":
+      return parseSecretRequest(data);
+    case "confirmation_request":
+      return parseConfirmationRequest(data);
+    case "contact_request":
+      return parseContactRequest(data);
+    case "question_request":
+      return parseQuestionRequest(data);
+
+    // --- Tool execution lifecycle ---
+    case "tool_use_start":
+      return parseToolUseStart(data);
+    case "tool_result":
+      return parseToolResult(data);
+    case "tool_progress":
+      return parseToolProgress(data);
+
+    // --- UI surface lifecycle ---
+    case "ui_surface_show":
+      return parseUISurfaceShow(data);
+    case "ui_surface_update":
+      return parseUISurfaceUpdate(data);
+    case "ui_surface_dismiss":
+      return parseUISurfaceDismiss(data);
+    case "ui_surface_complete":
+      return parseUISurfaceComplete(data);
+
+    // --- Subagent orchestration ---
+    case "subagent_spawned":
+      return parseSubagentSpawned(data);
+    case "subagent_status_changed":
+      return parseSubagentStatusChanged(data);
+    case "subagent_event":
+      return parseSubagentEvent(data);
+
+    // --- Resource invalidation / push signals ---
+    case "sync_changed":
+      return parseSyncChanged(data);
+    case "identity_changed":
+      return parseIdentityChanged();
+    case "avatar_updated":
+      return parseAvatarUpdated();
+    case "conversation_title_updated":
+      return parseConversationTitleUpdated(data);
+    case "conversation_list_invalidated":
+      return parseConversationListInvalidated(data);
+    case "notification_intent":
+      return parseNotificationIntent(data);
+    case "disk_pressure_status_changed":
+      return parseDiskPressureStatusChanged(data);
+    case "document_editor_update":
+      return parseDocumentEditorUpdate(data);
+
+    // --- Inline cases (small, no cohesive group) ---
 
     case "assistant_activity_state": {
       const phase = typeof data.phase === "string" ? data.phase : "";
@@ -241,310 +285,24 @@ function parseLegacyEvent(data: Record<string, unknown>): AssistantEvent {
             : undefined,
       };
 
-    case "secret_request":
+    case "conversation_error":
       return {
-        type: "secret_request",
-        requestId: typeof data.requestId === "string" ? data.requestId : "",
-        service: typeof data.service === "string" ? data.service : undefined,
-        field: typeof data.field === "string" ? data.field : undefined,
-        label: typeof data.label === "string" ? data.label : undefined,
-        description:
-          typeof data.description === "string" ? data.description : undefined,
-        placeholder:
-          typeof data.placeholder === "string" ? data.placeholder : undefined,
-        allowOneTimeSend:
-          typeof data.allowOneTimeSend === "boolean"
-            ? data.allowOneTimeSend
-            : undefined,
-        allowedTools: Array.isArray(data.allowedTools)
-          ? (data.allowedTools as string[])
-          : undefined,
-        allowedDomains: Array.isArray(data.allowedDomains)
-          ? (data.allowedDomains as string[])
-          : undefined,
-        purpose: typeof data.purpose === "string" ? data.purpose : undefined,
+        type: "conversation_error",
         conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
+          typeof data.conversationId === "string" ? data.conversationId : "",
+        code: typeof data.code === "string" ? data.code : "UNKNOWN",
+        userMessage:
+          typeof data.userMessage === "string"
+            ? data.userMessage
+            : "Something went wrong.",
+        retryable: typeof data.retryable === "boolean" ? data.retryable : false,
+        debugDetails:
+          typeof data.debugDetails === "string" ? data.debugDetails : undefined,
+        errorCategory:
+          typeof data.errorCategory === "string"
+            ? data.errorCategory
             : undefined,
       };
-
-    case "confirmation_request":
-      return {
-        type: "confirmation_request",
-        requestId: typeof data.requestId === "string" ? data.requestId : "",
-        title: typeof data.title === "string" ? data.title : undefined,
-        description:
-          typeof data.description === "string" ? data.description : undefined,
-        confirmLabel:
-          typeof data.confirmLabel === "string" ? data.confirmLabel : undefined,
-        denyLabel:
-          typeof data.denyLabel === "string" ? data.denyLabel : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-        toolName: typeof data.toolName === "string" ? data.toolName : undefined,
-        executionTarget:
-          typeof data.executionTarget === "string"
-            ? data.executionTarget
-            : undefined,
-        riskLevel:
-          typeof data.riskLevel === "string" ? data.riskLevel : undefined,
-        riskReason:
-          typeof data.riskReason === "string" ? data.riskReason : undefined,
-        allowlistOptions: Array.isArray(data.allowlistOptions)
-          ? (data.allowlistOptions as AllowlistOption[])
-          : undefined,
-        scopeOptions: Array.isArray(data.scopeOptions)
-          ? (data.scopeOptions as ScopeOption[])
-          : undefined,
-        directoryScopeOptions: Array.isArray(data.directoryScopeOptions)
-          ? (data.directoryScopeOptions as DirectoryScopeOption[])
-          : undefined,
-        persistentDecisionsAllowed:
-          typeof data.persistentDecisionsAllowed === "boolean"
-            ? data.persistentDecisionsAllowed
-            : undefined,
-        input:
-          typeof data.input === "object" &&
-          data.input !== null &&
-          !Array.isArray(data.input)
-            ? (data.input as Record<string, unknown>)
-            : undefined,
-        toolUseId:
-          typeof data.toolUseId === "string" ? data.toolUseId : undefined,
-      };
-
-    case "contact_request":
-      return {
-        type: "contact_request",
-        requestId: typeof data.requestId === "string" ? data.requestId : "",
-        channel: typeof data.channel === "string" ? data.channel : undefined,
-        placeholder:
-          typeof data.placeholder === "string" ? data.placeholder : undefined,
-        label: typeof data.label === "string" ? data.label : undefined,
-        description:
-          typeof data.description === "string" ? data.description : undefined,
-        role: typeof data.role === "string" ? data.role : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "question_request": {
-      const requestId =
-        typeof data.requestId === "string" ? data.requestId : "";
-      // Pass through both shapes: the new `questions` array (batched) and the
-      // legacy flat fields. `normalizeQuestionRequest` (in event-types) picks
-      // whichever is present; legacy daemons emit only the flat fields, newer
-      // daemons emit both for back-compat.
-      const options: QuestionOption[] | undefined = Array.isArray(data.options)
-        ? (data.options as QuestionOption[])
-        : undefined;
-      const questions: QuestionEntry[] | undefined = Array.isArray(
-        data.questions,
-      )
-        ? (data.questions as QuestionEntry[])
-        : undefined;
-      return {
-        type: "question_request",
-        requestId,
-        questions,
-        question: typeof data.question === "string" ? data.question : undefined,
-        description:
-          typeof data.description === "string" ? data.description : undefined,
-        options,
-        freeTextPlaceholder:
-          typeof data.freeTextPlaceholder === "string"
-            ? data.freeTextPlaceholder
-            : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-        toolUseId:
-          typeof data.toolUseId === "string" ? data.toolUseId : undefined,
-      };
-    }
-
-    case "ui_surface_show":
-      return {
-        type: "ui_surface_show",
-        surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
-        surfaceType:
-          typeof data.surfaceType === "string" ? data.surfaceType : "card",
-        title: typeof data.title === "string" ? data.title : undefined,
-        data:
-          typeof data.data === "object" && data.data !== null
-            ? (data.data as Record<string, unknown>)
-            : {},
-        actions: Array.isArray(data.actions)
-          ? (data.actions as UISurfaceShowEvent["actions"])
-          : undefined,
-        display:
-          data.display === "inline" || data.display === "panel"
-            ? data.display
-            : undefined,
-        messageId:
-          typeof data.messageId === "string" ? data.messageId : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "ui_surface_update":
-      return {
-        type: "ui_surface_update",
-        surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
-        data:
-          typeof data.data === "object" && data.data !== null
-            ? (data.data as Record<string, unknown>)
-            : {},
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "ui_surface_dismiss":
-      return {
-        type: "ui_surface_dismiss",
-        surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "ui_surface_complete":
-      return {
-        type: "ui_surface_complete",
-        surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
-        summary: typeof data.summary === "string" ? data.summary : "",
-        submittedData:
-          typeof data.submittedData === "object" && data.submittedData !== null
-            ? (data.submittedData as Record<string, unknown>)
-            : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "tool_use_start":
-      return {
-        type: "tool_use_start",
-        toolName: typeof data.toolName === "string" ? data.toolName : "unknown",
-        input:
-          typeof data.input === "object" && data.input !== null
-            ? (data.input as Record<string, unknown>)
-            : {},
-        toolUseId:
-          typeof data.toolUseId === "string" ? data.toolUseId : undefined,
-        messageId:
-          typeof data.messageId === "string" ? data.messageId : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "tool_result":
-      return {
-        type: "tool_result",
-        toolName: typeof data.toolName === "string" ? data.toolName : "unknown",
-        result: typeof data.result === "string" ? data.result : "",
-        isError: typeof data.isError === "boolean" ? data.isError : undefined,
-        toolUseId:
-          typeof data.toolUseId === "string" ? data.toolUseId : undefined,
-        messageId:
-          typeof data.messageId === "string" ? data.messageId : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-        riskLevel:
-          typeof data.riskLevel === "string" ? data.riskLevel : undefined,
-        riskReason:
-          typeof data.riskReason === "string" ? data.riskReason : undefined,
-        matchedTrustRuleId:
-          typeof data.matchedTrustRuleId === "string"
-            ? data.matchedTrustRuleId
-            : undefined,
-        approvalMode:
-          typeof data.approvalMode === "string" ? data.approvalMode : undefined,
-        approvalReason:
-          typeof data.approvalReason === "string"
-            ? data.approvalReason
-            : undefined,
-        riskThreshold:
-          typeof data.riskThreshold === "string"
-            ? data.riskThreshold
-            : undefined,
-        // The daemon emits two semantically distinct arrays on tool_result:
-        //   - `riskAllowlistOptions`  → Minimatch-glob save-path patterns (the
-        //     ones that get persisted as a trust rule's `pattern`). This is
-        //     what the rule editor's "Apply to" radio group needs.
-        //   - `riskScopeOptions`      → display-only ladder, can carry
-        //     regex-flavored descriptors that are NOT valid trust rule
-        //     patterns. We deliberately do not feed these into the save path.
-        // (Pre-PR-29826 the wire collapsed both into `riskScopeOptions` and
-        // we cast that into `allowlistOptions` — a silent shape/contract bug
-        // that produced unmatchable rules. See `assistant/src/tools/types.ts`.)
-        allowlistOptions: Array.isArray(data.riskAllowlistOptions)
-          ? (data.riskAllowlistOptions as AllowlistOption[])
-          : undefined,
-        directoryScopeOptions: Array.isArray(data.riskDirectoryScopeOptions)
-          ? (data.riskDirectoryScopeOptions as DirectoryScopeOption[])
-          : undefined,
-        // Daemon emits `activityMetadata` on tool_result for tools that report
-        // structured activity (currently Anthropic-native web_search). Treated
-        // as opaque on the wire — the downstream consumer (turn-state) keys
-        // off the discriminated child fields (webSearch/webFetch).
-        activityMetadata:
-          typeof data.activityMetadata === "object" &&
-          data.activityMetadata !== null &&
-          !Array.isArray(data.activityMetadata)
-            ? (data.activityMetadata as ToolActivityMetadata)
-            : undefined,
-      };
-
-    case "tool_progress": {
-      const toolName =
-        typeof data.toolName === "string" ? data.toolName : "unknown";
-      const elapsedSec =
-        typeof data.elapsedSec === "number" ? data.elapsedSec : 0;
-      const timeoutSec =
-        typeof data.timeoutSec === "number" ? data.timeoutSec : 0;
-      return {
-        type: "tool_progress",
-        toolName,
-        elapsedSec,
-        timeoutSec,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-        toolUseId:
-          typeof data.toolUseId === "string" ? data.toolUseId : undefined,
-      };
-    }
-
-    case "conversation_list_invalidated": {
-      const rawReason = typeof data.reason === "string" ? data.reason : "";
-      const reason: ConversationListInvalidatedReason =
-        rawReason === "created" ||
-        rawReason === "renamed" ||
-        rawReason === "deleted" ||
-        rawReason === "reordered" ||
-        rawReason === "seen_changed"
-          ? rawReason
-          : "created";
-      return { type: "conversation_list_invalidated", reason };
-    }
 
     case "usage_update": {
       const readNumber = (key: string): number | undefined => {
@@ -568,51 +326,6 @@ function parseLegacyEvent(data: Record<string, unknown>): AssistantEvent {
       };
     }
 
-    case "conversation_title_updated": {
-      const conversationId =
-        typeof data.conversationId === "string" ? data.conversationId : "";
-      const title = typeof data.title === "string" ? data.title : "";
-      if (!conversationId) {
-        return unknownEvent(rawType, data);
-      }
-      return { type: "conversation_title_updated", conversationId, title };
-    }
-
-    case "notification_intent": {
-      const title = typeof data.title === "string" ? data.title : "";
-      const body = typeof data.body === "string" ? data.body : "";
-      const sourceEventName =
-        typeof data.sourceEventName === "string" ? data.sourceEventName : "";
-      if (!title || !sourceEventName) {
-        return unknownEvent(rawType, data);
-      }
-      const deepLinkMetadata =
-        typeof data.deepLinkMetadata === "object" &&
-        data.deepLinkMetadata !== null &&
-        !Array.isArray(data.deepLinkMetadata)
-          ? (data.deepLinkMetadata as Record<string, unknown>)
-          : undefined;
-      return {
-        type: "notification_intent",
-        deliveryId:
-          typeof data.deliveryId === "string" ? data.deliveryId : undefined,
-        sourceEventName,
-        title,
-        body,
-        deepLinkMetadata,
-        targetGuardianPrincipalId:
-          typeof data.targetGuardianPrincipalId === "string"
-            ? data.targetGuardianPrincipalId
-            : undefined,
-      };
-    }
-
-    case "identity_changed":
-      return { type: "identity_changed" };
-
-    case "avatar_updated":
-      return { type: "avatar_updated" };
-
     case "turn_profile_auto_routed": {
       const conversationId =
         typeof data.conversationId === "string" ? data.conversationId : "";
@@ -632,232 +345,7 @@ function parseLegacyEvent(data: Record<string, unknown>): AssistantEvent {
       };
     }
 
-    case "conversation_error":
-      return {
-        type: "conversation_error",
-        conversationId:
-          typeof data.conversationId === "string" ? data.conversationId : "",
-        code: typeof data.code === "string" ? data.code : "UNKNOWN",
-        userMessage:
-          typeof data.userMessage === "string"
-            ? data.userMessage
-            : "Something went wrong.",
-        retryable: typeof data.retryable === "boolean" ? data.retryable : false,
-        debugDetails:
-          typeof data.debugDetails === "string" ? data.debugDetails : undefined,
-        errorCategory:
-          typeof data.errorCategory === "string"
-            ? data.errorCategory
-            : undefined,
-      };
-
-    case "disk_pressure_status_changed":
-      return {
-        type: "disk_pressure_status_changed",
-        status: parseDiskPressureStatus(
-          Object.prototype.hasOwnProperty.call(data, "status")
-            ? data.status
-            : data,
-        ),
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-
-    case "subagent_spawned": {
-      const subagentId =
-        typeof data.subagentId === "string" ? data.subagentId : "";
-      const label = typeof data.label === "string" ? data.label : "";
-      if (!subagentId || !label) {
-        return unknownEvent(rawType, data);
-      }
-      return {
-        type: "subagent_spawned",
-        subagentId,
-        parentConversationId:
-          typeof data.parentConversationId === "string"
-            ? data.parentConversationId
-            : undefined,
-        label,
-        objective: typeof data.objective === "string" ? data.objective : "",
-        isFork: typeof data.isFork === "boolean" ? data.isFork : undefined,
-        parentToolUseId:
-          typeof data.parentToolUseId === "string"
-            ? data.parentToolUseId
-            : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-    }
-
-    case "subagent_status_changed": {
-      const subagentId =
-        typeof data.subagentId === "string" ? data.subagentId : "";
-      const status = typeof data.status === "string" ? data.status : "";
-      if (!subagentId || !status) {
-        return unknownEvent(rawType, data);
-      }
-      const usage =
-        data.usage &&
-        typeof data.usage === "object" &&
-        !Array.isArray(data.usage)
-          ? (data.usage as Record<string, unknown>)
-          : null;
-      return {
-        type: "subagent_status_changed",
-        subagentId,
-        status: status as SubagentStatus,
-        error: typeof data.error === "string" ? data.error : undefined,
-        inputTokens:
-          typeof usage?.inputTokens === "number"
-            ? usage.inputTokens
-            : undefined,
-        outputTokens:
-          typeof usage?.outputTokens === "number"
-            ? usage.outputTokens
-            : undefined,
-        totalCost:
-          typeof usage?.estimatedCost === "number"
-            ? usage.estimatedCost
-            : undefined,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-      };
-    }
-
-    case "subagent_event": {
-      const subagentId =
-        typeof data.subagentId === "string" ? data.subagentId : "";
-      const event = data.event;
-      if (
-        !subagentId ||
-        !event ||
-        typeof event !== "object" ||
-        Array.isArray(event)
-      ) {
-        return unknownEvent(rawType, data);
-      }
-      return {
-        type: "subagent_event",
-        subagentId,
-        conversationId:
-          typeof data.conversationId === "string"
-            ? data.conversationId
-            : undefined,
-        event: event as SubagentInnerEvent,
-      };
-    }
-
-    case "document_editor_update": {
-      const surfaceId =
-        typeof data.surfaceId === "string" ? data.surfaceId : "";
-      const markdown = typeof data.markdown === "string" ? data.markdown : "";
-      const mode = typeof data.mode === "string" ? data.mode : "replace";
-      const conversationId =
-        typeof data.conversationId === "string"
-          ? data.conversationId
-          : undefined;
-      if (!surfaceId) {
-        return unknownEvent(rawType, data);
-      }
-      return {
-        type: "document_editor_update",
-        surfaceId,
-        markdown,
-        mode,
-        conversationId,
-      };
-    }
-
     default:
       return unknownEvent(rawType, data);
   }
-}
-
-function parseDiskPressureStatus(raw: unknown): DiskPressureStatus | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return null;
-  }
-
-  const data = raw as Record<string, unknown>;
-  const state =
-    data.state === "disabled" ||
-    data.state === "ok" ||
-    data.state === "critical" ||
-    data.state === "unknown"
-      ? data.state
-      : "unknown";
-
-  const finiteNumberOrNull = (value: unknown): number | null =>
-    typeof value === "number" && Number.isFinite(value) ? value : null;
-
-  const blockedCapabilities: DiskPressureBlockedCapability[] = Array.isArray(
-    data.blockedCapabilities,
-  )
-    ? data.blockedCapabilities.filter(
-        (capability): capability is DiskPressureBlockedCapability =>
-          capability === "agent-turns" ||
-          capability === "background-work" ||
-          capability === "remote-ingress",
-      )
-    : [];
-
-  return {
-    enabled: typeof data.enabled === "boolean" ? data.enabled : false,
-    state,
-    locked: typeof data.locked === "boolean" ? data.locked : false,
-    acknowledged:
-      typeof data.acknowledged === "boolean" ? data.acknowledged : false,
-    overrideActive:
-      typeof data.overrideActive === "boolean" ? data.overrideActive : false,
-    effectivelyLocked:
-      typeof data.effectivelyLocked === "boolean"
-        ? data.effectivelyLocked
-        : false,
-    lockId: typeof data.lockId === "string" ? data.lockId : null,
-    usagePercent: finiteNumberOrNull(data.usagePercent),
-    thresholdPercent: finiteNumberOrNull(data.thresholdPercent) ?? 0,
-    path: typeof data.path === "string" ? data.path : null,
-    lastCheckedAt:
-      typeof data.lastCheckedAt === "string" ? data.lastCheckedAt : null,
-    blockedCapabilities,
-    error: typeof data.error === "string" ? data.error : null,
-  };
-}
-
-/**
- * Convert backend `AssistantOutboundAttachment` objects into `DisplayAttachment`
- * objects suitable for rendering in chat message bubbles. When inline base64
- * data is available, a data-URI `previewUrl` is created for all MIME types so
- * the preview modal can render or download the content without a separate fetch.
- * When only a thumbnail is available (e.g. video with omitted data), the
- * thumbnail is used as a fallback preview. Files with `fileBacked: true` and no
- * inline data rely on the daemon's `/v1/attachments/:id/content` endpoint —
- * the modal fetches content lazily via the assistantId-scoped proxy URL.
- */
-export function toDisplayAttachments(
-  attachments: AssistantOutboundAttachment[] | undefined,
-): DisplayAttachment[] | undefined {
-  if (!attachments || attachments.length === 0) return undefined;
-  return attachments.map((att) => {
-    let previewUrl: string | null = null;
-    if (att.data) {
-      previewUrl = `data:${att.mimeType};base64,${att.data}`;
-    } else if (att.thumbnailData) {
-      previewUrl = `data:image/jpeg;base64,${att.thumbnailData}`;
-    }
-    return {
-      id: att.id ?? att.filename,
-      filename: att.filename,
-      mimeType: att.mimeType,
-      sizeBytes:
-        att.sizeBytes ?? (att.data ? Math.floor((att.data.length * 3) / 4) : 0),
-      previewUrl,
-    };
-  });
 }

--- a/apps/web/src/lib/streaming/parse-helpers.ts
+++ b/apps/web/src/lib/streaming/parse-helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared helpers for legacy event sub-parsers.
+ */
+
+import type { AssistantEvent } from "@/types/event-types";
+
+/**
+ * Build the `unknown` fallback event, preserving the raw type, the
+ * original payload, and any conversation scope so downstream filters
+ * (e.g. per-conversation SSE subscribers) still route correctly.
+ */
+export function unknownEvent(
+  rawType: string,
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "unknown",
+    rawType,
+    data,
+    conversationId:
+      typeof data.conversationId === "string" ? data.conversationId : undefined,
+  };
+}

--- a/apps/web/src/lib/streaming/parse-interaction-events.ts
+++ b/apps/web/src/lib/streaming/parse-interaction-events.ts
@@ -1,0 +1,150 @@
+/**
+ * Legacy parsers for user-facing interaction prompt events.
+ *
+ * Each function coerces a raw SSE payload into a typed event for one
+ * of the four daemon-initiated prompts that require the user to
+ * respond: secret entry, tool-risk confirmation, contact sharing,
+ * and multi-option questions.
+ */
+
+import type { AssistantEvent } from "@/types/event-types";
+import type {
+  AllowlistOption,
+  DirectoryScopeOption,
+  QuestionEntry,
+  QuestionOption,
+  ScopeOption,
+} from "@/types/interaction-ui-types";
+
+export function parseSecretRequest(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "secret_request",
+    requestId: typeof data.requestId === "string" ? data.requestId : "",
+    service: typeof data.service === "string" ? data.service : undefined,
+    field: typeof data.field === "string" ? data.field : undefined,
+    label: typeof data.label === "string" ? data.label : undefined,
+    description:
+      typeof data.description === "string" ? data.description : undefined,
+    placeholder:
+      typeof data.placeholder === "string" ? data.placeholder : undefined,
+    allowOneTimeSend:
+      typeof data.allowOneTimeSend === "boolean"
+        ? data.allowOneTimeSend
+        : undefined,
+    allowedTools: Array.isArray(data.allowedTools)
+      ? (data.allowedTools as string[])
+      : undefined,
+    allowedDomains: Array.isArray(data.allowedDomains)
+      ? (data.allowedDomains as string[])
+      : undefined,
+    purpose: typeof data.purpose === "string" ? data.purpose : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseConfirmationRequest(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "confirmation_request",
+    requestId: typeof data.requestId === "string" ? data.requestId : "",
+    title: typeof data.title === "string" ? data.title : undefined,
+    description:
+      typeof data.description === "string" ? data.description : undefined,
+    confirmLabel:
+      typeof data.confirmLabel === "string" ? data.confirmLabel : undefined,
+    denyLabel:
+      typeof data.denyLabel === "string" ? data.denyLabel : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    toolName: typeof data.toolName === "string" ? data.toolName : undefined,
+    executionTarget:
+      typeof data.executionTarget === "string"
+        ? data.executionTarget
+        : undefined,
+    riskLevel:
+      typeof data.riskLevel === "string" ? data.riskLevel : undefined,
+    riskReason:
+      typeof data.riskReason === "string" ? data.riskReason : undefined,
+    allowlistOptions: Array.isArray(data.allowlistOptions)
+      ? (data.allowlistOptions as AllowlistOption[])
+      : undefined,
+    scopeOptions: Array.isArray(data.scopeOptions)
+      ? (data.scopeOptions as ScopeOption[])
+      : undefined,
+    directoryScopeOptions: Array.isArray(data.directoryScopeOptions)
+      ? (data.directoryScopeOptions as DirectoryScopeOption[])
+      : undefined,
+    persistentDecisionsAllowed:
+      typeof data.persistentDecisionsAllowed === "boolean"
+        ? data.persistentDecisionsAllowed
+        : undefined,
+    input:
+      typeof data.input === "object" &&
+      data.input !== null &&
+      !Array.isArray(data.input)
+        ? (data.input as Record<string, unknown>)
+        : undefined,
+    toolUseId:
+      typeof data.toolUseId === "string" ? data.toolUseId : undefined,
+  };
+}
+
+export function parseContactRequest(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "contact_request",
+    requestId: typeof data.requestId === "string" ? data.requestId : "",
+    channel: typeof data.channel === "string" ? data.channel : undefined,
+    placeholder:
+      typeof data.placeholder === "string" ? data.placeholder : undefined,
+    label: typeof data.label === "string" ? data.label : undefined,
+    description:
+      typeof data.description === "string" ? data.description : undefined,
+    role: typeof data.role === "string" ? data.role : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseQuestionRequest(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const requestId =
+    typeof data.requestId === "string" ? data.requestId : "";
+  const options: QuestionOption[] | undefined = Array.isArray(data.options)
+    ? (data.options as QuestionOption[])
+    : undefined;
+  const questions: QuestionEntry[] | undefined = Array.isArray(data.questions)
+    ? (data.questions as QuestionEntry[])
+    : undefined;
+  return {
+    type: "question_request",
+    requestId,
+    questions,
+    question: typeof data.question === "string" ? data.question : undefined,
+    description:
+      typeof data.description === "string" ? data.description : undefined,
+    options,
+    freeTextPlaceholder:
+      typeof data.freeTextPlaceholder === "string"
+        ? data.freeTextPlaceholder
+        : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    toolUseId:
+      typeof data.toolUseId === "string" ? data.toolUseId : undefined,
+  };
+}

--- a/apps/web/src/lib/streaming/parse-resource-events.ts
+++ b/apps/web/src/lib/streaming/parse-resource-events.ts
@@ -1,0 +1,198 @@
+/**
+ * Legacy parsers for resource invalidation and push-signal events.
+ *
+ * These events notify the client about server-side state changes
+ * (cache invalidation tags, identity/avatar refreshes, conversation
+ * renames, notification intents, disk pressure) so the appropriate
+ * TanStack Query keys or Zustand stores can be updated. None of
+ * these carry chat-turn content — they are broadcast signals.
+ */
+
+import type {
+  DiskPressureBlockedCapability,
+  DiskPressureStatus,
+} from "@/assistant/types";
+import type {
+  AssistantEvent,
+  ConversationListInvalidatedReason,
+} from "@/types/event-types";
+import type { SyncInvalidationTag } from "@/lib/sync/types";
+import { unknownEvent } from "@/lib/streaming/parse-helpers";
+
+export function parseSyncChanged(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const tags = data.tags;
+  if (
+    !Array.isArray(tags) ||
+    !tags.every((tag): tag is string => typeof tag === "string")
+  ) {
+    return unknownEvent("sync_changed", data);
+  }
+  const rawOriginClientId =
+    typeof data.originClientId === "string"
+      ? data.originClientId.trim()
+      : "";
+  return {
+    type: "sync_changed",
+    tags: tags as SyncInvalidationTag[],
+    ...(rawOriginClientId ? { originClientId: rawOriginClientId } : {}),
+  };
+}
+
+export function parseIdentityChanged(): AssistantEvent {
+  return { type: "identity_changed" };
+}
+
+export function parseAvatarUpdated(): AssistantEvent {
+  return { type: "avatar_updated" };
+}
+
+export function parseConversationTitleUpdated(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const conversationId =
+    typeof data.conversationId === "string" ? data.conversationId : "";
+  const title = typeof data.title === "string" ? data.title : "";
+  if (!conversationId) {
+    return unknownEvent("conversation_title_updated", data);
+  }
+  return { type: "conversation_title_updated", conversationId, title };
+}
+
+export function parseConversationListInvalidated(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const rawReason = typeof data.reason === "string" ? data.reason : "";
+  const reason: ConversationListInvalidatedReason =
+    rawReason === "created" ||
+    rawReason === "renamed" ||
+    rawReason === "deleted" ||
+    rawReason === "reordered" ||
+    rawReason === "seen_changed"
+      ? rawReason
+      : "created";
+  return { type: "conversation_list_invalidated", reason };
+}
+
+export function parseNotificationIntent(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const title = typeof data.title === "string" ? data.title : "";
+  const body = typeof data.body === "string" ? data.body : "";
+  const sourceEventName =
+    typeof data.sourceEventName === "string" ? data.sourceEventName : "";
+  if (!title || !sourceEventName) {
+    return unknownEvent("notification_intent", data);
+  }
+  const deepLinkMetadata =
+    typeof data.deepLinkMetadata === "object" &&
+    data.deepLinkMetadata !== null &&
+    !Array.isArray(data.deepLinkMetadata)
+      ? (data.deepLinkMetadata as Record<string, unknown>)
+      : undefined;
+  return {
+    type: "notification_intent",
+    deliveryId:
+      typeof data.deliveryId === "string" ? data.deliveryId : undefined,
+    sourceEventName,
+    title,
+    body,
+    deepLinkMetadata,
+    targetGuardianPrincipalId:
+      typeof data.targetGuardianPrincipalId === "string"
+        ? data.targetGuardianPrincipalId
+        : undefined,
+  };
+}
+
+export function parseDiskPressureStatusChanged(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "disk_pressure_status_changed",
+    status: parseDiskPressureStatus(
+      Object.prototype.hasOwnProperty.call(data, "status")
+        ? data.status
+        : data,
+    ),
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseDocumentEditorUpdate(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const surfaceId =
+    typeof data.surfaceId === "string" ? data.surfaceId : "";
+  const markdown = typeof data.markdown === "string" ? data.markdown : "";
+  const mode = typeof data.mode === "string" ? data.mode : "replace";
+  const conversationId =
+    typeof data.conversationId === "string"
+      ? data.conversationId
+      : undefined;
+  if (!surfaceId) {
+    return unknownEvent("document_editor_update", data);
+  }
+  return {
+    type: "document_editor_update",
+    surfaceId,
+    markdown,
+    mode,
+    conversationId,
+  };
+}
+
+function parseDiskPressureStatus(raw: unknown): DiskPressureStatus | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+
+  const data = raw as Record<string, unknown>;
+  const state =
+    data.state === "disabled" ||
+    data.state === "ok" ||
+    data.state === "critical" ||
+    data.state === "unknown"
+      ? data.state
+      : "unknown";
+
+  const finiteNumberOrNull = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
+
+  const blockedCapabilities: DiskPressureBlockedCapability[] = Array.isArray(
+    data.blockedCapabilities,
+  )
+    ? data.blockedCapabilities.filter(
+        (capability): capability is DiskPressureBlockedCapability =>
+          capability === "agent-turns" ||
+          capability === "background-work" ||
+          capability === "remote-ingress",
+      )
+    : [];
+
+  return {
+    enabled: typeof data.enabled === "boolean" ? data.enabled : false,
+    state,
+    locked: typeof data.locked === "boolean" ? data.locked : false,
+    acknowledged:
+      typeof data.acknowledged === "boolean" ? data.acknowledged : false,
+    overrideActive:
+      typeof data.overrideActive === "boolean" ? data.overrideActive : false,
+    effectivelyLocked:
+      typeof data.effectivelyLocked === "boolean"
+        ? data.effectivelyLocked
+        : false,
+    lockId: typeof data.lockId === "string" ? data.lockId : null,
+    usagePercent: finiteNumberOrNull(data.usagePercent),
+    thresholdPercent: finiteNumberOrNull(data.thresholdPercent) ?? 0,
+    path: typeof data.path === "string" ? data.path : null,
+    lastCheckedAt:
+      typeof data.lastCheckedAt === "string" ? data.lastCheckedAt : null,
+    blockedCapabilities,
+    error: typeof data.error === "string" ? data.error : null,
+  };
+}

--- a/apps/web/src/lib/streaming/parse-subagent-events.ts
+++ b/apps/web/src/lib/streaming/parse-subagent-events.ts
@@ -1,0 +1,108 @@
+/**
+ * Legacy parsers for subagent orchestration events.
+ *
+ * Subagents are daemon-spawned child assistants that run in parallel
+ * with the parent conversation. These three events cover spawn,
+ * status transitions, and inner event forwarding.
+ */
+
+import type { AssistantEvent } from "@/types/event-types";
+import type {
+  SubagentInnerEvent,
+  SubagentStatus,
+} from "@/types/interaction-ui-types";
+import { unknownEvent } from "@/lib/streaming/parse-helpers";
+
+export function parseSubagentSpawned(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const subagentId =
+    typeof data.subagentId === "string" ? data.subagentId : "";
+  const label = typeof data.label === "string" ? data.label : "";
+  if (!subagentId || !label) {
+    return unknownEvent("subagent_spawned", data);
+  }
+  return {
+    type: "subagent_spawned",
+    subagentId,
+    parentConversationId:
+      typeof data.parentConversationId === "string"
+        ? data.parentConversationId
+        : undefined,
+    label,
+    objective: typeof data.objective === "string" ? data.objective : "",
+    isFork: typeof data.isFork === "boolean" ? data.isFork : undefined,
+    parentToolUseId:
+      typeof data.parentToolUseId === "string"
+        ? data.parentToolUseId
+        : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseSubagentStatusChanged(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const subagentId =
+    typeof data.subagentId === "string" ? data.subagentId : "";
+  const status = typeof data.status === "string" ? data.status : "";
+  if (!subagentId || !status) {
+    return unknownEvent("subagent_status_changed", data);
+  }
+  const usage =
+    data.usage &&
+    typeof data.usage === "object" &&
+    !Array.isArray(data.usage)
+      ? (data.usage as Record<string, unknown>)
+      : null;
+  return {
+    type: "subagent_status_changed",
+    subagentId,
+    status: status as SubagentStatus,
+    error: typeof data.error === "string" ? data.error : undefined,
+    inputTokens:
+      typeof usage?.inputTokens === "number"
+        ? usage.inputTokens
+        : undefined,
+    outputTokens:
+      typeof usage?.outputTokens === "number"
+        ? usage.outputTokens
+        : undefined,
+    totalCost:
+      typeof usage?.estimatedCost === "number"
+        ? usage.estimatedCost
+        : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseSubagentEvent(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  const subagentId =
+    typeof data.subagentId === "string" ? data.subagentId : "";
+  const event = data.event;
+  if (
+    !subagentId ||
+    !event ||
+    typeof event !== "object" ||
+    Array.isArray(event)
+  ) {
+    return unknownEvent("subagent_event", data);
+  }
+  return {
+    type: "subagent_event",
+    subagentId,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    event: event as SubagentInnerEvent,
+  };
+}

--- a/apps/web/src/lib/streaming/parse-surface-events.ts
+++ b/apps/web/src/lib/streaming/parse-surface-events.ts
@@ -1,0 +1,89 @@
+/**
+ * Legacy parsers for daemon-driven UI surface lifecycle events.
+ *
+ * Surfaces are ephemeral UI widgets the daemon projects into the chat
+ * view. The four events cover the full lifecycle: show → update →
+ * dismiss/complete.
+ */
+
+import type {
+  AssistantEvent,
+  UISurfaceShowEvent,
+} from "@/types/event-types";
+
+export function parseUISurfaceShow(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "ui_surface_show",
+    surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
+    surfaceType:
+      typeof data.surfaceType === "string" ? data.surfaceType : "card",
+    title: typeof data.title === "string" ? data.title : undefined,
+    data:
+      typeof data.data === "object" && data.data !== null
+        ? (data.data as Record<string, unknown>)
+        : {},
+    actions: Array.isArray(data.actions)
+      ? (data.actions as UISurfaceShowEvent["actions"])
+      : undefined,
+    display:
+      data.display === "inline" || data.display === "panel"
+        ? data.display
+        : undefined,
+    messageId:
+      typeof data.messageId === "string" ? data.messageId : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseUISurfaceUpdate(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "ui_surface_update",
+    surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
+    data:
+      typeof data.data === "object" && data.data !== null
+        ? (data.data as Record<string, unknown>)
+        : {},
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseUISurfaceDismiss(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "ui_surface_dismiss",
+    surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseUISurfaceComplete(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "ui_surface_complete",
+    surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : "",
+    summary: typeof data.summary === "string" ? data.summary : "",
+    submittedData:
+      typeof data.submittedData === "object" && data.submittedData !== null
+        ? (data.submittedData as Record<string, unknown>)
+        : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}

--- a/apps/web/src/lib/streaming/parse-tool-events.ts
+++ b/apps/web/src/lib/streaming/parse-tool-events.ts
@@ -1,0 +1,112 @@
+/**
+ * Legacy parsers for tool execution lifecycle events.
+ *
+ * Covers the three phases of a daemon-side tool call: start
+ * (with input), progress ticks, and the final result (with risk
+ * metadata for trust-rule evaluation).
+ */
+
+import type { AssistantEvent } from "@/types/event-types";
+import type {
+  AllowlistOption,
+  DirectoryScopeOption,
+} from "@/types/interaction-ui-types";
+import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
+
+export function parseToolUseStart(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "tool_use_start",
+    toolName: typeof data.toolName === "string" ? data.toolName : "unknown",
+    input:
+      typeof data.input === "object" && data.input !== null
+        ? (data.input as Record<string, unknown>)
+        : {},
+    toolUseId:
+      typeof data.toolUseId === "string" ? data.toolUseId : undefined,
+    messageId:
+      typeof data.messageId === "string" ? data.messageId : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+  };
+}
+
+export function parseToolResult(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "tool_result",
+    toolName: typeof data.toolName === "string" ? data.toolName : "unknown",
+    result: typeof data.result === "string" ? data.result : "",
+    isError: typeof data.isError === "boolean" ? data.isError : undefined,
+    toolUseId:
+      typeof data.toolUseId === "string" ? data.toolUseId : undefined,
+    messageId:
+      typeof data.messageId === "string" ? data.messageId : undefined,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    riskLevel:
+      typeof data.riskLevel === "string" ? data.riskLevel : undefined,
+    riskReason:
+      typeof data.riskReason === "string" ? data.riskReason : undefined,
+    matchedTrustRuleId:
+      typeof data.matchedTrustRuleId === "string"
+        ? data.matchedTrustRuleId
+        : undefined,
+    approvalMode:
+      typeof data.approvalMode === "string" ? data.approvalMode : undefined,
+    approvalReason:
+      typeof data.approvalReason === "string"
+        ? data.approvalReason
+        : undefined,
+    riskThreshold:
+      typeof data.riskThreshold === "string"
+        ? data.riskThreshold
+        : undefined,
+    // The daemon emits two semantically distinct arrays on tool_result:
+    //   - `riskAllowlistOptions`  → Minimatch-glob save-path patterns (the
+    //     ones that get persisted as a trust rule's `pattern`). This is
+    //     what the rule editor's "Apply to" radio group needs.
+    //   - `riskScopeOptions`      → display-only ladder, can carry
+    //     regex-flavored descriptors that are NOT valid trust rule
+    //     patterns. We deliberately do not feed these into the save path.
+    allowlistOptions: Array.isArray(data.riskAllowlistOptions)
+      ? (data.riskAllowlistOptions as AllowlistOption[])
+      : undefined,
+    directoryScopeOptions: Array.isArray(data.riskDirectoryScopeOptions)
+      ? (data.riskDirectoryScopeOptions as DirectoryScopeOption[])
+      : undefined,
+    // Daemon emits `activityMetadata` on tool_result for tools that report
+    // structured activity (currently Anthropic-native web_search). Treated
+    // as opaque on the wire — the downstream consumer (turn-state) keys
+    // off the discriminated child fields (webSearch/webFetch).
+    activityMetadata:
+      typeof data.activityMetadata === "object" &&
+      data.activityMetadata !== null &&
+      !Array.isArray(data.activityMetadata)
+        ? (data.activityMetadata as ToolActivityMetadata)
+        : undefined,
+  };
+}
+
+export function parseToolProgress(
+  data: Record<string, unknown>,
+): AssistantEvent {
+  return {
+    type: "tool_progress",
+    toolName: typeof data.toolName === "string" ? data.toolName : "unknown",
+    elapsedSec: typeof data.elapsedSec === "number" ? data.elapsedSec : 0,
+    timeoutSec: typeof data.timeoutSec === "number" ? data.timeoutSec : 0,
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    toolUseId:
+      typeof data.toolUseId === "string" ? data.toolUseId : undefined,
+  };
+}

--- a/apps/web/src/types/attachment-types.ts
+++ b/apps/web/src/types/attachment-types.ts
@@ -1,6 +1,6 @@
 /** Display metadata for a file attachment (user-uploaded or assistant-generated),
  *  used to render the chip inside a message bubble. For live sessions, populated
- *  from SSE event data via `toDisplayAttachments` in the streaming domain. For
+ *  from SSE event data via `toDisplayAttachments` (`utils/display-attachments.ts`). For
  *  history reload, populated from the daemon's structured attachment metadata
  *  (real UUIDs that resolve against the content endpoint) or, as a fallback,
  *  reverse-parsed from `[File attachment] …` summary lines in the message text. */

--- a/apps/web/src/utils/display-attachments.test.ts
+++ b/apps/web/src/utils/display-attachments.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { toDisplayAttachments } from "@/utils/display-attachments";
+
+describe("toDisplayAttachments", () => {
+  test("returns undefined for empty/missing input", () => {
+    expect(toDisplayAttachments(undefined)).toBeUndefined();
+    expect(toDisplayAttachments([])).toBeUndefined();
+  });
+
+  test("converts image attachment with data-URI previewUrl", () => {
+    const result = toDisplayAttachments([
+      {
+        id: "att-1",
+        filename: "photo.png",
+        mimeType: "image/png",
+        data: "iVBORw0KGgo=",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "att-1",
+        filename: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: expect.any(Number),
+        previewUrl: "data:image/png;base64,iVBORw0KGgo=",
+      },
+    ]);
+  });
+
+  test("creates data-URI previewUrl for non-image types with inline data", () => {
+    const result = toDisplayAttachments([
+      {
+        id: "att-2",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        data: "JVBERi0xLjQ=",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "att-2",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: expect.any(Number),
+        previewUrl: "data:application/pdf;base64,JVBERi0xLjQ=",
+      },
+    ]);
+  });
+
+  test("uses thumbnailData when data is empty", () => {
+    const result = toDisplayAttachments([
+      {
+        id: "att-3",
+        filename: "clip.mp4",
+        mimeType: "video/mp4",
+        data: "",
+        thumbnailData: "thumb123",
+        fileBacked: true,
+        sizeBytes: 1024,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "att-3",
+        filename: "clip.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 1024,
+        previewUrl: "data:image/jpeg;base64,thumb123",
+      },
+    ]);
+  });
+
+  test("falls back to filename for id when id is missing", () => {
+    const result = toDisplayAttachments([
+      {
+        filename: "noId.txt",
+        mimeType: "text/plain",
+        data: "aGVsbG8=",
+      },
+    ]);
+    expect(result?.[0]?.id).toBe("noId.txt");
+  });
+});

--- a/apps/web/src/utils/display-attachments.ts
+++ b/apps/web/src/utils/display-attachments.ts
@@ -1,0 +1,41 @@
+/**
+ * Convert backend attachment wire types into display-ready objects.
+ *
+ * Pure function — no side effects. Used by the streaming message
+ * updater to produce `DisplayAttachment` objects for chat bubbles.
+ */
+
+import type { AssistantOutboundAttachment } from "@vellumai/assistant-api";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+/**
+ * Convert `AssistantOutboundAttachment` objects into `DisplayAttachment`
+ * objects suitable for rendering in chat message bubbles. When inline base64
+ * data is available, a data-URI `previewUrl` is created for all MIME types so
+ * the preview modal can render or download the content without a separate fetch.
+ * When only a thumbnail is available (e.g. video with omitted data), the
+ * thumbnail is used as a fallback preview. Files with `fileBacked: true` and no
+ * inline data rely on the daemon's `/v1/attachments/:id/content` endpoint —
+ * the modal fetches content lazily via the assistantId-scoped proxy URL.
+ */
+export function toDisplayAttachments(
+  attachments: AssistantOutboundAttachment[] | undefined,
+): DisplayAttachment[] | undefined {
+  if (!attachments || attachments.length === 0) return undefined;
+  return attachments.map((att) => {
+    let previewUrl: string | null = null;
+    if (att.data) {
+      previewUrl = `data:${att.mimeType};base64,${att.data}`;
+    } else if (att.thumbnailData) {
+      previewUrl = `data:image/jpeg;base64,${att.thumbnailData}`;
+    }
+    return {
+      id: att.id ?? att.filename,
+      filename: att.filename,
+      mimeType: att.mimeType,
+      sizeBytes:
+        att.sizeBytes ?? (att.data ? Math.floor((att.data.length * 3) / 4) : 0),
+      previewUrl,
+    };
+  });
+}


### PR DESCRIPTION
## Prompt / plan

Closes [LUM-2055](https://linear.app/vellum/issue/LUM-2055) — split `event-parser.ts` (863 lines, ~3x the ~300-line guideline) into focused parsing modules.

### Why

`event-parser.ts` had a single `parseLegacyEvent` function with ~35 case branches in a 640-line switch statement. Finding and modifying a specific event parser required scrolling through hundreds of unrelated cases. The file also contained `toDisplayAttachments`, a pure display-mapping utility that has nothing to do with event parsing.

### Architecture

`event-parser.ts` remains the **thin orchestrator** — envelope unwrap → canonical `AssistantEventSchema` dispatch → legacy switch delegation to sub-modules. The switch cases now read as a routing table:

```ts
case "secret_request":     return parseSecretRequest(data);
case "tool_use_start":     return parseToolUseStart(data);
case "ui_surface_show":    return parseUISurfaceShow(data);
case "subagent_spawned":   return parseSubagentSpawned(data);
case "sync_changed":       return parseSyncChanged(data);
```

Six inline cases remain (`assistant_activity_state`, `navigate_settings`, `error`, `conversation_error`, `usage_update`, `turn_profile_auto_routed`) — they don't form a cohesive group and are small enough to stay in the orchestrator.

### What changed

| File | Lines | Contents |
|------|------:|---------|
| `event-parser.ts` | 351 ← 863 | Thin orchestrator only |
| `parse-helpers.ts` | 23 | Shared `unknownEvent()` builder (extracted to prevent redefinition across the 5 new sub-modules) |
| `parse-interaction-events.ts` | 150 | `secret_request`, `confirmation_request`, `contact_request`, `question_request` |
| `parse-tool-events.ts` | 112 | `tool_use_start`, `tool_result`, `tool_progress` |
| `parse-surface-events.ts` | 89 | `ui_surface_show/update/dismiss/complete` |
| `parse-subagent-events.ts` | 108 | `subagent_spawned/status_changed/event` |
| `parse-resource-events.ts` | 198 | `sync_changed`, `identity_changed`, `avatar_updated`, `conversation_title_updated`, `conversation_list_invalidated`, `notification_intent`, `disk_pressure_status_changed`, `document_editor_update` |
| `utils/display-attachments.ts` | 41 | `toDisplayAttachments` (moved — pure function, not event parsing) |

### Why it's safe

- **Zero behavioral changes** — parsing logic is identical, just relocated to sub-modules
- **127/127 tests pass** unchanged (5 `toDisplayAttachments` tests moved to colocated file)
- TypeScript type check clean, lint clean, cross-domain allowlist unchanged
- All sub-parsers are internal (only consumed by the orchestrator) — no public API surface change beyond the `toDisplayAttachments` import path update in `stream-message-updaters.ts`

### 20-point audit summary

| # | Check | Status |
|---|-------|--------|
| 1 | Location | Sub-parsers in `lib/streaming/` (part of streaming infrastructure module). `toDisplayAttachments` moved to `utils/` (pure function). |
| 2 | Abstraction type | All plain functions — correct for parsing logic |
| 3 | Domain boundaries | `lib/streaming/` is shared infrastructure, no domain coupling |
| 5 | DRY | `unknownEvent` extracted to `parse-helpers.ts` (prevents redefinition across 5 sub-modules) |
| 7 | Patterns | Thin orchestrator → pure handler delegation |
| 8 | Dead code | No dead code introduced or carried forward |
| 9 | Behavioral preservation | 127/127 tests pass, identical parsing logic |
| 10 | Tests | Integration tests stay in `event-parser.test.ts` (test the public API). `toDisplayAttachments` tests colocated with moved source. |
| 12 | Wire contracts | No event parsing logic changed |
| 13 | Cross-domain imports | Allowlist unchanged |
| 14 | `lib/` scoping | `toDisplayAttachments` correctly moved from `lib/` to `utils/` |
| 15 | No barrel files | All imports from source directly |
| 16 | Directory structure | No single-file dirs, tests colocated |
| 17 | File size | Orchestrator 351 lines (slightly over 300; remaining inline cases don't have a natural extraction point) |
| 18 | Security | No internal URLs or credentials |
| 19 | Documentation | Module JSDoc explains purpose and grouping rationale; stale `attachment-types.ts` doc reference updated |
| 20 | Fix-or-surface | DRY issue fixed; no remaining issues to ticket |

## Test plan

- 127 unit tests pass across `event-parser.test.ts` + `display-attachments.test.ts`
- TypeScript `tsc --noEmit`: clean
- ESLint: clean
- Production build: all modules bundled
- Vite dev server: starts cleanly, all `parse-*` modules resolved
- Cross-domain audit: unchanged (12 files, 14 imports)
- Pre-commit hooks: all passed

Link to Devin session: https://app.devin.ai/sessions/4370103ab5e547ae8696d39b423f7103
Requested by: @ashleeradka