### PR TITLE
feat(memory-v3): build the assignment index from page `leaves:` with json fallback

### DIFF
--- a/assistant/src/memory/v3/__tests__/tree.test.ts
+++ b/assistant/src/memory/v3/__tests__/tree.test.ts
@@ -100,6 +100,51 @@ describe("loadLeafTree", () => {
       "domain-a/topic-y",
     ]);
   });
+
+  test("frontmatter pageLeaves win over assignments.json per page", async () => {
+    const tree = await loadLeafTree(
+      BUNDLED_DATA_DIR,
+      new Map([["page-a", ["domain-a/topic-y"]]]),
+    );
+
+    // page-a is overridden by frontmatter; assignments.json said topic-x.
+    expect(leavesOf(tree, "page-a")).toEqual(["domain-a/topic-y"]);
+    expect(membersOf(tree, "domain-a/topic-y").sort()).toEqual([
+      "page-a",
+      "page-b",
+    ]);
+    expect(membersOf(tree, "domain-a/topic-x")).toEqual(["page-b"]);
+  });
+
+  test("pages absent from pageLeaves fall back to assignments.json", async () => {
+    // page-a override + a page-with-empty-frontmatter that must fall back.
+    const tree = await loadLeafTree(
+      BUNDLED_DATA_DIR,
+      new Map([
+        ["page-a", ["domain-a/topic-y"]],
+        ["page-c", []],
+      ]),
+    );
+
+    // page-b never appeared in pageLeaves → assignments.json.
+    expect(leavesOf(tree, "page-b")).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+    ]);
+    // page-c had an empty frontmatter array → falls back to assignments.json.
+    expect(leavesOf(tree, "page-c")).toEqual(["domain-b/topic-z"]);
+  });
+
+  test("omitting pageLeaves preserves assignments.json behavior", async () => {
+    const withMap = await loadLeafTree(BUNDLED_DATA_DIR, new Map());
+    const without = await loadLeafTree(BUNDLED_DATA_DIR);
+
+    // An empty map is equivalent to omitting it: pure assignments.json.
+    for (const slug of ["page-a", "page-b", "page-c"]) {
+      expect(leavesOf(withMap, slug)).toEqual(leavesOf(without, slug));
+    }
+    expect(leavesOf(without, "page-a")).toEqual(["domain-a/topic-x"]);
+  });
 });
 
 describe("resolveDataDir", () => {

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -125,7 +125,12 @@ async function pageSummary(slug: Slug): Promise<string> {
 
 async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const dataDir = resolveDataDir();
-  const tree = await loadLeafTree(dataDir);
+  const pageIndex = await getPageIndex(getWorkspaceDir());
+  const pageLeaves = new Map<Slug, LeafPath[]>();
+  for (const entry of pageIndex.entries) {
+    pageLeaves.set(entry.slug, entry.leaves);
+  }
+  const tree = await loadLeafTree(dataDir, pageLeaves);
   const core = await loadCore(dataDir);
 
   const needle = await buildNeedleIndex(tree, pageSummary);

--- a/assistant/src/memory/v3/tree.ts
+++ b/assistant/src/memory/v3/tree.ts
@@ -99,8 +99,18 @@ function pathFromLocation(leavesDir: string, file: string): LeafPath {
  * - `leaves`: leaf path → {@link LeafNode} (frontmatter, description, domain,
  *   and the slugs assigned to it).
  * - `byPage`: slug → the leaf paths it is assigned to (inverted assignments).
+ *
+ * Page→leaf membership precedence is per-page: when `pageLeaves` supplies a
+ * non-empty array for a slug, those frontmatter-derived leaves win for that
+ * page; slugs absent from `pageLeaves` (or mapped to an empty array) fall back
+ * to `assignments.json`. Omitting `pageLeaves` reproduces the legacy
+ * assignments.json-only behavior exactly (used by the bundled stub and tests);
+ * orchestrators supply `pageLeaves` from the page index.
  */
-export async function loadLeafTree(dataDir: string): Promise<LeafTree> {
+export async function loadLeafTree(
+  dataDir: string,
+  pageLeaves?: Map<Slug, LeafPath[]>,
+): Promise<LeafTree> {
   const leavesDir = join(dataDir, "leaves");
   const files = await collectMarkdownFiles(leavesDir);
 
@@ -129,8 +139,16 @@ export async function loadLeafTree(dataDir: string): Promise<LeafTree> {
   );
   const assignments = JSON.parse(assignmentsRaw) as Record<Slug, LeafPath[]>;
 
+  const slugs = new Set<Slug>(Object.keys(assignments));
+  if (pageLeaves) for (const slug of pageLeaves.keys()) slugs.add(slug);
+
   const byPage = new Map<Slug, LeafPath[]>();
-  for (const [slug, leafPaths] of Object.entries(assignments)) {
+  for (const slug of slugs) {
+    const fromFrontmatter = pageLeaves?.get(slug);
+    const leafPaths =
+      fromFrontmatter && fromFrontmatter.length > 0
+        ? fromFrontmatter
+        : (assignments[slug] ?? []);
     byPage.set(slug, [...leafPaths]);
     for (const leafPath of leafPaths) {
       leaves.get(leafPath)?.members.push(slug);


### PR DESCRIPTION
## Summary
- loadLeafTree accepts optional pageLeaves map; frontmatter leaves win, assignments.json is fallback
- shadow-plugin passes page-index leaves into the loader; omitting the map preserves current behavior

Part of plan: memory-v3-self-maintenance.md (PR 4 of 14)