### PR TITLE
feat(memory-v3): add the memory_v3_maintain job (classify-union → needle rebuild → prune)

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -44,6 +44,7 @@ export type MemoryJobType =
   | "memory_v2_migrate"
   | "memory_v2_reembed"
   | "memory_v2_activation_recompute"
+  | "memory_v3_maintain"
   // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"
@@ -71,7 +72,7 @@ export const SLOW_LLM_JOB_TYPES: MemoryJobType[] = [
   "generate_conversation_starters",
   "memory_v2_sweep",
   "memory_v2_consolidate",
-  "memory_v3_consolidate",
+  "memory_v3_maintain",
   "memory_v2_migrate",
   "memory_retrospective",
   "backfill",

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -84,6 +84,7 @@ import {
   memoryV2ConsolidateJob,
 } from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
+import { maintainJob as memoryV3MaintainJob } from "./v3/maintain-job.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -618,6 +619,9 @@ async function processJob(
     case "memory_v2_activation_recompute":
       await memoryV2ActivationRecomputeJob(job, config);
       return;
+    case "memory_v3_maintain":
+      await memoryV3MaintainJob(job, config);
+      return;
     case "memory_retrospective":
       await memoryRetrospectiveJob(job, config);
       return;
@@ -687,6 +691,7 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   patternScan: "graph_maintenance:pattern_scan:last_run",
   narrative: "graph_maintenance:narrative:last_run",
   memoryV2Consolidate: "memory_v2_consolidate_last_run",
+  memoryV3Maintain: "memory_v3_maintain_last_run",
 } as const;
 
 /**

--- a/assistant/src/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/memory/v3/__tests__/maintain-job.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { MemoryJob } from "../../jobs-store.js";
+import { readPage, writePage } from "../../v2/page-store.js";
+import type { ConceptPage } from "../../v2/types.js";
+import type { AssignPageResult, AssignPagesOptions } from "../assign.js";
+import { maintainJob, type MaintainJobDeps } from "../maintain-job.js";
+import type { LeafNode, LeafPath, LeafTree, Slug } from "../types.js";
+
+const FLAG_SHADOW = "memory-v3-shadow";
+const FLAG_LIVE = "memory-v3-live";
+
+function configWithFlags(flags: Record<string, boolean>): AssistantConfig {
+  return {
+    featureFlags: Object.entries(flags).map(([name, enabled]) => ({
+      name,
+      enabled,
+    })),
+  } as unknown as AssistantConfig;
+}
+
+function makeLeaf(path: LeafPath): LeafNode {
+  return {
+    path,
+    frontmatter: { path, in_core: false },
+    description: `${path} description`,
+    members: [],
+    domain: path.split("/")[0],
+  };
+}
+
+function makeTree(paths: LeafPath[]): LeafTree {
+  const leaves = new Map<LeafPath, LeafNode>();
+  for (const path of paths) leaves.set(path, makeLeaf(path));
+  return { leaves, byPage: new Map<Slug, LeafPath[]>() };
+}
+
+function makePage(slug: string, leaves?: string[]): ConceptPage {
+  return {
+    slug,
+    frontmatter: { summary: `Summary for ${slug}`, edges: [], leaves },
+    body: `Body content for ${slug}`,
+  };
+}
+
+const JOB = { id: "job-1", type: "memory_v3_maintain" } as unknown as MemoryJob;
+
+describe("maintainJob", () => {
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await mkdtemp(join(tmpdir(), "v3-maintain-"));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  function deps(overrides: Partial<MaintainJobDeps> = {}): {
+    deps: MaintainJobDeps;
+    calls: { assign: number; invalidate: number };
+  } {
+    const calls = { assign: 0, invalidate: 0 };
+    const base: MaintainJobDeps = {
+      workspaceDir,
+      loadTree: async () => makeTree(["domain/topic-a", "domain/topic-b"]),
+      assignPages: async (
+        _opts: AssignPagesOptions,
+      ): Promise<AssignPageResult[]> => {
+        calls.assign += 1;
+        return [];
+      },
+      invalidateLanes: () => {
+        calls.invalidate += 1;
+      },
+    };
+    return { deps: { ...base, ...overrides }, calls };
+  }
+
+  test("no-op when both v3 flags are off", async () => {
+    const { deps: d, calls } = deps();
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: false, [FLAG_LIVE]: false }),
+      d,
+    );
+    expect(outcome.disabled).toBe(true);
+    expect(calls.assign).toBe(0);
+    expect(calls.invalidate).toBe(0);
+  });
+
+  test("runs assign + invalidate when shadow flag is on", async () => {
+    const { deps: d, calls } = deps();
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: true }),
+      d,
+    );
+    expect(outcome.disabled).toBe(false);
+    expect(calls.assign).toBe(1);
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
+  });
+
+  test("runs when only the live flag is on", async () => {
+    const { deps: d, calls } = deps();
+    await maintainJob(JOB, configWithFlags({ [FLAG_LIVE]: true }), d);
+    expect(calls.assign).toBe(1);
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("counts pages newly assigned by the classify-union stage", async () => {
+    const { deps: d } = deps({
+      assignPages: async () => [
+        { slug: "p1", before: [], after: ["domain/topic-a"], failed: false },
+        { slug: "p2", before: [], after: [], failed: true },
+        {
+          slug: "p3",
+          before: ["domain/topic-a"],
+          after: ["domain/topic-a"],
+          failed: false,
+        },
+      ],
+    });
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: true }),
+      d,
+    );
+    expect(outcome.assigned).toBe(1);
+  });
+
+  test("prune drops dangling leaf refs and rewrites the page", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("dangling", ["domain/topic-a", "domain/gone"]),
+    );
+    await writePage(workspaceDir, makePage("clean", ["domain/topic-b"]));
+    await writePage(workspaceDir, makePage("empty", []));
+
+    const { deps: d } = deps();
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: true }),
+      d,
+    );
+
+    expect(outcome.pruned).toBe(1);
+    expect(outcome.prunedRefs).toBe(1);
+
+    const dangling = await readPage(workspaceDir, "dangling");
+    expect(dangling?.frontmatter.leaves).toEqual(["domain/topic-a"]);
+
+    const clean = await readPage(workspaceDir, "clean");
+    expect(clean?.frontmatter.leaves).toEqual(["domain/topic-b"]);
+  });
+
+  test("contains an assign failure without aborting prune or invalidate", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("dangling", ["domain/topic-a", "domain/gone"]),
+    );
+    const { deps: d, calls } = deps({
+      assignPages: async () => {
+        throw new Error("assign boom");
+      },
+    });
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: true }),
+      d,
+    );
+    expect(outcome.failures).toContain("assign");
+    expect(outcome.pruned).toBe(1);
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
+  });
+
+  test("contains a tree-load failure but still invalidates lanes", async () => {
+    const { deps: d, calls } = deps({
+      loadTree: async () => {
+        throw new Error("load boom");
+      },
+    });
+    const outcome = await maintainJob(
+      JOB,
+      configWithFlags({ [FLAG_SHADOW]: true }),
+      d,
+    );
+    expect(outcome.failures).toContain("load_tree");
+    expect(calls.assign).toBe(0);
+    expect(calls.invalidate).toBe(1);
+  });
+});

--- a/assistant/src/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/memory/v3/__tests__/maintain-job.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../../__tests__/feature-flag-test-helpers.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../jobs-store.js";
 import { readPage, writePage } from "../../v2/page-store.js";
@@ -14,14 +15,10 @@ import type { LeafNode, LeafPath, LeafTree, Slug } from "../types.js";
 const FLAG_SHADOW = "memory-v3-shadow";
 const FLAG_LIVE = "memory-v3-live";
 
-function configWithFlags(flags: Record<string, boolean>): AssistantConfig {
-  return {
-    featureFlags: Object.entries(flags).map(([name, enabled]) => ({
-      name,
-      enabled,
-    })),
-  } as unknown as AssistantConfig;
-}
+// The flag resolver ignores the passed config and reads the override cache; the
+// config arg only satisfies the signature. Flags are driven via
+// `setOverridesForTesting` below.
+const CONFIG = {} as AssistantConfig;
 
 function makeLeaf(path: LeafPath): LeafNode {
   return {
@@ -42,7 +39,13 @@ function makeTree(paths: LeafPath[]): LeafTree {
 function makePage(slug: string, leaves?: string[]): ConceptPage {
   return {
     slug,
-    frontmatter: { summary: `Summary for ${slug}`, edges: [], leaves },
+    frontmatter: {
+      summary: `Summary for ${slug}`,
+      edges: [],
+      ref_files: [],
+      ref_urls: [],
+      leaves,
+    },
     body: `Body content for ${slug}`,
   };
 }
@@ -57,6 +60,7 @@ describe("maintainJob", () => {
   });
 
   afterEach(async () => {
+    setOverridesForTesting({});
     await rm(workspaceDir, { recursive: true, force: true });
   });
 
@@ -82,24 +86,18 @@ describe("maintainJob", () => {
   }
 
   test("no-op when both v3 flags are off", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: false, [FLAG_LIVE]: false });
     const { deps: d, calls } = deps();
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: false, [FLAG_LIVE]: false }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.disabled).toBe(true);
     expect(calls.assign).toBe(0);
     expect(calls.invalidate).toBe(0);
   });
 
   test("runs assign + invalidate when shadow flag is on", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
     const { deps: d, calls } = deps();
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: true }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.disabled).toBe(false);
     expect(calls.assign).toBe(1);
     expect(calls.invalidate).toBe(1);
@@ -107,13 +105,15 @@ describe("maintainJob", () => {
   });
 
   test("runs when only the live flag is on", async () => {
+    setOverridesForTesting({ [FLAG_LIVE]: true });
     const { deps: d, calls } = deps();
-    await maintainJob(JOB, configWithFlags({ [FLAG_LIVE]: true }), d);
+    await maintainJob(JOB, CONFIG, d);
     expect(calls.assign).toBe(1);
     expect(calls.invalidate).toBe(1);
   });
 
   test("counts pages newly assigned by the classify-union stage", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
     const { deps: d } = deps({
       assignPages: async () => [
         { slug: "p1", before: [], after: ["domain/topic-a"], failed: false },
@@ -126,15 +126,12 @@ describe("maintainJob", () => {
         },
       ],
     });
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: true }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.assigned).toBe(1);
   });
 
   test("prune drops dangling leaf refs and rewrites the page", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
     await writePage(
       workspaceDir,
       makePage("dangling", ["domain/topic-a", "domain/gone"]),
@@ -143,11 +140,7 @@ describe("maintainJob", () => {
     await writePage(workspaceDir, makePage("empty", []));
 
     const { deps: d } = deps();
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: true }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
 
     expect(outcome.pruned).toBe(1);
     expect(outcome.prunedRefs).toBe(1);
@@ -160,6 +153,7 @@ describe("maintainJob", () => {
   });
 
   test("contains an assign failure without aborting prune or invalidate", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
     await writePage(
       workspaceDir,
       makePage("dangling", ["domain/topic-a", "domain/gone"]),
@@ -169,11 +163,7 @@ describe("maintainJob", () => {
         throw new Error("assign boom");
       },
     });
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: true }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.failures).toContain("assign");
     expect(outcome.pruned).toBe(1);
     expect(calls.invalidate).toBe(1);
@@ -181,16 +171,13 @@ describe("maintainJob", () => {
   });
 
   test("contains a tree-load failure but still invalidates lanes", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
     const { deps: d, calls } = deps({
       loadTree: async () => {
         throw new Error("load boom");
       },
     });
-    const outcome = await maintainJob(
-      JOB,
-      configWithFlags({ [FLAG_SHADOW]: true }),
-      d,
-    );
+    const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.failures).toContain("load_tree");
     expect(calls.assign).toBe(0);
     expect(calls.invalidate).toBe(1);

--- a/assistant/src/memory/v3/maintain-job.ts
+++ b/assistant/src/memory/v3/maintain-job.ts
@@ -1,0 +1,220 @@
+/**
+ * Memory v3 — `memory_v3_maintain` job handler.
+ *
+ * A flag-gated, best-effort self-maintenance pass over the v3 topic tree and
+ * its page→leaf assignments. It runs three independent stages, in order:
+ *
+ *   1. **Classify-union** — `assignPages` over every page whose `leaves:`
+ *      frontmatter is empty or missing, UNIONing freshly classified leaves into
+ *      each page (never dropping existing picks).
+ *   2. **Prune** — drop any frontmatter `leaves:` entry that points at a leaf
+ *      path no longer present in the tree (dangling references left behind when
+ *      a leaf is renamed or removed). Read + rewrite only the affected pages.
+ *   3. **Needle rebuild** — `invalidateLanes()` so the next turn rebuilds the
+ *      leaf tree and BM25 needle from the freshly-updated assignments.
+ *
+ * Best-effort by construction: each stage is wrapped so a failure in one is
+ * logged and recorded in the outcome but does NOT abort the others. The job is
+ * a no-op (returns a disabled outcome) unless `memory-v3-shadow` OR
+ * `memory-v3-live` is enabled — the same flags that gate the v3 plugin.
+ *
+ * Dependency-injectable: `deps` lets tests substitute the tree loader,
+ * `assignPages`, and `invalidateLanes` without process-global module mocks.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import type { MemoryJob } from "../jobs-store.js";
+import { getPageIndex } from "../v2/page-index.js";
+import { listPages, readPage, writePage } from "../v2/page-store.js";
+import { assignPages as realAssignPages } from "./assign.js";
+import { invalidateLanes as realInvalidateLanes } from "./shadow-plugin.js";
+import { loadLeafTree as realLoadLeafTree, resolveDataDir } from "./tree.js";
+import type { LeafPath, LeafTree, Slug } from "./types.js";
+
+const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
+const MEMORY_V3_LIVE = "memory-v3-live" as const;
+
+const log = getLogger("memory-v3-maintain");
+
+/** Injectable collaborators; defaults wire the real implementations. */
+export interface MaintainJobDeps {
+  /** Load the v3 leaf tree (page→leaf membership resolved from frontmatter). */
+  loadTree: () => Promise<LeafTree>;
+  /** Classify-union pass over pages. */
+  assignPages: typeof realAssignPages;
+  /** Drop the memoized v3 lanes so the next turn rebuilds tree + needle. */
+  invalidateLanes: () => void;
+  /** Workspace root; pages live under `<workspaceDir>/memory/concepts/`. */
+  workspaceDir: string;
+}
+
+/** Per-stage outcome surfaced in the structured log line. */
+export interface MaintainOutcome {
+  /** True when both v3 flags were off and the job no-opped. */
+  disabled: boolean;
+  /** Pages newly assigned by the classify-union stage. */
+  assigned: number;
+  /** Pages whose dangling refs were pruned. */
+  pruned: number;
+  /** Dangling leaf references dropped across all pruned pages. */
+  prunedRefs: number;
+  /** Whether the needle/tree lanes were invalidated. */
+  invalidated: boolean;
+  /** Stages that threw (and were contained). */
+  failures: string[];
+}
+
+/**
+ * Load the v3 leaf tree the same way the live plugin does: resolve the data
+ * dir, build the page→leaf membership map from the page index frontmatter, and
+ * hand both to `loadLeafTree`.
+ */
+async function loadTreeFromWorkspace(workspaceDir: string): Promise<LeafTree> {
+  const pageIndex = await getPageIndex(workspaceDir);
+  const pageLeaves = new Map<Slug, LeafPath[]>();
+  for (const entry of pageIndex.entries) {
+    pageLeaves.set(entry.slug, entry.leaves);
+  }
+  return realLoadLeafTree(resolveDataDir(), pageLeaves);
+}
+
+function defaultDeps(): MaintainJobDeps {
+  const workspaceDir = getWorkspaceDir();
+  return {
+    loadTree: () => loadTreeFromWorkspace(workspaceDir),
+    assignPages: realAssignPages,
+    invalidateLanes: realInvalidateLanes,
+    workspaceDir,
+  };
+}
+
+/**
+ * Prune dangling `leaves:` references: for every page, drop frontmatter leaf
+ * paths that are not present in `tree`. Read + rewrite only pages that actually
+ * change. Returns the number of pages rewritten and total refs dropped.
+ */
+async function prunePages(
+  tree: LeafTree,
+  workspaceDir: string,
+): Promise<{ pruned: number; prunedRefs: number }> {
+  const validLeaves = tree.leaves;
+  const slugs = await listPages(workspaceDir);
+  let pruned = 0;
+  let prunedRefs = 0;
+  for (const slug of slugs) {
+    const page = await readPage(workspaceDir, slug);
+    const leaves = page?.frontmatter.leaves;
+    if (!page || !leaves || leaves.length === 0) continue;
+    const kept = leaves.filter((leaf) => validLeaves.has(leaf));
+    if (kept.length === leaves.length) continue;
+    prunedRefs += leaves.length - kept.length;
+    pruned += 1;
+    await writePage(workspaceDir, {
+      ...page,
+      frontmatter: { ...page.frontmatter, leaves: kept },
+    });
+  }
+  return { pruned, prunedRefs };
+}
+
+/**
+ * Run the v3 self-maintenance pass. Each stage is independently contained: a
+ * thrown error is logged and recorded in `failures` without aborting the rest.
+ * No-ops when both v3 flags are off.
+ */
+export async function maintainJob(
+  _job: MemoryJob,
+  config: AssistantConfig,
+  deps: MaintainJobDeps = defaultDeps(),
+): Promise<MaintainOutcome> {
+  const outcome: MaintainOutcome = {
+    disabled: false,
+    assigned: 0,
+    pruned: 0,
+    prunedRefs: 0,
+    invalidated: false,
+    failures: [],
+  };
+
+  const enabled =
+    isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config) ||
+    isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
+  if (!enabled) {
+    outcome.disabled = true;
+    return outcome;
+  }
+
+  // The tree is shared input for both the assign and prune stages. If it can't
+  // load, those two stages are skipped (recorded as a failure), but we still
+  // invalidate the lanes so a transient load error doesn't wedge the next turn.
+  let tree: LeafTree | null = null;
+  try {
+    tree = await deps.loadTree();
+  } catch (err) {
+    outcome.failures.push("load_tree");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: tree load failed (non-fatal)",
+    );
+  }
+
+  if (tree) {
+    // Stage 1: classify-union over unassigned pages.
+    try {
+      const results = await deps.assignPages({
+        tree,
+        workspaceDir: deps.workspaceDir,
+      });
+      outcome.assigned = results.filter(
+        (r) => !r.failed && r.after.length > r.before.length,
+      ).length;
+    } catch (err) {
+      outcome.failures.push("assign");
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "memory-v3 maintain: classify-union failed (non-fatal)",
+      );
+    }
+
+    // Stage 2: prune dangling refs.
+    try {
+      const { pruned, prunedRefs } = await prunePages(tree, deps.workspaceDir);
+      outcome.pruned = pruned;
+      outcome.prunedRefs = prunedRefs;
+    } catch (err) {
+      outcome.failures.push("prune");
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "memory-v3 maintain: prune failed (non-fatal)",
+      );
+    }
+  }
+
+  // Stage 3: rebuild tree + needle on the next turn.
+  try {
+    deps.invalidateLanes();
+    outcome.invalidated = true;
+  } catch (err) {
+    outcome.failures.push("invalidate");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: lane invalidation failed (non-fatal)",
+    );
+  }
+
+  log.info(
+    {
+      assigned: outcome.assigned,
+      pruned: outcome.pruned,
+      prunedRefs: outcome.prunedRefs,
+      invalidated: outcome.invalidated,
+      failures: outcome.failures,
+    },
+    "memory-v3 maintain pass complete",
+  );
+
+  return outcome;
+}


### PR DESCRIPTION
## Summary
- New flag-gated memory_v3_maintain job: assignPages union over unassigned pages, prune dangling refs, invalidate lanes
- Registered job type + dispatch + checkpoint; no-op when v3 flags off

Part of plan: memory-v3-self-maintenance.md (PR 7 of 14)