### PR TITLE
cleanup(web): drop dead outlet-context pass-through from IntelligenceLayout

### DIFF
--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useLocation, useOutletContext } from "react-router";
+import { NavLink, Outlet, useLocation } from "react-router";
 
 import { cn } from "@vellum/design-library";
 
@@ -33,16 +33,13 @@ const PLUGINS_TAB: IntelligenceTab = {
  * routes keep their existing URL paths (`/assistant/identity`, etc.)
  * while inheriting the shared chrome.
  *
- * References:
- * - React Router layout routes: https://reactrouter.com/start/framework/routing#layout-routes
- * - Platform source: AssistantPageClient.tsx lines 2250-2290
+ * @see https://reactrouter.com/start/framework/routing#layout-routes
  */
 export function IntelligenceLayout() {
   const assistantName = useAssistantIdentityStore.use.name();
   const hasHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const externalPlugins = useAssistantFeatureFlagStore.use.externalPlugins();
   const { pathname } = useLocation();
-  const outletContext = useOutletContext();
 
   // Insert the Plugins tab between Identity and Skills when the
   // `external-plugins` flag is on. Gated on `hasHydrated` so we don't
@@ -91,7 +88,7 @@ export function IntelligenceLayout() {
       </nav>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-        <Outlet context={outletContext} />
+        <Outlet />
       </div>
     </PageShell>
   );


### PR DESCRIPTION
Tiny cleanup surfaced by a codebase-wide audit following PR #32641's outlet-context work.

## Why

`IntelligenceLayout` consumed `useOutletContext()` and re-published it via `<Outlet context={outletContext} />`. Both lines were dead:

1. **No descendant reads it.** A grep across `apps/web/src/` finds zero `useOutletContext()` calls under any of the layout's child routes (Identity, Skills, Workspace, Contacts, Plugins).
2. **It wouldn't work even if a descendant did read it.** `IntelligenceLayout` sits under `ActiveAssistantGate` (`apps/web/src/routes.tsx`). The gate renders a bare `<Outlet />` with no `context` prop, which wraps every matched child in `<OutletContext.Provider value={undefined}>` — that's [the React Router source behavior](https://reactrouter.com/start/framework/outlet) and the exact reason PR #32641 introduced `useChatLayoutSlotsStore` instead of plumbing slot setters through the chat layout's outlet context.

Removing 3 lines of misleading-but-functionally-dead code so the next person looking at outlet-context usage in this codebase doesn't think there's a working precedent here.

## Also

Dropped one line from the docstring that referenced an internal-codebase path (`Platform source: AssistantPageClient.tsx lines 2250-2290`). This repo is public; references to private codebase paths shouldn't live in docstrings here.

## Why safe

- `tsc --noEmit` clean
- `lint` clean
- `bun test src/domains/intelligence` — 12/12 pass
- No external API or behavior change. The diff is `useOutletContext` import + read + the `context` prop on `<Outlet />` — none of which were doing anything.

## References

- [React Router — Outlet](https://reactrouter.com/start/framework/outlet) — outlet context resolves through the nearest provider, which is the intermediate `<Outlet />`'s own (undefined) context.
- PR #32641 documented this exact failure mode and introduced `useChatLayoutSlotsStore` to work around it for slot setters.

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_