### PR TITLE
refactor(assistant): re-home checkpoint yield signals into the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/agent-loop-exit-reason.test.ts
@@ -266,9 +266,8 @@ describe("AgentLoop exit-reason instrumentation", () => {
       toolExecutor,
     );
 
-    const onCheckpoint = (_info: CheckpointInfo): CheckpointDecision => ({
-      yield: "budget",
-    });
+    const onCheckpoint = (_info: CheckpointInfo): CheckpointDecision =>
+      "budget";
 
     const events: AgentEvent[] = [];
     await loop.run(

--- a/assistant/src/__tests__/agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/agent-loop-exit-reason.test.ts
@@ -195,7 +195,7 @@ describe("AgentLoop exit-reason instrumentation", () => {
     const loop = new AgentLoop(provider, "system prompt", {}, dummyTools);
 
     const events: AgentEvent[] = [];
-    const result = await loop.run([userMessage], (e) => {
+    const { history: result } = await loop.run([userMessage], (e) => {
       events.push(e);
     });
 
@@ -266,7 +266,9 @@ describe("AgentLoop exit-reason instrumentation", () => {
       toolExecutor,
     );
 
-    const onCheckpoint = (_info: CheckpointInfo): CheckpointDecision => "yield";
+    const onCheckpoint = (_info: CheckpointInfo): CheckpointDecision => ({
+      yield: "budget",
+    });
 
     const events: AgentEvent[] = [];
     await loop.run(

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -969,7 +969,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
 
-    const onCheckpoint = (): CheckpointDecision => ({ yield: "budget" });
+    const onCheckpoint = (): CheckpointDecision => "budget";
 
     const { history } = await loop.run([userMessage], () => {}, {
       onCheckpoint,
@@ -1143,7 +1143,7 @@ describe("AgentLoop", () => {
     const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
       checkpoints.push(checkpoint);
       // Yield on turn 3 (0-indexed)
-      return checkpoint.turnIndex === 3 ? { yield: "budget" } : "continue";
+      return checkpoint.turnIndex === 3 ? "budget" : "continue";
     };
 
     const events: AgentEvent[] = [];
@@ -1213,7 +1213,7 @@ describe("AgentLoop", () => {
 
     const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
       // Yield on the second turn (turnIndex 1)
-      return checkpoint.turnIndex === 1 ? { yield: "budget" } : "continue";
+      return checkpoint.turnIndex === 1 ? "budget" : "continue";
     };
 
     const { history } = await loop.run([userMessage], () => {}, {

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -118,7 +118,7 @@ describe("AgentLoop", () => {
     const loop = new AgentLoop(provider, "system prompt");
 
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // History should contain original user message + assistant response
     expect(history).toHaveLength(2);
@@ -152,7 +152,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Tool executor was called with correct args
     expect(toolCalls).toHaveLength(1);
@@ -277,7 +277,7 @@ describe("AgentLoop", () => {
       dummyTools,
       toolExecutor,
     );
-    const history = await loop.run([userMessage], () => {});
+    const { history } = await loop.run([userMessage], () => {});
 
     // Provider called 3 times (two tool rounds + final text)
     expect(calls).toHaveLength(3);
@@ -297,7 +297,7 @@ describe("AgentLoop", () => {
 
     // No tool executor provided
     const loop = new AgentLoop(provider, "system", {}, dummyTools);
-    const history = await loop.run([userMessage], () => {});
+    const { history } = await loop.run([userMessage], () => {});
 
     // Should stop after first response (no executor to handle tool use)
     expect(history).toHaveLength(2);
@@ -316,7 +316,7 @@ describe("AgentLoop", () => {
 
     const loop = new AgentLoop(provider, "system");
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Only the original message remains (no assistant message added on error)
     expect(history).toHaveLength(1);
@@ -336,7 +336,7 @@ describe("AgentLoop", () => {
 
     const { provider } = createMockProvider([textResponse("Should not reach")]);
     const loop = new AgentLoop(provider, "system");
-    const history = await loop.run([userMessage], () => {}, {
+    const { history } = await loop.run([userMessage], () => {}, {
       signal: controller.signal,
     });
 
@@ -370,7 +370,7 @@ describe("AgentLoop", () => {
       dummyTools,
       toolExecutor,
     );
-    const history = await loop.run([userMessage], () => {}, {
+    const { history } = await loop.run([userMessage], () => {}, {
       signal: controller.signal,
     });
 
@@ -420,7 +420,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const start = Date.now();
-    const history = await loop.run([userMessage], () => {}, {
+    const { history } = await loop.run([userMessage], () => {}, {
       signal: controller.signal,
     });
     const elapsed = Date.now() - start;
@@ -695,7 +695,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // All 3 tools should have been called
     expect(executionLog).toHaveLength(3);
@@ -792,7 +792,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events), {
+    const { history } = await loop.run([userMessage], collectEvents(events), {
       signal: controller.signal,
     });
 
@@ -941,7 +941,9 @@ describe("AgentLoop", () => {
 
     const onCheckpoint = (): CheckpointDecision => "continue";
 
-    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
+    const { history } = await loop.run([userMessage], () => {}, {
+      onCheckpoint,
+    });
 
     // All 3 provider calls should happen (2 tool turns + final text)
     expect(calls).toHaveLength(3);
@@ -967,9 +969,11 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
 
-    const onCheckpoint = (): CheckpointDecision => "yield";
+    const onCheckpoint = (): CheckpointDecision => ({ yield: "budget" });
 
-    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
+    const { history } = await loop.run([userMessage], () => {}, {
+      onCheckpoint,
+    });
 
     // Only 1 provider call should happen — loop yields after first tool turn
     expect(calls).toHaveLength(1);
@@ -995,7 +999,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
 
-    const history = await loop.run([userMessage], () => {});
+    const { history } = await loop.run([userMessage], () => {});
 
     // Normal behavior: 2 provider calls, full history
     expect(calls).toHaveLength(2);
@@ -1048,7 +1052,9 @@ describe("AgentLoop", () => {
       return "continue";
     };
 
-    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
+    const { history } = await loop.run([userMessage], () => {}, {
+      onCheckpoint,
+    });
 
     // Checkpoint should never be called for a text-only response
     expect(checkpoints).toHaveLength(0);
@@ -1137,11 +1143,11 @@ describe("AgentLoop", () => {
     const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
       checkpoints.push(checkpoint);
       // Yield on turn 3 (0-indexed)
-      return checkpoint.turnIndex === 3 ? "yield" : "continue";
+      return checkpoint.turnIndex === 3 ? { yield: "budget" } : "continue";
     };
 
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events), {
+    const { history } = await loop.run([userMessage], collectEvents(events), {
       onCheckpoint,
     });
 
@@ -1207,10 +1213,12 @@ describe("AgentLoop", () => {
 
     const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
       // Yield on the second turn (turnIndex 1)
-      return checkpoint.turnIndex === 1 ? "yield" : "continue";
+      return checkpoint.turnIndex === 1 ? { yield: "budget" } : "continue";
     };
 
-    const history = await loop.run([userMessage], () => {}, { onCheckpoint });
+    const { history } = await loop.run([userMessage], () => {}, {
+      onCheckpoint,
+    });
 
     // 2 provider calls: first tool turn + second tool turn (yield after second)
     expect(calls).toHaveLength(2);
@@ -1422,7 +1430,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // The tool result user message is at index 2 in history
     const toolResultMsg = history[2];
@@ -1473,7 +1481,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // The tool result user message is at index 2 in history
     const toolResultMsg = history[2];
@@ -1533,7 +1541,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // The final assistant message in HISTORY should retain placeholders
     // (so the model never sees real values on subsequent turns)
@@ -1637,7 +1645,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     const lastAssistant = history[history.length - 1];
     const textBlock = lastAssistant.content.find(
@@ -1785,7 +1793,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Provider should be called 3 times: initial, empty response, retry
     expect(calls).toHaveLength(3);
@@ -1863,7 +1871,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Provider called exactly 2 times: initial [text+tool_use], then empty.
     // No third (retry) call because the prior turn had visible text.
@@ -1925,7 +1933,7 @@ describe("AgentLoop", () => {
       toolExecutor,
     );
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Provider called 3 times: initial, empty, retry (also empty)
     expect(calls).toHaveLength(3);
@@ -1956,7 +1964,7 @@ describe("AgentLoop", () => {
 
     const loop = new AgentLoop(provider, "system");
     const events: AgentEvent[] = [];
-    const history = await loop.run([userMessage], collectEvents(events));
+    const { history } = await loop.run([userMessage], collectEvents(events));
 
     // Should NOT retry — this is the first turn with no tool use history
     expect(calls).toHaveLength(1);

--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -76,7 +76,7 @@ function makeTarget(): WakeTarget {
     agentLoop: {
       run: (async (messages: Message[]) => ({
         history: messages,
-        checkpointYield: null,
+        exitReason: null,
       })) as WakeTarget["agentLoop"]["run"],
     },
     getMessages: () => history,

--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -74,8 +74,10 @@ function makeTarget(): WakeTarget {
   return {
     conversationId: "conv-wake-callsite",
     agentLoop: {
-      run: (async (messages: Message[]) =>
-        messages) as WakeTarget["agentLoop"]["run"],
+      run: (async (messages: Message[]) => ({
+        history: messages,
+        checkpointYield: null,
+      })) as WakeTarget["agentLoop"]["run"],
     },
     getMessages: () => history,
     pushMessage: (msg) => {

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -92,7 +92,7 @@ function makeTarget(): {
         });
         // Return the input verbatim → silent no-op (no assistant tail).
         // Wake never yields at a checkpoint, so the pause-reason is null.
-        return { history: messages, checkpointYield: null };
+        return { history: messages, exitReason: null };
       }) as WakeTarget["agentLoop"]["run"],
     },
     getMessages: () => history,

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -91,7 +91,8 @@ function makeTarget(): {
           options,
         });
         // Return the input verbatim → silent no-op (no assistant tail).
-        return messages;
+        // Wake never yields at a checkpoint, so the pause-reason is null.
+        return { history: messages, checkpointYield: null };
       }) as WakeTarget["agentLoop"]["run"],
     },
     getMessages: () => history,

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent } from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
 import type {
   ContentBlock,
   Message,
@@ -192,7 +192,7 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-    ): Promise<Message[]> {
+    ): Promise<AgentLoopRunResult> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -242,7 +242,7 @@ mock.module("../agent/loop.js", () => ({
       ];
       history.push({ role: "user", content: resultBlocks });
 
-      return history;
+      return { history, exitReason: null };
     }
   },
 }));

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -14,7 +14,11 @@
 import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
+import type {
+  AgentEvent,
+  AgentLoopRunOptions,
+  AgentLoopRunResult,
+} from "../agent/loop.js";
 import type { LLMConfig } from "../config/schemas/llm.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
@@ -434,6 +438,39 @@ type AgentLoopRun = (
   options?: AgentLoopRunOptions,
 ) => Promise<Message[]>;
 
+/**
+ * Adapt a `Message[]`-returning mock loop body into `run()`'s real result
+ * shape. Mirrors the production loop: the pause-reason carried back is
+ * whatever the most recent `onCheckpoint` call yielded with (null when it
+ * never yielded), so the orchestrator derives its yield bookkeeping the same
+ * way it does against the real loop.
+ */
+const asAgentLoopRun = (
+  fn: AgentLoopRun,
+): ((
+  messages: Message[],
+  onEvent: (event: AgentEvent) => void | Promise<void>,
+  options?: AgentLoopRunOptions,
+) => Promise<AgentLoopRunResult>) => {
+  return async (messages, onEvent, options) => {
+    let checkpointYield: AgentLoopRunResult["checkpointYield"] = null;
+    let wrapped = options;
+    if (options?.onCheckpoint) {
+      const inner = options.onCheckpoint;
+      wrapped = {
+        ...options,
+        onCheckpoint: async (info) => {
+          const decision = await inner(info);
+          checkpointYield = decision === "continue" ? null : decision.yield;
+          return decision;
+        },
+      };
+    }
+    const history = await fn(messages, onEvent, wrapped);
+    return { history, checkpointYield };
+  };
+};
+
 function makeCtx(
   overrides?: Partial<AgentLoopConversationContext> & {
     agentLoopRun?: AgentLoopRun;
@@ -459,7 +496,7 @@ function makeCtx(
     currentRequestId: "test-req",
 
     agentLoop: {
-      run: agentLoopRun,
+      run: asAgentLoopRun(agentLoopRun),
       getToolTokenBudget: () => 0,
       getResolvedTools: () => [],
       // Tests in this file don't exercise calibration, so returning
@@ -1508,7 +1545,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
               hasToolUse: true,
               history: withProgress,
             });
-            if (decision === "yield") {
+            if (decision !== "continue") {
               // Agent loop stops when checkpoint yields
               return withProgress;
             }
@@ -1679,7 +1716,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
                 hasToolUse: true,
                 history: currentHistory,
               });
-              if (decision === "yield") {
+              if (decision !== "continue") {
                 return currentHistory;
               }
             }
@@ -1860,7 +1897,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
           hasToolUse: true,
           history: withProgress,
         });
-        if (decision === "yield") {
+        if (decision !== "continue") {
           return withProgress;
         }
       }
@@ -2040,7 +2077,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
           hasToolUse: true,
           history: withProgress,
         });
-        if (decision === "yield") {
+        if (decision !== "continue") {
           return withProgress;
         }
       }
@@ -2185,7 +2222,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
           hasToolUse: true,
           history: withProgress,
         });
-        if (decision === "yield") {
+        if (decision !== "continue") {
           return withProgress;
         }
       }
@@ -2528,7 +2565,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
           hasToolUse: true,
           history: withProgress,
         });
-        if (decision === "yield") {
+        if (decision !== "continue") {
           return withProgress;
         }
       }

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -453,7 +453,7 @@ const asAgentLoopRun = (
   options?: AgentLoopRunOptions,
 ) => Promise<AgentLoopRunResult>) => {
   return async (messages, onEvent, options) => {
-    let checkpointYield: AgentLoopRunResult["checkpointYield"] = null;
+    let exitReason: AgentLoopRunResult["exitReason"] = null;
     let wrapped = options;
     if (options?.onCheckpoint) {
       const inner = options.onCheckpoint;
@@ -461,13 +461,13 @@ const asAgentLoopRun = (
         ...options,
         onCheckpoint: async (info) => {
           const decision = await inner(info);
-          checkpointYield = decision === "continue" ? null : decision.yield;
+          exitReason = decision === "continue" ? null : decision;
           return decision;
         },
       };
     }
     const history = await fn(messages, onEvent, wrapped);
-    return { history, checkpointYield };
+    return { history, exitReason };
   };
 };
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1,7 +1,11 @@
 import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent, AgentLoopRunOptions } from "../agent/loop.js";
+import type {
+  AgentEvent,
+  AgentLoopRunOptions,
+  AgentLoopRunResult,
+} from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -547,6 +551,39 @@ type AgentLoopRun = (
   options?: AgentLoopRunOptions,
 ) => Promise<Message[]>;
 
+/**
+ * Adapt a `Message[]`-returning mock loop body into `run()`'s real result
+ * shape. Mirrors the production loop: the pause-reason carried back is
+ * whatever the most recent `onCheckpoint` call yielded with (null when it
+ * never yielded), so the orchestrator derives its yield bookkeeping the same
+ * way it does against the real loop.
+ */
+const asAgentLoopRun = (
+  fn: AgentLoopRun,
+): ((
+  messages: Message[],
+  onEvent: (event: AgentEvent) => void | Promise<void>,
+  options?: AgentLoopRunOptions,
+) => Promise<AgentLoopRunResult>) => {
+  return async (messages, onEvent, options) => {
+    let checkpointYield: AgentLoopRunResult["checkpointYield"] = null;
+    let wrapped = options;
+    if (options?.onCheckpoint) {
+      const inner = options.onCheckpoint;
+      wrapped = {
+        ...options,
+        onCheckpoint: async (info) => {
+          const decision = await inner(info);
+          checkpointYield = decision === "continue" ? null : decision.yield;
+          return decision;
+        },
+      };
+    }
+    const history = await fn(messages, onEvent, wrapped);
+    return { history, checkpointYield };
+  };
+};
+
 function makeCtx(
   overrides?: Partial<AgentLoopConversationContext> & {
     agentLoopRun?: AgentLoopRun;
@@ -572,7 +609,7 @@ function makeCtx(
     currentRequestId: "test-req",
 
     agentLoop: {
-      run: agentLoopRun,
+      run: asAgentLoopRun(agentLoopRun),
       getToolTokenBudget: () => 0,
       getResolvedTools: () => [],
       // Tests here don't exercise calibration; returning undefined makes
@@ -1016,7 +1053,7 @@ describe("session-agent-loop", () => {
           },
         } as unknown as AgentLoopConversationContext["traceEmitter"],
       });
-      ctx.agentLoop.run = agentLoopRun as AgentLoopRun;
+      ctx.agentLoop.run = asAgentLoopRun(agentLoopRun);
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
@@ -2476,7 +2513,7 @@ describe("session-agent-loop", () => {
             hasToolUse: true,
             history: messages,
           });
-          if (decision === "yield") {
+          if (decision !== "continue") {
             return [
               ...messages,
               {
@@ -4313,7 +4350,7 @@ describe("session-agent-loop", () => {
             history: messages,
           });
           mockEstimateTokens = 1000;
-          if (decision === "yield") {
+          if (decision !== "continue") {
             return rawMidLoopBasis;
           }
         }

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -566,7 +566,7 @@ const asAgentLoopRun = (
   options?: AgentLoopRunOptions,
 ) => Promise<AgentLoopRunResult>) => {
   return async (messages, onEvent, options) => {
-    let checkpointYield: AgentLoopRunResult["checkpointYield"] = null;
+    let exitReason: AgentLoopRunResult["exitReason"] = null;
     let wrapped = options;
     if (options?.onCheckpoint) {
       const inner = options.onCheckpoint;
@@ -574,13 +574,13 @@ const asAgentLoopRun = (
         ...options,
         onCheckpoint: async (info) => {
           const decision = await inner(info);
-          checkpointYield = decision === "continue" ? null : decision.yield;
+          exitReason = decision === "continue" ? null : decision;
           return decision;
         },
       };
     }
     const history = await fn(messages, onEvent, wrapped);
-    return { history, checkpointYield };
+    return { history, exitReason };
   };
 };
 

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent } from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
 import type { UserMessageAttachment } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -277,7 +277,7 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-    ): Promise<Message[]> {
+    ): Promise<AgentLoopRunResult> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -331,7 +331,7 @@ mock.module("../agent/loop.js", () => ({
             { type: "tool_result", tool_use_id: "tu-1", content: "hi" },
           ],
         } as Message);
-        return history; // Progress was made — history grew
+        return { history, exitReason: null }; // Progress was made — history grew
       }
 
       // Context-too-large modes: keep failing when compaction can't help
@@ -373,7 +373,7 @@ mock.module("../agent/loop.js", () => ({
           );
         })();
         onEvent({ type: "error", error });
-        return [...messages]; // Return unchanged — no progress
+        return { history: [...messages], exitReason: null }; // Return unchanged — no progress
       }
 
       // Second call (retry) or non-error: succeed normally
@@ -391,7 +391,7 @@ mock.module("../agent/loop.js", () => ({
       };
       history.push(assistantMsg);
       onEvent({ type: "message_complete", message: assistantMsg });
-      return history;
+      return { history, exitReason: null };
     }
   },
 }));

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -6,7 +6,7 @@ import type {
   AgentLoopRunResult,
   CheckpointDecision,
   CheckpointInfo,
-  CheckpointYieldReason,
+  ExitReason,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -334,7 +334,7 @@ interface PendingRun {
    * `resolve(history)` packages this into the run result so the orchestrator
    * derives its handoff bookkeeping the same way it does against the real loop.
    */
-  checkpointYield: CheckpointYieldReason | null;
+  exitReason: ExitReason | null;
 }
 
 let pendingRuns: PendingRun[] = [];
@@ -365,17 +365,16 @@ mock.module("../agent/loop.js", () => ({
           resolve: (history: Message[]) =>
             resolveResult({
               history,
-              checkpointYield: pending.checkpointYield,
+              exitReason: pending.exitReason,
             }),
           reject,
           messages,
           onEvent,
-          checkpointYield: null,
+          exitReason: null,
           onCheckpoint: options?.onCheckpoint
             ? async (checkpoint) => {
                 const decision = await options.onCheckpoint!(checkpoint);
-                pending.checkpointYield =
-                  decision === "continue" ? null : decision.yield;
+                pending.exitReason = decision === "continue" ? null : decision;
                 return decision;
               }
             : undefined,
@@ -1838,7 +1837,7 @@ describe("Conversation checkpoint handoff", () => {
     });
 
     // Because there is a queued message, the callback should yield for handoff
-    expect(decision).toEqual({ yield: "handoff" });
+    expect(decision).toEqual("handoff");
 
     // Complete the run so the conversation finishes cleanly
     await resolveRun(0);
@@ -1937,7 +1936,7 @@ describe("Conversation checkpoint handoff", () => {
       hasToolUse: true,
       history: [],
     });
-    expect(decision).toEqual({ yield: "handoff" });
+    expect(decision).toEqual("handoff");
 
     // Complete first run
     await resolveRun(0);
@@ -1999,7 +1998,7 @@ describe("Conversation checkpoint handoff", () => {
       hasToolUse: true,
       history: [],
     });
-    expect(decision).toEqual({ yield: "handoff" });
+    expect(decision).toEqual("handoff");
 
     // Complete the run (AgentLoop resolves after yielding)
     await resolveRun(0);
@@ -2085,7 +2084,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toEqual({ yield: "handoff" });
+    ).toEqual("handoff");
     await resolveRun(0);
     await pA;
 
@@ -2102,7 +2101,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toEqual({ yield: "handoff" });
+    ).toEqual("handoff");
     await resolveRun(1);
     await waitForPendingRun(3);
 
@@ -2117,7 +2116,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toEqual({ yield: "handoff" });
+    ).toEqual("handoff");
     await resolveRun(2);
     await waitForPendingRun(4);
 
@@ -2577,7 +2576,7 @@ describe("Conversation attachment event payloads", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toEqual({ yield: "handoff" });
+    ).toEqual("handoff");
 
     const assistantMsg: Message = {
       role: "assistant",

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   AgentEvent,
+  AgentLoopRunResult,
   CheckpointDecision,
   CheckpointInfo,
+  CheckpointYieldReason,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -326,6 +328,13 @@ interface PendingRun {
   onCheckpoint?: (
     checkpoint: CheckpointInfo,
   ) => CheckpointDecision | Promise<CheckpointDecision>;
+  /**
+   * Pause-reason recorded from the most recent `onCheckpoint` call, mirroring
+   * how the production loop carries it back via {@link AgentLoopRunResult}.
+   * `resolve(history)` packages this into the run result so the orchestrator
+   * derives its handoff bookkeeping the same way it does against the real loop.
+   */
+  checkpointYield: CheckpointYieldReason | null;
 }
 
 let pendingRuns: PendingRun[] = [];
@@ -350,15 +359,28 @@ mock.module("../agent/loop.js", () => ({
           checkpoint: CheckpointInfo,
         ) => CheckpointDecision | Promise<CheckpointDecision>;
       },
-    ): Promise<Message[]> {
-      return new Promise<Message[]>((resolve, reject) => {
-        pendingRuns.push({
-          resolve,
+    ): Promise<AgentLoopRunResult> {
+      return new Promise<AgentLoopRunResult>((resolveResult, reject) => {
+        const pending: PendingRun = {
+          resolve: (history: Message[]) =>
+            resolveResult({
+              history,
+              checkpointYield: pending.checkpointYield,
+            }),
           reject,
           messages,
           onEvent,
-          onCheckpoint: options?.onCheckpoint,
-        });
+          checkpointYield: null,
+          onCheckpoint: options?.onCheckpoint
+            ? async (checkpoint) => {
+                const decision = await options.onCheckpoint!(checkpoint);
+                pending.checkpointYield =
+                  decision === "continue" ? null : decision.yield;
+                return decision;
+              }
+            : undefined,
+        };
+        pendingRuns.push(pending);
       });
     }
   },
@@ -1815,8 +1837,8 @@ describe("Conversation checkpoint handoff", () => {
       history: [],
     });
 
-    // Because there is a queued message, the callback should return 'yield'
-    expect(decision).toBe("yield");
+    // Because there is a queued message, the callback should yield for handoff
+    expect(decision).toEqual({ yield: "handoff" });
 
     // Complete the run so the conversation finishes cleanly
     await resolveRun(0);
@@ -1915,7 +1937,7 @@ describe("Conversation checkpoint handoff", () => {
       hasToolUse: true,
       history: [],
     });
-    expect(decision).toBe("yield");
+    expect(decision).toEqual({ yield: "handoff" });
 
     // Complete first run
     await resolveRun(0);
@@ -1965,7 +1987,7 @@ describe("Conversation checkpoint handoff", () => {
     expect(conversation.hasQueuedMessages()).toBe(true);
 
     // Simulate tool-use turns: the agent loop calls onCheckpoint at each turn boundary.
-    // Because there is a queued message, the callback should return 'yield'.
+    // Because there is a queued message, the callback should yield for handoff.
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
 
@@ -1977,7 +1999,7 @@ describe("Conversation checkpoint handoff", () => {
       hasToolUse: true,
       history: [],
     });
-    expect(decision).toBe("yield");
+    expect(decision).toEqual({ yield: "handoff" });
 
     // Complete the run (AgentLoop resolves after yielding)
     await resolveRun(0);
@@ -2063,7 +2085,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toBe("yield");
+    ).toEqual({ yield: "handoff" });
     await resolveRun(0);
     await pA;
 
@@ -2080,7 +2102,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toBe("yield");
+    ).toEqual({ yield: "handoff" });
     await resolveRun(1);
     await waitForPendingRun(3);
 
@@ -2095,7 +2117,7 @@ describe("Conversation checkpoint handoff", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toBe("yield");
+    ).toEqual({ yield: "handoff" });
     await resolveRun(2);
     await waitForPendingRun(4);
 
@@ -2555,7 +2577,7 @@ describe("Conversation attachment event payloads", () => {
         hasToolUse: true,
         history: [],
       }),
-    ).toBe("yield");
+    ).toEqual({ yield: "handoff" });
 
     const assistantMsg: Message = {
       role: "assistant",

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent } from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import {
   conversationMessagesSyncTag,
@@ -222,10 +222,11 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void | Promise<void>,
-    ): Promise<Message[]> {
-      return new Promise<Message[]>((resolve) => {
+    ): Promise<AgentLoopRunResult> {
+      const history = await new Promise<Message[]>((resolve) => {
         pendingRuns.push({ resolve, messages, onEvent });
       });
+      return { history, exitReason: null };
     }
   },
 }));

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AgentEvent } from "../agent/loop.js";
+import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -245,7 +245,7 @@ mock.module("../agent/loop.js", () => ({
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
-    ): Promise<Message[]> {
+    ): Promise<AgentLoopRunResult> {
       // Prime the assistant row anchor — production code emits this from
       // `AgentLoop.run` just before `provider.sendMessage`.
       await onEvent({ type: "llm_call_started" });
@@ -263,7 +263,7 @@ mock.module("../agent/loop.js", () => ({
         content: [{ type: "text", text: "ok" }],
       };
       onEvent({ type: "message_complete", message: assistantMessage });
-      return [...messages, assistantMessage];
+      return { history: [...messages, assistantMessage], exitReason: null };
     }
   },
 }));

--- a/assistant/src/__tests__/parallel-tool.benchmark.test.ts
+++ b/assistant/src/__tests__/parallel-tool.benchmark.test.ts
@@ -306,7 +306,7 @@ describe("Parallel tool execution benchmarks", () => {
         toolExecutor,
       );
       const start = Date.now();
-      const history = await loop.run([userMessage], () => {}, {
+      const { history } = await loop.run([userMessage], () => {}, {
         signal: controller.signal,
       });
       const elapsed = Date.now() - start;

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -66,7 +66,28 @@ export interface CheckpointInfo {
   history: Message[]; // current history snapshot for token estimation
 }
 
-export type CheckpointDecision = "continue" | "yield";
+/**
+ * Why a checkpoint paused the loop. Surfaced back to the caller via
+ * {@link AgentLoopRunResult.checkpointYield} so the orchestrator reacts to
+ * the loop's own signal (hand off to a queued message vs. compact and
+ * re-enter) instead of the checkpoint callback mutating orchestrator state.
+ */
+export type CheckpointYieldReason = "handoff" | "budget";
+
+export type CheckpointDecision = "continue" | { yield: CheckpointYieldReason };
+
+/**
+ * Result of {@link AgentLoop.run}.
+ *
+ * `checkpointYield` carries the reason the loop paused at a checkpoint so the
+ * orchestrator reads the loop's own signal instead of inferring it from
+ * callback side-effects. It is `null` whenever the loop reached a terminal
+ * stop (completion, error, abort, or a tool-requested yield-to-user).
+ */
+export interface AgentLoopRunResult {
+  history: Message[];
+  checkpointYield: CheckpointYieldReason | null;
+}
 
 /**
  * Why an agent turn reached a terminal state.
@@ -523,7 +544,7 @@ export class AgentLoop {
     messages: Message[],
     onEvent: (event: AgentEvent) => void | Promise<void>,
     options?: AgentLoopRunOptions,
-  ): Promise<Message[]> {
+  ): Promise<AgentLoopRunResult> {
     const {
       signal,
       requestId,
@@ -542,6 +563,7 @@ export class AgentLoop {
     let consecutiveErrorTurns = 0;
     let emptyResponseRetries = 0;
     let lastLlmCallTime = 0;
+    let checkpointYield: CheckpointYieldReason | null = null;
     const rlog = requestId ? log.child({ requestId }) : log;
 
     // Per-run substitution map for sensitive output placeholders.
@@ -1387,7 +1409,8 @@ export class AgentLoop {
             hasToolUse: true,
             history,
           });
-          if (decision === "yield") {
+          if (decision !== "continue") {
+            checkpointYield = decision.yield;
             break;
           }
         }
@@ -1438,7 +1461,7 @@ export class AgentLoop {
       "Agent loop exited",
     );
 
-    return history;
+    return { history, checkpointYield };
   }
 }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -68,25 +68,25 @@ export interface CheckpointInfo {
 
 /**
  * Why a checkpoint paused the loop. Surfaced back to the caller via
- * {@link AgentLoopRunResult.checkpointYield} so the orchestrator reacts to
+ * {@link AgentLoopRunResult.exitReason} so the orchestrator reacts to
  * the loop's own signal (hand off to a queued message vs. compact and
  * re-enter) instead of the checkpoint callback mutating orchestrator state.
  */
-export type CheckpointYieldReason = "handoff" | "budget";
+export type ExitReason = "handoff" | "budget";
 
-export type CheckpointDecision = "continue" | { yield: CheckpointYieldReason };
+export type CheckpointDecision = "continue" | ExitReason;
 
 /**
  * Result of {@link AgentLoop.run}.
  *
- * `checkpointYield` carries the reason the loop paused at a checkpoint so the
+ * `exitReason` carries the reason the loop paused at a checkpoint so the
  * orchestrator reads the loop's own signal instead of inferring it from
  * callback side-effects. It is `null` whenever the loop reached a terminal
  * stop (completion, error, abort, or a tool-requested yield-to-user).
  */
 export interface AgentLoopRunResult {
   history: Message[];
-  checkpointYield: CheckpointYieldReason | null;
+  exitReason: ExitReason | null;
 }
 
 /**
@@ -563,7 +563,7 @@ export class AgentLoop {
     let consecutiveErrorTurns = 0;
     let emptyResponseRetries = 0;
     let lastLlmCallTime = 0;
-    let checkpointYield: CheckpointYieldReason | null = null;
+    let exitReason: ExitReason | null = null;
     const rlog = requestId ? log.child({ requestId }) : log;
 
     // Per-run substitution map for sensitive output placeholders.
@@ -1410,7 +1410,7 @@ export class AgentLoop {
             history,
           });
           if (decision !== "continue") {
-            checkpointYield = decision.yield;
+            exitReason = decision;
             break;
           }
         }
@@ -1461,7 +1461,7 @@ export class AgentLoop {
       "Agent loop exited",
     );
 
-    return { history, checkpointYield };
+    return { history, exitReason };
   }
 }
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2276,9 +2276,7 @@ export async function runAgentLoopImpl(
       state.currentTurnToolNames = [];
 
       if (ctx.canHandoffAtCheckpoint()) {
-        yieldedForHandoff = true;
-        pendingCheckpointYield = "handoff";
-        return "yield";
+        return { yield: "handoff" };
       }
 
       // Mid-loop token budget check: estimate current context size and
@@ -2294,9 +2292,7 @@ export async function runAgentLoopImpl(
             { phase: "mid-loop", estimated, threshold: midLoopThreshold },
             "Token estimate approaching budget — yielding for compaction",
           );
-          yieldedForBudget = true;
-          pendingCheckpointYield = "budget";
-          return "yield";
+          return { yield: "budget" };
         }
       }
 
@@ -2315,23 +2311,41 @@ export async function runAgentLoopImpl(
     // and overwrites `turnIndex` with its own tool-use iteration counter.
     const loopTurnCtx = buildPluginTurnContext(ctx, reqId);
 
-    /** Shared closure: runs the agent loop with the orchestrator's turn context. */
-    const runAgentLoop = (msgs: Message[]) =>
-      ctx.agentLoop.run(msgs, eventHandler, {
-        signal: abortController.signal,
-        requestId: reqId,
-        onCheckpoint,
-        callSite: turnCallSite,
-        turnContext: loopTurnCtx,
-        overrideProfile: turnOverrideProfile,
-        effectiveMaxInputTokens: resolveCurrentMaxInputTokens(),
-        resolveOverrideProfile: resolveCurrentOverrideProfile,
-        resolveEffectiveMaxInputTokens: resolveCurrentMaxInputTokens,
-        // memory-v3-live: the latest user message carries the volatile v3
-        // `<memory>` block, so anchor the provider's long-TTL cache breakpoint
-        // on the most recent stable message instead.
-        mutableLatestUserMessage: memoryV3Live,
-      });
+    /**
+     * Shared closure: runs the agent loop with the orchestrator's turn
+     * context and maps the loop's returned checkpoint pause-reason into the
+     * orchestrator's yield bookkeeping. Returns the updated history so call
+     * sites consume it exactly as before.
+     */
+    const runAgentLoop = async (msgs: Message[]): Promise<Message[]> => {
+      const { history, checkpointYield } = await ctx.agentLoop.run(
+        msgs,
+        eventHandler,
+        {
+          signal: abortController.signal,
+          requestId: reqId,
+          onCheckpoint,
+          callSite: turnCallSite,
+          turnContext: loopTurnCtx,
+          overrideProfile: turnOverrideProfile,
+          effectiveMaxInputTokens: resolveCurrentMaxInputTokens(),
+          resolveOverrideProfile: resolveCurrentOverrideProfile,
+          resolveEffectiveMaxInputTokens: resolveCurrentMaxInputTokens,
+          // memory-v3-live: the latest user message carries the volatile v3
+          // `<memory>` block, so anchor the provider's long-TTL cache breakpoint
+          // on the most recent stable message instead.
+          mutableLatestUserMessage: memoryV3Live,
+        },
+      );
+      if (checkpointYield === "handoff") {
+        yieldedForHandoff = true;
+        pendingCheckpointYield = "handoff";
+      } else if (checkpointYield === "budget") {
+        yieldedForBudget = true;
+        pendingCheckpointYield = "budget";
+      }
+      return history;
+    };
 
     let updatedHistory = await runAgentLoop(runMessages);
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2276,7 +2276,7 @@ export async function runAgentLoopImpl(
       state.currentTurnToolNames = [];
 
       if (ctx.canHandoffAtCheckpoint()) {
-        return { yield: "handoff" };
+        return "handoff";
       }
 
       // Mid-loop token budget check: estimate current context size and
@@ -2292,7 +2292,7 @@ export async function runAgentLoopImpl(
             { phase: "mid-loop", estimated, threshold: midLoopThreshold },
             "Token estimate approaching budget — yielding for compaction",
           );
-          return { yield: "budget" };
+          return "budget";
         }
       }
 
@@ -2318,7 +2318,7 @@ export async function runAgentLoopImpl(
      * sites consume it exactly as before.
      */
     const runAgentLoop = async (msgs: Message[]): Promise<Message[]> => {
-      const { history, checkpointYield } = await ctx.agentLoop.run(
+      const { history, exitReason } = await ctx.agentLoop.run(
         msgs,
         eventHandler,
         {
@@ -2337,10 +2337,10 @@ export async function runAgentLoopImpl(
           mutableLatestUserMessage: memoryV3Live,
         },
       );
-      if (checkpointYield === "handoff") {
+      if (exitReason === "handoff") {
         yieldedForHandoff = true;
         pendingCheckpointYield = "handoff";
-      } else if (checkpointYield === "budget") {
+      } else if (exitReason === "budget") {
         yieldedForBudget = true;
         pendingCheckpointYield = "budget";
       }

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -135,7 +135,7 @@ import {
 // "continue" — so the loop result always carries a null pause-reason.
 const runResult = (history: Message[]): AgentLoopRunResult => ({
   history,
-  checkpointYield: null,
+  exitReason: null,
 });
 
 interface MockTarget extends WakeTarget {

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -117,7 +117,11 @@ mock.module("../../memory/llm-request-log-store.js", () => ({
   backfillMessageIdOnLogs: () => {},
 }));
 
-import type { AgentEvent, AgentLoopRunOptions } from "../../agent/loop.js";
+import type {
+  AgentEvent,
+  AgentLoopRunOptions,
+  AgentLoopRunResult,
+} from "../../agent/loop.js";
 import type { Message } from "../../providers/types.js";
 import {
   __resetWakeChainForTests,
@@ -126,6 +130,13 @@ import {
 } from "../agent-wake.js";
 
 // ── Test helpers ─────────────────────────────────────────────────────
+
+// Wake runs never pause at a checkpoint — their onCheckpoint always returns
+// "continue" — so the loop result always carries a null pause-reason.
+const runResult = (history: Message[]): AgentLoopRunResult => ({
+  history,
+  checkpointYield: null,
+});
 
 interface MockTarget extends WakeTarget {
   emittedEvents: AgentEvent[];
@@ -221,7 +232,7 @@ function makeTarget(options: {
             next.push(tailMsg);
           }
         }
-        return next;
+        return runResult(next);
       },
     },
     getMessages: () => history,
@@ -681,7 +692,7 @@ describe("wakeAgentForOpportunity", () => {
       agentLoop: {
         run: async (input) => {
           runCalls.push(callOrder++);
-          return [...input];
+          return runResult([...input]);
         },
       },
       getMessages: () => history,
@@ -724,7 +735,7 @@ describe("wakeAgentForOpportunity", () => {
     const target: WakeTarget = {
       conversationId: "conv-no-trust",
       agentLoop: {
-        run: async (input) => [...input],
+        run: async (input) => runResult([...input]),
       },
       getMessages: () => history,
       pushMessage: () => {},
@@ -776,7 +787,7 @@ describe("wakeAgentForOpportunity", () => {
             await gate2.promise;
           }
           runCompleteOrder.push(myIndex);
-          return input; // no assistant message → silent no-op
+          return runResult(input); // no assistant message → silent no-op
         },
       },
       getMessages: () => history,
@@ -824,7 +835,7 @@ describe("wakeAgentForOpportunity", () => {
     const target: WakeTarget & { setProcessing: (v: boolean) => void } = {
       conversationId: "conv-user-turn",
       agentLoop: {
-        run: async (input) => input,
+        run: async (input) => runResult(input),
       },
       getMessages: () => history,
       pushMessage: (msg) => {
@@ -890,7 +901,7 @@ describe("wakeAgentForOpportunity", () => {
     const history: Message[] = [];
     const target: WakeTarget = {
       conversationId: "conv-busy",
-      agentLoop: { run: async () => history },
+      agentLoop: { run: async () => runResult(history) },
       getMessages: () => history,
       pushMessage: () => {},
       emitAgentEvent: () => {},
@@ -1349,7 +1360,7 @@ describe("wakeAgentForOpportunity", () => {
               type: "message_complete",
               message: finalAssistant,
             });
-            return runHistory;
+            return runResult(runHistory);
           },
         },
         getMessages: () => history,
@@ -1446,7 +1457,7 @@ describe("wakeAgentForOpportunity", () => {
               hasToolUse: true,
               history: runHistory,
             });
-            return runHistory;
+            return runResult(runHistory);
           },
         },
         getMessages: () => history,
@@ -1631,7 +1642,7 @@ describe("wakeAgentForOpportunity", () => {
     let processing = false;
     return {
       conversationId,
-      agentLoop: { run: async (input) => input },
+      agentLoop: { run: async (input) => runResult(input) },
       getMessages: () => history,
       pushMessage: () => {},
       emitAgentEvent: () => {},
@@ -1718,7 +1729,7 @@ describe("wakeAgentForOpportunity", () => {
               hasToolUse: true,
               history: runHistory,
             });
-            return runHistory;
+            return runResult(runHistory);
           },
         },
         getMessages: () => history,

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -862,20 +862,24 @@ export async function wakeAgentForOpportunity(
     try {
       let updatedHistory: Message[];
       try {
-        updatedHistory = await target.agentLoop.run(runInput, onEvent, {
-          requestId: `wake:${source}`,
-          onCheckpoint,
-          // Route through the caller-supplied call site (defaults to
-          // `mainAgent` so a normal user-turn wake shares the user's chat
-          // selection). Without an explicit callSite, the resolver in
-          // `RetryProvider` and the routing in `CallSiteRoutingProvider`
-          // short-circuit and silently drop both per-callsite config and the
-          // pinned `overrideProfile` below.
-          callSite,
-          turnContext: wakeTurnContext,
-          overrideProfile,
-          effectiveMaxInputTokens: effectiveContextWindow.maxInputTokens,
-        });
+        ({ history: updatedHistory } = await target.agentLoop.run(
+          runInput,
+          onEvent,
+          {
+            requestId: `wake:${source}`,
+            onCheckpoint,
+            // Route through the caller-supplied call site (defaults to
+            // `mainAgent` so a normal user-turn wake shares the user's chat
+            // selection). Without an explicit callSite, the resolver in
+            // `RetryProvider` and the routing in `CallSiteRoutingProvider`
+            // short-circuit and silently drop both per-callsite config and the
+            // pinned `overrideProfile` below.
+            callSite,
+            turnContext: wakeTurnContext,
+            overrideProfile,
+            effectiveMaxInputTokens: effectiveContextWindow.maxInputTokens,
+          },
+        ));
       } catch (err) {
         // Capture the error for post-finally logging, then short-circuit
         // the rest of the try body — no tail to push/persist when the


### PR DESCRIPTION
Makes the agent loop surface a typed checkpoint pause-reason (`"handoff" | "budget"`) through its `run()` result instead of having the orchestrator infer it from `onCheckpoint` callback side-effects, so the loop owns its own control-flow signal. This is a no-behavior-change refactor that keeps the orchestrator's `yieldedForHandoff` / `yieldedForBudget` / `pendingCheckpointYield` bookkeeping intact for downstream consumers, and is the first in a sequence of safe re-homing PRs ahead of the compaction work.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/7c1b9633322c4bf284eb6ed8525ce389