### PR TITLE
feat(web): add velvetist theme with intense pink/red palette and tiled heart background

### DIFF
--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -51,10 +51,21 @@ const velvetTheme = create({
   colorSecondary: "#E83F5B",
 });
 
+const velvetistTheme = create({
+  base: "dark",
+  appBg: "#0D0A10",
+  appContentBg: "#0D0A10",
+  textColor: "#F6F5F4",
+  appBorderColor: "#241520",
+  colorPrimary: "#FF1744",
+  colorSecondary: "#FF1744",
+});
+
 const storybookThemeMap: Record<string, typeof themes.light> = {
   light: lightTheme,
   dark: darkTheme,
   velvet: velvetTheme,
+  velvetist: velvetistTheme,
 };
 
 function readInitialTheme(): string {
@@ -103,6 +114,7 @@ export default definePreview({
         light: "light",
         dark: "dark",
         velvet: "velvet",
+        velvetist: "velvetist",
       },
       defaultTheme: "light",
       attributeName: "data-theme",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -17,15 +17,17 @@
           window.matchMedia("(prefers-color-scheme: dark)").matches;
         var shouldBeDark =
           theme === "velvet" ||
+          theme === "velvetist" ||
           theme === "dark" ||
           (theme === "system" && prefersDark);
         var root = document.documentElement;
         root.setAttribute(
           "data-theme",
-          shouldBeDark ? "dark" : "light"
+          theme === "velvetist" ? "velvetist" : theme === "velvet" ? "velvet" : shouldBeDark ? "dark" : "light"
         );
         root.classList.toggle("dark", shouldBeDark);
         root.classList.remove("velvet");
+        root.classList.remove("velvetist");
       } catch {
         // Theme startup is best-effort. React will apply the default later.
       }

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,4 +1,4 @@
-import { Heart, Monitor, Moon, Sun } from "lucide-react";
+import { Flame, Heart, Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { cn, SegmentControl } from "@vellum/design-library";
@@ -32,6 +32,16 @@ const VELVET_THEME_OPTION = {
   Icon: typeof Monitor;
 };
 
+const VELVETIST_THEME_OPTION = {
+  value: "velvetist",
+  label: "Velvetist",
+  Icon: Flame,
+} satisfies {
+  value: ThemePreference;
+  label: string;
+  Icon: typeof Monitor;
+};
+
 export function ThemeToggle({ className }: { className?: string } = {}) {
   const velvet = useClientFeatureFlagStore.use.velvet();
   const [theme, setTheme] = useState<ThemePreference>(() =>
@@ -55,7 +65,7 @@ export function ThemeToggle({ className }: { className?: string } = {}) {
   };
 
   const themeOptions = velvet
-    ? [...BASE_THEME_OPTIONS, VELVET_THEME_OPTION]
+    ? [...BASE_THEME_OPTIONS, VELVET_THEME_OPTION, VELVETIST_THEME_OPTION]
     : BASE_THEME_OPTIONS;
 
   return (

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -209,6 +209,7 @@ export function ChatBody({
 
   return (
     <div
+      data-slot="chat-body"
       className={outerClass}
       onDragEnter={dragHandlers.onDragEnter}
       onDragOver={dragHandlers.onDragOver}

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -1,4 +1,4 @@
-import { Heart, Monitor, Moon, Sun } from "lucide-react";
+import { Flame, Heart, Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { SegmentControl } from "@vellum/design-library/components/segment-control";
@@ -84,6 +84,11 @@ function ThemeCard() {
             value: "velvet" as const,
             label: "Velvet",
             icon: <Heart className="h-4 w-4" />,
+          },
+          {
+            value: "velvetist" as const,
+            label: "Velvetist",
+            icon: <Flame className="h-4 w-4" />,
           },
         ]
       : []),

--- a/apps/web/src/domains/settings/utils/theme-preferences.ts
+++ b/apps/web/src/domains/settings/utils/theme-preferences.ts
@@ -1,10 +1,10 @@
 import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
 
-export type ThemePreference = "system" | "light" | "dark" | "velvet";
+export type ThemePreference = "system" | "light" | "dark" | "velvet" | "velvetist";
 
 interface NormalizeThemeOptions {
   velvetEnabled: boolean;
-  disabledVelvetFallback?: Exclude<ThemePreference, "velvet">;
+  disabledVelvetFallback?: Exclude<ThemePreference, "velvet" | "velvetist">;
 }
 
 function normalizeThemePreference(
@@ -17,8 +17,8 @@ function normalizeThemePreference(
   if (value === "light" || value === "dark" || value === "system") {
     return value;
   }
-  if (value === "velvet") {
-    return velvetEnabled ? "velvet" : disabledVelvetFallback;
+  if (value === "velvet" || value === "velvetist") {
+    return velvetEnabled ? (value as "velvet" | "velvetist") : disabledVelvetFallback;
   }
   return "system";
 }
@@ -42,21 +42,24 @@ export function applyThemePreference(theme: ThemePreference): void {
     typeof window !== "undefined" &&
     window.matchMedia("(prefers-color-scheme: dark)").matches;
   const isVelvet = theme === "velvet";
+  const isVelvetist = theme === "velvetist";
   const shouldBeDark =
-    isVelvet || theme === "dark" || (theme === "system" && prefersDark);
+    isVelvet || isVelvetist || theme === "dark" || (theme === "system" && prefersDark);
 
   const root = document.documentElement;
   root.setAttribute(
     "data-theme",
-    isVelvet ? "velvet" : shouldBeDark ? "dark" : "light",
+    isVelvetist ? "velvetist" : isVelvet ? "velvet" : shouldBeDark ? "dark" : "light",
   );
   root.classList.toggle("dark", shouldBeDark);
   root.classList.toggle("velvet", isVelvet);
+  root.classList.toggle("velvetist", isVelvetist);
 }
 
 export function getEffectiveThemePreference(
   theme: ThemePreference,
-): "light" | "dark" | "velvet" {
+): "light" | "dark" | "velvet" | "velvetist" {
+  if (theme === "velvetist") return "velvetist";
   if (theme === "velvet") return "velvet";
   if (theme === "dark") return "dark";
   if (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -211,6 +211,45 @@ body {
   background-clip: padding-box;
 }
 
+[data-theme="velvetist"] {
+  scrollbar-color: rgba(255, 23, 68, 0.30) transparent;
+}
+
+[data-theme="velvetist"] *,
+[data-theme="velvetist"] *::before,
+[data-theme="velvetist"] *::after {
+  scrollbar-color: rgba(255, 23, 68, 0.30) transparent;
+}
+
+[data-theme="velvetist"] ::-webkit-scrollbar-thumb {
+  background: rgba(255, 23, 68, 0.30);
+  background-clip: padding-box;
+}
+
+[data-theme="velvetist"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 23, 68, 0.55);
+  background-clip: padding-box;
+}
+
+/* Velvetist tiled heart background — rendered behind the main chat area
+ * via a pseudo-element on the chat body container. Uses an inline SVG
+ * heart in dark pink, repeated across the surface. */
+[data-theme="velvetist"] [data-slot="chat-body"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath d='M24 42 C14 32 4 22 4 14 C4 8 8 4 14 4 C17.5 4 21 6.5 24 10 C27 6.5 30.5 4 34 4 C40 4 44 8 44 14 C44 22 34 32 24 42Z' fill='%23330A15' fill-opacity='0.55'/%3E%3C/svg%3E");
+  background-size: 48px 48px;
+  background-repeat: repeat;
+}
+
+[data-theme="velvetist"] [data-slot="chat-body"] > * {
+  position: relative;
+  z-index: 1;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .busy-indicator {
     animation: none;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -231,17 +231,17 @@ body {
   background-clip: padding-box;
 }
 
-/* Velvetist tiled heart background — rendered behind the main chat area
- * via a pseudo-element on the chat body container. Uses an inline SVG
- * heart in dark pink, repeated across the surface. */
+/* Velvetist tiled card-suit background — hearts, diamonds, spades, clubs
+ * arranged in a 2×2 grid with generous spacing, repeated across the chat
+ * body via a CSS pseudo-element. */
 [data-theme="velvetist"] [data-slot="chat-body"]::before {
   content: "";
   position: absolute;
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath d='M24 42 C14 32 4 22 4 14 C4 8 8 4 14 4 C17.5 4 21 6.5 24 10 C27 6.5 30.5 4 34 4 C40 4 44 8 44 14 C44 22 34 32 24 42Z' fill='%23330A15' fill-opacity='0.55'/%3E%3C/svg%3E");
-  background-size: 48px 48px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cpath d='M30 40 C24 34 16 28 16 21 C16 16 19 13 23 13 C26 13 28 15 30 18 C32 15 34 13 37 13 C41 13 44 16 44 21 C44 28 36 34 30 40Z' fill='%23330A15' fill-opacity='0.30'/%3E%3Cpath d='M90 16 L100 30 L90 44 L80 30Z' fill='%23330A15' fill-opacity='0.30'/%3E%3Cpath d='M30 76 C30 76 18 86 18 93 C18 97 21 100 25 100 C27 100 29 99 30 97 C31 99 33 100 35 100 C39 100 42 97 42 93 C42 86 30 76 30 76Z M28 100 L32 100 L32 107 L28 107Z' fill='%23330A15' fill-opacity='0.30'/%3E%3Ccircle cx='90' cy='84' r='7' fill='%23330A15' fill-opacity='0.30'/%3E%3Ccircle cx='82' cy='96' r='7' fill='%23330A15' fill-opacity='0.30'/%3E%3Ccircle cx='98' cy='96' r='7' fill='%23330A15' fill-opacity='0.30'/%3E%3Crect x='88' y='99' width='4' height='8' fill='%23330A15' fill-opacity='0.30'/%3E%3C/svg%3E");
+  background-size: 120px 120px;
   background-repeat: repeat;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -238,16 +238,11 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 0;
+  z-index: -1;
   pointer-events: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath d='M24 42 C14 32 4 22 4 14 C4 8 8 4 14 4 C17.5 4 21 6.5 24 10 C27 6.5 30.5 4 34 4 C40 4 44 8 44 14 C44 22 34 32 24 42Z' fill='%23330A15' fill-opacity='0.55'/%3E%3C/svg%3E");
   background-size: 48px 48px;
   background-repeat: repeat;
-}
-
-[data-theme="velvetist"] [data-slot="chat-body"] > * {
-  position: relative;
-  z-index: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -25,7 +25,7 @@
  * when data-theme="dark" is set on an ancestor element.
  * https://tailwindcss.com/docs/dark-mode#using-a-data-attribute
  * --------------------------------------------------------------------------- */
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *, [data-theme=velvet], [data-theme=velvet] *, [data-theme=velvetist], [data-theme=velvetist] *));
 
 /* ---------------------------------------------------------------------------
  * @theme bridge — registers CSS variables as Tailwind theme variables so

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -415,6 +415,85 @@
   --foreground: #F6F5F4;
 }
 
+/* ===== Velvetist mode — velvet cranked up: hotter pink/red, deeper darks ===== */
+[data-theme="velvetist"] {
+  /* Surface — deeper, more saturated dark with red undertones */
+  --surface-base: #0D0A10;
+  --surface-overlay: #16111A;
+  --surface-active: #351D2A;
+  --surface-lift: #1E1522;
+  --surface-hover: rgba(255, 23, 68, 0.10);
+
+  /* Primary — intense hot pink/red */
+  --primary-base: #FF1744;
+  --primary-hover: #FF4569;
+  --primary-active: #D50032;
+  --primary-disabled: #351D2A;
+  --primary-second-hover: #FF2D55;
+
+  /* Border — warm with red-magenta tint */
+  --border-base: #241520;
+  --border-disabled: #1A0F18;
+  --border-element: #7A3B5C;
+  --border-hover: #351D2A;
+  --border-active: #FFB3C7;
+
+  /* Content */
+  --content-default: #F6F5F4;
+  --content-emphasised: #FFF0F3;
+  --content-secondary: #D4A0B2;
+  --content-tertiary: #B87090;
+  --content-quiet: #A9B2BB;
+  --content-strong: #E9E6E2;
+  --content-faint: #8D99A5;
+  --content-disabled: #6B3F58;
+  --content-inset: #FFF0F3;
+
+  /* Surface (extras) */
+  --surface-sunken: #120E16;
+
+  /* Border (extras) */
+  --border-subtle: #2D1E28;
+
+  /* System */
+  --system-positive-strong: #FF1744;
+  --system-positive-weak: #3D1524;
+  --system-negative-strong: #FF1744;
+  --system-negative-hover: #FF4569;
+  --system-negative-weak: #3D1524;
+  --system-mid-strong: #F1B21E;
+  --system-mid-weak: #42321C;
+  --system-info-strong: #467CC8;
+  --system-info-weak: #2A3A50;
+
+  /* Feed identifier — inherits velvet palette */
+  --feed-nudge-strong: #FF1744;
+  --feed-nudge-weak: #4D1828;
+  --feed-digest-strong: #0E9B8B;
+  --feed-digest-weak: #293D3B;
+  --feed-thread-strong: #E9C91A;
+  --feed-thread-weak: #464125;
+
+  /* Aux */
+  --aux-white: #FFFFFF;
+
+  /* Shadow */
+  --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.30), 0 4px 12px 0 rgba(0, 0, 0, 0.30);
+
+  /* Derived */
+  --ring: color-mix(in srgb, var(--system-positive-strong) 30%, transparent);
+  --border-overlay: var(--border-hover);
+  --ghost-hover: var(--border-base);
+  --ghost-pressed: var(--primary-active);
+  --field-bg: #221820;
+  --field-border: transparent;
+  --tag-bg-neutral: var(--primary-disabled);
+
+  /* Background / Foreground */
+  --background: #0D0A10;
+  --foreground: #F6F5F4;
+}
+
 /* ---------------------------------------------------------------------------
  * Typography tokens — Figma node 2193:4447.
  * --------------------------------------------------------------------------- */


### PR DESCRIPTION
Adds a new "velvetist" theme — a more intense variant of the existing velvet theme with hotter pink/red accent colors (#FF1744 primary vs velvet's #E83F5B) and deeper dark surfaces (#0D0A10). Includes a tiled blackish-pink heart SVG background behind the chat body via a CSS pseudo-element, and fixes the `@custom-variant dark` selector to also cover velvet and velvetist so `dark:` Tailwind utilities fire correctly for all dark themes.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/c183aa745a0244fbbebd7a09c7ba80eb
