### PR TITLE
feat(memory): route injection to v3 and shift cache anchor when memory-v3-live is on

### DIFF
--- a/assistant/src/__tests__/agent-loop-mutable-latest-user-message.test.ts
+++ b/assistant/src/__tests__/agent-loop-mutable-latest-user-message.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Verifies that the per-turn `mutableLatestUserMessage` plumbed into
+ * `AgentLoop.run()` surfaces on every `SendMessageOptions.config` the loop
+ * emits — this is the memory-v3-live cache-anchor signal (the latest user
+ * message carries a volatile `<memory>` block, so the provider must anchor its
+ * long-TTL cache breakpoint on the most recent STABLE message instead).
+ *
+ * Default behavior (option unset) must remain unchanged — the field is omitted
+ * from `providerConfig` rather than carrying `undefined`/`false`, so the wire
+ * is byte-identical to today when the flag is off.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import { AgentLoop } from "../agent/loop.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+function toolUseResponse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id, name, input }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "tool_use",
+  };
+}
+
+function makeRecordingProvider(responses: ProviderResponse[]): {
+  provider: Provider;
+  configs: () => Array<Record<string, unknown> | undefined>;
+} {
+  const configs: Array<Record<string, unknown> | undefined> = [];
+  let i = 0;
+  const provider: Provider = {
+    name: "mock",
+    async sendMessage(
+      _messages: Message[],
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      configs.push(options?.config as Record<string, unknown> | undefined);
+      const response = responses[i] ?? responses[responses.length - 1];
+      i++;
+      return response;
+    },
+  };
+  return { provider, configs: () => configs };
+}
+
+describe("AgentLoop.run — mutableLatestUserMessage plumbing", () => {
+  test("forwards mutableLatestUserMessage=true to providerConfig on every LLM call (multi-turn)", async () => {
+    const { provider, configs } = makeRecordingProvider([
+      toolUseResponse("t1", "echo", { value: "first" }),
+      textResponse("done"),
+    ]);
+
+    const dummyTools: ToolDefinition[] = [
+      {
+        name: "echo",
+        description: "Echo back the input",
+        input_schema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+      },
+    ];
+
+    const toolExecutor = async () => ({ content: "ok", isError: false });
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { maxTokens: 1024 },
+      dummyTools,
+      toolExecutor,
+    );
+
+    await loop.run([userMessage], () => {}, {
+      callSite: "mainAgent",
+      mutableLatestUserMessage: true,
+    });
+
+    // Two sends — initial + one tool round-trip. Every send carries the flag.
+    expect(configs()).toHaveLength(2);
+    for (const cfg of configs()) {
+      expect(cfg?.mutableLatestUserMessage).toBe(true);
+    }
+  });
+
+  test("omits mutableLatestUserMessage when unset (default behavior unchanged)", async () => {
+    const { provider, configs } = makeRecordingProvider([textResponse("hi")]);
+    const loop = new AgentLoop(provider, "system", { maxTokens: 1024 });
+
+    await loop.run([userMessage], () => {});
+
+    expect(configs()).toHaveLength(1);
+    expect("mutableLatestUserMessage" in (configs()[0] ?? {})).toBe(false);
+  });
+
+  test("omits mutableLatestUserMessage when explicitly false (flag-off byte-identity)", async () => {
+    const { provider, configs } = makeRecordingProvider([textResponse("hi")]);
+    const loop = new AgentLoop(provider, "system", { maxTokens: 1024 });
+
+    await loop.run([userMessage], () => {}, {
+      callSite: "mainAgent",
+      mutableLatestUserMessage: false,
+    });
+
+    expect("mutableLatestUserMessage" in (configs()[0] ?? {})).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the memory-v3-live v2-suppression branch in
+ * `applyRuntimeInjections` (PR L6 of the memory-v3-live plan).
+ *
+ * When `suppressV2MemoryForV3` is on AND the v3 injector (id `memory-v3`,
+ * placement `after-memory-prefix`) actually produces a block, runtime
+ * assembly strips the v2 `<memory>` prefix from EVERY user message before
+ * splicing the v3 block — so v3 becomes the sole `<memory>` source and history
+ * is byte-stable for prompt caching.
+ *
+ * Keyed off whether v3 produced a block, NOT off the option alone: a v3
+ * failure (`produce()` → null) leaves v2's block intact (fallback-to-v2).
+ *
+ * The flag-off path must be byte-for-byte identical to today — that is the
+ * load-bearing regression guard.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getInjectors,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  InjectionBlock,
+  Injector,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type { Message } from "../providers/types.js";
+
+const { applyRuntimeInjections } =
+  await import("../daemon/conversation-runtime-assembly.js");
+
+function makeTurnContext(): TurnContext {
+  return {
+    requestId: "req-test-1",
+    conversationId: "conv-test-1",
+    turnIndex: 0,
+    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+  };
+}
+
+function wrapInPlugin(name: string, injectors: Injector[]): Plugin {
+  return { manifest: { name, version: "0.0.1" }, injectors };
+}
+
+/**
+ * A fake v3 injector that mirrors the real one's id + placement. The real
+ * injector's `renderMemoryBlock` already wraps its content in
+ * `<memory>\n…\n</memory>`, so the fake does too — `inner === null` means the
+ * injector produced nothing this turn (error/empty selection).
+ */
+function v3Injector(inner: string | null): Injector {
+  return {
+    name: "memory-v3-shadow",
+    order: 1000,
+    async produce(): Promise<InjectionBlock | null> {
+      if (inner === null) return null;
+      return {
+        id: "memory-v3",
+        text: `<memory>\n${inner}\n</memory>`,
+        placement: "after-memory-prefix",
+      };
+    },
+  };
+}
+
+/** Build a user message whose tail carries a v2 `<memory>` prefix block. */
+function userMsgWithV2Memory(memoryText: string, userText: string): Message {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: `<memory>\n${memoryText}\n</memory>` },
+      { type: "text", text: userText },
+    ],
+  };
+}
+
+/** Extract the tail user message's text blocks. */
+function tailTexts(messages: Message[]): string[] {
+  const tail = messages[messages.length - 1];
+  return tail.content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text);
+}
+
+describe("memory-v3-live v2 suppression", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("flag ON + v3 produced a block → v2 stripped from all turns, exactly one <memory> (the v3 block)", async () => {
+    registerPlugin(wrapInPlugin("v3", [v3Injector("v3 working set")]));
+
+    // History: a prior user turn that still carries a v2 block (rehydrated),
+    // plus the current tail user turn with its own v2 block.
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("old recalled fact", "earlier question"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "earlier answer" }],
+      },
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      suppressV2MemoryForV3: true,
+    });
+
+    // Exactly one <memory> source across the WHOLE assembled context.
+    const allTexts = result.messages.flatMap((m) =>
+      m.content
+        .filter((b): b is { type: "text"; text: string } => b.type === "text")
+        .map((b) => b.text),
+    );
+    const memoryBlocks = allTexts.filter((t) => t.startsWith("<memory>"));
+    expect(memoryBlocks).toHaveLength(1);
+    // And it is the v3 block, not a v2 one.
+    expect(memoryBlocks[0]).toBe("<memory>\nv3 working set\n</memory>");
+
+    // The historical user turn no longer carries its v2 block (all-turns strip).
+    const firstUser = result.messages[0];
+    expect(
+      firstUser.content.every(
+        (b) => !(b.type === "text" && b.text.startsWith("<memory>")),
+      ),
+    ).toBe(true);
+
+    // The v3 block lands at the head of the tail user message; original user
+    // text is preserved right after it.
+    const texts = tailTexts(result.messages);
+    expect(texts[0]).toBe("<memory>\nv3 working set\n</memory>");
+    expect(texts[1]).toBe("current question");
+    expect(texts).toHaveLength(2);
+  });
+
+  test("flag ON but v3 produced NOTHING → v2 block left intact (fallback-to-v2)", async () => {
+    registerPlugin(wrapInPlugin("v3", [v3Injector(null)]));
+
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      suppressV2MemoryForV3: true,
+    });
+
+    // v2's block survives — the turn still ships memory.
+    const texts = tailTexts(result.messages);
+    expect(texts[0]).toBe("<memory>\nfresh recalled fact\n</memory>");
+    expect(texts[1]).toBe("current question");
+    // No v3 block was added.
+    expect(texts).toHaveLength(2);
+  });
+
+  test("flag OFF → byte-for-byte identical to today even when v3 would have produced a block", async () => {
+    registerPlugin(wrapInPlugin("v3", [v3Injector("v3 working set")]));
+
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("old recalled fact", "earlier question"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "earlier answer" }],
+      },
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+
+    // With suppression off, the v3 injector still runs through the chain
+    // (after-memory-prefix), but NO v2 stripping happens. This captures the
+    // exact pre-flag assembly behavior: v2 prefix stays, v3 splices after it.
+    const offResult = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      suppressV2MemoryForV3: false,
+    });
+
+    // The tail keeps v2's block AND gains v3's (the historical double-injection
+    // the suppression PR exists to prevent) — proving suppression is the ONLY
+    // behavior change and it is fully gated off here.
+    const texts = tailTexts(offResult.messages);
+    expect(texts[0]).toBe("<memory>\nfresh recalled fact\n</memory>");
+    expect(texts[1]).toBe("<memory>\nv3 working set\n</memory>");
+    expect(texts[2]).toBe("current question");
+
+    // Historical user turn keeps its v2 block (no all-turns strip when off).
+    const firstUserTexts = offResult.messages[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+    expect(firstUserTexts[0]).toBe("<memory>\nold recalled fact\n</memory>");
+
+    // Strongest guard: omitting the option entirely yields the SAME result as
+    // passing it false — the default path is untouched by this PR.
+    resetPluginRegistryForTests();
+    registerPlugin(wrapInPlugin("v3", [v3Injector("v3 working set")]));
+    const defaultResult = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+    });
+    expect(defaultResult.messages).toEqual(offResult.messages);
+  });
+
+  test("no v3 injector registered + flag ON → no stripping, messages untouched", async () => {
+    // No injector named memory-v3 at all (e.g. plugin not loaded): the
+    // suppression branch keys off the produced block, so nothing is stripped.
+    expect(getInjectors()).toHaveLength(0);
+
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      suppressV2MemoryForV3: true,
+    });
+
+    expect(result.messages).toEqual(runMessages);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -405,6 +405,15 @@ export interface AgentLoopRunOptions {
   effectiveMaxInputTokens?: number;
   resolveOverrideProfile?: () => string | undefined;
   resolveEffectiveMaxInputTokens?: () => number | undefined;
+  /**
+   * When true, the latest user message carries a volatile per-turn block
+   * (e.g. a memory-v3 `<memory>` injection) that varies across otherwise
+   * identical turns. Forwarded to each `SendMessageOptions.config` so the
+   * provider anchors its long-TTL cache breakpoint on the most recent STABLE
+   * user message instead of the volatile latest one, keeping the cached
+   * prefix reusable. Default unset → existing behavior.
+   */
+  mutableLatestUserMessage?: boolean;
 }
 
 /**
@@ -525,6 +534,7 @@ export class AgentLoop {
       effectiveMaxInputTokens,
       resolveOverrideProfile,
       resolveEffectiveMaxInputTokens,
+      mutableLatestUserMessage,
     } = options ?? {};
     const history = [...messages];
     const initialHistoryLength = messages.length;
@@ -628,6 +638,15 @@ export class AgentLoop {
 
         if (this.config.cacheTtl) {
           providerConfig.cacheTtl = this.config.cacheTtl;
+        }
+
+        // Cache-anchor signal for volatile latest-user-message turns (e.g.
+        // memory-v3 injects its `<memory>` block into the latest user
+        // message). Not part of the call-site schema, so it is always sourced
+        // from the per-run option regardless of `callSite`. Only set when true
+        // so the wire/config stays byte-identical when off.
+        if (mutableLatestUserMessage) {
+          providerConfig.mutableLatestUserMessage = true;
         }
 
         // Per-call LLM call-site identifier. Surfaces on the per-call

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -26,6 +26,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   contextWindowConfigFromEffective,
   type EffectiveContextWindow,
@@ -1760,8 +1761,21 @@ export async function runAgentLoopImpl(
     // to the reduced `ctx.messages`.
     let reducerCompacted = compactedThisTurn;
 
+    // memory-v3-live: route the turn's `<memory>` block to the v3 injector.
+    // When on, runtime assembly suppresses v2's `<memory>` injection (only
+    // when the v3 injector actually produced a block — otherwise v2 stays as a
+    // fallback) and the provider anchors its long-TTL cache breakpoint on the
+    // most recent STABLE user message, since the latest user message now
+    // carries the volatile per-turn memory block. Flag off → bit-for-bit
+    // identical to today's v2 path.
+    const memoryV3Live = isAssistantFeatureFlagEnabled(
+      "memory-v3-live",
+      getConfig(),
+    );
+
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
+      suppressV2MemoryForV3: memoryV3Live,
       diskPressureContext,
       activeSurface,
       activeDocuments,
@@ -2296,6 +2310,10 @@ export async function runAgentLoopImpl(
         effectiveMaxInputTokens: resolveCurrentMaxInputTokens(),
         resolveOverrideProfile: resolveCurrentOverrideProfile,
         resolveEffectiveMaxInputTokens: resolveCurrentMaxInputTokens,
+        // memory-v3-live: the latest user message carries the volatile v3
+        // `<memory>` block, so anchor the provider's long-TTL cache breakpoint
+        // on the most recent stable message instead.
+        mutableLatestUserMessage: memoryV3Live,
       });
 
     let updatedHistory = await runAgentLoop(runMessages);

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -19,6 +19,7 @@ import {
 import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
+  stripAllMemoryInjections,
 } from "../memory/graph/conversation-graph-memory.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import {
@@ -2100,6 +2101,20 @@ export interface RuntimeInjectionOptions {
   activeDocuments?: TurnInjectionInputs["activeDocuments"];
   mode?: InjectionMode;
   /**
+   * memory-v3-live: when true AND the v3 injector produced a `<memory>` block
+   * this turn (placement `after-memory-prefix`, id `memory-v3`), the v2
+   * `<memory>` injection that `graphMemory.prepareMemory` prepended to the
+   * tail is stripped from EVERY user message before the v3 block is spliced —
+   * so v3 becomes the sole `<memory>` source and history stays byte-stable for
+   * prompt caching.
+   *
+   * The strip is keyed off whether v3 ACTUALLY produced a block, not off the
+   * flag alone: when v3 errors or selects nothing (its injector returns
+   * `null`), v2's block is left in place so the turn still ships memory rather
+   * than dropping it (fallback-to-v2). Default false — v2 untouched.
+   */
+  suppressV2MemoryForV3?: boolean;
+  /**
    * Per-turn {@link TurnContext} forwarded to plugin-registered
    * {@link Injector}s via {@link collectInjectorBlocks}. When omitted,
    * `applyRuntimeInjections` synthesizes an ephemeral context (with a
@@ -2308,7 +2323,26 @@ export async function applyRuntimeInjections(
       ? injectorChainPieces.join("\n\n")
       : undefined;
 
-  let result = runMessages;
+  // ── Step 0: memory-v3-live v2 suppression ──
+  // When v3 live mode is on AND the v3 injector actually produced a block this
+  // turn, v3 is the sole `<memory>` source. v2's `prepareMemory` already
+  // prepended its own `<memory>` block to the tail user message (and historical
+  // turns may carry v2 blocks from earlier turns). Strip every user message's
+  // memory prefix here so:
+  //   1. The v3 `after-memory-prefix` block (Step 2) lands at the top of the
+  //      tail with no v2 prefix ahead of it — exactly one `<memory>` block.
+  //   2. History is byte-stable across turns for prompt caching.
+  // Keyed off the v3 block being present (not the flag alone) so a v3 failure
+  // (`produce()` → null) leaves v2's block intact — fallback rather than a
+  // memory-less turn. Idempotent: re-injection sites that already stripped
+  // see no change.
+  const v3ProducedBlock = afterMemory.some((b) => b.id === "memory-v3");
+  let runMessagesForAssembly = runMessages;
+  if (options.suppressV2MemoryForV3 && v3ProducedBlock) {
+    runMessagesForAssembly = stripAllMemoryInjections(runMessages);
+  }
+
+  let result = runMessagesForAssembly;
 
   // ── Step 1: Slack chronological replacement (chain "replace" block) ──
   if (replaceBlock && replaceBlock.messagesOverride) {
@@ -2317,7 +2351,9 @@ export async function applyRuntimeInjections(
     // runtime assembly runs. The Slack transcript is freshly rendered
     // from persisted rows and has no such prefix, so swap it in and then
     // re-prepend the captured prefix onto the new tail user message.
-    const carriedMemoryBlocks = extractMemoryPrefixBlocks(runMessages);
+    const carriedMemoryBlocks = extractMemoryPrefixBlocks(
+      runMessagesForAssembly,
+    );
     result = replaceBlock.messagesOverride;
     if (carriedMemoryBlocks.length > 0) {
       const slackTail = result[result.length - 1];


### PR DESCRIPTION
## Summary
- When memory-v3-live is on: suppress v2's <memory> injection (v3 injector is the sole source), strip <memory> from all historical user messages (stripAllMemoryInjections), and set mutableLatestUserMessage on the mainAgent provider call so the cache anchor lands on the most recent stable message. Flag off → v2 path bit-for-bit identical.
- v3-failure fallback: suppression is keyed off whether the v3 injector ACTUALLY produced a block this turn (block id `memory-v3` in the after-memory-prefix slot), not off the flag alone. The v3 injector returns null on error/empty selection; in that case v2's already-injected <memory> block is left in place, so the turn still ships memory instead of dropping it. This is cleanly feasible because the v2 block is already on runMessages when applyRuntimeInjections runs the v3 injector, so a single atomic check inside assembly decides strip-vs-keep before splicing.

Part of plan: memory-v3-live.md (PR L6 of 7)