### PR TITLE
Remove .strict() from event schemas for forward-compat

### DIFF
--- a/apps/web/src/lib/streaming/event-parser.test.ts
+++ b/apps/web/src/lib/streaming/event-parser.test.ts
@@ -45,16 +45,15 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown assistant_text_delta event when an unknown field is present", () => {
-    // Strict schema rejects forward-compat extras — the daemon and the
-    // canonical schema must move in lockstep.
-    const data = { type: "assistant_text_delta", text: "Hi", legacyField: "x" };
-    const event = parseAssistantEvent(data);
+  test("strips unknown fields from assistant_text_delta", () => {
+    const event = parseAssistantEvent({
+      type: "assistant_text_delta",
+      text: "Hi",
+      legacyField: "x",
+    });
     expect(event).toEqual({
-      type: "unknown",
-      rawType: "assistant_text_delta",
-      data,
-      conversationId: undefined,
+      type: "assistant_text_delta",
+      text: "Hi",
     });
   });
 
@@ -335,10 +334,8 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown document_comment_created event when an unknown field is present", () => {
-    // Strict schema rejects forward-compat extras — the daemon and the
-    // canonical schema must move in lockstep.
-    const data = {
+  test("strips unknown fields from document_comment_created", () => {
+    const event = parseAssistantEvent({
       type: "document_comment_created",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -352,12 +349,20 @@ describe("parseAssistantEvent", () => {
         updatedAt: 0,
       },
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "document_comment_created",
-      data,
+    });
+    expect(event).toEqual({
+      type: "document_comment_created",
       conversationId: "conv-1",
+      surfaceId: "surface-1",
+      comment: {
+        id: "c-1",
+        surfaceId: "surface-1",
+        author: "user",
+        content: "x",
+        status: "open",
+        createdAt: 0,
+        updatedAt: 0,
+      },
     });
   });
 
@@ -397,20 +402,21 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown document_comment_resolved event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from document_comment_resolved", () => {
+    const event = parseAssistantEvent({
       type: "document_comment_resolved",
       conversationId: "conv-1",
       surfaceId: "surface-1",
       commentId: "c-1",
       resolvedBy: "user-alice",
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "document_comment_resolved",
-      data,
+    });
+    expect(event).toEqual({
+      type: "document_comment_resolved",
       conversationId: "conv-1",
+      surfaceId: "surface-1",
+      commentId: "c-1",
+      resolvedBy: "user-alice",
     });
   });
 
@@ -447,19 +453,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown document_comment_reopened event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from document_comment_reopened", () => {
+    const event = parseAssistantEvent({
       type: "document_comment_reopened",
       conversationId: "conv-1",
       surfaceId: "surface-1",
       commentId: "c-1",
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "document_comment_reopened",
-      data,
+    });
+    expect(event).toEqual({
+      type: "document_comment_reopened",
       conversationId: "conv-1",
+      surfaceId: "surface-1",
+      commentId: "c-1",
     });
   });
 
@@ -496,19 +502,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown document_comment_deleted event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from document_comment_deleted", () => {
+    const event = parseAssistantEvent({
       type: "document_comment_deleted",
       conversationId: "conv-1",
       surfaceId: "surface-1",
       commentId: "c-1",
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "document_comment_deleted",
-      data,
+    });
+    expect(event).toEqual({
+      type: "document_comment_deleted",
       conversationId: "conv-1",
+      surfaceId: "surface-1",
+      commentId: "c-1",
     });
   });
 
@@ -545,19 +551,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown message_queued event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from message_queued", () => {
+    const event = parseAssistantEvent({
       type: "message_queued",
       conversationId: "conv-1",
       requestId: "req-1",
       position: 0,
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "message_queued",
-      data,
+    });
+    expect(event).toEqual({
+      type: "message_queued",
       conversationId: "conv-1",
+      requestId: "req-1",
+      position: 0,
     });
   });
 
@@ -591,18 +597,17 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown message_dequeued event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from message_dequeued", () => {
+    const event = parseAssistantEvent({
       type: "message_dequeued",
       conversationId: "conv-1",
       requestId: "req-1",
       stale: true,
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "message_dequeued",
-      data,
+    });
+    expect(event).toEqual({
+      type: "message_dequeued",
       conversationId: "conv-1",
+      requestId: "req-1",
     });
   });
 
@@ -636,18 +641,17 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown message_queued_deleted event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from message_queued_deleted", () => {
+    const event = parseAssistantEvent({
       type: "message_queued_deleted",
       conversationId: "conv-1",
       requestId: "req-1",
       legacyReason: "user_cancel",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "message_queued_deleted",
-      data,
+    });
+    expect(event).toEqual({
+      type: "message_queued_deleted",
       conversationId: "conv-1",
+      requestId: "req-1",
     });
   });
 
@@ -696,19 +700,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown message_request_complete event when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from message_request_complete", () => {
+    const event = parseAssistantEvent({
       type: "message_request_complete",
       conversationId: "conv-1",
       requestId: "req-1",
       runStillActive: false,
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "message_request_complete",
-      data,
+    });
+    expect(event).toEqual({
+      type: "message_request_complete",
       conversationId: "conv-1",
+      requestId: "req-1",
+      runStillActive: false,
     });
   });
 
@@ -838,20 +842,21 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown interaction_resolved when an unknown field is present", () => {
-    const data = {
+  test("strips unknown fields from interaction_resolved", () => {
+    const event = parseAssistantEvent({
       type: "interaction_resolved",
       requestId: "req-1",
       conversationId: "conv-1",
       state: "approved",
       kind: "confirmation",
       legacyField: "x",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "interaction_resolved",
-      data,
+    });
+    expect(event).toEqual({
+      type: "interaction_resolved",
+      requestId: "req-1",
       conversationId: "conv-1",
+      state: "approved",
+      kind: "confirmation",
     });
   });
 
@@ -1603,20 +1608,21 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown ui_surface_show when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from ui_surface_show", () => {
+    const event = parseAssistantEvent({
       type: "ui_surface_show",
       conversationId: "conv-4",
       surfaceId: "s-4",
       surfaceType: "card",
       data: {},
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "ui_surface_show",
-      data,
+    });
+    expect(event).toEqual({
+      type: "ui_surface_show",
       conversationId: "conv-4",
+      surfaceId: "s-4",
+      surfaceType: "card",
+      data: {},
     });
   });
 
@@ -1653,19 +1659,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown ui_surface_update when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from ui_surface_update", () => {
+    const event = parseAssistantEvent({
       type: "ui_surface_update",
       conversationId: "conv-1",
       surfaceId: "s-1",
       data: {},
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "ui_surface_update",
-      data,
+    });
+    expect(event).toEqual({
+      type: "ui_surface_update",
       conversationId: "conv-1",
+      surfaceId: "s-1",
+      data: {},
     });
   });
 
@@ -1699,18 +1705,17 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown ui_surface_dismiss when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from ui_surface_dismiss", () => {
+    const event = parseAssistantEvent({
       type: "ui_surface_dismiss",
       conversationId: "conv-1",
       surfaceId: "s-1",
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "ui_surface_dismiss",
-      data,
+    });
+    expect(event).toEqual({
+      type: "ui_surface_dismiss",
       conversationId: "conv-1",
+      surfaceId: "s-1",
     });
   });
 
@@ -1764,19 +1769,19 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown ui_surface_complete when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from ui_surface_complete", () => {
+    const event = parseAssistantEvent({
       type: "ui_surface_complete",
       conversationId: "conv-1",
       surfaceId: "s-1",
       summary: "Done",
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "ui_surface_complete",
-      data,
+    });
+    expect(event).toEqual({
+      type: "ui_surface_complete",
       conversationId: "conv-1",
+      surfaceId: "s-1",
+      summary: "Done",
     });
   });
 
@@ -2065,19 +2070,21 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown secret_request when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from secret_request", () => {
+    const event = parseAssistantEvent({
       type: "secret_request",
       requestId: "sr-4",
       service: "openai",
       field: "api_key",
       label: "Extra",
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "secret_request",
-      data,
+    });
+    expect(event).toEqual({
+      type: "secret_request",
+      requestId: "sr-4",
+      service: "openai",
+      field: "api_key",
+      label: "Extra",
     });
   });
 
@@ -2185,8 +2192,8 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown confirmation_request when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from confirmation_request", () => {
+    const event = parseAssistantEvent({
       type: "confirmation_request",
       requestId: "cr-4",
       toolName: "bash",
@@ -2195,11 +2202,15 @@ describe("parseAssistantEvent", () => {
       allowlistOptions: [],
       scopeOptions: [],
       title: "Allow?",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "confirmation_request",
-      data,
+    });
+    expect(event).toEqual({
+      type: "confirmation_request",
+      requestId: "cr-4",
+      toolName: "bash",
+      input: {},
+      riskLevel: "low",
+      allowlistOptions: [],
+      scopeOptions: [],
     });
   });
 
@@ -2248,16 +2259,15 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown contact_request when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from contact_request", () => {
+    const event = parseAssistantEvent({
       type: "contact_request",
       requestId: "ctc-3",
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "contact_request",
-      data,
+    });
+    expect(event).toEqual({
+      type: "contact_request",
+      requestId: "ctc-3",
     });
   });
 
@@ -2337,19 +2347,21 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("returns unknown question_request when extra field is present", () => {
-    const data = {
+  test("strips unknown fields from question_request", () => {
+    const event = parseAssistantEvent({
       type: "question_request",
       requestId: "qr-4",
       questions: [{ id: "q1", question: "?", options: [] }],
       question: "?",
       options: [],
       surpriseField: "boom",
-    };
-    expect(parseAssistantEvent(data)).toEqual({
-      type: "unknown",
-      rawType: "question_request",
-      data,
+    });
+    expect(event).toEqual({
+      type: "question_request",
+      requestId: "qr-4",
+      questions: [{ id: "q1", question: "?", options: [] }],
+      question: "?",
+      options: [],
     });
   });
 });

--- a/assistant/src/api/README.md
+++ b/assistant/src/api/README.md
@@ -30,20 +30,20 @@ one at a time — the per-batch overhead is the same regardless of count.
 
 ### 1. Add the canonical schema
 
-One file per event under `./events/`. Each schema is `.strict()` so unknown
-fields surface as `UnknownEvent` rather than silently passing through.
+One file per event under `./events/`. Schemas use Zod's default strip
+mode — unknown fields are silently discarded during parsing so the
+server can add transport-level metadata (e.g. `seq`) without breaking
+client validation.
 
 ```ts
 // assistant/src/api/events/my-event.ts
 import { z } from "zod";
 
-export const MyEventSchema = z
-  .object({
-    type: z.literal("my_event"),
-    conversationId: z.string(),
-    // …
-  })
-  .strict();
+export const MyEventSchema = z.object({
+  type: z.literal("my_event"),
+  conversationId: z.string(),
+  // …
+});
 
 export type MyEvent = z.infer<typeof MyEventSchema>;
 ```
@@ -95,7 +95,7 @@ Add parser tests for each migrated event covering:
 - happy path with all fields
 - minimal required only
 - missing required field → `UnknownEvent`
-- strict mode rejects an unknown extra field → `UnknownEvent`
+- unknown extra field is silently stripped, event still parses
 
 For happy-path tests, inline the discriminator literal in both the input and
 the expected object. `const data = { type: "my_event", … }` widens

--- a/assistant/src/api/events/assistant-outbound-attachment.ts
+++ b/assistant/src/api/events/assistant-outbound-attachment.ts
@@ -18,33 +18,31 @@
 
 import { z } from "zod";
 
-export const AssistantOutboundAttachmentSchema = z
-  .object({
-    /** Storage id assigned by the daemon's attachment store; absent on
-     *  in-memory drafts not backed by a stored row. */
-    id: z.string().optional(),
-    filename: z.string(),
-    mimeType: z.string(),
-    /** Base64-encoded file bytes. May be empty when `fileBacked` is
-     *  true and the client should hydrate via the /content endpoint. */
-    data: z.string(),
-    sourceType: z.enum(["sandbox_file", "host_file", "tool_block"]).optional(),
-    /** Original file size in bytes. Present when `data` was omitted to
-     *  keep payloads small. */
-    sizeBytes: z.number().optional(),
-    /** Base64-encoded JPEG thumbnail. Generated server-side for video
-     *  attachments. */
-    thumbnailData: z.string().optional(),
-    /** True when the attachment is stored on disk and clients should
-     *  hydrate via the /content endpoint instead of relying on `data`. */
-    fileBacked: z.boolean().optional(),
-    /** Local on-disk path for file-backed attachments. Used by the
-     *  macOS client to play recordings and render thumbnails directly
-     *  from the local file (see #9744 — eliminates the HTTP fetch +
-     *  ffmpeg dep for video). Web clients ignore this field. */
-    filePath: z.string().optional(),
-  })
-  .strict();
+export const AssistantOutboundAttachmentSchema = z.object({
+  /** Storage id assigned by the daemon's attachment store; absent on
+   *  in-memory drafts not backed by a stored row. */
+  id: z.string().optional(),
+  filename: z.string(),
+  mimeType: z.string(),
+  /** Base64-encoded file bytes. May be empty when `fileBacked` is
+   *  true and the client should hydrate via the /content endpoint. */
+  data: z.string(),
+  sourceType: z.enum(["sandbox_file", "host_file", "tool_block"]).optional(),
+  /** Original file size in bytes. Present when `data` was omitted to
+   *  keep payloads small. */
+  sizeBytes: z.number().optional(),
+  /** Base64-encoded JPEG thumbnail. Generated server-side for video
+   *  attachments. */
+  thumbnailData: z.string().optional(),
+  /** True when the attachment is stored on disk and clients should
+   *  hydrate via the /content endpoint instead of relying on `data`. */
+  fileBacked: z.boolean().optional(),
+  /** Local on-disk path for file-backed attachments. Used by the
+   *  macOS client to play recordings and render thumbnails directly
+   *  from the local file (see #9744 — eliminates the HTTP fetch +
+   *  ffmpeg dep for video). Web clients ignore this field. */
+  filePath: z.string().optional(),
+});
 
 export type AssistantOutboundAttachment = z.infer<
   typeof AssistantOutboundAttachmentSchema

--- a/assistant/src/api/events/assistant-text-delta.ts
+++ b/assistant/src/api/events/assistant-text-delta.ts
@@ -18,14 +18,12 @@
 
 import { z } from "zod";
 
-export const AssistantTextDeltaEventSchema = z
-  .object({
-    type: z.literal("assistant_text_delta"),
-    text: z.string(),
-    messageId: z.string().optional(),
-    conversationId: z.string().optional(),
-  })
-  .strict();
+export const AssistantTextDeltaEventSchema = z.object({
+  type: z.literal("assistant_text_delta"),
+  text: z.string(),
+  messageId: z.string().optional(),
+  conversationId: z.string().optional(),
+});
 
 export type AssistantTextDeltaEvent = z.infer<
   typeof AssistantTextDeltaEventSchema

--- a/assistant/src/api/events/assistant-turn-start.ts
+++ b/assistant/src/api/events/assistant-turn-start.ts
@@ -20,13 +20,11 @@
 
 import { z } from "zod";
 
-export const AssistantTurnStartEventSchema = z
-  .object({
-    type: z.literal("assistant_turn_start"),
-    messageId: z.string(),
-    conversationId: z.string().optional(),
-  })
-  .strict();
+export const AssistantTurnStartEventSchema = z.object({
+  type: z.literal("assistant_turn_start"),
+  messageId: z.string(),
+  conversationId: z.string().optional(),
+});
 
 export type AssistantTurnStartEvent = z.infer<
   typeof AssistantTurnStartEventSchema

--- a/assistant/src/api/events/avatar-updated.ts
+++ b/assistant/src/api/events/avatar-updated.ts
@@ -15,12 +15,10 @@
 
 import { z } from "zod";
 
-export const AvatarUpdatedEventSchema = z
-  .object({
-    type: z.literal("avatar_updated"),
-    /** Absolute path to the updated avatar image file. */
-    avatarPath: z.string(),
-  })
-  .strict();
+export const AvatarUpdatedEventSchema = z.object({
+  type: z.literal("avatar_updated"),
+  /** Absolute path to the updated avatar image file. */
+  avatarPath: z.string(),
+});
 
 export type AvatarUpdatedEvent = z.infer<typeof AvatarUpdatedEventSchema>;

--- a/assistant/src/api/events/compaction-circuit-closed.ts
+++ b/assistant/src/api/events/compaction-circuit-closed.ts
@@ -16,12 +16,10 @@
 
 import { z } from "zod";
 
-export const CompactionCircuitClosedEventSchema = z
-  .object({
-    type: z.literal("compaction_circuit_closed"),
-    conversationId: z.string(),
-  })
-  .strict();
+export const CompactionCircuitClosedEventSchema = z.object({
+  type: z.literal("compaction_circuit_closed"),
+  conversationId: z.string(),
+});
 
 export type CompactionCircuitClosedEvent = z.infer<
   typeof CompactionCircuitClosedEventSchema

--- a/assistant/src/api/events/compaction-circuit-open.ts
+++ b/assistant/src/api/events/compaction-circuit-open.ts
@@ -15,15 +15,13 @@
 
 import { z } from "zod";
 
-export const CompactionCircuitOpenEventSchema = z
-  .object({
-    type: z.literal("compaction_circuit_open"),
-    conversationId: z.string(),
-    reason: z.literal("3_consecutive_failures"),
-    /** Timestamp (ms since epoch) when the breaker will allow auto-compaction again. */
-    openUntil: z.number(),
-  })
-  .strict();
+export const CompactionCircuitOpenEventSchema = z.object({
+  type: z.literal("compaction_circuit_open"),
+  conversationId: z.string(),
+  reason: z.literal("3_consecutive_failures"),
+  /** Timestamp (ms since epoch) when the breaker will allow auto-compaction again. */
+  openUntil: z.number(),
+});
 
 export type CompactionCircuitOpenEvent = z.infer<
   typeof CompactionCircuitOpenEventSchema

--- a/assistant/src/api/events/confirmation-request.ts
+++ b/assistant/src/api/events/confirmation-request.ts
@@ -35,42 +35,34 @@
 
 import { z } from "zod";
 
-export const AllowlistOptionSchema = z
-  .object({
-    label: z.string(),
-    description: z.string(),
-    pattern: z.string(),
-  })
-  .strict();
+export const AllowlistOptionSchema = z.object({
+  label: z.string(),
+  description: z.string(),
+  pattern: z.string(),
+});
 
 export type AllowlistOption = z.infer<typeof AllowlistOptionSchema>;
 
-export const ScopeOptionSchema = z
-  .object({
-    label: z.string(),
-    scope: z.string(),
-  })
-  .strict();
+export const ScopeOptionSchema = z.object({
+  label: z.string(),
+  scope: z.string(),
+});
 
 export type ScopeOption = z.infer<typeof ScopeOptionSchema>;
 
-export const DirectoryScopeOptionSchema = z
-  .object({
-    label: z.string(),
-    scope: z.string(),
-  })
-  .strict();
+export const DirectoryScopeOptionSchema = z.object({
+  label: z.string(),
+  scope: z.string(),
+});
 
 export type DirectoryScopeOption = z.infer<typeof DirectoryScopeOptionSchema>;
 
-export const ConfirmationDiffSchema = z
-  .object({
-    filePath: z.string(),
-    oldContent: z.string(),
-    newContent: z.string(),
-    isNewFile: z.boolean(),
-  })
-  .strict();
+export const ConfirmationDiffSchema = z.object({
+  filePath: z.string(),
+  oldContent: z.string(),
+  newContent: z.string(),
+  isNewFile: z.boolean(),
+});
 
 export type ConfirmationDiff = z.infer<typeof ConfirmationDiffSchema>;
 
@@ -83,13 +75,11 @@ export const ACPOptionKindSchema = z.enum([
 
 export type ACPOptionKind = z.infer<typeof ACPOptionKindSchema>;
 
-export const ACPOptionSchema = z
-  .object({
-    optionId: z.string(),
-    name: z.string(),
-    kind: ACPOptionKindSchema,
-  })
-  .strict();
+export const ACPOptionSchema = z.object({
+  optionId: z.string(),
+  name: z.string(),
+  kind: ACPOptionKindSchema,
+});
 
 export type ACPOption = z.infer<typeof ACPOptionSchema>;
 
@@ -99,27 +89,25 @@ export type ConfirmationExecutionTarget = z.infer<
   typeof ConfirmationExecutionTargetSchema
 >;
 
-export const ConfirmationRequestEventSchema = z
-  .object({
-    type: z.literal("confirmation_request"),
-    requestId: z.string(),
-    toolName: z.string(),
-    input: z.record(z.string(), z.unknown()),
-    riskLevel: z.string(),
-    riskReason: z.string().optional(),
-    isContainerized: z.boolean().optional(),
-    executionTarget: ConfirmationExecutionTargetSchema.optional(),
-    allowlistOptions: z.array(AllowlistOptionSchema),
-    scopeOptions: z.array(ScopeOptionSchema),
-    directoryScopeOptions: z.array(DirectoryScopeOptionSchema).optional(),
-    diff: ConfirmationDiffSchema.optional(),
-    conversationId: z.string().optional(),
-    persistentDecisionsAllowed: z.boolean().optional(),
-    toolUseId: z.string().optional(),
-    acpToolKind: z.string().optional(),
-    acpOptions: z.array(ACPOptionSchema).optional(),
-  })
-  .strict();
+export const ConfirmationRequestEventSchema = z.object({
+  type: z.literal("confirmation_request"),
+  requestId: z.string(),
+  toolName: z.string(),
+  input: z.record(z.string(), z.unknown()),
+  riskLevel: z.string(),
+  riskReason: z.string().optional(),
+  isContainerized: z.boolean().optional(),
+  executionTarget: ConfirmationExecutionTargetSchema.optional(),
+  allowlistOptions: z.array(AllowlistOptionSchema),
+  scopeOptions: z.array(ScopeOptionSchema),
+  directoryScopeOptions: z.array(DirectoryScopeOptionSchema).optional(),
+  diff: ConfirmationDiffSchema.optional(),
+  conversationId: z.string().optional(),
+  persistentDecisionsAllowed: z.boolean().optional(),
+  toolUseId: z.string().optional(),
+  acpToolKind: z.string().optional(),
+  acpOptions: z.array(ACPOptionSchema).optional(),
+});
 
 export type ConfirmationRequestEvent = z.infer<
   typeof ConfirmationRequestEventSchema

--- a/assistant/src/api/events/contact-request.ts
+++ b/assistant/src/api/events/contact-request.ts
@@ -20,16 +20,14 @@
 
 import { z } from "zod";
 
-export const ContactRequestEventSchema = z
-  .object({
-    type: z.literal("contact_request"),
-    requestId: z.string(),
-    channel: z.string().optional(),
-    placeholder: z.string().optional(),
-    label: z.string().optional(),
-    description: z.string().optional(),
-    role: z.string().optional(),
-  })
-  .strict();
+export const ContactRequestEventSchema = z.object({
+  type: z.literal("contact_request"),
+  requestId: z.string(),
+  channel: z.string().optional(),
+  placeholder: z.string().optional(),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  role: z.string().optional(),
+});
 
 export type ContactRequestEvent = z.infer<typeof ContactRequestEventSchema>;

--- a/assistant/src/api/events/conversation-list-invalidated.ts
+++ b/assistant/src/api/events/conversation-list-invalidated.ts
@@ -27,13 +27,11 @@ export type ConversationListInvalidatedReason = z.infer<
   typeof ConversationListInvalidatedReasonSchema
 >;
 
-export const ConversationListInvalidatedEventSchema = z
-  .object({
-    type: z.literal("conversation_list_invalidated"),
-    /** Categorical cause of invalidation. */
-    reason: ConversationListInvalidatedReasonSchema,
-  })
-  .strict();
+export const ConversationListInvalidatedEventSchema = z.object({
+  type: z.literal("conversation_list_invalidated"),
+  /** Categorical cause of invalidation. */
+  reason: ConversationListInvalidatedReasonSchema,
+});
 
 export type ConversationListInvalidatedEvent = z.infer<
   typeof ConversationListInvalidatedEventSchema

--- a/assistant/src/api/events/conversation-title-updated.ts
+++ b/assistant/src/api/events/conversation-title-updated.ts
@@ -11,15 +11,13 @@
 
 import { z } from "zod";
 
-export const ConversationTitleUpdatedEventSchema = z
-  .object({
-    type: z.literal("conversation_title_updated"),
-    /** Conversation whose title changed. */
-    conversationId: z.string(),
-    /** New title. */
-    title: z.string(),
-  })
-  .strict();
+export const ConversationTitleUpdatedEventSchema = z.object({
+  type: z.literal("conversation_title_updated"),
+  /** Conversation whose title changed. */
+  conversationId: z.string(),
+  /** New title. */
+  title: z.string(),
+});
 
 export type ConversationTitleUpdatedEvent = z.infer<
   typeof ConversationTitleUpdatedEventSchema

--- a/assistant/src/api/events/document-comment-created.ts
+++ b/assistant/src/api/events/document-comment-created.ts
@@ -13,35 +13,31 @@
 
 import { z } from "zod";
 
-const DocumentCommentSchema = z
-  .object({
-    id: z.string(),
-    surfaceId: z.string(),
-    /** Author label — typically `"user"` or `"assistant"`. Wire is permissive `string`; clients narrow at the boundary. */
-    author: z.string(),
-    content: z.string(),
-    /** Character offsets into the rendered document text when the comment is anchored to a selection. */
-    anchorStart: z.number().optional(),
-    anchorEnd: z.number().optional(),
-    /** The selected text the comment was anchored to, for resilience to document edits. */
-    anchorText: z.string().optional(),
-    /** Set when the comment is a reply in a thread. */
-    parentCommentId: z.string().optional(),
-    /** Lifecycle state — `"open"` or `"resolved"`. Wire is permissive `string`; clients narrow at the boundary. */
-    status: z.string(),
-    createdAt: z.number(),
-    updatedAt: z.number(),
-  })
-  .strict();
+const DocumentCommentSchema = z.object({
+  id: z.string(),
+  surfaceId: z.string(),
+  /** Author label — typically `"user"` or `"assistant"`. Wire is permissive `string`; clients narrow at the boundary. */
+  author: z.string(),
+  content: z.string(),
+  /** Character offsets into the rendered document text when the comment is anchored to a selection. */
+  anchorStart: z.number().optional(),
+  anchorEnd: z.number().optional(),
+  /** The selected text the comment was anchored to, for resilience to document edits. */
+  anchorText: z.string().optional(),
+  /** Set when the comment is a reply in a thread. */
+  parentCommentId: z.string().optional(),
+  /** Lifecycle state — `"open"` or `"resolved"`. Wire is permissive `string`; clients narrow at the boundary. */
+  status: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
 
-export const DocumentCommentCreatedEventSchema = z
-  .object({
-    type: z.literal("document_comment_created"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    comment: DocumentCommentSchema,
-  })
-  .strict();
+export const DocumentCommentCreatedEventSchema = z.object({
+  type: z.literal("document_comment_created"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  comment: DocumentCommentSchema,
+});
 
 export type DocumentCommentCreatedEvent = z.infer<
   typeof DocumentCommentCreatedEventSchema

--- a/assistant/src/api/events/document-comment-deleted.ts
+++ b/assistant/src/api/events/document-comment-deleted.ts
@@ -10,14 +10,12 @@
 
 import { z } from "zod";
 
-export const DocumentCommentDeletedEventSchema = z
-  .object({
-    type: z.literal("document_comment_deleted"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    commentId: z.string(),
-  })
-  .strict();
+export const DocumentCommentDeletedEventSchema = z.object({
+  type: z.literal("document_comment_deleted"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  commentId: z.string(),
+});
 
 export type DocumentCommentDeletedEvent = z.infer<
   typeof DocumentCommentDeletedEventSchema

--- a/assistant/src/api/events/document-comment-reopened.ts
+++ b/assistant/src/api/events/document-comment-reopened.ts
@@ -11,14 +11,12 @@
 
 import { z } from "zod";
 
-export const DocumentCommentReopenedEventSchema = z
-  .object({
-    type: z.literal("document_comment_reopened"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    commentId: z.string(),
-  })
-  .strict();
+export const DocumentCommentReopenedEventSchema = z.object({
+  type: z.literal("document_comment_reopened"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  commentId: z.string(),
+});
 
 export type DocumentCommentReopenedEvent = z.infer<
   typeof DocumentCommentReopenedEventSchema

--- a/assistant/src/api/events/document-comment-resolved.ts
+++ b/assistant/src/api/events/document-comment-resolved.ts
@@ -11,16 +11,14 @@
 
 import { z } from "zod";
 
-export const DocumentCommentResolvedEventSchema = z
-  .object({
-    type: z.literal("document_comment_resolved"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    commentId: z.string(),
-    /** User or actor label that resolved the comment. */
-    resolvedBy: z.string(),
-  })
-  .strict();
+export const DocumentCommentResolvedEventSchema = z.object({
+  type: z.literal("document_comment_resolved"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  commentId: z.string(),
+  /** User or actor label that resolved the comment. */
+  resolvedBy: z.string(),
+});
 
 export type DocumentCommentResolvedEvent = z.infer<
   typeof DocumentCommentResolvedEventSchema

--- a/assistant/src/api/events/generation-cancelled.ts
+++ b/assistant/src/api/events/generation-cancelled.ts
@@ -12,12 +12,10 @@
 
 import { z } from "zod";
 
-export const GenerationCancelledEventSchema = z
-  .object({
-    type: z.literal("generation_cancelled"),
-    conversationId: z.string().optional(),
-  })
-  .strict();
+export const GenerationCancelledEventSchema = z.object({
+  type: z.literal("generation_cancelled"),
+  conversationId: z.string().optional(),
+});
 
 export type GenerationCancelledEvent = z.infer<
   typeof GenerationCancelledEventSchema

--- a/assistant/src/api/events/generation-handoff.ts
+++ b/assistant/src/api/events/generation-handoff.ts
@@ -20,21 +20,19 @@ import { z } from "zod";
 
 import { AssistantOutboundAttachmentSchema } from "./assistant-outbound-attachment.js";
 
-export const GenerationHandoffEventSchema = z
-  .object({
-    type: z.literal("generation_handoff"),
-    conversationId: z.string().optional(),
-    /** Daemon request id of the just-finished turn — correlates with
-     *  the request id surfaced by the inbound user message. */
-    requestId: z.string().optional(),
-    /** Depth of the pending-message queue at handoff time. */
-    queuedCount: z.number(),
-    /** Database row id of the just-finished assistant turn. */
-    messageId: z.string().optional(),
-    attachments: z.array(AssistantOutboundAttachmentSchema).optional(),
-    attachmentWarnings: z.array(z.string()).optional(),
-  })
-  .strict();
+export const GenerationHandoffEventSchema = z.object({
+  type: z.literal("generation_handoff"),
+  conversationId: z.string().optional(),
+  /** Daemon request id of the just-finished turn — correlates with
+   *  the request id surfaced by the inbound user message. */
+  requestId: z.string().optional(),
+  /** Depth of the pending-message queue at handoff time. */
+  queuedCount: z.number(),
+  /** Database row id of the just-finished assistant turn. */
+  messageId: z.string().optional(),
+  attachments: z.array(AssistantOutboundAttachmentSchema).optional(),
+  attachmentWarnings: z.array(z.string()).optional(),
+});
 
 export type GenerationHandoffEvent = z.infer<
   typeof GenerationHandoffEventSchema

--- a/assistant/src/api/events/home-feed-updated.ts
+++ b/assistant/src/api/events/home-feed-updated.ts
@@ -15,14 +15,12 @@
 
 import { z } from "zod";
 
-export const HomeFeedUpdatedEventSchema = z
-  .object({
-    type: z.literal("home_feed_updated"),
-    /** ISO-8601 timestamp of when the feed was written. */
-    updatedAt: z.string(),
-    /** Count of items with `status === "new"` after this write. */
-    newItemCount: z.number(),
-  })
-  .strict();
+export const HomeFeedUpdatedEventSchema = z.object({
+  type: z.literal("home_feed_updated"),
+  /** ISO-8601 timestamp of when the feed was written. */
+  updatedAt: z.string(),
+  /** Count of items with `status === "new"` after this write. */
+  newItemCount: z.number(),
+});
 
 export type HomeFeedUpdatedEvent = z.infer<typeof HomeFeedUpdatedEventSchema>;

--- a/assistant/src/api/events/identity-changed.ts
+++ b/assistant/src/api/events/identity-changed.ts
@@ -15,20 +15,18 @@
 
 import { z } from "zod";
 
-export const IdentityChangedEventSchema = z
-  .object({
-    type: z.literal("identity_changed"),
-    /** Updated assistant name. */
-    name: z.string(),
-    /** Updated role / job description. */
-    role: z.string(),
-    /** Updated personality description. */
-    personality: z.string(),
-    /** Updated emoji glyph. */
-    emoji: z.string(),
-    /** Updated home / origin description. */
-    home: z.string(),
-  })
-  .strict();
+export const IdentityChangedEventSchema = z.object({
+  type: z.literal("identity_changed"),
+  /** Updated assistant name. */
+  name: z.string(),
+  /** Updated role / job description. */
+  role: z.string(),
+  /** Updated personality description. */
+  personality: z.string(),
+  /** Updated emoji glyph. */
+  emoji: z.string(),
+  /** Updated home / origin description. */
+  home: z.string(),
+});
 
 export type IdentityChangedEvent = z.infer<typeof IdentityChangedEventSchema>;

--- a/assistant/src/api/events/interaction-resolved.ts
+++ b/assistant/src/api/events/interaction-resolved.ts
@@ -37,15 +37,13 @@ export type InteractionResolutionState = z.infer<
   typeof InteractionResolutionStateSchema
 >;
 
-export const InteractionResolvedEventSchema = z
-  .object({
-    type: z.literal("interaction_resolved"),
-    requestId: z.string(),
-    conversationId: z.string(),
-    state: InteractionResolutionStateSchema,
-    kind: z.string(),
-  })
-  .strict();
+export const InteractionResolvedEventSchema = z.object({
+  type: z.literal("interaction_resolved"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  state: InteractionResolutionStateSchema,
+  kind: z.string(),
+});
 
 export type InteractionResolvedEvent = z.infer<
   typeof InteractionResolvedEventSchema

--- a/assistant/src/api/events/message-complete.ts
+++ b/assistant/src/api/events/message-complete.ts
@@ -26,17 +26,15 @@ import { z } from "zod";
 
 import { AssistantOutboundAttachmentSchema } from "./assistant-outbound-attachment.js";
 
-export const MessageCompleteEventSchema = z
-  .object({
-    type: z.literal("message_complete"),
-    messageId: z.string().optional(),
-    conversationId: z.string().optional(),
-    source: z.enum(["main", "aux"]).optional(),
-    attachments: z.array(AssistantOutboundAttachmentSchema).optional(),
-    /** Soft warnings produced while resolving attachments (e.g. format
-     *  conversions, size truncations). Display-only — not blocking. */
-    attachmentWarnings: z.array(z.string()).optional(),
-  })
-  .strict();
+export const MessageCompleteEventSchema = z.object({
+  type: z.literal("message_complete"),
+  messageId: z.string().optional(),
+  conversationId: z.string().optional(),
+  source: z.enum(["main", "aux"]).optional(),
+  attachments: z.array(AssistantOutboundAttachmentSchema).optional(),
+  /** Soft warnings produced while resolving attachments (e.g. format
+   *  conversions, size truncations). Display-only — not blocking. */
+  attachmentWarnings: z.array(z.string()).optional(),
+});
 
 export type MessageCompleteEvent = z.infer<typeof MessageCompleteEventSchema>;

--- a/assistant/src/api/events/message-dequeued.ts
+++ b/assistant/src/api/events/message-dequeued.ts
@@ -12,12 +12,10 @@
 
 import { z } from "zod";
 
-export const MessageDequeuedEventSchema = z
-  .object({
-    type: z.literal("message_dequeued"),
-    conversationId: z.string(),
-    requestId: z.string(),
-  })
-  .strict();
+export const MessageDequeuedEventSchema = z.object({
+  type: z.literal("message_dequeued"),
+  conversationId: z.string(),
+  requestId: z.string(),
+});
 
 export type MessageDequeuedEvent = z.infer<typeof MessageDequeuedEventSchema>;

--- a/assistant/src/api/events/message-queued-deleted.ts
+++ b/assistant/src/api/events/message-queued-deleted.ts
@@ -12,13 +12,11 @@
 
 import { z } from "zod";
 
-export const MessageQueuedDeletedEventSchema = z
-  .object({
-    type: z.literal("message_queued_deleted"),
-    conversationId: z.string(),
-    requestId: z.string(),
-  })
-  .strict();
+export const MessageQueuedDeletedEventSchema = z.object({
+  type: z.literal("message_queued_deleted"),
+  conversationId: z.string(),
+  requestId: z.string(),
+});
 
 export type MessageQueuedDeletedEvent = z.infer<
   typeof MessageQueuedDeletedEventSchema

--- a/assistant/src/api/events/message-queued.ts
+++ b/assistant/src/api/events/message-queued.ts
@@ -12,13 +12,11 @@
 
 import { z } from "zod";
 
-export const MessageQueuedEventSchema = z
-  .object({
-    type: z.literal("message_queued"),
-    conversationId: z.string(),
-    requestId: z.string(),
-    position: z.number(),
-  })
-  .strict();
+export const MessageQueuedEventSchema = z.object({
+  type: z.literal("message_queued"),
+  conversationId: z.string(),
+  requestId: z.string(),
+  position: z.number(),
+});
 
 export type MessageQueuedEvent = z.infer<typeof MessageQueuedEventSchema>;

--- a/assistant/src/api/events/message-request-complete.ts
+++ b/assistant/src/api/events/message-request-complete.ts
@@ -17,14 +17,12 @@
 
 import { z } from "zod";
 
-export const MessageRequestCompleteEventSchema = z
-  .object({
-    type: z.literal("message_request_complete"),
-    conversationId: z.string(),
-    requestId: z.string(),
-    runStillActive: z.boolean().optional(),
-  })
-  .strict();
+export const MessageRequestCompleteEventSchema = z.object({
+  type: z.literal("message_request_complete"),
+  conversationId: z.string(),
+  requestId: z.string(),
+  runStillActive: z.boolean().optional(),
+});
 
 export type MessageRequestCompleteEvent = z.infer<
   typeof MessageRequestCompleteEventSchema

--- a/assistant/src/api/events/open-url.ts
+++ b/assistant/src/api/events/open-url.ts
@@ -18,13 +18,11 @@
 
 import { z } from "zod";
 
-export const OpenUrlEventSchema = z
-  .object({
-    type: z.literal("open_url"),
-    url: z.string().min(1),
-    title: z.string().optional(),
-    conversationId: z.string().optional(),
-  })
-  .strict();
+export const OpenUrlEventSchema = z.object({
+  type: z.literal("open_url"),
+  url: z.string().min(1),
+  title: z.string().optional(),
+  conversationId: z.string().optional(),
+});
 
 export type OpenUrlEvent = z.infer<typeof OpenUrlEventSchema>;

--- a/assistant/src/api/events/question-request.ts
+++ b/assistant/src/api/events/question-request.ts
@@ -34,40 +34,34 @@
 
 import { z } from "zod";
 
-export const QuestionOptionSchema = z
-  .object({
-    id: z.string(),
-    label: z.string(),
-    description: z.string().optional(),
-  })
-  .strict();
+export const QuestionOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+});
 
 export type QuestionOption = z.infer<typeof QuestionOptionSchema>;
 
-export const QuestionEntrySchema = z
-  .object({
-    id: z.string(),
-    question: z.string(),
-    description: z.string().optional(),
-    options: z.array(QuestionOptionSchema),
-    freeTextPlaceholder: z.string().optional(),
-  })
-  .strict();
+export const QuestionEntrySchema = z.object({
+  id: z.string(),
+  question: z.string(),
+  description: z.string().optional(),
+  options: z.array(QuestionOptionSchema),
+  freeTextPlaceholder: z.string().optional(),
+});
 
 export type QuestionEntry = z.infer<typeof QuestionEntrySchema>;
 
-export const QuestionRequestEventSchema = z
-  .object({
-    type: z.literal("question_request"),
-    requestId: z.string(),
-    questions: z.array(QuestionEntrySchema),
-    question: z.string(),
-    description: z.string().optional(),
-    options: z.array(QuestionOptionSchema),
-    freeTextPlaceholder: z.string().optional(),
-    conversationId: z.string().optional(),
-    toolUseId: z.string().optional(),
-  })
-  .strict();
+export const QuestionRequestEventSchema = z.object({
+  type: z.literal("question_request"),
+  requestId: z.string(),
+  questions: z.array(QuestionEntrySchema),
+  question: z.string(),
+  description: z.string().optional(),
+  options: z.array(QuestionOptionSchema),
+  freeTextPlaceholder: z.string().optional(),
+  conversationId: z.string().optional(),
+  toolUseId: z.string().optional(),
+});
 
 export type QuestionRequestEvent = z.infer<typeof QuestionRequestEventSchema>;

--- a/assistant/src/api/events/relationship-state-updated.ts
+++ b/assistant/src/api/events/relationship-state-updated.ts
@@ -13,12 +13,10 @@
 
 import { z } from "zod";
 
-export const RelationshipStateUpdatedEventSchema = z
-  .object({
-    type: z.literal("relationship_state_updated"),
-    updatedAt: z.string(),
-  })
-  .strict();
+export const RelationshipStateUpdatedEventSchema = z.object({
+  type: z.literal("relationship_state_updated"),
+  updatedAt: z.string(),
+});
 
 export type RelationshipStateUpdatedEvent = z.infer<
   typeof RelationshipStateUpdatedEventSchema

--- a/assistant/src/api/events/secret-request.ts
+++ b/assistant/src/api/events/secret-request.ts
@@ -24,21 +24,19 @@
 
 import { z } from "zod";
 
-export const SecretRequestEventSchema = z
-  .object({
-    type: z.literal("secret_request"),
-    requestId: z.string(),
-    service: z.string(),
-    field: z.string(),
-    label: z.string(),
-    description: z.string().optional(),
-    placeholder: z.string().optional(),
-    conversationId: z.string().optional(),
-    purpose: z.string().optional(),
-    allowedTools: z.array(z.string()).optional(),
-    allowedDomains: z.array(z.string()).optional(),
-    allowOneTimeSend: z.boolean().optional(),
-  })
-  .strict();
+export const SecretRequestEventSchema = z.object({
+  type: z.literal("secret_request"),
+  requestId: z.string(),
+  service: z.string(),
+  field: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  placeholder: z.string().optional(),
+  conversationId: z.string().optional(),
+  purpose: z.string().optional(),
+  allowedTools: z.array(z.string()).optional(),
+  allowedDomains: z.array(z.string()).optional(),
+  allowOneTimeSend: z.boolean().optional(),
+});
 
 export type SecretRequestEvent = z.infer<typeof SecretRequestEventSchema>;

--- a/assistant/src/api/events/tool-use-start.ts
+++ b/assistant/src/api/events/tool-use-start.ts
@@ -18,15 +18,13 @@
 
 import { z } from "zod";
 
-export const ToolUseStartEventSchema = z
-  .object({
-    type: z.literal("tool_use_start"),
-    toolName: z.string(),
-    input: z.record(z.string(), z.unknown()),
-    toolUseId: z.string().optional(),
-    messageId: z.string().optional(),
-    conversationId: z.string().optional(),
-  })
-  .strict();
+export const ToolUseStartEventSchema = z.object({
+  type: z.literal("tool_use_start"),
+  toolName: z.string(),
+  input: z.record(z.string(), z.unknown()),
+  toolUseId: z.string().optional(),
+  messageId: z.string().optional(),
+  conversationId: z.string().optional(),
+});
 
 export type ToolUseStartEvent = z.infer<typeof ToolUseStartEventSchema>;

--- a/assistant/src/api/events/ui-surface-complete.ts
+++ b/assistant/src/api/events/ui-surface-complete.ts
@@ -17,15 +17,13 @@
 
 import { z } from "zod";
 
-export const UISurfaceCompleteEventSchema = z
-  .object({
-    type: z.literal("ui_surface_complete"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    summary: z.string(),
-    submittedData: z.record(z.string(), z.unknown()).optional(),
-  })
-  .strict();
+export const UISurfaceCompleteEventSchema = z.object({
+  type: z.literal("ui_surface_complete"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  summary: z.string(),
+  submittedData: z.record(z.string(), z.unknown()).optional(),
+});
 
 export type UISurfaceCompleteEvent = z.infer<
   typeof UISurfaceCompleteEventSchema

--- a/assistant/src/api/events/ui-surface-dismiss.ts
+++ b/assistant/src/api/events/ui-surface-dismiss.ts
@@ -13,12 +13,10 @@
 
 import { z } from "zod";
 
-export const UISurfaceDismissEventSchema = z
-  .object({
-    type: z.literal("ui_surface_dismiss"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-  })
-  .strict();
+export const UISurfaceDismissEventSchema = z.object({
+  type: z.literal("ui_surface_dismiss"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+});
 
 export type UISurfaceDismissEvent = z.infer<typeof UISurfaceDismissEventSchema>;

--- a/assistant/src/api/events/ui-surface-show.ts
+++ b/assistant/src/api/events/ui-surface-show.ts
@@ -34,30 +34,26 @@
 
 import { z } from "zod";
 
-export const SurfaceActionSchema = z
-  .object({
-    id: z.string(),
-    label: z.string(),
-    style: z.enum(["primary", "secondary", "destructive"]).optional(),
-    data: z.record(z.string(), z.unknown()).optional(),
-  })
-  .strict();
+export const SurfaceActionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  style: z.enum(["primary", "secondary", "destructive"]).optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
+});
 
 export type SurfaceAction = z.infer<typeof SurfaceActionSchema>;
 
-export const UISurfaceShowEventSchema = z
-  .object({
-    type: z.literal("ui_surface_show"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    surfaceType: z.string(),
-    title: z.string().optional(),
-    data: z.record(z.string(), z.unknown()),
-    actions: z.array(SurfaceActionSchema).optional(),
-    display: z.enum(["inline", "panel"]).optional(),
-    messageId: z.string().optional(),
-    persistent: z.boolean().optional(),
-  })
-  .strict();
+export const UISurfaceShowEventSchema = z.object({
+  type: z.literal("ui_surface_show"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  surfaceType: z.string(),
+  title: z.string().optional(),
+  data: z.record(z.string(), z.unknown()),
+  actions: z.array(SurfaceActionSchema).optional(),
+  display: z.enum(["inline", "panel"]).optional(),
+  messageId: z.string().optional(),
+  persistent: z.boolean().optional(),
+});
 
 export type UISurfaceShowEvent = z.infer<typeof UISurfaceShowEventSchema>;

--- a/assistant/src/api/events/ui-surface-update.ts
+++ b/assistant/src/api/events/ui-surface-update.ts
@@ -16,13 +16,11 @@
 
 import { z } from "zod";
 
-export const UISurfaceUpdateEventSchema = z
-  .object({
-    type: z.literal("ui_surface_update"),
-    conversationId: z.string(),
-    surfaceId: z.string(),
-    data: z.record(z.string(), z.unknown()),
-  })
-  .strict();
+export const UISurfaceUpdateEventSchema = z.object({
+  type: z.literal("ui_surface_update"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  data: z.record(z.string(), z.unknown()),
+});
 
 export type UISurfaceUpdateEvent = z.infer<typeof UISurfaceUpdateEventSchema>;


### PR DESCRIPTION
All 33 canonical Zod event schemas used `.strict()`, which rejects unknown fields on parse. This means any server-stamped metadata (e.g. the `seq` field added by B7.1's `stampAndBuffer`) causes the canonical schema to fail, forcing every conversation-scoped event to fall through to the legacy parser. Removing `.strict()` switches to Zod's default strip mode — known fields are validated, unknown fields are silently discarded — so the server can evolve the wire format without requiring lockstep client schema updates.

## Prompt / plan

Remove `.strict()` from all event schemas so unknown keys (like `seq` from B7.1) don't break canonical parsing. Update tests and docs to match.

## Test plan

- `bunx tsc --noEmit` passes in both `assistant/` and `apps/web/`
- All 147 parser tests pass (`bun test src/lib/streaming/event-parser.test.ts`)
- 18 tests updated from "unknown field → UnknownEvent" to "unknown field stripped, event parses normally"
- Pre-push hook ran 713 assistant tests — all pass (2 pre-existing benchmark failures on `main` confirmed unrelated)

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/23bd280e47b645a39d2433185a906bc7