### PR TITLE
refactor(web): route inline localStorage calls through shared utilities (LUM-2047)

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -11,6 +11,7 @@ import { Outlet, useLocation, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { haptic } from "@/utils/haptics";
+import { getLocalBool, setLocalBool, getLocalNumber, setLocalNumber } from "@/utils/local-settings";
 import { routes } from "@/utils/routes";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile";
 import { useRootOutletContext } from "@/root-layout";
@@ -66,29 +67,16 @@ const FOCUSABLE_SELECTOR = [
 ].join(",");
 
 export function readPersistedCollapsed(): boolean {
-  try {
-    return (
-      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
-    );
-  } catch {
-    return false;
-  }
+  return getLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, false);
 }
 
 const MIN_SIDEBAR_WIDTH = 220;
 const MAX_SIDEBAR_WIDTH = 400;
 
 export function readPersistedWidth(): number {
-  try {
-    const stored = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
-    if (stored != null) {
-      const parsed = Number(stored);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, parsed));
-      }
-    }
-  } catch {
-    // Storage unavailable
+  const raw = getLocalNumber(SIDEBAR_WIDTH_STORAGE_KEY, DEFAULT_SIDEBAR_WIDTH);
+  if (raw > 0) {
+    return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, raw));
   }
   return DEFAULT_SIDEBAR_WIDTH;
 }
@@ -314,23 +302,12 @@ export function ChatLayout() {
   const [sidebarWidth, setSidebarWidth] = useState<number>(readPersistedWidth);
 
   useEffect(() => {
-    try {
-      window.localStorage.setItem(
-        SIDEBAR_COLLAPSED_STORAGE_KEY,
-        String(collapsed),
-      );
-    } catch {
-      // Storage unavailable (private mode, quota, etc.)
-    }
+    setLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed);
   }, [collapsed]);
 
   const handleSidebarWidthChange = useCallback((width: number) => {
     setSidebarWidth(width);
-    try {
-      window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(width)));
-    } catch {
-      // Storage unavailable
-    }
+    setLocalNumber(SIDEBAR_WIDTH_STORAGE_KEY, Math.round(width));
   }, []);
 
   const isMobile = useIsMobile();

--- a/apps/web/src/domains/chat/components/chat-composer/use-draft-input.ts
+++ b/apps/web/src/domains/chat/components/chat-composer/use-draft-input.ts
@@ -20,6 +20,8 @@ import {
   useState,
 } from "react";
 
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -35,10 +37,9 @@ function storageKey(assistantId: string): string {
 // ---------------------------------------------------------------------------
 
 function loadDrafts(assistantId: string): Map<string, string> {
-  if (typeof window === "undefined") return new Map();
+  const raw = getLocalSetting(storageKey(assistantId), "");
+  if (!raw) return new Map();
   try {
-    const raw = window.localStorage.getItem(storageKey(assistantId));
-    if (!raw) return new Map();
     const parsed: unknown = JSON.parse(raw);
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
       return new Map();
@@ -57,15 +58,10 @@ function persistDrafts(
   assistantId: string,
   drafts: Map<string, string>,
 ): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(
-      storageKey(assistantId),
-      JSON.stringify(Object.fromEntries(drafts)),
-    );
-  } catch {
-    // Storage can fail in private browsing / quota-exceeded.
-  }
+  setLocalSetting(
+    storageKey(assistantId),
+    JSON.stringify(Object.fromEntries(drafts)),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -50,6 +50,7 @@ import { IOSAppBanner } from "@/components/nudges/ios-app-banner";
 import { MacOSAppBanner } from "@/components/nudges/macos-app-banner";
 import { Loader2 } from "lucide-react";
 import { Button, Notice, ResizablePanel } from "@vellum/design-library";
+import { getLocalBool, setLocalBool, removeLocalSetting } from "@/utils/local-settings";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
 import { QueuedMessagesDrawer } from "@/domains/chat/components/queued-messages-drawer";
 import { AppViewerContainer } from "@/components/app-viewer-container";
@@ -1013,12 +1014,12 @@ export function ChatRouteContent({
 
   const [warningDismissed, setWarningDismissed] = useState(() => {
     if (!assistantId) return false;
-    return localStorage.getItem(`vellum:diskPressureDismissed:${assistantId}`) === "true";
+    return getLocalBool(`vellum:diskPressureDismissed:${assistantId}`, false);
   });
 
   const dismissWarning = useCallback(() => {
     if (!assistantId) return;
-    localStorage.setItem(`vellum:diskPressureDismissed:${assistantId}`, "true");
+    setLocalBool(`vellum:diskPressureDismissed:${assistantId}`, true);
     setWarningDismissed(true);
   }, [assistantId]);
 
@@ -1027,7 +1028,7 @@ export function ChatRouteContent({
     const st = diskPressure.status?.state;
     if (st && st !== "warning" && warningDismissed) {
       if (assistantId) {
-        localStorage.removeItem(`vellum:diskPressureDismissed:${assistantId}`);
+        removeLocalSetting(`vellum:diskPressureDismissed:${assistantId}`);
       }
       setWarningDismissed(false);
     }

--- a/apps/web/src/domains/chat/components/mic-permission-primer.tsx
+++ b/apps/web/src/domains/chat/components/mic-permission-primer.tsx
@@ -3,6 +3,7 @@ import { Mic } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
 import { Modal } from "@vellum/design-library";
+import { getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { isBatchSttSupported } from "@/domains/chat/components/voice-input-button";
 
 const MIC_PRIMER_STORAGE_KEY = "vellum:voice:permissionPrimerSeen";
@@ -13,17 +14,10 @@ const MIC_PRIMER_STORAGE_KEY = "vellum:voice:permissionPrimerSeen";
  * dismissed the primer dialog.
  */
 export function shouldShowMicPrimer(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
   if (!isBatchSttSupported()) {
     return false;
   }
-  try {
-    return localStorage.getItem(MIC_PRIMER_STORAGE_KEY) !== "true";
-  } catch {
-    return false;
-  }
+  return !getLocalBool(MIC_PRIMER_STORAGE_KEY, false);
 }
 
 export interface MicPermissionPrimerProps {
@@ -52,11 +46,7 @@ export function MicPermissionPrimer({
   onCancel,
 }: MicPermissionPrimerProps) {
   const handleContinue = () => {
-    try {
-      localStorage.setItem(MIC_PRIMER_STORAGE_KEY, "true");
-    } catch {
-      // localStorage may be unavailable (e.g. private browsing quota exceeded).
-    }
+    setLocalBool(MIC_PRIMER_STORAGE_KEY, true);
     onContinue();
   };
 

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -27,6 +27,7 @@ import {
 } from "react";
 
 import { Button, Card, ConfirmDialog, Input, Popover } from "@vellum/design-library";
+import { getLocalBool, setLocalBool } from "@/utils/local-settings";
 import {
   MobileSidebarDrawer,
   MobileSidebarTrigger,
@@ -95,10 +96,9 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   const [removingSkillId, setRemovingSkillId] = useState<string | null>(null);
   const [skillPendingRemoval, setSkillPendingRemoval] = useState<SkillInfo | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [tipDismissed, setTipDismissed] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(TIP_STORAGE_KEY) === "1";
-  });
+  const [tipDismissed, setTipDismissed] = useState(() =>
+    getLocalBool(TIP_STORAGE_KEY, false),
+  );
 
   useEffect(() => {
     const handle = setTimeout(() => {
@@ -185,9 +185,7 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
 
   const handleDismissTip = useCallback(() => {
     setTipDismissed(true);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(TIP_STORAGE_KEY, "1");
-    }
+    setLocalBool(TIP_STORAGE_KEY, true);
   }, []);
 
   const allSkills = useMemo(

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -39,6 +39,12 @@ import {
 } from "@/domains/settings/api/oauth-apps";
 
 import { IntegrationIcon } from "@/domains/settings/components/integration-icon";
+import {
+  type OAuthCompletePayload,
+  oauthCompletionStorageKey,
+  getOAuthCompleteMessagePayload,
+  getOAuthCompleteStoragePayload,
+} from "@/lib/auth/oauth-popup";
 
 function extractErrorDetail(error: unknown, fallback: string): string {
   if (typeof error === "object" && error !== null && "detail" in error) {
@@ -51,67 +57,6 @@ function extractErrorDetail(error: unknown, fallback: string): string {
     return error.message;
   }
   return fallback;
-}
-
-export interface OAuthCompletePayload {
-  type: "vellum:oauth-complete";
-  requestId?: string | null;
-  oauthStatus?: string | null;
-  oauthProvider?: string | null;
-  oauthCode?: string | null;
-}
-
-export function oauthCompletionStorageKey(requestId: string): string {
-  return `vellum:oauth-complete:${requestId}`;
-}
-
-export function isOAuthCompletePayloadForRequest(
-  payload: unknown,
-  requestId: string,
-): payload is OAuthCompletePayload {
-  return (
-    typeof payload === "object" &&
-    payload !== null &&
-    (payload as OAuthCompletePayload).type === "vellum:oauth-complete" &&
-    (payload as OAuthCompletePayload).requestId === requestId
-  );
-}
-
-export function getOAuthCompleteMessagePayload(
-  event: MessageEvent,
-  expectedOrigin: string,
-  requestId: string,
-): OAuthCompletePayload | null {
-  if (event.origin !== expectedOrigin) {
-    return null;
-  }
-
-  if (!isOAuthCompletePayloadForRequest(event.data, requestId)) {
-    return null;
-  }
-
-  return event.data;
-}
-
-export function getOAuthCompleteStoragePayload(
-  event: StorageEvent,
-  requestId: string,
-): OAuthCompletePayload | null {
-  if (
-    event.key !== oauthCompletionStorageKey(requestId) ||
-    event.newValue === null
-  ) {
-    return null;
-  }
-
-  try {
-    const payload = JSON.parse(event.newValue);
-    return isOAuthCompletePayloadForRequest(payload, requestId)
-      ? payload
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 function wait(ms: number): Promise<void> {

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -91,9 +91,10 @@ function SpeechServicesBanner() {
 }
 
 function PushToTalkCard() {
-  const [activator, setActivator] = useState<PTTActivator>(() =>
-    parseActivator(getLocalSetting(LS_PTT_ACTIVATION_KEY, "")),
-  );
+  const [activator, setActivator] = useState<PTTActivator>(() => {
+    const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
+    return raw ? parseActivator(raw) : { kind: "off" };
+  });
   const [isRecording, setIsRecording] = useState(false);
   const [pendingModifiers, setPendingModifiers] = useState<PTTModifier[]>([]);
   const recordingZoneRef = useRef<HTMLDivElement | null>(null);

--- a/apps/web/src/domains/voice/use-push-to-talk.ts
+++ b/apps/web/src/domains/voice/use-push-to-talk.ts
@@ -8,6 +8,7 @@ import {
   parseActivator,
   type PTTActivator,
 } from "@/utils/ptt-activator";
+import { getLocalSetting } from "@/utils/local-settings";
 
 /**
  * Imperative handle (subset of `VoiceInputButtonHandle`) that the hook drives.
@@ -119,13 +120,8 @@ export function usePushToTalk(
     }
 
     const readActivator = () => {
-      try {
-        activatorRef.current = parseActivator(
-          window.localStorage.getItem(LS_PTT_ACTIVATION_KEY),
-        );
-      } catch {
-        activatorRef.current = { kind: "off" };
-      }
+      const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
+      activatorRef.current = parseActivator(raw || null);
     };
     readActivator();
 

--- a/apps/web/src/domains/voice/use-push-to-talk.ts
+++ b/apps/web/src/domains/voice/use-push-to-talk.ts
@@ -121,7 +121,7 @@ export function usePushToTalk(
 
     const readActivator = () => {
       const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
-      activatorRef.current = parseActivator(raw || null);
+      activatorRef.current = raw ? parseActivator(raw) : { kind: "off" };
     };
     readActivator();
 

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -131,16 +131,20 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("vellum:onboarding:completed")).toBeNull();
   });
 
-  test("clears legacy app. prefixed nudge keys", () => {
+  test("preserves active app. nudge keys on logout", () => {
+    localStorage.setItem("app.iosNudge.downloaded", "true");
+    localStorage.setItem("app.macOsNudge.bannerDismissed", "true");
     localStorage.setItem("app.githubNudge.starred", "true");
-    localStorage.setItem("app.discordNudge.joined", "true");
-    localStorage.setItem("app.nudgeLegacy.cleaned", "true");
 
     clearUserScopedStorage();
 
-    expect(localStorage.getItem("app.githubNudge.starred")).toBeNull();
-    expect(localStorage.getItem("app.discordNudge.joined")).toBeNull();
-    expect(localStorage.getItem("app.nudgeLegacy.cleaned")).toBeNull();
+    // Active iOS/macOS nudge keys must survive logout — they are
+    // still read by use-ios-app-nudge.ts and use-macos-app-nudge.ts.
+    // Dead github/discord keys are removed at startup by removeKey()
+    // in storage-migration.ts, not by the logout sweep.
+    expect(localStorage.getItem("app.iosNudge.downloaded")).toBe("true");
+    expect(localStorage.getItem("app.macOsNudge.bannerDismissed")).toBe("true");
+    expect(localStorage.getItem("app.githubNudge.starred")).toBe("true");
   });
 
   test("clears legacy prefixed keys if startup migration failed", () => {

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -131,6 +131,18 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("vellum:onboarding:completed")).toBeNull();
   });
 
+  test("clears legacy app. prefixed nudge keys", () => {
+    localStorage.setItem("app.githubNudge.starred", "true");
+    localStorage.setItem("app.discordNudge.joined", "true");
+    localStorage.setItem("app.nudgeLegacy.cleaned", "true");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("app.githubNudge.starred")).toBeNull();
+    expect(localStorage.getItem("app.discordNudge.joined")).toBeNull();
+    expect(localStorage.getItem("app.nudgeLegacy.cleaned")).toBeNull();
+  });
+
   test("clears legacy prefixed keys if startup migration failed", () => {
     // eslint-disable-next-line no-restricted-syntax -- test: verifying cleanup of legacy auth token
     localStorage.setItem("gw:token", "legacy-jwt-token");

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -37,6 +37,7 @@ const LEGACY_USER_PREFIXES = [
   "integrations.",
   "vellumDebug.",
   "vellum_",
+  "app.",
 ];
 
 /**

--- a/apps/web/src/lib/auth/session-cleanup.ts
+++ b/apps/web/src/lib/auth/session-cleanup.ts
@@ -37,7 +37,6 @@ const LEGACY_USER_PREFIXES = [
   "integrations.",
   "vellumDebug.",
   "vellum_",
-  "app.",
 ];
 
 /**

--- a/apps/web/src/lib/backwards-compat/impersonate-version-flag.ts
+++ b/apps/web/src/lib/backwards-compat/impersonate-version-flag.ts
@@ -28,6 +28,8 @@
 //   impersonateVersion(null)     — clear + reload
 //   impersonateVersion()         — log + return current value, no reload
 
+import { getLocalSetting, setLocalSetting, removeLocalSetting } from "@/utils/local-settings";
+
 const STORAGE_KEY = "vellum:debug:impersonateAssistantVersion";
 
 /**
@@ -39,13 +41,8 @@ const STORAGE_KEY = "vellum:debug:impersonateAssistantVersion";
  * or localStorage access throws (private browsing / sandboxed iframes).
  */
 export function getImpersonatedAssistantVersion(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw && raw.length > 0 ? raw : null;
-  } catch {
-    return null;
-  }
+  const raw = getLocalSetting(STORAGE_KEY, "");
+  return raw.length > 0 ? raw : null;
 }
 
 /**
@@ -79,25 +76,18 @@ export function setImpersonatedAssistantVersion(
     return current;
   }
 
-  try {
-    if (value === null || value === "") {
-      window.localStorage.removeItem(STORAGE_KEY);
-      console.info(
-        "[vellumDebug] impersonateAssistantVersion = null (cleared) — reloading…",
-      );
-    } else {
-      window.localStorage.setItem(STORAGE_KEY, value);
-      console.info(
-        `[vellumDebug] impersonateAssistantVersion = ${JSON.stringify(
-          value,
-        )} — reloading…`,
-      );
-    }
-  } catch {
-    console.warn(
-      "[vellumDebug] failed to persist impersonateAssistantVersion flag",
+  if (value === null || value === "") {
+    removeLocalSetting(STORAGE_KEY);
+    console.info(
+      "[vellumDebug] impersonateAssistantVersion = null (cleared) — reloading…",
     );
-    return getImpersonatedAssistantVersion();
+  } else {
+    setLocalSetting(STORAGE_KEY, value);
+    console.info(
+      `[vellumDebug] impersonateAssistantVersion = ${JSON.stringify(
+        value,
+      )} — reloading…`,
+    );
   }
   window.location.reload();
   return value === "" ? null : value;

--- a/apps/web/src/lib/backwards-compat/impersonate-version-flag.ts
+++ b/apps/web/src/lib/backwards-compat/impersonate-version-flag.ts
@@ -78,11 +78,23 @@ export function setImpersonatedAssistantVersion(
 
   if (value === null || value === "") {
     removeLocalSetting(STORAGE_KEY);
+    if (getImpersonatedAssistantVersion() !== null) {
+      console.warn(
+        "[vellumDebug] failed to clear impersonateAssistantVersion flag",
+      );
+      return getImpersonatedAssistantVersion();
+    }
     console.info(
       "[vellumDebug] impersonateAssistantVersion = null (cleared) — reloading…",
     );
   } else {
     setLocalSetting(STORAGE_KEY, value);
+    if (getImpersonatedAssistantVersion() !== value) {
+      console.warn(
+        "[vellumDebug] failed to persist impersonateAssistantVersion flag",
+      );
+      return getImpersonatedAssistantVersion();
+    }
     console.info(
       `[vellumDebug] impersonateAssistantVersion = ${JSON.stringify(
         value,

--- a/apps/web/src/stores/nudge-store.ts
+++ b/apps/web/src/stores/nudge-store.ts
@@ -116,30 +116,4 @@ if (typeof window !== "undefined") {
   });
 }
 
-// ---------------------------------------------------------------------------
-// One-shot legacy cleanup
-// ---------------------------------------------------------------------------
 
-const LEGACY_CLEANUP_FLAG = "app.nudgeLegacy.cleaned";
-
-const LEGACY_KEYS = [
-  "app.githubNudge.starred",
-  "app.githubNudge.bannerDismissed",
-  "app.githubNudge.bannerDismissedAt",
-  "app.discordNudge.joined",
-  "app.discordNudge.bannerDismissed",
-  "app.discordNudge.firstSeenAt",
-];
-
-if (typeof window !== "undefined") {
-  try {
-    if (localStorage.getItem(LEGACY_CLEANUP_FLAG) !== "true") {
-      for (const key of LEGACY_KEYS) {
-        localStorage.removeItem(key);
-      }
-      localStorage.setItem(LEGACY_CLEANUP_FLAG, "true");
-    }
-  } catch {
-    // Storage unavailable (private mode, quota, etc.) — re-attempt next load.
-  }
-}

--- a/apps/web/src/utils/storage-migration.test.ts
+++ b/apps/web/src/utils/storage-migration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { migrateKey, migratePrefix, runStorageMigrations } from "./storage-migration";
+import { migrateKey, migratePrefix, removeKey, runStorageMigrations } from "./storage-migration";
 
 beforeEach(() => {
   localStorage.clear();
@@ -8,6 +8,22 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+});
+
+describe("removeKey", () => {
+  test("removes an existing key", () => {
+    localStorage.setItem("old:key", "value");
+
+    removeKey("old:key");
+
+    expect(localStorage.getItem("old:key")).toBeNull();
+  });
+
+  test("no-op when key is absent", () => {
+    removeKey("missing");
+
+    expect(localStorage.getItem("missing")).toBeNull();
+  });
 });
 
 describe("migrateKey", () => {
@@ -248,6 +264,18 @@ describe("runStorageMigrations", () => {
 
     expect(localStorage.getItem("_ga")).toBe("GA1.2.123456");
     expect(localStorage.getItem("intercom-session")).toBe("abc");
+  });
+
+  test("removes legacy nudge keys and their cleanup flag", () => {
+    localStorage.setItem("app.githubNudge.starred", "true");
+    localStorage.setItem("app.discordNudge.joined", "true");
+    localStorage.setItem("app.nudgeLegacy.cleaned", "true");
+
+    runStorageMigrations();
+
+    expect(localStorage.getItem("app.githubNudge.starred")).toBeNull();
+    expect(localStorage.getItem("app.discordNudge.joined")).toBeNull();
+    expect(localStorage.getItem("app.nudgeLegacy.cleaned")).toBeNull();
   });
 
   test("full migration is idempotent", () => {

--- a/apps/web/src/utils/storage-migration.test.ts
+++ b/apps/web/src/utils/storage-migration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { migrateKey, migratePrefix, removeKey, runStorageMigrations } from "./storage-migration";
+import { migrateKey, migratePrefix, migrateValue, removeKey, runStorageMigrations } from "./storage-migration";
 
 beforeEach(() => {
   localStorage.clear();
@@ -21,6 +21,30 @@ describe("removeKey", () => {
 
   test("no-op when key is absent", () => {
     removeKey("missing");
+
+    expect(localStorage.getItem("missing")).toBeNull();
+  });
+});
+
+describe("migrateValue", () => {
+  test("converts matching old value to new value", () => {
+    localStorage.setItem("key", "1");
+
+    migrateValue("key", "1", "true");
+
+    expect(localStorage.getItem("key")).toBe("true");
+  });
+
+  test("no-op when current value does not match old value", () => {
+    localStorage.setItem("key", "true");
+
+    migrateValue("key", "1", "true");
+
+    expect(localStorage.getItem("key")).toBe("true");
+  });
+
+  test("no-op when key is absent", () => {
+    migrateValue("missing", "1", "true");
 
     expect(localStorage.getItem("missing")).toBeNull();
   });
@@ -244,6 +268,14 @@ describe("runStorageMigrations", () => {
 
     expect(localStorage.getItem("vellum:skills:tipDismissed")).toBe("true");
     expect(localStorage.getItem("vellum:skillsTabTipDismissed")).toBeNull();
+  });
+
+  test("converts skills tip value from '1' to 'true'", () => {
+    localStorage.setItem("vellum:skills:tipDismissed", "1");
+
+    runStorageMigrations();
+
+    expect(localStorage.getItem("vellum:skills:tipDismissed")).toBe("true");
   });
 
   test("does not touch device: keys", () => {

--- a/apps/web/src/utils/storage-migration.ts
+++ b/apps/web/src/utils/storage-migration.ts
@@ -17,6 +17,18 @@
  */
 
 /**
+ * Remove a legacy key that has no successor. Idempotent.
+ */
+export function removeKey(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Storage unavailable — retry on next load.
+  }
+}
+
+/**
  * Migrate a single static key. Idempotent: writes the new key only
  * when it doesn't already exist, removes the old key only after the
  * new key is confirmed persisted (guards against QuotaExceededError
@@ -142,4 +154,15 @@ export function runStorageMigrations(): void {
 
   // vellum_ per-org → vellum:
   migratePrefix("vellum_current_assistant_id__", "vellum:currentAssistantId:");
+
+  // -- Dead key removals --------------------------------------------------
+  // Legacy nudge keys superseded by the `vellum:nudge-prefs` Zustand
+  // persist store. Also remove the one-time cleanup flag itself.
+  removeKey("app.githubNudge.starred");
+  removeKey("app.githubNudge.bannerDismissed");
+  removeKey("app.githubNudge.bannerDismissedAt");
+  removeKey("app.discordNudge.joined");
+  removeKey("app.discordNudge.bannerDismissed");
+  removeKey("app.discordNudge.firstSeenAt");
+  removeKey("app.nudgeLegacy.cleaned");
 }

--- a/apps/web/src/utils/storage-migration.ts
+++ b/apps/web/src/utils/storage-migration.ts
@@ -17,6 +17,22 @@
  */
 
 /**
+ * Migrate a key's stored value from one format to another without
+ * renaming the key. Idempotent — only writes when the current value
+ * matches `oldValue` exactly.
+ */
+export function migrateValue(key: string, oldValue: string, newValue: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (localStorage.getItem(key) === oldValue) {
+      localStorage.setItem(key, newValue);
+    }
+  } catch {
+    // Storage unavailable — retry on next load.
+  }
+}
+
+/**
  * Remove a legacy key that has no successor. Idempotent.
  */
 export function removeKey(key: string): void {
@@ -154,6 +170,10 @@ export function runStorageMigrations(): void {
 
   // vellum_ per-org → vellum:
   migratePrefix("vellum_current_assistant_id__", "vellum:currentAssistantId:");
+
+  // -- Value format migrations ---------------------------------------------
+  // Skills tip was stored as "1"; getLocalBool expects "true".
+  migrateValue("vellum:skills:tipDismissed", "1", "true");
 
   // -- Dead key removals --------------------------------------------------
   // Legacy nudge keys superseded by the `vellum:nudge-prefs` Zustand


### PR DESCRIPTION
## Prompt / plan

Final PR in the localStorage consolidation effort (LUM-2042). Routes all remaining inline `localStorage.getItem`/`setItem`/`removeItem` calls through the shared `local-settings.ts` helpers established in LUM-2044.

Closes LUM-2047

## Why needed

After PRs A–C (LUM-2044 typed-storage factory, LUM-2045 key naming standardization, LUM-2046 domain storage migration), 10 production files still used raw `localStorage` calls with duplicated SSR guards, try/catch wrappers, and `typeof window` checks. This final PR eliminates that boilerplate so all localStorage access flows through a single code path with consistent error handling, SSR safety, and same-tab change notifications.

## Changes

### Route inline calls through `local-settings.ts` (7 files, net −69 lines)

| File | Before | After |
|---|---|---|
| `skills-tab.tsx` | `window.localStorage.getItem(KEY) === "1"` + SSR guard | `getLocalBool(KEY, false)` |
| `mic-permission-primer.tsx` | `localStorage.getItem(KEY) !== "true"` + try/catch | `getLocalBool(KEY, false)` |
| `chat-route-content.tsx` | 3× raw get/set/remove with keyed name | `getLocalBool`/`setLocalBool`/`removeLocalSetting` |
| `chat-layout.tsx` | `window.localStorage.getItem/setItem` + try/catch + Number parsing | `getLocalBool`/`setLocalBool`/`getLocalNumber`/`setLocalNumber` |
| `impersonate-version-flag.ts` | 3× `window.localStorage.getItem/setItem/removeItem` + SSR + try/catch | `getLocalSetting`/`setLocalSetting`/`removeLocalSetting` + verify-after-write |
| `use-draft-input.ts` | `window.localStorage.getItem/setItem` + SSR + try/catch | `getLocalSetting`/`setLocalSetting` |
| `use-push-to-talk.ts` | `window.localStorage.getItem` + try/catch | `getLocalSetting` with explicit off-default |

### Fix DRY: deduplicate OAuth utilities (−60 lines)

`integration-detail-modal.tsx` had a full copy of 5 functions/types from `lib/auth/oauth-popup.ts` (`OAuthCompletePayload`, `oauthCompletionStorageKey`, `getOAuthCompleteMessagePayload`, `getOAuthCompleteStoragePayload`). Replaced with imports from the canonical source.

### Fix: move nudge legacy cleanup to storage-migration.ts

The one-time nudge key cleanup (removing 6 dead `app.githubNudge.*` / `app.discordNudge.*` keys + the `app.nudgeLegacy.cleaned` flag) was running inside `nudge-store.ts` with its own `app.nudgeLegacy.cleaned` flag. This is migration infrastructure, not store logic. Moved to `storage-migration.ts` using the new `removeKey()` helper, which makes the cleanup idempotent without needing a flag.

Note: the `"app."` prefix was intentionally NOT added to `LEGACY_USER_PREFIXES` in `session-cleanup.ts` because active iOS/macOS app-download nudge hooks (`use-ios-app-nudge.ts`, `use-macos-app-nudge.ts`) still read/write `app.iosNudge.*` and `app.macOsNudge.*` keys. Sweeping all `app.*` keys on logout would reset those dismissal states. The dead GitHub/Discord keys are removed at startup by explicit `removeKey()` calls instead.

### Fix: skills tip value format migration

The old code stored the tip-dismissed flag as `"1"`, but `getLocalBool` only recognizes `"true"`/`"false"`. Added `migrateValue(key, oldValue, newValue)` helper to `storage-migration.ts` for same-key value format conversions, and a migration that converts the old `"1"` to `"true"` at startup.

### Fix: PTT activator off-by-default on storage failure

When `localStorage` is unavailable, `getLocalSetting` returns `""`, and `parseActivator(null)` returns `{ kind: "modifierOnly", modifiers: ["control"] }` — PTT would silently activate with Ctrl. Fixed: `raw ? parseActivator(raw) : { kind: "off" }` preserves the old catch-block behavior.

### Fix: impersonate-version-flag reload on failed storage write

When `setLocalSetting`/`removeLocalSetting` swallow a storage exception, execution previously fell through to `window.location.reload()` even though the write didn't persist — causing a reload back into the old state. Fixed: verify the write took effect by re-reading the value immediately after. If the value doesn't match, log a warning and return early without reloading — matching the old catch-block behavior.

### Calls intentionally kept inline

| File | Reason |
|---|---|
| `current-platform-assistant-store.ts` | Custom Zustand `persist` `StateStorage` adapter |
| `client-feature-flag-store.ts` | Iterates dynamic key set; null-vs-absent distinction needed |
| `gateway-session.ts` | Auth infrastructure with multi-key coordination, legacy fallbacks |
| `local-settings.ts` | IS the base layer |
| `device-settings.ts` | Already a typed registry with legacy migration fallbacks |
| OAuth popup files | Cross-tab IPC via `StorageEvent`, not traditional storage |

### Intentional behavioral changes

1. **mic-permission-primer**: When `localStorage` is unavailable, `shouldShowMicPrimer()` now returns `true` (show primer) instead of `false` (hide). The primer is a consent flow — silently hiding it when storage is broken is worse than showing it again.

2. **PTT off-by-default**: When `localStorage` is unavailable, PTT activator now defaults to `{ kind: "off" }` instead of `{ kind: "modifierOnly", modifiers: ["control"] }`. PTT silently activating via Ctrl is a safety risk.

## Architectural audit

<details>
<summary>Full 20-item checklist</summary>

| # | Check | Result |
|---|---|---|
| 1 | Location | ✓ All files in correct directories |
| 2 | Abstraction type | ✓ Pure utilities (local-settings.ts), not hooks/stores |
| 3 | Domain boundaries | ✓ Helpers in utils/ (cross-domain), consumers in their domains |
| 4 | Sub-components | N/A |
| 5 | DRY | ✓ Fixed — OAuth duplication eliminated, nudge cleanup consolidated |
| 6 | State management | ✓ Imperative storage utilities, not Zustand |
| 7 | Patterns | ✓ All reads/writes through single code path |
| 8 | Dead code | ✓ Old SSR guards, try/catch wrappers, duplicate functions removed |
| 9 | Behavioral preservation | ✓ Two intentional changes documented above |
| 10 | Tests | ✓ 3 new unit tests for migrateValue, 1 integration test for skills tip migration |
| 11 | Tech debt | ✓ Reduces — eliminates copy-paste localStorage patterns |
| 12 | Wire contracts | N/A |
| 13 | Cross-domain imports | ✓ No new allowlist entries |
| 14 | lib/ scoping | ✓ |
| 15 | No barrel files | ✓ |
| 16 | Directory structure | ✓ |
| 17 | File size | ✓ All under 300 lines |
| 18 | Security | ✓ No internal URLs or credentials |
| 19 | Documentation | ✓ Comments describe code, not PR history |
| 20 | Fix-or-surface | ✓ All findings fixed in-PR |

</details>

## Test plan

- Playwright CDP tests against Vite dev server (port 3001) with 8 adversarial test cases
- Skills tip `"1"` → `"true"` migration verified via page.evaluate()
- Sidebar collapse/width persistence round-trip
- PTT off-by-default with missing key
- Legacy nudge key cleanup at startup + active nudge key preservation
- Draft input JSON persistence
- Disk pressure dismissal persistence
- Impersonate version flag round-trip

## Safety

- All changes are additive refactoring — public APIs unchanged
- 37 unit tests pass (session-cleanup + storage-migration)
- No new cross-domain imports
- Migrations are idempotent (safe to re-run)
- Behavioral changes are safety improvements (PTT off, primer shown)

Link to Devin session: https://app.devin.ai/sessions/4b3b130bbf274e5487da3b4992883093
Requested by: @ashleeradka