### PR TITLE
feat(assistant): native audio input for Gemini models

### DIFF
--- a/assistant/src/__tests__/gemini-inline-media.test.ts
+++ b/assistant/src/__tests__/gemini-inline-media.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  base64ByteLength,
+  estimateGeminiAudioTokens,
+  GEMINI_MAX_INLINE_AUDIO_BYTES,
+  normalizeGeminiAudioMime,
+} from "../providers/gemini/inline-media.js";
+
+describe("normalizeGeminiAudioMime", () => {
+  test("maps audio/mpeg onto Gemini's audio/mp3 spelling", () => {
+    expect(normalizeGeminiAudioMime("audio/mpeg")).toBe("audio/mp3");
+  });
+
+  test("passes supported audio types through unchanged", () => {
+    for (const mime of [
+      "audio/wav",
+      "audio/mp3",
+      "audio/aiff",
+      "audio/aac",
+      "audio/ogg",
+      "audio/flac",
+    ]) {
+      expect(normalizeGeminiAudioMime(mime)).toBe(mime);
+    }
+  });
+
+  test("is case-insensitive and strips parameters", () => {
+    expect(normalizeGeminiAudioMime("AUDIO/MPEG")).toBe("audio/mp3");
+    expect(normalizeGeminiAudioMime("audio/ogg; codecs=opus")).toBe(
+      "audio/ogg",
+    );
+  });
+
+  test("returns null for types Gemini cannot take inline", () => {
+    for (const mime of [
+      "audio/x-m4a",
+      "audio/mp4",
+      "audio/opus",
+      "application/pdf",
+      "image/png",
+      "",
+    ]) {
+      expect(normalizeGeminiAudioMime(mime)).toBeNull();
+    }
+  });
+});
+
+describe("base64ByteLength", () => {
+  test("approximates raw bytes from base64 length", () => {
+    // 8 base64 chars → 6 raw bytes
+    expect(base64ByteLength("QUJDREVG")).toBe(6);
+    expect(base64ByteLength("")).toBe(0);
+  });
+});
+
+describe("estimateGeminiAudioTokens", () => {
+  test("scales with payload size and stays far below the base64-as-text count", () => {
+    // ~3 MB of base64 ≈ ~2.25 MB raw ≈ ~140s at 16 KB/s ≈ ~4.5k tokens.
+    const data = "A".repeat(3 * 1024 * 1024);
+    const tokens = estimateGeminiAudioTokens(data);
+    expect(tokens).toBeGreaterThan(1_000);
+    // Must be a small fraction of the naive base64-length/4 estimate (~786k).
+    expect(tokens).toBeLessThan(data.length / 40);
+  });
+
+  test("returns zero for empty data", () => {
+    expect(estimateGeminiAudioTokens("")).toBe(0);
+  });
+});
+
+test("inline audio cap leaves headroom under Gemini's 20 MB request limit", () => {
+  expect(GEMINI_MAX_INLINE_AUDIO_BYTES).toBe(12 * 1024 * 1024);
+  // Base64 of the cap (~16 MB) must stay under the 20 MB wire limit.
+  expect(GEMINI_MAX_INLINE_AUDIO_BYTES * (4 / 3)).toBeLessThan(
+    20 * 1024 * 1024,
+  );
+});

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -866,6 +866,127 @@ describe("GeminiProvider", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Audio content (native Gemini audio input)
+  // -----------------------------------------------------------------------
+  test("sends audio file blocks inline, normalizing audio/mpeg → audio/mp3", async () => {
+    fakeChunks = [textChunk("I hear a bell"), finishChunk("STOP", 100, 5)];
+
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What do you hear?" },
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "audio/mpeg",
+              data: "QUJDREVG",
+              filename: "clip.mp3",
+            },
+          },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{
+      role: string;
+      parts: unknown[];
+    }>;
+    expect(contents[0].parts).toHaveLength(2);
+    expect(contents[0].parts[1]).toEqual({
+      inlineData: { mimeType: "audio/mp3", data: "QUJDREVG" },
+    });
+  });
+
+  test("sends supported audio types inline unchanged", async () => {
+    for (const mime of ["audio/wav", "audio/ogg", "audio/flac", "audio/aac"]) {
+      fakeChunks = [textChunk("ok"), finishChunk("STOP", 10, 2)];
+      await provider.sendMessage([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              source: {
+                type: "base64",
+                media_type: mime,
+                data: "QUJDREVG",
+                filename: `clip.${mime.split("/")[1]}`,
+              },
+            },
+          ],
+        },
+      ]);
+      const contents = lastStreamParams!.contents as Array<{
+        parts: unknown[];
+      }>;
+      expect(contents[0].parts[0]).toEqual({
+        inlineData: { mimeType: mime, data: "QUJDREVG" },
+      });
+    }
+  });
+
+  test("degrades unsupported audio (m4a/mp4) to a text placeholder", async () => {
+    for (const mime of ["audio/x-m4a", "audio/mp4"]) {
+      fakeChunks = [textChunk("ok"), finishChunk("STOP", 10, 2)];
+      await provider.sendMessage([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              source: {
+                type: "base64",
+                media_type: mime,
+                data: "QUJDREVG",
+                filename: "memo.m4a",
+              },
+            },
+          ],
+        },
+      ]);
+      const parts = (
+        lastStreamParams!.contents as Array<{ parts: unknown[] }>
+      )[0].parts;
+      expect(parts[0]).toHaveProperty("text");
+      expect(parts[0]).not.toHaveProperty("inlineData");
+      expect((parts[0] as { text: string }).text).toContain("memo.m4a");
+    }
+  });
+
+  test("degrades oversize inline audio to a text placeholder", async () => {
+    fakeChunks = [textChunk("ok"), finishChunk("STOP", 10, 2)];
+    // base64 length * 3/4 must exceed the 12 MB inline cap.
+    const oversize = "A".repeat(17_000_000);
+
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "audio/mpeg",
+              data: oversize,
+              filename: "long.mp3",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const parts = (lastStreamParams!.contents as Array<{ parts: unknown[] }>)[0]
+      .parts;
+    expect(parts[0]).not.toHaveProperty("inlineData");
+    expect((parts[0] as { text: string }).text).toContain("too large");
+    expect((parts[0] as { text: string }).text).toContain("long.mp3");
+  });
+
+  // -----------------------------------------------------------------------
   // max_tokens config
   // -----------------------------------------------------------------------
   test("passes max_tokens as maxOutputTokens", async () => {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -1,3 +1,7 @@
+import {
+  estimateGeminiAudioTokens,
+  normalizeGeminiAudioMime,
+} from "../providers/gemini/inline-media.js";
 import type {
   ContentBlock,
   Message,
@@ -114,6 +118,16 @@ function estimateFileDataTokens(
     block.source.media_type === "application/pdf"
   ) {
     return estimateAnthropicPdfTokens(block.source.data);
+  }
+
+  // Gemini hears audio natively (inline base64) but bills it at ~32 tokens/sec.
+  // Estimate from duration, not payload size, to avoid a ~170x over-count that
+  // would trigger spurious compaction.
+  if (
+    providerName === "gemini" &&
+    normalizeGeminiAudioMime(block.source.media_type) !== null
+  ) {
+    return estimateGeminiAudioTokens(block.source.data);
   }
 
   // Gemini sends certain file types inline as base64

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -17,6 +17,11 @@ import {
   ContextOverflowError,
   extractOverflowTokensFromMessage,
 } from "../types.js";
+import {
+  base64ByteLength,
+  GEMINI_MAX_INLINE_AUDIO_BYTES,
+  normalizeGeminiAudioMime,
+} from "./inline-media.js";
 
 /**
  * Token/context-specific phrases that reliably indicate context-overflow
@@ -496,14 +501,27 @@ export class GeminiProvider implements Provider {
             },
           });
           break;
-        case "file":
+        case "file": {
           if (this.supportsGeminiInlineFile(block.source.media_type)) {
-            parts.push({
-              inlineData: {
-                mimeType: block.source.media_type,
-                data: block.source.data,
-              },
-            });
+            // Normalize audio MIME onto Gemini's spelling (e.g. audio/mpeg →
+            // audio/mp3); PDFs pass through unchanged. Guard the 20 MB inline
+            // request limit for audio so an oversize clip degrades to a text
+            // note rather than 400ing the whole request.
+            const audioMime = normalizeGeminiAudioMime(block.source.media_type);
+            const rawBytes = base64ByteLength(block.source.data);
+            if (audioMime && rawBytes > GEMINI_MAX_INLINE_AUDIO_BYTES) {
+              const approxMb = Math.round(rawBytes / (1024 * 1024));
+              parts.push({
+                text: `[Audio file too large to send inline: ${block.source.filename} (${block.source.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
+              });
+            } else {
+              parts.push({
+                inlineData: {
+                  mimeType: audioMime ?? block.source.media_type,
+                  data: block.source.data,
+                },
+              });
+            }
           } else {
             const fallback = block.extracted_text?.trim()
               ? `[Attached file: ${block.source.filename} (${block.source.media_type})]\n${block.extracted_text}`
@@ -511,6 +529,7 @@ export class GeminiProvider implements Provider {
             parts.push({ text: fallback });
           }
           break;
+        }
         case "tool_use":
           {
             const functionCallPart: genai.Part = {
@@ -598,6 +617,9 @@ export class GeminiProvider implements Provider {
   }
 
   private supportsGeminiInlineFile(mimeType: string): boolean {
-    return mimeType === "application/pdf";
+    return (
+      mimeType === "application/pdf" ||
+      normalizeGeminiAudioMime(mimeType) !== null
+    );
   }
 }

--- a/assistant/src/providers/gemini/inline-media.ts
+++ b/assistant/src/providers/gemini/inline-media.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared source of truth for how Gemini ingests inline audio: which MIME types
+ * it accepts, how our stored MIME types normalize onto Gemini's spelling, the
+ * inline-request size ceiling, and the token cost.
+ *
+ * Imported by both the Gemini serializer (`client.ts`) and the token estimator
+ * (`context/token-estimator.ts`) so the two cannot drift — if they disagreed on
+ * which audio is sent inline, the context budgeter would mis-count what
+ * actually goes on the wire.
+ *
+ * Ref: https://ai.google.dev/gemini-api/docs/audio
+ *   - Inline-accepted audio: wav, mp3, aiff, aac, ogg, flac
+ *   - Inline request size limit: 20 MB total (prompt + system + inline files)
+ *   - Audio is billed at ~32 tokens/second
+ */
+
+/**
+ * Audio MIME types Gemini accepts as inline data, in Gemini's own spelling
+ * (the values we emit on the wire). Our upload allowlist stores mp3 as
+ * `audio/mpeg`; {@link normalizeGeminiAudioMime} maps that onto `audio/mp3`.
+ */
+export const GEMINI_INLINE_AUDIO_MIME_TYPES = new Set([
+  "audio/wav",
+  "audio/mp3",
+  "audio/aiff",
+  "audio/aac",
+  "audio/ogg",
+  "audio/flac",
+]);
+
+/**
+ * Map a stored attachment MIME type onto Gemini's inline-audio spelling, or
+ * `null` when Gemini cannot take it inline.
+ *
+ * m4a (`audio/x-m4a`, `audio/mp4`) and opus are intentionally unsupported:
+ * m4a bytes are an MP4 container, not raw AAC, so we must not relabel them as
+ * `audio/aac` — they fall through to a text placeholder instead.
+ */
+export function normalizeGeminiAudioMime(mimeType: string): string | null {
+  const normalized = mimeType.toLowerCase().split(";")[0]?.trim() ?? "";
+  const remapped = normalized === "audio/mpeg" ? "audio/mp3" : normalized;
+  return GEMINI_INLINE_AUDIO_MIME_TYPES.has(remapped) ? remapped : null;
+}
+
+/** Raw byte length backing a base64 string (4 base64 chars → 3 bytes). */
+export function base64ByteLength(base64Data: string): number {
+  return Math.floor((base64Data.length * 3) / 4);
+}
+
+/**
+ * Max raw bytes of audio we send inline to Gemini. Gemini's total inline
+ * request limit is 20 MB and base64 inflates payloads ~33%, so we cap raw
+ * audio at ~12 MB (≈16 MB encoded) to leave headroom for the prompt, system
+ * instruction, and conversation history. Larger files degrade to a text
+ * placeholder (the Gemini Files API is a future enhancement).
+ */
+export const GEMINI_MAX_INLINE_AUDIO_BYTES = 12 * 1024 * 1024;
+
+/**
+ * Gemini bills audio at ~32 tokens/second, NOT by payload size. We don't have
+ * the decoded duration at estimate time, so approximate it from byte size
+ * assuming ~128 kbps (~16 KB/s) typical compressed audio. This keeps the
+ * context budgeter within range instead of the ~170x over-count that treating
+ * the base64 payload as text produces. (Uncompressed WAV is under-counted, but
+ * the inline size guard caps it at {@link GEMINI_MAX_INLINE_AUDIO_BYTES}.)
+ */
+const GEMINI_AUDIO_TOKENS_PER_SECOND = 32;
+const APPROX_AUDIO_BYTES_PER_SECOND = 16_000;
+
+export function estimateGeminiAudioTokens(base64Data: string): number {
+  const approxSeconds =
+    base64ByteLength(base64Data) / APPROX_AUDIO_BYTES_PER_SECOND;
+  return Math.ceil(approxSeconds * GEMINI_AUDIO_TOKENS_PER_SECOND);
+}


### PR DESCRIPTION
## Summary
- Route Gemini-supported audio attachments (mp3/wav/ogg/flac/aac) through the inline-data path Gemini already uses for PDFs, so Gemini can natively *hear* attached audio instead of receiving a `[Attached file: …]` text placeholder. The only gate dropping audio was `supportsGeminiInlineFile()` returning true for PDFs only.
- Add MIME normalization (`audio/mpeg` → `audio/mp3`), a ~12 MB inline size guard (oversize clips degrade to a text note rather than 400ing Gemini's 20 MB request limit), and a Gemini token estimate based on its ~32 tokens/sec audio billing instead of base64 length — the latter avoids a ~170× over-count that would trigger spurious compaction on every Gemini request carrying audio.
- New shared `providers/gemini/inline-media.ts` is the single source of truth for the audio MIME set / normalization / sizing, imported by both the serializer (`client.ts`) and the token estimator so they cannot drift. The mapping is aligned with the codebase's canonical audio MIME types (migration 191). Non-Gemini providers continue to degrade audio gracefully; m4a/opus (not in Gemini's inline set) degrade to a placeholder. No new content-block type, no DB migration.

## Original prompt
Asked whether we support sending audio files to models with native audio input (e.g. Gemini), and if not, to add it the same way images work. Investigation showed audio already uploads and flows end-to-end as a generic `file` block but was dropped at Gemini's PDF-only inline gate. We chose to extend the existing file-inline path rather than add a dedicated `audio` content block (minimal blast radius vs. ~12 files and a silent-drop hazard), and to degrade gracefully on non-Gemini models without a capability gate for v1.

## Test plan
- New `gemini-inline-media.test.ts` covers the pure helpers (mpeg→mp3 normalization, supported passthrough, m4a/opus/mp4 → null, byte-length, ~32 tok/sec estimate, size-cap headroom).
- New audio cases in `gemini-provider.test.ts` assert the serializer: `audio/mpeg` → `inlineData{audio/mp3}`, supported types passthrough, m4a/mp4 degrade to a text placeholder, oversize audio degrades to a "too large" note.
- `bun test` (gemini + token-estimator suites) green; `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)