### PR TITLE
[codex] Leave Slack assistant history unprefixed

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3990,11 +3990,11 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     expect(result!).not.toContain("Sibling top-level");
   });
 
-  test("preserves speaker attribution when flattening to plain text", () => {
+  test("preserves user attribution while leaving assistant text unchanged", () => {
     // The `<active_thread>` block is rendered as newline-joined plain text,
-    // discarding `Message.role`. Assistant rows and unnamed user rows must
-    // therefore carry an explicit `@assistant` / `@user` label so the model
-    // can still tell turns apart inside the flattened block.
+    // discarding `Message.role`. User rows keep explicit Slack attribution,
+    // while assistant rows remain raw to avoid teaching the model a synthetic
+    // reply prefix.
     const rows: SlackTranscriptInputRow[] = [
       buildRow(
         "user",
@@ -4021,17 +4021,16 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
     expect(result).not.toBeNull();
     expect(result!).toContain("@alice");
-    expect(result!).toContain("@assistant");
+    expect(result!).toContain("Assistant reply");
+    expect(result!).not.toContain("@assistant: Assistant reply");
     expect(result!).toContain("@user");
   });
 
   test("assistant reactions are not double-attributed (`@assistant: [... @assistant reacted ...]`)", () => {
     // `renderReaction` bakes `@assistant` into the reaction tag line
     // (`[11/14/23 14:28 @assistant reacted 👍 to Mxxxxxx]`). The
-    // post-render step that prepends `@assistant: ` to assistant content
-    // lines must skip reaction lines, otherwise the flattened block
-    // produces `@assistant: [... @assistant reacted ...]` — two
-    // attributions for one event.
+    // flattened block should preserve that renderer-owned attribution without
+    // adding any extra assistant-message prefix.
     const rows: SlackTranscriptInputRow[] = [
       buildRow(
         "user",
@@ -4039,7 +4038,7 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
         1_000,
         buildMeta({ channelTs: PARENT_TS, displayName: "@alice" }),
       ),
-      // Assistant reply in the thread — gets an `@assistant:` prefix.
+      // Assistant reply in the thread — stays unchanged.
       buildRow(
         "assistant",
         "Assistant reply",
@@ -4081,12 +4080,13 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     expect(result).not.toBeNull();
     // Double-attribution anti-pattern must NOT appear anywhere.
     expect(result!).not.toContain("@assistant: [");
-    // Both the reaction attribution and the reply prefix are still present.
+    // Reaction attribution remains, and the assistant reply stays raw.
     expect(result!).toContain("@assistant reacted 👍");
-    expect(result!).toContain("@assistant: Assistant reply");
+    expect(result!).toContain("Assistant reply");
+    expect(result!).not.toContain("@assistant: Assistant reply");
   });
 
-  test("timezone-aware assistant rows keep renderer attribution in active-thread focus block", () => {
+  test("timezone-aware assistant rows stay unchanged in active-thread focus block", () => {
     const rows: SlackTranscriptInputRow[] = [
       buildRow(
         "user",
@@ -4127,15 +4127,12 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
 
     const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
     expect(result).not.toBeNull();
-    expect(result!).toContain(
-      "[nov 14 2023 3:13 PM MT assistant] Assistant reply",
-    );
-    expect(result!).not.toContain(
-      "@assistant: [nov 14 2023 3:13 PM MT assistant]",
-    );
+    expect(result!).toContain("\nAssistant reply\n");
+    expect(result!).not.toContain("[nov 14 2023 3:13 PM MT assistant]");
+    expect(result!).not.toContain("@assistant: Assistant reply");
   });
 
-  test("assistant content that only looks like a compact tag still gets active-thread attribution", () => {
+  test("assistant content that only looks like a compact tag stays unchanged", () => {
     const compactLookingContent =
       "[nov 14 2023 3:13 PM MT assistant] Assistant reply";
     const rows: SlackTranscriptInputRow[] = [
@@ -4168,7 +4165,8 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
 
     const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
     expect(result).not.toBeNull();
-    expect(result!).toContain(`@assistant: ${compactLookingContent}`);
+    expect(result!).toContain(`\n${compactLookingContent}\n`);
+    expect(result!).not.toContain(`@assistant: ${compactLookingContent}`);
   });
 
   test("assistant reaction overflow trailer is not double-attributed", () => {

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -1284,7 +1284,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
         content: [
           {
             type: "text",
-            text: "[mar 4 2026 8:38 PM MT assistant] earlier assistant reply",
+            text: "earlier assistant reply",
           },
         ],
       },

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1647,10 +1647,9 @@ function buildActiveThreadBlockFromRenderable(
 
   if (members.length === 0) return null;
 
-  // The active-thread block is flattened to plain text below, which discards
-  // `Message.role`. Assistant rows that render content-only are relabeled in
-  // the post-render step. Timezone-aware assistant rows are already
-  // bracket-tagged by the renderer and must not receive another prefix.
+  // The active-thread block is flattened to plain text below. User rows keep
+  // explicit Slack attribution through the renderer; assistant rows pass
+  // through unchanged so the model does not learn a synthetic reply prefix.
   // Unnamed user rows (no real Slack displayName) get a `@user` senderLabel
   // here so their tag line carries attribution through the renderer. Labeled
   // user rows and assistant rows pass through unchanged.
@@ -1662,18 +1661,8 @@ function buildActiveThreadBlockFromRenderable(
 
   const rendered = renderSlackTranscriptWithProvenance(labeledMembers);
   if (rendered.renderedMessages.length === 0) return null;
-  // Reaction / overflow-trailer lines are renderer-owned Slack event lines,
-  // and timezone-aware assistant rows already carry metadata-backed compact
-  // attribution. Regular assistant content and the `[deleted]` sentinel get
-  // the prefix so attribution survives flattening.
   const lines = rendered.renderedMessages
-    .map((entry) => {
-      const text = extractTagLineTexts([entry.message])[0] ?? "";
-      return entry.message.role === "assistant" &&
-        entry.tagLineProvenance === "none"
-        ? `@assistant: ${text}`
-        : text;
-    })
+    .map((entry) => extractTagLineTexts([entry.message])[0] ?? "")
     .join("\n");
   return `<active_thread>\n${lines}\n</active_thread>`;
 }

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -200,7 +200,7 @@ describe("renderSlackTranscript — basics", () => {
         "user",
         "[mar 4 2026 8:37 PM MT aaron] nm, i wonder how my assistant is doing",
       ),
-      textMsg("assistant", "[mar 4 2026 8:38 PM MT assistant] i'm good"),
+      textMsg("assistant", "i'm good"),
       textMsg("user", "[mar 4 2026 8:39 PM MT jordan (ET)] ayeeeee"),
     ]);
   });

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -348,7 +348,7 @@ function maxNullableSlackTs(a: string | null, b: string | null): string | null {
 function renderMessage(msg: RenderableSlackMessage): string {
   const meta = msg.metadata;
 
-  if (msg.role === "assistant" && !hasTimestampTimezone(meta)) {
+  if (msg.role === "assistant") {
     if (msg.metadata?.deletedAt !== undefined) return "[deleted]";
     return appendSlackFileMarkers(msg.content, msg.metadata?.slackFiles);
   }
@@ -704,7 +704,7 @@ export function renderSlackTranscriptWithProvenance(
       },
       sourceChannelTs: meta?.channelTs ?? null,
       tagLineProvenance:
-        hasRenderedText && hasTimestampTimezone(meta)
+        m.role !== "assistant" && hasRenderedText && hasTimestampTimezone(meta)
           ? "slack-timezone-message"
           : "none",
     });


### PR DESCRIPTION
## Summary

- render assistant-authored Slack history as the original assistant text, even when Slack timezone metadata is present
- stop adding `@assistant:` in the active-thread focus block so assistant rows stay unaltered there too
- update regression coverage for timezone-aware Slack transcript rendering, backfilled assistant history, and active-thread injection

## Root Cause

The Slack transcript renderer already had a content-only path for assistant rows, but timezone-aware Slack metadata bypassed it and used the compact timestamp formatter. That produced prefixes like `[may 29 2026 4:43 PM MT assistant]` in assistant history. The active-thread focus block also added an `@assistant:` prefix while flattening rows to text.

## Impact

Past assistant messages in Slack context no longer teach the model to copy synthetic timestamp or speaker prefixes into new outbound Slack replies. User-authored Slack rows still keep timestamp and sender attribution.

## Validation

- `cd assistant && bun test src/messaging/providers/slack/render-transcript.test.ts`
- `cd assistant && bun test src/__tests__/conversation-runtime-assembly.test.ts`
- `cd assistant && bun test src/__tests__/thread-backfill.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `git diff --check`

Pre-push also ran assistant typecheck and eslint for the five changed assistant files successfully.