### PR TITLE
feat(assistant+macos): stream host_file_read audio over the proxy so Gemini can hear it

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11093,6 +11093,12 @@ paths:
                 imageData:
                   type: string
                   description: Optional base64-encoded image bytes for successful image reads
+                audioData:
+                  type: string
+                  description: Optional base64-encoded audio bytes for successful audio reads
+                audioMimeType:
+                  type: string
+                  description: MIME type for audioData (e.g. audio/mpeg)
               required:
                 - requestId
               additionalProperties: false

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -163,6 +163,37 @@ describe("HostFileProxy", () => {
       });
     });
 
+    test("rebuilds audio tool results from proxied audio payloads", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/Users/test/Desktop/voice.mp3" },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, {
+        content: "Audio loaded on host",
+        isError: false,
+        audioData: Buffer.from("fake-audio-bytes").toString("base64"),
+        audioMimeType: "audio/mpeg",
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Audio loaded");
+      expect(result.contentBlocks).toHaveLength(1);
+      expect(result.contentBlocks?.[0]).toMatchObject({
+        type: "file",
+        source: {
+          media_type: "audio/mpeg",
+          filename: "voice.mp3",
+        },
+      });
+    });
+
     test("handles write operations", async () => {
       setup();
 

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -10,6 +10,7 @@ import {
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { readAudioBase64 } from "../tools/shared/filesystem/audio-read.js";
 import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -225,7 +226,13 @@ export class HostFileProxy {
    */
   resolve(
     requestId: string,
-    response: { content: string; isError: boolean; imageData?: string },
+    response: {
+      content: string;
+      isError: boolean;
+      imageData?: string;
+      audioData?: string;
+      audioMimeType?: string;
+    },
   ): void {
     const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
@@ -241,6 +248,23 @@ export class HostFileProxy {
     ) {
       interaction.rpcResolve(
         readImageBase64(response.imageData, meta.path as string),
+      );
+      return;
+    }
+    if (
+      meta.operation === "read" &&
+      !response.isError &&
+      typeof response.audioData === "string" &&
+      response.audioData.length > 0 &&
+      typeof response.audioMimeType === "string" &&
+      response.audioMimeType.length > 0
+    ) {
+      interaction.rpcResolve(
+        readAudioBase64(
+          response.audioData,
+          meta.path as string,
+          response.audioMimeType,
+        ),
       );
       return;
     }

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -31,12 +31,15 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     throw new BadRequestError("Request body is required");
   }
 
-  const { requestId, content, isError, imageData } = body as {
-    requestId?: string;
-    content?: string;
-    isError?: boolean;
-    imageData?: string;
-  };
+  const { requestId, content, isError, imageData, audioData, audioMimeType } =
+    body as {
+      requestId?: string;
+      content?: string;
+      isError?: boolean;
+      imageData?: string;
+      audioData?: string;
+      audioMimeType?: string;
+    };
 
   if (!requestId || typeof requestId !== "string") {
     throw new BadRequestError("requestId is required");
@@ -88,6 +91,8 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     content: content ?? "",
     isError: isError ?? false,
     imageData,
+    audioData,
+    audioMimeType,
   });
 
   return { accepted: true };
@@ -123,6 +128,16 @@ export const ROUTES: RouteDefinition[] = [
         .describe(
           "Optional base64-encoded image bytes for successful image reads",
         )
+        .optional(),
+      audioData: z
+        .string()
+        .describe(
+          "Optional base64-encoded audio bytes for successful audio reads",
+        )
+        .optional(),
+      audioMimeType: z
+        .string()
+        .describe("MIME type for audioData (e.g. audio/mpeg)")
         .optional(),
     }),
     responseBody: z.object({

--- a/assistant/src/tools/shared/filesystem/audio-read.ts
+++ b/assistant/src/tools/shared/filesystem/audio-read.ts
@@ -104,3 +104,19 @@ export function readAudioFile(resolvedPath: string): ToolExecutionResult {
 
   return buildAudioToolResult(buffer, resolvedPath, mimeType);
 }
+
+/**
+ * Build an audio ToolExecutionResult from already-read base64 bytes. Used by
+ * the host-file proxy when a remote client streams audio back over the wire.
+ */
+export function readAudioBase64(
+  base64Data: string,
+  sourceLabel: string,
+  mimeType: string,
+): ToolExecutionResult {
+  return buildAudioToolResult(
+    Buffer.from(base64Data, "base64"),
+    sourceLabel,
+    mimeType,
+  );
+}

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -42,9 +42,9 @@ public struct HostProxyClient: HostProxyClientProtocol {
     public func postFileResult(_ result: HostFileResultPayload) async -> Bool {
         do {
             let body = try JSONEncoder().encode(result)
-            // Scale the timeout for large payloads (e.g. base64-encoded images)
-            // to avoid triggering Foundation's URLSession cancellation race.
-            let timeout: TimeInterval = result.imageData != nil
+            // Scale the timeout for large payloads (e.g. base64-encoded images
+            // or audio) to avoid triggering Foundation's URLSession cancellation race.
+            let timeout: TimeInterval = result.imageData != nil || result.audioData != nil
                 ? max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
                 : 30
             let response = try await GatewayHTTPClient.post(

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -15,6 +15,17 @@ public enum HostToolExecutor {
         ".webp",
     ]
     private static let maxImageSourceBytes = 10 * 1024 * 1024
+    private static let audioExtensions: Set<String> = [
+        ".mp3",
+        ".wav",
+        ".ogg",
+        ".flac",
+        ".aac",
+        ".m4a",
+        ".opus",
+    ]
+    // Matches the daemon's 12 MB Gemini inline-audio limit.
+    private static let maxAudioSourceBytes = 12 * 1024 * 1024
 
     // MARK: - Cancelled Request Tracking
 
@@ -335,6 +346,10 @@ public enum HostToolExecutor {
             return try readImageFile(requestId: requestId, path: path)
         }
 
+        if isAudioPath(path) {
+            return try readAudioFile(requestId: requestId, path: path)
+        }
+
         let content = try readTextFile(path: path, offset: offset, limit: limit)
         return HostFileResultPayload(
             requestId: requestId,
@@ -394,6 +409,33 @@ public enum HostToolExecutor {
         )
     }
 
+    private static func readAudioFile(requestId: String, path: String) throws -> HostFileResultPayload {
+        let fileURL = URL(fileURLWithPath: path)
+        let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        if values.isRegularFile != true {
+            throw FileOperationError.notAFile(path)
+        }
+
+        let sourceBytes = values.fileSize ?? 0
+        if sourceBytes > maxAudioSourceBytes {
+            let sizeMB = Double(sourceBytes) / (1024 * 1024)
+            throw FileOperationError.audioTooLarge(sizeMB)
+        }
+
+        guard let mediaType = audioMediaType(path) else {
+            throw FileOperationError.invalidAudioFormat(path)
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        return HostFileResultPayload(
+            requestId: requestId,
+            content: "Audio loaded on host: \(path) (\(data.count) bytes, \(mediaType))",
+            isError: false,
+            audioData: data.base64EncodedString(),
+            audioMimeType: mediaType
+        )
+    }
+
     private static func writeFile(path: String, content: String) throws -> String {
         let fileURL = URL(fileURLWithPath: path)
         let parentDir = fileURL.deletingLastPathComponent().path
@@ -441,6 +483,27 @@ public enum HostToolExecutor {
         let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
         guard !ext.isEmpty else { return false }
         return imageExtensions.contains(".\(ext)")
+    }
+
+    private static func isAudioPath(_ path: String) -> Bool {
+        let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
+        guard !ext.isEmpty else { return false }
+        return audioExtensions.contains(".\(ext)")
+    }
+
+    /// Extension → MIME for host audio reads. Mirrors the daemon's audio-read
+    /// map and migration 191 so a `.mp3` produces `audio/mpeg`.
+    private static func audioMediaType(_ path: String) -> String? {
+        switch URL(fileURLWithPath: path).pathExtension.lowercased() {
+        case "mp3": return "audio/mpeg"
+        case "wav": return "audio/wav"
+        case "ogg": return "audio/ogg"
+        case "flac": return "audio/flac"
+        case "aac": return "audio/aac"
+        case "m4a": return "audio/x-m4a"
+        case "opus": return "audio/opus"
+        default: return nil
+        }
     }
 
     private static func detectImageMediaType(_ data: Data) -> String? {
@@ -777,6 +840,8 @@ public enum HostToolExecutor {
         case notAFile(String)
         case imageTooLarge(Double)
         case invalidImageFormat(String)
+        case audioTooLarge(Double)
+        case invalidAudioFormat(String)
 
         var errorDescription: String? {
             switch self {
@@ -792,6 +857,10 @@ public enum HostToolExecutor {
                 return String(format: "image too large (%.1f MB). Maximum source file size is 10 MB.", sizeMB)
             case .invalidImageFormat(let path):
                 return "could not detect image format for \(path). The file may be corrupt."
+            case .audioTooLarge(let sizeMB):
+                return String(format: "audio too large (%.1f MB). Maximum source file size is 12 MB.", sizeMB)
+            case .invalidAudioFormat(let path):
+                return "unsupported audio format for \(path)."
             }
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1723,12 +1723,23 @@ public struct HostFileResultPayload: Codable, Sendable {
     public let content: String
     public let isError: Bool
     public let imageData: String?
+    public let audioData: String?
+    public let audioMimeType: String?
 
-    public init(requestId: String, content: String, isError: Bool, imageData: String? = nil) {
+    public init(
+        requestId: String,
+        content: String,
+        isError: Bool,
+        imageData: String? = nil,
+        audioData: String? = nil,
+        audioMimeType: String? = nil
+    ) {
         self.requestId = requestId
         self.content = content
         self.isError = isError
         self.imageData = imageData
+        self.audioData = audioData
+        self.audioMimeType = audioMimeType
     }
 }
 


### PR DESCRIPTION
## Summary
- Completes `host_file_read` audio for the **proxy path** (the one the desktop app uses): a connected client now reads an audio file on the user's device, base64-encodes it (12 MB cap), and streams it back as `audioData`/`audioMimeType` so an audio-capable model (Gemini) can *hear* it — mirroring how images already flow over the proxy. Follows #32686 (daemon-local paths).
- **Daemon:** `host-file-proxy.ts` `resolve()` rebuilds a `file` content block from `audioData` via new `readAudioBase64`; `POST /v1/host-file-result` accepts `audioData`/`audioMimeType` (Zod schema + handler); `openapi.yaml` regenerated.
- **Swift client:** `HostToolExecutor` detects audio extensions and returns base64 + MIME (aligned with migration 191); `HostFileResultPayload` gains `audioData`/`audioMimeType`; `HostProxyClient` scales the upload timeout for audio.

## Original prompt
Second of two PRs (per the approved plan) extending native Gemini audio input to the file-read tools. PR #32686 covered `file_read` and `host_file_read`'s local fallback; this one covers `host_file_read` over the client↔daemon proxy, which needs a cross-stack client + wire change. The user opted for full cross-stack scope and accepted that the Swift host executor (mid Swift→Electron migration) isn't compile-verified here.

## Test plan
- `host-file-proxy.test.ts`: a proxied `read` resolving with `audioData`/`audioMimeType` rebuilds a `file` block (`audio/mpeg`, filename from path) — mirrors the existing image-payload test.
- `bunx tsc --noEmit`, `eslint`, `bun run generate:openapi` (committed), and the proxy/audio suites green.
- ⚠️ Swift not compile-verified in this environment (accepted) — the macOS client build / CI will catch any Swift issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)