### PR TITLE
feat(web): folder upload in chat composer (POC)

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -1,13 +1,14 @@
 
-import { AlertCircle, Paperclip } from "lucide-react";
+import { AlertCircle, FolderUp, Paperclip } from "lucide-react";
 import type { ChangeEvent, FC } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@vellum/design-library";
 
 import { AttachmentChip } from "@/domains/chat/components/chat-attachments/attachment-chip";
 import { AttachmentLoadingChip } from "@/domains/chat/components/chat-attachments/attachment-loading-chip";
 import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+import { filterFolderFiles } from "@/domains/chat/components/chat-attachments/folder-files";
 import type { ChatAttachment, UploadedAttachment } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
 import { formatAttachmentSize, middleTruncate } from "@/domains/chat/components/chat-attachments/utils";
 
@@ -101,24 +102,48 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
 
 interface AttachFileButtonProps {
   disabled?: boolean;
-  onFilesSelected: (files: FileList) => void;
+  onFilesSelected: (files: FileList | File[]) => void;
   /** Tooltip override; defaults to "Attach file" when unset. */
   title?: string;
+  /**
+   * When true (default), render a second button that opens a directory picker
+   * so the user can attach an entire folder at once. The folder's files are
+   * filtered (junk dirs/files removed, count capped) before being forwarded to
+   * `onFilesSelected`.
+   */
+  enableFolderUpload?: boolean;
 }
 
 /**
- * Paperclip button that triggers a hidden file input. Lives in the lower-left
- * of the composer action bar to match the macOS layout.
+ * Paperclip button that triggers a hidden file input, plus an optional folder
+ * button that opens a directory picker. Lives in the lower-left of the composer
+ * action bar to match the macOS layout.
  */
 export const AttachFileButton: FC<AttachFileButtonProps> = ({
   disabled = false,
   onFilesSelected,
   title = "Attach file",
+  enableFolderUpload = true,
 }) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const folderInputRef = useRef<HTMLInputElement | null>(null);
+
+  // `webkitdirectory` is a non-standard attribute that React/TS won't accept as
+  // a JSX prop, so set it imperatively on the hidden folder input once mounted.
+  useEffect(() => {
+    const input = folderInputRef.current;
+    if (input) {
+      input.setAttribute("webkitdirectory", "");
+      input.setAttribute("directory", "");
+    }
+  }, []);
 
   const handleClick = useCallback(() => {
     inputRef.current?.click();
+  }, []);
+
+  const handleFolderClick = useCallback(() => {
+    folderInputRef.current?.click();
   }, []);
 
   const handleChange = useCallback(
@@ -133,26 +158,66 @@ export const AttachFileButton: FC<AttachFileButtonProps> = ({
     [onFilesSelected],
   );
 
+  const handleFolderChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { files } = event.target;
+      if (files && files.length > 0) {
+        // The directory picker returns every descendant file; drop noise and
+        // cap the count before staging uploads.
+        const { accepted } = filterFolderFiles(Array.from(files));
+        if (accepted.length > 0) {
+          onFilesSelected(accepted);
+        }
+      }
+      event.target.value = "";
+    },
+    [onFilesSelected],
+  );
+
   return (
-    <div className="relative">
-      <input
-        ref={inputRef}
-        type="file"
-        multiple
-        className="absolute inset-0 opacity-0 pointer-events-none"
-        onChange={handleChange}
-        aria-hidden="true"
-        tabIndex={-1}
-      />
-      <Button
-        variant="ghost"
-        iconOnly={<Paperclip />}
-        onClick={handleClick}
-        disabled={disabled}
-        aria-label="Attach file"
-        title={title}
-        className="[--vbtn-fg:var(--content-secondary)]"
-      />
-    </div>
+    <>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="absolute inset-0 opacity-0 pointer-events-none"
+          onChange={handleChange}
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+        <Button
+          variant="ghost"
+          iconOnly={<Paperclip />}
+          onClick={handleClick}
+          disabled={disabled}
+          aria-label="Attach file"
+          title={title}
+          className="[--vbtn-fg:var(--content-secondary)]"
+        />
+      </div>
+      {enableFolderUpload && (
+        <div className="relative">
+          <input
+            ref={folderInputRef}
+            type="file"
+            multiple
+            className="absolute inset-0 opacity-0 pointer-events-none"
+            onChange={handleFolderChange}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
+          <Button
+            variant="ghost"
+            iconOnly={<FolderUp />}
+            onClick={handleFolderClick}
+            disabled={disabled}
+            aria-label="Attach folder"
+            title={disabled ? title : "Attach folder"}
+            className="[--vbtn-fg:var(--content-secondary)]"
+          />
+        </div>
+      )}
+    </>
   );
 };

--- a/apps/web/src/domains/chat/components/chat-attachments/folder-files.test.ts
+++ b/apps/web/src/domains/chat/components/chat-attachments/folder-files.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  FOLDER_FILE_LIMIT,
+  filterFolderFiles,
+  shouldIgnoreFolderPath,
+} from "./folder-files";
+
+/** Build a File whose webkitRelativePath reports the given folder path. */
+function fileAt(relativePath: string): File {
+  const name = relativePath.split("/").pop() ?? relativePath;
+  const file = new File(["x"], name, { type: "text/plain" });
+  Object.defineProperty(file, "webkitRelativePath", {
+    value: relativePath,
+    configurable: true,
+  });
+  return file;
+}
+
+describe("shouldIgnoreFolderPath", () => {
+  test("keeps ordinary source files", () => {
+    expect(shouldIgnoreFolderPath("proj/src/index.ts")).toBe(false);
+    expect(shouldIgnoreFolderPath("README.md")).toBe(false);
+  });
+
+  test("skips dependency and build directories anywhere in the tree", () => {
+    expect(shouldIgnoreFolderPath("proj/node_modules/lib/index.js")).toBe(true);
+    expect(shouldIgnoreFolderPath("proj/dist/bundle.js")).toBe(true);
+    expect(shouldIgnoreFolderPath("proj/.git/HEAD")).toBe(true);
+  });
+
+  test("skips hidden directories but keeps leaf dotfiles", () => {
+    expect(shouldIgnoreFolderPath("proj/.cache/x")).toBe(true);
+    expect(shouldIgnoreFolderPath("proj/.idea/workspace.xml")).toBe(true);
+    expect(shouldIgnoreFolderPath("proj/.env")).toBe(false);
+  });
+
+  test("skips OS junk files", () => {
+    expect(shouldIgnoreFolderPath("proj/.DS_Store")).toBe(true);
+    expect(shouldIgnoreFolderPath("proj/sub/Thumbs.db")).toBe(true);
+  });
+});
+
+describe("filterFolderFiles", () => {
+  test("partitions accepted vs ignored", () => {
+    const result = filterFolderFiles([
+      fileAt("proj/src/a.ts"),
+      fileAt("proj/node_modules/b.js"),
+      fileAt("proj/.DS_Store"),
+      fileAt("proj/README.md"),
+    ]);
+    expect(result.accepted.map((f) => f.name)).toEqual(["a.ts", "README.md"]);
+    expect(result.ignored).toBe(2);
+    expect(result.truncated).toBe(false);
+  });
+
+  test("caps the result at FOLDER_FILE_LIMIT and flags truncation", () => {
+    const files = Array.from({ length: FOLDER_FILE_LIMIT + 5 }, (_, i) =>
+      fileAt(`proj/src/file-${i}.ts`),
+    );
+    const result = filterFolderFiles(files);
+    expect(result.accepted.length).toBe(FOLDER_FILE_LIMIT);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/apps/web/src/domains/chat/components/chat-attachments/folder-files.ts
+++ b/apps/web/src/domains/chat/components/chat-attachments/folder-files.ts
@@ -1,0 +1,251 @@
+
+/**
+ * Helpers for attaching an entire folder to a chat message.
+ *
+ * Mirrors how Claude Desktop treats a dropped/selected folder: walk the tree,
+ * skip noise (VCS metadata, dependency/build output, OS junk, hidden dirs),
+ * cap the total file count, then hand the surviving files to the normal
+ * per-file upload pipeline (`useChatAttachments.addFiles`). Folder upload is
+ * otherwise just "many attachments on one message", which the composer, upload
+ * API, and message protocol already support.
+ *
+ * Two entry points feed these helpers:
+ *  - The `webkitdirectory` file picker, which yields a flat `FileList` where
+ *    each file carries a `webkitRelativePath` like `my-folder/src/index.ts`.
+ *  - A folder drag-and-drop, which exposes a `FileSystemEntry` tree we walk via
+ *    `webkitGetAsEntry()`; we backfill `webkitRelativePath` so both paths share
+ *    the same filtering logic.
+ */
+
+/**
+ * Upper bound on how many files a single folder selection may queue. Folders
+ * can hold thousands of files; this keeps a POC from spamming the per-file
+ * upload endpoint and overwhelming the composer. Excess files past this limit
+ * are dropped (see `filterFolderFiles`).
+ */
+export const FOLDER_FILE_LIMIT = 200;
+
+/** Directory names skipped anywhere in a folder tree. */
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "node_modules",
+  "bower_components",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".cache",
+  "coverage",
+  ".idea",
+  ".vscode",
+  ".gradle",
+  "target",
+  "vendor",
+]);
+
+/** Exact file names skipped regardless of which directory they live in. */
+const IGNORED_FILES = new Set([".DS_Store", "Thumbs.db"]);
+
+/** True for a hidden path segment (dotfile/dotdir), excluding `.`/`..`. */
+function isHiddenSegment(segment: string): boolean {
+  return segment.startsWith(".") && segment !== "." && segment !== "..";
+}
+
+/**
+ * True when a POSIX-style relative path (e.g. `src/index.ts`) should be
+ * excluded from a folder upload because some segment is ignored noise. Hidden
+ * *directories* are skipped, but a hidden *file* at the leaf (e.g. `.env`) is
+ * kept — only explicit `IGNORED_FILES` names are dropped.
+ */
+export function shouldIgnoreFolderPath(relativePath: string): boolean {
+  const segments = relativePath.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return true;
+  }
+  const fileName = segments[segments.length - 1] ?? "";
+  if (IGNORED_FILES.has(fileName)) {
+    return true;
+  }
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index] ?? "";
+    const isLast = index === segments.length - 1;
+    if (IGNORED_DIRECTORIES.has(segment)) {
+      return true;
+    }
+    if (!isLast && isHiddenSegment(segment)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Best-effort relative path for a file from either entry point. */
+function relativePathFor(file: File): string {
+  const withPath = file as File & { webkitRelativePath?: string };
+  const rel = withPath.webkitRelativePath;
+  return rel && rel.length > 0 ? rel : file.name;
+}
+
+export interface FolderFilterResult {
+  /** Files that survived filtering, capped at `FOLDER_FILE_LIMIT`. */
+  accepted: File[];
+  /** Count of files dropped as ignored noise (junk dirs/files). */
+  ignored: number;
+  /** True when more than `FOLDER_FILE_LIMIT` files survived and were trimmed. */
+  truncated: boolean;
+}
+
+/**
+ * Filters a flat list of folder files down to the ones worth attaching:
+ * removes ignored noise and caps the result at `FOLDER_FILE_LIMIT`.
+ */
+export function filterFolderFiles(files: File[]): FolderFilterResult {
+  const kept: File[] = [];
+  let ignored = 0;
+  for (const file of files) {
+    if (shouldIgnoreFolderPath(relativePathFor(file))) {
+      ignored += 1;
+      continue;
+    }
+    kept.push(file);
+  }
+  const truncated = kept.length > FOLDER_FILE_LIMIT;
+  return {
+    accepted: truncated ? kept.slice(0, FOLDER_FILE_LIMIT) : kept,
+    ignored,
+    truncated,
+  };
+}
+
+/** Read a single `FileSystemFileEntry` into a `File`, or null on error. */
+function readFileEntry(entry: FileSystemFileEntry): Promise<File | null> {
+  return new Promise((resolve) => {
+    entry.file(
+      (file) => resolve(file),
+      () => resolve(null),
+    );
+  });
+}
+
+/** Drain a directory reader fully (it returns entries in batches of ~100). */
+function readDirectoryEntries(
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+  return new Promise((resolve) => {
+    reader.readEntries(
+      (entries) => resolve(entries),
+      () => resolve([]),
+    );
+  });
+}
+
+/** Recursively collect files from a `FileSystemEntry` into `out`. */
+async function walkEntry(entry: FileSystemEntry, out: File[]): Promise<void> {
+  if (entry.isFile) {
+    const file = await readFileEntry(entry as FileSystemFileEntry);
+    if (file) {
+      // `entry.fullPath` looks like `/my-folder/src/index.ts`; strip the
+      // leading slash so it matches the picker's `webkitRelativePath` shape,
+      // then shadow the (read-only) prototype getter so filtering/display can
+      // read folder structure uniformly across both entry points.
+      const relativePath = entry.fullPath.replace(/^\/+/, "");
+      try {
+        Object.defineProperty(file, "webkitRelativePath", {
+          value: relativePath,
+          configurable: true,
+        });
+      } catch {
+        // Some engines disallow shadowing the getter; filtering then falls
+        // back to `file.name`, which is still correct for top-level files.
+      }
+      out.push(file);
+    }
+    return;
+  }
+  if (entry.isDirectory) {
+    // Prune ignored/hidden directories before descending so we never read into
+    // node_modules, .git, etc.
+    if (IGNORED_DIRECTORIES.has(entry.name) || isHiddenSegment(entry.name)) {
+      return;
+    }
+    const reader = (entry as FileSystemDirectoryEntry).createReader();
+    let batch = await readDirectoryEntries(reader);
+    while (batch.length > 0) {
+      for (const child of batch) {
+        await walkEntry(child, out);
+      }
+      batch = await readDirectoryEntries(reader);
+    }
+  }
+}
+
+/**
+ * True when a drag contains at least one directory entry, meaning the caller
+ * must use the async `collectDataTransferFolderFiles` walk instead of the flat
+ * `DataTransfer.files` list. Must be called synchronously inside the drop
+ * handler while the `DataTransfer` is still live.
+ */
+export function dataTransferHasDirectory(dataTransfer: DataTransfer): boolean {
+  const items = dataTransfer.items;
+  if (!items) {
+    return false;
+  }
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (
+      item &&
+      item.kind === "file" &&
+      typeof item.webkitGetAsEntry === "function"
+    ) {
+      const entry = item.webkitGetAsEntry();
+      if (entry?.isDirectory) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Collects every file from a drag that includes one or more folders, walking
+ * directory entries recursively. Returns a flat `File[]` with
+ * `webkitRelativePath` backfilled so folder structure survives to filtering.
+ *
+ * The `DataTransferItemList` is invalidated once the drop handler returns, so
+ * we snapshot all entries synchronously (before the first `await`) — callers
+ * must invoke this synchronously from within the drop handler.
+ */
+export async function collectDataTransferFolderFiles(
+  dataTransfer: DataTransfer,
+): Promise<File[]> {
+  const items = dataTransfer.items;
+  const out: File[] = [];
+  if (!items) {
+    return out;
+  }
+  const entries: FileSystemEntry[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (
+      item &&
+      item.kind === "file" &&
+      typeof item.webkitGetAsEntry === "function"
+    ) {
+      const entry = item.webkitGetAsEntry();
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+  }
+  for (const entry of entries) {
+    await walkEntry(entry, out);
+  }
+  return out;
+}

--- a/apps/web/src/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone.ts
+++ b/apps/web/src/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone.ts
@@ -7,6 +7,12 @@ import {
   type DragEvent,
 } from "react";
 
+import {
+  collectDataTransferFolderFiles,
+  dataTransferHasDirectory,
+  filterFolderFiles,
+} from "@/domains/chat/components/chat-attachments/folder-files";
+
 interface UseChatAttachmentDropZoneOptions {
   /** Callback that receives files dropped on the zone. */
   onFiles: (files: File[]) => void;
@@ -157,6 +163,24 @@ export function useChatAttachmentDropZone({
         return;
       }
       event.preventDefault();
+      // A folder drop exposes a FileSystemEntry tree rather than flat files;
+      // walk it asynchronously, then strip noise (node_modules, .git, …) and
+      // cap the count before handing the survivors to the upload pipeline.
+      // `dataTransferHasDirectory` and the synchronous prefix of
+      // `collectDataTransferFolderFiles` both run before this handler returns,
+      // while the DataTransfer is still live.
+      if (dataTransferHasDirectory(event.dataTransfer)) {
+        void collectDataTransferFolderFiles(event.dataTransfer).then(
+          (collected) => {
+            const { accepted } = filterFolderFiles(collected);
+            if (accepted.length > 0) {
+              onFiles(accepted);
+            }
+          },
+        );
+        reset();
+        return;
+      }
       const files = extractFiles(event.dataTransfer);
       reset();
       if (files.length > 0) {


### PR DESCRIPTION
## What

Proof-of-concept **folder upload** for the web chat composer, following Claude Desktop's approach.

Today you can attach individual files in a conversation. This lets you attach a **whole folder** in one action — via a new directory-picker button or by **dragging a folder** onto the composer.

## Why this is small

Folder upload is really just *"many attachments on one message"*, and the backend already supports that end-to-end (the upload API is one-file-per-request, `attachmentIds` is already a `string[]`, and storage/message-protocol handle multiple attachments). So this is a **front-end-only** change that reuses the existing per-file upload pipeline (`useChatAttachments.addFiles`).

## Approach (mirrors Claude Desktop)

When a folder is selected/dropped, we walk the tree and:
- skip noise: `node_modules`, `.git`, `dist`/`build`/`out`/`.next`, `.idea`/`.vscode`, `__pycache__`, `vendor`, `target`, hidden dirs, `.DS_Store`/`Thumbs.db`, …
- preserve relative paths (`webkitRelativePath`) so structure survives filtering
- cap the count at **`FOLDER_FILE_LIMIT = 200`** so a deep folder can't spam the upload endpoint
- hand survivors to the normal upload flow (each file still respects the existing 50 MB / image-resize rules)

## Changes

- **`folder-files.ts`** (new) — pure filtering (`shouldIgnoreFolderPath`, `filterFolderFiles`) + recursive `FileSystemEntry` traversal (`collectDataTransferFolderFiles`, `dataTransferHasDirectory`).
- **`chat-attachments.tsx`** — `AttachFileButton` gains a directory-picker button (`webkitdirectory`), gated behind `enableFolderUpload` (default on).
- **`use-chat-attachment-drop-zone.ts`** — folder drops are walked via `webkitGetAsEntry` before staging.
- **`folder-files.test.ts`** (new) — unit tests for the filtering logic (6 tests, passing).

## Platform note

File upload currently has **two separate implementations**: web (`apps/web`) and native Swift (`clients/macos/.../ComposerAttachments.swift`). This POC targets **web only**. Since macOS is migrating to Electron-on-web-code, this should carry over to Mac with that migration; the native Swift composer would need a separate change if we want it before then.

## Known POC limitations / follow-ups

- Truncation past 200 files is silent — no toast yet (the `truncated`/`ignored` counts are returned but unused in the UI).
- Each file becomes its own attachment chip — fine for small folders, noisy for large ones. A future iteration could render a single collapsible "folder" chip and/or a dedicated bundled folder attachment type.
- Relative paths are preserved internally but not yet sent as the filename, so the model doesn't see folder structure yet. Easy follow-up if we want it.
- Linting/full typecheck couldn't run in the container (deps not installed); the changed files typecheck clean and the new unit tests pass via `bun test`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016qQxo9SS4wk3bk5fT7bveG

---
_Generated by [Claude Code](https://claude.ai/code/session_016qQxo9SS4wk3bk5fT7bveG)_