### PR TITLE
feat(memory-v3): add a rebuild/invalidate hook for the needle index and lanes

### DIFF
--- a/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
@@ -191,8 +191,12 @@ mock.module("../orchestrate.js", () => ({
 }));
 
 // Import AFTER mocks so the plugin binds to them.
-const { runShadowObservation, resetShadowLanesForTests, memoryV3ShadowPlugin } =
-  await import("../shadow-plugin.js");
+const {
+  runShadowObservation,
+  resetShadowLanesForTests,
+  invalidateLanes,
+  memoryV3ShadowPlugin,
+} = await import("../shadow-plugin.js");
 
 // The module stubs above stay installed for the rest of the process (Bun can't
 // reliably uninstall them), but `shadowMockActive` gates their fake behavior to
@@ -335,6 +339,56 @@ describe("memory-v3 shadow plugin", () => {
     expect(coreLoads).toBe(1);
     expect(needleBuilds).toBe(1);
     expect(orchestrateSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("invalidateLanes forces a one-time rebuild on the next turn", async () => {
+    shadowEnabled = true;
+    await runShadowObservation("conv-1", 0);
+    await runShadowObservation("conv-1", 1);
+    // One build so far; invalidation drops it.
+    expect(treeLoads).toBe(1);
+    expect(needleBuilds).toBe(1);
+
+    invalidateLanes();
+
+    // The next turn rebuilds (fresh tree load + fresh needle index)...
+    await runShadowObservation("conv-1", 2);
+    expect(treeLoads).toBe(2);
+    expect(coreLoads).toBe(2);
+    expect(needleBuilds).toBe(2);
+
+    // ...and the rebuild is memoized again — no further builds until the next
+    // invalidation.
+    await runShadowObservation("conv-1", 3);
+    expect(treeLoads).toBe(2);
+    expect(needleBuilds).toBe(2);
+  });
+
+  test("resetShadowLanesForTests invalidates like invalidateLanes", async () => {
+    shadowEnabled = true;
+    await runShadowObservation("conv-1", 0);
+    expect(treeLoads).toBe(1);
+
+    resetShadowLanesForTests();
+
+    await runShadowObservation("conv-1", 1);
+    expect(treeLoads).toBe(2);
+  });
+
+  test("concurrent first turns after invalidation share a single build", async () => {
+    shadowEnabled = true;
+    await runShadowObservation("conv-1", 0);
+    expect(treeLoads).toBe(1);
+
+    invalidateLanes();
+
+    // Both turns race the rebuild; memoization must collapse them to one build.
+    await Promise.all([
+      runShadowObservation("conv-1", 1),
+      runShadowObservation("conv-1", 2),
+    ]);
+    expect(treeLoads).toBe(2);
+    expect(needleBuilds).toBe(2);
   });
 
   test("no user message → no orchestrate, no writes", async () => {

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -92,9 +92,21 @@ export interface ShadowLanes {
  */
 let lanesPromise: Promise<ShadowLanes> | null = null;
 
-/** Test-only: drop the memoized lanes so a fresh init runs next turn. */
-export function resetShadowLanesForTests(): void {
+/**
+ * Drop the memoized lanes so the NEXT `getLanes` rebuilds them from scratch
+ * (fresh topic-tree load + fresh needle index). The rebuild is lazy — this only
+ * clears the cache, so the cost is paid by the next caller, and concurrent
+ * first-callers after the invalidation still share a single build via the
+ * re-memoized promise. Call this whenever the underlying tree or needle sources
+ * change on disk.
+ */
+export function invalidateLanes(): void {
   lanesPromise = null;
+}
+
+/** Test-only alias for {@link invalidateLanes}. */
+export function resetShadowLanesForTests(): void {
+  invalidateLanes();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add exported invalidateLanes() that clears the memoized lanes so the next getLanes rebuilds
- resetShadowLanesForTests becomes a thin wrapper over it

Part of plan: memory-v3-self-maintenance.md (PR 3 of 14)