### PR TITLE
refactor(web): extract assistant lifecycle state machine into a non-React service

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Direct unit tests for the lifecycle state machine — no React tree,
+ * no `renderHook`. Demonstrates the testability that moving the
+ * machine out of React unlocks.
+ *
+ * Side-effect helpers (`setSelfHostedConnection`, `isGatewayAuthMode`,
+ * etc.) are mocked at module scope. API calls go through mock
+ * versions of `getAssistant` / `hatchAssistant` / `retireAssistantById`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { QueryClient } from "@tanstack/react-query";
+
+// --- module mocks --- //
+
+const getAssistantMock = mock(async () => ({ ok: false, status: 404 }));
+const hatchAssistantMock = mock(
+  async (
+    _opts?: { version?: string },
+  ): Promise<
+    | { ok: true; status: number; data: { id: string; status?: string } }
+    | { ok: false; status: number; error?: { message?: string } }
+  > => ({ ok: true, status: 201, data: { id: "asst-1" } }),
+);
+const retireAssistantMock = mock(async () => ({ ok: true, status: 200 }));
+
+mock.module("@/assistant/api", () => ({
+  getAssistant: getAssistantMock,
+  hatchAssistant: hatchAssistantMock,
+  retireAssistantById: retireAssistantMock,
+}));
+
+const setSelfHostedConnectionMock = mock((_args: unknown) => {});
+mock.module("@/lib/self-hosted/connection", () => ({
+  setSelfHostedConnection: setSelfHostedConnectionMock,
+}));
+
+const isGatewayAuthModeMock = mock(() => false);
+const getGatewayTokenMock = mock(() => "token");
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthMode: isGatewayAuthModeMock,
+  getGatewayToken: getGatewayTokenMock,
+}));
+
+const isLocalModeMock = mock(() => false);
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: isLocalModeMock,
+  getSelectedAssistant: () => null,
+  getLocalGatewayUrl: () => null,
+}));
+
+// Sentry is a side-effect-only dep here; silence it.
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+}));
+
+// --- imports under test --- //
+
+const { lifecycleService } = await import("./lifecycle-service");
+const { useAssistantLifecycleStore } = await import("./lifecycle-store");
+const { useAssistantSelectionStore } = await import("./selection-store");
+
+// --- fake query client --- //
+
+function makeQueryClient(): QueryClient {
+  return {
+    fetchQuery: async ({ queryFn }: { queryFn: () => Promise<unknown> }) =>
+      queryFn(),
+    setQueryData: () => undefined,
+    invalidateQueries: async () => undefined,
+  } as unknown as QueryClient;
+}
+
+const baseInputs = {
+  isLoggedIn: true,
+  isLoading: false,
+  isRetired: false,
+  isNonProduction: false,
+  hasPlatformSession: true,
+  onRedirect: () => {},
+  resolveOnboardingRedirect: () => null,
+};
+
+beforeEach(() => {
+  getAssistantMock.mockClear();
+  hatchAssistantMock.mockClear();
+  retireAssistantMock.mockClear();
+  setSelfHostedConnectionMock.mockClear();
+  // Re-baseline implementations every test so a `mockImplementationOnce`
+  // or `mockImplementation` from a prior test doesn't leak.
+  isGatewayAuthModeMock.mockImplementation(() => false);
+  isLocalModeMock.mockImplementation(() => false);
+  hatchAssistantMock.mockImplementation(async () => ({
+    ok: true,
+    status: 201,
+    data: { id: "asst-1" },
+  }));
+  getAssistantMock.mockImplementation(async () => ({ ok: false, status: 404 }));
+  lifecycleService.__resetForTesting();
+});
+
+afterEach(() => {
+  lifecycleService.__resetForTesting();
+});
+
+describe("lifecycleService — server state projection", () => {
+  test("active result writes the assistant id and flips to active", async () => {
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-1",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    expect(
+      useAssistantSelectionStore.getState().activeAssistantId,
+    ).toBe("asst-1");
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "active",
+      isLocal: false,
+      maintenanceMode: { enabled: false },
+    });
+  });
+
+  test("self_hosted result primes the self-hosted connection and writes the id", async () => {
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-local-1",
+        status: "active",
+        is_local: true,
+        ingress_url: "https://gateway.example/path",
+        platform_actor_token: "tok",
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledWith({
+      url: "https://gateway.example/path",
+      token: "tok",
+    });
+    expect(
+      useAssistantSelectionStore.getState().activeAssistantId,
+    ).toBe("asst-local-1");
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "self_hosted",
+    );
+  });
+});
+
+describe("lifecycleService — bootstrap branches", () => {
+  test("logout clears both stores", async () => {
+    // Drive the service into an `active` state through the
+    // legitimate path so its internal state mirrors the store.
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-prev-session",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "active",
+    );
+
+    // Now flip isLoggedIn false and reconcile.
+    lifecycleService.setInputs({
+      ...baseInputs,
+      isLoggedIn: false,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+
+    expect(
+      useAssistantSelectionStore.getState().activeAssistantId,
+    ).toBeNull();
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
+  });
+
+  test("gateway-auth short-circuit writes active state without calling the server", async () => {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "active",
+      isLocal: true,
+    });
+  });
+});
+
+describe("lifecycleService — auto-hatch cascade", () => {
+  test("404 → auto_hatch path issues hatchAssistant and lands the seeded id", async () => {
+    // checkAssistant fetches the cache, gets a 404, which
+    // resolves to `auto_hatch`. With no onboarding redirect and
+    // isNonProduction=false, the service then issues hatchAssistant,
+    // which succeeds and seeds the cache.
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 404,
+    }));
+    hatchAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 201,
+      data: { id: "asst-hatched-1", status: "initializing" },
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+  });
+
+  test("auto_hatch + nonprod transitions to awaiting_version_selection instead of hatching", async () => {
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 404,
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      isNonProduction: true,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "awaiting_version_selection",
+    );
+  });
+
+  test("auto_hatch + isRetired transitions to retired (no hatch)", async () => {
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 404,
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      isRetired: true,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "retired",
+    );
+  });
+});
+

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -291,6 +291,26 @@ describe("lifecycleService — auto-hatch cascade", () => {
   });
 });
 
+describe("lifecycleService — pre-init guards", () => {
+  test("public actions called before setInputs are no-ops, not crashes", async () => {
+    // Don't call setInputs at all — simulate a child route mounting
+    // a `useEffect` that calls a lifecycle action before
+    // `RootLayout`'s passive effect has installed inputs.
+    await lifecycleService.checkAssistant();
+    lifecycleService.retryAssistant();
+    lifecycleService.hatchVersion("v1");
+    await lifecycleService.respondToInputs();
+
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    // Initial state should be untouched — no spurious error
+    // transition (the bug the guard prevents).
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
+  });
+});
+
 describe("lifecycleService — stuck-initializing watchdog", () => {
   test("redundant initializing→initializing transitions do not reset the 5-minute clock", async () => {
     const setTimeoutSpy = mock(globalThis.setTimeout);

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -288,3 +288,94 @@ describe("lifecycleService — auto-hatch cascade", () => {
   });
 });
 
+describe("lifecycleService — stuck-initializing watchdog", () => {
+  test("redundant initializing→initializing transitions do not reset the 5-minute clock", async () => {
+    const setTimeoutSpy = mock(globalThis.setTimeout);
+    const clearTimeoutSpy = mock(globalThis.clearTimeout);
+    const originalSet = globalThis.setTimeout;
+    const originalClear = globalThis.clearTimeout;
+    globalThis.setTimeout = setTimeoutSpy as unknown as typeof setTimeout;
+    globalThis.clearTimeout = clearTimeoutSpy as unknown as typeof clearTimeout;
+    try {
+      getAssistantMock.mockImplementation(async () => ({
+        ok: true,
+        status: 200,
+        data: { id: "asst-init", status: "initializing" },
+      }));
+      lifecycleService.setInputs({
+        ...baseInputs,
+        queryClient: makeQueryClient(),
+      });
+
+      // First check: loading → initializing → arms the watchdog
+      // (one setTimeout for INITIALIZING_TIMEOUT_MS).
+      await lifecycleService.checkAssistant();
+      const armCalls = setTimeoutSpy.mock.calls.filter(
+        (call) => typeof call[1] === "number" && call[1] > 1000,
+      ).length;
+      const clearCallsAfterFirst = clearTimeoutSpy.mock.calls.length;
+
+      // Subsequent polls that re-confirm initializing must NOT
+      // rearm the watchdog (would reset the clock and the recovery
+      // path would never run).
+      await lifecycleService.applyServerResult({
+        ok: true,
+        status: 200,
+        data: { id: "asst-init", status: "initializing" },
+      });
+      await lifecycleService.applyServerResult({
+        ok: true,
+        status: 200,
+        data: { id: "asst-init", status: "initializing" },
+      });
+
+      const armCallsAfter = setTimeoutSpy.mock.calls.filter(
+        (call) => typeof call[1] === "number" && call[1] > 1000,
+      ).length;
+      const clearCallsAfter = clearTimeoutSpy.mock.calls.length;
+
+      expect(armCallsAfter).toBe(armCalls);
+      expect(clearCallsAfter).toBe(clearCallsAfterFirst);
+    } finally {
+      globalThis.setTimeout = originalSet;
+      globalThis.clearTimeout = originalClear;
+    }
+  });
+});
+
+describe("lifecycleService — retry budget exhaustion", () => {
+  test("3 recoverable hatch failures in the auto-hatch poll loop surface as error", async () => {
+    // Server says 404 (no assistant) → service hits the auto_hatch
+    // branch → calls hatchAssistant. The mock returns a recoverable
+    // 5xx, so each pass increments `hatchRetryCount` without ever
+    // succeeding. Three failed `checkAssistant`s reach the budget;
+    // the fourth surfaces the terminal error state.
+    getAssistantMock.mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+    }));
+    hatchAssistantMock.mockImplementation(async () => ({
+      ok: false,
+      status: 502,
+      error: { message: "bad gateway" },
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+    await lifecycleService.checkAssistant();
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "error",
+    );
+  });
+});
+

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -11,6 +11,20 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { QueryClient } from "@tanstack/react-query";
 
+// Import the real helpers from `@/assistant/lifecycle` before mocking
+// the module — we need the actual resolver / error-builder logic in
+// the mocked surface but with `INITIALIZING_TIMEOUT_MS` shrunk so the
+// 5-minute watchdog is reachable from a test.
+import {
+  buildInitializingTimeoutError,
+  isPlatformHostedDisabled,
+  PLATFORM_HOSTED_DISABLED_MESSAGE,
+  resolveAssistantLifecycleState,
+  shouldRecoverFromHatchFailure,
+} from "@/assistant/lifecycle";
+
+const TEST_INITIALIZING_TIMEOUT_MS = 30;
+
 // --- module mocks --- //
 
 const getAssistantMock = mock(async () => ({ ok: false, status: 404 }));
@@ -53,6 +67,15 @@ mock.module("@/lib/local-mode", () => ({
 mock.module("@sentry/react", () => ({
   captureException: () => {},
   captureMessage: () => {},
+}));
+
+mock.module("@/assistant/lifecycle", () => ({
+  buildInitializingTimeoutError,
+  INITIALIZING_TIMEOUT_MS: TEST_INITIALIZING_TIMEOUT_MS,
+  isPlatformHostedDisabled,
+  PLATFORM_HOSTED_DISABLED_MESSAGE,
+  resolveAssistantLifecycleState,
+  shouldRecoverFromHatchFailure,
 }));
 
 // --- imports under test --- //
@@ -395,4 +418,135 @@ describe("lifecycleService — retry budget exhaustion", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Watchdog → recovery flow (LUM-2067)
+//
+// These tests shrink `INITIALIZING_TIMEOUT_MS` to 30ms (via the
+// `@/assistant/lifecycle` mock above) so the recovery path is
+// reachable from a unit test without time-travel reasoning. The same
+// 5-minute watchdog runs in production; only the timeout constant
+// differs here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Spin until `predicate()` returns true or `timeoutMs` elapses. Bun
+ * doesn't ship fake-timer helpers we can rely on for setTimeout, so
+ * the watchdog tests use a small real timer and a poll loop.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor: condition not met within timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function initializingResult(id: string) {
+  return {
+    ok: true as const,
+    status: 200,
+    data: {
+      id,
+      status: "initializing",
+      is_local: false,
+      maintenance_mode: { enabled: false },
+    },
+  };
+}
+
+describe("lifecycleService — watchdog → recovery", () => {
+  test("watchdog firing on a still-initializing assistant retires and re-hatches", async () => {
+    // checkAssistant fetches → initializing → applyServerStateUpdate
+    // → transitions to initializing → arms the watchdog. The first
+    // recovery's mid-flight `getAssistant` (when
+    // `initializingAssistantId` is already set, this call is
+    // skipped — but on a fresh mount the id IS captured by the first
+    // projection, so the recovery branch goes straight to retire).
+    getAssistantMock.mockImplementation(async () =>
+      initializingResult("asst-stuck"),
+    );
+    retireAssistantMock.mockImplementation(async () => ({
+      ok: true,
+      status: 200,
+    }));
+    // After retire, the rehatch succeeds with a fresh id.
+    hatchAssistantMock.mockImplementation(async () => ({
+      ok: true,
+      status: 201,
+      data: { id: "asst-fresh", status: "initializing" },
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+
+    // Watchdog fires after TEST_INITIALIZING_TIMEOUT_MS.
+    await waitFor(() => retireAssistantMock.mock.calls.length >= 1);
+
+    expect(retireAssistantMock).toHaveBeenCalledWith("asst-stuck");
+    await waitFor(() => hatchAssistantMock.mock.calls.length >= 1);
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+  });
+
+  // Note: the "force-refresh found active" branch inside recovery
+  // (when `initializingAssistantId` was null at watchdog time) and
+  // the post-hatch active landing both depend on the React-tree
+  // polling loop firing `applyServerResult` from the next
+  // `useAssistantQuery` data tick. The state machine alone can't
+  // reach those outcomes without a poll driver, so they're left to
+  // integration coverage (`onboarding-lifecycle-sync.test.tsx`)
+  // rather than reconstructed in isolation here.
+
+  test("MAX_INITIALIZING_RECOVERIES failed recoveries surface as a terminal timeout error", async () => {
+    // Each recovery cycle: retire+rehatch succeeds, but hatch keeps
+    // returning initializing — so the next watchdog firing kicks off
+    // another recovery. Three cycles consume the budget; the fourth
+    // firing trips the budget guard and transitions to error.
+    getAssistantMock.mockImplementation(async () =>
+      initializingResult("asst-stuck"),
+    );
+    retireAssistantMock.mockImplementation(async () => ({
+      ok: true,
+      status: 200,
+    }));
+    hatchAssistantMock.mockImplementation(async () => ({
+      ok: true,
+      status: 201,
+      data: { id: "asst-still-stuck", status: "initializing" },
+    }));
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+
+    await waitFor(
+      () =>
+        useAssistantLifecycleStore.getState().assistantState.kind === "error",
+      1000,
+    );
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("error");
+    if (state.kind === "error") {
+      // Should be the timeout-specific error, not a generic one.
+      expect(state.message).toEqual(buildInitializingTimeoutError().message);
+    }
+  });
+});
+
 

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -89,6 +89,9 @@ beforeEach(() => {
   setSelfHostedConnectionMock.mockClear();
   // Re-baseline implementations every test so a `mockImplementationOnce`
   // or `mockImplementation` from a prior test doesn't leak.
+  // `mockClear` resets only the call history, not the implementation —
+  // any new mocked dep added here MUST re-set its baseline below or
+  // tests will silently inherit the previous test's stub.
   isGatewayAuthModeMock.mockImplementation(() => false);
   isLocalModeMock.mockImplementation(() => false);
   hatchAssistantMock.mockImplementation(async () => ({
@@ -317,17 +320,11 @@ describe("lifecycleService — stuck-initializing watchdog", () => {
 
       // Subsequent polls that re-confirm initializing must NOT
       // rearm the watchdog (would reset the clock and the recovery
-      // path would never run).
-      await lifecycleService.applyServerResult({
-        ok: true,
-        status: 200,
-        data: { id: "asst-init", status: "initializing" },
-      });
-      await lifecycleService.applyServerResult({
-        ok: true,
-        status: 200,
-        data: { id: "asst-init", status: "initializing" },
-      });
+      // path would never run). Driving through `checkAssistant`
+      // exercises the same `applyServerStateUpdate` path the
+      // background poll takes.
+      await lifecycleService.checkAssistant();
+      await lifecycleService.checkAssistant();
 
       const armCallsAfter = setTimeoutSpy.mock.calls.filter(
         (call) => typeof call[1] === "number" && call[1] > 1000,

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -1,0 +1,620 @@
+/**
+ * Assistant lifecycle state machine — the non-React core.
+ *
+ * Owns: hatching, recovery, retry budgets, the generation counter
+ * that drops stale async responses on timeout escalations, the
+ * 5-minute stuck-initializing watchdog, the gateway-auth
+ * short-circuit, post-hatch cache seeding, and the
+ * onboarding-redirect coordination.
+ *
+ * Publishes its observable state — `assistantState` and
+ * `activeAssistantId` — into the two Zustand stores
+ * (`useAssistantLifecycleStore`, `useAssistantSelectionStore`),
+ * which is how the React tree reads it. Inputs from React (auth,
+ * env, the navigate callback, the TanStack Query client) flow in
+ * through `setInputs()`; `useAssistantLifecycle` is the thin
+ * wiring layer that pushes them.
+ *
+ * Module-level singleton — instantiated at import, survives every
+ * mount/unmount cycle. Tests can swap in a fresh instance via
+ * `__resetForTesting`.
+ */
+
+import * as Sentry from "@sentry/react";
+import type { QueryClient } from "@tanstack/react-query";
+
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import {
+  getAssistant,
+  hatchAssistant,
+  retireAssistantById,
+  type GetAssistantResult,
+} from "@/assistant/api";
+import {
+  buildInitializingTimeoutError,
+  INITIALIZING_TIMEOUT_MS,
+  isPlatformHostedDisabled,
+  PLATFORM_HOSTED_DISABLED_MESSAGE,
+  resolveAssistantLifecycleState,
+  shouldRecoverFromHatchFailure,
+} from "@/assistant/lifecycle";
+import { ASSISTANT_QUERY_KEY, POLL_INTERVAL_MS } from "@/assistant/queries";
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import type { AssistantState } from "@/assistant/types";
+import { extractErrorMessage } from "@/utils/api-errors";
+import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
+import {
+  getSelectedAssistant,
+  getLocalGatewayUrl,
+  isLocalMode,
+} from "@/lib/local-mode";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
+
+const MAX_HATCH_RETRIES = 3;
+const MAX_INITIALIZING_RECOVERIES = 3;
+
+export interface LifecycleServiceInputs {
+  isLoggedIn: boolean;
+  isLoading: boolean;
+  isRetired: boolean;
+  isNonProduction: boolean;
+  hasPlatformSession: boolean;
+  /** Framework-agnostic redirect — called instead of router.replace(). */
+  onRedirect: (url: string) => void;
+  /**
+   * Returns the path to redirect to when onboarding should intercept,
+   * or `null` if the intended destination is fine as-is. Injected so
+   * `assistant/` stays free of the onboarding domain (the
+   * `shared → domains` direction).
+   */
+  resolveOnboardingRedirect: (input: {
+    intendedDestination: string;
+  }) => string | null;
+  /** The TanStack Query client owned by `RootLayout`'s provider. */
+  queryClient: QueryClient;
+}
+
+const NOOP_REDIRECT = (_: string) => {};
+const NOOP_RESOLVE: LifecycleServiceInputs["resolveOnboardingRedirect"] =
+  () => null;
+
+class AssistantLifecycleService {
+  private state: AssistantState = { kind: "loading" };
+  private hatching = false;
+  private hatchRetryCount = 0;
+  private initializingAssistantId: string | null = null;
+  private initializingRecoveryCount = 0;
+  private hatchingVersion: string | undefined = undefined;
+  /**
+   * Bumped when an `initializing` cycle times out. Async work that
+   * captured a prior value compares against this and drops its
+   * response, so stale `initializing` answers can't revive the
+   * spinner after timeout → error.
+   */
+  private generation = 0;
+  private initializingTimeout: ReturnType<typeof setTimeout> | null = null;
+  private inputs: LifecycleServiceInputs = {
+    isLoggedIn: false,
+    isLoading: true,
+    isRetired: false,
+    isNonProduction: false,
+    hasPlatformSession: false,
+    onRedirect: NOOP_REDIRECT,
+    resolveOnboardingRedirect: NOOP_RESOLVE,
+    queryClient: null as unknown as QueryClient,
+  };
+
+  // ---------------------------------------------------------------------------
+  // React-facing API
+  // ---------------------------------------------------------------------------
+
+  setInputs(inputs: LifecycleServiceInputs): void {
+    this.inputs = inputs;
+  }
+
+  /**
+   * Reconcile against the current inputs — drives initial bootstrap
+   * (post-login `checkAssistant`), logout reset, and the local-mode
+   * branches. Safe to call on every input change.
+   */
+  async respondToInputs(): Promise<void> {
+    if (!this.inputs.isLoggedIn || this.inputs.isLoading) {
+      // Logout / pre-auth boot. Drop selection + lifecycle state
+      // so a returning login doesn't observe the previous user's id.
+      // Guarded resets avoid spurious subscriber wake-ups when the
+      // stores are already at defaults.
+      if (useAssistantSelectionStore.getState().activeAssistantId !== null) {
+        useAssistantSelectionStore.getState().setActiveAssistantId(null);
+      }
+      if (this.state.kind !== "loading") {
+        this.transition({ kind: "loading" });
+      }
+      return;
+    }
+
+    if (isGatewayAuthMode()) {
+      this.applyGatewayAuthShortCircuit();
+      return;
+    }
+    if (
+      isLocalMode() &&
+      !isGatewayAuthMode() &&
+      !this.inputs.hasPlatformSession
+    ) {
+      const redirect = this.inputs.resolveOnboardingRedirect({
+        intendedDestination: window.location.pathname,
+      });
+      if (redirect) this.inputs.onRedirect(redirect);
+      return;
+    }
+    if (this.inputs.hasPlatformSession) {
+      setSelfHostedConnection(null);
+    }
+    await this.checkAssistant();
+  }
+
+  /**
+   * Project a fresh `/assistant/` poll result into local state.
+   * Called by the React wiring on every `useAssistantQuery` data
+   * change — the service decides whether to act on it (only while
+   * the lifecycle is transient).
+   */
+  async applyServerResult(result: GetAssistantResult): Promise<void> {
+    if (this.state.kind !== "initializing" && this.state.kind !== "cleaning_up") {
+      return;
+    }
+    await this.applyServerStateUpdate(result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Imperative actions — called from event handlers / consumers
+  // ---------------------------------------------------------------------------
+
+  async checkAssistant(): Promise<void> {
+    if (isGatewayAuthMode()) {
+      this.applyGatewayAuthShortCircuit();
+      return;
+    }
+    const generation = this.generation;
+    try {
+      // Force a fresh fetch through the query cache. `fetchQuery`
+      // updates the cache atomically so any other subscriber
+      // (sidebar header, identity panel, etc.) sees the same answer
+      // this code path acts on. `staleTime: 0` is required: the
+      // app's QueryClient sets a 10s default staleTime, and
+      // imperative re-checks (visibility-change return, retry
+      // button, onboarding pre-chat verification) must hit the
+      // network so a 10s-old cached 404 or initializing result
+      // doesn't silently replay. Poll-driven projections go through
+      // `applyServerResult` to avoid the read-back loop.
+      const result = await this.inputs.queryClient.fetchQuery({
+        queryKey: ASSISTANT_QUERY_KEY,
+        queryFn: () => getAssistant(),
+        staleTime: 0,
+      });
+      if (generation !== this.generation) return;
+      await this.applyServerStateUpdate(result);
+    } catch (err) {
+      console.error("Error checking assistant status:", err);
+      Sentry.captureException(err, { tags: { context: "check_assistant" } });
+      if (generation !== this.generation) return;
+      this.transition({
+        kind: "error",
+        message: "Network error. Please check your connection and try again.",
+      });
+    }
+  }
+
+  retryAssistant(): void {
+    this.hatchRetryCount = 0;
+    this.initializingRecoveryCount = 0;
+    void this.checkAssistant();
+  }
+
+  hatchVersion(version?: string): void {
+    this.hatchRetryCount = 0;
+    void this.hatchAndCheck(version);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private state machine
+  // ---------------------------------------------------------------------------
+
+  private transition(next: AssistantState): void {
+    this.state = next;
+    useAssistantLifecycleStore.setState({ assistantState: next });
+    this.syncInitializingWatchdog(next.kind);
+  }
+
+  /**
+   * Owns the 5-minute stuck-initializing timer. Entering
+   * `initializing` arms it; leaving clears it. A re-entry during an
+   * active hatch attempt (e.g. retry → initializing again) clears
+   * the prior timer and starts a fresh one, matching the previous
+   * React implementation's `initializingCycle`-driven re-arming.
+   */
+  private syncInitializingWatchdog(kind: AssistantState["kind"]): void {
+    if (this.initializingTimeout) {
+      clearTimeout(this.initializingTimeout);
+      this.initializingTimeout = null;
+    }
+    if (kind === "initializing") {
+      this.initializingTimeout = setTimeout(() => {
+        Sentry.captureMessage("Assistant hatch stuck in initializing state", {
+          level: "warning",
+          extra: { timeoutMs: INITIALIZING_TIMEOUT_MS },
+        });
+        void this.recoverStuckInitializingAssistant();
+      }, INITIALIZING_TIMEOUT_MS);
+    }
+  }
+
+  /**
+   * Gateway-auth resolves the assistant locally — bypasses
+   * `/assistant/` entirely because the gateway issues the session
+   * token directly. Mount-time init and imperative `checkAssistant`
+   * both short-circuit through this; keep them in lockstep.
+   */
+  private applyGatewayAuthShortCircuit(): void {
+    let ingressUrl = window.location.origin;
+    let resolvedAssistantId = "self";
+    const localGateway = getLocalGatewayUrl();
+    if (localGateway) {
+      const assistant = getSelectedAssistant();
+      ingressUrl = `${window.location.origin}${localGateway}`;
+      resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;
+    }
+    setSelfHostedConnection({ url: ingressUrl, token: getGatewayToken() });
+    useAssistantSelectionStore
+      .getState()
+      .setActiveAssistantId(resolvedAssistantId);
+    this.transition({ kind: "active", isLocal: true });
+  }
+
+  private async applyServerStateUpdate(
+    result: GetAssistantResult,
+  ): Promise<void> {
+    const generation = this.generation;
+    const nextState = resolveAssistantLifecycleState(result);
+    if (result.ok && nextState.kind === "initializing") {
+      this.initializingAssistantId = result.data.id;
+    } else if (nextState.kind !== "initializing") {
+      this.initializingAssistantId = null;
+    }
+
+    if (nextState.kind === "auto_hatch") {
+      // If we just retired, show the retired screen instead of auto-hatching.
+      if (this.inputs.isRetired) {
+        this.transition({ kind: "retired" });
+        return;
+      }
+      // New signups without completed onboarding land on
+      // `/onboarding/privacy` before we hatch an assistant for them.
+      const onboardingRedirect = this.inputs.resolveOnboardingRedirect({
+        intendedDestination: window.location.pathname,
+      });
+      if (onboardingRedirect) {
+        this.inputs.onRedirect(onboardingRedirect);
+        return;
+      }
+      // In nonprod, let the user pick a release version before hatching.
+      if (this.inputs.isNonProduction) {
+        this.transition({ kind: "awaiting_version_selection" });
+        return;
+      }
+      await this.hatchAndCheck();
+      return;
+    }
+
+    if (nextState.kind === "active" && result.ok) {
+      const mm = result.data.maintenance_mode;
+      this.initializingRecoveryCount = 0;
+      this.hatchingVersion = undefined;
+      // Drop any stale self-hosted connection: the server says the
+      // assistant is now managed-active, so runtime calls belong on
+      // the platform and we don't want a leftover token attached.
+      setSelfHostedConnection(null);
+      // Set the assistant id BEFORE the kind flips. The `init`
+      // effect that fetches conversations gates on
+      // `assistantState.kind === "active"`, and that fetch is what
+      // the unreachable-bus interceptor is meant to notice. If we
+      // wait until after the conversation list query succeeds to
+      // set this, the reachability hook's probe() has no target
+      // assistant when the 503 arrives and the connecting overlay
+      // never shows.
+      useAssistantSelectionStore
+        .getState()
+        .setActiveAssistantId(result.data.id);
+      this.transition({
+        kind: "active",
+        isLocal: result.data.is_local ?? false,
+        maintenanceMode: { enabled: mm?.enabled },
+      });
+      return;
+    }
+
+    if (nextState.kind === "self_hosted" && result.ok) {
+      this.initializingRecoveryCount = 0;
+      this.hatchingVersion = undefined;
+      // Record the user's gateway + actor token so the request
+      // interceptor can rewrite runtime-proxied calls to the
+      // gateway and attach `Authorization: Bearer`. The slots have
+      // to be primed before `assistantId` flips, otherwise the
+      // first conversation list fetch races us and hits the
+      // platform.
+      //
+      // Both fields are nullable in the serializer:
+      //   - `ingress_url`: an assistant can be `is_local=true`
+      //     before its gateway hostname is known. In that case the
+      //     URL slot stays null and the platform's proxy view 404s
+      //     cleanly.
+      //   - `platform_actor_token`: there's a brief window after
+      //     hatch where `bootstrap_platform_actor_token` is still
+      //     in-flight. In that case the request fires
+      //     unauthenticated, the gateway responds 401, and the
+      //     chat surface lands on its error state.
+      setSelfHostedConnection({
+        url: result.data.ingress_url,
+        token: result.data.platform_actor_token,
+      });
+      useAssistantSelectionStore
+        .getState()
+        .setActiveAssistantId(result.data.id);
+      this.transition({ kind: "self_hosted" });
+      return;
+    }
+
+    if (generation !== this.generation) return;
+    if (nextState.kind !== "active") {
+      this.transition(nextState);
+    }
+  }
+
+  private async hatchAndCheck(version?: string): Promise<void> {
+    if (this.hatching) return;
+
+    if (this.hatchRetryCount >= MAX_HATCH_RETRIES) {
+      this.transition({
+        kind: "error",
+        message:
+          "Failed to start your assistant after multiple attempts. Please refresh the page to try again.",
+      });
+      return;
+    }
+
+    this.hatching = true;
+    this.hatchingVersion = version;
+    const generation = this.generation;
+    this.transition({ kind: "initializing" });
+    try {
+      const result = await hatchAssistant(version ? { version } : undefined);
+      if (generation !== this.generation) return;
+      if (result.ok) {
+        this.initializingAssistantId = result.data.id;
+        // Seed the assistant-query cache with the hatch response so
+        // post-hatch polling actually begins. The initial
+        // `/assistant/` read for a fresh user caches a 404; without
+        // this seed, `pollIntervalFor(404)` keeps the query idle
+        // and newly-hatched users sit on the initializing screen
+        // until the 5-minute stuck-assistant recovery timer fires.
+        // The hatch response is shape-compatible with
+        // `GetAssistantResult`, so projecting it directly avoids an
+        // extra round-trip.
+        this.inputs.queryClient.setQueryData<GetAssistantResult>(
+          ASSISTANT_QUERY_KEY,
+          { ok: true, status: result.status, data: result.data },
+        );
+      }
+      if (!result.ok) {
+        this.hatchRetryCount += 1;
+        Sentry.captureMessage("Hatch request failed", {
+          level: "warning",
+          extra: {
+            status: result.status,
+            error: result.error,
+            attempt: this.hatchRetryCount,
+          },
+        });
+        // Capacity / kill-switch from the backend
+        // (platform-hosted-enabled flag is off). Surface the
+        // tailored message instead of treating this as a
+        // recoverable 5xx — retrying just burns the
+        // MAX_HATCH_RETRIES budget and ends in a generic error.
+        if (isPlatformHostedDisabled(result.status, result.error)) {
+          this.transition({
+            kind: "error",
+            message: PLATFORM_HOSTED_DISABLED_MESSAGE,
+          });
+          return;
+        }
+        if (shouldRecoverFromHatchFailure(result.status)) {
+          this.transition({ kind: "initializing" });
+          // Cache is still 404 → `pollIntervalFor` keeps the query
+          // idle → no automatic retry. Space the next attempt by
+          // `POLL_INTERVAL_MS` to preserve the 3-second backoff
+          // between hatch retries: rapid back-to-back invalidations
+          // burn the `MAX_HATCH_RETRIES` budget in milliseconds and
+          // hammer the server.
+          setTimeout(() => {
+            void this.inputs.queryClient.invalidateQueries({
+              queryKey: ASSISTANT_QUERY_KEY,
+            });
+          }, POLL_INTERVAL_MS);
+          return;
+        }
+
+        this.transition({
+          kind: "error",
+          message: extractErrorMessage(
+            result.error,
+            undefined,
+            "Failed to start your assistant. Please refresh the page to try again.",
+          ),
+        });
+        return;
+      }
+      this.hatchRetryCount = 0;
+    } catch (err) {
+      this.hatchRetryCount += 1;
+      Sentry.captureException(err, { tags: { context: "hatch_assistant" } });
+      if (generation !== this.generation) return;
+      this.transition({ kind: "initializing" });
+      // Network error during hatch behaves like a recoverable
+      // failure (cache still 404, no automatic poll). Apply the
+      // same 3-second backoff before driving the next attempt.
+      setTimeout(() => {
+        void this.inputs.queryClient.invalidateQueries({
+          queryKey: ASSISTANT_QUERY_KEY,
+        });
+      }, POLL_INTERVAL_MS);
+      return;
+    } finally {
+      this.hatching = false;
+    }
+    if (generation !== this.generation) return;
+    // Re-assert `initializing` so the poll loop restarts in case an
+    // early poll returned 404 and switched state to `initializing`
+    // while the hatch request was still in-flight.
+    this.transition({ kind: "initializing" });
+  }
+
+  private async recoverStuckInitializingAssistant(): Promise<void> {
+    if (this.initializingRecoveryCount >= MAX_INITIALIZING_RECOVERIES) {
+      this.generation++;
+      this.transition(buildInitializingTimeoutError());
+      return;
+    }
+
+    this.initializingRecoveryCount++;
+    this.generation++;
+    const generation = this.generation;
+
+    try {
+      let assistantIdToRetire = this.initializingAssistantId;
+      if (!assistantIdToRetire) {
+        // Force-refresh the cached status. We need to know whether
+        // the assistant moved off `initializing` before deciding
+        // whether to retire-and-rehatch — a cached 10s-old
+        // `initializing` result would mislead the decision into an
+        // unnecessary retire.
+        const result = await this.inputs.queryClient.fetchQuery({
+          queryKey: ASSISTANT_QUERY_KEY,
+          queryFn: () => getAssistant(),
+          staleTime: 0,
+        });
+        if (generation !== this.generation) return;
+        if (result.ok && result.data.status === "initializing") {
+          assistantIdToRetire = result.data.id;
+        } else {
+          const nextState = resolveAssistantLifecycleState(result);
+          this.initializingAssistantId = null;
+          if (nextState.kind === "auto_hatch") {
+            await this.hatchAndCheck(this.hatchingVersion);
+          } else if (nextState.kind === "active" && result.ok) {
+            const mm = result.data.maintenance_mode;
+            this.initializingRecoveryCount = 0;
+            setSelfHostedConnection(null);
+            useAssistantSelectionStore
+              .getState()
+              .setActiveAssistantId(result.data.id);
+            this.transition({
+              kind: "active",
+              isLocal: result.data.is_local ?? false,
+              maintenanceMode: { enabled: mm?.enabled },
+            });
+          } else if (nextState.kind === "self_hosted" && result.ok) {
+            // Mirror `applyServerStateUpdate`'s `self_hosted`
+            // branch: an assistant can graduate from `initializing`
+            // straight into `is_local: true` once it registers its
+            // gateway. Without this the recovery path leaves
+            // `assistantId` null and the chat surface keeps showing
+            // the initializing-timeout error after the assistant
+            // has actually come up.
+            this.initializingRecoveryCount = 0;
+            setSelfHostedConnection({
+              url: result.data.ingress_url,
+              token: result.data.platform_actor_token,
+            });
+            useAssistantSelectionStore
+              .getState()
+              .setActiveAssistantId(result.data.id);
+            this.transition({ kind: "self_hosted" });
+          } else if (nextState.kind !== "active") {
+            this.transition(nextState);
+          }
+          return;
+        }
+      }
+
+      // Prevent the poll loop from calling `hatchAndCheck()` while
+      // we retire the stuck assistant. Without this, a poll that
+      // observes the 404 (after the retire takes effect on the
+      // backend but before our own `hatchAndCheck` creates the
+      // replacement) races to create a duplicate.
+      this.hatching = true;
+
+      const retireResult = await retireAssistantById(assistantIdToRetire);
+      if (generation !== this.generation) {
+        this.hatching = false;
+        return;
+      }
+      if (!retireResult.ok && retireResult.status !== 404) {
+        this.hatching = false;
+        Sentry.captureMessage(
+          "Failed to retire stuck initializing assistant",
+          {
+            level: "warning",
+            extra: { status: retireResult.status, error: retireResult.error },
+          },
+        );
+        this.transition(buildInitializingTimeoutError());
+        return;
+      }
+
+      this.initializingAssistantId = null;
+      useAssistantSelectionStore.getState().setActiveAssistantId(null);
+      this.hatching = false;
+      await this.hatchAndCheck(this.hatchingVersion);
+    } catch (err) {
+      this.hatching = false;
+      Sentry.captureException(err, {
+        tags: { context: "recover_stuck_initializing_assistant" },
+      });
+      if (generation !== this.generation) return;
+      this.transition(buildInitializingTimeoutError());
+    }
+  }
+
+  /**
+   * Reset all state to the post-import default. For tests only —
+   * production code should never call this. (Use `respondToInputs`
+   * with `isLoggedIn: false` for logout reset.)
+   */
+  __resetForTesting(): void {
+    if (this.initializingTimeout) {
+      clearTimeout(this.initializingTimeout);
+      this.initializingTimeout = null;
+    }
+    this.state = { kind: "loading" };
+    this.hatching = false;
+    this.hatchRetryCount = 0;
+    this.initializingAssistantId = null;
+    this.initializingRecoveryCount = 0;
+    this.hatchingVersion = undefined;
+    this.generation = 0;
+    this.inputs = {
+      isLoggedIn: false,
+      isLoading: true,
+      isRetired: false,
+      isNonProduction: false,
+      hasPlatformSession: false,
+      onRedirect: NOOP_REDIRECT,
+      resolveOnboardingRedirect: NOOP_RESOLVE,
+      queryClient: null as unknown as QueryClient,
+    };
+    useAssistantLifecycleStore.setState({ assistantState: this.state });
+    useAssistantSelectionStore.setState({ activeAssistantId: null });
+  }
+}
+
+export const lifecycleService = new AssistantLifecycleService();

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -93,6 +93,16 @@ class AssistantLifecycleService {
    */
   private generation = 0;
   private initializingTimeout: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Flips true on the first `setInputs()` call. Public action
+   * methods early-return until then. Without this, a child route's
+   * `useEffect` calling e.g. `lifecycleService.checkAssistant()`
+   * BEFORE `RootLayout`'s passive effect has installed the
+   * `queryClient` would catch a TypeError on `null.fetchQuery` and
+   * publish a spurious network-error state. Mirrors the no-op
+   * defaults the pre-service store action API used to ship with.
+   */
+  private ready = false;
   private inputs: LifecycleServiceInputs = {
     isLoggedIn: false,
     isLoading: true,
@@ -110,6 +120,7 @@ class AssistantLifecycleService {
 
   setInputs(inputs: LifecycleServiceInputs): void {
     this.inputs = inputs;
+    this.ready = true;
   }
 
   /**
@@ -118,6 +129,7 @@ class AssistantLifecycleService {
    * branches. Safe to call on every input change.
    */
   async respondToInputs(): Promise<void> {
+    if (!this.ready) return;
     if (!this.inputs.isLoggedIn || this.inputs.isLoading) {
       // Logout / pre-auth boot. Drop selection + lifecycle state
       // so a returning login doesn't observe the previous user's id.
@@ -160,6 +172,7 @@ class AssistantLifecycleService {
    * the lifecycle is transient).
    */
   async applyServerResult(result: GetAssistantResult): Promise<void> {
+    if (!this.ready) return;
     if (this.state.kind !== "initializing" && this.state.kind !== "cleaning_up") {
       return;
     }
@@ -171,6 +184,7 @@ class AssistantLifecycleService {
   // ---------------------------------------------------------------------------
 
   async checkAssistant(): Promise<void> {
+    if (!this.ready) return;
     if (isGatewayAuthMode()) {
       this.applyGatewayAuthShortCircuit();
       return;
@@ -206,12 +220,14 @@ class AssistantLifecycleService {
   }
 
   retryAssistant(): void {
+    if (!this.ready) return;
     this.hatchRetryCount = 0;
     this.initializingRecoveryCount = 0;
     void this.checkAssistant();
   }
 
   hatchVersion(version?: string): void {
+    if (!this.ready) return;
     this.hatchRetryCount = 0;
     void this.hatchAndCheck(version);
   }
@@ -607,6 +623,7 @@ class AssistantLifecycleService {
     this.initializingRecoveryCount = 0;
     this.hatchingVersion = undefined;
     this.generation = 0;
+    this.ready = false;
     this.inputs = {
       isLoggedIn: false,
       isLoading: true,

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -221,32 +221,34 @@ class AssistantLifecycleService {
   // ---------------------------------------------------------------------------
 
   private transition(next: AssistantState): void {
+    const prevKind = this.state.kind;
     this.state = next;
     useAssistantLifecycleStore.setState({ assistantState: next });
-    this.syncInitializingWatchdog(next.kind);
+    // Watchdog edge-trigger: entering `initializing` arms it,
+    // leaving clears it. A repeat `initializing → initializing`
+    // is a no-op so back-to-back poll results that re-confirm
+    // the same phase don't reset the 5-minute clock — only a
+    // fresh hatch attempt should, and `hatchAndCheck` calls
+    // `armInitializingWatchdog()` explicitly for that.
+    if (next.kind !== "initializing") {
+      if (this.initializingTimeout) {
+        clearTimeout(this.initializingTimeout);
+        this.initializingTimeout = null;
+      }
+    } else if (prevKind !== "initializing") {
+      this.armInitializingWatchdog();
+    }
   }
 
-  /**
-   * Owns the 5-minute stuck-initializing timer. Entering
-   * `initializing` arms it; leaving clears it. A re-entry during an
-   * active hatch attempt (e.g. retry → initializing again) clears
-   * the prior timer and starts a fresh one, matching the previous
-   * React implementation's `initializingCycle`-driven re-arming.
-   */
-  private syncInitializingWatchdog(kind: AssistantState["kind"]): void {
-    if (this.initializingTimeout) {
-      clearTimeout(this.initializingTimeout);
-      this.initializingTimeout = null;
-    }
-    if (kind === "initializing") {
-      this.initializingTimeout = setTimeout(() => {
-        Sentry.captureMessage("Assistant hatch stuck in initializing state", {
-          level: "warning",
-          extra: { timeoutMs: INITIALIZING_TIMEOUT_MS },
-        });
-        void this.recoverStuckInitializingAssistant();
-      }, INITIALIZING_TIMEOUT_MS);
-    }
+  private armInitializingWatchdog(): void {
+    if (this.initializingTimeout) clearTimeout(this.initializingTimeout);
+    this.initializingTimeout = setTimeout(() => {
+      Sentry.captureMessage("Assistant hatch stuck in initializing state", {
+        level: "warning",
+        extra: { timeoutMs: INITIALIZING_TIMEOUT_MS },
+      });
+      void this.recoverStuckInitializingAssistant();
+    }, INITIALIZING_TIMEOUT_MS);
   }
 
   /**
@@ -255,6 +257,60 @@ class AssistantLifecycleService {
    * token directly. Mount-time init and imperative `checkAssistant`
    * both short-circuit through this; keep them in lockstep.
    */
+  /**
+   * Project a managed-active server result. Drops any stale
+   * self-hosted connection (runtime calls belong on the platform
+   * now, and we don't want a leftover token attached), sets the
+   * id BEFORE the kind flips so the conversation list query and
+   * the unreachable-bus interceptor have a target on first
+   * `kind === "active"` render, then transitions.
+   */
+  private projectActive(
+    result: GetAssistantResult & { ok: true },
+  ): void {
+    const mm = result.data.maintenance_mode;
+    setSelfHostedConnection(null);
+    useAssistantSelectionStore
+      .getState()
+      .setActiveAssistantId(result.data.id);
+    this.transition({
+      kind: "active",
+      isLocal: result.data.is_local ?? false,
+      maintenanceMode: { enabled: mm?.enabled },
+    });
+  }
+
+  /**
+   * Project a self-hosted server result. Records the user's
+   * gateway + actor token so the request interceptor can rewrite
+   * runtime-proxied calls to the gateway and attach
+   * `Authorization: Bearer`. The slots have to be primed before
+   * `assistantId` flips, otherwise the first conversation list
+   * fetch races us and hits the platform.
+   *
+   * Both `ingress_url` and `platform_actor_token` are nullable
+   * in the serializer:
+   *   - `ingress_url`: an assistant can be `is_local=true` before
+   *     its gateway hostname is known. In that case the URL slot
+   *     stays null and the platform's proxy view 404s cleanly.
+   *   - `platform_actor_token`: brief window after hatch where
+   *     `bootstrap_platform_actor_token` is still in-flight. The
+   *     request fires unauthenticated, the gateway responds 401,
+   *     and the chat surface lands on its error state.
+   */
+  private projectSelfHosted(
+    result: GetAssistantResult & { ok: true },
+  ): void {
+    setSelfHostedConnection({
+      url: result.data.ingress_url,
+      token: result.data.platform_actor_token,
+    });
+    useAssistantSelectionStore
+      .getState()
+      .setActiveAssistantId(result.data.id);
+    this.transition({ kind: "self_hosted" });
+  }
+
   private applyGatewayAuthShortCircuit(): void {
     let ingressUrl = window.location.origin;
     let resolvedAssistantId = "self";
@@ -307,60 +363,16 @@ class AssistantLifecycleService {
     }
 
     if (nextState.kind === "active" && result.ok) {
-      const mm = result.data.maintenance_mode;
       this.initializingRecoveryCount = 0;
       this.hatchingVersion = undefined;
-      // Drop any stale self-hosted connection: the server says the
-      // assistant is now managed-active, so runtime calls belong on
-      // the platform and we don't want a leftover token attached.
-      setSelfHostedConnection(null);
-      // Set the assistant id BEFORE the kind flips. The `init`
-      // effect that fetches conversations gates on
-      // `assistantState.kind === "active"`, and that fetch is what
-      // the unreachable-bus interceptor is meant to notice. If we
-      // wait until after the conversation list query succeeds to
-      // set this, the reachability hook's probe() has no target
-      // assistant when the 503 arrives and the connecting overlay
-      // never shows.
-      useAssistantSelectionStore
-        .getState()
-        .setActiveAssistantId(result.data.id);
-      this.transition({
-        kind: "active",
-        isLocal: result.data.is_local ?? false,
-        maintenanceMode: { enabled: mm?.enabled },
-      });
+      this.projectActive(result);
       return;
     }
 
     if (nextState.kind === "self_hosted" && result.ok) {
       this.initializingRecoveryCount = 0;
       this.hatchingVersion = undefined;
-      // Record the user's gateway + actor token so the request
-      // interceptor can rewrite runtime-proxied calls to the
-      // gateway and attach `Authorization: Bearer`. The slots have
-      // to be primed before `assistantId` flips, otherwise the
-      // first conversation list fetch races us and hits the
-      // platform.
-      //
-      // Both fields are nullable in the serializer:
-      //   - `ingress_url`: an assistant can be `is_local=true`
-      //     before its gateway hostname is known. In that case the
-      //     URL slot stays null and the platform's proxy view 404s
-      //     cleanly.
-      //   - `platform_actor_token`: there's a brief window after
-      //     hatch where `bootstrap_platform_actor_token` is still
-      //     in-flight. In that case the request fires
-      //     unauthenticated, the gateway responds 401, and the
-      //     chat surface lands on its error state.
-      setSelfHostedConnection({
-        url: result.data.ingress_url,
-        token: result.data.platform_actor_token,
-      });
-      useAssistantSelectionStore
-        .getState()
-        .setActiveAssistantId(result.data.id);
-      this.transition({ kind: "self_hosted" });
+      this.projectSelfHosted(result);
       return;
     }
 
@@ -386,6 +398,10 @@ class AssistantLifecycleService {
     this.hatchingVersion = version;
     const generation = this.generation;
     this.transition({ kind: "initializing" });
+    // Restart the 5-minute watchdog for every fresh hatch attempt
+    // (transition is a no-op kind-wise when we were already
+    // initializing, but a new attempt deserves a new clock).
+    this.armInitializingWatchdog();
     try {
       const result = await hatchAssistant(version ? { version } : undefined);
       if (generation !== this.generation) return;
@@ -511,34 +527,23 @@ class AssistantLifecycleService {
           if (nextState.kind === "auto_hatch") {
             await this.hatchAndCheck(this.hatchingVersion);
           } else if (nextState.kind === "active" && result.ok) {
-            const mm = result.data.maintenance_mode;
             this.initializingRecoveryCount = 0;
-            setSelfHostedConnection(null);
-            useAssistantSelectionStore
-              .getState()
-              .setActiveAssistantId(result.data.id);
-            this.transition({
-              kind: "active",
-              isLocal: result.data.is_local ?? false,
-              maintenanceMode: { enabled: mm?.enabled },
-            });
+            this.projectActive(result);
+            // Note: `hatchingVersion` is intentionally not cleared
+            // on the recovery path's active landing — matches the
+            // shape this code carried before being extracted. Not
+            // observable to consumers either way (only `hatchAndCheck`
+            // reads it, and we won't re-enter that until the next
+            // user-driven retry).
           } else if (nextState.kind === "self_hosted" && result.ok) {
-            // Mirror `applyServerStateUpdate`'s `self_hosted`
-            // branch: an assistant can graduate from `initializing`
-            // straight into `is_local: true` once it registers its
-            // gateway. Without this the recovery path leaves
+            // An assistant can graduate from `initializing` straight
+            // into `is_local: true` once it registers its gateway.
+            // Without this branch the recovery path leaves
             // `assistantId` null and the chat surface keeps showing
             // the initializing-timeout error after the assistant
-            // has actually come up.
+            // has come up.
             this.initializingRecoveryCount = 0;
-            setSelfHostedConnection({
-              url: result.data.ingress_url,
-              token: result.data.platform_actor_token,
-            });
-            useAssistantSelectionStore
-              .getState()
-              .setActiveAssistantId(result.data.id);
-            this.transition({ kind: "self_hosted" });
+            this.projectSelfHosted(result);
           } else if (nextState.kind !== "active") {
             this.transition(nextState);
           }

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -94,13 +94,13 @@ class AssistantLifecycleService {
   private generation = 0;
   private initializingTimeout: ReturnType<typeof setTimeout> | null = null;
   /**
-   * Flips true on the first `setInputs()` call. Public action
-   * methods early-return until then. Without this, a child route's
-   * `useEffect` calling e.g. `lifecycleService.checkAssistant()`
-   * BEFORE `RootLayout`'s passive effect has installed the
-   * `queryClient` would catch a TypeError on `null.fetchQuery` and
-   * publish a spurious network-error state. Mirrors the no-op
-   * defaults the pre-service store action API used to ship with.
+   * Public action methods early-return until `setInputs()` flips
+   * this true. Without the guard, a child route's `useEffect`
+   * calling e.g. `lifecycleService.checkAssistant()` BEFORE
+   * `RootLayout`'s passive effect installs the `queryClient` would
+   * catch a TypeError on `null.fetchQuery` and publish a spurious
+   * network-error state — children's effects commit before
+   * parents' in the same render cycle.
    */
   private ready = false;
   private inputs: LifecycleServiceInputs = {

--- a/apps/web/src/assistant/lifecycle-store.test.ts
+++ b/apps/web/src/assistant/lifecycle-store.test.ts
@@ -2,49 +2,24 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { useAssistantLifecycleStore } from "./lifecycle-store";
 
-const NOOP_CHECK = async () => {};
-const NOOP_VOID = () => {};
-
 afterEach(() => {
-  useAssistantLifecycleStore.setState({
-    assistantState: { kind: "loading" },
-    checkAssistant: NOOP_CHECK,
-    retryAssistant: NOOP_VOID,
-    hatchVersion: NOOP_VOID,
-  });
+  useAssistantLifecycleStore.setState({ assistantState: { kind: "loading" } });
 });
 
 describe("useAssistantLifecycleStore", () => {
-  test("starts in loading state with no-op imperative actions", () => {
-    const s = useAssistantLifecycleStore.getState();
-    expect(s.assistantState).toEqual({ kind: "loading" });
-    expect(typeof s.checkAssistant).toBe("function");
-    expect(typeof s.retryAssistant).toBe("function");
-    expect(typeof s.hatchVersion).toBe("function");
+  test("starts in the loading phase", () => {
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
   });
 
-  test("setAssistantState replaces the discriminated state", () => {
-    useAssistantLifecycleStore
-      .getState()
-      .setAssistantState({ kind: "active", isLocal: false });
+  test("setState replaces the discriminated state", () => {
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "active", isLocal: false },
+    });
     expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
       kind: "active",
       isLocal: false,
     });
-  });
-
-  test("registerImperativeActions swaps in real callbacks", () => {
-    const check = async () => {};
-    const retry = () => {};
-    const hatch = (_v?: string) => {};
-    useAssistantLifecycleStore.getState().registerImperativeActions({
-      checkAssistant: check,
-      retryAssistant: retry,
-      hatchVersion: hatch,
-    });
-    const s = useAssistantLifecycleStore.getState();
-    expect(s.checkAssistant).toBe(check);
-    expect(s.retryAssistant).toBe(retry);
-    expect(s.hatchVersion).toBe(hatch);
   });
 });

--- a/apps/web/src/assistant/lifecycle-store.ts
+++ b/apps/web/src/assistant/lifecycle-store.ts
@@ -1,41 +1,22 @@
 /**
- * Assistant lifecycle state — the data side of `use-lifecycle.ts`.
+ * Assistant lifecycle state — the data side of the lifecycle service.
  *
- * `use-lifecycle.ts` runs the behavior (mount-time init, polling,
- * recovery timers, mutation calls). This store holds the state it
- * produces: the discriminated `AssistantState` and the hook's
- * imperative callbacks.
+ * `lifecycle-service.ts` owns the behavior (state machine, polling
+ * reactions, recovery, retry budgets, mutation calls). This store
+ * holds the observable result: the discriminated `AssistantState`
+ * the React tree subscribes to.
  *
- * The store-not-context choice: every page that decides "what should
- * I render right now?" reads `assistantState`. Pushing it through
- * outlet context forces a bundled value through every layout layer
- * and re-renders every consumer on any field change. Atomic Zustand
- * selectors mean a route reading only `checkAssistant` doesn't
- * re-render when the state machine transitions. See
- * `apps/web/docs/STATE_MANAGEMENT.md` for the boundary rule.
+ * The store-not-context choice: every page that decides "what
+ * should I render right now?" reads `assistantState`. Pushing it
+ * through outlet context forces a bundled value through every
+ * layout layer and re-renders every consumer on any field change.
+ * The atomic Zustand selector pattern avoids both costs. See
+ * `apps/web/docs/STATE_MANAGEMENT.md`.
  *
- * **Reading the imperative actions: call them inline via
- * `.getState()` at the use site.** The store ships no-op defaults
- * that `useAssistantLifecycle` overwrites in a passive `useEffect`
- * after its first render — children of `RootLayout` render in the
- * same commit, so neither render-time capture nor selector
- * subscription is right:
+ * Writers: only `lifecycle-service.ts` should call
+ * `useAssistantLifecycleStore.setState(...)`. Consumers read.
  *
- *   - `const fn = useAssistantLifecycleStore.getState().checkAssistant`
- *     at render time captures the no-op and never updates.
- *   - `const fn = useAssistantLifecycleStore.use.checkAssistant()`
- *     re-renders when registration lands; if `fn` is in any effect's
- *     dep list, the effect cleans up and re-runs after the identity
- *     flip — which **re-executes any side effect the effect already
- *     started** (e.g. duplicate hatch requests).
- *
- * The right pattern is to call the store action inline at the moment
- * it's needed: `await useAssistantLifecycleStore.getState().checkAssistant()`.
- * For actions that need to flow through a prop boundary, wrap in a
- * stable `useCallback(() => useAssistantLifecycleStore.getState().X(),
- * [])` so the prop identity doesn't flip when registration lands.
- *
- * @see {@link ./use-lifecycle.ts}
+ * @see {@link ./lifecycle-service.ts}
  * @see {@link ./selection-store.ts}
  */
 
@@ -47,62 +28,10 @@ import type { AssistantState } from "./types";
 
 interface LifecycleState {
   assistantState: AssistantState;
-  /**
-   * Imperative re-check from the server. Called by the
-   * visibility-change handler in `useEventBusInit`, onboarding
-   * pre-chat verification, and `chat-route-content` when maintenance
-   * mode exits.
-   */
-  checkAssistant: () => Promise<void>;
-  /**
-   * Reset both retry budgets and re-check. For the error-screen
-   * "Try again" button.
-   */
-  retryAssistant: () => void;
-  /**
-   * Reset hatch retries and hatch with the given version. For the
-   * version-selection screen in nonprod.
-   */
-  hatchVersion: (version?: string) => void;
 }
 
-interface LifecycleActions {
-  setAssistantState: (state: AssistantState) => void;
-  /**
-   * Called once by `useAssistantLifecycle` after mount to expose the
-   * stable callback references. Registering here keeps the hook the
-   * single owner of the closures (so they see fresh React state and
-   * the latest mutations) while letting any consumer call them
-   * without prop drilling.
-   */
-  registerImperativeActions: (
-    actions: Pick<
-      LifecycleState,
-      "checkAssistant" | "retryAssistant" | "hatchVersion"
-    >,
-  ) => void;
-}
-
-type LifecycleStore = LifecycleState & LifecycleActions;
-
-// No-op defaults cover the brief pre-registration window between
-// `RootLayout` mounting and `useAssistantLifecycle` running its
-// register-actions effect. In practice a real route never observes
-// these (renders are downstream of `RootLayout`), but typing the
-// actions as non-nullable keeps every call site free of `?.()`
-// guards and `!` assertions.
-const NOOP_CHECK = async () => {};
-const NOOP_VOID = () => {};
-
-const useAssistantLifecycleStoreBase = create<LifecycleStore>((set) => ({
+const useAssistantLifecycleStoreBase = create<LifecycleState>(() => ({
   assistantState: { kind: "loading" },
-  checkAssistant: NOOP_CHECK,
-  retryAssistant: NOOP_VOID,
-  hatchVersion: NOOP_VOID,
-
-  setAssistantState: (assistantState) => set({ assistantState }),
-  registerImperativeActions: ({ checkAssistant, retryAssistant, hatchVersion }) =>
-    set({ checkAssistant, retryAssistant, hatchVersion }),
 }));
 
 export const useAssistantLifecycleStore = createSelectors(

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -1,37 +1,24 @@
+/**
+ * Wires React lifecycle into the non-React lifecycle service.
+ *
+ * The state machine itself lives in `lifecycle-service.ts` — a
+ * module-level singleton that owns retry budgets, recovery timers,
+ * the generation counter, and all the state transitions. This hook
+ * only does the React-bound work: pull the auth/env signals out of
+ * their Zustand stores, pull the TanStack Query client and the
+ * `/assistant/` poll result out of the React tree, and push them
+ * into the service.
+ *
+ * Mount this once at the application root (`RootLayout`).
+ */
 
-import * as Sentry from "@sentry/react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
-import { extractErrorMessage } from "@/utils/api-errors";
-import {
-  getAssistant,
-  hatchAssistant,
-  retireAssistantById,
-  type GetAssistantResult,
-} from "@/assistant/api";
-import {
-  buildInitializingTimeoutError,
-  INITIALIZING_TIMEOUT_MS,
-  isPlatformHostedDisabled,
-  PLATFORM_HOSTED_DISABLED_MESSAGE,
-  resolveAssistantLifecycleState,
-  shouldRecoverFromHatchFailure,
-} from "@/assistant/lifecycle";
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
-import {
-  ASSISTANT_QUERY_KEY,
-  POLL_INTERVAL_MS,
-  useAssistantQuery,
-} from "@/assistant/queries";
-import { useAssistantSelectionStore } from "@/assistant/selection-store";
-import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
-import { getSelectedAssistant, getLocalGatewayUrl, isLocalMode } from "@/lib/local-mode";
-import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
-
-
-const MAX_HATCH_RETRIES = 3;
-const MAX_INITIALIZING_RECOVERIES = 3;
+import { lifecycleService } from "@/assistant/lifecycle-service";
+import { useAssistantQuery } from "@/assistant/queries";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import { isLocalMode } from "@/lib/local-mode";
 
 interface UseAssistantLifecycleOptions {
   isLoggedIn: boolean;
@@ -43,51 +30,15 @@ interface UseAssistantLifecycleOptions {
   onRedirect: (url: string) => void;
   /**
    * Returns the path to redirect to when onboarding should intercept,
-   * or `null` if the intended destination is fine as-is. Injected as
-   * an option so this hook stays free of the onboarding domain (the
-   * `assistant/` module is shared infrastructure; depending on a
-   * domain would invert the `shared → domains` direction).
+   * or `null` if the intended destination is fine as-is. Injected so
+   * `assistant/` stays free of the onboarding domain (the
+   * `shared → domains` direction).
    */
   resolveOnboardingRedirect: (input: {
     intendedDestination: string;
   }) => string | null;
 }
 
-/**
- * Drives the assistant lifecycle state machine: hatching, recovery,
- * and the derived `AssistantState` that drives top-level page
- * rendering.
- *
- * Returns `void` — all output flows through Zustand stores:
- *   - `useAssistantLifecycleStore` for `assistantState` and the
- *     imperative actions (`checkAssistant` / `retryAssistant` /
- *     `hatchVersion`).
- *   - `useAssistantSelectionStore` for the active assistant id.
- *
- * Cross-domain consumers subscribe to those stores via atomic
- * selectors. No outlet context, no prop drilling.
- *
- * The server-side resource (`/assistant/`) is owned by the
- * `useAssistantQuery` TanStack Query — this hook subscribes to its
- * result and layers a client-side state machine on top:
- *
- *   - Retry budgets that distinguish recoverable 5xx from terminal
- *     errors like the platform-hosted-disabled capacity kill-switch.
- *   - A "stuck initializing" recovery path that retires and re-hatches
- *     an assistant the daemon never promoted to `active`.
- *   - Generation counters that drop responses from a previous recovery
- *     cycle so a slow `getAssistant()` can't revive the spinner after
- *     a timeout already escalated the state to `error`.
- *   - Side effects on lifecycle transitions: priming / clearing the
- *     self-hosted connection, redirecting to onboarding, surfacing
- *     awaiting-version-selection in nonprod.
- *
- * Framework-agnostic — no Next.js or React Router imports. Routing is
- * delegated to the caller via the `onRedirect` callback.
- *
- * Mount this once at the application root (`RootLayout`). Mounting
- * multiple instances would race on the store writes.
- */
 export function useAssistantLifecycle({
   isLoggedIn,
   isLoading,
@@ -97,580 +48,52 @@ export function useAssistantLifecycle({
   onRedirect,
   resolveOnboardingRedirect,
 }: UseAssistantLifecycleOptions): void {
-  // All client lifecycle state lives in `useAssistantLifecycleStore`
-  // so cross-domain readers can subscribe with atomic selectors. The
-  // hook only holds private bookkeeping (retry counters, generation
-  // ids, in-flight guards) that no other component should see.
-  const setAssistantState =
-    useAssistantLifecycleStore.use.setAssistantState();
-  const registerImperativeActions =
-    useAssistantLifecycleStore.use.registerImperativeActions();
-  const assistantStateKind = useAssistantLifecycleStore(
-    (s) => s.assistantState.kind,
-  );
-  // The active assistant id lives in `useAssistantSelectionStore` so
-  // cross-domain consumers (RootLayout sync hooks, page routes)
-  // subscribe via atomic selectors. The hook drives the writes; readers
-  // go through the store.
-  const setAssistantId =
-    useAssistantSelectionStore.use.setActiveAssistantId();
-
-  const hatchingRef = useRef(false);
-  const hatchRetryCountRef = useRef(0);
-  const initializingAssistantIdRef = useRef<string | null>(null);
-  const initializingRecoveryCountRef = useRef(0);
-  const hatchingVersionRef = useRef<string | undefined>(undefined);
-  const [initializingCycle, setInitializingCycle] = useState(0);
-  // Bumped when an "initializing" cycle times out. Async work that captured a
-  // prior value compares against this and drops its response, so stale
-  // "initializing" answers can't revive the spinner after timeout -> error.
-  const initializingGenerationRef = useRef(0);
-
-  // Stabilize external values with refs so useCallback identities stay stable.
-  const isRetiredRef = useRef(isRetired);
-  isRetiredRef.current = isRetired;
-  const isNonProductionRef = useRef(isNonProduction);
-  isNonProductionRef.current = isNonProduction;
-  const onRedirectRef = useRef(onRedirect);
-  onRedirectRef.current = onRedirect;
-  const resolveOnboardingRedirectRef = useRef(resolveOnboardingRedirect);
-  resolveOnboardingRedirectRef.current = resolveOnboardingRedirect;
-
   const queryClient = useQueryClient();
-  // Dumb mutation wrappers — no implicit retry, no Sentry capture.
-  // The recovery state machine below owns retry budgets
-  // (`MAX_HATCH_RETRIES`, `MAX_INITIALIZING_RECOVERIES`) and stacks
-  // hatch + retire across recovery cycles. TanStack Query retrying
-  // on top would burn the budget twice as fast and double-log.
-  const hatchMutation = useMutation({ mutationFn: hatchAssistant });
-  const retireMutation = useMutation({ mutationFn: retireAssistantById });
 
-  // `useMutation` returns a new object reference every render, but the
-  // bound `mutateAsync` methods on the underlying observer don't.
-  // Capture them in refs so the `useCallback`s below don't have to list
-  // an unstable object in their deps array — without this, every render
-  // would re-issue `hatchAndCheck` / `checkAssistant` / `recoverStuck...`
-  // identities, the init effect would re-fire, and active users would
-  // see a continuous `/assistant/` fetch loop.
-  const hatchMutateRef = useRef(hatchMutation.mutateAsync);
-  hatchMutateRef.current = hatchMutation.mutateAsync;
-  const retireMutateRef = useRef(retireMutation.mutateAsync);
-  retireMutateRef.current = retireMutation.mutateAsync;
-
-  // Whether to query the server-side status at all. Gateway-auth mode
-  // and "local mode without platform session" short-circuit to local
-  // states without ever calling /assistant/.
+  // Whether to query the server-side status at all. Gateway-auth
+  // mode and "local mode without platform session" short-circuit
+  // to local states without ever calling /assistant/.
   const shouldQueryServer =
     isLoggedIn &&
     !isLoading &&
     !isGatewayAuthMode() &&
     (hasPlatformSession || !isLocalMode());
 
-  // Background poll + cache writes. Side effects run from the
-  // `assistantResult` effect below, not from the query's return
-  // shape itself, so the recovery state machine controls when
-  // projections fire (only while the lifecycle is transient).
   const { data: assistantResult } = useAssistantQuery({
     enabled: shouldQueryServer,
   });
 
-  /**
-   * Imperative re-check. Today the TanStack Query polls in the
-   * background while the lifecycle is transient; callers use this for
-   * the `app.resume` / visibility-change handler that needs to verify
-   * the daemon is still alive immediately on return.
-   *
-   * Falls back to a direct `getAssistant()` call when the
-   * gateway-auth / local-mode short-circuit means the query is
-   * disabled. In those modes the lifecycle is local-only and the
-   * "re-check" is a no-op refresh of the gateway connection.
-   */
-  const hatchAndCheck = useCallback(async (version?: string) => {
-    if (hatchingRef.current) return;
-
-    if (hatchRetryCountRef.current >= MAX_HATCH_RETRIES) {
-      setAssistantState({
-        kind: "error",
-        message: "Failed to start your assistant after multiple attempts. Please refresh the page to try again.",
-      });
-      return;
-    }
-
-    hatchingRef.current = true;
-    hatchingVersionRef.current = version;
-    const generation = initializingGenerationRef.current;
-    setInitializingCycle((n) => n + 1);
-    setAssistantState({ kind: "initializing" });
-    try {
-      const result = await hatchMutateRef.current(
-        version ? { version } : undefined,
-      );
-      if (generation !== initializingGenerationRef.current) return;
-      if (result.ok) {
-        initializingAssistantIdRef.current = result.data.id;
-        // Seed the assistant-query cache with the hatch response so
-        // post-hatch polling actually begins. The initial /assistant/
-        // read for a fresh user caches a 404; without this seed,
-        // `pollIntervalFor(404)` keeps the query idle and newly-hatched
-        // users sit on the initializing screen until the 5-minute
-        // stuck-assistant recovery timer fires. The hatch response is
-        // shape-compatible with `GetAssistantResult`, so projecting it
-        // directly avoids an extra round-trip we don't need.
-        queryClient.setQueryData<GetAssistantResult>(ASSISTANT_QUERY_KEY, {
-          ok: true,
-          status: result.status,
-          data: result.data,
-        });
-      }
-      if (!result.ok) {
-        hatchRetryCountRef.current += 1;
-        Sentry.captureMessage("Hatch request failed", {
-          level: "warning",
-          extra: { status: result.status, error: result.error, attempt: hatchRetryCountRef.current },
-        });
-        // Capacity / kill-switch from the backend (platform-hosted-enabled
-        // flag is off). Surface the tailored message instead of treating
-        // this as a recoverable 5xx — retrying just burns the
-        // MAX_HATCH_RETRIES budget and ends in a generic error.
-        if (isPlatformHostedDisabled(result.status, result.error)) {
-          setAssistantState({
-            kind: "error",
-            message: PLATFORM_HOSTED_DISABLED_MESSAGE,
-          });
-          return;
-        }
-        if (shouldRecoverFromHatchFailure(result.status)) {
-          setAssistantState({ kind: "initializing" });
-          // Cache is still 404 → `pollIntervalFor` keeps the query
-          // idle → no automatic retry. Space the next attempt by
-          // `POLL_INTERVAL_MS` to preserve the 3-second backoff
-          // between hatch retries: rapid back-to-back invalidations
-          // burn the `MAX_HATCH_RETRIES` budget in milliseconds and
-          // hammer the server. The invalidation refetch lands the
-          // 404 in cache; the data-watcher effect below re-enters
-          // `applyServerStateUpdate` → `auto_hatch` → `hatchAndCheck`
-          // against the next retry slot.
-          setTimeout(() => {
-            void queryClient.invalidateQueries({ queryKey: ASSISTANT_QUERY_KEY });
-          }, POLL_INTERVAL_MS);
-          return;
-        }
-
-        setAssistantState({
-          kind: "error",
-          message: extractErrorMessage(
-            result.error,
-            undefined,
-            "Failed to start your assistant. Please refresh the page to try again.",
-          ),
-        });
-        return;
-      }
-      hatchRetryCountRef.current = 0;
-    } catch (err) {
-      hatchRetryCountRef.current += 1;
-      Sentry.captureException(err, {
-        tags: { context: "hatch_assistant" },
-      });
-      if (generation !== initializingGenerationRef.current) return;
-      setAssistantState({ kind: "initializing" });
-      // Network error during hatch behaves like a recoverable failure
-      // (cache still 404, no automatic poll). Apply the same
-      // 3-second backoff before driving the next attempt.
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ASSISTANT_QUERY_KEY });
-      }, POLL_INTERVAL_MS);
-      return;
-    } finally {
-      hatchingRef.current = false;
-    }
-    if (generation !== initializingGenerationRef.current) return;
-    // Re-assert "initializing" so the poll loop restarts in case an
-    // early poll returned 404 and switched state to "initializing"
-    // while the hatch request was still in-flight.
-    setAssistantState({ kind: "initializing" });
-  }, [queryClient]);
-
-  /**
-   * Project a server result onto local lifecycle state + side effects.
-   *
-   * Splitting this out of `checkAssistant` matters for the cache
-   * subscription below: a successful 3-second poll lands the new
-   * result in the query cache, the subscription fires, and we want to
-   * re-apply the side effects without triggering another network
-   * round-trip. Calling `checkAssistant` from the subscription would
-   * `fetchQuery({ staleTime: 0 })` again and collapse the polling
-   * cadence into a request loop.
-   *
-   * Imperative re-checks (visibility-change handler, retry button)
-   * still go through `checkAssistant`, which forces a fresh fetch and
-   * then delegates here.
-   */
-  const applyServerStateUpdate = useCallback(
-    async (result: Awaited<ReturnType<typeof getAssistant>>) => {
-      const generation = initializingGenerationRef.current;
-      const nextState = resolveAssistantLifecycleState(result);
-      if (result.ok && nextState.kind === "initializing") {
-        initializingAssistantIdRef.current = result.data.id;
-      } else if (nextState.kind !== "initializing") {
-        initializingAssistantIdRef.current = null;
-      }
-      if (nextState.kind === "auto_hatch") {
-        // If we just retired, show the retired screen instead of auto-hatching.
-        if (isRetiredRef.current) {
-          setAssistantState({ kind: "retired" });
-          return;
-        }
-        // New signups without completed onboarding should land on
-        // `/onboarding/privacy` before we hatch an assistant for them.
-        const onboardingRedirect = resolveOnboardingRedirectRef.current({
-          intendedDestination: window.location.pathname,
-        });
-        if (onboardingRedirect) {
-          onRedirectRef.current(onboardingRedirect);
-          return;
-        }
-        // In nonprod, let the user pick a release version before hatching.
-        if (isNonProductionRef.current) {
-          setAssistantState({ kind: "awaiting_version_selection" });
-          return;
-        }
-        // No assistant exists — auto-hatch using managed credentials.
-        await hatchAndCheck();
-        return;
-      }
-
-      if (nextState.kind === "active" && result.ok) {
-        const mm = result.data.maintenance_mode;
-        initializingRecoveryCountRef.current = 0;
-        hatchingVersionRef.current = undefined;
-        // Drop any stale self-hosted connection: the server says the
-        // assistant is now managed-active, so runtime calls belong on
-        // the platform and we don't want a leftover token attached to
-        // those requests either.
-        setSelfHostedConnection(null);
-        // Set the assistant id here, before any pod-facing fetch runs.
-        // The `init` effect below only fetches conversations once
-        // `assistantState.kind === "active"`, and that fetch is what
-        // the unreachable-bus interceptor is meant to notice. If we
-        // wait until after the conversation list query succeeds to set this,
-        // the reachability hook's probe() has no target assistant
-        // when the 503 arrives and the connecting overlay never
-        // shows.
-        setAssistantId(result.data.id);
-        setAssistantState({
-          kind: "active",
-          isLocal: result.data.is_local ?? false,
-          maintenanceMode: {
-            enabled: mm?.enabled,
-          },
-        });
-        return;
-      }
-
-      if (nextState.kind === "self_hosted" && result.ok) {
-        initializingRecoveryCountRef.current = 0;
-        hatchingVersionRef.current = undefined;
-        // Record the user's gateway + actor token so the request
-        // interceptor can rewrite runtime-proxied calls to the
-        // gateway and attach `Authorization: Bearer`. The slots have
-        // to be primed before `assistantId` flips, otherwise the
-        // first conversation list fetch races us and hits the
-        // platform.
-        //
-        // Both fields are nullable in the serializer:
-        //   - `ingress_url`: an assistant can be `is_local=true`
-        //     before its gateway hostname is known. In that case the
-        //     URL slot stays null and the platform's proxy view 404s
-        //     cleanly — surfaces as the chat error state, just one
-        //     HTTP hop sooner.
-        //   - `platform_actor_token`: there's a brief window after
-        //     hatch where `bootstrap_platform_actor_token` is still
-        //     in-flight. In that case the request fires
-        //     unauthenticated, the gateway responds 401, and the
-        //     chat surface lands on its error state.
-        setSelfHostedConnection({
-          url: result.data.ingress_url,
-          token: result.data.platform_actor_token,
-        });
-        setAssistantId(result.data.id);
-        setAssistantState({ kind: "self_hosted" });
-        return;
-      }
-
-      if (generation !== initializingGenerationRef.current) return;
-      if (nextState.kind !== "active") {
-        setAssistantState(nextState);
-      }
-    },
-    [hatchAndCheck],
-  );
-
-  /**
-   * Resolve gateway-auth mode locally and write the active state.
-   *
-   * Gateway-auth bypasses `/assistant/` entirely — the gateway issues
-   * the session token directly and the local assistant resolution
-   * lives in `lib/local-mode`. The mount-time init effect and the
-   * imperative `checkAssistant` both short-circuit through this
-   * helper, so keep them in lockstep.
-   */
-  const applyGatewayAuthShortCircuit = useCallback(() => {
-    let ingressUrl = window.location.origin;
-    let resolvedAssistantId = "self";
-    const localGateway = getLocalGatewayUrl();
-    if (localGateway) {
-      const assistant = getSelectedAssistant();
-      ingressUrl = `${window.location.origin}${localGateway}`;
-      resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;
-    }
-    setSelfHostedConnection({
-      url: ingressUrl,
-      token: getGatewayToken(),
+  // Push inputs into the service and let it react. The service is a
+  // singleton so the React tree's render cadence is just a feeder
+  // for `setInputs` / `respondToInputs` — no state lives in the
+  // hook itself.
+  useEffect(() => {
+    lifecycleService.setInputs({
+      isLoggedIn,
+      isLoading,
+      isRetired,
+      isNonProduction,
+      hasPlatformSession,
+      onRedirect,
+      resolveOnboardingRedirect,
+      queryClient,
     });
-    setAssistantId(resolvedAssistantId);
-    setAssistantState({ kind: "active", isLocal: true });
-  }, []);
+    void lifecycleService.respondToInputs();
+  }, [
+    isLoggedIn,
+    isLoading,
+    isRetired,
+    isNonProduction,
+    hasPlatformSession,
+    onRedirect,
+    resolveOnboardingRedirect,
+    queryClient,
+  ]);
 
-  const checkAssistant = useCallback(async () => {
-    if (isGatewayAuthMode()) {
-      applyGatewayAuthShortCircuit();
-      return;
-    }
-    const generation = initializingGenerationRef.current;
-    try {
-      // Force a fresh fetch through the query cache. `fetchQuery`
-      // updates the cache atomically so any other subscriber
-      // (sidebar header, identity panel, etc.) sees the same answer
-      // this code path acts on. `staleTime: 0` is required: the app's
-      // QueryClient sets a 10s default staleTime for queries, and
-      // imperative re-checks (visibility-change return, retry button,
-      // onboarding pre-chat verification) must hit the network so a
-      // 10s-old cached 404 or initializing result doesn't silently
-      // replay. Cache-subscription callers go through
-      // `applyServerStateUpdate` directly to avoid the read-back loop.
-      const result = await queryClient.fetchQuery({
-        queryKey: ASSISTANT_QUERY_KEY,
-        queryFn: () => getAssistant(),
-        staleTime: 0,
-      });
-      if (generation !== initializingGenerationRef.current) return;
-      await applyServerStateUpdate(result);
-    } catch (err) {
-      console.error("Error checking assistant status:", err);
-      Sentry.captureException(err, {
-        tags: { context: "check_assistant" },
-      });
-      if (generation !== initializingGenerationRef.current) return;
-      setAssistantState({
-        kind: "error",
-        message: "Network error. Please check your connection and try again.",
-      });
-    }
-  }, [applyServerStateUpdate, queryClient]);
-
-  const recoverStuckInitializingAssistant = useCallback(async () => {
-    if (initializingRecoveryCountRef.current >= MAX_INITIALIZING_RECOVERIES) {
-      initializingGenerationRef.current++;
-      setAssistantState(buildInitializingTimeoutError());
-      return;
-    }
-
-    initializingRecoveryCountRef.current++;
-    initializingGenerationRef.current++;
-    const generation = initializingGenerationRef.current;
-
-    try {
-      let assistantIdToRetire = initializingAssistantIdRef.current;
-      if (!assistantIdToRetire) {
-        // Force-refresh the cached status. We need to know whether the
-        // assistant moved off "initializing" before deciding whether to
-        // retire-and-rehatch — a cached 10s-old "initializing" result
-        // would mislead the decision into an unnecessary retire.
-        const result = await queryClient.fetchQuery({
-          queryKey: ASSISTANT_QUERY_KEY,
-          queryFn: () => getAssistant(),
-          staleTime: 0,
-        });
-        if (generation !== initializingGenerationRef.current) return;
-        if (result.ok && result.data.status === "initializing") {
-          assistantIdToRetire = result.data.id;
-        } else {
-          const nextState = resolveAssistantLifecycleState(result);
-          initializingAssistantIdRef.current = null;
-          if (nextState.kind === "auto_hatch") {
-            await hatchAndCheck(hatchingVersionRef.current);
-          } else if (nextState.kind === "active" && result.ok) {
-            const mm = result.data.maintenance_mode;
-            initializingRecoveryCountRef.current = 0;
-            setSelfHostedConnection(null);
-            setAssistantId(result.data.id);
-            setAssistantState({
-              kind: "active",
-              isLocal: result.data.is_local ?? false,
-              maintenanceMode: {
-                enabled: mm?.enabled,
-              },
-            });
-          } else if (nextState.kind === "self_hosted" && result.ok) {
-            // Mirror the `self_hosted` branch in `checkAssistant`: an
-            // assistant can graduate from `initializing` straight into
-            // `is_local: true` once the assistant registers its gateway.
-            // Without this branch the recovery path leaves
-            // `assistantId` null and the chat surface keeps showing
-            // the initializing-timeout error after the assistant has
-            // actually come up.
-            initializingRecoveryCountRef.current = 0;
-            setSelfHostedConnection({
-              url: result.data.ingress_url,
-              token: result.data.platform_actor_token,
-            });
-            setAssistantId(result.data.id);
-            setAssistantState({ kind: "self_hosted" });
-          } else {
-            if (nextState.kind !== "active") {
-              setAssistantState(nextState);
-            }
-          }
-          return;
-        }
-      }
-
-      // Prevent the poll loop from calling hatchAndCheck() while we retire
-      // the stuck assistant. Without this, a poll that observes the 404 (after
-      // the retire takes effect on the backend but before our own hatchAndCheck
-      // creates the replacement) races to create a duplicate assistant.
-      hatchingRef.current = true;
-
-      const retireResult = await retireMutateRef.current(assistantIdToRetire);
-      if (generation !== initializingGenerationRef.current) {
-        hatchingRef.current = false;
-        return;
-      }
-      if (!retireResult.ok && retireResult.status !== 404) {
-        hatchingRef.current = false;
-        Sentry.captureMessage("Failed to retire stuck initializing assistant", {
-          level: "warning",
-          extra: { status: retireResult.status, error: retireResult.error },
-        });
-        setAssistantState(buildInitializingTimeoutError());
-        return;
-      }
-
-      initializingAssistantIdRef.current = null;
-      setAssistantId(null);
-      hatchingRef.current = false;
-      await hatchAndCheck(hatchingVersionRef.current);
-    } catch (err) {
-      hatchingRef.current = false;
-      Sentry.captureException(err, {
-        tags: { context: "recover_stuck_initializing_assistant" },
-      });
-      if (generation !== initializingGenerationRef.current) return;
-      setAssistantState(buildInitializingTimeoutError());
-    }
-  }, [hatchAndCheck, queryClient]);
-
-  // Local-mode: gateway token and connection are primed during onboarding hatch.
+  // Hand poll results to the service — it decides whether to
+  // project them (only while the lifecycle is transient).
   useEffect(() => {
-    if (!isLoggedIn || isLoading) {
-      // Logout (or pre-auth boot) — drop any lingering selection and
-      // lifecycle state so a returning login doesn't observe the
-      // previous user's assistant id. The stores are module-level
-      // singletons; if we don't reset here, any store subscriber that
-      // runs before `checkAssistant()` resolves (e.g. feature-flag
-      // sync, notification ack) will fire against the previous
-      // session's id. Guarded reads avoid spurious subscriber
-      // wake-ups when the stores are already at defaults.
-      if (useAssistantSelectionStore.getState().activeAssistantId !== null) {
-        setAssistantId(null);
-      }
-      if (useAssistantLifecycleStore.getState().assistantState.kind !== "loading") {
-        setAssistantState({ kind: "loading" });
-      }
-      return;
-    }
-    // Gateway auth takes priority over the platform session path below.
-    // In local mode after hatch, this branch is the entry point.
-    if (isGatewayAuthMode()) {
-      applyGatewayAuthShortCircuit();
-      return;
-    }
-    // In local mode without a gateway token AND no platform session,
-    // the platform API isn't available — redirect to onboarding.
-    // If the user logged in and chose Vellum Cloud, hasPlatformSession
-    // is true and we fall through to checkAssistant() below.
-    if (isLocalMode() && !isGatewayAuthMode() && !hasPlatformSession) {
-      const redirect = resolveOnboardingRedirectRef.current({ intendedDestination: window.location.pathname });
-      if (redirect) {
-        onRedirectRef.current(redirect);
-      }
-      return;
-    }
-    if (hasPlatformSession) {
-      setSelfHostedConnection(null);
-      checkAssistant();
-      return;
-    }
-    checkAssistant();
-  }, [isLoggedIn, isLoading, hasPlatformSession, checkAssistant, applyGatewayAuthShortCircuit]);
-
-  // While the lifecycle is transient (`initializing` / `cleaning_up`),
-  // project each new query result into local state. The query polls
-  // on the 3-second cadence defined by `pollIntervalFor`; `data`
-  // updates as each successful poll (or hatch-time `setQueryData`
-  // seed, or `invalidateQueries` refetch) lands in cache. Once the
-  // lifecycle reaches a stable phase (`active`, `self_hosted`,
-  // `error`, etc.), the kind-gate short-circuits and nothing
-  // projects — which is the right contract, because once we know
-  // where we landed the user shouldn't be silently re-routed by a
-  // late-arriving query result.
-  useEffect(() => {
-    if (
-      assistantStateKind !== "initializing" &&
-      assistantStateKind !== "cleaning_up"
-    ) {
-      return;
-    }
     if (!assistantResult) return;
-    void applyServerStateUpdate(assistantResult);
-  }, [assistantResult, assistantStateKind, applyServerStateUpdate]);
-
-  // If the backend assigns an assistant but never promotes it to "active",
-  // retire that stuck row and hatch a replacement.
-  useEffect(() => {
-    if (assistantStateKind !== "initializing") {
-      return;
-    }
-    const timeout = setTimeout(() => {
-      Sentry.captureMessage("Assistant hatch stuck in initializing state", {
-        level: "warning",
-        extra: { timeoutMs: INITIALIZING_TIMEOUT_MS },
-      });
-      void recoverStuckInitializingAssistant();
-    }, INITIALIZING_TIMEOUT_MS);
-    return () => clearTimeout(timeout);
-  }, [assistantStateKind, initializingCycle, recoverStuckInitializingAssistant]);
-
-  const retryAssistant = useCallback(() => {
-    hatchRetryCountRef.current = 0;
-    initializingRecoveryCountRef.current = 0;
-    checkAssistant();
-  }, [checkAssistant]);
-
-  const hatchVersion = useCallback((version?: string) => {
-    hatchRetryCountRef.current = 0;
-    hatchAndCheck(version);
-  }, [hatchAndCheck]);
-
-  // Register the imperative callbacks into the store once they're
-  // stable. Consumers (visibility-change handler, error retry button,
-  // version-selection screen, maintenance-mode exit) call them via
-  // `useAssistantLifecycleStore.getState().checkAssistant?.()` so they
-  // never have to be passed as props through layout layers. The
-  // identities only flip when their `useCallback` deps change (e.g.
-  // `queryClient` swap) which never happens after mount.
-  useEffect(() => {
-    registerImperativeActions({ checkAssistant, retryAssistant, hatchVersion });
-  }, [checkAssistant, retryAssistant, hatchVersion, registerImperativeActions]);
+    void lifecycleService.applyServerResult(assistantResult);
+  }, [assistantResult]);
 }

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -166,11 +166,9 @@ export function ChatPage() {
   const setOnSearchClick = useChatLayoutSlotsStore.use.setOnSearchClick();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
-  // Imperative actions are read inline from the store at call time
-  // via `.getState()` (see `lifecycle-store.ts` — neither render-time
-  // capture nor selector subscription is right for actions registered
-  // in a passive effect). Stable wrappers below let the actions flow
-  // through prop boundaries without identity flips.
+  // Wrap the service methods in stable `useCallback`s so they can flow
+  // through prop boundaries (downstream effects' dep arrays stay
+  // stable) and the `this` binding is preserved on call.
   const checkAssistant = useCallback(
     () => lifecycleService.checkAssistant(),
     [],
@@ -180,8 +178,7 @@ export function ChatPage() {
     [],
   );
   const hatchVersion = useCallback(
-    (version?: string) =>
-      lifecycleService.hatchVersion(version),
+    (version?: string) => lifecycleService.hatchVersion(version),
     [],
   );
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -23,6 +23,7 @@ import * as Sentry from "@sentry/react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useAuthStore } from "@/stores/auth-store";
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -171,16 +172,16 @@ export function ChatPage() {
   // in a passive effect). Stable wrappers below let the actions flow
   // through prop boundaries without identity flips.
   const checkAssistant = useCallback(
-    () => useAssistantLifecycleStore.getState().checkAssistant(),
+    () => lifecycleService.checkAssistant(),
     [],
   );
   const retryAssistant = useCallback(
-    () => useAssistantLifecycleStore.getState().retryAssistant(),
+    () => lifecycleService.retryAssistant(),
     [],
   );
   const hatchVersion = useCallback(
     (version?: string) =>
-      useAssistantLifecycleStore.getState().hatchVersion(version),
+      lifecycleService.hatchVersion(version),
     [],
   );
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -61,16 +61,10 @@ mock.module("react-router", () => ({
   useSearchParams: () => [searchParams],
 }));
 
-mock.module("@/assistant/lifecycle-store", () => ({
-  useAssistantLifecycleStore: Object.assign(
-    () => ({ checkAssistant: checkAssistantMock }),
-    {
-      use: {
-        checkAssistant: () => checkAssistantMock,
-      },
-      getState: () => ({ checkAssistant: checkAssistantMock }),
-    },
-  ),
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    checkAssistant: checkAssistantMock,
+  },
 }));
 
 mock.module("@/assistant/api", () => ({

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -20,7 +20,7 @@ import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-lay
 import { extractErrorMessage } from "@/utils/api-errors";
 import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection, getLocalGatewayUrl } from "@/lib/local-mode";
 import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import {
   readAiDataConsent,
   readOnboardingCompleted,
@@ -192,7 +192,7 @@ export function HatchingScreen() {
       navigateTimer = setTimeout(() => {
         if (cancelled) return;
         void (async () => {
-          await useAssistantLifecycleStore.getState().checkAssistant();
+          await lifecycleService.checkAssistant();
           if (cancelled) return;
           if (isNativePlatform()) {
             try {

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -65,7 +65,7 @@ import {
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useIsNativePlatform } from "@/runtime/native-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { routes } from "@/utils/routes.js";
 
@@ -185,7 +185,7 @@ export function PreChatFlow() {
     !localMode || hasPlatformSession || localPlatformAssistantId !== null;
 
   const navigateToChatAfterLifecycleRefresh = useCallback(async () => {
-    await useAssistantLifecycleStore.getState().checkAssistant();
+    await lifecycleService.checkAssistant();
     void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
   }, [navigate]);
 

--- a/apps/web/src/hooks/use-event-bus-init.test.tsx
+++ b/apps/web/src/hooks/use-event-bus-init.test.tsx
@@ -42,9 +42,9 @@ mock.module("@/lib/streaming/stream-transport", () => ({
 // resume time. Mock the store so tests can assert on the call without
 // running the real lifecycle hook.
 const checkAssistantMock = mock(async () => {});
-mock.module("@/assistant/lifecycle-store", () => ({
-  useAssistantLifecycleStore: {
-    getState: () => ({ checkAssistant: checkAssistantMock }),
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    checkAssistant: checkAssistantMock,
   },
 }));
 

--- a/apps/web/src/hooks/use-event-bus-init.ts
+++ b/apps/web/src/hooks/use-event-bus-init.ts
@@ -32,7 +32,7 @@ import { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
 import type { PluginListenerHandle } from "@capacitor/core";
 
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { subscribeChatEvents } from "@/lib/streaming/stream-transport";
 import type { ChatEventStream } from "@/lib/streaming/stream-transport";
 import { subscribeToPowerEvents } from "@/runtime/power-events";
@@ -227,7 +227,7 @@ export function useEventBusInit({
       // Daemon health check via the lifecycle store. The no-op
       // default covers the pre-registration window but no foreground
       // resume event can fire before `RootLayout` has mounted.
-      void useAssistantLifecycleStore.getState().checkAssistant();
+      void lifecycleService.checkAssistant();
       // App-resume means the renderer became visible; if a connection
       // is already live, it was either never torn down or just opened
       // moments ago — either way, leave it alone.
@@ -248,7 +248,7 @@ export function useEventBusInit({
       const now = Date.now();
       if (now - lastPowerActionAt < RESUME_DEDUP_WINDOW_MS) return;
       lastPowerActionAt = now;
-      void useAssistantLifecycleStore.getState().checkAssistant();
+      void lifecycleService.checkAssistant();
       teardown();
       open();
     };


### PR DESCRIPTION
Closes [LUM-2062](https://linear.app/vellum/issue/LUM-2062). Follow-up to #32641.

## Why

#32641 published assistant lifecycle through Zustand and killed the outlet-context plumbing, but left the state machine itself React-shaped. The hook held all the domain state in `useRef`s and `useState`, defined the actions inside `useCallback` closures over React-bound primitives (`useQueryClient`, `useMutation`), and registered them into the store via a passive `useEffect`. That shape produced every Codex P1 we caught during #32641 cleanup:

- The action-registry pattern (actions can't be defined inline in `create()` because they close over React state, so they have to be registered via `useEffect` after mount).
- The `NOOP_CHECK` / `NOOP_VOID` defaults that cover the brief registration race.
- The cold-mount capture bug — render-time `.getState()` captures the no-op because the parent's register-actions effect hasn't committed yet.
- The selector-flip bug — `.use.X()` re-renders on registration, which cleans up and re-runs any effect listing the action as a dep, which can re-execute side effects (duplicate hatch POST in the cloud path).

The PR description on #32641 explicitly called out the action-registry pattern as the trade we made and pointed at LUM-2062 as the architectural finish line. This is that.

## What changed

The state machine moves out of React entirely.

| Concern | Before (#32641 final) | After (this PR) |
|---|---|---|
| State machine | `useAssistantLifecycle` (676 lines): `useState` for `assistantState`, 6 `useRef`s for counters/generation/in-flight flags, action `useCallback`s, register-actions `useEffect`, watchdog `useEffect` | `lifecycle-service.ts` (620 lines): plain TypeScript class, module-level singleton, instantiated at import |
| Hook | 676 lines | **99 lines** — `useQueryClient`, `useAssistantQuery`, two `useEffect`s that push inputs and poll results into the service |
| Store | 110 lines, holds state + 3 action fields + NOOP defaults + `registerImperativeActions` action | **39 lines**, holds `assistantState` only |
| Consumer call shape | `useAssistantLifecycleStore.getState().checkAssistant()` (sometimes wrapped in `useCallback` to defeat identity flips) | `lifecycleService.checkAssistant()` — service methods are stable from instant zero |

The state machine semantics don't change. Same phases, same retry budgets, same recovery paths, same gateway-auth / local-mode branches, same post-hatch cache seed, same onboarding-redirect coordination. The extraction is purely structural.

## Benefits

- **Direct unit tests for the state machine.** [`lifecycle-service.test.ts`](apps/web/src/assistant/lifecycle-service.test.ts) exercises the server-state projection (active and self-hosted result handling), the auto-hatch cascade (the nonprod / retired / vanilla-managed branches), the logout reset, and the gateway-auth short-circuit — no `renderHook`, no React tree. Recovery paths and retry budgets are reachable from tests for the first time.
- **Cold-mount race goes away.** Service methods are stable from import, so consumers can call them inline without selector subscriptions or wrapping. The duplicate-hatch bug Codex caught in #32641 cleanup is structurally impossible.
- **No more `.use.X()` vs `.getState()` decision for lifecycle actions.** Either pattern would have worked equally well before — neither does anything special now, because the action isn't on the store. Just import the service and call methods.
- **Single state system.** Counters, generation, in-flight guards no longer live in `useRef` parallel to the store. Service fields are the only place state lives; the store mirrors `assistantState` for React reactivity.
- **The hook is small enough to read in one sitting.** 99 lines including the docstring and the inputs interface.

## Why safe

- **Behavioral parity.** Every transition in the service runs in the same conditions as the previous hook. Every `setSelfHostedConnection(...)`, every `setQueryData` cache seed, every `invalidateQueries` backoff fires under the same predicate.
- **Integration tests pass unmodified.** `queries.test.ts`, `onboarding-lifecycle-sync.test.tsx`, `use-event-bus-init.test.tsx` — the existing behavioral coverage of the hook. The only test changes are mock targets (`@/assistant/lifecycle-store` → `@/assistant/lifecycle-service` in two test files; both tests still assert the same behavior).
- **`tsc --noEmit`, `lint`, `audit:cross-domain`, `test:ci` all clean.** 181/181 test files pass (added one new unit-test file).
- **No new cross-domain imports.** Service lives in `src/assistant/` next to the existing files; consumers are unchanged in scope.

## References

- [Zustand — Reading state outside components](https://zustand.docs.pmnd.rs/guides/extracting-state-outside-components) — `.getState()` and `.setState()` work on module-level Zustand stores without React. Used by the service to write `assistantState`.
- [TkDodo — Working with Zustand](https://tkdodo.eu/blog/working-with-zustand) — server-state / client-state boundary; the service straddles it (derives `AssistantState` from server polling results but layers in client retry/recovery logic that doesn't reduce to a query).
- [`apps/web/docs/STATE_MANAGEMENT.md`](apps/web/docs/STATE_MANAGEMENT.md) — the canonical-migration pointer extended in #32641. This PR is the natural next step but doesn't require new doc rules; the lifecycle-store docstring nuance ("subscribe vs `.getState()` for the registered actions") is now deleted because the trap no longer exists.

## What I considered and did NOT do, and why

**Did not switch `useAssistantLifecycleStore` to a `zustand/vanilla` store or `useSyncExternalStore`.** Either would work — the service would own the vanilla store as its private state container, and `useAssistantLifecycleStore` would be a thin React wrapper around it. Kept the `create<...>` + `createSelectors` shape because (a) it's consistent with every other store in the codebase, (b) `useAssistantLifecycleStore.setState({...})` from the service is the same operation the previous code did via the store's own action, just inline, and (c) the migration was big enough already.

**Did not own the polling timer inside the service.** TanStack Query's `refetchInterval` (in `useAssistantQuery`) still drives the 3-second poll cadence; the service just receives results via the hook's `useEffect`. Doing in-service polling would lose TanStack Query's dedup with other `/assistant/` subscribers (sidebar header, identity panel) and the integration with the `setQueryData` post-hatch seed. Out of scope for this ticket.

**Did not move the logout-clear into a synchronous call at the logout site** (the vex-bot non-blocking observation on #32641). Same code as before — service resets when `respondToInputs()` sees `!isLoggedIn`. Moving it earlier in the call chain (e.g. into the `auth-store` logout action calling `lifecycleService.respondToInputs()` directly) is a one-line follow-up if you ever see flake; not in scope here.

**Did not inject the API functions (`getAssistant`, `hatchAssistant`, `retireAssistantById`) through `setInputs`.** The service imports them at module level. Tests mock via `mock.module(...)` — same pattern as everything else in the codebase. Constructor injection would have been the "more textbook" non-React shape but adds plumbing without solving a real problem for one consumer.

**Did not extract a `LifecycleStateMachine` interface separate from the service.** Could have separated "pure transitions" (a state-table-like function) from "side effects" (the cache seeding, the self-hosted connection priming). Considered briefly; the recovery and post-hatch paths are so interleaved with side effects that separating them just spreads the logic across two files. Held off.

**Did not delete `useAssistantLifecycleStore`** in favor of subscribing directly to a service emitter. The store is still the React tree's reactive view; the service writes to it. Two-layer separation (service for logic, store for reactivity) is the same trade `useEventBusStore` makes for the event bus. Consistent across the codebase.

---

## Root cause analysis

### How did the code get into this state?

#32641 extracted lifecycle into Zustand stores, which fixed the outlet-context plumbing problem. But the hook kept owning the state machine through React primitives (`useRef`, `useCallback`, `useEffect`) because that was the smallest diff that achieved the outlet-context fix. The trade was explicit in the #32641 PR description, with this ticket as the planned follow-up.

The deeper cause is structural: the lifecycle state machine is domain logic with no React-specific dependencies. React was the wrong shape for it from the start, but it was *also* the lowest-friction shape when the hook was small. As the machine grew (retry budgets, recovery paths, generation counter, watchdog), the React-bound shape became increasingly costly.

### What mistakes or decisions led to it?

1. **Built the state machine inside the hook to begin with.** The first version was `useState` + `useEffect` — small, simple, idiomatic React. Each new responsibility (retry budgets, recovery, watchdog) was added inside the hook because the hook already existed. No one stopped to ask "should this live outside React?"
2. **Stopped at the Zustand-store refactor in #32641.** That was a real architectural improvement, but it left the action-registry pattern in place. The PR called out the trade, but a "stop at the trade" PR will accumulate workarounds (NOOP defaults, selector-vs-getState debates, cold-mount bugs) if not finished.

### Were there warning signs we missed?

- The lifecycle hook needed 6 `useRef`s just to hold private state. Refs are a code smell for state that's outgrowing the hook shape.
- `hatchMutateRef`, `retireMutateRef` — capturing `useMutation`'s `.mutateAsync` in refs because the mutation object itself was unstable. That's React fighting React.
- The `isRetiredRef` / `isNonProductionRef` / `onRedirectRef` / `resolveOnboardingRedirectRef` pattern — capturing every external value in a ref to keep `useCallback` identities stable. Each ref was a workaround for the fact that the actions wanted to be stable but the hook couldn't make them so.
- Three Codex P1s in #32641 cleanup, all variants of "action identity does something unexpected at the React/non-React boundary." The frequency was the signal.

### What can we do to prevent this pattern from recurring?

1. **Ask "does this need React?" before building state machines in hooks.** If the answer is "the state machine doesn't, but reactivity does," that's the service-with-store-output shape this PR demonstrates. Build that from the start rather than landing in it.
2. **Treat `useRef`-as-private-state count as a smell.** A handful is normal. Six refs is a hook trying to be a class.
3. **Don't stop at "trade" PRs unless the next step is filed.** #32641 did this right (LUM-2062 was filed before merge). The systemic issue is when "trade" PRs get filed without the finish line tracked — the workaround becomes permanent.

### AGENTS.md changes

No new rule. The outlet-context rule from #32641 stays in place. The lifecycle-store docstring nuance about "selector subscription vs `.getState()` for the registered actions" is **deleted**, not preserved — the trap no longer exists, so leaving the warning would mislead.

The pattern this PR demonstrates (hook-as-React-wiring + module-level service-as-state-machine + Zustand-as-reactive-output) is worth a brief mention in `STATE_MANAGEMENT.md` if a second example appears. For now the in-file docstrings (`lifecycle-service.ts` header) carry the explanation.

---

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_