### PR TITLE
feat(memory-v3): render the working-set selection as a memory block

### DIFF
--- a/assistant/src/memory/v3/__tests__/render-injection.test.ts
+++ b/assistant/src/memory/v3/__tests__/render-injection.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { renderMemoryBlock } from "../render-injection.js";
+import { Slug } from "../types.js";
+
+const resolver =
+  (pages: Record<Slug, string>) =>
+  async (slug: Slug): Promise<string> =>
+    pages[slug] ?? "";
+
+describe("renderMemoryBlock", () => {
+  test("wraps the selection in a single <memory> block, in order", async () => {
+    const pages: Record<Slug, string> = {
+      "page-a": "alpha body",
+      "page-b": "beta body",
+    };
+
+    const block = await renderMemoryBlock(
+      ["page-a", "page-b"],
+      resolver(pages),
+    );
+
+    expect(block).toBe("<memory>\nalpha body\nbeta body\n</memory>");
+  });
+
+  test("empty selection renders the empty string", async () => {
+    const block = await renderMemoryBlock([], async () => "unused");
+    expect(block).toBe("");
+  });
+
+  test("preserves input order deterministically", async () => {
+    const pages: Record<Slug, string> = {
+      "page-a": "A",
+      "page-b": "B",
+      "page-c": "C",
+    };
+
+    const forward = await renderMemoryBlock(
+      ["page-a", "page-b", "page-c"],
+      resolver(pages),
+    );
+    const reversed = await renderMemoryBlock(
+      ["page-c", "page-b", "page-a"],
+      resolver(pages),
+    );
+
+    expect(forward).toBe("<memory>\nA\nB\nC\n</memory>");
+    expect(reversed).toBe("<memory>\nC\nB\nA\n</memory>");
+  });
+
+  test("reuses the marker the v2 stripper recognizes", async () => {
+    const block = await renderMemoryBlock(
+      ["page-a"],
+      resolver({ "page-a": "x" }),
+    );
+    expect(block.startsWith("<memory>\n")).toBe(true);
+    expect(block.endsWith("\n</memory>")).toBe(true);
+  });
+});

--- a/assistant/src/memory/v3/render-injection.ts
+++ b/assistant/src/memory/v3/render-injection.ts
@@ -1,0 +1,31 @@
+import { Slug } from "./types.js";
+
+/**
+ * Render a v3 working-set selection into a single `<memory>…</memory>` text
+ * block.
+ *
+ * Pure and side-effect-free: all I/O is delegated to the injected
+ * `pageContent` resolver, which is awaited once per slug in input order. The
+ * resulting block reuses the same `<memory>\n…\n</memory>` marker that the v2
+ * graph-memory path emits, so the existing strip machinery in
+ * `conversation-graph-memory.ts` already recognizes (and evicts) it.
+ *
+ * Resolution is concurrent; the rendered block preserves `finalInjection`
+ * order regardless of which fetch settles first.
+ *
+ * @param finalInjection - The working-set selection for the turn, in the order
+ *   it should appear in the rendered block.
+ * @param pageContent - Resolver returning a page's rendered content for a slug.
+ * @returns The wrapped `<memory>` block, or `""` for an empty selection (the
+ *   caller injects nothing).
+ */
+export async function renderMemoryBlock(
+  finalInjection: Slug[],
+  pageContent: (slug: Slug) => Promise<string>,
+): Promise<string> {
+  if (finalInjection.length === 0) return "";
+
+  const contents = await Promise.all(finalInjection.map(pageContent));
+
+  return `<memory>\n${contents.join("\n")}\n</memory>`;
+}


### PR DESCRIPTION
## Summary
- Add renderMemoryBlock(finalInjection, pageContent): a pure function that renders the v3 working-set selection into one <memory>...</memory> block (reusing the existing marker so the current stripper recognizes it). Empty selection -> empty string. No wiring yet.

Part of plan: memory-v3-live.md (PR L3 of 7)