### PR TITLE
feat(gemini): surface implicit cache-read tokens in usage accounting

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -36,6 +36,7 @@ interface FakeChunk {
   usageMetadata?: {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
+    cachedContentTokenCount?: number;
   };
   modelVersion?: string;
 }
@@ -98,10 +99,15 @@ function finishChunk(
   reason: string,
   prompt: number,
   output: number,
+  cached?: number,
 ): FakeChunk {
   return {
     candidates: [{ finishReason: reason }],
-    usageMetadata: { promptTokenCount: prompt, candidatesTokenCount: output },
+    usageMetadata: {
+      promptTokenCount: prompt,
+      candidatesTokenCount: output,
+      ...(cached !== undefined ? { cachedContentTokenCount: cached } : {}),
+    },
     modelVersion: "gemini-3-flash-preview-001",
   };
 }
@@ -1447,6 +1453,36 @@ describe("GeminiProvider", () => {
     ]);
 
     expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+
+  // -----------------------------------------------------------------------
+  // Implicit prompt caching (cache reads)
+  // -----------------------------------------------------------------------
+  test("surfaces cachedContentTokenCount as cacheReadInputTokens", async () => {
+    // Gemini reports cached tokens as a subset already included in
+    // promptTokenCount, so inputTokens stays the inclusive total and the
+    // cached subset is reported separately for the discounted cache-read rate.
+    fakeChunks = [textChunk("Hi back"), finishChunk("STOP", 100, 20, 30)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadInputTokens: 30,
+    });
+  });
+
+  test("omits cacheReadInputTokens when no tokens were cached", async () => {
+    fakeChunks = [textChunk("Hi back"), finishChunk("STOP", 100, 20, 0)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 20 });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -363,6 +363,7 @@ export class GeminiProvider implements Provider {
       let finishReason = "unknown";
       let promptTokens = 0;
       let outputTokens = 0;
+      let cachedTokens = 0;
       let responseModel = activeModel;
 
       try {
@@ -410,6 +411,11 @@ export class GeminiProvider implements Provider {
           if (chunk.usageMetadata) {
             promptTokens = chunk.usageMetadata.promptTokenCount ?? 0;
             outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+            // Gemini 2.5+/3.x cache a stable request prefix implicitly (on by
+            // default). promptTokenCount already includes these cached tokens,
+            // so cachedContentTokenCount is the read subset — surface it so the
+            // pricing layer applies the discounted cache-read rate.
+            cachedTokens = chunk.usageMetadata.cachedContentTokenCount ?? 0;
           }
 
           if (chunk.modelVersion) {
@@ -453,13 +459,18 @@ export class GeminiProvider implements Provider {
         usageMetadata: {
           promptTokenCount: promptTokens,
           candidatesTokenCount: outputTokens,
+          cachedContentTokenCount: cachedTokens,
         },
       };
 
       return {
         content,
         model: responseModel,
-        usage: { inputTokens: promptTokens, outputTokens },
+        usage: {
+          inputTokens: promptTokens,
+          outputTokens,
+          ...(cachedTokens > 0 ? { cacheReadInputTokens: cachedTokens } : {}),
+        },
         stopReason: finishReason,
         rawRequest,
         rawResponse,


### PR DESCRIPTION
## Summary
- Gemini's provider never read back `usageMetadata.cachedContentTokenCount`, so implicit prompt caching (automatic on the Gemini 2.5+/3.x models we run) was invisible — every token was priced as full-rate direct input even when Google discounted it on the bill.
- Surface `cachedContentTokenCount` as `usage.cacheReadInputTokens`, mirroring the OpenAI providers (`responses-provider.ts`, `chat-completions-provider.ts`). The downstream pricing layer already carries Gemini `cacheReadPer1mTokens` rates and subtracts cache reads to compute direct input — it just never received any counts for Gemini. `promptTokenCount` already includes the cached subset, so `inputTokens` stays the inclusive total and there's no double-count.
- Add regression tests asserting cached tokens flow through to `cacheReadInputTokens` (and are omitted when zero).

## Original prompt
Asked whether we use prompt caching for Gemini models and, if not, how it should work. Investigation found explicit caching unused and implicit caching — on by default for the 2.5+/3.x models in our catalog — happening on Google's side but never measured, because the Gemini client only extracted prompt/output token counts. Since the usage/pricing plumbing already supports cache-read tokens (as the OpenAI providers use), the fix wires Gemini into it. Scoped deliberately to capturing and correctly pricing implicit caching; an explicit-cache subsystem and thinking-token accounting were left as flagged follow-ups.