### PR TITLE
fix(gemini): model-aware thinking level + make it configurable (web & macOS)

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -260,7 +260,7 @@ export interface ProfileEntry {
   speed?: string;
   verbosity?: string;
   temperature?: number | null;
-  thinking?: { enabled?: boolean; streamThinking?: boolean };
+  thinking?: { enabled?: boolean; streamThinking?: boolean; level?: string };
   contextWindow?: { maxInputTokens?: number };
 }
 

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -57,7 +57,7 @@ export interface Profile {
   speed?: string;
   verbosity?: string;
   temperature?: number | null;
-  thinking?: { enabled?: boolean; streamThinking?: boolean };
+  thinking?: { enabled?: boolean; streamThinking?: boolean; level?: string };
   contextWindow?: { maxInputTokens?: number };
 }
 

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -18,7 +18,7 @@ import {
 
 import { type ProfileEntry, formatCompactTokens } from "@/domains/settings/ai/ai-page";
 import { type Profile } from "@/domains/settings/ai/manage-profiles-modal";
-import { resolveProfileParamVisibility } from "@/domains/settings/ai/profile-param-visibility";
+import { geminiThinkingLevels, resolveProfileParamVisibility } from "@/domains/settings/ai/profile-param-visibility";
 import { type ConnectionModel, type ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
 import { toKebabCase as toKebabCaseImpl } from "@/domains/settings/ai/slugify";
 
@@ -41,6 +41,10 @@ const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
 const EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh", "max"] as const;
 const SPEED_OPTIONS = ["standard", "fast"] as const;
 const VERBOSITY_OPTIONS = ["low", "medium", "high"] as const;
+// Sentinel for the Gemini thinking-level selector: "inherit" → omit
+// thinking.level so the daemon applies the model default (mirrors effort's
+// "none"). Concrete levels come from `geminiThinkingLevels(model)`.
+const THINKING_LEVEL_INHERIT = "default";
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 const MIN_MAX_OUTPUT_TOKENS = 1_000; // matches TOKEN_SLIDER_MIN_TOKENS in page.tsx
@@ -238,6 +242,10 @@ function ProfileEditorModalInner({
   const [thinkingStreamThinking, setThinkingStreamThinking] = useState<boolean>(
     initialValues?.thinking?.streamThinking ?? false,
   );
+  // Gemini reasoning-depth knob. "default" = inherit the model default.
+  const [thinkingLevel, setThinkingLevel] = useState<string>(
+    initialValues?.thinking?.level ?? THINKING_LEVEL_INHERIT,
+  );
 
   // Derived: selected model from catalog
   const selectedModel = useMemo(
@@ -386,6 +394,7 @@ function ProfileEditorModalInner({
     setTemperature(0.7);
     setThinkingEnabled(false);
     setThinkingStreamThinking(false);
+    setThinkingLevel(THINKING_LEVEL_INHERIT);
   }
 
   function handleConnectionChange(newConnection: string) {
@@ -528,6 +537,11 @@ function ProfileEditorModalInner({
           enabled: thinkingEnabled,
           ...(thinkingEnabled ? { streamThinking: thinkingStreamThinking } : {}),
         };
+      }
+      // Gemini: a chosen level implies thinking is on; "default" omits the
+      // field so the daemon applies the model default.
+      if (visibility.thinkingLevel && thinkingLevel !== THINKING_LEVEL_INHERIT) {
+        entry.thinking = { enabled: true, level: thinkingLevel };
       }
       // Status — always include in edit mode; omit in create when active (default)
       if (effectiveMode === "edit") {
@@ -1028,6 +1042,25 @@ function ProfileEditorModalInner({
                   />
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Thinking level (Gemini) */}
+          {visibility.thinkingLevel && (
+            <div className="space-y-1">
+              <label className="block text-body-small-default text-[var(--content-tertiary)]">
+                Thinking level{" "}
+                <span className="text-[var(--content-disabled)]">(default = inherit)</span>
+              </label>
+              <SegmentControl
+                items={[THINKING_LEVEL_INHERIT, ...geminiThinkingLevels(model)].map((v) => ({
+                  value: v,
+                  label: v,
+                }))}
+                value={thinkingLevel}
+                onChange={(v) => setThinkingLevel(v)}
+                ariaLabel="Thinking level"
+              />
             </div>
           )}
 

--- a/apps/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/apps/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -13,6 +13,9 @@ export interface ProfileParamVisibility {
   verbosity: boolean;
   temperature: boolean;
   thinking: boolean;
+  /** Gemini's reasoning-depth knob (`thinking.level`). Distinct from `thinking`
+   * (Anthropic/OpenRouter enable + stream toggles) — Gemini uses a level. */
+  thinkingLevel: boolean;
 }
 
 export const VISIBILITY_NONE: ProfileParamVisibility = {
@@ -23,6 +26,7 @@ export const VISIBILITY_NONE: ProfileParamVisibility = {
   verbosity: false,
   temperature: false,
   thinking: false,
+  thinkingLevel: false,
 };
 
 function isOpenAIGPT5Family(modelId: string): boolean {
@@ -42,6 +46,29 @@ function knownOpenRouterReasoningModel(modelId: string): boolean {
     modelId === "qwen/qwen3.5-397b-a17b" ||
     modelId === "moonshotai/kimi-k2.6"
   );
+}
+
+const GEMINI_THINKING_LEVELS_FULL = ["minimal", "low", "medium", "high"] as const;
+const GEMINI_THINKING_LEVELS_PRO = ["low", "medium", "high"] as const;
+
+/**
+ * Gemini 3.x Pro family accepts only low/medium/high (no "minimal") and cannot
+ * disable thinking. Mirrors the daemon's `isGeminiProModel` in
+ * `assistant/src/providers/gemini/client.ts`.
+ */
+function isGeminiProModel(modelId: string): boolean {
+  return /^gemini-3.*pro/.test(modelId);
+}
+
+/**
+ * Thinking levels selectable for a Gemini model, lowest → highest. Pro models
+ * omit "minimal". The daemon clamps anything below a model's floor, so this is
+ * a UX nicety rather than a correctness guarantee.
+ */
+export function geminiThinkingLevels(modelId: string): readonly string[] {
+  return isGeminiProModel(modelId.toLowerCase())
+    ? GEMINI_THINKING_LEVELS_PRO
+    : GEMINI_THINKING_LEVELS_FULL;
 }
 
 function modelSupportsThinking(provider: string, modelId: string): boolean {
@@ -102,5 +129,6 @@ export function resolveProfileParamVisibility(
     verbosity: providerId === "openai" && isOpenAIGPT5Family(modelId),
     temperature: usesAnthropicWire,
     thinking: (providerId === "anthropic" || providerId === "openrouter") && supportsThinkingResult,
+    thinkingLevel: providerId === "gemini" && supportsThinkingResult,
   };
 }

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -316,6 +316,112 @@ describe("GeminiProvider", () => {
     expect(config.thinkingConfig).toBeUndefined();
   });
 
+  // Gemini 3.x Pro models reject MINIMAL and cannot disable thinking, so the
+  // provider must never send a level below the Pro floor ("low") and must pin
+  // a supported default when none is requested.
+  test("Pro: adaptive with no level pins the documented default (high)", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const proProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-3.1-pro-preview",
+    );
+    await proProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { thinking: { type: "adaptive", streamThinking: true } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "HIGH",
+      includeThoughts: true,
+    });
+  });
+
+  test("Pro: disabled maps to the LOW floor, not MINIMAL", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const proProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-3.1-pro-preview",
+    );
+    await proProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { thinking: { type: "disabled" } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "LOW",
+      includeThoughts: false,
+    });
+  });
+
+  test("Pro: an explicit minimal level is clamped up to LOW", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const proProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-3.1-pro-preview-customtools",
+    );
+    await proProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      {
+        config: {
+          thinking: {
+            type: "adaptive",
+            level: "minimal",
+            streamThinking: false,
+          },
+        },
+      },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "LOW",
+      includeThoughts: false,
+    });
+  });
+
+  test("Pro: a supported explicit level passes through unchanged", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const proProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-3.1-pro-preview",
+    );
+    await proProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      {
+        config: {
+          thinking: { type: "adaptive", level: "medium", streamThinking: true },
+        },
+      },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "MEDIUM",
+      includeThoughts: true,
+    });
+  });
+
+  test("non-Pro: adaptive with no level keeps Google's default (only includeThoughts)", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    // Default provider is gemini-3-flash-preview (Flash). Flash accepts MINIMAL
+    // and resolves an absent level via Google's per-model default, so we leave
+    // thinkingLevel unset and only forward the streaming preference.
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { thinking: { type: "adaptive", streamThinking: true } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({ includeThoughts: true });
+  });
+
   // -----------------------------------------------------------------------
   // Tool definitions
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,6 +1,10 @@
 import type * as genai from "@google/genai";
 import { ApiError, GoogleGenAI, ThinkingLevel } from "@google/genai";
 
+import {
+  THINKING_LEVELS,
+  type ThinkingLevel as ThinkingLevelName,
+} from "../../config/schemas/llm.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
@@ -38,7 +42,7 @@ function isGemini3Model(model: string): boolean {
   return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
 }
 
-const THINKING_LEVEL_BY_NAME: Record<string, ThinkingLevel> = {
+const THINKING_LEVEL_BY_NAME: Record<ThinkingLevelName, ThinkingLevel> = {
   minimal: ThinkingLevel.MINIMAL,
   low: ThinkingLevel.LOW,
   medium: ThinkingLevel.MEDIUM,
@@ -46,32 +50,92 @@ const THINKING_LEVEL_BY_NAME: Record<string, ThinkingLevel> = {
 };
 
 /**
+ * Default thinking level for Gemini Pro models when the profile doesn't pin
+ * one. Pro rejects `"minimal"` and an absent level resolves to `"minimal"`
+ * upstream, so we pin Google's documented Pro default (`"high"`) — always a
+ * supported value.
+ */
+const GEMINI_PRO_DEFAULT_THINKING_LEVEL: ThinkingLevelName = "high";
+
+/**
+ * Gemini 3.x Pro family accepts only `low`/`medium`/`high` (no `"minimal"`) and
+ * cannot fully disable thinking. Matches `gemini-3.1-pro-preview`,
+ * `gemini-3.1-pro-preview-customtools`, and future `gemini-3*pro*`.
+ */
+function isGeminiProModel(model: string): boolean {
+  const normalized = model.startsWith("models/")
+    ? model.slice("models/".length)
+    : model;
+  return /^gemini-3.*pro/.test(normalized);
+}
+
+/**
+ * Lowest thinking level the model accepts. Pro's floor is `"low"`; every other
+ * thinking-capable Gemini model accepts `"minimal"`.
+ */
+function geminiThinkingFloor(model: string): ThinkingLevelName {
+  return isGeminiProModel(model) ? "low" : "minimal";
+}
+
+/**
+ * Raise `level` to `floor` when it sits below it, so we never send a level the
+ * model rejects (e.g. `"minimal"` to a Pro model).
+ */
+function clampThinkingLevelToFloor(
+  level: ThinkingLevelName,
+  floor: ThinkingLevelName,
+): ThinkingLevelName {
+  return THINKING_LEVELS.indexOf(level) < THINKING_LEVELS.indexOf(floor)
+    ? floor
+    : level;
+}
+
+/**
  * Translate the resolved wire-shape `thinking` config into Gemini's
- * `thinkingConfig`. Returns `undefined` when no thinking config was supplied,
- * which lets Google's per-model default apply (e.g. `gemini-3.5-flash`
- * defaults to dynamic medium-level thinking).
+ * `thinkingConfig`, guaranteeing the emitted `thinkingLevel` is one the model
+ * accepts. Returns `undefined` when nothing needs to be set, which lets
+ * Google's per-model default apply (e.g. `gemini-3.5-flash` defaults to
+ * dynamic medium-level thinking).
  *
- * `enabled: false` maps to `thinkingLevel: MINIMAL` because Gemini 3.x cannot
- * fully disable thinking — `"minimal"` is the floor. `includeThoughts` is
- * gated on `streamThinking` so callers that opted out of streaming thoughts
- * don't pay for thought tokens in the response.
+ * - `enabled: false` maps to the model's floor — the most "off" state it
+ *   allows (`"minimal"` for most models, `"low"` for Pro, which can't disable
+ *   thinking).
+ * - An explicit `level` below the floor is raised to the floor.
+ * - When no `level` is pinned, Pro models get the documented default (`"high"`)
+ *   because an absent level resolves to the unsupported `"minimal"` upstream;
+ *   other models keep Google's per-model default by leaving the level unset.
+ *
+ * `includeThoughts` is gated on `streamThinking` so callers that opted out of
+ * streaming thoughts don't pay for thought tokens in the response.
  */
 function buildThinkingConfig(
   thinking: Record<string, unknown> | undefined,
+  model: string,
 ): genai.ThinkingConfig | undefined {
   if (!thinking) return undefined;
+  const floor = geminiThinkingFloor(model);
+
   if (thinking.type === "disabled") {
     return {
-      thinkingLevel: ThinkingLevel.MINIMAL,
+      thinkingLevel: THINKING_LEVEL_BY_NAME[floor],
       includeThoughts: false,
     };
   }
   if (thinking.type !== "adaptive") return undefined;
 
   const result: genai.ThinkingConfig = {};
-  if (typeof thinking.level === "string") {
-    const mapped = THINKING_LEVEL_BY_NAME[thinking.level];
-    if (mapped) result.thinkingLevel = mapped;
+  if (
+    typeof thinking.level === "string" &&
+    thinking.level in THINKING_LEVEL_BY_NAME
+  ) {
+    const clamped = clampThinkingLevelToFloor(
+      thinking.level as ThinkingLevelName,
+      floor,
+    );
+    result.thinkingLevel = THINKING_LEVEL_BY_NAME[clamped];
+  } else if (isGeminiProModel(model)) {
+    result.thinkingLevel =
+      THINKING_LEVEL_BY_NAME[GEMINI_PRO_DEFAULT_THINKING_LEVEL];
   }
   if (typeof thinking.streamThinking === "boolean") {
     result.includeThoughts = thinking.streamThinking;
@@ -240,6 +304,7 @@ export class GeminiProvider implements Provider {
     const thinkingConfig = geminiModelSupportsThinking(activeModel)
       ? buildThinkingConfig(
           configObj?.thinking as Record<string, unknown> | undefined,
+          activeModel,
         )
       : undefined;
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// Only the leaves the macOS UI exposes are modeled here: `provider`,
 /// `model`, `maxTokens`, `effort`, `speed`, `verbosity`, `temperature`,
-/// the two `thinking` sub-fields, and `contextWindow.maxInputTokens`.
+/// the three `thinking` sub-fields, and `contextWindow.maxInputTokens`.
 /// Other `LLMConfigFragment` leaves (e.g. `openrouter` and non-UI
 /// `contextWindow` sub-fields) are preserved by the JSON mapper so edits
 /// can round-trip profile fragments without clobbering hidden settings.
@@ -81,6 +81,10 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// Maps to `thinking.streamThinking` in the fragment JSON.
     public var thinkingStreamThinking: Bool?
 
+    /// Maps to `thinking.level` in the fragment JSON. Gemini's reasoning-depth
+    /// knob (`minimal`/`low`/`medium`/`high`); other providers ignore it.
+    public var thinkingLevel: String?
+
     private var preservedJSON: [String: Any]
 
     public var id: String { name }
@@ -117,7 +121,8 @@ public struct InferenceProfile: Hashable, Identifiable {
         contextWindowMaxInputTokens: Int? = nil,
         temperature: TemperatureValue = .unset,
         thinkingEnabled: Bool? = nil,
-        thinkingStreamThinking: Bool? = nil
+        thinkingStreamThinking: Bool? = nil,
+        thinkingLevel: String? = nil
     ) {
         self.name = name
         self.source = source
@@ -135,6 +140,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         self.temperature = temperature
         self.thinkingEnabled = thinkingEnabled
         self.thinkingStreamThinking = thinkingStreamThinking
+        self.thinkingLevel = thinkingLevel
         self.preservedJSON = [:]
     }
 
@@ -157,7 +163,8 @@ public struct InferenceProfile: Hashable, Identifiable {
         contextWindowMaxInputTokens: Int? = nil,
         temperature: Double?,
         thinkingEnabled: Bool? = nil,
-        thinkingStreamThinking: Bool? = nil
+        thinkingStreamThinking: Bool? = nil,
+        thinkingLevel: String? = nil
     ) {
         self.init(
             name: name,
@@ -175,7 +182,8 @@ public struct InferenceProfile: Hashable, Identifiable {
             contextWindowMaxInputTokens: contextWindowMaxInputTokens,
             temperature: TemperatureValue(value: temperature),
             thinkingEnabled: thinkingEnabled,
-            thinkingStreamThinking: thinkingStreamThinking
+            thinkingStreamThinking: thinkingStreamThinking,
+            thinkingLevel: thinkingLevel
         )
     }
 
@@ -204,6 +212,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         let thinking = json["thinking"] as? [String: Any]
         self.thinkingEnabled = thinking?["enabled"] as? Bool
         self.thinkingStreamThinking = thinking?["streamThinking"] as? Bool
+        self.thinkingLevel = (thinking?["level"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.preservedJSON = Self.preservedJSON(from: json)
     }
 
@@ -226,6 +235,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         if fragment.temperature != .unset { merged.temperature = fragment.temperature }
         if let v = fragment.thinkingEnabled { merged.thinkingEnabled = v }
         if let v = fragment.thinkingStreamThinking { merged.thinkingStreamThinking = v }
+        if let v = fragment.thinkingLevel { merged.thinkingLevel = v }
         return merged
     }
 
@@ -271,6 +281,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         var thinking: [String: Any] = [:]
         if let thinkingEnabled { thinking["enabled"] = thinkingEnabled }
         if let thinkingStreamThinking { thinking["streamThinking"] = thinkingStreamThinking }
+        if let thinkingLevel { thinking["level"] = thinkingLevel }
         if !thinking.isEmpty {
             result["thinking"] = thinking
         }
@@ -341,6 +352,7 @@ public struct InferenceProfile: Hashable, Identifiable {
             && lhs.temperature == rhs.temperature
             && lhs.thinkingEnabled == rhs.thinkingEnabled
             && lhs.thinkingStreamThinking == rhs.thinkingStreamThinking
+            && lhs.thinkingLevel == rhs.thinkingLevel
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -360,6 +372,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         hasher.combine(temperature)
         hasher.combine(thinkingEnabled)
         hasher.combine(thinkingStreamThinking)
+        hasher.combine(thinkingLevel)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -270,6 +270,9 @@ struct InferenceProfileEditor: View {
                         if visibility.thinking {
                             thinkingSection
                         }
+                        if visibility.thinkingLevel {
+                            thinkingLevelField
+                        }
                     }
                     .disabled(isReadOnly)
 
@@ -884,6 +887,23 @@ struct InferenceProfileEditor: View {
             // the daemon would ignore the leaf either way but the disabled
             // affordance keeps the UI honest.
             .disabled(!(profile.thinkingEnabled ?? false))
+        }
+    }
+
+    // Gemini's reasoning-depth knob. The model's supported levels come from
+    // the catalog family rule; "default" omits `thinking.level` so the daemon
+    // applies the model default (and clamps anything below a Pro model's floor).
+    private var thinkingLevelField: some View {
+        let levels = ["default"]
+            + InferenceProfileParameterVisibility.geminiThinkingLevels(profile.model ?? "")
+        return labeled("Thinking level") {
+            VSegmentControl(
+                items: levels.map { (label: $0, tag: $0) },
+                selection: Binding(
+                    get: { profile.thinkingLevel ?? "default" },
+                    set: { profile.thinkingLevel = $0 == "default" ? nil : $0 }
+                )
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileParameterVisibility.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileParameterVisibility.swift
@@ -10,6 +10,9 @@ struct InferenceProfileParameterVisibility: Equatable {
     var verbosity: Bool
     var temperature: Bool
     var thinking: Bool
+    /// Gemini's reasoning-depth knob (`thinking.level`). Distinct from
+    /// `thinking` (Anthropic/OpenRouter enable + stream toggles).
+    var thinkingLevel: Bool
 
     static let none = InferenceProfileParameterVisibility(
         maxTokens: false,
@@ -17,7 +20,8 @@ struct InferenceProfileParameterVisibility: Equatable {
         speed: false,
         verbosity: false,
         temperature: false,
-        thinking: false
+        thinking: false,
+        thinkingLevel: false
     )
 
     static func resolve(
@@ -54,7 +58,8 @@ struct InferenceProfileParameterVisibility: Equatable {
             speed: provider == "anthropic" && modelId.contains("opus"),
             verbosity: provider == "openai" && isOpenAIGPT5Family(modelId),
             temperature: usesAnthropicWire,
-            thinking: (provider == "anthropic" || provider == "openrouter") && supportsThinking
+            thinking: (provider == "anthropic" || provider == "openrouter") && supportsThinking,
+            thinkingLevel: provider == "gemini" && supportsThinking
         )
     }
 
@@ -69,6 +74,7 @@ struct InferenceProfileParameterVisibility: Equatable {
             sanitized.thinkingEnabled = nil
             sanitized.thinkingStreamThinking = nil
         }
+        if !thinkingLevel { sanitized.thinkingLevel = nil }
         return sanitized
     }
 
@@ -116,6 +122,22 @@ struct InferenceProfileParameterVisibility: Equatable {
 
     private static func isOpenAIGPT5Family(_ modelId: String) -> Bool {
         modelId == "gpt-5" || modelId.hasPrefix("gpt-5.") || modelId.hasPrefix("gpt-5-")
+    }
+
+    /// Gemini 3.x Pro family accepts only low/medium/high (no "minimal") and
+    /// cannot disable thinking. Mirrors the daemon's `isGeminiProModel` in
+    /// `assistant/src/providers/gemini/client.ts`.
+    private static func isGeminiProModel(_ modelId: String) -> Bool {
+        modelId.range(of: #"^gemini-3.*pro"#, options: .regularExpression) != nil
+    }
+
+    /// Thinking levels selectable for a Gemini model, lowest → highest. Pro
+    /// models omit "minimal". The daemon clamps anything below a model's floor,
+    /// so this is a UX nicety rather than a correctness guarantee.
+    static func geminiThinkingLevels(_ modelId: String) -> [String] {
+        isGeminiProModel(modelId.lowercased())
+            ? ["low", "medium", "high"]
+            : ["minimal", "low", "medium", "high"]
     }
 
     private static func knownOpenRouterReasoningModel(_ modelId: String) -> Bool {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -197,7 +197,8 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: true,
                 temperature: false,
-                thinking: false
+                thinking: false,
+                thinkingLevel: false
             )
         )
     }
@@ -223,7 +224,8 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: true,
                 verbosity: false,
                 temperature: true,
-                thinking: true
+                thinking: true,
+                thinkingLevel: false
             )
         )
     }
@@ -249,12 +251,13 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: false,
                 temperature: true,
-                thinking: true
+                thinking: true,
+                thinkingLevel: false
             )
         )
     }
 
-    func testGeminiShowsOnlyMaxTokensWithCurrentProviderSupport() {
+    func testGemini25ShowsThinkingLevelSelector() {
         let visibility = InferenceProfileParameterVisibility.resolve(
             provider: "gemini",
             model: "gemini-2.5-flash",
@@ -275,12 +278,13 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: false,
                 temperature: false,
-                thinking: false
+                thinking: false,
+                thinkingLevel: true
             )
         )
     }
 
-    func testGemini3ShowsOnlyMaxTokensWithCurrentProviderSupport() {
+    func testGemini3ProShowsThinkingLevelSelector() {
         let visibility = InferenceProfileParameterVisibility.resolve(
             provider: "gemini",
             model: "gemini-3.1-pro-preview",
@@ -301,7 +305,8 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: false,
                 temperature: false,
-                thinking: false
+                thinking: false,
+                thinkingLevel: true
             )
         )
     }
@@ -365,7 +370,8 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: false,
                 temperature: false,
-                thinking: true
+                thinking: true,
+                thinkingLevel: false
             )
         )
     }
@@ -391,7 +397,8 @@ final class InferenceProfileEditorTests: XCTestCase {
                 speed: false,
                 verbosity: false,
                 temperature: false,
-                thinking: false
+                thinking: false,
+                thinkingLevel: false
             )
         )
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -144,6 +144,25 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertEqual(onlyStreamThinking?["streamThinking"] as? Bool, true)
     }
 
+    func testThinkingLevelRoundTrips() {
+        let original = InferenceProfile(
+            name: "gemini-level",
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview",
+            thinkingLevel: "high"
+        )
+
+        let thinking = original.toJSON()["thinking"] as? [String: Any]
+        XCTAssertNotNil(thinking, "Thinking dict must be present when a level is set")
+        XCTAssertEqual(thinking?["level"] as? String, "high")
+        XCTAssertNil(thinking?["enabled"])
+        XCTAssertNil(thinking?["streamThinking"])
+
+        let decoded = InferenceProfile(name: "gemini-level", json: original.toJSON())
+        XCTAssertEqual(decoded.thinkingLevel, "high")
+        XCTAssertEqual(decoded, original)
+    }
+
     // MARK: - Decoder edge cases
 
     func testEmptyStringFieldsDecodeAsNil() {


### PR DESCRIPTION
## Summary
- Fix HTTP 400 "Thinking level MINIMAL is not supported" on `gemini-3.1-pro-preview`: the Gemini provider (`buildThinkingConfig`) now resolves a model-aware thinking level — Pro models (which reject `minimal` and can't disable thinking) get a `low` floor and a `high` default, an explicit sub-floor level is clamped up, and other Gemini models keep Google's per-model default unchanged.
- Add a **Thinking level** selector for Gemini inference profiles in both the web client (`apps/web`, which also ships as the Electron macOS app) and the native macOS Swift client (`clients/macos`), wiring `thinking.level` through the profile model, the visibility resolver, and the editor.
- Tests: backend cases for the Pro floor/default/clamp behavior, and a Swift `thinking.level` JSON round-trip test.

## Original prompt
While using `gemini-3.1-pro-preview`, chat failed with an API 400: "Thinking level MINIMAL is not supported for this model." The ask was to check the Gemini docs for the allowed thinking levels, make the thinking level configurable in both the macOS and web clients, and fix the bad default that was sending MINIMAL. Per the docs the valid levels are minimal/low/medium/high, but 3.x Pro models accept only low/medium/high and can't disable thinking; the user chose `high` as the default and a single level dropdown for the UI, and asked that `clients/macos` be updated as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)