### PR TITLE
fix(memory-v3): green the CI test + OpenAPI-spec jobs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13332,6 +13332,42 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v3/health:
+    post:
+      operationId: memory_v3_health_post
+      summary: Print the v3 structural health report (read-only)
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+  /v1/memory/v3/rebuild-index:
+    post:
+      operationId: memory_v3_rebuildindex_post
+      summary: Invalidate the v3 lanes so the next turn rebuilds
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+  /v1/memory/v3/reconcile:
+    post:
+      operationId: memory_v3_reconcile_post
+      summary: v1 convergence/prune pass over page+core refs (no rename detection without a prior snapshot)
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+  /v1/memory/v3/set-core:
+    post:
+      operationId: memory_v3_setcore_post
+      summary: Add/remove always-on core leaves (validates + previews cost)
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
   /v1/messages:
     get:
       operationId: messages_get

--- a/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
@@ -40,11 +40,12 @@ describe("memory job classes", () => {
     expect(set.size).toBe(SLOW_LLM_JOB_TYPES.length);
   });
 
-  test("memory_v3_consolidate is a slow LLM job (lane isolation)", () => {
-    // It hands off to a background agent for up to 15 min, like
+  test("memory_v3_maintain is a slow LLM job (lane isolation)", () => {
+    // It runs an LLM classify-union pass over unassigned pages, like
     // memory_v2_consolidate; it must not sit in the fast lane and starve
-    // short jobs. The mechanical v3 jobs intentionally stay fast.
-    expect(SLOW_LLM_JOB_TYPES).toContain("memory_v3_consolidate");
+    // short jobs. The retired v3 job literals intentionally stay out.
+    expect(SLOW_LLM_JOB_TYPES).toContain("memory_v3_maintain");
+    expect(SLOW_LLM_JOB_TYPES).not.toContain("memory_v3_consolidate");
     expect(SLOW_LLM_JOB_TYPES).not.toContain("memory_v3_index_maintenance");
     expect(SLOW_LLM_JOB_TYPES).not.toContain("memory_v3_edge_learning");
   });

--- a/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
@@ -43,6 +43,9 @@ const realNeedle = { ...(await import("../needle.js")) };
 const realOrchestrate = { ...(await import("../orchestrate.js")) };
 const realPlatform = { ...(await import("../../../util/platform.js")) };
 const realPageStore = { ...(await import("../../v2/page-store.js")) };
+const realConversationCrud = {
+  ...(await import("../../conversation-crud.js")),
+};
 
 let shadowMockActive = false;
 
@@ -106,7 +109,12 @@ mock.module("../../../config/loader.js", () => ({
   }),
 }));
 
+// Spread the real module so every export the live path transitively imports
+// (e.g. `getMessageById` via page-content.ts) stays present — replacing the
+// whole module with a bare `{ getMessages }` made those consumers fail to load.
+// Only `getMessages` is overridden, since that's the one the plugin reads.
 mock.module("../../conversation-crud.js", () => ({
+  ...realConversationCrud,
   getMessages: () => messages.map((m, i) => ({ ...m, id: `m${i}` })),
 }));
 


### PR DESCRIPTION
## Summary
Three real CI failures on the memory-v3 self-maintenance branch (caught because `--skip-ci` was used during the run; CI runs each test file in its own process via `scripts/test.sh`, so the directory-sweep mock-leak is irrelevant here):

- **OpenAPI Spec Check** was stale — the 4 new `/v1/memory/v3/*` routes (health, rebuild-index, reconcile, set-core) weren't in `openapi.yaml`. Regenerated via `bun run generate:openapi`.
- **`jobs-store-job-classes.test.ts`** still asserted the renamed `memory_v3_consolidate` was in `SLOW_LLM_JOB_TYPES`; the job is now `memory_v3_maintain` (PR #32712). Updated the assertion to the new name (and to confirm the retired literal is absent).
- **`shadow-plugin.test.ts`** replaced `conversation-crud.js` with a bare `{ getMessages }` stub, but the live path transitively imports `getMessageById` (via `page-content.ts`), so the module failed to load and orchestrate never ran. Fixed by spreading the real module and overriding only `getMessages`.

## Verification
- `bunx tsc --noEmit` clean.
- `bun run generate:openapi -- --check` → up to date.
- jobs-store-job-classes 5/0, shadow-plugin 12/0 (each in isolation, as CI runs them).

Part of plan: memory-v3-self-maintenance.md (CI-green fix)