### PR TITLE
feat(memory): prepend the v3 health block to consolidation when enabled & non-empty

### DIFF
--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -105,6 +105,43 @@ mock.module("../../jobs-store.js", () => ({
   isMemoryEnabled: () => true,
 }));
 
+// ── v3 health-injection mocks ───────────────────────────────────────
+//
+// The consolidation handler optionally prepends a v3 health block to the
+// prompt when a v3 flag is on AND the rendered report is non-empty. These
+// mocks let each test (a) toggle the flag, (b) decide what health block the
+// renderer produces, and (c) force the health computation to throw — without
+// materializing a real v3 data dir. The tree/core/page-index loaders are
+// stubbed to inert values; `computeV3Health` is a pass-through whose result is
+// fed to the toggleable `renderV3Health`.
+let v3FlagOn = false;
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => v3FlagOn,
+}));
+
+let renderedHealth = "";
+let computeThrows = false;
+mock.module("../../v3/health.js", () => ({
+  computeV3Health: () => {
+    if (computeThrows) throw new Error("simulated health compute failure");
+    return {};
+  },
+  renderV3Health: () => renderedHealth,
+}));
+
+mock.module("../../v3/tree.js", () => ({
+  loadLeafTree: async () => ({ leaves: new Map(), byPage: new Map() }),
+  resolveDataDir: () => "/tmp/v3-data-stub",
+}));
+
+mock.module("../../v3/core.js", () => ({
+  loadCore: async () => new Set<string>(),
+}));
+
+mock.module("../../v2/page-index.js", () => ({
+  getPageIndex: async () => ({ entries: [] }),
+}));
+
 // ── Workspace pin ───────────────────────────────────────────────────
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;
@@ -173,6 +210,11 @@ beforeEach(() => {
   emitCalls.length = 0;
   enqueuedJobs.length = 0;
   nextJobIdCounter = 0;
+
+  // v3 health injection defaults: flag off, no rendered block, no throw.
+  v3FlagOn = false;
+  renderedHealth = "";
+  computeThrows = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -345,6 +387,69 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(emitCalls).toHaveLength(0);
+  });
+});
+
+describe("memoryV2ConsolidateJob — v3 health injection", () => {
+  beforeEach(() => {
+    writeFileSync(
+      bufferPath(),
+      "- [Apr 27, 9:00 AM] Alice prefers VS Code over Vim.\n",
+    );
+  });
+
+  test("prepends the health block when a v3 flag is on and the report is actionable", async () => {
+    v3FlagOn = true;
+    renderedHealth = "memory-v3 health:\n- 2 unassigned slug(s): a, b";
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    const prompt = runnerLastArgs?.prompt as string;
+    // The health block is PREPENDED, separated by a blank line, with the
+    // base consolidation prompt still present underneath it.
+    expect(prompt.startsWith(`${renderedHealth}\n\n`)).toBe(true);
+    expect(prompt).toContain("memory consolidation");
+    expect(prompt).not.toContain(CUTOFF_PLACEHOLDER);
+  });
+
+  test("leaves the prompt unchanged when the report is all-green (empty render)", async () => {
+    v3FlagOn = true;
+    renderedHealth = "";
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    const prompt = runnerLastArgs?.prompt as string;
+    expect(prompt).not.toContain("memory-v3 health:");
+    // Prompt is exactly the resolved consolidation body.
+    expect(prompt).toContain("memory consolidation");
+  });
+
+  test("leaves the prompt unchanged when v3 flags are off even if a block would render", async () => {
+    v3FlagOn = false;
+    renderedHealth = "memory-v3 health:\n- 1 unassigned slug(s): a";
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    const prompt = runnerLastArgs?.prompt as string;
+    expect(prompt).not.toContain("memory-v3 health:");
+    expect(prompt).toContain("memory consolidation");
+  });
+
+  test("falls back to the base prompt when health computation throws", async () => {
+    v3FlagOn = true;
+    computeThrows = true;
+    renderedHealth = "memory-v3 health:\n- should not appear";
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    // A health-compute failure must NEVER break consolidation.
+    expect(result.kind).toBe("invoked");
+    const prompt = runnerLastArgs?.prompt as string;
+    expect(prompt).not.toContain("memory-v3 health:");
+    expect(prompt).toContain("memory consolidation");
   });
 });
 

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -347,6 +347,25 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     expect(existsSync(lockPath())).toBe(false);
   });
 
+  test("enqueues memory_v3_maintain as a follow-up when a v3 flag is on", async () => {
+    v3FlagOn = true;
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(enqueuedJobs.map((j) => j.type)).toEqual([
+      "memory_v2_reembed",
+      "memory_v3_maintain",
+    ]);
+  });
+
+  test("does not enqueue memory_v3_maintain when v3 flags are off", async () => {
+    v3FlagOn = false;
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v2_reembed"]);
+  });
+
   test("returns run_failed and skips follow-ups when the runner reports failure", async () => {
     runnerImpl = async () => ({
       conversationId: "conv-1",

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -86,7 +86,11 @@ const log = getLogger("memory-v2-consolidate");
 /** Stable identifier surfaced in `runBackgroundJob` logs and notifications. */
 const JOB_NAME = "memory.consolidate";
 
-/** v3 plugin flags. Either being on enables the health-block injection. */
+/**
+ * v3 plugin flags. Either being on (a) prepends a v3 health block to the
+ * consolidation prompt and (b) enqueues `memory_v3_maintain` as a
+ * post-consolidation follow-up. These gate the v3 plugin itself.
+ */
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
 const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
@@ -105,9 +109,10 @@ const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
  * agent touched: mtime-diffing is fragile across filesystems, and the
  * embedder's content-hash cache makes unchanged pages effectively free.
  */
-const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [
-  "memory_v2_reembed",
-] as const;
+const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = ["memory_v2_reembed"];
+
+/** Follow-up enqueued only when a v3 flag is on. */
+const V3_FOLLOW_UP_JOB_TYPE: MemoryJobType = "memory_v3_maintain";
 
 /**
  * Job handler. See file header for the full lifecycle. Returns a discriminated
@@ -214,9 +219,17 @@ export async function memoryV2ConsolidateJob(
 
     // Step 5: enqueue follow-up jobs. Enqueueing now keeps the dispatch
     // wiring exercised end-to-end so PR 21 only has to swap in the handler
-    // bodies.
+    // bodies. v3 maintenance is appended only while a v3 path (shadow or live)
+    // is active, so it never fans out on v2-only installs.
     const followUpJobIds: string[] = [];
-    for (const jobType of FOLLOW_UP_JOB_TYPES) {
+    const jobTypes: MemoryJobType[] = [...FOLLOW_UP_JOB_TYPES];
+    if (
+      isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config) ||
+      isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config)
+    ) {
+      jobTypes.push(V3_FOLLOW_UP_JOB_TYPE);
+    }
+    for (const jobType of jobTypes) {
       try {
         followUpJobIds.push(enqueueMemoryJob(jobType, {}));
       } catch (err) {

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -177,10 +177,10 @@ export async function memoryV2ConsolidateJob(
     // it to a regular file under 1 MiB before substitution so a stray path
     // (or a `/dev/zero`-style pseudo-file) cannot exfiltrate megabytes of
     // bytes through the wake hint.
-    // The maintainer's (possibly overridden) consolidation prompt is the base.
-    // When a v3 flag is on and the tree has actionable drift, prepend a freshly
-    // computed health block so the run can fold maintenance into its pass. The
-    // base prompt is left untouched when v3 is off or the tree is all-green.
+    //
+    // That resolved prompt is the base; `maybePrependV3Health` prepends a
+    // freshly computed v3 health block when a v3 flag is on and the tree has
+    // actionable drift, leaving it untouched otherwise.
     const basePrompt = resolveConsolidationPrompt(
       config.memory.v2.consolidation_prompt_path,
       cutoff,

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -61,6 +61,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { runBackgroundJob } from "../../runtime/background-job-runner.js";
 import { getLogger } from "../../util/logger.js";
@@ -72,6 +73,11 @@ import {
   type MemoryJob,
   type MemoryJobType,
 } from "../jobs-store.js";
+import { getPageIndex } from "../v2/page-index.js";
+import { loadCore } from "../v3/core.js";
+import { computeV3Health, renderV3Health } from "../v3/health.js";
+import { loadLeafTree, resolveDataDir } from "../v3/tree.js";
+import type { LeafPath, Slug } from "../v3/types.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./constants.js";
 import { resolveConsolidationPrompt } from "./prompts/consolidation.js";
 
@@ -79,6 +85,10 @@ const log = getLogger("memory-v2-consolidate");
 
 /** Stable identifier surfaced in `runBackgroundJob` logs and notifications. */
 const JOB_NAME = "memory.consolidate";
+
+/** v3 plugin flags. Either being on enables the health-block injection. */
+const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
+const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 /**
  * Hard timeout for the consolidation run. Consolidation reads the buffer,
@@ -167,13 +177,20 @@ export async function memoryV2ConsolidateJob(
     // it to a regular file under 1 MiB before substitution so a stray path
     // (or a `/dev/zero`-style pseudo-file) cannot exfiltrate megabytes of
     // bytes through the wake hint.
+    // The maintainer's (possibly overridden) consolidation prompt is the base.
+    // When a v3 flag is on and the tree has actionable drift, prepend a freshly
+    // computed health block so the run can fold maintenance into its pass. The
+    // base prompt is left untouched when v3 is off or the tree is all-green.
+    const basePrompt = resolveConsolidationPrompt(
+      config.memory.v2.consolidation_prompt_path,
+      cutoff,
+    );
+    const prompt = await maybePrependV3Health(basePrompt, config);
+
     const runResult = await runBackgroundJob({
       jobName: JOB_NAME,
       source: MEMORY_V2_CONSOLIDATION_SOURCE,
-      prompt: resolveConsolidationPrompt(
-        config.memory.v2.consolidation_prompt_path,
-        cutoff,
-      ),
+      prompt,
       trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
       callSite: "mainAgent",
       timeoutMs: CONSOLIDATION_TIMEOUT_MS,
@@ -228,6 +245,56 @@ export async function memoryV2ConsolidateJob(
     };
   } finally {
     releaseLock(lockPath);
+  }
+}
+
+/**
+ * When a v3 flag is enabled and the v3 tree has actionable structural drift,
+ * prepend a rendered health block to `basePrompt` so the consolidation run can
+ * fold tree maintenance into its pass. Returns `basePrompt` UNCHANGED when:
+ *   - neither `memory-v3-shadow` nor `memory-v3-live` is enabled,
+ *   - the health report is all-green (`renderV3Health` returns ""), or
+ *   - computing the report throws for any reason.
+ *
+ * The block is computed here (not baked into the prompt template) so an
+ * operator's custom consolidation prompt stays untouched and the block reflects
+ * the tree state at run time. Health computation is wrapped so a load/compute
+ * failure can never break consolidation — the run proceeds on the base prompt.
+ */
+async function maybePrependV3Health(
+  basePrompt: string,
+  config: AssistantConfig,
+): Promise<string> {
+  const v3Enabled =
+    isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config) ||
+    isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
+  if (!v3Enabled) return basePrompt;
+
+  try {
+    const pageIndex = await getPageIndex(getWorkspaceDir());
+    const pageLeaves = new Map<Slug, LeafPath[]>();
+    const allSlugs: Slug[] = [];
+    for (const entry of pageIndex.entries) {
+      pageLeaves.set(entry.slug, entry.leaves);
+      allSlugs.push(entry.slug);
+    }
+
+    const dataDir = resolveDataDir();
+    const [tree, core] = await Promise.all([
+      loadLeafTree(dataDir, pageLeaves),
+      loadCore(dataDir),
+    ]);
+
+    const report = computeV3Health({ tree, allSlugs, core });
+    const healthBlock = renderV3Health(report);
+    if (healthBlock.length === 0) return basePrompt;
+    return `${healthBlock}\n\n${basePrompt}`;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "consolidation: v3 health computation failed; using base prompt",
+    );
+    return basePrompt;
   }
 }
 


### PR DESCRIPTION
## Summary
- When a v3 flag is on, prepend a non-empty v3 health block to the consolidation prompt the agent receives
- All-green or flag-off → prompt unchanged; health-compute failure falls back safely

Part of plan: memory-v3-self-maintenance.md (PR 10 of 14)