### PR TITLE
refactor(memory-v3): de-duplicate block id + memory marker, fix stale docs

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -22,6 +22,7 @@ import {
   stripAllMemoryInjections,
 } from "../memory/graph/conversation-graph-memory.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
+import { MEMORY_V3_BLOCK_ID } from "../memory/v3/types.js";
 import {
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
@@ -2336,7 +2337,7 @@ export async function applyRuntimeInjections(
   // (`produce()` → null) leaves v2's block intact — fallback rather than a
   // memory-less turn. Idempotent: re-injection sites that already stripped
   // see no change.
-  const v3ProducedBlock = afterMemory.some((b) => b.id === "memory-v3");
+  const v3ProducedBlock = afterMemory.some((b) => b.id === MEMORY_V3_BLOCK_ID);
   let runMessagesForAssembly = runMessages;
   if (options.suppressV2MemoryForV3 && v3ProducedBlock) {
     runMessagesForAssembly = stripAllMemoryInjections(runMessages);

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -22,6 +22,7 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import { getDb } from "../db-connection.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
+import { wrapMemoryBlock } from "../memory-marker.js";
 import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
@@ -922,8 +923,9 @@ function stripMemoryPrefixFromUserMessage(message: Message): Message {
  * user messages each turn: it keeps the prompt lean and makes history
  * byte-stable for prompt caching (v2 strips only the last user message — see
  * `stripExistingMemoryInjections`). Reuses the same per-message block
- * recognition as the last-message strip. Not wired into any live path yet — a
- * later PR calls it under the `memory-v3-live` flag.
+ * recognition as the last-message strip. Wired into the runtime-assembly
+ * suppression step (`conversation-runtime-assembly.ts`), which calls it when
+ * `memory-v3-live` is on and the v3 injector produced a block this turn.
  */
 export function stripAllMemoryInjections(messages: Message[]): Message[] {
   let changed = false;
@@ -964,7 +966,7 @@ function injectTextBlock(messages: Message[], text: string): Message[] {
       content: [
         {
           type: "text" as const,
-          text: `<memory>\n${text}\n</memory>`,
+          text: wrapMemoryBlock(text),
         },
         ...userTail.content,
       ],
@@ -1008,7 +1010,7 @@ function injectMemoryBlock(
 
   blocks.push({
     type: "text" as const,
-    text: `<memory>\n${text}\n</memory>`,
+    text: wrapMemoryBlock(text),
   });
 
   return [

--- a/assistant/src/memory/memory-marker.ts
+++ b/assistant/src/memory/memory-marker.ts
@@ -1,0 +1,17 @@
+/**
+ * The shared `<memory>…</memory>` injection marker.
+ *
+ * Both the v2 graph-memory producers (`conversation-graph-memory.ts`) and the
+ * v3 live renderer (`v3/render-injection.ts`) emit memory blocks with this
+ * exact wrapper, and the strip/recognition machinery in
+ * `conversation-graph-memory.ts` (`countMemoryPrefixBlocks`) matches the same
+ * `"<memory>\n"` / `"\n</memory>"` delimiters. Keeping the producer wrapper in
+ * one leaf module guarantees the byte-for-byte marker contract across v2 and
+ * v3 — a change here updates every producer at once.
+ *
+ * This is a tiny dependency-free leaf so the pure v3 renderer can import it
+ * without pulling in the heavyweight graph-memory module.
+ */
+export function wrapMemoryBlock(text: string): string {
+  return `<memory>\n${text}\n</memory>`;
+}

--- a/assistant/src/memory/v3/__tests__/render-injection.test.ts
+++ b/assistant/src/memory/v3/__tests__/render-injection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { wrapMemoryBlock } from "../../memory-marker.js";
 import { renderMemoryBlock } from "../render-injection.js";
 import { Slug } from "../types.js";
 
@@ -48,12 +49,13 @@ describe("renderMemoryBlock", () => {
     expect(reversed).toBe("<memory>\nC\nB\nA\n</memory>");
   });
 
-  test("reuses the marker the v2 stripper recognizes", async () => {
+  test("emits the shared wrapMemoryBlock marker the v2 stripper recognizes", async () => {
     const block = await renderMemoryBlock(
       ["page-a"],
       resolver({ "page-a": "x" }),
     );
-    expect(block.startsWith("<memory>\n")).toBe(true);
-    expect(block.endsWith("\n</memory>")).toBe(true);
+    // Guard the v2/v3 marker contract: the rendered block must be byte-identical
+    // to wrapping the joined content with the shared helper.
+    expect(block).toBe(wrapMemoryBlock("x"));
   });
 });

--- a/assistant/src/memory/v3/render-injection.ts
+++ b/assistant/src/memory/v3/render-injection.ts
@@ -1,3 +1,4 @@
+import { wrapMemoryBlock } from "../memory-marker.js";
 import { Slug } from "./types.js";
 
 /**
@@ -6,8 +7,8 @@ import { Slug } from "./types.js";
  *
  * Pure and side-effect-free: all I/O is delegated to the injected
  * `pageContent` resolver, which is awaited once per slug in input order. The
- * resulting block reuses the same `<memory>\n…\n</memory>` marker that the v2
- * graph-memory path emits, so the existing strip machinery in
+ * resulting block uses the shared {@link wrapMemoryBlock} marker — the same
+ * wrapper the v2 graph-memory path emits — so the existing strip machinery in
  * `conversation-graph-memory.ts` already recognizes (and evicts) it.
  *
  * Resolution is concurrent; the rendered block preserves `finalInjection`
@@ -27,5 +28,5 @@ export async function renderMemoryBlock(
 
   const contents = await Promise.all(finalInjection.map(pageContent));
 
-  return `<memory>\n${contents.join("\n")}\n</memory>`;
+  return wrapMemoryBlock(contents.join("\n"));
 }

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -24,9 +24,9 @@
  *
  * Everything after the flag read is wrapped in try/catch — any failure is
  * logged and swallowed so it can never affect the live turn. In live mode a
- * failure returns `null` (no v3 injection); v2 suppression (a later PR) keys
- * off the FLAG, not off whether `produce()` returned a block, so a v3 failure
- * falls back to v2 memory rather than dropping all memory.
+ * failure returns `null` (no v3 injection); v2 suppression keys off BOTH the
+ * flag AND whether `produce()` actually returned a block, so a v3 failure (or
+ * empty selection) falls back to v2 memory rather than dropping all memory.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -54,12 +54,13 @@ import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
 import { renderMemoryBlock } from "./render-injection.js";
 import { coreSlugs, loadLeafTree, resolveDataDir } from "./tree.js";
-import type {
-  LeafPath,
-  LeafTree,
-  SelectionSource,
-  Slug,
-  TurnContext,
+import {
+  type LeafPath,
+  type LeafTree,
+  MEMORY_V3_BLOCK_ID,
+  type SelectionSource,
+  type Slug,
+  type TurnContext,
 } from "./types.js";
 import { WorkingSet } from "./working-set.js";
 
@@ -293,9 +294,12 @@ async function observeTurn(
 }
 
 /**
- * Core shadow observation: run v3 orchestration for one turn and log the
- * selection set. Exported for unit testing. Never throws — all failures are
- * logged and swallowed so the live turn is unaffected.
+ * Test-facing shadow wrapper: gate on the shadow flag, then run v3
+ * orchestration for one turn and log the selection set. Production injection
+ * goes through `produce()` → {@link observeTurn} directly (which checks both
+ * flags); this wrapper exists so tests can drive shadow observation in
+ * isolation. Never throws — all failures are logged and swallowed so the live
+ * turn is unaffected.
  */
 export async function runShadowObservation(
   conversationId: string,
@@ -313,8 +317,9 @@ export async function runShadowObservation(
  *   - both off → return `null` (no orchestration).
  *
  * Empty selection and any failure return `null` (no v3 injection). v2
- * suppression (a later PR) keys off the FLAG, not off this return value, so a
- * v3 failure falls back to v2 memory rather than dropping all memory.
+ * suppression keys off BOTH the flag AND this return value, so a `null` here
+ * (failure or empty selection) falls back to v2 memory rather than dropping all
+ * memory.
  */
 const memoryV3Injector: Injector = {
   name: "memory-v3-shadow",
@@ -336,7 +341,7 @@ const memoryV3Injector: Injector = {
       const text = await renderMemoryBlock(result.finalInjection, pageContent);
       if (text.length === 0) return null;
       return {
-        id: "memory-v3",
+        id: MEMORY_V3_BLOCK_ID,
         text,
         // Mirror v2's dynamic `<memory>` block placement.
         placement: "after-memory-prefix",

--- a/assistant/src/memory/v3/types.ts
+++ b/assistant/src/memory/v3/types.ts
@@ -1,6 +1,16 @@
 export type LeafPath = string; // dot- or slash-pathed taxonomy node
 export type Slug = string;
 
+/**
+ * Injection-block id for the v3 live `<memory>` block. Shared between the
+ * producer (the v3 injector in `shadow-plugin.ts`) and the v2-suppression
+ * consumer (`conversation-runtime-assembly.ts`), which keys off this id to
+ * detect that v3 actually produced a block this turn. Keeping it in one place
+ * makes a rename a compile error on both sides instead of a silent
+ * suppression bypass.
+ */
+export const MEMORY_V3_BLOCK_ID = "memory-v3" as const;
+
 export interface LeafFrontmatter {
   path: LeafPath;
   in_core: boolean;


### PR DESCRIPTION
## Summary
Behavior-preserving cleanups from plan review (v2 path byte-identical, flag default-off):
- Couple the 'memory-v3' injector block id via a shared MEMORY_V3_BLOCK_ID const used by both the producer (shadow-plugin) and the v2-suppression consumer (runtime-assembly), so a rename can't silently break suppression.
- Extract a shared wrapMemoryBlock helper for the <memory> marker, used by v2's two producer sites and v3's renderMemoryBlock (output byte-identical) to enforce the marker contract.
- Drop the redundant render-injection marker test (subsumed by exact-equality) / repoint it at the shared helper.
- Refresh stale docstrings (v2-suppression keys off flag+block; stripAllMemoryInjections is now wired).

Gaps found during plan review for memory-v3-live.md.