### PR TITLE
feat(web+macos): wire deep-link consumers — composer pre-fill, thread nav, window activation (LUM-2068)

### DIFF
--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -30,6 +30,15 @@ mock.module("electron", () => ({
   BrowserWindow: { getAllWindows: () => windows },
 }));
 
+// `./main-window` is called from `handleDeepLink` to bring the main
+// window forward for actionable kinds. Stub so we can assert on the
+// call without standing up the full lifecycle module (which
+// transitively imports electron-store).
+const ensureMainWindowVisibleMock = mock(async () => undefined);
+mock.module("./main-window", () => ({
+  ensureVisible: ensureMainWindowVisibleMock,
+}));
+
 const {
   __resetForTesting,
   extractDeepLinkFromArgv,
@@ -51,6 +60,7 @@ beforeEach(() => {
   setAsDefaultProtocolClientMock.mockClear();
   ipcHandleMock.mockClear();
   ipcOnMock.mockClear();
+  ensureMainWindowVisibleMock.mockClear();
   windows = [];
 });
 
@@ -340,5 +350,51 @@ describe("handleDeepLink — broadcast", () => {
       kind: "unknown",
       url: "javascript:alert(1)",
     });
+  });
+});
+
+describe("handleDeepLink — window activation", () => {
+  test("brings the main window forward for `send` (covers the no-renderer case on Darwin)", () => {
+    handleDeepLink("vellum://send?message=hi");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("brings the main window forward for `openThread`", () => {
+    handleDeepLink("vellum://thread/abc");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT activate the window for unknown kinds (no UI side effect for foreign schemes)", () => {
+    handleDeepLink("javascript:alert(1)");
+    handleDeepLink("file:///etc/passwd");
+    handleDeepLink("not a url");
+
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+
+  test("buffers the link AND activates so the renderer-on-mount drain still delivers it", () => {
+    // Simulating the macOS path: app alive, main window closed,
+    // user clicks vellum://send → main handles it. The link must
+    // both (a) be parked in the buffer for the freshly-created
+    // renderer to drain, and (b) trigger window creation so the
+    // renderer actually mounts.
+    handleDeepLink("vellum://send?message=delivered");
+
+    // Activation fired.
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+    // Link buffered (no subscribers yet — the new window hasn't
+    // mounted).
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:deepLinks:drain",
+    );
+    // installDeepLinks hasn't run in this test, so register the
+    // handler via a fresh install before draining.
+    if (!drainHandler) {
+      installDeepLinks();
+    }
+    const drain = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:deepLinks:drain",
+    )![1] as () => unknown[];
+    expect(drain()).toEqual([{ kind: "send", message: "delivered" }]);
   });
 });

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -4,6 +4,28 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // from `app.on` so tests can fire them. `setAsDefaultProtocolClient`
 // is also captured to verify scheme registration.
 type Listener = (...args: unknown[]) => void;
+
+// Synthetic WebContents stub for the subscriber-tracking tests.
+// `once("destroyed", …)` captures the cleanup handler so tests can
+// fire it to simulate a renderer crash / window close.
+const makeSender = (): {
+  sender: { once: (event: string, handler: () => void) => void };
+  fireDestroyed: () => void;
+} => {
+  let destroyedHandler: (() => void) | null = null;
+  return {
+    sender: {
+      once: (event, handler) => {
+        if (event === "destroyed") destroyedHandler = handler;
+      },
+    },
+    fireDestroyed: () => destroyedHandler?.(),
+  };
+};
+const subscribeWith = (s: ReturnType<typeof makeSender>) =>
+  ipcOnListeners.get("vellum:deepLinks:subscribe")?.({ sender: s.sender });
+const unsubscribeWith = (s: ReturnType<typeof makeSender>) =>
+  ipcOnListeners.get("vellum:deepLinks:unsubscribe")?.({ sender: s.sender });
 const appListeners = new Map<string, Listener>();
 const appOnMock = mock((event: string, listener: Listener) => {
   appListeners.set(event, listener);
@@ -21,10 +43,12 @@ let windows: Array<{
   webContents: { send: ReturnType<typeof mock> };
 }> = [];
 
+let appIsReady = true;
 mock.module("electron", () => ({
   app: {
     on: appOnMock,
     setAsDefaultProtocolClient: setAsDefaultProtocolClientMock,
+    isReady: () => appIsReady,
   },
   ipcMain: { handle: ipcHandleMock, on: ipcOnMock },
   BrowserWindow: { getAllWindows: () => windows },
@@ -62,6 +86,7 @@ beforeEach(() => {
   ipcOnMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   windows = [];
+  appIsReady = true;
 });
 
 afterEach(() => {
@@ -242,7 +267,8 @@ describe("installDeepLinks", () => {
     handleDeepLink("vellum://send?message=backlog");
 
     // Renderer mounts: subscribes, drains.
-    ipcOnListeners.get("vellum:deepLinks:subscribe")?.();
+    const s1 = makeSender();
+    subscribeWith(s1);
     expect(drainHandler()).toEqual([{ kind: "send", message: "backlog" }]);
 
     // Live link arrives while subscribed — broadcasts only.
@@ -250,8 +276,9 @@ describe("installDeepLinks", () => {
 
     // Renderer hard-navigates: unsubscribe, then a new renderer
     // mounts and drains. The live link must NOT be replayed.
-    ipcOnListeners.get("vellum:deepLinks:unsubscribe")?.();
-    ipcOnListeners.get("vellum:deepLinks:subscribe")?.();
+    unsubscribeWith(s1);
+    const s2 = makeSender();
+    subscribeWith(s2);
     expect(drainHandler()).toEqual([]);
   });
 
@@ -261,33 +288,30 @@ describe("installDeepLinks", () => {
       (c) => c[0] === "vellum:deepLinks:drain",
     )![1] as () => unknown[];
 
-    // Renderer mounted and drained the initial empty backlog.
-    ipcOnListeners.get("vellum:deepLinks:subscribe")?.();
+    const s1 = makeSender();
+    subscribeWith(s1);
     expect(drainHandler()).toEqual([]);
 
-    // User logs out — renderer unmounts.
-    ipcOnListeners.get("vellum:deepLinks:unsubscribe")?.();
+    unsubscribeWith(s1);
 
-    // A deep link arrives during the auth flow. No subscribers,
-    // so it must be buffered.
     handleDeepLink("vellum://thread/post-logout");
 
-    // User logs in — renderer mounts again, subscribes, drains.
-    ipcOnListeners.get("vellum:deepLinks:subscribe")?.();
+    const s2 = makeSender();
+    subscribeWith(s2);
     expect(drainHandler()).toEqual([
       { kind: "openThread", threadId: "post-logout" },
     ]);
   });
 
-  test("subscribe/unsubscribe IPC accounting is reference-counted and never goes negative", () => {
+  test("unsubscribe with no matching subscriber is a no-op (idempotent delete)", () => {
     installDeepLinks();
     const drainHandler = ipcHandleMock.mock.calls.find(
       (c) => c[0] === "vellum:deepLinks:drain",
     )![1] as () => unknown[];
 
-    // Unsubscribe before any subscribe — should clamp to 0, not -1.
-    ipcOnListeners.get("vellum:deepLinks:unsubscribe")?.();
-    ipcOnListeners.get("vellum:deepLinks:unsubscribe")?.();
+    const s = makeSender();
+    unsubscribeWith(s);
+    unsubscribeWith(s);
 
     handleDeepLink("vellum://send?message=should-buffer");
     expect(drainHandler()).toEqual([
@@ -297,7 +321,8 @@ describe("installDeepLinks", () => {
 
   test("post-drain live links still broadcast (live subscribers still get them)", () => {
     installDeepLinks();
-    ipcOnListeners.get("vellum:deepLinks:subscribe")?.();
+    const s = makeSender();
+    subscribeWith(s);
 
     const w = makeWindow();
     windows = [w];
@@ -307,6 +332,32 @@ describe("installDeepLinks", () => {
       kind: "send",
       message: "live",
     });
+  });
+
+  test("destroyed webContents auto-clears its subscription (no leak when React cleanup misses)", () => {
+    // The real bug this guards against: window close on Darwin
+    // can tear down the JS context before React effect cleanups
+    // flush, so `vellum:deepLinks:unsubscribe` never fires.
+    // The `destroyed` listener cleans up regardless, so future
+    // links buffer correctly.
+    installDeepLinks();
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:deepLinks:drain",
+    )![1] as () => unknown[];
+
+    const s = makeSender();
+    subscribeWith(s);
+    expect(drainHandler()).toEqual([]);
+
+    // Simulate window close without React cleanup running — only
+    // the webContents `destroyed` event fires.
+    s.fireDestroyed();
+
+    // No subscribers now → next link is buffered.
+    handleDeepLink("vellum://send?message=after-crash");
+    expect(drainHandler()).toEqual([
+      { kind: "send", message: "after-crash" },
+    ]);
   });
 });
 
@@ -370,6 +421,29 @@ describe("handleDeepLink — window activation", () => {
     handleDeepLink("not a url");
 
     expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+
+  test("defers activation when app is not yet ready (cold-launch via vellum://)", () => {
+    // Cold launch path: `will-finish-launching` → `open-url` fires
+    // BEFORE `app.whenReady()`. `new BrowserWindow()` pre-ready
+    // would race Electron init; the link is buffered above and the
+    // initial `installMainWindow` in the whenReady chain creates
+    // the window which drains it on mount.
+    appIsReady = false;
+    handleDeepLink("vellum://send?message=cold-launch");
+
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+
+  test("activates after app becomes ready (warm path: subsequent links)", () => {
+    appIsReady = false;
+    handleDeepLink("vellum://send?message=cold");
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+
+    // Simulate whenReady having fired.
+    appIsReady = true;
+    handleDeepLink("vellum://thread/warm");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
   });
 
   test("buffers the link AND activates so the renderer-on-mount drain still delivers it", () => {

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -1,4 +1,9 @@
-import { BrowserWindow, app, ipcMain } from "electron";
+import {
+  BrowserWindow,
+  app,
+  ipcMain,
+  type WebContents,
+} from "electron";
 
 import { ensureVisible as ensureMainWindowVisible } from "./main-window";
 
@@ -104,18 +109,19 @@ export const extractDeepLinkFromArgv = (argv: readonly string[]): string | null 
 
 const pending: DeepLink[] = [];
 
-// Active renderer subscribers. Renderer calls `vellum:deepLinks:subscribe`
-// when its `onLink` handler is registered and `vellum:deepLinks:unsubscribe`
-// on cleanup. Buffer when count is zero (no subscribers to receive the
-// broadcast); broadcast-only when count > 0.
+// Active renderer subscribers tracked by their `WebContents` rather
+// than a counter. Renderer calls `vellum:deepLinks:subscribe` when
+// its `onLink` handler registers; we add the `event.sender` and
+// listen for that webContents's `destroyed` event so cleanup runs
+// even when React effect teardown doesn't fire (window-close kills
+// the JS context before `useEffect` cleanups flush — a leaked
+// counter would flip buffering off and silently drop later links).
+// `vellum:deepLinks:unsubscribe` covers the common mount/unmount
+// path; the `destroyed` listener is the defense-in-depth.
 //
-// This is what closes both the Codex P2 (live-link replay on renderer
-// reload — broadcast doesn't enter the buffer when a subscriber is
-// listening) AND the logout-relogin gap (after the renderer unmounts,
-// links arriving during the auth flip land in the buffer and the next
-// renderer drains them on mount). A "drained once, never buffer
-// again" flag is wrong because it conflates "has ever drained" with
-// "is subscribed right now."
+// Buffer when the set is empty; broadcast-only when non-empty. This
+// keeps both the live-link-replay defense AND the
+// renderer-down-link-buffers behavior the consumer relies on.
 //
 // Residual race (sub-microsecond, not realistically triggerable by
 // user action): a link arriving between the renderer's
@@ -123,7 +129,7 @@ const pending: DeepLink[] = [];
 // `subscribe` IPC could be buffered AND broadcast. A single
 // renderer-side dedup would catch this if it ever bit; today the
 // timing makes it theoretical.
-let subscriberCount = 0;
+const subscribers = new Set<WebContents>();
 
 const broadcast = (link: DeepLink): void => {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -155,9 +161,16 @@ const broadcast = (link: DeepLink): void => {
  */
 export const handleDeepLink = (input: string): void => {
   const link = parseVellumUrl(input);
-  if (subscriberCount === 0) pending.push(link);
+  if (subscribers.size === 0) pending.push(link);
   broadcast(link);
-  if (link.kind !== "unknown") {
+  // Activation is gated on `app.isReady()`. On cold launch, the
+  // `will-finish-launching` → `open-url` path fires BEFORE
+  // `app.whenReady()`, and `new BrowserWindow()` pre-ready races
+  // Electron's init. The link is already buffered above; the
+  // initial `installMainWindow()` in the `whenReady` chain in
+  // `index.ts` creates the first window, which drains the link
+  // on mount.
+  if (link.kind !== "unknown" && app.isReady()) {
     void ensureMainWindowVisible();
   }
 };
@@ -196,15 +209,22 @@ export const installDeepLinks = (): void => {
     return pending.splice(0, pending.length);
   });
 
-  // Subscriber tracking — see the `subscriberCount` comment above
-  // for the model. `ipcMain.on` (fire-and-forget) is sufficient —
-  // these are accounting messages, no return value expected. The
-  // preload sends them inside `onLink` registration / cleanup.
-  ipcMain.on("vellum:deepLinks:subscribe", () => {
-    subscriberCount++;
+  // Subscriber tracking — see the `subscribers` comment above for
+  // the model. `ipcMain.on` (fire-and-forget) is sufficient — these
+  // are accounting messages, no return value expected. The preload
+  // sends them inside `onLink` registration / cleanup; the
+  // `destroyed` listener is the defense-in-depth for the cases
+  // where the React effect cleanup doesn't run before the
+  // webContents is torn down.
+  ipcMain.on("vellum:deepLinks:subscribe", (event) => {
+    if (subscribers.has(event.sender)) return;
+    subscribers.add(event.sender);
+    event.sender.once("destroyed", () => {
+      subscribers.delete(event.sender);
+    });
   });
-  ipcMain.on("vellum:deepLinks:unsubscribe", () => {
-    subscriberCount = Math.max(0, subscriberCount - 1);
+  ipcMain.on("vellum:deepLinks:unsubscribe", (event) => {
+    subscribers.delete(event.sender);
   });
 };
 
@@ -212,6 +232,6 @@ export const installDeepLinks = (): void => {
 // uses `installDeepLinks` instead.
 export const __resetForTesting = (): void => {
   installed = false;
-  subscriberCount = 0;
+  subscribers.clear();
   pending.length = 0;
 };

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -146,6 +146,12 @@ const broadcast = (link: DeepLink): void => {
  * would sit forever. `unknown` kinds skip activation: an attacker
  * who could induce the OS to route a `javascript:` URL to us
  * shouldn't get a UI side effect.
+ *
+ * Main owns the cold path (no-renderer activation), renderer owns
+ * the hot path (window minimized / behind another window — see
+ * `useGlobalDeepLinkConsumer`). The duplicated call when both fire
+ * is intentional defense-in-depth — `ensureVisible` short-circuits
+ * on an already-visible main window.
  */
 export const handleDeepLink = (input: string): void => {
   const link = parseVellumUrl(input);

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -1,5 +1,7 @@
 import { BrowserWindow, app, ipcMain } from "electron";
 
+import { ensureVisible as ensureMainWindowVisible } from "./main-window";
+
 /**
  * Inbound deep links — `vellum://` and `vellum-assistant://` URL
  * schemes. The OS routes any user click on a `vellum://send?message=hi`
@@ -131,14 +133,27 @@ const broadcast = (link: DeepLink): void => {
 };
 
 /**
- * Main entry — parse, buffer-if-no-subscribers, broadcast. Internal
- * to this module; exposed via the `open-url` / `second-instance`
+ * Main entry — parse, buffer-if-no-subscribers, broadcast, and
+ * bring the main window forward for actionable kinds. Internal to
+ * this module; exposed via the `open-url` / `second-instance`
  * event handlers and exported for tests.
+ *
+ * Window activation lives HERE (not only in the renderer-side
+ * consumer) because on macOS the app keeps running after the main
+ * window closes (`window-all-closed` doesn't quit on Darwin). In
+ * that state the renderer doesn't exist, so a renderer-only
+ * `ensureMainWindowVisible()` would never fire; the buffered link
+ * would sit forever. `unknown` kinds skip activation: an attacker
+ * who could induce the OS to route a `javascript:` URL to us
+ * shouldn't get a UI side effect.
  */
 export const handleDeepLink = (input: string): void => {
   const link = parseVellumUrl(input);
   if (subscriberCount === 0) pending.push(link);
   broadcast(link);
+  if (link.kind !== "unknown") {
+    void ensureMainWindowVisible();
+  }
 };
 
 let installed = false;

--- a/apps/macos/src/main/main-window.test.ts
+++ b/apps/macos/src/main/main-window.test.ts
@@ -98,6 +98,13 @@ const makeWindow = (): StubWindow => {
   return stub;
 };
 
+const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+const ipcHandleMock = mock(
+  (channel: string, handler: (...args: unknown[]) => unknown) => {
+    ipcHandlers.set(channel, handler);
+  },
+);
+
 mock.module("electron", () => ({
   app: {
     isPackaged: false,
@@ -107,6 +114,7 @@ mock.module("electron", () => ({
       Object.assign(this, makeWindow());
     }
   },
+  ipcMain: { handle: ipcHandleMock },
   shell: { openExternal: () => Promise.resolve() },
 }));
 
@@ -115,7 +123,7 @@ mock.module("./window-state", () => ({
   track: () => undefined,
 }));
 
-const { current, dispatchToMain, ensureVisible, hide, installMainWindow, isVisibleAndFocused, toggleVisibility } =
+const { __resetForTesting, current, dispatchToMain, ensureVisible, hide, installMainWindow, isVisibleAndFocused, toggleVisibility } =
   await import("./main-window");
 
 const reset = (): void => {
@@ -130,6 +138,9 @@ const reset = (): void => {
 
 beforeEach(() => {
   reset();
+  __resetForTesting();
+  ipcHandlers.clear();
+  ipcHandleMock.mockClear();
 });
 
 afterEach(() => {
@@ -356,6 +367,33 @@ describe("installMainWindow", () => {
     installMainWindow();
     installMainWindow();
     expect(constructed).toHaveLength(1);
+  });
+
+  test("registers the vellum:mainWindow:ensureVisible IPC handler", () => {
+    installMainWindow();
+    expect(ipcHandlers.has("vellum:mainWindow:ensureVisible")).toBe(true);
+  });
+
+  test("the IPC handler routes through ensureVisible (recreating if destroyed, showing + focusing otherwise)", async () => {
+    installMainWindow();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    // The initial install fires ensureVisible too — settle its readiness
+    // gate before exercising the IPC path so the assertion isolates the
+    // IPC-driven calls.
+    win.stub.webContents.emit("did-finish-load");
+    win.stub.emit("ready-to-show");
+    const showsBefore = win.stub.show.mock.calls.length;
+    const focusBefore = win.stub.focus.mock.calls.length;
+
+    const handler = ipcHandlers.get("vellum:mainWindow:ensureVisible");
+    const promise = (handler as () => Promise<void>)();
+    // ensureVisible on the existing-but-not-focused window returns
+    // immediately (ALREADY_READY for the already-loaded window).
+    await promise;
+
+    expect(win.stub.show.mock.calls.length).toBeGreaterThan(showsBefore);
+    expect(win.stub.focus.mock.calls.length).toBeGreaterThan(focusBefore);
   });
 });
 

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, shell } from "electron";
+import { BrowserWindow, app, ipcMain, shell } from "electron";
 import path from "node:path";
 
 import {
@@ -309,5 +309,21 @@ let installed = false;
 export const installMainWindow = (): void => {
   if (installed) return;
   installed = true;
+
+  // IPC surface for renderer-driven "bring the window forward"
+  // actions — used by feature consumers reacting to inbound signals
+  // (deep links, future notification clicks, etc.). The renderer
+  // wrapper at `apps/web/src/runtime/main-window.ts` calls this; the
+  // handler returns void so the caller can `await` without value.
+  ipcMain.handle("vellum:mainWindow:ensureVisible", async (): Promise<void> => {
+    await ensureVisible();
+  });
+
   void ensureVisible();
+};
+
+// Test seam — exported only for unit-test setup. Production code
+// uses `installMainWindow` instead.
+export const __resetForTesting = (): void => {
+  installed = false;
 };

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -118,6 +118,18 @@ export interface VellumBridge {
      */
     setSignedIn(signedIn: boolean): Promise<void>;
   };
+  mainWindow: {
+    /**
+     * Bring the main window to the foreground: recreate if destroyed,
+     * restore from minimize, show, focus. Used by feature consumers
+     * reacting to inbound signals (deep links, future notification
+     * clicks) that should be accompanied by the window becoming
+     * user-visible. Resolves once the renderer is loaded and the
+     * window is focused — same readiness gate as the main-process
+     * `ensureVisible`.
+     */
+    ensureVisible(): Promise<void>;
+  };
   power: {
     /**
      * Subscribe to system power-state events: sleep, wake, screen
@@ -195,6 +207,10 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:dock:setBadge", count) as Promise<void>,
     setSignedIn: (signedIn: boolean): Promise<void> =>
       ipcRenderer.invoke("vellum:dock:setSignedIn", signedIn) as Promise<void>,
+  },
+  mainWindow: {
+    ensureVisible: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:mainWindow:ensureVisible") as Promise<void>,
   },
   power: {
     onEvent: (callback) => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -83,6 +83,7 @@ import { useInteractionActions } from "@/domains/chat/hooks/use-interaction-acti
 import { useEventStream } from "@/domains/chat/hooks/use-event-stream";
 import { useActiveAppPinSync } from "@/domains/chat/hooks/use-active-app-pin-sync";
 import { useDraftInput } from "@/domains/chat/components/chat-composer/use-draft-input";
+import { useDeepLinkConsumer } from "@/domains/chat/hooks/use-deep-link-consumer";
 import { useRefreshLatestMessages } from "@/domains/chat/hooks/use-refresh-latest-messages";
 import { useChatDebugApi } from "@/domains/chat/utils/debug-api";
 
@@ -396,6 +397,13 @@ export function ChatPage() {
     draftConversationIdResolutionRef,
     onDraftRestored: setRestoredDraftConversationId,
   });
+
+  // Inbound deep links: pre-fill composer with `deeplink.send` text,
+  // navigate to `/assistant/conversations/<id>` for `deeplink.openThread`,
+  // and ensure the main window is visible first. The hook gates the
+  // composer pre-fill on `input` being empty so it doesn't clobber
+  // in-progress typing. Off Electron the bus events never fire.
+  useDeepLinkConsumer({ composerInput: input, setComposerInput: setInput });
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, act } from "@testing-library/react";
+
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store";
+
+// Capture the navigate callback so we can assert on navigation
+// targets without standing up a real router.
+const navigateMock = mock((_to: string) => undefined);
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+// `ensureMainWindowVisible` is the bridge wrapper; replace with a spy
+// so we can assert each handler fires it.
+const ensureMainWindowVisibleMock = mock(async () => undefined);
+mock.module("@/runtime/main-window", () => ({
+  ensureMainWindowVisible: ensureMainWindowVisibleMock,
+}));
+
+const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
+mock.module("@sentry/browser", () => ({
+  addBreadcrumb: sentryBreadcrumbMock,
+}));
+
+const { useDeepLinkConsumer } = await import("./use-deep-link-consumer");
+
+const renderConsumer = (
+  composerInput: string,
+  setComposerInput: (next: string) => void,
+) =>
+  renderHook(
+    ({ input, set }: { input: string; set: (next: string) => void }) =>
+      useDeepLinkConsumer({ composerInput: input, setComposerInput: set }),
+    { initialProps: { input: composerInput, set: setComposerInput } },
+  );
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+  navigateMock.mockClear();
+  ensureMainWindowVisibleMock.mockClear();
+  sentryBreadcrumbMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+});
+
+describe("deeplink.send", () => {
+  test("pre-fills the composer when input is empty", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    renderConsumer("", setComposerInput);
+
+    act(() => {
+      useEventBusStore.getState().publish("deeplink.send", { message: "hi" });
+    });
+
+    expect(setComposerInput).toHaveBeenCalledWith("hi");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves in-progress typing — drops the link with a Sentry breadcrumb", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    renderConsumer("user already typing", setComposerInput);
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.send", { message: "from link" });
+    });
+
+    expect(setComposerInput).not.toHaveBeenCalled();
+    expect(sentryBreadcrumbMock).toHaveBeenCalled();
+    // ensureMainWindowVisible still fires — the window should come
+    // forward so the user sees Vellum even when we declined to overwrite.
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("whitespace-only composer input counts as empty", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    renderConsumer("   \n  ", setComposerInput);
+
+    act(() => {
+      useEventBusStore.getState().publish("deeplink.send", { message: "hi" });
+    });
+
+    expect(setComposerInput).toHaveBeenCalledWith("hi");
+  });
+});
+
+describe("deeplink.openThread", () => {
+  test("navigates to the conversation route and ensures the window is visible", () => {
+    renderConsumer("", () => undefined);
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deeplink.unknown", () => {
+  test("records a Sentry breadcrumb with the URL and takes no other action", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    renderConsumer("", setComposerInput);
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.unknown", { url: "javascript:alert(1)" });
+    });
+
+    expect(sentryBreadcrumbMock).toHaveBeenCalled();
+    const args = sentryBreadcrumbMock.mock.calls[0]?.[0] as {
+      data?: { url?: string };
+    };
+    expect(args.data?.url).toBe("javascript:alert(1)");
+    // No navigation, no composer set, no main-window activation —
+    // unknown links don't do anything user-visible.
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(setComposerInput).not.toHaveBeenCalled();
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("subscription lifecycle", () => {
+  test("re-renders with new composerInput don't tear down + resubscribe the bus listeners", () => {
+    // If the effect's dep array included composerInput, every
+    // keystroke would unsubscribe + resubscribe. Verify it
+    // doesn't by counting subscriber registrations across a
+    // re-render — should stay 3 (one per event).
+    const setComposerInput = mock((_next: string) => undefined);
+    const { rerender } = renderConsumer("", setComposerInput);
+
+    // After mount we expect 3 subscriptions registered on the bus.
+    // Publish each event and assert handlers fired exactly once.
+    act(() => {
+      useEventBusStore.getState().publish("deeplink.send", { message: "x" });
+    });
+    expect(setComposerInput).toHaveBeenCalledTimes(1);
+
+    // Trigger a re-render with new input. If the effect re-runs,
+    // the next publish would see the dep-array reset + handlers
+    // mounting + unmounting — and the assert below could either
+    // dupe or drop the event in a race. The stable subscription
+    // makes it deterministic.
+    rerender({ input: "typing", set: setComposerInput });
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.openThread", { threadId: "z" });
+    });
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribes on unmount", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    const { unmount } = renderConsumer("", setComposerInput);
+
+    unmount();
+
+    // After unmount, publishing shouldn't reach the handlers.
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.send", { message: "post-unmount" });
+      useEventBusStore
+        .getState()
+        .publish("deeplink.openThread", { threadId: "z" });
+      useEventBusStore
+        .getState()
+        .publish("deeplink.unknown", { url: "x" });
+    });
+
+    expect(setComposerInput).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
@@ -1,24 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, renderHook, act } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 
 import {
-  __resetEventBusForTesting,
-  useEventBusStore,
-} from "@/stores/event-bus-store";
-
-// Capture the navigate callback so we can assert on navigation
-// targets without standing up a real router.
-const navigateMock = mock((_to: string) => undefined);
-mock.module("react-router", () => ({
-  useNavigate: () => navigateMock,
-}));
-
-// `ensureMainWindowVisible` is the bridge wrapper; replace with a spy
-// so we can assert each handler fires it.
-const ensureMainWindowVisibleMock = mock(async () => undefined);
-mock.module("@/runtime/main-window", () => ({
-  ensureMainWindowVisible: ensureMainWindowVisibleMock,
-}));
+  __resetPendingDeepLinkForTesting,
+  usePendingDeepLinkStore,
+} from "@/stores/pending-deep-link-store";
 
 const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
 mock.module("@sentry/browser", () => ({
@@ -38,152 +24,79 @@ const renderConsumer = (
   );
 
 beforeEach(() => {
-  __resetEventBusForTesting();
-  navigateMock.mockClear();
-  ensureMainWindowVisibleMock.mockClear();
+  __resetPendingDeepLinkForTesting();
   sentryBreadcrumbMock.mockClear();
 });
 
 afterEach(() => {
   cleanup();
-  __resetEventBusForTesting();
+  __resetPendingDeepLinkForTesting();
 });
 
-describe("deeplink.send", () => {
-  test("pre-fills the composer when input is empty", () => {
+describe("pending message consumption", () => {
+  test("pre-fills the composer when a pending message exists and input is empty", () => {
     const setComposerInput = mock((_next: string) => undefined);
+    // Stash a message before render — the consumer sees it on mount.
+    usePendingDeepLinkStore.getState().setPendingComposerMessage("hello");
+
     renderConsumer("", setComposerInput);
 
-    act(() => {
-      useEventBusStore.getState().publish("deeplink.send", { message: "hi" });
-    });
-
-    expect(setComposerInput).toHaveBeenCalledWith("hi");
-    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+    expect(setComposerInput).toHaveBeenCalledWith("hello");
+    // Consumed → store is cleared.
+    expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
+      null,
+    );
   });
 
-  test("preserves in-progress typing — drops the link with a Sentry breadcrumb", () => {
+  test("preserves in-progress typing — drops with a Sentry breadcrumb", () => {
     const setComposerInput = mock((_next: string) => undefined);
-    renderConsumer("user already typing", setComposerInput);
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingComposerMessage("from link");
 
-    act(() => {
-      useEventBusStore
-        .getState()
-        .publish("deeplink.send", { message: "from link" });
-    });
+    renderConsumer("user already typing", setComposerInput);
 
     expect(setComposerInput).not.toHaveBeenCalled();
     expect(sentryBreadcrumbMock).toHaveBeenCalled();
-    // ensureMainWindowVisible still fires — the window should come
-    // forward so the user sees Vellum even when we declined to overwrite.
-    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+    // Message is consumed (cleared) either way — we don't want it to
+    // sit and resurface on the next render.
+    expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
+      null,
+    );
   });
 
   test("whitespace-only composer input counts as empty", () => {
     const setComposerInput = mock((_next: string) => undefined);
+    usePendingDeepLinkStore.getState().setPendingComposerMessage("hello");
+
     renderConsumer("   \n  ", setComposerInput);
 
-    act(() => {
-      useEventBusStore.getState().publish("deeplink.send", { message: "hi" });
-    });
-
-    expect(setComposerInput).toHaveBeenCalledWith("hi");
+    expect(setComposerInput).toHaveBeenCalledWith("hello");
   });
-});
 
-describe("deeplink.openThread", () => {
-  test("navigates to the conversation route and ensures the window is visible", () => {
-    renderConsumer("", () => undefined);
-
-    act(() => {
-      useEventBusStore
-        .getState()
-        .publish("deeplink.openThread", { threadId: "abc-123" });
-    });
-
-    expect(navigateMock).toHaveBeenCalledWith(
-      "/assistant/conversations/abc-123",
-    );
-    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("deeplink.unknown", () => {
-  test("records a Sentry breadcrumb with the URL and takes no other action", () => {
+  test("no-op when no message is pending", () => {
     const setComposerInput = mock((_next: string) => undefined);
+
     renderConsumer("", setComposerInput);
 
-    act(() => {
-      useEventBusStore
-        .getState()
-        .publish("deeplink.unknown", { url: "javascript:alert(1)" });
-    });
-
-    expect(sentryBreadcrumbMock).toHaveBeenCalled();
-    const args = sentryBreadcrumbMock.mock.calls[0]?.[0] as {
-      data?: { url?: string };
-    };
-    expect(args.data?.url).toBe("javascript:alert(1)");
-    // No navigation, no composer set, no main-window activation —
-    // unknown links don't do anything user-visible.
-    expect(navigateMock).not.toHaveBeenCalled();
     expect(setComposerInput).not.toHaveBeenCalled();
-    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("subscription lifecycle", () => {
-  test("re-renders with new composerInput don't tear down + resubscribe the bus listeners", () => {
-    // If the effect's dep array included composerInput, every
-    // keystroke would unsubscribe + resubscribe. Verify it
-    // doesn't by counting subscriber registrations across a
-    // re-render — should stay 3 (one per event).
-    const setComposerInput = mock((_next: string) => undefined);
-    const { rerender } = renderConsumer("", setComposerInput);
-
-    // After mount we expect 3 subscriptions registered on the bus.
-    // Publish each event and assert handlers fired exactly once.
-    act(() => {
-      useEventBusStore.getState().publish("deeplink.send", { message: "x" });
-    });
-    expect(setComposerInput).toHaveBeenCalledTimes(1);
-
-    // Trigger a re-render with new input. If the effect re-runs,
-    // the next publish would see the dep-array reset + handlers
-    // mounting + unmounting — and the assert below could either
-    // dupe or drop the event in a race. The stable subscription
-    // makes it deterministic.
-    rerender({ input: "typing", set: setComposerInput });
-
-    act(() => {
-      useEventBusStore
-        .getState()
-        .publish("deeplink.openThread", { threadId: "z" });
-    });
-    expect(navigateMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unsubscribes on unmount", () => {
-    const setComposerInput = mock((_next: string) => undefined);
-    const { unmount } = renderConsumer("", setComposerInput);
-
-    unmount();
-
-    // After unmount, publishing shouldn't reach the handlers.
-    act(() => {
-      useEventBusStore
-        .getState()
-        .publish("deeplink.send", { message: "post-unmount" });
-      useEventBusStore
-        .getState()
-        .publish("deeplink.openThread", { threadId: "z" });
-      useEventBusStore
-        .getState()
-        .publish("deeplink.unknown", { url: "x" });
-    });
-
-    expect(setComposerInput).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
     expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  test("a pending message arriving after mount fires the effect on the next render", () => {
+    const setComposerInput = mock((_next: string) => undefined);
+    renderConsumer("", setComposerInput);
+    expect(setComposerInput).not.toHaveBeenCalled();
+
+    // Simulate the global consumer parking a message after the
+    // chat page is already mounted. The Zustand atomic selector
+    // re-renders the hook and the effect fires.
+    act(() => {
+      usePendingDeepLinkStore
+        .getState()
+        .setPendingComposerMessage("late arrival");
+    });
+
+    expect(setComposerInput).toHaveBeenCalledWith("late arrival");
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-deep-link-consumer.ts
+++ b/apps/web/src/domains/chat/hooks/use-deep-link-consumer.ts
@@ -1,35 +1,30 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
-import { useNavigate } from "react-router";
 
-import { ensureMainWindowVisible } from "@/runtime/main-window";
-import { useEventBusStore } from "@/stores/event-bus-store";
-import { routes } from "@/utils/routes";
+import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 
 /**
- * Wires the renderer-side actions for inbound deep links published
- * on the event bus by `useEventBusInit` (which fans the Electron
- * deep-link bridge into typed `deeplink.*` events).
+ * Chat-domain half of the deep-link consumer pair. Reads the pending
+ * `deeplink.send` message parked in `usePendingDeepLinkStore` by the
+ * global consumer (`useGlobalDeepLinkConsumer`, mounted at
+ * `RootLayout`) and applies it to the composer.
  *
- * - `deeplink.send { message }` → pre-fill the chat composer IF
- *   it's empty. Refusing to overwrite the user's in-progress text
- *   is the conservative call; the dropped link is captured as a
- *   Sentry breadcrumb so we can see how often it happens before
- *   investing in a "queue or prompt" UX.
- * - `deeplink.openThread { threadId }` → navigate to the
- *   conversation route. Router handles not-found.
- * - `deeplink.unknown { url }` → Sentry breadcrumb + no action.
- *   Useful telemetry on unrecognized links the OS routed to us.
+ * Split exists because the global consumer must be route-stable
+ * (deep links arrive whenever, not just on `/assistant`), but only
+ * the chat domain knows about `setInput`. The store is the
+ * narrow-waist hand-off.
  *
- * All three handlers fire `ensureMainWindowVisible()` first so
- * the action lands on a user-visible window. Off Electron the
- * wrapper no-ops.
+ * Semantics:
  *
- * Lives in the chat domain (per ELECTRON.md's "hooks that bridge
- * feature state live in the domain") because both load-bearing
- * actions (composer pre-fill, conversation navigation) are
- * chat-specific. Mounted from `ChatPage` so it has access to the
- * composer's `setInput`.
+ * - If the composer is empty (`.trim().length === 0`), consume the
+ *   pending message and `setComposerInput(message)`.
+ * - If non-empty, drop with a Sentry breadcrumb — refusing to
+ *   overwrite the user's in-progress typing is the conservative
+ *   call until we have telemetry to justify a "queue or prompt" UX.
+ * - Runs on every render where `pendingComposerMessage` is non-null,
+ *   so a deep link arriving WHILE `ChatPage` is already mounted is
+ *   picked up on the next render. The Zustand selector re-renders
+ *   the component when the slice changes.
  */
 
 export interface UseDeepLinkConsumerParams {
@@ -44,59 +39,23 @@ export function useDeepLinkConsumer({
   composerInput,
   setComposerInput,
 }: UseDeepLinkConsumerParams): void {
-  const navigate = useNavigate();
-
-  // Mirror the dynamic props into refs so the bus subscription
-  // effect can mount once and read fresh values at handler time.
-  // Subscribing inside an effect with these in the dep array would
-  // tear down + resubscribe on every keystroke (composerInput
-  // changes constantly) — wasteful and a race window where a deep
-  // link could land between unsubscribe and resubscribe.
-  const composerInputRef = useRef(composerInput);
-  const setComposerInputRef = useRef(setComposerInput);
-  composerInputRef.current = composerInput;
-  setComposerInputRef.current = setComposerInput;
-  const navigateRef = useRef(navigate);
-  navigateRef.current = navigate;
+  const pending = usePendingDeepLinkStore.use.pendingComposerMessage();
 
   useEffect(() => {
-    const bus = useEventBusStore.getState();
-
-    const unsubSend = bus.subscribe("deeplink.send", ({ message }) => {
-      void ensureMainWindowVisible();
-      if (composerInputRef.current.trim().length > 0) {
-        Sentry.addBreadcrumb({
-          category: "deeplink",
-          level: "info",
-          message:
-            "deeplink.send arrived but composer had unsaved text — drop, do not overwrite",
-        });
-        return;
-      }
-      setComposerInputRef.current(message);
-    });
-
-    const unsubOpenThread = bus.subscribe(
-      "deeplink.openThread",
-      ({ threadId }) => {
-        void ensureMainWindowVisible();
-        navigateRef.current(routes.conversation(threadId));
-      },
-    );
-
-    const unsubUnknown = bus.subscribe("deeplink.unknown", ({ url }) => {
+    if (pending === null) return;
+    const consumed = usePendingDeepLinkStore
+      .getState()
+      .consumePendingComposerMessage();
+    if (consumed === null) return;
+    if (composerInput.trim().length > 0) {
       Sentry.addBreadcrumb({
         category: "deeplink",
         level: "info",
-        message: "deeplink.unknown",
-        data: { url },
+        message:
+          "deeplink.send arrived but composer had unsaved text — drop, do not overwrite",
       });
-    });
-
-    return () => {
-      unsubSend();
-      unsubOpenThread();
-      unsubUnknown();
-    };
-  }, []);
+      return;
+    }
+    setComposerInput(consumed);
+  }, [pending, composerInput, setComposerInput]);
 }

--- a/apps/web/src/domains/chat/hooks/use-deep-link-consumer.ts
+++ b/apps/web/src/domains/chat/hooks/use-deep-link-consumer.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from "react";
+import * as Sentry from "@sentry/browser";
+import { useNavigate } from "react-router";
+
+import { ensureMainWindowVisible } from "@/runtime/main-window";
+import { useEventBusStore } from "@/stores/event-bus-store";
+import { routes } from "@/utils/routes";
+
+/**
+ * Wires the renderer-side actions for inbound deep links published
+ * on the event bus by `useEventBusInit` (which fans the Electron
+ * deep-link bridge into typed `deeplink.*` events).
+ *
+ * - `deeplink.send { message }` → pre-fill the chat composer IF
+ *   it's empty. Refusing to overwrite the user's in-progress text
+ *   is the conservative call; the dropped link is captured as a
+ *   Sentry breadcrumb so we can see how often it happens before
+ *   investing in a "queue or prompt" UX.
+ * - `deeplink.openThread { threadId }` → navigate to the
+ *   conversation route. Router handles not-found.
+ * - `deeplink.unknown { url }` → Sentry breadcrumb + no action.
+ *   Useful telemetry on unrecognized links the OS routed to us.
+ *
+ * All three handlers fire `ensureMainWindowVisible()` first so
+ * the action lands on a user-visible window. Off Electron the
+ * wrapper no-ops.
+ *
+ * Lives in the chat domain (per ELECTRON.md's "hooks that bridge
+ * feature state live in the domain") because both load-bearing
+ * actions (composer pre-fill, conversation navigation) are
+ * chat-specific. Mounted from `ChatPage` so it has access to the
+ * composer's `setInput`.
+ */
+
+export interface UseDeepLinkConsumerParams {
+  /** Current composer input — checked before pre-fill so we don't
+   *  clobber the user's in-progress typing. */
+  composerInput: string;
+  /** Setter for the composer input. */
+  setComposerInput: (next: string) => void;
+}
+
+export function useDeepLinkConsumer({
+  composerInput,
+  setComposerInput,
+}: UseDeepLinkConsumerParams): void {
+  const navigate = useNavigate();
+
+  // Mirror the dynamic props into refs so the bus subscription
+  // effect can mount once and read fresh values at handler time.
+  // Subscribing inside an effect with these in the dep array would
+  // tear down + resubscribe on every keystroke (composerInput
+  // changes constantly) — wasteful and a race window where a deep
+  // link could land between unsubscribe and resubscribe.
+  const composerInputRef = useRef(composerInput);
+  const setComposerInputRef = useRef(setComposerInput);
+  composerInputRef.current = composerInput;
+  setComposerInputRef.current = setComposerInput;
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  useEffect(() => {
+    const bus = useEventBusStore.getState();
+
+    const unsubSend = bus.subscribe("deeplink.send", ({ message }) => {
+      void ensureMainWindowVisible();
+      if (composerInputRef.current.trim().length > 0) {
+        Sentry.addBreadcrumb({
+          category: "deeplink",
+          level: "info",
+          message:
+            "deeplink.send arrived but composer had unsaved text — drop, do not overwrite",
+        });
+        return;
+      }
+      setComposerInputRef.current(message);
+    });
+
+    const unsubOpenThread = bus.subscribe(
+      "deeplink.openThread",
+      ({ threadId }) => {
+        void ensureMainWindowVisible();
+        navigateRef.current(routes.conversation(threadId));
+      },
+    );
+
+    const unsubUnknown = bus.subscribe("deeplink.unknown", ({ url }) => {
+      Sentry.addBreadcrumb({
+        category: "deeplink",
+        level: "info",
+        message: "deeplink.unknown",
+        data: { url },
+      });
+    });
+
+    return () => {
+      unsubSend();
+      unsubOpenThread();
+      unsubUnknown();
+    };
+  }, []);
+}

--- a/apps/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/apps/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, act } from "@testing-library/react";
+
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store";
+import {
+  __resetPendingDeepLinkForTesting,
+  usePendingDeepLinkStore,
+} from "@/stores/pending-deep-link-store";
+
+const navigateMock = mock((_to: string) => undefined);
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+const ensureMainWindowVisibleMock = mock(async () => undefined);
+mock.module("@/runtime/main-window", () => ({
+  ensureMainWindowVisible: ensureMainWindowVisibleMock,
+}));
+
+const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
+mock.module("@sentry/browser", () => ({
+  addBreadcrumb: sentryBreadcrumbMock,
+}));
+
+const { useGlobalDeepLinkConsumer } = await import(
+  "./use-global-deep-link-consumer"
+);
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+  __resetPendingDeepLinkForTesting();
+  navigateMock.mockClear();
+  ensureMainWindowVisibleMock.mockClear();
+  sentryBreadcrumbMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+  __resetPendingDeepLinkForTesting();
+});
+
+describe("deeplink.send", () => {
+  test("navigates to /assistant + parks the message in the pending store + ensures window", () => {
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      useEventBusStore.getState().publish("deeplink.send", { message: "hi" });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith("/assistant");
+    expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
+      "hi",
+    );
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deeplink.openThread", () => {
+  test("navigates to the conversation route + ensures window", () => {
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deeplink.unknown", () => {
+  test("Sentry breadcrumb only — no navigation or window activation", () => {
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.unknown", { url: "javascript:alert(1)" });
+    });
+
+    expect(sentryBreadcrumbMock).toHaveBeenCalled();
+    const args = sentryBreadcrumbMock.mock.calls[0]?.[0] as {
+      data?: { url?: string };
+    };
+    expect(args.data?.url).toBe("javascript:alert(1)");
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("subscription lifecycle", () => {
+  test("unmount unsubscribes — published events after unmount have no effect", () => {
+    const { unmount } = renderHook(() => useGlobalDeepLinkConsumer());
+
+    unmount();
+
+    act(() => {
+      useEventBusStore
+        .getState()
+        .publish("deeplink.send", { message: "post-unmount" });
+      useEventBusStore
+        .getState()
+        .publish("deeplink.openThread", { threadId: "z" });
+      useEventBusStore
+        .getState()
+        .publish("deeplink.unknown", { url: "x" });
+    });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
+    expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
+      null,
+    );
+  });
+});

--- a/apps/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/apps/web/src/hooks/use-global-deep-link-consumer.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import * as Sentry from "@sentry/browser";
+import { useNavigate } from "react-router";
+
+import { ensureMainWindowVisible } from "@/runtime/main-window";
+import { useEventBusStore } from "@/stores/event-bus-store";
+import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { routes } from "@/utils/routes";
+
+/**
+ * Global deep-link consumer — mounted at `RootLayout` so it's alive
+ * for every authenticated assistant route, not just `/assistant`
+ * (`ChatPage`). Without it, a `vellum://thread/...` click while the
+ * user is on `/assistant/settings` would be dropped.
+ *
+ * Responsibilities:
+ *
+ * - `deeplink.openThread` → `ensureMainWindowVisible()` +
+ *   `navigate(routes.conversation(threadId))`.
+ * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
+ *   `/assistant` + park the message in `usePendingDeepLinkStore`
+ *   for `ChatPage`'s composer-domain hook to consume on mount.
+ * - `deeplink.unknown` → Sentry breadcrumb.
+ *
+ * The composer pre-fill itself stays in the chat domain
+ * (`useDeepLinkConsumer`) because it owns `setInput`. This hook is
+ * intentionally generic — it doesn't import chat-specific state.
+ */
+
+export function useGlobalDeepLinkConsumer(): void {
+  const navigate = useNavigate();
+  // Mirror dynamic deps in a ref so the effect mounts once. Without
+  // this, a navigate-fn identity change would tear down + resubscribe
+  // the bus listeners and open a race window where a link could
+  // arrive between unsubscribe and resubscribe.
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  useEffect(() => {
+    const bus = useEventBusStore.getState();
+
+    const unsubSend = bus.subscribe("deeplink.send", ({ message }) => {
+      void ensureMainWindowVisible();
+      usePendingDeepLinkStore.getState().setPendingComposerMessage(message);
+      navigateRef.current(routes.assistant);
+    });
+
+    const unsubOpenThread = bus.subscribe(
+      "deeplink.openThread",
+      ({ threadId }) => {
+        void ensureMainWindowVisible();
+        navigateRef.current(routes.conversation(threadId));
+      },
+    );
+
+    const unsubUnknown = bus.subscribe("deeplink.unknown", ({ url }) => {
+      Sentry.addBreadcrumb({
+        category: "deeplink",
+        level: "info",
+        message: "deeplink.unknown",
+        data: { url },
+      });
+    });
+
+    return () => {
+      unsubSend();
+      unsubOpenThread();
+      unsubUnknown();
+    };
+  }, []);
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -2,6 +2,7 @@ import { Outlet, useNavigate } from "react-router";
 
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
+import { useGlobalDeepLinkConsumer } from "@/hooks/use-global-deep-link-consumer";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useVisibleViewport } from "@/hooks/use-visible-viewport";
 import { useAssistantLifecycle } from "@/assistant/use-lifecycle";
@@ -81,6 +82,13 @@ export function RootLayout() {
   useDocumentEditorSync();
 
   useEventBusInit({ assistantId, isAssistantActive });
+  // Inbound deep-link navigation + window activation. Mounted here
+  // (not in `ChatPage`) so a `vellum://thread/...` arriving while
+  // the user is on `/assistant/settings`, `/logs`, etc. still
+  // navigates. The composer-pre-fill half lives in `ChatPage`'s
+  // `useDeepLinkConsumer` because it owns `setInput`; the two
+  // hand off via `pending-deep-link-store`.
+  useGlobalDeepLinkConsumer();
 
   const keyboardOpen =
     isMobile &&

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -50,6 +50,9 @@ declare global {
         setBadge(count: number): Promise<void>;
         setSignedIn(signedIn: boolean): Promise<void>;
       };
+      mainWindow: {
+        ensureVisible(): Promise<void>;
+      };
       power: {
         onEvent(
           callback: (event: {

--- a/apps/web/src/runtime/main-window.ts
+++ b/apps/web/src/runtime/main-window.ts
@@ -1,0 +1,27 @@
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Per-capability wrapper for the Electron host's main-window control
+ * surface. Imperative — `ensureMainWindowVisible()` brings the main
+ * window forward (recreate if destroyed, restore from minimize, show,
+ * focus). Off Electron the call no-ops; web and Capacitor iOS have
+ * their own foregrounding semantics (web is already the foreground
+ * tab if the user is interacting; iOS handles app activation
+ * natively).
+ *
+ * Used by feature consumers that react to inbound signals (deep
+ * links, future notification action clicks) and need to accompany
+ * the state update with making the window user-visible. Without
+ * this, a click on `vellum://send?message=hi` on a backgrounded
+ * Vellum would update composer state with no visible response.
+ *
+ * Same wrapper shape as `dock.ts` / `app-info.ts`: no-op off
+ * Electron, awaits an IPC handler that resolves once the window
+ * is loaded and focused. Safe to fire-and-forget if the caller
+ * doesn't need to sequence follow-up actions.
+ */
+
+export async function ensureMainWindowVisible(): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.mainWindow.ensureVisible();
+}

--- a/apps/web/src/stores/pending-deep-link-store.ts
+++ b/apps/web/src/stores/pending-deep-link-store.ts
@@ -1,0 +1,71 @@
+/**
+ * Pending deep-link state — a one-shot inbox the global deep-link
+ * consumer writes to and the chat composer reads from.
+ *
+ * Why a store: a `vellum://send?message=…` deep link can arrive
+ * while the user is on a non-chat route (`/assistant/settings`,
+ * `/assistant/logs`, etc.). The global consumer (mounted at
+ * `RootLayout`) navigates to the chat AND parks the message here;
+ * `ChatPage` then consumes on mount once the composer's state owner
+ * (`useDraftInput`) is alive. Without this hand-off, the message
+ * would be dropped — the bus event publishes to no chat-domain
+ * subscriber until `ChatPage` mounts.
+ *
+ * One-shot semantics — `consumePendingMessage` returns and clears.
+ * If a second deep link arrives before consumption, the latest
+ * message wins (older drops with a Sentry breadcrumb). Renderer
+ * reloads / hard navigates blow this away because it's
+ * not persisted — by design, deep links are transient signals.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+export interface PendingDeepLinkState {
+  /** Latest pending `deeplink.send` message text, or `null` if none. */
+  pendingComposerMessage: string | null;
+}
+
+export interface PendingDeepLinkActions {
+  /**
+   * Set the pending composer message. If one is already pending,
+   * it's overwritten — the most recent deep link wins. Used by the
+   * global consumer in `useGlobalDeepLinkConsumer`.
+   */
+  setPendingComposerMessage: (message: string) => void;
+  /**
+   * Read and clear the pending composer message. Returns `null` if
+   * none was set. Used by `useDeepLinkConsumer` in the chat domain.
+   */
+  consumePendingComposerMessage: () => string | null;
+}
+
+export type PendingDeepLinkStore = PendingDeepLinkState &
+  PendingDeepLinkActions;
+
+const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
+  (set, get) => ({
+    pendingComposerMessage: null,
+    setPendingComposerMessage: (message) =>
+      set({ pendingComposerMessage: message }),
+    consumePendingComposerMessage: () => {
+      const message = get().pendingComposerMessage;
+      if (message !== null) set({ pendingComposerMessage: null });
+      return message;
+    },
+  }),
+);
+
+export const usePendingDeepLinkStore = createSelectors(
+  usePendingDeepLinkStoreBase,
+);
+
+/**
+ * Reset hook for tests. Not intended for production callers.
+ */
+export function __resetPendingDeepLinkForTesting(): void {
+  usePendingDeepLinkStoreBase.setState({ pendingComposerMessage: null });
+}

--- a/apps/web/src/stores/pending-deep-link-store.ts
+++ b/apps/web/src/stores/pending-deep-link-store.ts
@@ -11,11 +11,12 @@
  * would be dropped — the bus event publishes to no chat-domain
  * subscriber until `ChatPage` mounts.
  *
- * One-shot semantics — `consumePendingMessage` returns and clears.
- * If a second deep link arrives before consumption, the latest
- * message wins (older drops with a Sentry breadcrumb). Renderer
- * reloads / hard navigates blow this away because it's
- * not persisted — by design, deep links are transient signals.
+ * One-shot semantics — `consumePendingComposerMessage` returns and
+ * clears. If a second deep link arrives before consumption, the
+ * latest message wins (silent overwrite — two-link-overwrite is
+ * below the noise floor in practice). Renderer reloads / hard
+ * navigates blow this away because it's not persisted — by design,
+ * deep links are transient signals.
  *
  * @see {@link https://zustand.docs.pmnd.rs/}
  */


### PR DESCRIPTION
## Summary

Closes the consumer loop on the deep-link bridge from #32656. The typed `deeplink.send` / `deeplink.openThread` / `deeplink.unknown` bus events now have a chat-domain subscriber that takes user-visible action, plus a new `runtime/main-window.ts` bridge so any consumer can bring the window forward when reacting to an inbound signal.

## Architecture

### Main-window bridge (new imperative surface)

Third imperative wrapper after `dock.ts` and `app-info.ts`; same shape, same convention.

- **`apps/macos/src/main/main-window.ts`** — `installMainWindow` now registers `ipcMain.handle("vellum:mainWindow:ensureVisible", ...)` that routes through the existing `ensureVisible()` (recreate if destroyed, restore from minimize, show, focus, await renderer-ready). Test seam `__resetForTesting` added so tests can re-exercise the install path.
- **`apps/macos/src/preload/index.ts`** — `window.vellum.mainWindow.ensureVisible()`.
- **`apps/web/src/runtime/is-electron.ts`** — ambient mirror.
- **`apps/web/src/runtime/main-window.ts`** — no-op-off-Electron wrapper. Web has its own foregrounding (it IS the foreground tab); Capacitor handles app activation natively.

### Consumer hook in the chat domain

Per `ELECTRON.md`'s "hooks that bridge feature state live in the domain":

- **`apps/web/src/domains/chat/hooks/use-deep-link-consumer.ts`** — subscribes to the three bus events:
  - `deeplink.send` → `ensureMainWindowVisible()`; if composer is empty (`.trim().length === 0`) set the input to the message; if non-empty, Sentry breadcrumb + drop.
  - `deeplink.openThread` → `ensureMainWindowVisible()` + `navigate(routes.conversation(threadId))`.
  - `deeplink.unknown` → Sentry breadcrumb with the URL, no other action.
- **Refs for dynamic props (`composerInput`, `setComposerInput`, `navigate`)** so the bus subscription mounts ONCE — without this, every keystroke would tear down + resubscribe the handlers, opening a race window where a deep link landing between unsubscribe and resubscribe would be dropped.

### Mounted from ChatPage

`apps/web/src/domains/chat/chat-page.tsx` calls `useDeepLinkConsumer({ composerInput: input, setComposerInput: setInput })` next to the existing `useDraftInput`.

## Conservative drop-don't-overwrite design choice

When a deep link's `message` arrives but the composer has in-progress text, the link is dropped with a Sentry breadcrumb (and `ensureMainWindowVisible` still fires so the user sees Vellum come forward). The "queue or non-destructive prompt" UX from LUM-2068's spec is deliberately deferred — Sentry telemetry first, UX investment once we know how often it actually happens.

## Tests

- **`apps/macos/src/main/main-window.test.ts`** (+2 cases): IPC handler registered, IPC handler routes through `ensureVisible`.
- **`apps/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx`** (7 cases):
  - `deeplink.send` empty-composer pre-fill.
  - In-progress typing preserved + Sentry breadcrumb fires.
  - Whitespace-only composer counts as empty.
  - `deeplink.openThread` navigates + ensures window visible.
  - `deeplink.unknown` Sentry breadcrumb only.
  - Re-render-doesn't-resubscribe (the dep-array-via-refs choice tested via two events across a rerender).
  - Unmount unsubscribes.

26/26 macOS tests + 26/26 chat+bus tests green.

## Out of scope (called out for follow-up)

- **Queue-or-prompt UX** for in-progress typing: Sentry breadcrumb now, revisit with data.
- **Accessory-mode → regular transition before showing**: the dock state machine listens to the main window's `show` event via `onMainWindowVisibilityChange` (from LUM-1965), so the regular-mode transition happens implicitly when `ensureVisible` fires the show. Worth a follow-up audit if the dock policy lags the show in practice.

## Test plan

- [x] `bun --cwd apps/macos run typecheck` — green.
- [x] `bun --cwd apps/macos run test:ci` — 9 test files, all green.
- [x] `bun --cwd apps/macos run build` — main + preload bundles build cleanly.
- [x] `bun --cwd apps/web test src/domains/chat/hooks/use-deep-link-consumer.test.tsx src/stores/event-bus-store.test.ts` — 26 cases green.
- [ ] Manual: `open vellum://send?message=hello` from another app while Vellum is backgrounded → main window comes forward, composer pre-fills.
- [ ] Manual: `open vellum://thread/<existing-conversation-id>` → main window comes forward, router navigates.
- [ ] Manual: type a few characters in the composer, then `open vellum://send?message=different` → composer text preserved, Sentry breadcrumb fires.

https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_