### PR TITLE
feat(assistant): embed audio read by file_read/host_file_read so Gemini can hear it

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -126,6 +126,40 @@ describe("token estimator", () => {
     expect(largeFileTokens - smallFileTokens).toBeGreaterThan(1000);
   });
 
+  test("counts nested audio file blocks in a tool_result for Gemini", () => {
+    const audioBlock = {
+      type: "file" as const,
+      source: {
+        type: "base64" as const,
+        filename: "clip.mp3",
+        media_type: "audio/mpeg",
+        data: "a".repeat(400_000), // ~300 KB raw → ~18s → ~600 audio tokens
+      },
+    };
+    const base = {
+      type: "tool_result" as const,
+      tool_use_id: "t1",
+      content: "Audio loaded",
+      is_error: false,
+    };
+
+    const geminiDelta =
+      estimateContentBlockTokens(
+        { ...base, contentBlocks: [audioBlock] },
+        { providerName: "gemini" },
+      ) - estimateContentBlockTokens(base, { providerName: "gemini" });
+    const openaiDelta =
+      estimateContentBlockTokens(
+        { ...base, contentBlocks: [audioBlock] },
+        { providerName: "openai" },
+      ) - estimateContentBlockTokens(base, { providerName: "openai" });
+
+    // Gemini hears the audio (charged ~32 tok/sec); other providers drop it,
+    // so only Gemini accrues the payload-scaled cost.
+    expect(geminiDelta).toBeGreaterThan(500);
+    expect(geminiDelta).toBeGreaterThan(openaiDelta + 400);
+  });
+
   test("does not count file base64 payload for OpenAI-style file fallback", () => {
     const sharedSource = {
       type: "base64" as const,

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -648,6 +648,91 @@ describe("GeminiProvider", () => {
     });
   });
 
+  function toolResultWithAudio(mediaType: string, data: string): Message[] {
+    return [
+      { role: "user", content: [{ type: "text", text: "Read clip" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_audio",
+            name: "file_read",
+            input: { path: "/tmp/clip" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_audio",
+            content: "Audio loaded: /tmp/clip",
+            is_error: false,
+            contentBlocks: [
+              {
+                type: "file",
+                source: {
+                  type: "base64",
+                  media_type: mediaType,
+                  data,
+                  filename: "clip",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+  }
+
+  test("sends tool_result audio as a separate inlineData Content (audio/mpeg → audio/mp3)", async () => {
+    fakeChunks = [textChunk("I hear a bell"), finishChunk("STOP", 20, 10)];
+
+    await provider.sendMessage(toolResultWithAudio("audio/mpeg", "QUJDREVG"));
+
+    const contents = lastStreamParams!.contents as Array<{
+      role: string;
+      parts: Array<Record<string, unknown>>;
+    }>;
+    // user, model(functionCall), user(functionResponse), user(audio inlineData)
+    expect(contents).toHaveLength(4);
+    expect(contents[2].parts[0]).toMatchObject({
+      functionResponse: { name: "file_read" },
+    });
+    // Audio must NOT be mixed into the functionResponse Content.
+    expect(contents[2].parts.some((p) => "inlineData" in p)).toBe(false);
+    expect(contents[3].role).toBe("user");
+    expect(contents[3].parts[0]).toEqual({
+      inlineData: { mimeType: "audio/mp3", data: "QUJDREVG" },
+    });
+  });
+
+  test("drops unsupported tool_result audio (m4a) — no extra Content", async () => {
+    fakeChunks = [textChunk("ok"), finishChunk("STOP", 10, 2)];
+
+    await provider.sendMessage(toolResultWithAudio("audio/x-m4a", "QUJDREVG"));
+
+    const contents = lastStreamParams!.contents as Array<{ parts: unknown[] }>;
+    expect(contents).toHaveLength(3); // no separate media Content
+  });
+
+  test("degrades oversize tool_result audio into the functionResponse output", async () => {
+    fakeChunks = [textChunk("ok"), finishChunk("STOP", 10, 2)];
+    const oversize = "A".repeat(17_000_000); // > 12 MB raw
+
+    await provider.sendMessage(toolResultWithAudio("audio/mpeg", oversize));
+
+    const contents = lastStreamParams!.contents as Array<{
+      parts: Array<{ functionResponse?: { response: { output: string } } }>;
+    }>;
+    expect(contents).toHaveLength(3); // no inlineData Content
+    expect(contents[2].parts[0].functionResponse?.response.output).toContain(
+      "too large",
+    );
+  });
+
   test("replays Gemini thought signatures on serialized tool_use history", async () => {
     fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
 

--- a/assistant/src/__tests__/tools-audio-read.test.ts
+++ b/assistant/src/__tests__/tools-audio-read.test.ts
@@ -1,0 +1,113 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  AUDIO_EXTENSIONS,
+  readAudioFile,
+} from "../tools/shared/filesystem/audio-read.js";
+
+let dir: string;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "audio-read-"));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("readAudioFile", () => {
+  test("reads an mp3 into a base64 file block with audio/mpeg", () => {
+    const p = join(dir, "clip.mp3");
+    const bytes = Buffer.from("fake-audio-bytes");
+    writeFileSync(p, bytes);
+
+    const result = readAudioFile(p);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Audio loaded");
+    expect(result.contentBlocks).toEqual([
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "audio/mpeg",
+          data: bytes.toString("base64"),
+          filename: "clip.mp3",
+        },
+      },
+    ]);
+  });
+
+  test("maps each extension to the canonical MIME (matches migration 191)", () => {
+    const cases: Record<string, string> = {
+      "a.mp3": "audio/mpeg",
+      "a.wav": "audio/wav",
+      "a.ogg": "audio/ogg",
+      "a.flac": "audio/flac",
+      "a.aac": "audio/aac",
+      "a.m4a": "audio/x-m4a",
+      "a.opus": "audio/opus",
+    };
+    for (const [name, mime] of Object.entries(cases)) {
+      const p = join(dir, name);
+      writeFileSync(p, Buffer.from("x"));
+      const result = readAudioFile(p);
+      expect(result.isError).toBe(false);
+      const block = result.contentBlocks?.[0] as {
+        source: { media_type: string };
+      };
+      expect(block.source.media_type).toBe(mime);
+    }
+  });
+
+  test("rejects audio larger than the 12 MB inline cap", () => {
+    const p = join(dir, "big.mp3");
+    writeFileSync(p, "");
+    truncateSync(p, 13 * 1024 * 1024); // sparse — no 13 MB allocation
+
+    const result = readAudioFile(p);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("too large");
+    expect(result.contentBlocks).toBeUndefined();
+  });
+
+  test("errors on a missing file", () => {
+    const result = readAudioFile(join(dir, "nope.mp3"));
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not found");
+  });
+
+  test("errors when the path is a directory", () => {
+    const p = join(dir, "adir.mp3");
+    mkdirSync(p);
+    const result = readAudioFile(p);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not a file");
+  });
+});
+
+describe("AUDIO_EXTENSIONS", () => {
+  test("covers the supported set and excludes non-audio", () => {
+    for (const ext of [
+      ".mp3",
+      ".wav",
+      ".ogg",
+      ".flac",
+      ".aac",
+      ".m4a",
+      ".opus",
+    ]) {
+      expect(AUDIO_EXTENSIONS.has(ext)).toBe(true);
+    }
+    expect(AUDIO_EXTENSIONS.has(".txt")).toBe(false);
+    expect(AUDIO_EXTENSIONS.has(".png")).toBe(false);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -724,7 +724,7 @@ export class AgentLoop {
         // Also strip old AX tree snapshots to keep TTFT from growing
         // linearly with step count in computer-use sessions.
         const providerHistory = compactAxTreeHistory(
-          stripOldImageBlocks(history),
+          stripOldMediaBlocks(history),
         );
 
         // Wrap the provider call in the `llmCall` pipeline so middleware
@@ -1539,7 +1539,7 @@ export function compactAxTreeHistory(messages: Message[]): Message[] {
  * turn. Using the last user message unconditionally would leave the most
  * recent tool screenshots unprotected from stripping.
  */
-function stripOldImageBlocks(history: Message[]): Message[] {
+function stripOldMediaBlocks(history: Message[]): Message[] {
   // Find the last user message that contains tool_result blocks.
   let lastToolResultUserIdx = -1;
   for (let i = history.length - 1; i >= 0; i--) {
@@ -1556,29 +1556,32 @@ function stripOldImageBlocks(history: Message[]): Message[] {
     // Keep the most recent tool-result user message intact (current turn)
     if (idx === lastToolResultUserIdx || msg.role !== "user") return msg;
 
-    // Check if any tool_result blocks have image contentBlocks
-    const hasImages = msg.content.some(
+    // Check if any tool_result blocks carry embedded media (image or audio).
+    const isMedia = (cb: ContentBlock) =>
+      cb.type === "image" || cb.type === "file";
+    const hasMedia = msg.content.some(
       (b) =>
         b.type === "tool_result" &&
-        (b as ToolResultContent).contentBlocks?.some(
-          (cb) => cb.type === "image",
-        ),
+        (b as ToolResultContent).contentBlocks?.some(isMedia),
     );
-    if (!hasImages) return msg;
+    if (!hasMedia) return msg;
 
-    // Strip images from tool_result blocks, replacing with text marker
+    // Strip media from tool_result blocks, replacing with a text marker. The
+    // model already saw/heard the media in the turn it was captured; resending
+    // the bytes every turn (a 12 MB audio clip isn't optimized like images)
+    // bloats the request until compaction.
     return {
       ...msg,
       content: msg.content.map((b) => {
         if (b.type !== "tool_result") return b;
         const tr = b as ToolResultContent;
-        if (!tr.contentBlocks?.some((cb) => cb.type === "image")) return b;
+        if (!tr.contentBlocks?.some(isMedia)) return b;
         return {
           ...tr,
           contentBlocks: undefined,
           content:
             (tr.content || "") +
-            "\n[Screenshot was captured and shown previously — image data removed to save context.]",
+            "\n[Media (image/audio) was captured and shown previously — binary data removed to save context.]",
         };
       }),
     };

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -239,6 +239,11 @@ export function estimateContentBlockTokens(
             tokens += estimateContentBlockTokens(cb, options);
           } else if (cb.type === "image" && !anthropicDropsErrorImage) {
             tokens += estimateContentBlockTokens(cb, options);
+          } else if (cb.type === "file") {
+            // Audio file sub-blocks (e.g. file_read on an .mp3) are sent inline
+            // to Gemini; estimateFileDataTokens charges the ~32 tok/sec audio
+            // rate for Gemini and ~0 for providers that drop the block.
+            tokens += estimateContentBlockTokens(cb, options);
           }
         }
       }

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -458,7 +458,7 @@ export class GeminiProvider implements Provider {
 
     for (const msg of messages) {
       const role = msg.role === "assistant" ? "model" : "user";
-      const { parts, toolResultImageParts } = this.toGeminiParts(
+      const { parts, toolResultMediaParts } = this.toGeminiParts(
         msg.content,
         toolCallNames,
         model,
@@ -470,8 +470,8 @@ export class GeminiProvider implements Provider {
       // Gemini requires that a Content with functionResponse parts must not
       // contain non-functionResponse parts. Emit tool-result images in a
       // separate user Content entry.
-      if (toolResultImageParts.length > 0) {
-        result.push({ role: "user", parts: toolResultImageParts });
+      if (toolResultMediaParts.length > 0) {
+        result.push({ role: "user", parts: toolResultMediaParts });
       }
     }
 
@@ -484,9 +484,9 @@ export class GeminiProvider implements Provider {
     toolCallNames: Map<string, string>,
     model: string,
     role: "model" | "user",
-  ): { parts: genai.Part[]; toolResultImageParts: genai.Part[] } {
+  ): { parts: genai.Part[]; toolResultMediaParts: genai.Part[] } {
     const parts: genai.Part[] = [];
-    const toolResultImageParts: genai.Part[] = [];
+    const toolResultMediaParts: genai.Part[] = [];
 
     for (const block of blocks) {
       switch (block.type) {
@@ -558,16 +558,39 @@ export class GeminiProvider implements Provider {
             if (extraText.length > 0) {
               outputText = outputText + "\n" + extraText.join("\n");
             }
-            // Collect images separately — Gemini rejects mixing inlineData
-            // with functionResponse in the same Content entry.
+            // Collect images and inline-able audio separately — Gemini rejects
+            // mixing inlineData with functionResponse in the same Content entry.
             for (const cb of block.contentBlocks) {
               if (cb.type === "image") {
-                toolResultImageParts.push({
+                toolResultMediaParts.push({
                   inlineData: {
                     mimeType: cb.source.media_type,
                     data: cb.source.data,
                   },
                 });
+              } else if (cb.type === "file") {
+                const audioMime = normalizeGeminiAudioMime(
+                  cb.source.media_type,
+                );
+                if (
+                  audioMime &&
+                  base64ByteLength(cb.source.data) <=
+                    GEMINI_MAX_INLINE_AUDIO_BYTES
+                ) {
+                  toolResultMediaParts.push({
+                    inlineData: { mimeType: audioMime, data: cb.source.data },
+                  });
+                } else if (audioMime) {
+                  // Oversize audio: note it in the functionResponse output
+                  // rather than a media part (a text part can't ride the
+                  // separate media Content, and inline audio would blow
+                  // Gemini's request-size limit).
+                  outputText =
+                    outputText +
+                    `\n[Audio too large to send inline: ${cb.source.filename}. Ask for a shorter clip.]`;
+                }
+                // Non-inline-able file sub-blocks (m4a/opus/pdf) are skipped
+                // here; the tool's text output already conveys the file.
               }
             }
           }
@@ -593,7 +616,7 @@ export class GeminiProvider implements Provider {
       this.addGemini3UnsignedToolCallFallback(parts, model);
     }
 
-    return { parts, toolResultImageParts };
+    return { parts, toolResultMediaParts };
   }
 
   private addGemini3UnsignedToolCallFallback(

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -2,6 +2,10 @@ import { extname } from "node:path";
 
 import { RiskLevel } from "../../permissions/types.js";
 import { registerTool } from "../registry.js";
+import {
+  AUDIO_EXTENSIONS,
+  readAudioFile,
+} from "../shared/filesystem/audio-read.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import {
   IMAGE_EXTENSIONS,
@@ -17,7 +21,7 @@ import type {
 export const fileReadTool = {
   name: "file_read",
   description:
-    "Read the contents of a file on your own machine. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. Use host_file_read for files on your guardian's device instead.",
+    "Read the contents of a file on your own machine. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
   category: "filesystem",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
@@ -70,6 +74,18 @@ export const fileReadTool = {
         };
       }
       return readImageFile(pathCheck.resolved);
+    }
+
+    // For audio files, delegate to the shared audio reader.
+    if (AUDIO_EXTENSIONS.has(ext)) {
+      const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+      if (!pathCheck.ok) {
+        return {
+          content: `Error: ${pathCheck.error}. To read files outside the workspace, use the host_file_read tool instead.`,
+          isError: true,
+        };
+      }
+      return readAudioFile(pathCheck.resolved);
     }
 
     const ops = new FileSystemOps((path, opts) =>

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -4,6 +4,10 @@ import { supportsHostProxy } from "../../channels/types.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import {
+  AUDIO_EXTENSIONS,
+  readAudioFile,
+} from "../shared/filesystem/audio-read.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import {
   IMAGE_EXTENSIONS,
@@ -19,7 +23,7 @@ import type {
 export const hostFileReadTool = {
   name: "host_file_read",
   description:
-    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP). For files on your own machine, use file_read instead.",
+    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). For files on your own machine, use file_read instead.",
   category: "host-filesystem",
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
@@ -144,6 +148,14 @@ export const hostFileReadTool = {
         return { content: `Error: ${pathCheck.error}`, isError: true };
       }
       return readImageFile(pathCheck.resolved);
+    }
+
+    if (AUDIO_EXTENSIONS.has(ext)) {
+      const pathCheck = hostPolicy(rawPath);
+      if (!pathCheck.ok) {
+        return { content: `Error: ${pathCheck.error}`, isError: true };
+      }
+      return readAudioFile(pathCheck.resolved);
     }
 
     const ops = new FileSystemOps(hostPolicy);

--- a/assistant/src/tools/shared/filesystem/audio-read.ts
+++ b/assistant/src/tools/shared/filesystem/audio-read.ts
@@ -1,0 +1,106 @@
+import { readFileSync, statSync } from "node:fs";
+import { basename, extname } from "node:path";
+
+import { GEMINI_MAX_INLINE_AUDIO_BYTES } from "../../../providers/gemini/inline-media.js";
+import type { FileContent } from "../../../providers/types.js";
+import type { ToolExecutionResult } from "../../types.js";
+
+/**
+ * Extension → MIME map for audio files the agent can read. Kept identical to
+ * the canonical upload mapping (`migrations/191-backfill-audio-attachment-mime-types`)
+ * so a `.mp3` read produces `audio/mpeg` — the same input the attachment path
+ * feeds `normalizeGeminiAudioMime` (which maps it to Gemini's `audio/mp3`).
+ */
+const EXTENSION_MIME: Record<string, string> = {
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".flac": "audio/flac",
+  ".aac": "audio/aac",
+  ".m4a": "audio/x-m4a",
+  ".opus": "audio/opus",
+};
+
+export const AUDIO_EXTENSIONS = new Set(Object.keys(EXTENSION_MIME));
+
+// Audio is sent to Gemini inline; its inline-request ceiling is the binding
+// limit and the only consumer that uses the bytes. Cap the read there rather
+// than embedding a payload that would just be dropped.
+const MAX_AUDIO_BYTES = GEMINI_MAX_INLINE_AUDIO_BYTES;
+const MAX_AUDIO_MB = Math.round(MAX_AUDIO_BYTES / (1024 * 1024));
+
+function buildAudioToolResult(
+  buffer: Buffer,
+  sourceLabel: string,
+  mimeType: string,
+): ToolExecutionResult {
+  if (buffer.length > MAX_AUDIO_BYTES) {
+    const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
+    return {
+      content: `Error: audio too large (${sizeMB} MB). Maximum is ${MAX_AUDIO_MB} MB (the inline-audio limit). Ask for a shorter clip.`,
+      isError: true,
+    };
+  }
+
+  const fileBlock: FileContent = {
+    type: "file",
+    source: {
+      type: "base64",
+      media_type: mimeType,
+      data: buffer.toString("base64"),
+      filename: basename(sourceLabel),
+    },
+  };
+
+  return {
+    content: `Audio loaded: ${sourceLabel} (${buffer.length} bytes, ${mimeType})`,
+    isError: false,
+    contentBlocks: [fileBlock],
+  };
+}
+
+/**
+ * Read an audio file from disk and return a ToolExecutionResult carrying a
+ * base64 `file` content block so an audio-capable model (Gemini) can hear it.
+ * No transcoding — audio can't be cheaply optimized like images.
+ *
+ * The caller is responsible for path resolution and sandbox enforcement —
+ * `resolvedPath` must be an already-validated absolute path.
+ */
+export function readAudioFile(resolvedPath: string): ToolExecutionResult {
+  const mimeType = EXTENSION_MIME[extname(resolvedPath).toLowerCase()];
+  if (!mimeType) {
+    // Defensive: callers gate on AUDIO_EXTENSIONS, so this is unreachable.
+    return {
+      content: `Error: unsupported audio file: ${resolvedPath}`,
+      isError: true,
+    };
+  }
+
+  let stat;
+  try {
+    stat = statSync(resolvedPath);
+  } catch {
+    return { content: `Error: file not found: ${resolvedPath}`, isError: true };
+  }
+  if (!stat.isFile()) {
+    return { content: `Error: ${resolvedPath} is not a file`, isError: true };
+  }
+  if (stat.size > MAX_AUDIO_BYTES) {
+    const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
+    return {
+      content: `Error: audio too large (${sizeMB} MB). Maximum is ${MAX_AUDIO_MB} MB (the inline-audio limit). Ask for a shorter clip.`,
+      isError: true,
+    };
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = readFileSync(resolvedPath) as Buffer;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error reading file: ${msg}`, isError: true };
+  }
+
+  return buildAudioToolResult(buffer, resolvedPath, mimeType);
+}


### PR DESCRIPTION
## Summary
- `file_read` and `host_file_read` now embed audio files (mp3/wav/ogg/flac/aac/m4a/opus) the same way they already embed images — as a base64 `file` content block — so an audio-capable model (Gemini) can *hear* a file the agent reads, instead of getting utf-8 garbage. New `tools/shared/filesystem/audio-read.ts` mirrors `image-read.ts`, capped at the 12 MB Gemini inline limit.
- Gemini's `toGeminiParts` `case "tool_result"` now collects audio `file` sub-blocks into the separate media `Content` (renamed `toolResultImageParts` → `toolResultMediaParts`); `audio/mpeg` normalizes to `audio/mp3`, oversize degrades into the functionResponse output text. Reuses the `inline-media.ts` helpers shipped in #32674.
- Token estimator counts nested `file` sub-blocks in tool results (~32 tok/sec for Gemini, ~0 for providers that drop them); `stripOldImageBlocks` → `stripOldMediaBlocks` also strips old audio so a 12 MB clip isn't re-sent every turn. No capability gate — mirrors image behavior; non-Gemini models get the "Audio loaded" text and drop the bytes gracefully (no error).

## Original prompt
Following up on native Gemini audio input: the user asked whether, like images, audio files read via the file-read tools get passed to the model when it's audio-capable — and to add that if not. There's no model gate today (images embed unconditionally), so this mirrors that for audio. Scoped to the daemon-local paths (`file_read` + `host_file_read` local fallback); the `host_file_read` proxy path needs a cross-stack client+wire change and lands in a follow-up PR.

## Test plan
- New `tools-audio-read.test.ts`: per-extension MIME mapping (matches migration 191), 12 MB cap, missing/dir errors.
- `gemini-provider.test.ts`: tool_result audio → separate `inlineData{audio/mp3}` Content (not mixed with functionResponse); m4a dropped; oversize degrades into output text.
- `context-token-estimator.test.ts`: nested audio file in tool_result counted for Gemini, ~0 for others.
- `bunx tsc --noEmit`, `eslint`, and the three suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)