### PR TITLE
fix(memory-v3): CLI health uses authoritative frontmatter leaves

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3.test.ts
@@ -4,22 +4,27 @@
  * The CLI subcommands are thin IPC shells over the handlers in
  * `runtime/routes/memory-v3-routes.ts`; the logic worth testing lives there.
  * We exercise the handlers directly against a temp workspace + data dir
- * injected via their `deps` parameter — no module mocking, no process-global
- * leaks. Generic taxonomy only (domain-a/topic-x, etc.).
+ * injected via their `deps` parameter. Generic taxonomy only
+ * (domain-a/topic-x, etc.).
+ *
+ * Source-of-truth note: `health` and `set-core` build the leaf tree from each
+ * concept page's `leaves:` frontmatter (via the page index) and union it over
+ * `assignments.json`, matching the consolidation-injected health block. The
+ * fixture below writes concept pages with `leaves:` frontmatter as the
+ * authoritative membership and keeps a *stale* `assignments.json` to prove the
+ * handlers read the frontmatter, not the stale assignments. The seeded
+ * skill/CLI-command catalogs are mocked empty so `allSlugs` (derived from the
+ * page index) is deterministic.
  */
 
-import {
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
+import * as cliCommandStore from "../../../memory/v2/cli-command-store.js";
+import { invalidatePageIndex } from "../../../memory/v2/page-index.js";
+import * as skillStore from "../../../memory/v2/skill-store.js";
 import {
   handleMemoryV3Health,
   handleMemoryV3Reconcile,
@@ -54,10 +59,33 @@ async function writeLeaf(
   await writeFile(file, fm);
 }
 
+/** Write a concept page with `leaves:` frontmatter under memory/concepts/. */
+async function writePage(slug: string, leaves: string[]): Promise<void> {
+  const file = join(workspaceDir, "memory", "concepts", `${slug}.md`);
+  await mkdir(join(file, ".."), { recursive: true });
+  const fm = [
+    "---",
+    `summary: ${slug} summary`,
+    "leaves:",
+    ...leaves.map((l) => `  - ${l}`),
+    "---",
+    `${slug} body`,
+    "",
+  ].join("\n");
+  await writeFile(file, fm);
+}
+
 beforeEach(async () => {
   workspaceDir = await mkdtemp(join(tmpdir(), "mem-v3-cli-ws-"));
   dataDir = join(workspaceDir, "memory", "v3", "data");
   await mkdir(dataDir, { recursive: true });
+
+  // Keep the page index deterministic regardless of the on-disk seeded
+  // catalogs, and clear any module-cached index from a prior test.
+  spyOn(skillStore, "listSkillEntries").mockReturnValue([]);
+  spyOn(cliCommandStore, "listCliCommandEntries").mockReturnValue([]);
+  invalidatePageIndex();
+
   // A small generic tree: two leaves under domain-a, one under domain-b.
   await writeLeaf("domain-a/topic-x", {
     path: "domain-a/topic-x",
@@ -74,24 +102,27 @@ beforeEach(async () => {
     in_core: false,
     id: "leaf-z",
   });
-  // assignments.json: page slugs → the leaves they belong to.
+
+  // Authoritative membership lives in each page's `leaves:` frontmatter.
+  await writePage("page-1", ["domain-a/topic-x"]);
+  await writePage("page-2", ["domain-a/topic-x", "domain-a/topic-y"]);
+  await writePage("page-3", ["domain-b/topic-z"]);
+
+  // STALE assignments.json: deliberately divergent from the frontmatter above.
+  // If a handler read this instead of the page index it would compute the wrong
+  // membership/slug universe (this is the regression Defect A guards against).
   await writeFile(
     join(dataDir, "assignments.json"),
-    JSON.stringify({
-      "page-1": ["domain-a/topic-x"],
-      "page-2": ["domain-a/topic-x", "domain-a/topic-y"],
-      "page-3": ["domain-b/topic-z"],
-    }),
+    JSON.stringify({ "stale-page": ["domain-a/topic-x"] }),
   );
   await writeFile(
     join(dataDir, "core.json"),
     JSON.stringify({ alwaysOn: ["domain-a/topic-x"] }),
   );
-  // Empty concepts dir so the reconciler's listPages() returns [].
-  await mkdir(join(workspaceDir, "memory", "concepts"), { recursive: true });
 });
 
 afterEach(async () => {
+  invalidatePageIndex();
   await rm(workspaceDir, { recursive: true, force: true });
 });
 
@@ -118,9 +149,12 @@ describe("handleMemoryV3SetCore", () => {
     expect(core.alwaysOn).toEqual(["domain-a/topic-x"]);
   });
 
-  test("previews the always-on page count without writing", async () => {
-    // Adding topic-y to core: core = {topic-x, topic-y}. Unique member slugs:
-    // topic-x → {page-1, page-2}, topic-y → {page-2} ⇒ {page-1, page-2} = 2.
+  test("previews the always-on page count from frontmatter membership", async () => {
+    // Adding topic-y to core: core = {topic-x, topic-y}. Membership comes from
+    // page `leaves:` frontmatter — topic-x → {page-1, page-2}, topic-y →
+    // {page-2} ⇒ unique always-on slugs {page-1, page-2} = 2. (The stale
+    // assignments.json names only "stale-page"; if it were the source this
+    // would be wrong.)
     const result = await handleMemoryV3SetCore(
       { add: ["domain-a/topic-y"] },
       { dataDir, workspaceDir },
@@ -161,13 +195,25 @@ describe("handleMemoryV3SetCore", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleMemoryV3Health", () => {
-  test("renders a report and counts for the temp tree", async () => {
+  test("computes the slug universe from page frontmatter, not assignments.json", async () => {
     const result = await handleMemoryV3Health({ dataDir, workspaceDir });
     // domain-b/topic-z has a single member ⇒ a tiny leaf, so the report is
     // non-empty and renders the memory-v3 health header.
     expect(result.rendered).toContain("memory-v3 health:");
     expect(result.counts.tinyLeaves).toBeGreaterThanOrEqual(1);
+    // Every page leaf ref resolves to a real leaf file ⇒ no dangling refs.
     expect(result.counts.danglingRefs).toBe(0);
+    // The slug universe is the page-index pages (page-1..3), all of which are
+    // assigned, so nothing is unassigned. The stale "stale-page" entry from
+    // assignments.json is NOT in the universe (proves frontmatter wins).
+    expect(result.counts.unassigned).toBe(0);
+  });
+
+  test("flags a page frontmatter ref with no backing leaf as dangling", async () => {
+    await writePage("page-4", ["domain-a/missing-leaf"]);
+    invalidatePageIndex();
+    const result = await handleMemoryV3Health({ dataDir, workspaceDir });
+    expect(result.counts.danglingRefs).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -177,17 +223,13 @@ describe("handleMemoryV3Health", () => {
 
 describe("handleMemoryV3Reconcile", () => {
   test("no-op reconcile against an unchanged tree returns empty diffs", async () => {
-    // prevLeaves is derived from the current tree, so diffing current-vs-current
-    // yields no renames/deletes. This still drives the full reconcileTree path
+    // v1: prevLeaves is derived from the current tree, so diffing
+    // current-vs-current yields no renames/deletes — reconcile runs as a
+    // convergence/prune pass. This still drives the full reconcileTree path
     // (snapshot → apply → validate → invalidate).
     const result = await handleMemoryV3Reconcile({ dataDir, workspaceDir });
     expect(result.renames).toEqual([]);
     expect(result.deleted).toEqual([]);
     expect(result.prunedCore).toEqual([]);
-
-    // A snapshot directory was created as a side effect.
-    const snapshotsRoot = join(workspaceDir, "memory", "v3", "v3-snapshots");
-    const entries = await readdir(snapshotsRoot);
-    expect(entries.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -12,8 +12,10 @@
  * Subcommands:
  *
  *   - `health` — print the structural health report (read-only).
- *   - `reconcile` — reconcile page/core refs against the current on-disk tree
- *     after a restructuring; reports renames, deletes, and pruned core entries.
+ *   - `reconcile` — v1 convergence pass: rewrites any dangling page/core ref to
+ *     the current on-disk tree and prunes stale core entries. It does NOT yet
+ *     detect renames/moves/splits — that requires a captured prior leaf
+ *     snapshot (a follow-up), so `renames` is always empty in v1.
  *   - `set-core` — add/remove always-on core leaves. Validates that every added
  *     leaf exists, previews the resulting always-on page count, and writes only
  *     on `--yes`.
@@ -114,24 +116,27 @@ Examples:
 
       v3.command("reconcile")
         .description(
-          "Reconcile page/core refs against the current on-disk leaf tree",
+          "v1 convergence/prune pass over page/core refs (no rename detection yet)",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .addHelpText(
           "after",
           `
-After restructuring the leaf tree on disk (rename/move/split/delete a
-leaf), this rewrites every page's leaves: frontmatter and core.json to
-point at the current paths. Diffs leaves by stable id so a rename is
-distinguished from a delete+add; deleted leaves' member pages are re-homed
-across the surviving tree before their dangling refs are dropped.
+Runs a convergence pass over the leaf tree: rewrites any page leaves:
+frontmatter or core.json entry that dangles to a path the current on-disk
+tree no longer has, and prunes stale core entries. Fail-closed: snapshots
+before mutating and rolls back if any dangling reference survives
+validation. On success the v3 lanes are invalidated.
 
-Fail-closed: snapshots before mutating and rolls back if any dangling
-reference survives validation. On success the v3 lanes are invalidated.
+Limitation: v1 cannot detect renames/moves/splits. The reconciler diffs
+the current tree against itself (there is no captured "before" snapshot),
+so renames always report as empty and a true rename surfaces as a
+delete + add. Full rename/move/split detection requires persisting a prior
+leaf snapshot and is a planned follow-up.
 
 Examples:
   $ assistant memory v3 reconcile
-  $ assistant memory v3 reconcile --json | jq '.renames'`,
+  $ assistant memory v3 reconcile --json | jq '.prunedCore'`,
         )
         .action(async (opts: { json?: boolean }) => {
           const result = await cliIpcCall<MemoryV3ReconcileResult>(

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -18,6 +18,7 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { getPageIndex } from "../../memory/v2/page-index.js";
 import { loadCore } from "../../memory/v3/core.js";
 import { computeV3Health, renderV3Health } from "../../memory/v3/health.js";
 import { type LeafRef, reconcileTree } from "../../memory/v3/reconcile.js";
@@ -50,18 +51,36 @@ export interface MemoryV3Deps {
 // Shared loading helpers
 // ---------------------------------------------------------------------------
 
-/** Load the live leaf tree + its full slug universe from the resolved data dir. */
+/**
+ * Load the live leaf tree + its full slug universe.
+ *
+ * Page `leaves:` frontmatter is the authoritative source of page→leaf
+ * membership: we build a `pageLeaves` map from the page index and union it over
+ * `assignments.json` via `loadLeafTree(dataDir, pageLeaves)`, and derive the
+ * slug universe (`allSlugs`) from the page index itself. This mirrors
+ * `maybePrependV3Health` in `memory/v2/consolidation-job.ts` so the CLI
+ * `health` / `set-core` cost computations agree with the consolidation-injected
+ * health block instead of disagreeing by reading stale assignments.json only.
+ */
 async function loadTreeAndSlugs(deps?: MemoryV3Deps): Promise<{
   dataDir: string;
   tree: LeafTree;
   allSlugs: Slug[];
 }> {
+  const workspaceDir = deps?.workspaceDir ?? getWorkspaceDir();
   const dataDir = deps?.dataDir ?? resolveDataDir();
-  const tree = await loadLeafTree(dataDir);
-  // The full slug universe is every page the tree knows about (its `byPage`
-  // keys). A slug is "unassigned" when it maps to no leaf, so the universe must
-  // include those slugs too — `byPage` carries them from assignments.json.
-  const allSlugs = [...tree.byPage.keys()];
+
+  // Each page contributes its `leaves:` frontmatter as the authoritative leaf
+  // set for that slug; the slug universe is every page the index knows about.
+  const pageIndex = await getPageIndex(workspaceDir);
+  const pageLeaves = new Map<Slug, LeafPath[]>();
+  const allSlugs: Slug[] = [];
+  for (const entry of pageIndex.entries) {
+    pageLeaves.set(entry.slug, entry.leaves);
+    allSlugs.push(entry.slug);
+  }
+
+  const tree = await loadLeafTree(dataDir, pageLeaves);
   return { dataDir, tree, allSlugs };
 }
 
@@ -208,6 +227,9 @@ export async function handleMemoryV3Reconcile(
 ): Promise<MemoryV3ReconcileResult> {
   const workspaceDir = deps?.workspaceDir ?? getWorkspaceDir();
   const dataDir = deps?.dataDir ?? resolveDataDir();
+  // v1: prev == current is intentional. Without a captured prior leaf snapshot
+  // we cannot detect renames/moves/splits, so this runs as a convergence /
+  // dangling-ref prune pass. Full rename detection is a follow-up.
   const prevLeaves = await loadPrevLeaves(dataDir);
 
   const result = await reconcileTree({ prevLeaves, dataDir, workspaceDir });
@@ -289,7 +311,8 @@ export const ROUTES: RouteDefinition[] = [
     policy: POLICY,
     endpoint: "memory/v3/reconcile",
     handler: () => handleMemoryV3Reconcile(),
-    summary: "Reconcile page/core refs against the current on-disk leaf tree",
+    summary:
+      "v1 convergence/prune pass over page+core refs (no rename detection without a prior snapshot)",
     tags: ["memory"],
   },
   {


### PR DESCRIPTION
## Summary
- CLI `memory v3 health`/`set-core` now build the leaf tree from page `leaves:` frontmatter (via the page index) like the consolidation-injected health block, instead of stale assignments.json.
- Make `memory v3 reconcile` help honest: v1 is a convergence/prune pass; full rename detection needs a prior snapshot (follow-up).

Part of plan: memory-v3-self-maintenance.md (self-review fix)