### PR TITLE
fix(macos): play just-sent audio attachments; surface real fetch errors

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -182,6 +182,25 @@ final class ChatActionHandler {
                 vm.messages[idx].daemonMessageId = messageId
             }
 
+        case .attachmentIdsReconciled(let conversationId, let mapping):
+            guard belongsToConversation(conversationId) else { return }
+            // Rewrite the optimistic row's client-local attachment IDs to the
+            // daemon-assigned IDs so lazy-load fetch/Save resolve. Matched by the
+            // unique local ID, so only the just-sent row is touched.
+            for mIdx in vm.messages.indices {
+                guard vm.messages[mIdx].role == .user,
+                      !vm.messages[mIdx].attachments.isEmpty else { continue }
+                var changed = false
+                let remapped = vm.messages[mIdx].attachments.map { att -> ChatAttachment in
+                    guard let serverId = mapping[att.id] else { return att }
+                    changed = true
+                    return att.withId(serverId)
+                }
+                if changed {
+                    vm.messages[mIdx].attachments = remapped
+                }
+            }
+
         case .assistantThinkingDelta(let delta):
             guard belongsToConversation(delta.conversationId) else { return }
             guard !vm.isCancelling else { break }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -217,7 +217,10 @@ public final class ChatAttachmentManager {
     /// All blocking work runs off the main actor; platform image construction
     /// happens back on @MainActor where it is safe.
     private func loadAttachment(url: URL) async -> Result<ChatAttachment, AttachmentError> {
-        let attachmentId = UUID().uuidString
+        // Lowercase to match the daemon's canonical (lowercase) attachment IDs —
+        // Swift's UUID().uuidString is uppercase, and the daemon looks up IDs
+        // case-sensitively.
+        let attachmentId = UUID().uuidString.lowercased()
         let filename = url.lastPathComponent
         log.debug("[Attachment] readStart id=\(attachmentId) source=fileURL filename=\(filename)")
         let acquired = await loadSemaphore.wait()
@@ -377,7 +380,8 @@ public final class ChatAttachmentManager {
     /// All blocking work (ImageIO decode/encode, compression) runs off the main actor;
     /// platform image construction happens back on @MainActor where it is safe.
     private func loadAttachment(imageData: Data, filename: String) async -> Result<ChatAttachment, AttachmentError> {
-        let attachmentId = UUID().uuidString
+        // Lowercase to match the daemon's canonical (lowercase) attachment IDs.
+        let attachmentId = UUID().uuidString.lowercased()
         log.debug("[Attachment] readStart id=\(attachmentId) source=imageData filename=\(filename) rawBytes=\(imageData.count)")
         let acquired = await loadSemaphore.wait()
         guard acquired else { return .failure(.message("Attachment load cancelled.")) }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1495,6 +1495,26 @@ public struct ChatAttachment: Identifiable {
         self.filePath = filePath
         self.rawData = rawData
     }
+
+    /// Returns a copy with a different `id`, preserving all other fields.
+    /// Used to reconcile an optimistic client-local attachment ID with the
+    /// canonical daemon-assigned ID returned from upload, so lazy-load fetch
+    /// resolves against the daemon instead of 404ing on the unknown local ID.
+    public func withId(_ newId: String) -> ChatAttachment {
+        ChatAttachment(
+            id: newId,
+            filename: filename,
+            mimeType: mimeType,
+            data: data,
+            thumbnailData: thumbnailData,
+            dataLength: dataLength,
+            sizeBytes: sizeBytes,
+            thumbnailImage: thumbnailImage,
+            filePath: filePath,
+            sourceType: sourceType,
+            rawData: rawData
+        )
+    }
 }
 
 /// Tracks the state of a guardian decision prompt displayed in chat.

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -270,7 +270,9 @@ public enum HistoryReconstructionService {
     /// Map attachment DTOs to ChatAttachment values, generating thumbnails for images.
     nonisolated static func mapMessageAttachmentsStatic(_ attachments: [UserMessageAttachment]) -> [ChatAttachment] {
         attachments.compactMap { attachment in
-            let id = attachment.id ?? UUID().uuidString
+            // Fall back to a lowercase UUID (matching the daemon's canonical case)
+            // when the server omits the id — Swift's UUID().uuidString is uppercase.
+            let id = attachment.id ?? UUID().uuidString.lowercased()
             let base64 = attachment.data
             let dataLength = base64.count
             let sizeBytes: Int? = attachment.sizeBytes.flatMap { Int(exactly: $0) }

--- a/clients/shared/Network/AttachmentContentClient.swift
+++ b/clients/shared/Network/AttachmentContentClient.swift
@@ -3,6 +3,23 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AttachmentContentClient")
 
+/// Error thrown when the gateway returns a non-2xx status for an attachment
+/// content request. Carries the HTTP status so callers can surface a meaningful
+/// message (e.g. "Attachment not found") instead of an opaque transport error
+/// like `NSURLErrorDomain error -1011`.
+public enum AttachmentContentError: LocalizedError {
+    case httpStatus(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .httpStatus(404):
+            return "Attachment not found"
+        case .httpStatus(let status):
+            return "Couldn't load attachment (HTTP \(status))"
+        }
+    }
+}
+
 /// Fetches raw attachment bytes via the gateway, supporting both local and
 /// managed (platform-hosted) assistants through ``GatewayHTTPClient``.
 public enum AttachmentContentClient {
@@ -15,13 +32,14 @@ public enum AttachmentContentClient {
     ///
     /// - Parameter attachmentId: The unique identifier of the attachment.
     /// - Returns: The raw attachment bytes.
-    /// - Throws: ``GatewayHTTPClient/ClientError`` or network errors.
+    /// - Throws: ``AttachmentContentError`` carrying the HTTP status on a non-2xx
+    ///   response, ``GatewayHTTPClient/ClientError``, or network errors.
     public static func fetchContent(attachmentId: String) async throws -> Data {
         let path = "attachments/\(attachmentId)/content"
         let response = try await GatewayHTTPClient.get(path: path, timeout: 120)
         guard response.isSuccess else {
             log.error("Attachment fetch failed with HTTP \(response.statusCode) for \(attachmentId)")
-            throw URLError(.badServerResponse)
+            throw AttachmentContentError.httpStatus(response.statusCode)
         }
         return response.data
     }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -302,6 +302,27 @@ public final class EventStreamClient {
                 }
             }
 
+            // Reconcile the optimistic row's client-local attachment IDs to the
+            // daemon-assigned IDs. The client mints a local UUID per attachment for
+            // the optimistic render; the daemon assigns its own (lowercase) ID on
+            // upload and returns it. Without this, a just-sent file-backed clip whose
+            // local staged file is gone would lazy-load fetch by the unknown local ID
+            // and 404 (surfacing as a cryptic NSURLErrorDomain error on the chip).
+            if let attachments, !attachmentIds.isEmpty {
+                var idRemap: [String: String] = [:]
+                for (attachment, serverId) in zip(attachments, attachmentIds) {
+                    if let localId = attachment.id, localId != serverId {
+                        idRemap[localId] = serverId
+                    }
+                }
+                if !idRemap.isEmpty {
+                    self.broadcastMessage(.attachmentIdsReconciled(
+                        conversationId: conversationId,
+                        mapping: idRemap
+                    ))
+                }
+            }
+
             // Send the message
             let sendResult = await messageClient.sendMessage(
                 content: content,

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -3107,6 +3107,12 @@ public enum ServerMessage: Decodable, Sendable {
     /// queued message. Populates requestIdToMessageId from the HTTP response so
     /// the steer button works even before the SSE message_queued event arrives.
     case queuedMessageAcked(conversationId: String, requestId: String)
+    /// Synthetic client-side event: attachments uploaded during send were assigned
+    /// canonical (daemon) IDs. Broadcast so the per-conversation ChatActionHandler
+    /// can rewrite the optimistic row's client-local attachment IDs to the server
+    /// IDs, so lazy-load fetch (and Save) resolve against the daemon instead of
+    /// 404ing on the unknown local ID. Maps clientLocalId → serverId.
+    case attachmentIdsReconciled(conversationId: String, mapping: [String: String])
     case relationshipStateUpdated(updatedAt: String)
     case homeFeedUpdated(updatedAt: String, newItemCount: Int)
     case pong


### PR DESCRIPTION
## Summary
- **Playback fix:** After attachments upload, reconcile the optimistic chat row's client-local attachment IDs to the daemon-assigned IDs (broadcast a new synthetic `attachmentIdsReconciled` event, handled in `ChatActionHandler`). A just-sent file-backed clip was rendering with a client-minted ID the daemon never assigned, so once its local staged file was gone, lazy-load playback fetched by that ID and got a 404.
- **Error surfacing:** `AttachmentContentClient.fetchContent` now throws a typed `AttachmentContentError.httpStatus(_)` carrying the real status (e.g. "Attachment not found") instead of a bare `URLError(.badServerResponse)`, which rendered as the cryptic "The operation couldn't be completed. (NSURLErrorDomain error -1011.)" on the chip.
- **ID hygiene:** Lowercase client-minted attachment UUIDs (`UUID().uuidString` is uppercase) so they match the daemon's canonical lowercase, case-sensitive IDs. Daemon lookup stays strict (client-side fix only).

## Original prompt
While QAing the Gemini audio feature, sending an audio clip to the assistant in the macOS (Swift) app showed a warning triangle reading "The operation couldn't be completed. (NSURLErrorDomain error -1011.)" instead of playing — and the user asked specifically to check UUID capitalization. The daemon log confirmed the client was fetching the attachment by an UPPERCASE UUID and getting a 404. Root cause: the Swift client mints client-local uppercase UUIDs for attachments that the daemon never assigns (it returns its own lowercase IDs on upload), the optimistic row was never reconciled to the server ID, and the 404 was masked by a discarded status code. This fixes the playback path, the misleading error, and the UUID-case hygiene, keeping the daemon's exact-match lookup strict.