### PR TITLE
feat(memory-v3): deterministic tree reconciler for safe restructuring

### DIFF
--- a/assistant/src/memory/v3/__tests__/reconcile.test.ts
+++ b/assistant/src/memory/v3/__tests__/reconcile.test.ts
@@ -1,0 +1,249 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { Provider } from "../../../providers/types.js";
+import { readPage, writePage } from "../../v2/page-store.js";
+import { type LeafRef, reconcileTree } from "../reconcile.js";
+
+/**
+ * A canned provider whose `assign_leaves` tool-use response is computed from
+ * the user message (the page content) via `idsForMessage`. This lets a test
+ * deterministically re-home each page onto specific surviving leaves without a
+ * real LLM. The leaf index in the system prompt is sorted by path; tests pass
+ * the 1-based id of the target leaf in that sorted order.
+ */
+function stubProvider(
+  idsForMessage: (message: string, systemPrompt: string) => number[],
+): Provider {
+  return {
+    name: "stub",
+    async sendMessage(messages: unknown, opts: unknown) {
+      const msg = messages as Array<{
+        content: Array<{ type: string; text?: string }>;
+      }>;
+      const text = msg[0]?.content?.map((c) => c.text ?? "").join("") ?? "";
+      const systemPrompt =
+        (opts as { systemPrompt?: string }).systemPrompt ?? "";
+      const ids = idsForMessage(text, systemPrompt);
+      return {
+        id: "msg_stub",
+        role: "assistant",
+        model: "stub-model",
+        stopReason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "assign_leaves",
+            input: { ids },
+          },
+        ],
+      };
+    },
+  } as unknown as Provider;
+}
+
+let workspaceDir: string;
+let dataDir: string;
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), "reconcile-ws-"));
+  dataDir = await mkdtemp(join(tmpdir(), "reconcile-data-"));
+});
+
+afterEach(async () => {
+  await rm(workspaceDir, { recursive: true, force: true });
+  await rm(dataDir, { recursive: true, force: true });
+  await rm(join(dataDir, "..", "v3-snapshots"), {
+    recursive: true,
+    force: true,
+  }).catch(() => {});
+});
+
+/** Write a leaf `.md` with `{path, in_core, id}` frontmatter. */
+async function writeLeaf(
+  path: string,
+  opts: { id?: string; inCore?: boolean; body?: string } = {},
+): Promise<void> {
+  const full = join(dataDir, "leaves", `${path}.md`);
+  await mkdir(join(full, ".."), { recursive: true });
+  const lines = [`path: ${path}`, `in_core: ${opts.inCore ?? false}`];
+  if (opts.id) lines.push(`id: ${opts.id}`);
+  await writeFile(
+    full,
+    `---\n${lines.join("\n")}\n---\n${opts.body ?? `Leaf ${path}.`}\n`,
+  );
+}
+
+async function writeCore(alwaysOn: string[]): Promise<void> {
+  await writeFile(join(dataDir, "core.json"), JSON.stringify({ alwaysOn }));
+}
+
+/**
+ * `loadLeafTree` (used by the re-homing path) reads `assignments.json`
+ * unconditionally, so seed an empty one. Page→leaf membership comes from page
+ * frontmatter, not this file.
+ */
+async function seedAssignments(): Promise<void> {
+  await writeFile(join(dataDir, "assignments.json"), "{}");
+}
+
+async function writePageWithLeaves(
+  slug: string,
+  leaves: string[],
+): Promise<void> {
+  await writePage(workspaceDir, {
+    slug,
+    frontmatter: { edges: [], ref_files: [], ref_urls: [], leaves },
+    body: `Body of ${slug}.`,
+  });
+}
+
+async function pageLeaves(slug: string): Promise<string[]> {
+  const page = await readPage(workspaceDir, slug);
+  return page?.frontmatter.leaves ?? [];
+}
+
+async function coreOf(): Promise<string[]> {
+  const raw = await readFile(join(dataDir, "core.json"), "utf8");
+  return (JSON.parse(raw) as { alwaysOn: string[] }).alwaysOn;
+}
+
+describe("reconcileTree", () => {
+  test("rename preserves assignments (refs rewritten old → new)", async () => {
+    // Current tree: the leaf moved from domain-a/topic-x → domain-b/topic-x,
+    // keeping its stable id.
+    await writeLeaf("domain-b/topic-x", { id: "leaf-x" });
+    await writeCore(["domain-a/topic-x"]);
+    await writePageWithLeaves("page-a", ["domain-a/topic-x"]);
+
+    const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+    const result = await reconcileTree({
+      prevLeaves: prev,
+      dataDir,
+      workspaceDir,
+    });
+
+    expect(await pageLeaves("page-a")).toEqual(["domain-b/topic-x"]);
+    expect(await coreOf()).toEqual(["domain-b/topic-x"]);
+    expect(result.renames).toEqual([
+      {
+        id: "leaf-x",
+        oldPath: "domain-a/topic-x",
+        newPath: "domain-b/topic-x",
+      },
+    ]);
+    expect(result.idToNewPath.get("leaf-x")).toBe("domain-b/topic-x");
+  });
+
+  test("delete re-homes members with no orphan", async () => {
+    // leaf-x is deleted; leaf-y survives. page-a was only on leaf-x.
+    await writeLeaf("domain-a/topic-y", { id: "leaf-y" });
+    await writeCore([]);
+    await seedAssignments();
+    await writePageWithLeaves("page-a", ["domain-a/topic-x"]);
+
+    // Surviving leaf is sorted index 1 (only leaf in tree).
+    const provider = stubProvider(() => [1]);
+
+    const prev: LeafRef[] = [
+      { id: "leaf-x", path: "domain-a/topic-x" },
+      { id: "leaf-y", path: "domain-a/topic-y" },
+    ];
+    const result = await reconcileTree({
+      prevLeaves: prev,
+      dataDir,
+      workspaceDir,
+      provider,
+    });
+
+    const after = await pageLeaves("page-a");
+    // No orphan: at least one surviving leaf, and the dead path is gone.
+    expect(after.length).toBeGreaterThanOrEqual(1);
+    expect(after).not.toContain("domain-a/topic-x");
+    expect(after).toContain("domain-a/topic-y");
+    expect(result.deleted).toEqual(["domain-a/topic-x"]);
+  });
+
+  test("split distributes members across toPaths", async () => {
+    // leaf-x splits into leaf-x1 (domain-a/x1) and leaf-x2 (domain-a/x2).
+    await writeLeaf("domain-a/x1", { id: "leaf-x1" });
+    await writeLeaf("domain-a/x2", { id: "leaf-x2" });
+    // A third surviving leaf NOT in the split target set — members must not
+    // land here.
+    await writeLeaf("domain-b/other", { id: "leaf-other" });
+    await writeCore([]);
+    await seedAssignments();
+    await writePageWithLeaves("page-a", ["domain-a/topic-x"]);
+    await writePageWithLeaves("page-b", ["domain-a/topic-x"]);
+
+    // Restricted tree (split.toPaths) sorts as [domain-a/x1, domain-a/x2].
+    // page-a → x1 (id 1), page-b → x2 (id 2).
+    const provider = stubProvider((message) =>
+      message.includes("page-a") ? [1] : [2],
+    );
+
+    const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+    await reconcileTree({
+      prevLeaves: prev,
+      dataDir,
+      workspaceDir,
+      provider,
+      splits: [{ fromId: "leaf-x", toPaths: ["domain-a/x1", "domain-a/x2"] }],
+    });
+
+    expect(await pageLeaves("page-a")).toEqual(["domain-a/x1"]);
+    expect(await pageLeaves("page-b")).toEqual(["domain-a/x2"]);
+    // Neither page landed on the off-target leaf.
+    expect(await pageLeaves("page-a")).not.toContain("domain-b/other");
+    expect(await pageLeaves("page-b")).not.toContain("domain-b/other");
+  });
+
+  test("dangling core entry is pruned", async () => {
+    await writeLeaf("domain-a/topic-x", { id: "leaf-x" });
+    // core.json points at a leaf that no longer exists in the tree.
+    await writeCore(["domain-a/topic-x", "domain-a/gone"]);
+    await writePageWithLeaves("page-a", ["domain-a/topic-x"]);
+
+    // No prev entry for the gone leaf and no page references it, so reconcile
+    // succeeds and prunes the stale core entry.
+    const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+    const result = await reconcileTree({
+      prevLeaves: prev,
+      dataDir,
+      workspaceDir,
+    });
+
+    expect(await coreOf()).toEqual(["domain-a/topic-x"]);
+    expect(result.prunedCore).toEqual(["domain-a/gone"]);
+  });
+
+  test("residual dangling ref triggers validation throw + restore", async () => {
+    // The current tree has only leaf-x. page-a references leaf-x (fine) PLUS a
+    // residual leaf path that exists in NEITHER prev nor current — so it is
+    // not a rename target and not a deleted-path drop, and survives the
+    // rewrite as a dangling ref. Validation must fail closed and restore.
+    await writeLeaf("domain-a/topic-x", { id: "leaf-x" });
+    await writeCore(["domain-a/topic-x"]);
+    await writePageWithLeaves("page-a", [
+      "domain-a/topic-x",
+      "domain-a/residual",
+    ]);
+
+    const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+
+    await expect(
+      reconcileTree({ prevLeaves: prev, dataDir, workspaceDir }),
+    ).rejects.toThrow(/validation failed/);
+
+    // Restored: page frontmatter reverted to its pre-reconcile state (both
+    // refs, including the residual one) and core.json reverted.
+    expect(await pageLeaves("page-a")).toEqual([
+      "domain-a/topic-x",
+      "domain-a/residual",
+    ]);
+    expect(await coreOf()).toEqual(["domain-a/topic-x"]);
+  });
+});

--- a/assistant/src/memory/v3/reconcile.ts
+++ b/assistant/src/memory/v3/reconcile.ts
@@ -1,0 +1,510 @@
+/**
+ * Memory v3 — deterministic tree reconciler.
+ *
+ * After a maintainer restructures the leaf tree on disk (renames a leaf, moves
+ * it under a new domain, splits one leaf into several, or deletes a leaf), the
+ * page→leaf assignment store (each page's `leaves:` frontmatter) and the
+ * always-on `core.json` set still point at the OLD leaf paths. This module
+ * reconciles those references against the CURRENT on-disk tree, diffing leaves
+ * by their stable `id` so a rename is distinguishable from a delete+add:
+ *
+ *   - id in prev and current with a changed path  → RENAME/MOVE. Every page
+ *     `leaves:` ref and every `core.json` entry pointing at the old path is
+ *     rewritten to the new path. Assignments are preserved verbatim.
+ *   - id in prev but absent from current          → DELETE. The deleted leaf's
+ *     member pages are first RE-HOMED across the surviving tree via
+ *     {@link assignPages} (union semantics — no page is left orphaned), then the
+ *     dangling ref to the old path is dropped from page frontmatter and core.
+ *   - id in current but absent from prev          → ADD. Nothing to migrate.
+ *
+ * Splits are expressed as a removed `from` leaf whose members re-home across the
+ * remaining/new leaves. Pass `splits` to restrict a from-leaf's members to a
+ * specific target set; otherwise a removed leaf's members re-home across the
+ * whole surviving tree (the generic delete path).
+ *
+ * Fail-closed: the whole operation runs against a snapshot taken BEFORE any
+ * mutation. After rewrites, the reconciler VALIDATES that no page `leaves:` ref
+ * and no `core.json` entry points at a leaf path absent from the current tree.
+ * If any dangling reference survives, it restores the data dir and reverts the
+ * affected page frontmatter from the snapshot, then re-throws — leaving the
+ * workspace exactly as it was before the call.
+ *
+ * On a successful reconcile it invalidates the v3 lanes ({@link invalidateLanes})
+ * so the next turn rebuilds the tree/needle from the reconciled state.
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+import type { Provider } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { listPages, readPage, writePage } from "../v2/page-store.js";
+import { assignPages } from "./assign.js";
+import { loadCore } from "./core.js";
+import { invalidateLanes } from "./shadow-plugin.js";
+import { restoreDataDir, snapshotDataDir } from "./snapshot.js";
+import { loadLeafTree } from "./tree.js";
+import type { LeafPath, LeafTree, Slug } from "./types.js";
+
+const log = getLogger("memory-v3-reconcile");
+
+/** A leaf as seen at a point in time: its stable id (if any) and its path. */
+export interface LeafRef {
+  id?: string;
+  path: LeafPath;
+}
+
+/**
+ * Optional split directive: re-home `fromId`'s member pages across `toPaths`
+ * only (instead of the whole surviving tree). `toPaths` must be leaf paths
+ * present in the current tree.
+ */
+export interface SplitDirective {
+  fromId: string;
+  toPaths: LeafPath[];
+}
+
+export interface ReconcileArgs {
+  /** The leaf set as it was BEFORE the maintainer's on-disk restructuring. */
+  prevLeaves: LeafRef[];
+  /** Absolute path to the v3 data dir (`<workspace>/memory/v3/data`). */
+  dataDir: string;
+  /** Workspace root; pages live under `<workspaceDir>/memory/concepts/`. */
+  workspaceDir: string;
+  /** Optional split directives (see {@link SplitDirective}). */
+  splits?: SplitDirective[];
+  /** Provider override forwarded to {@link assignPages} for re-homing. */
+  provider?: Provider;
+}
+
+export interface ReconcileResult {
+  /**
+   * Continuity map for telemetry/eval: each entry maps a leaf's prior identity
+   * (`id` when known, else its old path) to its new path. Renames record the
+   * new path; deletes are omitted (the leaf has no new path).
+   */
+  idToNewPath: Map<string, LeafPath>;
+  /** Leaf paths that were renamed/moved (old → new). */
+  renames: Array<{ id?: string; oldPath: LeafPath; newPath: LeafPath }>;
+  /** Leaf paths that were deleted (present in prev, absent from current). */
+  deleted: LeafPath[];
+  /** `core.json` entries pruned because they pointed outside the current tree. */
+  prunedCore: LeafPath[];
+}
+
+// ---------------------------------------------------------------------------
+// On-disk leaf reading (mirrors the parse approach in tree.ts; the helpers
+// there are not exported, so we replicate the minimal slice we need here).
+// ---------------------------------------------------------------------------
+
+/** Recursively collect every `*.md` file under `dir`. */
+async function collectMarkdownFiles(dir: string): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectMarkdownFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function parseLeafRef(yaml: string, leavesDir: string, file: string): LeafRef {
+  const parsed = parseYaml(yaml) as unknown;
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`leaf ${file} frontmatter is not a mapping`);
+  }
+  const record = parsed as Record<string, unknown>;
+  // Prefer the frontmatter `path`; fall back to the file location so a leaf with
+  // a missing/empty path still resolves to its on-disk identity.
+  const path =
+    typeof record.path === "string" && record.path.length > 0
+      ? record.path
+      : relative(leavesDir, file).replace(/\.md$/, "").split(sep).join("/");
+  return {
+    path,
+    ...(typeof record.id === "string" ? { id: record.id } : {}),
+  };
+}
+
+/** Read the CURRENT leaf set (id + path) from `<dataDir>/leaves/**`. */
+async function readCurrentLeaves(dataDir: string): Promise<LeafRef[]> {
+  const leavesDir = join(dataDir, "leaves");
+  const files = await collectMarkdownFiles(leavesDir);
+  return Promise.all(
+    files.map(async (file) => {
+      const raw = await readFile(file, "utf8");
+      const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(
+        raw.replace(/^﻿/, ""),
+      );
+      if (!match) throw new Error(`leaf ${file} is missing YAML frontmatter`);
+      return parseLeafRef(match[1], leavesDir, file);
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+interface TreeDiff {
+  /** old path → new path for leaves whose id persisted but path changed. */
+  renames: Map<LeafPath, LeafPath>;
+  /** leaves present in prev but absent from current (by id, or by path when no id). */
+  deleted: LeafRef[];
+}
+
+/**
+ * Diff `prev` against `current` BY id. Leaves without an id fall back to a
+ * path-keyed comparison (legacy leaves predating stable ids): an id-less prev
+ * leaf is "deleted" only if its path is absent from current.
+ */
+function diffByIdThenPath(prev: LeafRef[], current: LeafRef[]): TreeDiff {
+  const currentById = new Map<string, LeafRef>();
+  const currentPaths = new Set<LeafPath>();
+  for (const leaf of current) {
+    if (leaf.id) currentById.set(leaf.id, leaf);
+    currentPaths.add(leaf.path);
+  }
+
+  const renames = new Map<LeafPath, LeafPath>();
+  const deleted: LeafRef[] = [];
+
+  for (const prevLeaf of prev) {
+    if (prevLeaf.id) {
+      const match = currentById.get(prevLeaf.id);
+      if (!match) {
+        deleted.push(prevLeaf);
+      } else if (match.path !== prevLeaf.path) {
+        renames.set(prevLeaf.path, match.path);
+      }
+      continue;
+    }
+    // No id: identity is the path. Deleted iff the path is gone.
+    if (!currentPaths.has(prevLeaf.path)) deleted.push(prevLeaf);
+  }
+
+  return { renames, deleted };
+}
+
+// ---------------------------------------------------------------------------
+// Page-frontmatter ref rewriting
+// ---------------------------------------------------------------------------
+
+/** Load every page's `leaves:` frontmatter as a slug → leaf-paths map. */
+async function loadPageRefs(
+  workspaceDir: string,
+): Promise<Map<Slug, LeafPath[]>> {
+  const slugs = await listPages(workspaceDir);
+  const refs = new Map<Slug, LeafPath[]>();
+  for (const slug of slugs) {
+    const page = await readPage(workspaceDir, slug);
+    if (page) refs.set(slug, page.frontmatter.leaves ?? []);
+  }
+  return refs;
+}
+
+/**
+ * Apply a leaf-path transform to a single page's `leaves:` frontmatter and
+ * persist it iff the result changed. `transform` returns the rewritten list
+ * (renamed/dropped entries already applied), de-duplicated by the caller.
+ */
+async function rewritePageRefs(
+  workspaceDir: string,
+  slug: Slug,
+  transform: (leaves: LeafPath[]) => LeafPath[],
+): Promise<void> {
+  const page = await readPage(workspaceDir, slug);
+  if (!page) return;
+  const before = page.frontmatter.leaves ?? [];
+  const after = transform(before);
+  if (sameLeaves(before, after)) return;
+  await writePage(workspaceDir, {
+    ...page,
+    frontmatter: { ...page.frontmatter, leaves: after },
+  });
+}
+
+function sameLeaves(a: LeafPath[], b: LeafPath[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}
+
+/** De-duplicate a leaf-path list, preserving first-seen order. */
+function dedupe(leaves: LeafPath[]): LeafPath[] {
+  const out: LeafPath[] = [];
+  for (const leaf of leaves) if (!out.includes(leaf)) out.push(leaf);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile page + core references against the current on-disk leaf tree.
+ * See the module docstring for the full contract. Fail-closed: throws (after
+ * restoring from snapshot) if any dangling reference survives validation.
+ */
+export async function reconcileTree(
+  args: ReconcileArgs,
+): Promise<ReconcileResult> {
+  const { prevLeaves, dataDir, workspaceDir, splits, provider } = args;
+
+  const current = await readCurrentLeaves(dataDir);
+  const currentPaths = new Set<LeafPath>(current.map((l) => l.path));
+  const { renames, deleted } = diffByIdThenPath(prevLeaves, current);
+
+  // Capture the prior page->leaves map so a failed reconcile can revert the
+  // external page frontmatter the same way the snapshot reverts the data dir.
+  const priorPageRefs = await loadPageRefs(workspaceDir);
+  const snapshotPath = await snapshotDataDir(dataDir, {
+    pageRefs: priorPageRefs,
+  });
+
+  try {
+    const result = await applyReconcile({
+      current,
+      currentPaths,
+      renames,
+      deleted,
+      splits: splits ?? [],
+      workspaceDir,
+      dataDir,
+      provider,
+    });
+    await validateNoDangling(workspaceDir, dataDir, currentPaths);
+    invalidateLanes();
+    return result;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "reconcile failed validation — restoring from snapshot",
+    );
+    await revertFromSnapshot(snapshotPath, dataDir, workspaceDir);
+    throw err;
+  }
+}
+
+interface ApplyArgs {
+  current: LeafRef[];
+  currentPaths: Set<LeafPath>;
+  renames: Map<LeafPath, LeafPath>;
+  deleted: LeafRef[];
+  splits: SplitDirective[];
+  workspaceDir: string;
+  dataDir: string;
+  provider?: Provider;
+}
+
+async function applyReconcile(args: ApplyArgs): Promise<ReconcileResult> {
+  const {
+    current,
+    currentPaths,
+    renames,
+    deleted,
+    splits,
+    workspaceDir,
+    dataDir,
+    provider,
+  } = args;
+
+  // 1. Re-home members of deleted leaves BEFORE dropping any refs, so a page
+  //    that loses its only leaf gains a surviving one (no orphan). We re-home
+  //    first, against the still-intact assignments, then drop the dead path.
+  const splitById = new Map<string, SplitDirective>(
+    splits.map((s) => [s.fromId, s]),
+  );
+  const deletedPaths = new Set<LeafPath>();
+  for (const leaf of deleted) {
+    deletedPaths.add(leaf.path);
+
+    const members = await pagesAssignedTo(workspaceDir, leaf.path);
+    if (members.length > 0) {
+      const split = leaf.id ? splitById.get(leaf.id) : undefined;
+      await rehomeMembers(workspaceDir, dataDir, members, split, provider);
+    }
+  }
+
+  // 2. Rewrite renamed paths and drop deleted paths from page frontmatter.
+  const slugs = await listPages(workspaceDir);
+  for (const slug of slugs) {
+    await rewritePageRefs(workspaceDir, slug, (leaves) =>
+      dedupe(
+        leaves
+          .map((p) => renames.get(p) ?? p)
+          .filter((p) => !deletedPaths.has(p)),
+      ),
+    );
+  }
+
+  // 3. Rewrite renamed paths, drop deleted paths, and PRUNE any core entry that
+  //    points outside the current tree.
+  const core = await loadCore(dataDir);
+  const prunedCore: LeafPath[] = [];
+  const nextCore: LeafPath[] = [];
+  for (const path of core) {
+    const renamed = renames.get(path);
+    const resolved = renamed ?? path;
+    if (deletedPaths.has(resolved) || !currentPaths.has(resolved)) {
+      prunedCore.push(path);
+      continue;
+    }
+    if (!nextCore.includes(resolved)) nextCore.push(resolved);
+  }
+  await writeCore(dataDir, nextCore);
+
+  // 4. Build the continuity map (renames → new path; deletes have no new path).
+  const idToNewPath = new Map<string, LeafPath>();
+  const renameList: ReconcileResult["renames"] = [];
+  for (const [oldPath, newPath] of renames) {
+    const id = current.find((l) => l.path === newPath)?.id;
+    renameList.push({ id, oldPath, newPath });
+    idToNewPath.set(id ?? oldPath, newPath);
+  }
+
+  return {
+    idToNewPath,
+    renames: renameList,
+    deleted: deleted.map((l) => l.path),
+    prunedCore,
+  };
+}
+
+/** Slugs whose `leaves:` frontmatter currently includes `leafPath`. */
+async function pagesAssignedTo(
+  workspaceDir: string,
+  leafPath: LeafPath,
+): Promise<Slug[]> {
+  const slugs = await listPages(workspaceDir);
+  const members: Slug[] = [];
+  for (const slug of slugs) {
+    const page = await readPage(workspaceDir, slug);
+    if (page && (page.frontmatter.leaves ?? []).includes(leafPath)) {
+      members.push(slug);
+    }
+  }
+  return members;
+}
+
+/**
+ * Re-home a deleted leaf's member pages onto the surviving tree via
+ * {@link assignPages} (union semantics — never drops a page's other leaves).
+ * When a {@link SplitDirective} is supplied, the classifier is restricted to a
+ * sub-tree containing only the split's `toPaths` so members redistribute across
+ * the explicit targets; otherwise it runs against the whole current tree.
+ */
+async function rehomeMembers(
+  workspaceDir: string,
+  dataDir: string,
+  members: Slug[],
+  split: SplitDirective | undefined,
+  provider?: Provider,
+): Promise<void> {
+  const fullTree: LeafTree = await loadLeafTreeForReconcile(
+    workspaceDir,
+    dataDir,
+  );
+  const tree =
+    split && split.toPaths.length > 0
+      ? restrictTree(fullTree, split.toPaths)
+      : fullTree;
+  if (tree.leaves.size === 0) return;
+  await assignPages({
+    tree,
+    workspaceDir,
+    slugs: members,
+    provider,
+    throttleMs: 0,
+  });
+}
+
+/** Load the current tree with page-frontmatter assignments folded in. */
+async function loadLeafTreeForReconcile(
+  workspaceDir: string,
+  dataDir: string,
+): Promise<LeafTree> {
+  const pageRefs = await loadPageRefs(workspaceDir);
+  return loadLeafTree(dataDir, pageRefs);
+}
+
+/** A view of `tree` containing only the leaves in `keep`. */
+function restrictTree(tree: LeafTree, keep: LeafPath[]): LeafTree {
+  const keepSet = new Set(keep);
+  const leaves = new Map(
+    [...tree.leaves].filter(([path]) => keepSet.has(path)),
+  );
+  return { leaves, byPage: tree.byPage };
+}
+
+/** Persist the always-on core set back to `<dataDir>/core.json`. */
+async function writeCore(dataDir: string, alwaysOn: LeafPath[]): Promise<void> {
+  await writeFile(
+    join(dataDir, "core.json"),
+    `${JSON.stringify({ alwaysOn }, null, 2)}\n`,
+  );
+}
+
+/**
+ * Fail-closed validation: after all rewrites, NO page `leaves:` ref and NO
+ * core entry may point at a leaf path absent from the current tree. Throws on
+ * the first dangling reference found.
+ */
+async function validateNoDangling(
+  workspaceDir: string,
+  dataDir: string,
+  currentPaths: Set<LeafPath>,
+): Promise<void> {
+  const pageRefs = await loadPageRefs(workspaceDir);
+  for (const [slug, leaves] of pageRefs) {
+    for (const leaf of leaves) {
+      if (!currentPaths.has(leaf)) {
+        throw new Error(
+          `reconcile validation failed: page "${slug}" references missing leaf "${leaf}"`,
+        );
+      }
+    }
+  }
+  const core = await loadCore(dataDir);
+  for (const leaf of core) {
+    if (!currentPaths.has(leaf)) {
+      throw new Error(
+        `reconcile validation failed: core references missing leaf "${leaf}"`,
+      );
+    }
+  }
+}
+
+/**
+ * Restore the data dir from the snapshot AND revert external page frontmatter
+ * from the snapshot's captured `pageRefs`, so a failed reconcile leaves the
+ * workspace byte-for-byte as it was before the call.
+ */
+async function revertFromSnapshot(
+  snapshotPath: string,
+  dataDir: string,
+  workspaceDir: string,
+): Promise<void> {
+  const { pageRefs } = await restoreDataDir(snapshotPath, dataDir);
+  if (!pageRefs) return;
+  for (const [slug, leaves] of pageRefs) {
+    const page = await readPage(workspaceDir, slug);
+    if (!page) continue;
+    if (sameLeaves(page.frontmatter.leaves ?? [], leaves)) continue;
+    await writePage(workspaceDir, {
+      ...page,
+      frontmatter: { ...page.frontmatter, leaves },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- reconcileTree diffs leaves by stable id: rename rewrites refs, delete/split re-homes via assignPages (no orphans), prunes dangling core, validates fail-closed
- Snapshots before mutating; restores on validation failure; invalidates lanes on success

Part of plan: memory-v3-self-maintenance.md (PR 12 of 14)