### PR TITLE
[DON'T MERGE] Add local Stage 1 platform proxy spike

### DIFF
--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -25,7 +25,12 @@ import {
 } from "@/assistant/queries";
 import type { AssistantState } from "@/assistant/types";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
-import { getSelectedAssistant, getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
+import {
+  getSelectedAssistant,
+  getLocalGatewayUrl,
+  isLocalMode,
+  isStage1PlatformProxyEnabled,
+} from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
 
@@ -426,9 +431,22 @@ export function useAssistantLifecycle({
     setAssistantState({ kind: "active", isLocal: true });
   }, []);
 
+  const applyStage1PlatformProxyShortCircuit = useCallback(() => {
+    const assistant = getSelectedAssistant();
+    if (!assistant?.resources?.gatewayPort) return false;
+
+    setSelfHostedConnection(null);
+    setAssistantId(assistant.assistantId);
+    setAssistantState({ kind: "active", isLocal: true });
+    return true;
+  }, []);
+
   const checkAssistant = useCallback(async () => {
     if (isGatewayAuthMode()) {
       applyGatewayAuthShortCircuit();
+      return;
+    }
+    if (isStage1PlatformProxyEnabled() && applyStage1PlatformProxyShortCircuit()) {
       return;
     }
     const generation = initializingGenerationRef.current;
@@ -576,6 +594,9 @@ export function useAssistantLifecycle({
       applyGatewayAuthShortCircuit();
       return;
     }
+    if (isStage1PlatformProxyEnabled() && applyStage1PlatformProxyShortCircuit()) {
+      return;
+    }
     // In local mode without a gateway token AND no platform session,
     // the platform API isn't available — redirect to onboarding.
     // If the user logged in and chose Vellum Cloud, hasPlatformSession
@@ -593,7 +614,7 @@ export function useAssistantLifecycle({
       return;
     }
     checkAssistant();
-  }, [isLoggedIn, isLoading, hasPlatformSession, checkAssistant, applyGatewayAuthShortCircuit]);
+  }, [isLoggedIn, isLoading, hasPlatformSession, checkAssistant, applyGatewayAuthShortCircuit, applyStage1PlatformProxyShortCircuit]);
 
   // While the lifecycle is transient (`initializing` / `cleaning_up`),
   // project each new query result into local state. The query polls

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -20,6 +20,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   /** When set, the app runs in platform (cloud-hosted) mode. Unset = local mode. */
   readonly VITE_PLATFORM_MODE?: string;
+  /** Local-only spike: route self-hosted runtime calls through the Vite same-origin proxy. */
+  readonly VITE_LOCAL_PLATFORM_PROXY_STAGE1?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -138,6 +138,8 @@ describe("api-interceptors / self-hosted rewriting", () => {
   });
 
   afterEach(() => {
+    process.env.VITE_PLATFORM_MODE = "true";
+    delete process.env.VITE_LOCAL_PLATFORM_PROXY_STAGE1;
     setSelfHostedConnection(null);
   });
 
@@ -215,6 +217,21 @@ describe("api-interceptors / self-hosted rewriting", () => {
     const output = await requestInterceptor(input);
     expect(new URL(output.url).origin).toBe("https://platform.test");
     expect(output.headers.get("Vellum-Organization-Id")).toBe(TEST_ORG_ID);
+    expect(output.headers.get("Authorization")).toBeNull();
+  });
+
+  test("routes runtime calls through the app base when the local Stage 1 platform proxy is enabled", async () => {
+    process.env.VITE_PLATFORM_MODE = "false";
+    process.env.VITE_LOCAL_PLATFORM_PROXY_STAGE1 = "true";
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+
+    const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`);
+    const output = await requestInterceptor(input);
+    const outUrl = new URL(output.url);
+
+    expect(outUrl.origin).toBe("https://platform.test");
+    expect(outUrl.pathname).toBe(`/assistant${RUNTIME_PROXIED_PATH}`);
+    expect(output.headers.get("Vellum-Organization-Id")).toBeNull();
     expect(output.headers.get("Authorization")).toBeNull();
   });
 

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -34,7 +34,7 @@ import {
   getSelfHostedActorToken,
   getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalMode, isStage1PlatformProxyEnabled } from "@/lib/local-mode";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
@@ -59,6 +59,15 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * error state. Add segments here as additional self-hosted flows light up.
  */
 const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>(["conversations"]);
+const STAGE1_PLATFORM_PROXY_FIRST_SEGMENTS = new Set<string>([
+  "attachments",
+  "config",
+  "conversations",
+  "events",
+  "feature-flags",
+  "identity",
+  "messages",
+]);
 
 const ASSISTANT_PATH_RE =
   /^\/v1\/assistants\/[^/]+\/([^/?#]+)(?:\/.*)?$/;
@@ -145,6 +154,38 @@ export async function rewriteForSelfHostedIngress(
   return new Request(rewrittenUrl.toString(), init);
 }
 
+async function rewriteForStage1PlatformProxy(
+  request: Request,
+): Promise<Request | null> {
+  if (!isStage1PlatformProxyEnabled()) return null;
+
+  const url = new URL(request.url);
+  const match = ASSISTANT_PATH_RE.exec(url.pathname);
+  if (!match) return null;
+
+  const firstSegment = match[1];
+  if (
+    !firstSegment ||
+    !STAGE1_PLATFORM_PROXY_FIRST_SEGMENTS.has(firstSegment)
+  ) {
+    return null;
+  }
+
+  const rewrittenUrl = new URL(request.url);
+  rewrittenUrl.pathname = `/assistant${url.pathname}`;
+
+  const body = request.body ? await request.arrayBuffer() : null;
+  const init: RequestInit = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body,
+    credentials: request.credentials,
+    redirect: request.redirect,
+    signal: request.signal,
+  };
+  return new Request(rewrittenUrl.toString(), init);
+}
+
 /**
  * Exported for direct unit testing — production code paths invoke this
  * via the registrations at the bottom of the module. Keeping the function
@@ -161,12 +202,19 @@ export async function requestInterceptor(request: Request): Promise<Request> {
     newRequest.headers.set(name, value);
   }
 
+  const stage1PlatformProxy = await rewriteForStage1PlatformProxy(newRequest);
+  if (stage1PlatformProxy) {
+    return stage1PlatformProxy;
+  }
+
   // Self-hosted assistant + runtime-proxied path → talk to the user's
   // gateway directly instead of stamping the platform's session/CSRF
   // headers and hitting the runtime proxy view that filters us out.
-  const selfHosted = await rewriteForSelfHostedIngress(newRequest);
-  if (selfHosted) {
-    return selfHosted;
+  if (!isStage1PlatformProxyEnabled()) {
+    const selfHosted = await rewriteForSelfHostedIngress(newRequest);
+    if (selfHosted) {
+      return selfHosted;
+    }
   }
 
   // Platform path — Django session auth.

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -54,10 +54,35 @@ const SELECTED_ASSISTANT_STORAGE_KEY = "local:selectedAssistantId";
 
 const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 
+function readEnvValue(key: string): string | undefined {
+  const processEnv = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  const processValue = processEnv?.[key];
+  if (typeof processValue === "string") return processValue;
+
+  return (import.meta.env as Record<string, string | undefined> | undefined)?.[
+    key
+  ];
+}
+
+function isTruthyEnvValue(raw: string | undefined): boolean {
+  return raw != null && PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
+}
+
 export function isLocalMode(): boolean {
-  const raw = import.meta.env.VITE_PLATFORM_MODE;
+  const raw = readEnvValue("VITE_PLATFORM_MODE");
   if (!raw) return true;
-  return !PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
+  return !isTruthyEnvValue(raw);
+}
+
+export function isStage1PlatformProxyEnabled(): boolean {
+  return (
+    isLocalMode() &&
+    isTruthyEnvValue(readEnvValue("VITE_LOCAL_PLATFORM_PROXY_STAGE1"))
+  );
 }
 
 export async function loadLockfile(): Promise<Lockfile> {
@@ -275,6 +300,12 @@ export async function fetchGuardianToken(assistantId: string): Promise<string> {
  * In Electron, replace with direct IPC token acquisition. (LUM-1999)
  */
 export async function primeLocalGatewayConnection(): Promise<void> {
+  if (isStage1PlatformProxyEnabled()) {
+    clearGatewayToken();
+    setSelfHostedConnection(null);
+    return;
+  }
+
   const tokenUrl = getLocalTokenUrl();
   if (!tokenUrl) return;
   const assistant = getSelectedAssistant();

--- a/apps/web/vite-plugin-local-mode.test.ts
+++ b/apps/web/vite-plugin-local-mode.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildStage1PlatformProxyHeaders,
+  isStage1PlatformProxyEnabledForEnv,
+  resolveStage1PlatformProxyRequest,
+  stage1PlatformProxyResponseHeaders,
+} from "./vite-plugin-local-mode";
+
+describe("vite-plugin-local-mode / Stage 1 platform proxy", () => {
+  test("reads the Stage 1 env flag", () => {
+    expect(
+      isStage1PlatformProxyEnabledForEnv({
+        VITE_LOCAL_PLATFORM_PROXY_STAGE1: "true",
+      }),
+    ).toBe(true);
+    expect(isStage1PlatformProxyEnabledForEnv({})).toBe(false);
+  });
+
+  test("matches assistant runtime routes and strips the app base path", () => {
+    expect(
+      resolveStage1PlatformProxyRequest(
+        "/assistant/v1/assistants/local-1/conversations/?limit=25",
+      ),
+    ).toEqual({
+      kind: "proxy",
+      assistantId: "local-1",
+      firstSegment: "conversations",
+      targetPath: "/v1/assistants/local-1/conversations/?limit=25",
+    });
+  });
+
+  test("ignores non-assistant routes", () => {
+    expect(resolveStage1PlatformProxyRequest("/v1/feature-flags")).toBeNull();
+  });
+
+  test("rejects gateway auth and non-allowlisted assistant routes", () => {
+    expect(
+      resolveStage1PlatformProxyRequest("/v1/assistants/local-1/auth/token"),
+    ).toEqual({ kind: "reject" });
+    expect(
+      resolveStage1PlatformProxyRequest("/v1/assistants/local-1/terminal/"),
+    ).toEqual({ kind: "reject" });
+  });
+
+  test("rejects malformed assistant ids", () => {
+    expect(
+      resolveStage1PlatformProxyRequest(
+        "/v1/assistants/local%2Fbad/conversations/",
+      ),
+    ).toEqual({ kind: "reject" });
+  });
+
+  test("injects gateway auth server-side and forwards only allowlisted headers", () => {
+    const headers = buildStage1PlatformProxyHeaders(
+      {
+        accept: "text/event-stream",
+        authorization: "Bearer browser-token",
+        cookie: "sessionid=secret",
+        origin: "https://platform.example",
+        "x-csrf-token": "csrf",
+        "x-vellum-client-id": "client-123",
+      },
+      18100,
+      "server-gateway-token",
+    );
+
+    expect(headers).toEqual({
+      accept: "text/event-stream",
+      authorization: "Bearer server-gateway-token",
+      host: "127.0.0.1:18100",
+      "x-vellum-client-id": "client-123",
+      "x-vellum-stage1-platform-proxy": "true",
+    });
+  });
+
+  test("marks proxy responses and strips unsafe upstream headers", () => {
+    const headers = stage1PlatformProxyResponseHeaders({
+      "content-type": "application/json",
+      "set-cookie": "gateway=secret",
+      connection: "keep-alive",
+    });
+
+    expect(headers).toEqual({
+      "content-type": "application/json",
+      "x-vellum-stage1-platform-proxy": "true",
+    });
+  });
+});

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -8,6 +8,7 @@ import type { Plugin, Connect } from "vite";
 
 const PRODUCTION_ENVIRONMENT_NAME = "production";
 const CLI_PACKAGE_NAME = "@vellumai/cli";
+const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 
 let _resolvedCliPath: string | undefined;
 
@@ -119,9 +120,11 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     name: "vellum-local-mode",
     configureServer(server) {
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
+      server.middlewares.use(localModeDiagnosticsMiddleware(env));
       server.middlewares.use(hatchMiddleware());
       server.middlewares.use(retireMiddleware());
       server.middlewares.use(guardianTokenMiddleware(env));
+      server.middlewares.use(stage1PlatformProxyMiddleware(env, lockfilePaths));
       server.middlewares.use(gatewayProxyMiddleware());
     },
   };
@@ -144,6 +147,28 @@ function lockfileMiddleware(
       res.statusCode = 405;
       res.end();
     }
+  };
+}
+
+function localModeDiagnosticsMiddleware(
+  env: Record<string, string>,
+): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/stage1-proxy-status" &&
+      req.url !== "/__local/stage1-proxy-status"
+    ) {
+      return next();
+    }
+
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        enabled: isStage1PlatformProxyEnabledForEnv(env),
+        stage1Flag: env[STAGE1_PLATFORM_PROXY_FLAG] ?? null,
+        platformMode: env.VITE_PLATFORM_MODE ?? null,
+      }),
+    );
   };
 }
 
@@ -661,6 +686,352 @@ function guardianTokenMiddleware(
     child.on("error", (err) => {
       respond(500, { error: `Failed to spawn CLI: ${err.message}` });
     });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1 platform proxy middleware
+// ---------------------------------------------------------------------------
+
+const STAGE1_PLATFORM_PROXY_FLAG = "VITE_LOCAL_PLATFORM_PROXY_STAGE1";
+const STAGE1_ASSISTANT_ID_RE = /^[A-Za-z0-9_.:-]+$/;
+const STAGE1_ALLOWED_ASSISTANT_SEGMENTS = new Set([
+  "attachments",
+  "config",
+  "conversations",
+  "events",
+  "feature-flags",
+  "identity",
+  "messages",
+]);
+const STAGE1_BLOCKED_ASSISTANT_SEGMENTS = new Set([
+  "auth",
+  "guardian",
+  "pair",
+]);
+const STAGE1_REQUEST_HEADER_ALLOWLIST = new Set([
+  "accept",
+  "content-length",
+  "content-type",
+  "x-vellum-client-id",
+  "x-vellum-interface-id",
+]);
+const STAGE1_RESPONSE_HEADER_BLOCKLIST = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "set-cookie",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+type Stage1ProxyRequest =
+  | {
+      kind: "proxy";
+      assistantId: string;
+      firstSegment: string;
+      targetPath: string;
+    }
+  | { kind: "reject" };
+
+interface Stage1LocalAssistant {
+  assistantId: string;
+  gatewayPort: number;
+}
+
+interface Stage1GatewayTokenCacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+class Stage1PlatformProxyError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const stage1GatewayTokenCache = new Map<string, Stage1GatewayTokenCacheEntry>();
+
+export function isStage1PlatformProxyEnabledForEnv(
+  env: Record<string, string>,
+): boolean {
+  return PLATFORM_MODE_TRUTHY.has(
+    (env[STAGE1_PLATFORM_PROXY_FLAG] ?? "").toLowerCase(),
+  );
+}
+
+export function resolveStage1PlatformProxyRequest(
+  rawUrl: string | undefined,
+): Stage1ProxyRequest | null {
+  if (!rawUrl) return null;
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl, "http://localhost");
+  } catch {
+    return null;
+  }
+
+  const pathname = url.pathname.replace(/^\/assistant(?=\/v1\/)/, "");
+  const match = /^\/v1\/assistants\/([^/]+)\/([^/?#]+)(?:\/.*)?$/.exec(
+    pathname,
+  );
+  if (!match) return null;
+
+  const assistantId = match[1]!;
+  const firstSegment = match[2]!;
+  if (!STAGE1_ASSISTANT_ID_RE.test(assistantId)) {
+    return { kind: "reject" };
+  }
+  if (
+    STAGE1_BLOCKED_ASSISTANT_SEGMENTS.has(firstSegment) ||
+    !STAGE1_ALLOWED_ASSISTANT_SEGMENTS.has(firstSegment)
+  ) {
+    return { kind: "reject" };
+  }
+
+  return {
+    kind: "proxy",
+    assistantId,
+    firstSegment,
+    targetPath: `${pathname}${url.search}`,
+  };
+}
+
+export function buildStage1PlatformProxyHeaders(
+  incomingHeaders: http.IncomingHttpHeaders,
+  gatewayPort: number,
+  token: string,
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {
+    authorization: `Bearer ${token}`,
+    host: `127.0.0.1:${gatewayPort}`,
+    "x-vellum-stage1-platform-proxy": "true",
+  };
+
+  for (const [rawName, value] of Object.entries(incomingHeaders)) {
+    const name = rawName.toLowerCase();
+    if (!STAGE1_REQUEST_HEADER_ALLOWLIST.has(name)) continue;
+    headers[name] = value;
+  }
+
+  return headers;
+}
+
+export function stage1PlatformProxyResponseHeaders(
+  incomingHeaders: http.IncomingHttpHeaders,
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {
+    "x-vellum-stage1-platform-proxy": "true",
+  };
+  for (const [rawName, value] of Object.entries(incomingHeaders)) {
+    const name = rawName.toLowerCase();
+    if (STAGE1_RESPONSE_HEADER_BLOCKLIST.has(name)) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function sendStage1PlatformProxyError(
+  res: http.ServerResponse,
+  statusCode: number,
+  error: string,
+): void {
+  if (res.headersSent) return;
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ error }));
+}
+
+function readStage1Lockfile(lockfilePaths: string[]): Record<string, unknown> {
+  for (const candidate of lockfilePaths) {
+    try {
+      return JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw new Stage1PlatformProxyError(500, "Failed to read lockfile");
+    }
+  }
+  return { assistants: [] };
+}
+
+function getStage1LocalAssistant(
+  lockfilePaths: string[],
+  assistantId: string,
+): Stage1LocalAssistant | null {
+  const lockfile = readStage1Lockfile(lockfilePaths);
+  const assistants = lockfile.assistants;
+  if (!Array.isArray(assistants)) return null;
+
+  for (const assistant of assistants) {
+    if (!assistant || typeof assistant !== "object") continue;
+    const entry = assistant as Record<string, unknown>;
+    if (entry.assistantId !== assistantId || entry.cloud !== "local") continue;
+
+    const resources = entry.resources;
+    if (!resources || typeof resources !== "object") return null;
+    const gatewayPort = (resources as Record<string, unknown>).gatewayPort;
+    if (typeof gatewayPort !== "number" || !Number.isInteger(gatewayPort)) {
+      return null;
+    }
+    if (gatewayPort < 1024 || gatewayPort > 65535) {
+      return null;
+    }
+    return { assistantId, gatewayPort };
+  }
+
+  return null;
+}
+
+function loadGuardianAccessTokenForStage1(
+  env: Record<string, string>,
+  assistantId: string,
+): string {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(resolveGuardianTokenPath(env, assistantId), "utf-8");
+  } catch {
+    throw new Stage1PlatformProxyError(401, "Guardian token not found");
+  }
+
+  let data: GuardianTokenData;
+  try {
+    data = JSON.parse(raw) as GuardianTokenData;
+  } catch {
+    throw new Stage1PlatformProxyError(500, "Malformed guardian token file");
+  }
+
+  if (!data.accessToken || isAccessTokenExpired(data)) {
+    throw new Stage1PlatformProxyError(
+      401,
+      "Guardian token expired; run `vellum wake` and reload",
+    );
+  }
+
+  return data.accessToken;
+}
+
+async function acquireGatewayTokenForStage1(
+  env: Record<string, string>,
+  assistant: Stage1LocalAssistant,
+): Promise<string> {
+  const cacheKey = `${assistant.assistantId}:${assistant.gatewayPort}`;
+  const cached = stage1GatewayTokenCache.get(cacheKey);
+  if (cached && Date.now() / 1000 < cached.expiresAt - 60) {
+    return cached.token;
+  }
+
+  const guardianToken = loadGuardianAccessTokenForStage1(
+    env,
+    assistant.assistantId,
+  );
+  const response = await fetch(
+    `http://127.0.0.1:${assistant.gatewayPort}/auth/token`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${guardianToken}`,
+        Origin: "http://localhost:3000",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Stage1PlatformProxyError(
+      response.status,
+      "Gateway token request failed",
+    );
+  }
+
+  const body = (await response.json()) as {
+    token?: unknown;
+    expiresAt?: unknown;
+  };
+  if (typeof body.token !== "string" || typeof body.expiresAt !== "number") {
+    throw new Stage1PlatformProxyError(
+      502,
+      "Gateway token response was malformed",
+    );
+  }
+
+  stage1GatewayTokenCache.set(cacheKey, {
+    token: body.token,
+    expiresAt: body.expiresAt,
+  });
+  return body.token;
+}
+
+function stage1PlatformProxyMiddleware(
+  env: Record<string, string>,
+  lockfilePaths: string[],
+): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (!isStage1PlatformProxyEnabledForEnv(env)) return next();
+
+    const resolved = resolveStage1PlatformProxyRequest(req.url);
+    if (!resolved) return next();
+    if (resolved.kind === "reject") {
+      sendStage1PlatformProxyError(res, 404, "Not found");
+      return;
+    }
+
+    let assistant: Stage1LocalAssistant | null;
+    try {
+      assistant = getStage1LocalAssistant(lockfilePaths, resolved.assistantId);
+    } catch (err) {
+      const statusCode =
+        err instanceof Stage1PlatformProxyError ? err.statusCode : 500;
+      sendStage1PlatformProxyError(res, statusCode, "Proxy setup failed");
+      return;
+    }
+
+    if (!assistant) {
+      sendStage1PlatformProxyError(res, 404, "Assistant not found");
+      return;
+    }
+
+    void acquireGatewayTokenForStage1(env, assistant)
+      .then((token) => {
+        const proxyReq = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: assistant.gatewayPort,
+            path: resolved.targetPath,
+            method: req.method,
+            headers: buildStage1PlatformProxyHeaders(
+              req.headers,
+              assistant.gatewayPort,
+              token,
+            ),
+          },
+          (proxyRes) => {
+            res.writeHead(
+              proxyRes.statusCode ?? 502,
+              stage1PlatformProxyResponseHeaders(proxyRes.headers),
+            );
+            proxyRes.pipe(res);
+          },
+        );
+
+        proxyReq.on("error", () => {
+          sendStage1PlatformProxyError(res, 502, "Gateway proxy error");
+        });
+
+        req.pipe(proxyReq);
+      })
+      .catch((err: unknown) => {
+        const statusCode =
+          err instanceof Stage1PlatformProxyError ? err.statusCode : 502;
+        sendStage1PlatformProxyError(res, statusCode, "Gateway proxy error");
+      });
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a local Stage 1 spike for the Milestone 2 self-hosted assistant access model. When `VITE_LOCAL_PLATFORM_PROXY_STAGE1=true` in local mode, the web app stops storing a browser-readable gateway JWT, routes allowlisted assistant runtime requests through the same-origin `/assistant/v1/assistants/:id/...` path, and lets the local Vite middleware inject gateway auth server-side before proxying to the local gateway.

## Why

The current local JWT flow is acceptable for all-local Milestone 1, but it does not model the safer Milestone 2 shape where the browser should authenticate to the Platform with a cookie and never receive a gateway bearer token. This spike proves that shape locally without touching the companion platform repo.

## What changed

- Adds `isStage1PlatformProxyEnabled()` and bypasses local gateway token priming in Stage 1 mode.
- Rewrites allowlisted runtime requests to `/assistant/v1/...` so local Caddy/Vite routes them through the app proxy instead of Django's root `/v1` proxy.
- Adds Vite middleware that maps assistant id to local gateway port, obtains/caches gateway auth server-side, strips unsafe browser headers, and marks responses with `X-Vellum-Stage1-Platform-Proxy: true`.
- Adds focused tests for request rewriting and proxy header handling.

## Validation

- `bun test ./src/lib/api-interceptors.test.ts ./vite-plugin-local-mode.test.ts`
- `bunx tsc --noEmit`
- targeted `bunx eslint ...`
- local manual check: `/assistant/v1/assistants/web-local/conversations?...` returns gateway JSON with `X-Vellum-Stage1-Platform-Proxy: true`, while `localStorage.getItem("gw:token")` remains `null`.

## Notes for review

This is intentionally a local spike. The allowlist is narrow and does not attempt full chat-page runtime route coverage. The important security contract is that browser-held gateway JWTs are removed from the tested path and gateway auth is injected only server-side.