### PR TITLE
refactor(assistant): re-home mid-loop compaction into the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -2048,6 +2048,90 @@ describe("AgentLoop", () => {
     ]);
   });
 
+  // Regression: the "prior visible text" signal must survive a mid-loop
+  // compaction. The model says its piece, calls a tool, the tool result
+  // triggers compaction (which collapses the messages that carried the text),
+  // then the model ends with an empty turn. Because the visible text is no
+  // longer present in `history` after compaction, a scan-based check would
+  // wrongly nudge; the loop tracks the signal as run-scoped state instead.
+  test("does not nudge empty response when visible text preceded a compaction", async () => {
+    // GIVEN a first turn that delivers visible text and calls a tool
+    const textPlusToolUseResponse: ProviderResponse = {
+      content: [
+        { type: "text", text: "your move, husband." },
+        {
+          type: "tool_use",
+          id: "t1",
+          name: "read_file",
+          input: { path: "/note.txt" },
+        },
+      ],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "tool_use",
+    };
+    // AND a second turn that is empty (the model correctly ending its turn)
+    const emptyResponse: ProviderResponse = {
+      content: [],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 0 },
+      stopReason: "end_turn",
+    };
+    const { provider, calls } = createMockProvider([
+      textPlusToolUseResponse,
+      emptyResponse,
+    ]);
+    const toolExecutor = async () => ({ content: "noted", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // AND a strategy that compacts once after the tool result, replacing the
+    // history with a summary that no longer contains the visible text
+    let shouldCompactCalls = 0;
+    const compactionStrategy: CompactionStrategy = {
+      shouldCompact: () => {
+        shouldCompactCalls++;
+        return shouldCompactCalls === 1;
+      },
+      compact: async () => ({
+        ok: true,
+        history: [
+          { role: "user", content: [{ type: "text", text: "SUMMARY" }] },
+        ],
+      }),
+    };
+
+    // WHEN the loop runs with the compaction strategy
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events), {
+      compactionStrategy,
+    });
+
+    // THEN the provider is called exactly twice — no third (retry) call,
+    // because the visible text delivered before compaction suppresses the nudge
+    expect(calls).toHaveLength(2);
+
+    // AND no nudge message is appended to history
+    const nudgeInHistory = history.some(
+      (m) =>
+        m.role === "user" &&
+        m.content.some(
+          (b) =>
+            b.type === "text" &&
+            "text" in b &&
+            (b as { text: string }).text.includes(
+              "previous response was empty",
+            ),
+        ),
+    );
+    expect(nudgeInHistory).toBe(false);
+  });
+
   test("gives up after max empty response retries", async () => {
     const emptyResponse: ProviderResponse = {
       content: [],

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -4,6 +4,7 @@ import type {
   AgentEvent,
   CheckpointDecision,
   CheckpointInfo,
+  CompactionStrategy,
 } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type {
@@ -1056,6 +1057,155 @@ describe("AgentLoop", () => {
     expect(history).toHaveLength(2);
     expect(history[1].content).toEqual([
       { type: "text", text: "Just a text response" },
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inline mid-loop compaction strategy tests
+  // ---------------------------------------------------------------------------
+
+  test("inline compaction continues in place and feeds the compacted history to the next turn", async () => {
+    // GIVEN a provider that requests one tool call and then finishes
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      textResponse("Done"),
+    ]);
+    const toolExecutor = async () => ({ content: "data", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // AND a strategy that compacts once, replacing history with a marker
+    const compactedHistory: Message[] = [
+      { role: "user", content: [{ type: "text", text: "COMPACTED" }] },
+    ];
+    let shouldCompactCalls = 0;
+    const compactInputs: Message[][] = [];
+    const compactionStrategy: CompactionStrategy = {
+      shouldCompact: () => {
+        shouldCompactCalls++;
+        return shouldCompactCalls === 1;
+      },
+      compact: async (history) => {
+        compactInputs.push(history);
+        return { ok: true, history: compactedHistory };
+      },
+    };
+
+    // WHEN the loop runs with the strategy
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events), {
+      compactionStrategy,
+    });
+
+    // THEN compaction ran once against the in-flight history
+    expect(compactInputs).toHaveLength(1);
+    // AND the loop continued in place — the next provider call sees the
+    // compacted history rather than a fresh run's seed messages
+    expect(calls).toHaveLength(2);
+    expect(calls[1].messages[0].content).toEqual([
+      { type: "text", text: "COMPACTED" },
+    ]);
+    // AND the turn completed normally without a terminal exhaustion exit
+    expect(history[history.length - 1].content).toEqual([
+      { type: "text", text: "Done" },
+    ]);
+    expect(
+      events.some(
+        (e) =>
+          e.type === "agent_loop_exit" &&
+          e.reason === "context_exhausted_mid_loop",
+      ),
+    ).toBe(false);
+  });
+
+  test("inline compaction failure terminates the loop with context_exhausted_mid_loop", async () => {
+    // GIVEN a provider that would continue past the first tool turn
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      textResponse("should not reach"),
+    ]);
+    const toolExecutor = async () => ({ content: "data", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // AND a strategy whose compaction cannot bring context under budget
+    const compactionStrategy: CompactionStrategy = {
+      shouldCompact: () => true,
+      compact: async () => ({ ok: false, reason: "exhausted" }),
+    };
+
+    // WHEN the loop runs
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events), {
+      compactionStrategy,
+    });
+
+    // THEN the loop stopped after the first tool turn — no further calls
+    expect(calls).toHaveLength(1);
+    // AND it emitted exactly one terminal mid-loop exhaustion exit reason
+    const exitEvents = events.filter((e) => e.type === "agent_loop_exit");
+    expect(exitEvents).toHaveLength(1);
+    expect(exitEvents[0]).toMatchObject({
+      reason: "context_exhausted_mid_loop",
+    });
+    // AND history ends at the tool result, not a final assistant message
+    expect(history[history.length - 1].role).toBe("user");
+  });
+
+  test("inline compaction is skipped when shouldCompact declines, and the checkpoint still runs", async () => {
+    // GIVEN a provider that requests one tool call and then finishes
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      textResponse("Done"),
+    ]);
+    const toolExecutor = async () => ({ content: "data", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // AND a strategy that never wants to compact
+    let compactCalled = false;
+    const compactionStrategy: CompactionStrategy = {
+      shouldCompact: () => false,
+      compact: async () => {
+        compactCalled = true;
+        return { ok: true, history: [] };
+      },
+    };
+    const checkpoints: CheckpointInfo[] = [];
+    const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
+      checkpoints.push(checkpoint);
+      return "continue";
+    };
+
+    // WHEN the loop runs with both a declining strategy and a checkpoint
+    const history = await loop.run([userMessage], () => {}, {
+      compactionStrategy,
+      onCheckpoint,
+    });
+
+    // THEN compaction never ran
+    expect(compactCalled).toBe(false);
+    // AND the checkpoint was still consulted after the tool turn
+    expect(checkpoints).toHaveLength(1);
+    // AND the turn completed normally
+    expect(calls).toHaveLength(2);
+    expect(history[history.length - 1].content).toEqual([
+      { type: "text", text: "Done" },
     ]);
   });
 

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -434,6 +434,36 @@ type AgentLoopRun = (
   options?: AgentLoopRunOptions,
 ) => Promise<Message[]>;
 
+/**
+ * Reproduces the inner agent loop's inline mid-loop compaction so these
+ * orchestrator-level tests (which mock {@link AgentLoopRun}) exercise the
+ * `compactionStrategy` contract that the real `AgentLoop.run` drives.
+ *
+ * Mirrors the loop body: after a tool-result turn lands, ask the strategy
+ * whether to compact; on a productive outcome adopt the returned history and
+ * iterate again; on `ok: false` (the compactor exhausted its retries or timed
+ * out) stop so the orchestrator can escalate via the
+ * `state.contextTooLargeDetected` flag the strategy sets. `maxIterations`
+ * stands in for the loop reaching a natural turn boundary (no further tool
+ * calls) and keeps the simulation bounded.
+ */
+async function simulateInlineMidLoopCompaction(
+  history: Message[],
+  options: AgentLoopRunOptions | undefined,
+  maxIterations: number,
+): Promise<Message[]> {
+  const strategy = options?.compactionStrategy;
+  if (!strategy) return history;
+  let current = history;
+  for (let i = 0; i < maxIterations; i++) {
+    if (!(await strategy.shouldCompact(current))) break;
+    const outcome = await strategy.compact(current);
+    if (!outcome.ok) break;
+    current = outcome.history;
+  }
+  return current;
+}
+
 function makeCtx(
   overrides?: Partial<AgentLoopConversationContext> & {
     agentLoopRun?: AgentLoopRun;
@@ -1852,7 +1882,16 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
         providerDurationMs: 100,
       });
 
-      // Always yield at checkpoint — simulates compaction not helping
+      // Primary run: the loop drives mid-loop compaction inline via the
+      // strategy. The first `compact` surfaces `exhausted: true`, which flips
+      // `state.contextTooLargeDetected` and stops the loop so the orchestrator
+      // escalates to the convergence reducer.
+      if (options?.compactionStrategy) {
+        return await simulateInlineMidLoopCompaction(withProgress, options, 1);
+      }
+
+      // Convergence / auto-compress reruns keep budget detection on the full
+      // checkpoint.
       if (options?.onCheckpoint) {
         const decision = await options.onCheckpoint({
           turnIndex: 0,
@@ -1946,19 +1985,17 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   });
 
   // ── Test 8b ───────────────────────────────────────────────────────
-  // Counterpart to Test 8: when each mid-loop `maybeCompact` returns
-  // productive (`compacted: true`, no `exhausted` flag), the
-  // orchestrator iterates indefinitely without ever escalating to the
-  // convergence loop. The retry budget for the compactor lives INSIDE
-  // `ContextWindowManager.maybeCompact` now; the orchestrator's outer
-  // loop has no count cap of its own.
+  // Counterpart to Test 8: when each mid-loop `compact` returns productive
+  // (`compacted: true`, no `exhausted` flag), the inner loop compacts in
+  // place and continues without ever escalating to the convergence loop or
+  // re-entering the orchestrator. The retry budget for the compactor lives
+  // INSIDE `ContextWindowManager.maybeCompact`; neither the loop nor the
+  // orchestrator imposes a count cap of its own.
   //
-  // Pre-refactor this case would have tripped the daemon-level
-  // `midLoopCompactAttempts` counter after 3 cycles and dumped the turn
-  // into convergence, even though every cycle was clearly forward
-  // progress (170k → 100k each time). The relocate makes the
-  // orchestrator agnostic to attempt counts — it only sees the binary
-  // `exhausted` signal.
+  // Because productive compactions stay inside a single `AgentLoop.run`
+  // call, the orchestrator sees exactly one agent-loop invocation no matter
+  // how many times the context is compacted — it only escalates on the
+  // binary `exhausted` signal, which this mock never sets.
   test("productive mid-loop compactions iterate without daemon-level cap", async () => {
     const events: ServerMessage[] = [];
 
@@ -1975,9 +2012,9 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       return 170_000;
     };
 
-    // Agent loop yields on its first 5 calls so the test exercises more
-    // mid-loop iterations than `maxAttempts = 3`. The 6th call returns
-    // without yielding so the test terminates cleanly.
+    // The single agent-loop run compacts five times inline before reaching a
+    // natural turn boundary, exercising more mid-loop iterations than the
+    // former daemon-level `maxAttempts = 3` cap.
     let agentLoopCallCount = 0;
     const agentLoopRun: AgentLoopRun = async (messages, onEvent, options) => {
       await onEvent({ type: "llm_call_started" });
@@ -2033,16 +2070,11 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
         providerDurationMs: 100,
       });
 
-      if (agentLoopCallCount <= 5 && options?.onCheckpoint) {
-        const decision = await options.onCheckpoint({
-          turnIndex: 0,
-          toolCount: 1,
-          hasToolUse: true,
-          history: withProgress,
-        });
-        if (decision === "yield") {
-          return withProgress;
-        }
+      // Primary run: the loop compacts inline and continues in place for each
+      // productive outcome. Five productive compactions stand in for a long
+      // turn whose tool results repeatedly inflate the context past 85%.
+      if (options?.compactionStrategy) {
+        return await simulateInlineMidLoopCompaction(withProgress, options, 5);
       }
 
       return withProgress;
@@ -2084,14 +2116,11 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
     await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    // 1 initial auto-compact + 5 productive mid-loop compactions ran
-    // before the agent loop stopped yielding on its 6th call. Pre-
-    // relocate this would have capped at 1 initial + 3 mid-loop = 4
-    // and escalated to convergence after the 3rd mid-loop attempt.
-    // Now the orchestrator has no count cap of its own — it only sees
-    // the `exhausted` signal (never set by this mock).
+    // 1 initial auto-compact + 5 productive mid-loop compactions = 6 total
+    // `maybeCompact` calls. The five mid-loop compactions all happen inline
+    // within a single agent-loop run, so the orchestrator never re-enters.
     expect(compactionCallCount).toBe(6);
-    expect(agentLoopCallCount).toBe(6);
+    expect(agentLoopCallCount).toBe(1);
 
     // No escalation to the convergence loop because every mid-loop
     // `maybeCompact` returned productive (no `exhausted` flag).
@@ -2177,7 +2206,14 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
         providerDurationMs: 100,
       });
 
-      // Always yield at checkpoint — simulates reduction not helping enough
+      // Primary run: the loop compacts inline; the mocked `compact` reports
+      // `exhausted: true`, escalating to convergence. The convergence reruns
+      // (no inline strategy) still yield for budget through the full
+      // checkpoint, which drives the additional reduction tiers under test.
+      if (options?.compactionStrategy) {
+        return await simulateInlineMidLoopCompaction(withProgress, options, 1);
+      }
+
       if (options?.onCheckpoint) {
         const decision = await options.onCheckpoint({
           turnIndex: 0,
@@ -2520,7 +2556,15 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
         providerDurationMs: 100,
       });
 
-      // Every checkpoint yields — including the final auto_compress rerun.
+      // Primary run: the loop compacts inline; the first mid-loop `compact`
+      // reports `exhausted: true` and escalates to convergence. Every
+      // subsequent rerun (convergence and the final auto_compress run, none of
+      // which carry an inline strategy) keeps yielding for budget through the
+      // full checkpoint, ending in BUDGET_YIELD_UNRECOVERED.
+      if (options?.compactionStrategy) {
+        return await simulateInlineMidLoopCompaction(withProgress, options, 1);
+      }
+
       if (options?.onCheckpoint) {
         const decision = await options.onCheckpoint({
           turnIndex: 0,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -4304,18 +4304,16 @@ describe("session-agent-loop", () => {
         options,
       ) => {
         runCount++;
-        if (runCount === 1) {
+        if (runCount === 1 && options?.compactionStrategy) {
+          // The loop's in-flight history at the compaction boundary is the
+          // fresh DB basis, not the rendered Slack rows used at start-of-turn.
+          // Drive the inline strategy against it so the mid-loop compaction
+          // summarizes the correct basis.
           mockEstimateTokens = 90_000;
-          const decision = await options?.onCheckpoint?.({
-            turnIndex: 0,
-            toolCount: 1,
-            hasToolUse: true,
-            history: messages,
-          });
-          mockEstimateTokens = 1000;
-          if (decision === "yield") {
-            return rawMidLoopBasis;
+          if (await options.compactionStrategy.shouldCompact(rawMidLoopBasis)) {
+            await options.compactionStrategy.compact(rawMidLoopBasis);
           }
+          mockEstimateTokens = 1000;
         }
         return [
           ...messages,

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -69,6 +69,34 @@ export interface CheckpointInfo {
 export type CheckpointDecision = "continue" | "yield";
 
 /**
+ * Outcome of a mid-loop compaction attempt.
+ *
+ * `ok: true` carries the post-compaction history the loop continues from.
+ * `ok: false` signals the compactor could not bring the context back under
+ * budget (`exhausted`) or did not finish in time (`timeout`); the loop then
+ * terminates with `context_exhausted_mid_loop` and the orchestrator escalates
+ * to its more aggressive reducer tiers.
+ */
+export type CompactionOutcome =
+  | { ok: true; history: Message[] }
+  | { ok: false; reason: "exhausted" | "timeout" };
+
+/**
+ * Compaction the loop runs inline when context approaches the budget.
+ *
+ * Supplied by the orchestrator so the inner tool-use iteration — which is the
+ * natural compaction boundary — can compact in place and `continue` rather
+ * than unwinding to the orchestrator and re-entering a fresh `run()` (which
+ * would reset the loop's per-run counters). The loop stays ignorant of *how*
+ * compaction works (history stripping, summarization, runtime re-injection
+ * all live behind these two methods); it only decides *when* to ask.
+ */
+export interface CompactionStrategy {
+  shouldCompact(history: Message[]): boolean | Promise<boolean>;
+  compact(history: Message[]): Promise<CompactionOutcome>;
+}
+
+/**
  * Why an agent turn reached a terminal state.
  *
  * Emitted as part of an {@link AgentEvent} of type `agent_loop_exit`, then
@@ -111,6 +139,14 @@ export type AgentLoopExitReason =
    * leaving `agent_loop_exit_reason` NULL.
    */
   | "budget_yield_unrecovered"
+  /**
+   * Mid-loop compaction (via {@link CompactionStrategy}) could not bring the
+   * context back under budget — the compactor exhausted its internal retry
+   * budget or timed out. The loop terminates so the orchestrator can escalate
+   * to its more aggressive reducer tiers. Distinct from a non-terminal budget
+   * yield, which transfers control to the orchestrator and re-enters the loop.
+   */
+  | "context_exhausted_mid_loop"
   /** Provider stopped because the configured output-token limit was reached. */
   | "max_tokens_reached"
   /** User cancellation landed after a non-terminal checkpoint yield. */
@@ -384,6 +420,15 @@ export interface AgentLoopRunOptions {
   onCheckpoint?: (
     checkpoint: CheckpointInfo,
   ) => CheckpointDecision | Promise<CheckpointDecision>;
+  /**
+   * Optional inline compaction the loop runs when context approaches the
+   * budget. When supplied, the loop compacts in place at the tool-use
+   * iteration boundary and continues (preserving its per-run counters)
+   * instead of leaving budget handling to a post-`run()` orchestrator
+   * ceremony. When omitted, budget handling falls back to the orchestrator
+   * via {@link onCheckpoint} yielding.
+   */
+  compactionStrategy?: CompactionStrategy;
   callSite?: LLMCallSite;
   /**
    * Per-turn context supplied by the orchestrator. Every pipeline
@@ -528,6 +573,7 @@ export class AgentLoop {
       signal,
       requestId,
       onCheckpoint,
+      compactionStrategy,
       callSite,
       turnContext,
       overrideProfile,
@@ -536,8 +582,11 @@ export class AgentLoop {
       resolveEffectiveMaxInputTokens,
       mutableLatestUserMessage,
     } = options ?? {};
-    const history = [...messages];
-    const initialHistoryLength = messages.length;
+    let history = [...messages];
+    // Lower bound for "messages produced during this run" scans. Reset after
+    // a mid-loop compaction collapses `history` so the scan boundary tracks
+    // the post-compaction context rather than the original seed length.
+    let initialHistoryLength = messages.length;
     let toolUseTurns = 0;
     let consecutiveErrorTurns = 0;
     let emptyResponseRetries = 0;
@@ -1376,6 +1425,27 @@ export class AgentLoop {
 
         // Add tool results as a user message and continue the loop
         history.push({ role: "user", content: resultBlocks });
+
+        // Mid-loop compaction. The tool-use iteration boundary is the natural
+        // place to compact: tool results have just landed, so this is where
+        // context bloat accrues. Running it here — rather than yielding to the
+        // orchestrator and re-entering a fresh `run()` — keeps `toolUseTurns`,
+        // `consecutiveErrorTurns`, and `emptyResponseRetries` intact across the
+        // compaction. `shouldCompact` declines when a handoff is pending, so
+        // the handoff branch in `onCheckpoint` below retains priority.
+        if (
+          compactionStrategy &&
+          (await compactionStrategy.shouldCompact(history))
+        ) {
+          const outcome = await compactionStrategy.compact(history);
+          if (outcome.ok) {
+            history = outcome.history;
+            initialHistoryLength = history.length;
+            continue;
+          }
+          await emitExit("context_exhausted_mid_loop");
+          break;
+        }
 
         // Invoke checkpoint callback after tool results are in history.
         // The callback may be async — the mid-loop budget check delegates

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -583,13 +583,14 @@ export class AgentLoop {
       mutableLatestUserMessage,
     } = options ?? {};
     let history = [...messages];
-    // Lower bound for "messages produced during this run" scans. Reset after
-    // a mid-loop compaction collapses `history` so the scan boundary tracks
-    // the post-compaction context rather than the original seed length.
-    let initialHistoryLength = messages.length;
     let toolUseTurns = 0;
     let consecutiveErrorTurns = 0;
     let emptyResponseRetries = 0;
+    // Whether the model has already delivered user-visible text during this
+    // run. A flag rather than a scan over `history` so the signal survives a
+    // mid-loop compaction that collapses the message array — an empty turn
+    // following earlier visible text must not be nudged into re-summarizing.
+    let producedVisibleTextThisRun = false;
     let lastLlmCallTime = 0;
     const rlog = requestId ? log.child({ requestId }) : log;
 
@@ -1023,26 +1024,21 @@ export class AgentLoop {
         // the message is persisted.
         //
         // Only nudge when the model hasn't already delivered text to the user
-        // earlier in this tool-use chain. If a prior assistant turn in history
-        // contained visible text (e.g. the model said its piece before calling
-        // a side-effect tool like `remember`), an empty follow-up is the model
+        // earlier in this run. If any prior assistant turn this run contained
+        // visible text (e.g. the model said its piece before calling a
+        // side-effect tool like `remember`), an empty follow-up is the model
         // correctly ending its turn — nudging would mislead it into thinking
-        // its earlier text didn't land and cause a verbatim re-send.
+        // its earlier text didn't land and cause a verbatim re-send. This
+        // covers multi-step tool-use chains (say-something → call-tool →
+        // call-another-tool → end), where the visible text lives on an earlier
+        // turn than the final pure tool_use.
         //
-        // Note: we check ANY prior assistant turn from this run()
-        // invocation, not just the most recent one. In multi-step tool-use
-        // chains (say-something → call-tool → call-another-tool → end),
-        // the "say-something" text lives on an earlier assistant turn while
-        // the most recent assistant turn is a pure tool_use with no text.
-        // Restricting the check to the most recent assistant turn would
-        // falsely nudge in that case and trigger a duplicate re-send of
-        // text the user already saw.
-        //
-        // Scope the scan to messages appended during this run() call only.
-        // Assistant text from prior conversation turns (earlier run()
-        // invocations passed in via `messages`) must NOT suppress the
-        // nudge — those turns completed long ago and have no bearing on
-        // whether the current tool-use chain has delivered text yet.
+        // `producedVisibleTextThisRun` carries this across the whole run,
+        // including a mid-loop compaction that collapses `history`: text the
+        // user already saw stays acknowledged even after the messages that
+        // carried it are summarized away. The flag starts false, so visible
+        // text from prior conversation turns (earlier run() invocations passed
+        // in via `messages`) never suppresses the nudge on its own.
         //
         // The actual decision (nudge vs. accept vs. error) is delegated to
         // the `emptyResponse` plugin pipeline. The pipeline returns a
@@ -1052,20 +1048,8 @@ export class AgentLoop {
         const hasVisibleText = response.content.some(
           (block) => block.type === "text" && block.text.trim().length > 0,
         );
-        const priorAssistantHadVisibleText = (() => {
-          for (let i = history.length - 1; i >= initialHistoryLength; i--) {
-            const msg = history[i];
-            if (msg.role !== "assistant") continue;
-            const hasText = msg.content.some(
-              (block) =>
-                block.type === "text" &&
-                typeof (block as { text?: unknown }).text === "string" &&
-                (block as { text: string }).text.trim().length > 0,
-            );
-            if (hasText) return true;
-          }
-          return false;
-        })();
+        const priorAssistantHadVisibleText = producedVisibleTextThisRun;
+        if (hasVisibleText) producedVisibleTextThisRun = true;
 
         const emptyResponseArgs: EmptyResponseArgs = {
           responseContent: response.content,
@@ -1440,7 +1424,6 @@ export class AgentLoop {
           const outcome = await compactionStrategy.compact(history);
           if (outcome.ok) {
             history = outcome.history;
-            initialHistoryLength = history.length;
             continue;
           }
           await emitExit("context_exhausted_mid_loop");

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -16,8 +16,10 @@ import type {
   AgentEvent,
   AgentLoop,
   AgentLoopExitReason,
+  AgentLoopRunOptions,
   CheckpointDecision,
   CheckpointInfo,
+  CompactionStrategy,
 } from "../agent/loop.js";
 import { createAssistantMessage } from "../agent/message-types.js";
 import type {
@@ -2270,37 +2272,196 @@ export async function runAgentLoopImpl(
       await eventHandler({ type: "agent_loop_exit", reason });
     };
 
-    const onCheckpoint = async (
-      checkpoint: CheckpointInfo,
-    ): Promise<CheckpointDecision> => {
-      state.currentTurnToolNames = [];
+    // Estimate the current context size and report whether it is approaching
+    // the preflight budget. Shared by the primary run's inline compaction
+    // strategy and the convergence/auto-compress reruns' checkpoint so budget
+    // detection lives in exactly one place.
+    const isApproachingMidLoopBudget = async (
+      history: Message[],
+    ): Promise<boolean> => {
+      if (!overflowRecovery.enabled) return false;
+      const midLoopThreshold =
+        resolveCurrentContextBudget().preflightBudget *
+        MID_LOOP_YIELD_THRESHOLD_RATIO;
+      const estimated = await runTokenEstimatePipeline(history);
+      if (estimated > midLoopThreshold) {
+        rlog.warn(
+          { phase: "mid-loop", estimated, threshold: midLoopThreshold },
+          "Token estimate approaching budget",
+        );
+        return true;
+      }
+      return false;
+    };
 
+    // Handoff-only checkpoint for the primary run. Budget handling is owned by
+    // `midLoopCompactionStrategy` (compaction happens inline in the loop), so
+    // this only yields when a queued message wants to take over.
+    const onCheckpointHandoffOnly = (): CheckpointDecision => {
+      state.currentTurnToolNames = [];
       if (ctx.canHandoffAtCheckpoint()) {
         yieldedForHandoff = true;
         pendingCheckpointYield = "handoff";
         return "yield";
       }
-
-      // Mid-loop token budget check: estimate current context size and
-      // yield if we're approaching the preflight budget. This lets the
-      // conversation-agent-loop run compaction before the provider rejects.
-      if (overflowRecovery.enabled) {
-        const midLoopThreshold =
-          resolveCurrentContextBudget().preflightBudget *
-          MID_LOOP_YIELD_THRESHOLD_RATIO;
-        const estimated = await runTokenEstimatePipeline(checkpoint.history);
-        if (estimated > midLoopThreshold) {
-          rlog.warn(
-            { phase: "mid-loop", estimated, threshold: midLoopThreshold },
-            "Token estimate approaching budget — yielding for compaction",
-          );
-          yieldedForBudget = true;
-          pendingCheckpointYield = "budget";
-          return "yield";
-        }
-      }
-
       return "continue";
+    };
+
+    // Full checkpoint for the convergence / auto-compress reruns, which run
+    // without an inline compaction strategy: handoff first, then a budget
+    // yield that returns control to the orchestrator's reducer tiers.
+    const onCheckpoint = async (
+      checkpoint: CheckpointInfo,
+    ): Promise<CheckpointDecision> => {
+      if (onCheckpointHandoffOnly() === "yield") return "yield";
+      if (await isApproachingMidLoopBudget(checkpoint.history)) {
+        yieldedForBudget = true;
+        pendingCheckpointYield = "budget";
+        return "yield";
+      }
+      return "continue";
+    };
+
+    // Inline mid-loop compaction supplied to the primary run. `shouldCompact`
+    // mirrors the budget gate but defers to a pending handoff; `compact`
+    // performs the strip → compaction-pipeline → apply → runtime-reinject
+    // ceremony and returns the history the loop continues from. A failed
+    // compaction (exhausted retries or timeout) flips
+    // `state.contextTooLargeDetected` and reports `ok: false`, so the loop
+    // terminates and the orchestrator's convergence loop takes over.
+    const midLoopCompactionStrategy: CompactionStrategy = {
+      shouldCompact: async (history) => {
+        if (ctx.canHandoffAtCheckpoint()) return false;
+        return isApproachingMidLoopBudget(history);
+      },
+      compact: async (history) => {
+        rlog.info({ phase: "mid-loop-compact" }, "Running mid-loop compaction");
+
+        // Strip injected context before compacting so we summarize the "raw"
+        // persistent messages.
+        const rawHistory = stripInjectionsForCompaction(history);
+        ctx.messages = rawHistory;
+        markHistoryStrippedBestEffort(ctx.conversationId, Date.now(), rlog);
+
+        ctx.emitActivityState(
+          "thinking",
+          "context_compacting",
+          "assistant_turn",
+          reqId,
+          "Compacting context",
+        );
+
+        let midLoopCompact: Awaited<
+          ReturnType<typeof ctx.contextWindowManager.maybeCompact>
+        >;
+        try {
+          midLoopCompact = (await runPipeline<CompactionArgs, CompactionResult>(
+            "compaction",
+            getMiddlewaresFor("compaction"),
+            (args) =>
+              defaultCompactionTerminal(
+                args,
+                buildPluginTurnContext(ctx, reqId),
+              ),
+            {
+              messages: ctx.messages,
+              signal: abortController.signal,
+              options: {
+                lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+                force: true,
+                targetInputTokensOverride:
+                  resolveCurrentContextBudget().preflightBudget,
+                conversationOriginChannel:
+                  getConversationOriginChannel(ctx.conversationId) ?? undefined,
+                overrideProfile: resolveCurrentOverrideProfile() ?? null,
+              },
+            },
+            buildPluginTurnContext(ctx, reqId),
+            DEFAULT_TIMEOUTS.compaction,
+          )) as Awaited<
+            ReturnType<typeof ctx.contextWindowManager.maybeCompact>
+          >;
+        } catch (err) {
+          if (err instanceof PluginTimeoutError) {
+            rlog.warn(
+              { err, phase: "mid-loop-compact" },
+              "Compaction pipeline timed out — escalating to convergence loop",
+            );
+            await trackCompactionOutcome(ctx, true, onEvent);
+            state.contextTooLargeDetected = true;
+            return { ok: false, reason: "timeout" };
+          }
+          throw err;
+        }
+
+        // `force: true` bypasses the cooldown/threshold gates but early
+        // returns for "no eligible messages" / "insufficient messages" still
+        // leave `summaryFailed` undefined. Only track when the summary LLM
+        // actually ran.
+        if (midLoopCompact.summaryFailed !== undefined) {
+          await trackCompactionOutcome(
+            ctx,
+            midLoopCompact.summaryFailed,
+            onEvent,
+          );
+        }
+
+        if (midLoopCompact.compacted) {
+          await applySuccessfulCompaction(midLoopCompact, rawHistory);
+          reducerCompacted = true;
+          shouldInjectWorkspace = true;
+        }
+
+        // When the compactor exhausts its internal retry budget without
+        // dropping below the auto-threshold, re-entering would just yield
+        // again on a stuck compactor. Escalate to the convergence loop's more
+        // aggressive reducer tiers instead.
+        if (midLoopCompact.exhausted) {
+          rlog.warn(
+            { phase: "mid-loop-compact" },
+            "Compaction reported exhausted — escalating to convergence loop",
+          );
+          state.contextTooLargeDetected = true;
+          return { ok: false, reason: "exhausted" };
+        }
+
+        // Re-inject runtime context so the loop continues with a coherent
+        // prompt. stripInjectionsForCompaction() unconditionally removed the
+        // existing NOW.md block from ctx.messages above, so re-inject the
+        // current content regardless of whether compaction actually ran.
+        const injection = await applyRuntimeInjections(ctx.messages, {
+          ...injectionOpts,
+          pkbContext: currentPkbContent,
+          memoryV2Static: currentMemoryV2Static,
+          nowScratchpad: currentNowContent,
+          workspaceTopLevelContext: shouldInjectWorkspace
+            ? ctx.workspaceTopLevelContext
+            : null,
+          slackChronologicalMessages: reducerCompacted
+            ? null
+            : injectionOpts.slackChronologicalMessages,
+          mode: currentInjectionMode,
+          turnContext: buildPluginTurnContext(ctx, reqId),
+        });
+        let newRunMessages = injection.messages;
+        if (isTrustedActor && currentInjectionMode !== "minimal") {
+          ctx.graphMemory.retrackCachedNodes();
+        }
+        const midLoopCompactStrip =
+          stripHistoricalWebSearchResults(newRunMessages);
+        if (midLoopCompactStrip.stats.blocksStripped > 0) {
+          rlog.info(
+            { phase: "mid-loop-compact", ...midLoopCompactStrip.stats },
+            "Converted historical web_search_tool_result blocks to text summaries",
+          );
+          newRunMessages = midLoopCompactStrip.messages;
+        }
+        runMessages = newRunMessages;
+        preRepairMessages = newRunMessages;
+        preRunHistoryLength = newRunMessages.length;
+
+        return { ok: true, history: newRunMessages };
+      },
     };
 
     turnStarted = true;
@@ -2315,12 +2476,25 @@ export async function runAgentLoopImpl(
     // and overwrites `turnIndex` with its own tool-use iteration counter.
     const loopTurnCtx = buildPluginTurnContext(ctx, reqId);
 
-    /** Shared closure: runs the agent loop with the orchestrator's turn context. */
-    const runAgentLoop = (msgs: Message[]) =>
+    /**
+     * Shared closure: runs the agent loop with the orchestrator's turn
+     * context. The primary run supplies the handoff-only checkpoint plus
+     * `midLoopCompactionStrategy` so budget compaction happens inline; the
+     * convergence / auto-compress reruns omit both and fall back to the full
+     * `onCheckpoint`, whose budget yield returns control to the reducer tiers.
+     */
+    const runAgentLoop = (
+      msgs: Message[],
+      opts?: {
+        onCheckpoint?: AgentLoopRunOptions["onCheckpoint"];
+        compactionStrategy?: CompactionStrategy;
+      },
+    ) =>
       ctx.agentLoop.run(msgs, eventHandler, {
         signal: abortController.signal,
         requestId: reqId,
-        onCheckpoint,
+        onCheckpoint: opts?.onCheckpoint ?? onCheckpoint,
+        compactionStrategy: opts?.compactionStrategy,
         callSite: turnCallSite,
         turnContext: loopTurnCtx,
         overrideProfile: turnOverrideProfile,
@@ -2333,7 +2507,10 @@ export async function runAgentLoopImpl(
         mutableLatestUserMessage: memoryV3Live,
       });
 
-    let updatedHistory = await runAgentLoop(runMessages);
+    let updatedHistory = await runAgentLoop(runMessages, {
+      onCheckpoint: onCheckpointHandoffOnly,
+      compactionStrategy: midLoopCompactionStrategy,
+    });
 
     rlog.info(
       { resultMessageCount: updatedHistory.length },
@@ -2343,175 +2520,6 @@ export async function runAgentLoopImpl(
     if (yieldedForHandoff) {
       await emitTerminalExit?.("checkpoint_handoff");
       pendingCheckpointYield = null;
-    }
-
-    // ── Proactive mid-loop compaction ───────────────────────────────
-    // When the agent loop yielded because the token budget check in
-    // onCheckpoint detected approaching limits, run compaction on the
-    // accumulated history and re-enter the agent loop. This is distinct
-    // from the reactive convergence loop below that fires after a
-    // provider rejection — here we compact *before* hitting the limit.
-    //
-    // The retry budget lives INSIDE `ContextWindowManager.maybeCompact`
-    // now: a single call to it may run the compactor up to
-    // `overflowRecovery.maxAttempts` times internally before giving up
-    // and reporting `exhausted: true`. The orchestrator's outer loop
-    // here has no count cap — it iterates as long as the agent loop
-    // makes forward progress (each productive turn re-yields against
-    // fresh tool-result bloat, which is a separate scenario from "the
-    // compactor itself is stuck"). When `exhausted` flips true we
-    // escalate to the convergence loop's more aggressive reducer tiers.
-    while (
-      yieldedForBudget &&
-      !state.contextTooLargeDetected &&
-      !abortController.signal.aborted
-    ) {
-      yieldedForBudget = false;
-      pendingCheckpointYield = null;
-
-      rlog.info(
-        { phase: "mid-loop-compact" },
-        "Running compaction after checkpoint yield",
-      );
-
-      // Strip injected context from updated history before compacting,
-      // so we compact the "raw" persistent messages.
-      const rawHistory = stripInjectionsForCompaction(updatedHistory);
-      ctx.messages = rawHistory;
-      markHistoryStrippedBestEffort(ctx.conversationId, Date.now(), rlog);
-
-      ctx.emitActivityState(
-        "thinking",
-        "context_compacting",
-        "assistant_turn",
-        reqId,
-        "Compacting context",
-      );
-      let midLoopCompact: Awaited<
-        ReturnType<typeof ctx.contextWindowManager.maybeCompact>
-      >;
-      try {
-        midLoopCompact = (await runPipeline<CompactionArgs, CompactionResult>(
-          "compaction",
-          getMiddlewaresFor("compaction"),
-          (args) =>
-            defaultCompactionTerminal(args, buildPluginTurnContext(ctx, reqId)),
-          {
-            messages: ctx.messages,
-            signal: abortController.signal,
-            options: {
-              lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-              force: true,
-              targetInputTokensOverride:
-                resolveCurrentContextBudget().preflightBudget,
-              conversationOriginChannel:
-                getConversationOriginChannel(ctx.conversationId) ?? undefined,
-              overrideProfile: resolveCurrentOverrideProfile() ?? null,
-            },
-          },
-          buildPluginTurnContext(ctx, reqId),
-          DEFAULT_TIMEOUTS.compaction,
-        )) as Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>;
-      } catch (err) {
-        if (err instanceof PluginTimeoutError) {
-          // Mid-loop compaction timed out. Record the failure for the
-          // circuit breaker and escalate to the convergence loop's more
-          // aggressive reducer tiers (tool-result truncation, media
-          // stubbing, injection downgrade) by flipping the overflow flag
-          // and breaking out of the mid-loop retry. The existing
-          // "exhausted all attempts" block further down handles the
-          // escalation.
-          rlog.warn(
-            { err, phase: "mid-loop-compact" },
-            "Compaction pipeline timed out — escalating to convergence loop",
-          );
-          await trackCompactionOutcome(ctx, true, onEvent);
-          state.contextTooLargeDetected = true;
-          break;
-        }
-        throw err;
-      }
-      // `force: true` bypasses the cooldown/threshold gates but early returns
-      // for "no eligible messages" / "insufficient messages" still leave
-      // `summaryFailed` undefined. Only track when the summary LLM actually ran.
-      if (midLoopCompact.summaryFailed !== undefined) {
-        await trackCompactionOutcome(
-          ctx,
-          midLoopCompact.summaryFailed,
-          onEvent,
-        );
-      }
-      if (midLoopCompact.compacted) {
-        await applySuccessfulCompaction(midLoopCompact, rawHistory);
-        reducerCompacted = true;
-        shouldInjectWorkspace = true;
-      }
-
-      // When the compactor exhausts its internal retry budget without
-      // dropping below the auto-threshold, there's no point re-entering
-      // the agent loop — it will yield again and we'll just loop on
-      // a stuck compactor. Escalate to the convergence loop's more
-      // aggressive reducer tiers instead.
-      if (midLoopCompact.exhausted) {
-        rlog.warn(
-          { phase: "mid-loop-compact" },
-          "Compaction reported exhausted — escalating to convergence loop",
-        );
-        state.contextTooLargeDetected = true;
-        break;
-      }
-
-      // Re-inject runtime context and re-enter the agent loop.
-      // stripInjectionsForCompaction() unconditionally removed the existing
-      // NOW.md block from ctx.messages above, so we must always re-inject
-      // the current content regardless of whether compaction actually ran.
-      const injection = await applyRuntimeInjections(ctx.messages, {
-        ...injectionOpts,
-        pkbContext: currentPkbContent,
-        memoryV2Static: currentMemoryV2Static,
-        nowScratchpad: currentNowContent,
-        workspaceTopLevelContext: shouldInjectWorkspace
-          ? ctx.workspaceTopLevelContext
-          : null,
-        // Suppress the chronological-transcript snapshot once the reducer
-        // has collapsed `ctx.messages`; the captured snapshot reflects the
-        // full persisted transcript and would overwrite compaction.
-        slackChronologicalMessages: reducerCompacted
-          ? null
-          : injectionOpts.slackChronologicalMessages,
-        mode: currentInjectionMode,
-        turnContext: buildPluginTurnContext(ctx, reqId),
-      });
-      runMessages = injection.messages;
-      if (isTrustedActor && currentInjectionMode !== "minimal") {
-        ctx.graphMemory.retrackCachedNodes();
-      }
-      const midLoopCompactStrip = stripHistoricalWebSearchResults(runMessages);
-      if (midLoopCompactStrip.stats.blocksStripped > 0) {
-        rlog.info(
-          { phase: "mid-loop-compact", ...midLoopCompactStrip.stats },
-          "Converted historical web_search_tool_result blocks to text summaries",
-        );
-        runMessages = midLoopCompactStrip.messages;
-      }
-      preRepairMessages = runMessages;
-      preRunHistoryLength = runMessages.length;
-
-      updatedHistory = await runAgentLoop(runMessages);
-    }
-
-    // Defensive: the mid-loop above breaks on `exhausted` and on the
-    // PluginTimeoutError catch — both of which flip
-    // `state.contextTooLargeDetected`. If we somehow exit with
-    // `yieldedForBudget` still set (e.g. compaction was disabled
-    // outside the normal path), force escalation so a half-finished
-    // turn doesn't reach the user.
-    if (yieldedForBudget && !abortController.signal.aborted) {
-      rlog.warn(
-        { phase: "mid-loop-compact" },
-        "Mid-loop exited with yieldedForBudget still set — escalating to convergence loop",
-      );
-      state.contextTooLargeDetected = true;
     }
 
     // One-shot ordering error retry


### PR DESCRIPTION
Mid-loop compaction (the reactive "context approaching budget" path) was orchestrator-initiated: the loop yielded for budget via `onCheckpoint`, the orchestrator ran the strip → compaction-pipeline → apply → runtime-reinject ceremony, then re-entered a *fresh* `AgentLoop.run()`. That fresh run reset the loop's per-run counters (`toolUseTurns`, `consecutiveErrorTurns`, `emptyResponseRetries`), which is wrong — compaction is a context operation, not a turn boundary. This moves compaction into the loop as an inline `CompactionStrategy` callback so the loop compacts in place and `continue`s, preserving those counters, and removes the orchestrator's `while (yieldedForBudget)` block (~170 lines) plus its defensive post-loop escalation.

## Prompt / plan

"Compaction Re-homing: Interrogate, Don't Consolidate" — site #3 of four. Rather than consolidating all four `runPipeline("compaction", …)` call sites into one helper, each site is interrogated for whether it should exist and where it belongs. Site #3's trigger genuinely belongs in the loop (the tool-use iteration boundary *is* the compaction boundary), so it becomes a function the loop calls, with the orchestrator supplying the implementation.

Design decisions:
- **Loop-state carries across compaction.** The loop uses `continue` (preserving counters) instead of unwinding to a fresh `run()`. Observable because `consecutiveErrorTurns` drives nudge suppression and empty-response detection gates on `toolUseTurns > 0`.
- **`yieldedForBudget` is retained**, not deleted. It is still the "reduction still insufficient" signal for the convergence-loop rerun, auto-compress, ordering-error retry, and image-recovery retry — none of which receive a `compactionStrategy`. They keep the full `onCheckpoint` (handoff + budget yield). Only the primary run gets the handoff-only checkpoint plus the inline strategy.
- **Escalation is unchanged.** The orchestrator's `compact()` flips `state.contextTooLargeDetected` on exhausted/timeout exactly as the old ceremony did, so the convergence loop still engages. The new `context_exhausted_mid_loop` exit reason is telemetry that makes the terminal mid-loop case observable (it persists like other exit reasons; intermediate turns stay NULL).
- **Handoff retains priority.** `shouldCompact` declines when a handoff is pending, so a queued takeover still wins over compaction.

The loop stays ignorant of *how* compaction works — stripping, summarization, and runtime re-injection all live behind the strategy's two methods.

## Test plan

- `bunx tsc --noEmit` and `bun run lint` clean.
- Added unit tests in `agent-loop.test.ts` for the new loop behavior: inline compaction continues in place and feeds the compacted history to the next turn; a failed compaction terminates with `context_exhausted_mid_loop`; `shouldCompact` declining skips compaction and still consults the checkpoint.
- Updated the orchestrator-level overflow tests (which mock `AgentLoop.run`) to drive the `compactionStrategy` contract instead of the removed budget-yield ceremony.
- `bun test` across `agent-loop`, `agent-loop-exit-reason`, `conversation-agent-loop`, and `conversation-agent-loop-overflow` suites passes. The only failures in the affected-test sweep are two pre-existing `*.benchmark.test.ts` ESM-resolution failures that reproduce identically on clean `origin/main` and are unrelated to this change.

This is an internal state-machine refactor only — no wire protocol, IPC payload, or event-shape changes.

Link to Devin session: https://app.devin.ai/sessions/7c1b9633322c4bf284eb6ed8525ce389
Requested by: @dvargas92495