### PR TITLE
fix(design-library): include velvet in dark custom-variant

### DIFF
--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -150,7 +150,7 @@ function DefaultLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-[var(--system-positive-strong)] underline hover:opacity-80"
+      className="text-[var(--system-positive-strong)] underline decoration-1 hover:decoration-2"
     >
       {children}
     </a>

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -35,7 +35,7 @@ function CopyButton({ visible, onClick, copied }: {
       className={cn(
         // Touch devices (hover: none): always visible since hover isn't available.
         // Constraint: WKWebView on Capacitor iOS lacks hover events.
-        "flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-[var(--border-subtle)] text-[var(--content-tertiary)] transition-[opacity] duration-150 ease-out hover:bg-[var(--border-element)] hover:text-[var(--content-default)] [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+        "flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-stone-200/80 text-[var(--content-tertiary)] transition-[opacity] duration-150 ease-out hover:bg-stone-300 hover:text-[var(--content-secondary)] [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100 dark:bg-moss-600/80 dark:hover:bg-moss-500 dark:hover:text-stone-200",
         visible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
       )}
     >
@@ -97,7 +97,7 @@ function CodeBlockWrapper({ children }: { children: ReactNode }) {
 
   return (
     <div
-      className="group/code relative mb-2 overflow-hidden rounded-md bg-[var(--surface-code)] last:mb-0"
+      className="group/code relative mb-2 overflow-hidden rounded-md bg-stone-100 last:mb-0 dark:bg-moss-800"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setHasFocusWithin(true)}
@@ -150,7 +150,7 @@ function DefaultLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-[var(--system-positive-strong)] underline decoration-1 hover:decoration-2"
+      className="text-forest-600 underline hover:text-forest-700 dark:text-forest-400 dark:hover:text-forest-300"
     >
       {children}
     </a>
@@ -205,14 +205,14 @@ function buildMarkdownComponents(
         );
       }
       return (
-        <code className="rounded bg-[var(--surface-code)] px-1 py-0.5 font-mono text-body-small-default">
+        <code className="rounded bg-stone-100 px-1 py-0.5 font-mono text-body-small-default dark:bg-moss-800">
           {children}
         </code>
       );
     },
     pre: ({ children }) => <CodeBlockWrapper>{children}</CodeBlockWrapper>,
     blockquote: ({ children }) => (
-      <blockquote className="mb-2 border-l-2 border-[var(--border-element)] pl-3 italic text-[var(--content-tertiary)] last:mb-0">
+      <blockquote className="mb-2 border-l-2 border-stone-300 pl-3 italic text-stone-600 last:mb-0 dark:border-stone-600 dark:text-stone-400">
         {children}
       </blockquote>
     ),
@@ -226,12 +226,12 @@ function buildMarkdownComponents(
     ),
     th: ({ children }) => (
        
-      <th className={"border border-[var(--border-subtle)] px-2 py-1 text-left font-semibold" /* typography: off-scale — no canonical variant */}>
+      <th className={"border border-stone-200 px-2 py-1 text-left font-semibold dark:border-moss-600" /* typography: off-scale — no canonical variant */}>
         {children}
       </th>
     ),
     td: ({ children }) => (
-      <td className="border border-[var(--border-subtle)] px-2 py-1">
+      <td className="border border-stone-200 px-2 py-1 dark:border-moss-600">
         {children}
       </td>
     ),
@@ -251,7 +251,7 @@ function buildMarkdownComponents(
         return <img src={srcStr} alt={altStr} className="my-1 max-w-full rounded" />;
       }
       return (
-        <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-code)] px-1.5 py-0.5 text-body-small-default text-[var(--content-quiet)]">
+        <span className="inline-flex items-center gap-1 rounded bg-stone-100 px-1.5 py-0.5 text-body-small-default text-stone-500 dark:bg-moss-800 dark:text-stone-400">
           🔗 External image not rendered ({altStr || srcStr})
         </span>
       );

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -35,7 +35,7 @@ function CopyButton({ visible, onClick, copied }: {
       className={cn(
         // Touch devices (hover: none): always visible since hover isn't available.
         // Constraint: WKWebView on Capacitor iOS lacks hover events.
-        "flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-stone-200/80 text-[var(--content-tertiary)] transition-[opacity] duration-150 ease-out hover:bg-stone-300 hover:text-[var(--content-secondary)] [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100 dark:bg-moss-600/80 dark:hover:bg-moss-500 dark:hover:text-stone-200",
+        "flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-[var(--border-subtle)] text-[var(--content-tertiary)] transition-[opacity] duration-150 ease-out hover:bg-[var(--border-element)] hover:text-[var(--content-default)] [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
         visible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
       )}
     >
@@ -97,7 +97,7 @@ function CodeBlockWrapper({ children }: { children: ReactNode }) {
 
   return (
     <div
-      className="group/code relative mb-2 overflow-hidden rounded-md bg-stone-100 last:mb-0 dark:bg-moss-800"
+      className="group/code relative mb-2 overflow-hidden rounded-md bg-[var(--surface-code)] last:mb-0"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setHasFocusWithin(true)}
@@ -150,7 +150,7 @@ function DefaultLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-forest-600 underline hover:text-forest-700 dark:text-forest-400 dark:hover:text-forest-300"
+      className="text-[var(--system-positive-strong)] underline hover:opacity-80"
     >
       {children}
     </a>
@@ -205,14 +205,14 @@ function buildMarkdownComponents(
         );
       }
       return (
-        <code className="rounded bg-stone-100 px-1 py-0.5 font-mono text-body-small-default dark:bg-moss-800">
+        <code className="rounded bg-[var(--surface-code)] px-1 py-0.5 font-mono text-body-small-default">
           {children}
         </code>
       );
     },
     pre: ({ children }) => <CodeBlockWrapper>{children}</CodeBlockWrapper>,
     blockquote: ({ children }) => (
-      <blockquote className="mb-2 border-l-2 border-stone-300 pl-3 italic text-stone-600 last:mb-0 dark:border-stone-600 dark:text-stone-400">
+      <blockquote className="mb-2 border-l-2 border-[var(--border-element)] pl-3 italic text-[var(--content-tertiary)] last:mb-0">
         {children}
       </blockquote>
     ),
@@ -226,12 +226,12 @@ function buildMarkdownComponents(
     ),
     th: ({ children }) => (
        
-      <th className={"border border-stone-200 px-2 py-1 text-left font-semibold dark:border-moss-600" /* typography: off-scale — no canonical variant */}>
+      <th className={"border border-[var(--border-subtle)] px-2 py-1 text-left font-semibold" /* typography: off-scale — no canonical variant */}>
         {children}
       </th>
     ),
     td: ({ children }) => (
-      <td className="border border-stone-200 px-2 py-1 dark:border-moss-600">
+      <td className="border border-[var(--border-subtle)] px-2 py-1">
         {children}
       </td>
     ),
@@ -251,7 +251,7 @@ function buildMarkdownComponents(
         return <img src={srcStr} alt={altStr} className="my-1 max-w-full rounded" />;
       }
       return (
-        <span className="inline-flex items-center gap-1 rounded bg-stone-100 px-1.5 py-0.5 text-body-small-default text-stone-500 dark:bg-moss-800 dark:text-stone-400">
+        <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-code)] px-1.5 py-0.5 text-body-small-default text-[var(--content-quiet)]">
           🔗 External image not rendered ({altStr || srcStr})
         </span>
       );

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -22,10 +22,11 @@
 /* ---------------------------------------------------------------------------
  * Tailwind v4 dark variant — wired to the data-theme attribute.
  * Enables `dark:` utility prefixes (e.g. `dark:bg-white`) that activate
- * when data-theme="dark" is set on an ancestor element.
+ * when any dark-family theme is set on an ancestor element.
+ * Velvet is a dark theme variant, so `dark:` utilities apply to it too.
  * https://tailwindcss.com/docs/dark-mode#using-a-data-attribute
  * --------------------------------------------------------------------------- */
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *, [data-theme=velvet], [data-theme=velvet] *));
 
 /* ---------------------------------------------------------------------------
  * @theme bridge — registers CSS variables as Tailwind theme variables so
@@ -206,7 +207,6 @@
 
   /* Surface (extras beyond the base/overlay/active/lift/hover ramp) */
   --surface-sunken: #F6F5F4;    /* = surface-base in light; recessed in dark */
-  --surface-code: #F2F0EE;      /* code block / inline code chip background */
 
   /* Border (extras beyond base/disabled/element/hover/active/overlay) */
   --border-subtle: #E9E6E2;     /* = border-disabled in light; soft in dark */
@@ -287,7 +287,6 @@
 
   /* Surface (extras) */
   --surface-sunken: #1C2024;
-  --surface-code: #1C2024;
 
   /* Border (extras) */
   --border-subtle: #2D3339;
@@ -372,7 +371,6 @@
   /* Surface (extras). Sunken inherits dark — design to refine if velvet
    * wants its own subdued surface. */
   --surface-sunken: #1C2024;
-  --surface-code: #211D22;
 
   /* Border (extras) */
   --border-subtle: #2D3339;

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -206,6 +206,7 @@
 
   /* Surface (extras beyond the base/overlay/active/lift/hover ramp) */
   --surface-sunken: #F6F5F4;    /* = surface-base in light; recessed in dark */
+  --surface-code: #F2F0EE;      /* code block / inline code chip background */
 
   /* Border (extras beyond base/disabled/element/hover/active/overlay) */
   --border-subtle: #E9E6E2;     /* = border-disabled in light; soft in dark */
@@ -286,6 +287,7 @@
 
   /* Surface (extras) */
   --surface-sunken: #1C2024;
+  --surface-code: #1C2024;
 
   /* Border (extras) */
   --border-subtle: #2D3339;
@@ -370,6 +372,7 @@
   /* Surface (extras). Sunken inherits dark — design to refine if velvet
    * wants its own subdued surface. */
   --surface-sunken: #1C2024;
+  --surface-code: #211D22;
 
   /* Border (extras) */
   --border-subtle: #2D3339;


### PR DESCRIPTION
The `@custom-variant dark` selector in `tokens.css` only matched `data-theme="dark"`, so all `dark:` Tailwind utilities (code blocks, inline code, blockquotes, table borders, links, etc.) fell back to light-mode colors when velvet was active. Since velvet is a dark theme variant, the fix is to include `[data-theme=velvet]` in the `@custom-variant dark` selector — one line that fixes all `dark:` usage across the entire codebase.

## Root cause

The `@custom-variant dark` was defined as `(&:where([data-theme=dark], [data-theme=dark] *))`, which does not match velvet. This was an oversight when velvet was added as a theme — it should have been registered as a dark-family theme at the variant level. The fix is additive and safe: velvet's semantic tokens already define dark-appropriate values, and the `dark:` utilities provide the correct dark-mode overrides for raw color scales.

## Test plan

- Typecheck and lint pass
- CI checks

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/5f56dfcaded24809b368eafa91a92811