### PR TITLE
feat(memory-v3): add optional stable `id` to leaf frontmatter schema

### DIFF
--- a/assistant/src/memory/v3/__tests__/tree.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree.test.ts
@@ -33,6 +33,38 @@ describe("loadLeafTree", () => {
     const topicZ = tree.leaves.get("domain-b/topic-z");
     expect(topicZ?.frontmatter.in_core).toBe(false);
     expect(topicZ?.domain).toBe("domain-b");
+
+    // Bundled leaves predate the optional `id` field.
+    expect(topicX?.frontmatter.id).toBeUndefined();
+  });
+
+  test("parses the optional stable id when present, omits it otherwise", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "v3-leaf-id-"));
+    try {
+      await mkdir(join(dataDir, "leaves", "domain-a"), { recursive: true });
+      await writeFile(
+        join(dataDir, "leaves", "domain-a", "topic-x.md"),
+        "---\npath: domain-a/topic-x\nin_core: true\nid: leaf-123\n---\n\nWith id.\n",
+      );
+      await writeFile(
+        join(dataDir, "leaves", "domain-a", "topic-y.md"),
+        "---\npath: domain-a/topic-y\nin_core: false\n---\n\nNo id.\n",
+      );
+      await writeFile(
+        join(dataDir, "assignments.json"),
+        JSON.stringify({ "page-a": ["domain-a/topic-x"] }),
+      );
+
+      const tree = await loadLeafTree(dataDir);
+      expect(tree.leaves.get("domain-a/topic-x")?.frontmatter.id).toBe(
+        "leaf-123",
+      );
+      expect(
+        tree.leaves.get("domain-a/topic-y")?.frontmatter.id,
+      ).toBeUndefined();
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
   });
 
   test("builds members and byPage from assignments", async () => {

--- a/assistant/src/memory/v3/tree.ts
+++ b/assistant/src/memory/v3/tree.ts
@@ -79,7 +79,11 @@ function parseLeafFrontmatter(yaml: string, file: string): LeafFrontmatter {
       `leaf ${file} frontmatter is missing a boolean \`in_core\``,
     );
   }
-  return { path: record.path, in_core: record.in_core };
+  return {
+    path: record.path,
+    in_core: record.in_core,
+    ...(typeof record.id === "string" ? { id: record.id } : {}),
+  };
 }
 
 /** Derive the canonical leaf path from a file's location under `leaves/`. */

--- a/assistant/src/memory/v3/types.ts
+++ b/assistant/src/memory/v3/types.ts
@@ -14,6 +14,11 @@ export const MEMORY_V3_BLOCK_ID = "memory-v3" as const;
 export interface LeafFrontmatter {
   path: LeafPath;
   in_core: boolean;
+  /**
+   * Optional stable identifier for the leaf, independent of its taxonomy path.
+   * Older leaves predate this field and omit it, so it is optional.
+   */
+  id?: string;
 }
 
 export interface LeafNode {


### PR DESCRIPTION
## Summary
- Add optional `id` field to LeafFrontmatter (backward compatible; older leaves omit it)
- Parse it in parseLeafFrontmatter when present, tolerate absence
- Exposed on loaded leaves via `LeafNode.frontmatter.id`

Part of plan: memory-v3-self-maintenance.md (PR 1 of 14)