### PR TITLE
feat(web): add download button to workspace file viewer

### DIFF
--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -301,6 +301,7 @@ function EditFooter({
 
 function ContentActionBar({
   content,
+  downloadContent,
   fileName,
   mimeType,
   showEdit,
@@ -308,6 +309,7 @@ function ContentActionBar({
   onToggleEdit,
 }: {
   content: string;
+  downloadContent?: string;
   fileName: string;
   mimeType: string;
   showEdit: boolean;
@@ -327,15 +329,16 @@ function ContentActionBar({
     });
   }, [content]);
 
+  const rawContent = downloadContent ?? content;
   const handleDownload = useCallback(() => {
-    const blob = new Blob([content], { type: mimeType });
+    const blob = new Blob([rawContent], { type: mimeType });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
     a.download = fileName;
     a.click();
     URL.revokeObjectURL(url);
-  }, [content, fileName, mimeType]);
+  }, [rawContent, fileName, mimeType]);
 
   useEffect(() => {
     return () => {
@@ -664,6 +667,7 @@ export function WorkspaceFileViewer({
         <div className="relative flex-1 overflow-hidden">
           <ContentActionBar
             content={viewMode === "preview" ? previewContent : sourceContent}
+            downloadContent={sourceContent}
             fileName={name}
             mimeType={mimeType}
             showEdit={!readOnly && viewMode === "source"}

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -9,6 +9,7 @@ import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/r
 import {
   Check,
   Copy,
+  Download,
   FileIcon,
   FileText,
   FolderOpen,
@@ -300,11 +301,15 @@ function EditFooter({
 
 function ContentActionBar({
   content,
+  fileName,
+  mimeType,
   showEdit,
   isEditing,
   onToggleEdit,
 }: {
   content: string;
+  fileName: string;
+  mimeType: string;
   showEdit: boolean;
   isEditing: boolean;
   onToggleEdit: () => void;
@@ -321,6 +326,16 @@ function ContentActionBar({
       timerRef.current = setTimeout(() => setCopied(false), 1500);
     });
   }, [content]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [content, fileName, mimeType]);
 
   useEffect(() => {
     return () => {
@@ -352,6 +367,14 @@ function ContentActionBar({
         iconOnly={copied ? <Check aria-hidden /> : <Copy aria-hidden />}
         onClick={handleCopy}
         aria-label={copied ? "Copied" : "Copy file contents"}
+        className="hover:bg-[var(--surface-base)]"
+      />
+      <Button
+        variant="ghost"
+        size="regular"
+        iconOnly={<Download aria-hidden />}
+        onClick={handleDownload}
+        aria-label="Download file"
         className="hover:bg-[var(--surface-base)]"
       />
     </div>
@@ -585,6 +608,8 @@ export function WorkspaceFileViewer({
         <div className="relative flex-1 overflow-hidden">
           <ContentActionBar
             content={sourceContent}
+            fileName={name}
+            mimeType={mimeType}
             showEdit={!readOnly && viewMode === "source"}
             isEditing={isEditing}
             onToggleEdit={() =>
@@ -639,6 +664,8 @@ export function WorkspaceFileViewer({
         <div className="relative flex-1 overflow-hidden">
           <ContentActionBar
             content={viewMode === "preview" ? previewContent : sourceContent}
+            fileName={name}
+            mimeType={mimeType}
             showEdit={!readOnly && viewMode === "source"}
             isEditing={isEditing}
             onToggleEdit={() =>
@@ -674,6 +701,8 @@ export function WorkspaceFileViewer({
         <div className="relative flex-1 overflow-hidden">
           <ContentActionBar
             content={isEditing ? editableContent : (data.content ?? "")}
+            fileName={name}
+            mimeType={mimeType}
             showEdit={!readOnly}
             isEditing={isEditing}
             onToggleEdit={() =>


### PR DESCRIPTION
Adds a download button next to the existing copy button in the workspace file viewer's `ContentActionBar`. Users can now download text-based files (markdown, JSON, plain text) directly from the viewer instead of having to copy the content and paste it elsewhere.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/c66693f204404ffeaa3fcd831e422393