### PR TITLE
refactor(permissions): inject broadcastMessage via direct import in QuestionPrompter

### DIFF
--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -11,7 +11,12 @@ import type {
 const mockConfig = {
   timeouts: { permissionTimeoutSec: 0.05 },
 };
+// Preserve every other export from the real config/loader so other
+// tests in the same `bun test` run (which share module-level mocks)
+// don't lose access to e.g. `setNestedValue`.
+const realConfigLoader = await import("../config/loader.js");
 mock.module("../config/loader.js", () => ({
+  ...realConfigLoader,
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
   invalidateConfigCache: () => {},
@@ -61,14 +66,26 @@ mock.module("../runtime/pending-interactions.js", () => ({
   clear: () => _piStore.clear(),
 }));
 
+// `QuestionPrompter` imports `broadcastMessage` directly from
+// assistant-event-hub now (the constructor-injection seam was removed).
+// Intercept that one export so each test instance can observe what the
+// prompter would have broadcast — but preserve every other export from
+// the real module so other tests in the same `bun test` run (which
+// share module-level mocks) still see e.g. `assistantEventHub`.
+let _sentBuffer: ServerMessage[] = [];
+const realEventHub = await import("../runtime/assistant-event-hub.js");
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  ...realEventHub,
+  broadcastMessage: (msg: ServerMessage) => _sentBuffer.push(msg),
+}));
+
 const { QuestionPrompter, QuestionBatchValidationError, buildBatchEntries } =
   await import("./question-prompter.js");
 
 function makePrompter() {
   const sent: ServerMessage[] = [];
-  const prompter = new QuestionPrompter({
-    broadcastMessage: (msg) => sent.push(msg),
-  });
+  _sentBuffer = sent;
+  const prompter = new QuestionPrompter();
   return { prompter, sent };
 }
 

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -5,7 +5,7 @@ import type {
   QuestionRequestEvent,
 } from "../api/events/question-request.js";
 import { getConfig } from "../config/loader.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -161,8 +161,6 @@ export interface QuestionBatchMetadata {
  * secret prompts, so they share the same idle-timeout knob.
  */
 export class QuestionPrompter {
-  constructor(private deps: { broadcastMessage(msg: ServerMessage): void }) {}
-
   async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
     const { conversationId, questions, toolUseId, signal } = params;
 
@@ -289,7 +287,7 @@ export class QuestionPrompter {
         toolUseId,
       };
 
-      this.deps.broadcastMessage(msg);
+      broadcastMessage(msg);
     });
   }
 }

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 import { QuestionPrompter } from "../../permissions/question-prompter.js";
 import { RiskLevel } from "../../permissions/types.js";
-import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -242,7 +241,7 @@ export const askQuestionTool = {
       },
     ];
 
-    const prompter = new QuestionPrompter({ broadcastMessage });
+    const prompter = new QuestionPrompter();
     const result = await prompter.prompt({
       conversationId: context.conversationId,
       questions,


### PR DESCRIPTION
Removes the `broadcastMessage` constructor-injection seam from `QuestionPrompter` and imports it directly from `assistant-event-hub`, simplifying the only two call sites (`ask-question-tool.ts` and the test). The test now mocks the module export instead of passing a dependency object, preserving every other export so sibling tests sharing module-level mocks are unaffected.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/59e1d9bfdd584bcb9571addbcd80a056