### PR TITLE
feat(providers): add mutableLatestUserMessage cache-anchor option

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -459,6 +459,128 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   });
 
   // -----------------------------------------------------------------------
+  // mutableLatestUserMessage — volatile trailing user message cache anchor
+  // -----------------------------------------------------------------------
+  test("mutableLatestUserMessage: first-of-turn skips the volatile turn-start anchor and anchors the previous stable user message", async () => {
+    // The latest user message carries per-turn-volatile content (e.g. an
+    // injected memory block). The long-TTL anchor must move off it onto the
+    // most recent stable user message so the cached prefix stays reusable.
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2 (volatile)"),
+    ];
+    await provider.sendMessage(messages, {
+      config: { mutableLatestUserMessage: true },
+    });
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        text: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const userMessages = sent.filter((m) => m.role === "user");
+
+    // Latest (turn-start) user message gets NO long-TTL breakpoint — it's volatile.
+    const latest = userMessages[userMessages.length - 1];
+    for (const block of latest.content) {
+      expect(block.cache_control).toBeUndefined();
+    }
+
+    // Previous stable user message (Turn 1) becomes the primary anchor.
+    const prev = userMessages[userMessages.length - 2];
+    const prevLast = prev.content[prev.content.length - 1];
+    expect(prevLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("mutableLatestUserMessage absent: breakpoint placement is byte-identical to default behavior (v2 regression guard)", async () => {
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const userMessages = sent.filter((m) => m.role === "user");
+
+    // Current-turn (latest) anchor keeps 1h.
+    const latest = userMessages[userMessages.length - 1];
+    const latestLast = latest.content[latest.content.length - 1];
+    expect(latestLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Previous-turn anchor keeps 1h.
+    const prev = userMessages[userMessages.length - 2];
+    const prevLast = prev.content[prev.content.length - 1];
+    expect(prevLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("mutableLatestUserMessage: during a tool-use loop placement is unchanged (block is fixed within the turn)", async () => {
+    // Turn-start is not the last message (tool_result follows), so the
+    // turn-start block is fixed for the rest of the turn — the flag must not
+    // move the anchor.
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2"),
+      toolUseMsg("tu_1", "bash"),
+      toolResultMsg("tu_1", "output"),
+    ];
+    await provider.sendMessage(messages, {
+      config: { mutableLatestUserMessage: true },
+    });
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+
+    // Turn-start (Turn 2, index 2) still gets the 1h anchor — within a tool-use
+    // loop the block is fixed, so the volatile-latest flag must not move it.
+    const turn2 = sent[2];
+    const turn2Last = turn2.content[turn2.content.length - 1];
+    expect(turn2Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("mutableLatestUserMessage: first turn with no previous user message does not throw and applies no long-TTL anchor", async () => {
+    await provider.sendMessage([userMsg("First ever turn (volatile)")], {
+      config: { mutableLatestUserMessage: true },
+    });
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    // Only user message is volatile and there is no prior stable one, so no
+    // long-TTL breakpoint lands on any user message — graceful, no throw.
+    const lastBlock = sent[0].content[sent[0].content.length - 1];
+    expect(lastBlock.cache_control).toBeUndefined();
+  });
+
+  test("mutableLatestUserMessage is not forwarded to the Anthropic API", async () => {
+    await provider.sendMessage([userMsg("Hi")], {
+      config: { mutableLatestUserMessage: true },
+    });
+    expect(
+      (lastStreamParams as Record<string, unknown>).mutableLatestUserMessage,
+    ).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
   // Negative: assistant messages never get cache_control
   // -----------------------------------------------------------------------
   test("assistant messages do not get cache_control", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -824,6 +824,13 @@ export class AnthropicProvider implements Provider {
     const disableTurnStartCache =
       (config as Record<string, unknown> | undefined)?.disableTurnStartCache ===
       true;
+    // When true, the latest user message carries per-turn-volatile content
+    // (e.g. an injected memory block), so the long-TTL anchor must skip it and
+    // land on the most recent stable user message instead. See the breakpoint
+    // block below.
+    const mutableLatestUserMessage =
+      (config as Record<string, unknown> | undefined)
+        ?.mutableLatestUserMessage === true;
     let sentMessages: Anthropic.MessageParam[] | undefined;
     const startedAt = Date.now();
     // Hoisted so the catch block can distinguish our inner stream timeout
@@ -1012,6 +1019,7 @@ export class AnthropicProvider implements Provider {
         output_config,
         cacheTtl: _cacheTtl,
         disableTurnStartCache: _disableTurnStartCache,
+        mutableLatestUserMessage: _mutableLatestUserMessage,
         max_tokens: callerMaxTokens,
         usageAttributionHeaders,
         ...restConfig
@@ -1142,7 +1150,21 @@ export class AnthropicProvider implements Provider {
         }
       };
       const turnStartIdx = findUserTextMsgIdx(msgs.length - 1);
-      if (turnStartIdx >= 0 && !disableTurnStartCache) {
+      // When the latest user message is volatile (`mutableLatestUserMessage`)
+      // and it is itself the turn-start (first-of-turn, no tool-use loop yet),
+      // skip the long-TTL anchor here — it would land on per-turn-varying
+      // content and never hit again. The previous-turn anchor below becomes the
+      // primary stable breakpoint. During tool-use loops (`turnStartIdx <
+      // msgs.length - 1`) the turn-start block is fixed within the turn, so
+      // behavior is unchanged. Independent from `disableTurnStartCache`, which
+      // expresses a different intent (one-shot callers with no future hit).
+      const skipVolatileTurnStartAnchor =
+        mutableLatestUserMessage && turnStartIdx === msgs.length - 1;
+      if (
+        turnStartIdx >= 0 &&
+        !disableTurnStartCache &&
+        !skipVolatileTurnStartAnchor
+      ) {
         applyCacheControlToLastBlock(turnStartIdx);
       }
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -207,6 +207,15 @@ export interface SendMessageConfig {
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   verbosity?: "low" | "medium" | "high";
+  /**
+   * When true, the most recent user message's content varies across
+   * otherwise-identical turns (e.g. a per-turn memory block was injected into
+   * it). The provider places the primary long-TTL cache breakpoint on the most
+   * recent *stable* user message instead of the volatile latest one, so the
+   * cached prefix stays reusable across turns. Default false — existing
+   * behavior.
+   */
+  mutableLatestUserMessage?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add a default-off SendMessageConfig.mutableLatestUserMessage option: when set, the Anthropic provider anchors the long-TTL prompt-cache breakpoint on the most recent STABLE user message instead of the volatile latest one (first-of-turn only). Off by default → all existing callers, including v2, are byte-for-byte unchanged. Foundational for memory-v3 live injection.

Part of plan: memory-v3-live.md (PR L1 of 7)