### PR TITLE
refactor(web): synchronize lifecycle clear at the auth-store logout site (LUM-2063 part 1)

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -230,6 +230,38 @@ describe("lifecycleService — bootstrap branches", () => {
     });
   });
 
+  test("resetForLogout clears both stores synchronously without needing setInputs", async () => {
+    // Drive into active first via the normal flow.
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-prev",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(
+      useAssistantSelectionStore.getState().activeAssistantId,
+    ).toBe("asst-prev");
+
+    // Synchronous reset — no `await`, no input flip needed.
+    lifecycleService.resetForLogout();
+
+    expect(
+      useAssistantSelectionStore.getState().activeAssistantId,
+    ).toBeNull();
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
+  });
+
   test("gateway-auth short-circuit writes active state without calling the server", async () => {
     isGatewayAuthModeMock.mockImplementation(() => true);
 

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -192,7 +192,7 @@ describe("lifecycleService — server state projection", () => {
 });
 
 describe("lifecycleService — bootstrap branches", () => {
-  test("logout clears both stores", async () => {
+  test("respondToInputs with isLoggedIn=false clears both stores (safety-net for token-expiry-style auth flips that don't call logout())", async () => {
     // Drive the service into an `active` state through the
     // legitimate path so its internal state mirrors the store.
     getAssistantMock.mockImplementationOnce(async () => ({

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -124,6 +124,28 @@ class AssistantLifecycleService {
   }
 
   /**
+   * Synchronously drop the selection + lifecycle state. Called from
+   * `auth-store.logout()` before `isLoggedIn` flips, so subscribers
+   * to either store don't observe a stale id in their first
+   * re-render after logout. The `respondToInputs` `!isLoggedIn`
+   * branch is the safety net for cases where auth flips without
+   * going through the explicit logout call (e.g. token expiry
+   * detected by an interceptor and surfaced as a state change
+   * rather than an action).
+   *
+   * Guarded resets avoid spurious subscriber wake-ups when the
+   * stores are already at defaults.
+   */
+  resetForLogout(): void {
+    if (useAssistantSelectionStore.getState().activeAssistantId !== null) {
+      useAssistantSelectionStore.getState().setActiveAssistantId(null);
+    }
+    if (this.state.kind !== "loading") {
+      this.transition({ kind: "loading" });
+    }
+  }
+
+  /**
    * Reconcile against the current inputs — drives initial bootstrap
    * (post-login `checkAssistant`), logout reset, and the local-mode
    * branches. Safe to call on every input change.
@@ -131,16 +153,10 @@ class AssistantLifecycleService {
   async respondToInputs(): Promise<void> {
     if (!this.ready) return;
     if (!this.inputs.isLoggedIn || this.inputs.isLoading) {
-      // Logout / pre-auth boot. Drop selection + lifecycle state
-      // so a returning login doesn't observe the previous user's id.
-      // Guarded resets avoid spurious subscriber wake-ups when the
-      // stores are already at defaults.
-      if (useAssistantSelectionStore.getState().activeAssistantId !== null) {
-        useAssistantSelectionStore.getState().setActiveAssistantId(null);
-      }
-      if (this.state.kind !== "loading") {
-        this.transition({ kind: "loading" });
-      }
+      // Logout / pre-auth boot — same reset as `resetForLogout` but
+      // reachable from the input-driven path for token-expiry style
+      // flips that don't call `logout()` explicitly.
+      this.resetForLogout();
       return;
     }
 

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -70,6 +70,13 @@ mock.module("@/stores/event-bus-store", () => ({
   },
 }));
 
+const lifecycleResetForLogoutMock = mock(() => {});
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    resetForLogout: lifecycleResetForLogoutMock,
+  },
+}));
+
 const { useAuthStore } = await import("@/stores/auth-store");
 
 function resetAuthStore(): void {
@@ -95,6 +102,7 @@ beforeEach(() => {
   deleteBiometricTokenMock.mockClear();
   installSessionCookiesMock.mockClear();
   retrieveBiometricTokenMock.mockClear();
+  lifecycleResetForLogoutMock.mockClear();
   resetAuthStore();
 });
 
@@ -144,6 +152,25 @@ describe("session cleanup on logout", () => {
     await useAuthStore.getState().logout();
 
     expect(clearUserScopedStorageMock).toHaveBeenCalled();
+  });
+
+  test("logout clears assistant lifecycle synchronously, before flipping isLoggedIn", async () => {
+    // The lifecycle reset must happen before the auth state flips,
+    // otherwise sync hooks like `useAssistantResourceSync` get one
+    // re-render with the previous user's assistant id and fire
+    // requests that 401. The order is verified by recording the
+    // sequence of side effects vs the `isLoggedIn` flip.
+    let isLoggedInAtResetTime = useAuthStore.getState().isLoggedIn;
+    lifecycleResetForLogoutMock.mockImplementationOnce(() => {
+      isLoggedInAtResetTime = useAuthStore.getState().isLoggedIn;
+    });
+    useAuthStore.setState({ isLoggedIn: true });
+
+    await useAuthStore.getState().logout();
+
+    expect(lifecycleResetForLogoutMock).toHaveBeenCalledTimes(1);
+    expect(isLoggedInAtResetTime).toBe(true);
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
   });
 });
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -13,6 +13,7 @@
  */
 import { create } from "zustand";
 
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { createSelectors } from "@/utils/create-selectors";
 
 import {
@@ -235,6 +236,11 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       clearOnboardingFlags();
       clearOrganization();
       clearUserScopedStorage();
+      // Clear lifecycle state BEFORE flipping `isLoggedIn` so the
+      // assistant sync hooks don't observe a stale assistant id in
+      // their first re-render. The `respondToInputs` `!isLoggedIn`
+      // branch is the safety net for token-expiry-style flips.
+      lifecycleService.resetForLogout();
       set({ isLoggedIn: false, user: null, hasPlatformSession: false });
       broadcastAuthChange();
       return;
@@ -247,6 +253,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       clearOnboardingFlags();
       clearOrganization();
       clearUserScopedStorage();
+      lifecycleService.resetForLogout();
       set({ isLoggedIn: false, user: null, hasPlatformSession: false });
       broadcastAuthChange();
     }


### PR DESCRIPTION
Partially closes [LUM-2063](https://linear.app/vellum/issue/LUM-2063) — the synchronous-logout half. The other half (atomic store writes in `projectActive` / `projectSelfHosted`) is intentionally not done; see "What I considered and did NOT do" below.

## Why

When `auth-store.logout()` runs today:

1. `allauthLogout()` clears the server session (or the gateway-auth branch clears local tokens).
2. `clearOnboardingFlags()`, `clearOrganization()`, `clearUserScopedStorage()` fire.
3. `set({ isLoggedIn: false, user: null, hasPlatformSession: false })` — auth subscribers re-render.
4. Some ticks later, `useAssistantLifecycle`'s `useEffect` observes `isLoggedIn: false` via `setInputs`, calls `respondToInputs()`, which clears the assistant stores.

Between step 3 and step 4, the React tree re-renders with `isLoggedIn: false` but `activeAssistantId: "asst-prev-session"` and `assistantState.kind` set to whatever it was. The sync hooks in `RootLayout` (`useAssistantResourceSync`, `useConversationSync`, `useFeatureFlagBusSync`, `useNotificationIntentSync`) read those store values and may fire fetches against the previous user's id. In practice the token's already gone so each fetch 401s harmlessly — but the request still fires, and the timing creates a footgun for anything that *would* observe the stale id.

## What changed

Two pieces:

1. **`lifecycleService.resetForLogout()`** — a new synchronous public method that drops the selection id and the lifecycle state. Refactored from the existing `respondToInputs` `!isLoggedIn` branch, which now delegates to it (DRY + safety net).
2. **`auth-store.logout()`** — calls `lifecycleService.resetForLogout()` BEFORE `set({ isLoggedIn: false, ... })` in both logout branches (gateway-auth and standard). After this lands, every subscriber re-render sees both stores cleared AND `isLoggedIn` flipped together, never half-cleared.

The existing `respondToInputs` `!isLoggedIn` reset stays as the safety net for cases where auth flips without going through the explicit logout action (e.g. token expiry caught by a 401 interceptor that surfaces as a state change rather than an action call).

## Why safe

- `tsc --noEmit` clean
- `bun run lint` clean
- `bun run test:ci` — 181/181 test files pass
- Two new tests:
  - **`lifecycle-service.test.ts`** — `resetForLogout` clears both stores after a real `checkAssistant` cycle puts the service in `active`. Verifies the synchronous semantics.
  - **`auth-store.test.ts`** — the new "logout clears assistant lifecycle synchronously, before flipping isLoggedIn" test captures the ordering: it asserts that `lifecycleResetForLogout` is observed while `useAuthStore.getState().isLoggedIn === true`, which only holds if the reset runs before the `set()`.

Behavioral change is one-directional and well-bounded: a logout that took N+1 store-subscriber wake-ups now takes 1. No new code paths, no behavior changes for non-logout flows.

## References

- [Zustand — set semantics](https://zustand.docs.pmnd.rs/guides/updating-state) — `set()` runs subscribers synchronously, so calling the lifecycle reset inside `logout()` before `set({ isLoggedIn: false })` gives us atomic-from-React's-perspective ordering.
- [React 18 — Automatic Batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching) — confirms that multiple `set()` calls inside one event handler / async continuation get batched into one React render, which is the reason "call reset, then call set" produces one re-render instead of two.
- [`apps/web/src/assistant/lifecycle-service.ts`](apps/web/src/assistant/lifecycle-service.ts) — the service this work hardens.

## What I considered and did NOT do, and why

**Did not address the atomic-store-write half of LUM-2063.** On re-examination, `projectActive` / `projectSelfHosted` make their two `set()` calls synchronously within the same JS task. React 18 batches subscriber re-renders within one tick. The only callers that could observe the intermediate state (id flipped but kind unchanged) are non-React `.subscribe()` listeners — of which the codebase has none. The "consumers see brief intermediate state" framing in the original ticket was more theoretical than I claimed when I filed it. Closing that half of LUM-2063 as no-action; the synchronous-logout half is the one with measurable impact (one fewer wake-up per logout, no spurious 401s in network logs).

**Did not implement this as a Zustand `subscribe` from the lifecycle service to the auth store.** That would have been an alternative way to avoid the runtime coupling — the lifecycle service would subscribe to auth state and react to logout transitions. Trade-off: module-init subscription is harder to reason about than an explicit call in the logout flow, and would mean lifecycle-service runs side effects during test imports unless we wrapped it in an `init()` function. The auth-store calling the lifecycle service is consistent with how it already calls `clearSelectedAssistant`, `clearGatewayToken`, `clearOnboardingFlags`, `clearOrganization`, `clearUserScopedStorage` — one more explicit clear in the same list, in the same order it currently runs.

**Did not narrow the auth-store import to just `resetForLogout`.** Imports `lifecycleService` as a value because the service is a singleton; importing just one method would require breaking the service's encapsulation. The runtime coupling already exists (the lifecycle service is the source of truth for assistant state; auth-store needs to flush it on logout); this just makes it explicit at the call site.

## Stepping back

This PR closes the half of LUM-2063 with measurable impact and explicitly closes the other half as "considered, decided not to do, here's why." The remaining lifecycle-related backlog (LUM-2060, LUM-2064, LUM-2065, LUM-2066) is unaffected.

https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQuUAiXsS4DVEmKPsb1uE)_