### PR TITLE
feat(memory): surface page `leaves:` frontmatter in the page index

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-index.test.ts
@@ -76,7 +76,12 @@ afterEach(() => {
 
 function makePage(
   slug: string,
-  opts: { edges?: string[]; summary?: string; body?: string } = {},
+  opts: {
+    edges?: string[];
+    summary?: string;
+    body?: string;
+    leaves?: string[];
+  } = {},
 ): ConceptPage {
   return {
     slug,
@@ -85,6 +90,7 @@ function makePage(
       ref_files: [],
       ref_urls: [],
       ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
+      ...(opts.leaves !== undefined ? { leaves: opts.leaves } : {}),
     },
     body: opts.body ?? "",
   };
@@ -228,6 +234,36 @@ describe("getPageIndex", () => {
     const alice = idx.bySlug.get("alice")!;
     const bob = idx.bySlug.get("bob")!;
     expect(alice.edges).toEqual([bob.id]);
+  });
+
+  test("exposes frontmatter leaves in the index entry", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", {
+        summary: "A",
+        leaves: ["page-a", "domain-a/topic-x"],
+      }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.leaves).toEqual([
+      "page-a",
+      "domain-a/topic-x",
+    ]);
+  });
+
+  test("defaults leaves to an empty array when the field is absent", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "A" }));
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.leaves).toEqual([]);
+  });
+
+  test("seeded skill entries carry an empty leaves list", async () => {
+    skillState.entries = [{ id: "browser", content: "Drive a browser." }];
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("skills/browser")?.leaves).toEqual([]);
   });
 
   test("falls back to body when frontmatter.summary is absent", async () => {

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -56,6 +56,11 @@ export interface PageIndexEntry {
   /** Numeric IDs of outgoing edges, in sorted order. */
   edges: number[];
   /**
+   * Leaf slugs declared in the page's `leaves:` frontmatter; `[]` when absent.
+   * Synthetic entries (skills, CLI commands) never declare leaves.
+   */
+  leaves: string[];
+  /**
    * File mtime in epoch ms; 0 for synthetic entries (skills, CLI commands)
    * that have no on-disk source file. Used by `splitTier1` to rank pages
    * by recency.
@@ -118,6 +123,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     slug: string;
     summary: string;
     outgoingSlugs: string[];
+    leaves: string[];
     modifiedAt: number;
   }
 
@@ -177,6 +183,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       slug,
       summary: normalizeSummary(summarySource),
       outgoingSlugs: page.frontmatter.edges,
+      leaves: page.frontmatter.leaves ?? [],
       modifiedAt: mtimeMs,
     });
   }
@@ -186,6 +193,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       slug: `${SKILL_SLUG_PREFIX}${entry.id}`,
       summary: normalizeSummary(entry.content),
       outgoingSlugs: [],
+      leaves: [],
       modifiedAt: 0,
     });
   }
@@ -195,6 +203,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       slug: `${CLI_COMMAND_SLUG_PREFIX}${entry.id}`,
       summary: normalizeSummary(entry.description),
       outgoingSlugs: [],
+      leaves: [],
       modifiedAt: 0,
     });
   }
@@ -210,6 +219,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       slug: draft.slug,
       summary: draft.summary,
       edges: [],
+      leaves: draft.leaves,
       modifiedAt: draft.modifiedAt,
     };
     bySlug.set(entry.slug, entry);
@@ -329,6 +339,7 @@ function buildLocalPageIndex(
       slug: src.slug,
       summary: src.summary,
       edges: [],
+      leaves: src.leaves,
       modifiedAt: src.modifiedAt,
     };
     localBySlug.set(local.slug, local);

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -40,6 +40,7 @@ export const ConceptPageFrontmatterSchema = z
     ref_files: z.array(z.string()).default([]),
     ref_urls: z.array(z.string().url()).default([]),
     summary: z.string().optional(),
+    leaves: z.array(z.string()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Add optional `leaves` to ConceptPageFrontmatter (additive)
- Populate PageIndexEntry.leaves from frontmatter (default [])

Part of plan: memory-v3-self-maintenance.md (PR 2 of 14)