### PR TITLE
feat(workspace): backfill v3 `leaves:` into page frontmatter from assignments.json

### DIFF
--- a/assistant/src/workspace/migrations/092-backfill-v3-leaves.ts
+++ b/assistant/src/workspace/migrations/092-backfill-v3-leaves.ts
@@ -1,0 +1,74 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { readPage, writePage } from "../../memory/v2/page-store.js";
+import type { LeafPath, Slug } from "../../memory/v3/types.js";
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Read the v3 slug -> leaf-path assignment map from the workspace data dir.
+ *
+ * Returns an empty map when `assignments.json` is absent (the v3 data dir was
+ * never materialized for this workspace) so the migration is a clean no-op.
+ */
+async function readAssignments(
+  workspaceDir: string,
+): Promise<Record<Slug, LeafPath[]>> {
+  const assignmentsPath = join(
+    workspaceDir,
+    "memory",
+    "v3",
+    "data",
+    "assignments.json",
+  );
+  let raw: string;
+  try {
+    raw = await readFile(assignmentsPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+  return JSON.parse(raw) as Record<Slug, LeafPath[]>;
+}
+
+/**
+ * Backfill `leaves:` into concept-page frontmatter from the v3 assignment map.
+ *
+ * v3 routing persists a slug -> leaf-path map at
+ * `<workspace>/memory/v3/data/assignments.json`. Concept pages gained an
+ * optional `leaves` frontmatter field (`ConceptPageFrontmatterSchema`), but
+ * existing pages predate it. This one-time migration copies each slug's
+ * assignment into the matching page's frontmatter.
+ *
+ * Idempotent: pages that already carry a non-empty `leaves` are left untouched
+ * (never clobbered). A missing `assignments.json` or a slug with no matching
+ * page is a no-op — neither throws.
+ */
+export const backfillV3LeavesMigration: WorkspaceMigration = {
+  id: "092-backfill-v3-leaves",
+  description: "Backfill v3 leaf assignments into concept-page frontmatter",
+
+  async run(workspaceDir: string): Promise<void> {
+    const assignments = await readAssignments(workspaceDir);
+
+    for (const [slug, leaves] of Object.entries(assignments)) {
+      if (!leaves || leaves.length === 0) continue;
+
+      const page = await readPage(workspaceDir, slug);
+      if (!page) continue;
+
+      const existing = page.frontmatter.leaves;
+      if (existing && existing.length > 0) continue;
+
+      await writePage(workspaceDir, {
+        slug: page.slug,
+        frontmatter: { ...page.frontmatter, leaves: [...leaves] },
+        body: page.body,
+      });
+    }
+  },
+
+  down(): void {
+    // no-op: `leaves` is an additive field; removing it would lose data.
+  },
+};

--- a/assistant/src/workspace/migrations/__tests__/backfill-v3-leaves.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/backfill-v3-leaves.test.ts
@@ -1,0 +1,124 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { readPage, writePage } from "../../../memory/v2/page-store.js";
+import type { ConceptPageFrontmatter } from "../../../memory/v2/types.js";
+import { backfillV3LeavesMigration } from "../092-backfill-v3-leaves.js";
+
+describe("092 backfill v3 leaves", () => {
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(path.join(tmpdir(), "ws-mig-leaves-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  async function writeAssignments(
+    assignments: Record<string, string[]>,
+  ): Promise<void> {
+    const dataDir = path.join(workspaceDir, "memory", "v3", "data");
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(
+      path.join(dataDir, "assignments.json"),
+      JSON.stringify(assignments),
+      "utf8",
+    );
+  }
+
+  async function seedPage(
+    slug: string,
+    frontmatter: Partial<ConceptPageFrontmatter> = {},
+    body = "Body text.\n",
+  ): Promise<void> {
+    await writePage(workspaceDir, {
+      slug,
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        ref_urls: [],
+        ...frontmatter,
+      },
+      body,
+    });
+  }
+
+  it("backfills leaves from assignments.json onto assigned pages", async () => {
+    await writeAssignments({
+      "page-a": ["domain-a/topic-x", "domain-a/topic-y"],
+      "page-b": ["domain-b/topic-z"],
+    });
+    await seedPage("page-a", { summary: "Page A summary" });
+    await seedPage("page-b");
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+
+    const pageA = await readPage(workspaceDir, "page-a");
+    const pageB = await readPage(workspaceDir, "page-b");
+    expect(pageA?.frontmatter.leaves).toEqual([
+      "domain-a/topic-x",
+      "domain-a/topic-y",
+    ]);
+    expect(pageB?.frontmatter.leaves).toEqual(["domain-b/topic-z"]);
+    // Other frontmatter and body preserved.
+    expect(pageA?.frontmatter.summary).toBe("Page A summary");
+    expect(pageA?.body).toContain("Body text.");
+  });
+
+  it("never clobbers a page that already has non-empty leaves", async () => {
+    await writeAssignments({ "page-a": ["domain-a/topic-new"] });
+    await seedPage("page-a", { leaves: ["domain-a/topic-existing"] });
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+
+    const pageA = await readPage(workspaceDir, "page-a");
+    expect(pageA?.frontmatter.leaves).toEqual(["domain-a/topic-existing"]);
+  });
+
+  it("fills a page whose leaves field is present but empty", async () => {
+    await writeAssignments({ "page-a": ["domain-a/topic-x"] });
+    await seedPage("page-a", { leaves: [] });
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+
+    const pageA = await readPage(workspaceDir, "page-a");
+    expect(pageA?.frontmatter.leaves).toEqual(["domain-a/topic-x"]);
+  });
+
+  it("is idempotent across re-runs", async () => {
+    await writeAssignments({ "page-a": ["domain-a/topic-x"] });
+    await seedPage("page-a");
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+    const pagePath = path.join(workspaceDir, "memory", "concepts", "page-a.md");
+    const first = await fs.readFile(pagePath, "utf8");
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+    const second = await fs.readFile(pagePath, "utf8");
+
+    expect(second).toBe(first);
+  });
+
+  it("skips slugs that have no matching page", async () => {
+    await writeAssignments({ "page-missing": ["domain-a/topic-x"] });
+
+    // Should not throw even though no page exists for the slug.
+    await backfillV3LeavesMigration.run(workspaceDir);
+
+    const missing = await readPage(workspaceDir, "page-missing");
+    expect(missing).toBeNull();
+  });
+
+  it("is a no-op when assignments.json is absent", async () => {
+    await seedPage("page-a");
+
+    await backfillV3LeavesMigration.run(workspaceDir);
+
+    const pageA = await readPage(workspaceDir, "page-a");
+    expect(pageA?.frontmatter.leaves).toBeUndefined();
+  });
+});

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -89,6 +89,7 @@ import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecat
 import { moveMemoryTreeOutOfV3Migration } from "./089-move-memory-tree-out-of-v3.js";
 import { memoryRouterCostOptimizedProfileMigration } from "./090-memory-router-cost-optimized-profile.js";
 import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-migration-onboarding-thread.js";
+import { backfillV3LeavesMigration } from "./092-backfill-v3-leaves.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -189,4 +190,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveMemoryTreeOutOfV3Migration,
   memoryRouterCostOptimizedProfileMigration,
   retightenMigrationOnboardingThreadMigration,
+  backfillV3LeavesMigration,
 ];


### PR DESCRIPTION
## Summary
- New idempotent workspace migration: backfills page frontmatter `leaves:` from v3 assignments.json
- Skips pages that already have leaves (no clobber); no-op when assignments.json absent

Part of plan: memory-v3-self-maintenance.md (PR 5 of 14)