### PR TITLE
feat(cli): memory v3 tree-gardening and core-editing commands

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the `memory v3` CLI command group's daemon-side handlers.
+ *
+ * The CLI subcommands are thin IPC shells over the handlers in
+ * `runtime/routes/memory-v3-routes.ts`; the logic worth testing lives there.
+ * We exercise the handlers directly against a temp workspace + data dir
+ * injected via their `deps` parameter — no module mocking, no process-global
+ * leaks. Generic taxonomy only (domain-a/topic-x, etc.).
+ */
+
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  handleMemoryV3Health,
+  handleMemoryV3Reconcile,
+  handleMemoryV3SetCore,
+  UnknownLeafError,
+} from "../../../runtime/routes/memory-v3-routes.js";
+
+// ---------------------------------------------------------------------------
+// Temp data-dir fixture
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let dataDir: string;
+
+/** Write a leaf markdown file with the given frontmatter under leaves/. */
+async function writeLeaf(
+  relPath: string,
+  frontmatter: { path: string; in_core: boolean; id?: string },
+  body = "description",
+): Promise<void> {
+  const file = join(dataDir, "leaves", `${relPath}.md`);
+  await mkdir(join(file, ".."), { recursive: true });
+  const fm = [
+    "---",
+    `path: ${frontmatter.path}`,
+    `in_core: ${frontmatter.in_core}`,
+    ...(frontmatter.id ? [`id: ${frontmatter.id}`] : []),
+    "---",
+    body,
+    "",
+  ].join("\n");
+  await writeFile(file, fm);
+}
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), "mem-v3-cli-ws-"));
+  dataDir = join(workspaceDir, "memory", "v3", "data");
+  await mkdir(dataDir, { recursive: true });
+  // A small generic tree: two leaves under domain-a, one under domain-b.
+  await writeLeaf("domain-a/topic-x", {
+    path: "domain-a/topic-x",
+    in_core: true,
+    id: "leaf-x",
+  });
+  await writeLeaf("domain-a/topic-y", {
+    path: "domain-a/topic-y",
+    in_core: false,
+    id: "leaf-y",
+  });
+  await writeLeaf("domain-b/topic-z", {
+    path: "domain-b/topic-z",
+    in_core: false,
+    id: "leaf-z",
+  });
+  // assignments.json: page slugs → the leaves they belong to.
+  await writeFile(
+    join(dataDir, "assignments.json"),
+    JSON.stringify({
+      "page-1": ["domain-a/topic-x"],
+      "page-2": ["domain-a/topic-x", "domain-a/topic-y"],
+      "page-3": ["domain-b/topic-z"],
+    }),
+  );
+  await writeFile(
+    join(dataDir, "core.json"),
+    JSON.stringify({ alwaysOn: ["domain-a/topic-x"] }),
+  );
+  // Empty concepts dir so the reconciler's listPages() returns [].
+  await mkdir(join(workspaceDir, "memory", "concepts"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workspaceDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// set-core
+// ---------------------------------------------------------------------------
+
+describe("handleMemoryV3SetCore", () => {
+  test("rejects an unknown leaf and does not write", async () => {
+    const call = handleMemoryV3SetCore(
+      { add: ["domain-a/does-not-exist"], write: true },
+      { dataDir, workspaceDir },
+    );
+    await expect(call).rejects.toThrow(/domain-a\/does-not-exist/);
+    await expect(
+      handleMemoryV3SetCore(
+        { add: ["domain-a/does-not-exist"], write: true },
+        { dataDir, workspaceDir },
+      ),
+    ).rejects.toBeInstanceOf(UnknownLeafError);
+
+    // core.json must be untouched (still just the original entry).
+    const core = JSON.parse(await readFile(join(dataDir, "core.json"), "utf8"));
+    expect(core.alwaysOn).toEqual(["domain-a/topic-x"]);
+  });
+
+  test("previews the always-on page count without writing", async () => {
+    // Adding topic-y to core: core = {topic-x, topic-y}. Unique member slugs:
+    // topic-x → {page-1, page-2}, topic-y → {page-2} ⇒ {page-1, page-2} = 2.
+    const result = await handleMemoryV3SetCore(
+      { add: ["domain-a/topic-y"] },
+      { dataDir, workspaceDir },
+    );
+    expect(result.written).toBe(false);
+    expect(result.nextCore).toEqual(["domain-a/topic-x", "domain-a/topic-y"]);
+    expect(result.alwaysOnPageCount).toBe(2);
+
+    // No write happened — core.json still holds only the original entry.
+    const core = JSON.parse(await readFile(join(dataDir, "core.json"), "utf8"));
+    expect(core.alwaysOn).toEqual(["domain-a/topic-x"]);
+  });
+
+  test("writes core.json on --yes (write: true)", async () => {
+    const result = await handleMemoryV3SetCore(
+      { add: ["domain-b/topic-z"], write: true },
+      { dataDir, workspaceDir },
+    );
+    expect(result.written).toBe(true);
+    expect(result.nextCore).toEqual(["domain-a/topic-x", "domain-b/topic-z"]);
+
+    const core = JSON.parse(await readFile(join(dataDir, "core.json"), "utf8"));
+    expect(core.alwaysOn).toEqual(["domain-a/topic-x", "domain-b/topic-z"]);
+  });
+
+  test("remove is idempotent for an absent entry", async () => {
+    const result = await handleMemoryV3SetCore(
+      { remove: ["domain-a/topic-y"], write: true },
+      { dataDir, workspaceDir },
+    );
+    // topic-y was never in core; result is the original core unchanged.
+    expect(result.nextCore).toEqual(["domain-a/topic-x"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// health
+// ---------------------------------------------------------------------------
+
+describe("handleMemoryV3Health", () => {
+  test("renders a report and counts for the temp tree", async () => {
+    const result = await handleMemoryV3Health({ dataDir, workspaceDir });
+    // domain-b/topic-z has a single member ⇒ a tiny leaf, so the report is
+    // non-empty and renders the memory-v3 health header.
+    expect(result.rendered).toContain("memory-v3 health:");
+    expect(result.counts.tinyLeaves).toBeGreaterThanOrEqual(1);
+    expect(result.counts.danglingRefs).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcile
+// ---------------------------------------------------------------------------
+
+describe("handleMemoryV3Reconcile", () => {
+  test("no-op reconcile against an unchanged tree returns empty diffs", async () => {
+    // prevLeaves is derived from the current tree, so diffing current-vs-current
+    // yields no renames/deletes. This still drives the full reconcileTree path
+    // (snapshot → apply → validate → invalidate).
+    const result = await handleMemoryV3Reconcile({ dataDir, workspaceDir });
+    expect(result.renames).toEqual([]);
+    expect(result.deleted).toEqual([]);
+    expect(result.prunedCore).toEqual([]);
+
+    // A snapshot directory was created as a side effect.
+    const snapshotsRoot = join(workspaceDir, "memory", "v3", "v3-snapshots");
+    const entries = await readdir(snapshotsRoot);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -1,0 +1,276 @@
+/**
+ * `assistant memory v3` CLI subgroup.
+ *
+ * Operator-facing tree-gardening + core-editing subcommands for the v3 memory
+ * subsystem (leaf-tree activation model). The daemon owns the live tree, so the
+ * mutating verbs route through `cliIpcCall` to handlers that run inside the
+ * assistant process (where the in-memory lanes can be invalidated after a
+ * write). The read-only `health` report and the `set-core` cost preview also
+ * route through the daemon so it stays the single source of truth for the live
+ * workspace tree.
+ *
+ * Subcommands:
+ *
+ *   - `health` — print the structural health report (read-only).
+ *   - `reconcile` — reconcile page/core refs against the current on-disk tree
+ *     after a restructuring; reports renames, deletes, and pruned core entries.
+ *   - `set-core` — add/remove always-on core leaves. Validates that every added
+ *     leaf exists, previews the resulting always-on page count, and writes only
+ *     on `--yes`.
+ *   - `rebuild-index` — invalidate the v3 lanes so the next turn rebuilds.
+ *
+ * Deferred to follow-ups: thin `add-leaf` / `rename-leaf` / `delete-leaf`
+ * wrappers (edit the leaf file[s] then reconcile).
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import type {
+  MemoryV3HealthResult,
+  MemoryV3RebuildIndexResult,
+  MemoryV3ReconcileResult,
+  MemoryV3SetCoreResult,
+} from "../../runtime/routes/memory-v3-routes.js";
+import { registerCommand } from "../lib/register-command.js";
+import { log } from "../logger.js";
+
+export function registerMemoryV3Command(program: Command): void {
+  // Reuse an existing `memory` parent if some other registrar attached to it
+  // first; otherwise create one. This keeps the registration order between
+  // sibling memory registrars unconstrained.
+  const memory =
+    program.commands.find((c) => c.name() === "memory") ??
+    program.command("memory").description("Manage the memory subsystem");
+
+  registerCommand(memory, {
+    name: "v3",
+    transport: "ipc",
+    description: "Memory v3 tree-gardening and core-editing (leaf-tree model)",
+    build: (v3) => {
+      v3.addHelpText(
+        "after",
+        `
+The v3 memory subsystem organizes concept pages under a curated leaf tree
+(/workspace/memory/v3/data/) and pins an always-on "core" set of leaves.
+These commands garden that tree safely: each mutating verb snapshots and
+fail-closed validates before committing, and invalidates the live lanes so
+the next turn rebuilds from the reconciled state.
+
+Examples:
+  $ assistant memory v3 health
+  $ assistant memory v3 set-core --add domain-a/topic-x
+  $ assistant memory v3 set-core --remove domain-a/topic-y --yes
+  $ assistant memory v3 reconcile
+  $ assistant memory v3 rebuild-index`,
+      );
+
+      // ── health ────────────────────────────────────────────────────────────
+
+      v3.command("health")
+        .description("Print the v3 structural health report (read-only)")
+        .option("--json", "Emit raw JSON instead of the rendered report")
+        .addHelpText(
+          "after",
+          `
+Loads the live leaf tree + core set and reports where the taxonomy has
+drifted from the page graph: unassigned slugs, dangling refs, novel
+clusters, and over/under-sized leaves. Read-only — no writes. Prints
+"all green" when no maintenance is warranted.
+
+Examples:
+  $ assistant memory v3 health
+  $ assistant memory v3 health --json | jq '.counts'`,
+        )
+        .action(async (opts: { json?: boolean }) => {
+          const result = await cliIpcCall<MemoryV3HealthResult>(
+            "memory_v3_health",
+            { body: {} },
+          );
+          if (!result.ok) {
+            log.error(result.error ?? "Failed to compute v3 health");
+            process.exitCode = 1;
+            return;
+          }
+          const payload = result.result!;
+          if (opts.json === true) {
+            log.info(JSON.stringify(payload, null, 2));
+            return;
+          }
+          log.info(
+            payload.rendered === ""
+              ? "memory-v3 health: all green"
+              : payload.rendered,
+          );
+        });
+
+      // ── reconcile ─────────────────────────────────────────────────────────
+
+      v3.command("reconcile")
+        .description(
+          "Reconcile page/core refs against the current on-disk leaf tree",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted summary")
+        .addHelpText(
+          "after",
+          `
+After restructuring the leaf tree on disk (rename/move/split/delete a
+leaf), this rewrites every page's leaves: frontmatter and core.json to
+point at the current paths. Diffs leaves by stable id so a rename is
+distinguished from a delete+add; deleted leaves' member pages are re-homed
+across the surviving tree before their dangling refs are dropped.
+
+Fail-closed: snapshots before mutating and rolls back if any dangling
+reference survives validation. On success the v3 lanes are invalidated.
+
+Examples:
+  $ assistant memory v3 reconcile
+  $ assistant memory v3 reconcile --json | jq '.renames'`,
+        )
+        .action(async (opts: { json?: boolean }) => {
+          const result = await cliIpcCall<MemoryV3ReconcileResult>(
+            "memory_v3_reconcile",
+            { body: {} },
+          );
+          if (!result.ok) {
+            log.error(result.error ?? "Failed to reconcile the v3 tree");
+            process.exitCode = 1;
+            return;
+          }
+          const payload = result.result!;
+          if (opts.json === true) {
+            log.info(JSON.stringify(payload, null, 2));
+            return;
+          }
+          log.info(
+            `Renamed: ${payload.renames.length === 0 ? "none" : payload.renames.length}`,
+          );
+          for (const r of payload.renames) {
+            log.info(`  - ${r.oldPath} → ${r.newPath}`);
+          }
+          log.info(
+            `Deleted: ${payload.deleted.length === 0 ? "none" : payload.deleted.join(", ")}`,
+          );
+          log.info(
+            `Pruned core: ${payload.prunedCore.length === 0 ? "none" : payload.prunedCore.join(", ")}`,
+          );
+        });
+
+      // ── set-core ──────────────────────────────────────────────────────────
+
+      v3.command("set-core")
+        .description(
+          "Add/remove always-on core leaves (previews cost; writes on --yes)",
+        )
+        .option(
+          "--add <leaf>",
+          "Leaf path to add to the always-on core set (repeatable)",
+          (val: string, acc: string[]) => {
+            acc.push(val);
+            return acc;
+          },
+          [] as string[],
+        )
+        .option(
+          "--remove <leaf>",
+          "Leaf path to remove from the always-on core set (repeatable)",
+          (val: string, acc: string[]) => {
+            acc.push(val);
+            return acc;
+          },
+          [] as string[],
+        )
+        .option("--yes", "Apply the change (otherwise preview only)")
+        .option("--json", "Emit raw JSON instead of a formatted summary")
+        .addHelpText(
+          "after",
+          `
+Edits the always-on core leaf set in core.json. Every --add entry must
+exist in the live tree (unknown leaves are rejected). Without --yes this
+PREVIEWS the resulting core set and the number of unique page slugs it
+would pin always-on, WITHOUT writing. Pass --yes to persist and invalidate
+the lanes.
+
+Examples:
+  $ assistant memory v3 set-core --add domain-a/topic-x        # preview
+  $ assistant memory v3 set-core --add domain-a/topic-x --yes  # apply
+  $ assistant memory v3 set-core --remove domain-b/topic-z --yes`,
+        )
+        .action(
+          async (opts: {
+            add: string[];
+            remove: string[];
+            yes?: boolean;
+            json?: boolean;
+          }) => {
+            if (opts.add.length === 0 && opts.remove.length === 0) {
+              log.error("Pass at least one --add or --remove leaf path.");
+              process.exitCode = 1;
+              return;
+            }
+
+            const result = await cliIpcCall<MemoryV3SetCoreResult>(
+              "memory_v3_set_core",
+              {
+                body: {
+                  add: opts.add,
+                  remove: opts.remove,
+                  write: opts.yes === true,
+                },
+              },
+            );
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to update the v3 core set");
+              process.exitCode = 1;
+              return;
+            }
+            const payload = result.result!;
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+            log.info(
+              `Core leaves (${payload.nextCore.length}): ${
+                payload.nextCore.length === 0
+                  ? "none"
+                  : payload.nextCore.join(", ")
+              }`,
+            );
+            log.info(`Always-on page count: ${payload.alwaysOnPageCount}`);
+            if (payload.written) {
+              log.info("Written to core.json; lanes invalidated.");
+            } else {
+              log.info("Preview only — re-run with --yes to apply.");
+            }
+          },
+        );
+
+      // ── rebuild-index ─────────────────────────────────────────────────────
+
+      v3.command("rebuild-index")
+        .description("Invalidate the v3 lanes so the next turn rebuilds")
+        .addHelpText(
+          "after",
+          `
+Drops the daemon's cached v3 shadow lanes so the tree + needle are rebuilt
+from the current on-disk state on the next turn. Useful after editing leaf
+files or assignments out-of-band.
+
+Examples:
+  $ assistant memory v3 rebuild-index`,
+        )
+        .action(async () => {
+          const result = await cliIpcCall<MemoryV3RebuildIndexResult>(
+            "memory_v3_rebuild_index",
+            { body: {} },
+          );
+          if (!result.ok) {
+            log.error(result.error ?? "Failed to invalidate the v3 lanes");
+            process.exitCode = 1;
+            return;
+          }
+          log.info("v3 lanes invalidated; next turn will rebuild.");
+        });
+    },
+  });
+}

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -35,6 +35,12 @@ import type {
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 
+/** Commander collector for a repeatable option: accumulates each value. */
+function collect(val: string, acc: string[]): string[] {
+  acc.push(val);
+  return acc;
+}
+
 export function registerMemoryV3Command(program: Command): void {
   // Reuse an existing `memory` parent if some other registrar attached to it
   // first; otherwise create one. This keeps the registration order between
@@ -165,19 +171,13 @@ Examples:
         .option(
           "--add <leaf>",
           "Leaf path to add to the always-on core set (repeatable)",
-          (val: string, acc: string[]) => {
-            acc.push(val);
-            return acc;
-          },
+          collect,
           [] as string[],
         )
         .option(
           "--remove <leaf>",
           "Leaf path to remove from the always-on core set (repeatable)",
-          (val: string, acc: string[]) => {
-            acc.push(val);
-            return acc;
-          },
+          collect,
           [] as string[],
         )
         .option("--yes", "Apply the change (otherwise preview only)")

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -36,6 +36,7 @@ import { registerInferenceCommand } from "./commands/inference.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
 import { registerMemoryV2Command } from "./commands/memory-v2.js";
+import { registerMemoryV3Command } from "./commands/memory-v3.js";
 import { registerNotificationsCommand } from "./commands/notifications.js";
 import { registerOAuthCommand } from "./commands/oauth/index.js";
 import { registerPendingCommand } from "./commands/pending.js";
@@ -133,6 +134,7 @@ Examples:
   registerKeysCommand(program);
   registerMcpCommand(program);
   registerMemoryV2Command(program);
+  registerMemoryV3Command(program);
   registerNotificationsCommand(program);
   registerOAuthCommand(program);
   registerPendingCommand(program);

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -91,6 +91,7 @@ import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
 import { ROUTES as MCP_AUTH_ROUTES } from "./mcp-auth-routes.js";
 import { ROUTES as MEMORY_ITEM_ROUTES } from "./memory-item-routes.js";
 import { ROUTES as MEMORY_V2_ROUTES } from "./memory-v2-routes.js";
+import { ROUTES as MEMORY_V3_ROUTES } from "./memory-v3-routes.js";
 import { ROUTES as MIGRATION_ROLLBACK_ROUTES } from "./migration-rollback-routes.js";
 import { ROUTES as MIGRATION_ROUTES } from "./migration-routes.js";
 import { ROUTES as NOTIFICATION_ROUTES } from "./notification-routes.js";
@@ -218,6 +219,7 @@ export const ROUTES: RouteDefinition[] = [
   ...LLM_CALL_SITES_ROUTES,
   ...MEMORY_ITEM_ROUTES,
   ...MEMORY_V2_ROUTES,
+  ...MEMORY_V3_ROUTES,
   ...MIGRATION_ROLLBACK_ROUTES,
   ...MIGRATION_ROUTES,
   ...NOTIFICATION_ROUTES,

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -1,0 +1,304 @@
+/**
+ * Memory v3 route definitions — tree-gardening + core-editing operations for
+ * the leaf-tree memory model.
+ *
+ * The daemon owns the live tree, so the *mutating* gardening verbs
+ * (`reconcile`, `set-core --write`, `rebuild-index`) run here, inside the
+ * daemon process, where the in-memory shadow lanes can be invalidated after a
+ * write. The read-only `health` report and the `set-core` cost preview also
+ * route through the daemon so it stays the single source of truth for the live
+ * workspace tree.
+ *
+ * Each route's behavior lives in a small DI-friendly `handle*` function that
+ * takes an optional `MemoryV3Deps` (filesystem overrides) so tests can drive it
+ * against a temp workspace without mocking module globals. The exported
+ * `RouteDefinition`s are thin `RouteHandlerArgs` adapters over those handlers.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { loadCore } from "../../memory/v3/core.js";
+import { computeV3Health, renderV3Health } from "../../memory/v3/health.js";
+import { type LeafRef, reconcileTree } from "../../memory/v3/reconcile.js";
+import { invalidateLanes } from "../../memory/v3/shadow-plugin.js";
+import {
+  coreSlugs,
+  loadLeafTree,
+  resolveDataDir,
+} from "../../memory/v3/tree.js";
+import type { LeafPath, LeafTree, Slug } from "../../memory/v3/types.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { RouteError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("memory-v3-routes");
+
+/**
+ * Filesystem location overrides. Production callers omit these and the handlers
+ * resolve the live workspace; tests inject a temp workspace + data dir to
+ * exercise the handlers without mocking module globals.
+ */
+export interface MemoryV3Deps {
+  dataDir?: string;
+  workspaceDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared loading helpers
+// ---------------------------------------------------------------------------
+
+/** Load the live leaf tree + its full slug universe from the resolved data dir. */
+async function loadTreeAndSlugs(deps?: MemoryV3Deps): Promise<{
+  dataDir: string;
+  tree: LeafTree;
+  allSlugs: Slug[];
+}> {
+  const dataDir = deps?.dataDir ?? resolveDataDir();
+  const tree = await loadLeafTree(dataDir);
+  // The full slug universe is every page the tree knows about (its `byPage`
+  // keys). A slug is "unassigned" when it maps to no leaf, so the universe must
+  // include those slugs too — `byPage` carries them from assignments.json.
+  const allSlugs = [...tree.byPage.keys()];
+  return { dataDir, tree, allSlugs };
+}
+
+// ---------------------------------------------------------------------------
+// health
+// ---------------------------------------------------------------------------
+
+export interface MemoryV3HealthResult {
+  /** Pre-rendered, human-readable report. Empty string when all-green. */
+  rendered: string;
+  /** The structural counts, for `--json` consumers. */
+  counts: {
+    unassigned: number;
+    danglingRefs: number;
+    novelClusters: number;
+    oversizedLeaves: number;
+    tinyLeaves: number;
+  };
+}
+
+export async function handleMemoryV3Health(
+  deps?: MemoryV3Deps,
+): Promise<MemoryV3HealthResult> {
+  const { dataDir, tree, allSlugs } = await loadTreeAndSlugs(deps);
+  const core = await loadCore(dataDir);
+  const report = computeV3Health({ tree, allSlugs, core });
+  return {
+    rendered: renderV3Health(report),
+    counts: {
+      unassigned: report.unassigned.length,
+      danglingRefs: report.danglingRefs.length,
+      novelClusters: report.novelClusters.length,
+      oversizedLeaves: report.oversizedLeaves.length,
+      tinyLeaves: report.tinyLeaves.length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// set-core
+// ---------------------------------------------------------------------------
+
+export interface MemoryV3SetCoreBody {
+  /** Leaves to add to the always-on core set. */
+  add?: LeafPath[];
+  /** Leaves to remove from the always-on core set. */
+  remove?: LeafPath[];
+  /**
+   * When true, persist the new core to `core.json` and invalidate the lanes.
+   * When false (default), compute the preview WITHOUT writing.
+   */
+  write?: boolean;
+}
+
+export interface MemoryV3SetCoreResult {
+  /** The core leaf set that would result (or did result, when `write`). */
+  nextCore: LeafPath[];
+  /** Number of unique page slugs the new core set pins always-on. */
+  alwaysOnPageCount: number;
+  /** Whether `core.json` was written. */
+  written: boolean;
+}
+
+/** Wire-format error code for a `set-core` add referencing an unknown leaf. */
+export const MEMORY_V3_UNKNOWN_LEAF_CODE = "MEMORY_V3_UNKNOWN_LEAF";
+
+/** Thrown when a `set-core` add entry does not exist in the live tree. */
+export class UnknownLeafError extends Error {
+  constructor(public readonly unknown: LeafPath[]) {
+    super(
+      `Unknown leaf path(s) — not present in the tree: ${unknown.join(", ")}`,
+    );
+    this.name = "UnknownLeafError";
+  }
+}
+
+/** Persist the always-on core set back to `<dataDir>/core.json`. */
+async function writeCore(dataDir: string, alwaysOn: LeafPath[]): Promise<void> {
+  await writeFile(
+    join(dataDir, "core.json"),
+    `${JSON.stringify({ alwaysOn }, null, 2)}\n`,
+  );
+}
+
+export async function handleMemoryV3SetCore(
+  body: MemoryV3SetCoreBody,
+  deps?: MemoryV3Deps,
+): Promise<MemoryV3SetCoreResult> {
+  const add = body.add ?? [];
+  const remove = body.remove ?? [];
+  const { dataDir, tree } = await loadTreeAndSlugs(deps);
+
+  // Validate every ADD entry exists in the live tree. Removing an entry that is
+  // already absent is a no-op (idempotent), so only adds are validated.
+  const unknown = add.filter((leaf) => !tree.leaves.has(leaf));
+  if (unknown.length > 0) throw new UnknownLeafError(unknown);
+
+  const core = await loadCore(dataDir);
+  for (const leaf of remove) core.delete(leaf);
+  for (const leaf of add) core.add(leaf);
+
+  // Drop any pre-existing core entry that no longer maps to a live leaf, so the
+  // preview reflects what the tree can actually pin. Sorted for stable output.
+  const nextCore = [...core].filter((leaf) => tree.leaves.has(leaf)).sort();
+  const nextCoreSet = new Set<LeafPath>(nextCore);
+
+  // Cost preview: the number of UNIQUE page slugs the new core pins always-on.
+  const alwaysOnPageCount = coreSlugs(tree, nextCoreSet).size;
+
+  if (body.write === true) {
+    await writeCore(dataDir, nextCore);
+    invalidateLanes();
+    log.info(
+      { coreSize: nextCore.length, alwaysOnPageCount },
+      "memory-v3 core updated",
+    );
+  }
+
+  return { nextCore, alwaysOnPageCount, written: body.write === true };
+}
+
+// ---------------------------------------------------------------------------
+// reconcile
+// ---------------------------------------------------------------------------
+
+export interface MemoryV3ReconcileResult {
+  renames: Array<{ id?: string; oldPath: LeafPath; newPath: LeafPath }>;
+  deleted: LeafPath[];
+  prunedCore: LeafPath[];
+}
+
+/**
+ * Reconcile page + core references against the live on-disk tree.
+ *
+ * `prevLeaves` describes the tree as it was BEFORE the maintainer's on-disk
+ * restructuring. We derive it from the current leaf set, which makes reconcile
+ * a safe convergence pass: renames/deletes already applied on disk diff to
+ * nothing, while it still rewrites any page/core ref left dangling and prunes
+ * stale core entries (and fail-closed restores on a residual dangling ref).
+ * `reconcileTree` snapshots, applies, validates, and invalidates the lanes.
+ */
+export async function handleMemoryV3Reconcile(
+  deps?: MemoryV3Deps,
+): Promise<MemoryV3ReconcileResult> {
+  const workspaceDir = deps?.workspaceDir ?? getWorkspaceDir();
+  const dataDir = deps?.dataDir ?? resolveDataDir();
+  const prevLeaves = await loadPrevLeaves(dataDir);
+
+  const result = await reconcileTree({ prevLeaves, dataDir, workspaceDir });
+  return {
+    renames: result.renames,
+    deleted: result.deleted,
+    prunedCore: result.prunedCore,
+  };
+}
+
+/** The current leaf set as `LeafRef`s (path + stable id when present). */
+async function loadPrevLeaves(dataDir: string): Promise<LeafRef[]> {
+  const tree = await loadLeafTree(dataDir);
+  return [...tree.leaves.values()].map((node) => ({
+    path: node.path,
+    ...(node.frontmatter.id ? { id: node.frontmatter.id } : {}),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// rebuild-index
+// ---------------------------------------------------------------------------
+
+export interface MemoryV3RebuildIndexResult {
+  ok: true;
+}
+
+/**
+ * Invalidate the v3 shadow lanes so the next turn rebuilds the tree/needle
+ * from the current on-disk state. Runs in-daemon so it acts on the live
+ * process's cached lanes (an in-CLI call would invalidate nothing).
+ */
+export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndexResult> {
+  invalidateLanes();
+  log.info("memory-v3 lanes invalidated (rebuild-index)");
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions (RouteHandlerArgs adapters over the handlers above)
+// ---------------------------------------------------------------------------
+
+const POLICY = {
+  requiredScopes: ["settings.read"],
+  allowedPrincipalTypes: ACTOR_PRINCIPALS,
+} as const;
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "memory_v3_health",
+    method: "POST",
+    policy: POLICY,
+    endpoint: "memory/v3/health",
+    handler: () => handleMemoryV3Health(),
+    summary: "Print the v3 structural health report (read-only)",
+    tags: ["memory"],
+  },
+  {
+    operationId: "memory_v3_set_core",
+    method: "POST",
+    policy: POLICY,
+    endpoint: "memory/v3/set-core",
+    handler: async ({ body = {} }: RouteHandlerArgs) => {
+      try {
+        return await handleMemoryV3SetCore(body as MemoryV3SetCoreBody);
+      } catch (err) {
+        if (err instanceof UnknownLeafError) {
+          throw new RouteError(err.message, MEMORY_V3_UNKNOWN_LEAF_CODE, 422);
+        }
+        throw err;
+      }
+    },
+    summary: "Add/remove always-on core leaves (validates + previews cost)",
+    tags: ["memory"],
+  },
+  {
+    operationId: "memory_v3_reconcile",
+    method: "POST",
+    policy: POLICY,
+    endpoint: "memory/v3/reconcile",
+    handler: () => handleMemoryV3Reconcile(),
+    summary: "Reconcile page/core refs against the current on-disk leaf tree",
+    tags: ["memory"],
+  },
+  {
+    operationId: "memory_v3_rebuild_index",
+    method: "POST",
+    policy: POLICY,
+    endpoint: "memory/v3/rebuild-index",
+    handler: () => handleMemoryV3RebuildIndex(),
+    summary: "Invalidate the v3 lanes so the next turn rebuilds",
+    tags: ["memory"],
+  },
+];

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -30,7 +30,7 @@ import {
 import type { LeafPath, LeafTree, Slug } from "../../memory/v3/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { ACTOR_PRINCIPALS, type RoutePolicy } from "../auth/route-policy.js";
 import { RouteError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -250,10 +250,10 @@ export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndex
 // Route definitions (RouteHandlerArgs adapters over the handlers above)
 // ---------------------------------------------------------------------------
 
-const POLICY = {
+const POLICY: RoutePolicy = {
   requiredScopes: ["settings.read"],
   allowedPrincipalTypes: ACTOR_PRINCIPALS,
-} as const;
+};
 
 export const ROUTES: RouteDefinition[] = [
   {


### PR DESCRIPTION
## Summary
- New 'memory v3' CLI group: health, reconcile, set-core (validate + cost preview), rebuild-index
- Mutating ops route through the daemon; reuses reconcileTree/snapshot/health building blocks

Part of plan: memory-v3-self-maintenance.md (PR 14 of 14)