### PR TITLE
feat(schedule): per-schedule script execution timeout override

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -52,6 +52,34 @@ export async function createSchedule(
   }
 }
 
+export interface UpdateSchedulePayload {
+  timeoutMs?: number | null;
+}
+
+export async function updateSchedule(
+  assistantId: string,
+  scheduleId: string,
+  payload: UpdateSchedulePayload,
+): Promise<void> {
+  const { error, response } = await client.patch<
+    SchedulesListResponse,
+    unknown
+  >({
+    url: "/v1/assistants/{assistant_id}/schedules/{schedule_id}/",
+    path: { assistant_id: assistantId, schedule_id: scheduleId },
+    body: payload,
+    headers: { "Content-Type": "application/json" },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to update schedule.");
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to update schedule."),
+    );
+  }
+}
+
 export async function fetchSchedules(assistantId: string): Promise<Schedule[]> {
   const { data, error, response } = await client.get<
     SchedulesListResponse,

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -11,6 +11,7 @@ import {
 import { useCallback, useMemo, useState } from "react";
 
 import { Button } from "@vellum/design-library/components/button";
+import { Input } from "@vellum/design-library/components/input";
 import { Notice } from "@vellum/design-library/components/notice";
 import { PanelItem } from "@vellum/design-library/components/panel-item";
 import { Tag } from "@vellum/design-library/components/tag";
@@ -29,6 +30,7 @@ import {
   runHeartbeatNow,
   runScheduleNow,
   toggleSchedule,
+  updateSchedule,
 } from "@/domains/settings/api/schedules";
 import { reportError } from "@/utils/error-report";
 import {
@@ -269,16 +271,140 @@ function RecentRunsCard({
 // Schedule detail view (runs list)
 // ---------------------------------------------------------------------------
 
+const DEFAULT_SCRIPT_TIMEOUT_MS = 60_000;
+const MIN_SCRIPT_TIMEOUT_SECONDS = 1;
+const MAX_SCRIPT_TIMEOUT_SECONDS = 30 * 60;
+
+/**
+ * Inline editor for a script schedule's execution timeout. Displays the
+ * effective timeout (the per-schedule override, or the default when unset)
+ * and lets the guardian change it or reset it back to the default.
+ */
+function ScriptTimeoutField({
+  schedule,
+  assistantId,
+  onUpdated,
+}: {
+  schedule: Schedule;
+  assistantId: string;
+  onUpdated: () => void;
+}) {
+  const effectiveSeconds = Math.round(
+    (schedule.timeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS) / 1000,
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(String(effectiveSeconds));
+  const [isSaving, setIsSaving] = useState(false);
+
+  const startEditing = useCallback(() => {
+    setValue(String(effectiveSeconds));
+    setIsEditing(true);
+  }, [effectiveSeconds]);
+
+  const save = useCallback(
+    async (timeoutMs: number | null) => {
+      setIsSaving(true);
+      try {
+        await updateSchedule(assistantId, schedule.id, { timeoutMs });
+        setIsEditing(false);
+        onUpdated();
+      } catch (error) {
+        reportError(error, {
+          context: "schedule_update_timeout",
+          userMessage: "Failed to update timeout.",
+        });
+        toast.error("Failed to update timeout.");
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [assistantId, schedule.id, onUpdated],
+  );
+
+  const handleSave = useCallback(() => {
+    const seconds = Number(value);
+    if (
+      !Number.isInteger(seconds) ||
+      seconds < MIN_SCRIPT_TIMEOUT_SECONDS ||
+      seconds > MAX_SCRIPT_TIMEOUT_SECONDS
+    ) {
+      toast.error(
+        `Timeout must be a whole number between ${MIN_SCRIPT_TIMEOUT_SECONDS} and ${MAX_SCRIPT_TIMEOUT_SECONDS} seconds.`,
+      );
+      return;
+    }
+    void save(seconds * 1000);
+  }, [value, save]);
+
+  if (isEditing) {
+    return (
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[var(--content-secondary)]">Timeout</span>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            min={MIN_SCRIPT_TIMEOUT_SECONDS}
+            max={MAX_SCRIPT_TIMEOUT_SECONDS}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="w-24"
+            aria-label="Timeout in seconds"
+          />
+          <span className="text-[var(--content-tertiary)]">sec</span>
+          <Button size="compact" onClick={handleSave} disabled={isSaving}>
+            {isSaving ? "Saving…" : "Save"}
+          </Button>
+          <Button
+            variant="outlined"
+            size="compact"
+            onClick={() => setIsEditing(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-[var(--content-secondary)]">Timeout</span>
+      <div className="flex items-center gap-2">
+        <span>
+          {effectiveSeconds}s
+          {schedule.timeoutMs == null ? " (default)" : ""}
+        </span>
+        <Button variant="outlined" size="compact" onClick={startEditing}>
+          Edit
+        </Button>
+        {schedule.timeoutMs != null && (
+          <Button
+            variant="outlined"
+            size="compact"
+            onClick={() => void save(null)}
+            disabled={isSaving}
+          >
+            Reset
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function ScheduleDetailView({
   schedule,
   assistantId,
   onBack,
   onDeleted,
+  onUpdated,
 }: {
   schedule: Schedule;
   assistantId: string;
   onBack: () => void;
   onDeleted: () => void;
+  onUpdated: () => void;
 }) {
   const [selectedRun, setSelectedRun] = useState<ScheduleRun | null>(null);
 
@@ -381,6 +507,13 @@ export function ScheduleDetailView({
                 {schedule.script}
               </pre>
             </div>
+          )}
+          {schedule.mode === "script" && (
+            <ScriptTimeoutField
+              schedule={schedule}
+              assistantId={assistantId}
+              onUpdated={onUpdated}
+            />
           )}
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Status</span>
@@ -1023,6 +1156,7 @@ export function SchedulesPage() {
           setSelectedScheduleId(null);
           void refetch();
         }}
+        onUpdated={() => void refetch()}
       />
     );
   }

--- a/apps/web/src/domains/settings/types/schedules.ts
+++ b/apps/web/src/domains/settings/types/schedules.ts
@@ -16,6 +16,7 @@ export interface Schedule {
   status: "active" | "firing" | "fired" | "cancelled";
   routingIntent: string;
   reuseConversation: boolean;
+  timeoutMs: number | null;
   isOneShot: boolean;
 }
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15702,6 +15702,11 @@ paths:
                 retryBackoffMs:
                   type: number
                   description: Retry backoff in milliseconds
+                timeoutMs:
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                  description: Script-mode execution timeout in ms; null = use default
               required:
                 - name
                 - expression
@@ -15714,6 +15719,7 @@ paths:
                 - reuseConversation
                 - maxRetries
                 - retryBackoffMs
+                - timeoutMs
               additionalProperties: false
   /v1/schedules/{id}/cancel:
     post:

--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -47,6 +47,7 @@ describe("schedule_syntax column migration", () => {
         reuse_conversation INTEGER NOT NULL DEFAULT 0,
         script TEXT,
         wake_conversation_id TEXT,
+        timeout_ms INTEGER,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -128,6 +129,11 @@ describe("schedule_syntax column migration", () => {
     } catch {
       /* already exists */
     }
+    try {
+      raw.exec(`ALTER TABLE cron_jobs ADD COLUMN timeout_ms INTEGER`);
+    } catch {
+      /* already exists */
+    }
 
     const row = db
       .select()
@@ -183,6 +189,11 @@ describe("schedule_syntax column migration", () => {
       raw.exec(
         `ALTER TABLE cron_jobs ADD COLUMN reuse_conversation INTEGER NOT NULL DEFAULT 0`,
       );
+    } catch {
+      /* ok */
+    }
+    try {
+      raw.exec(`ALTER TABLE cron_jobs ADD COLUMN timeout_ms INTEGER`);
     } catch {
       /* ok */
     }

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -538,3 +538,73 @@ describe("wake mode in schedule routes", () => {
     expect(wakeSchedule!.wakeConversationId).toBe("conv-abc");
   });
 });
+
+describe("PATCH /schedules/:id — timeout override", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  function listOne(): { id: string; timeoutMs: number | null } {
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{ id: string; timeoutMs: number | null }>;
+    };
+    return result.schedules[0];
+  }
+
+  test("sets and clears the script timeout, exposing it in the list", () => {
+    // GIVEN a script schedule with no timeout override
+    const schedule = createSchedule({
+      name: "Script job",
+      cronExpression: "0 9 * * *",
+      message: "",
+      script: "echo hi",
+      mode: "script",
+      syntax: "cron",
+    });
+    expect(listOne().timeoutMs).toBeNull();
+
+    const patch = findRoute("schedules/:id", "PATCH");
+
+    // WHEN the guardian sets a custom timeout
+    patch.handler({
+      pathParams: { id: schedule.id },
+      body: { timeoutMs: 5000 },
+    });
+
+    // THEN the list reflects the override
+    expect(listOne().timeoutMs).toBe(5000);
+
+    // AND WHEN the guardian clears it
+    patch.handler({
+      pathParams: { id: schedule.id },
+      body: { timeoutMs: null },
+    });
+
+    // THEN it reverts to null
+    expect(listOne().timeoutMs).toBeNull();
+  });
+
+  test("rejects an out-of-range timeout", () => {
+    // GIVEN a script schedule
+    const schedule = createSchedule({
+      name: "Guarded job",
+      cronExpression: "0 9 * * *",
+      message: "",
+      script: "echo hi",
+      mode: "script",
+      syntax: "cron",
+    });
+
+    const patch = findRoute("schedules/:id", "PATCH");
+
+    // WHEN/THEN patching with a below-minimum timeout throws a RouteError
+    expect(() =>
+      patch.handler({
+        pathParams: { id: schedule.id },
+        body: { timeoutMs: 10 },
+      }),
+    ).toThrow("timeout_ms must be between");
+    expect(listOne().timeoutMs).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1034,6 +1034,73 @@ describe("routing and mode fields", () => {
   });
 });
 
+// ── Script timeout override ─────────────────────────────────────────
+
+describe("script timeout override", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("defaults timeoutMs to null when not provided", () => {
+    // GIVEN a schedule created without a timeout override
+    const job = createSchedule({
+      name: "No timeout",
+      cronExpression: "0 9 * * *",
+      message: "no timeout",
+      syntax: "cron",
+    });
+
+    // THEN the stored timeout is null (the runner falls back to the default)
+    expect(job.timeoutMs).toBeNull();
+    expect(getSchedule(job.id)!.timeoutMs).toBeNull();
+  });
+
+  test("persists a timeoutMs override through create/read", () => {
+    // GIVEN a script schedule created with a custom timeout
+    const job = createSchedule({
+      name: "Slow script",
+      cronExpression: "0 9 * * *",
+      message: "",
+      script: "sleep 5",
+      mode: "script",
+      syntax: "cron",
+      timeoutMs: 120_000,
+    });
+
+    // THEN the override round-trips through the store
+    expect(job.timeoutMs).toBe(120_000);
+    expect(getSchedule(job.id)!.timeoutMs).toBe(120_000);
+  });
+
+  test("updateSchedule sets and clears the timeout override", () => {
+    // GIVEN a schedule with a custom timeout
+    const job = createSchedule({
+      name: "Adjust timeout",
+      cronExpression: "0 9 * * *",
+      message: "",
+      script: "echo hi",
+      mode: "script",
+      syntax: "cron",
+      timeoutMs: 90_000,
+    });
+
+    // WHEN the timeout is changed
+    const updated = updateSchedule(job.id, { timeoutMs: 5_000 });
+
+    // THEN the new value is stored
+    expect(updated!.timeoutMs).toBe(5_000);
+
+    // AND WHEN the timeout is cleared back to the default
+    const cleared = updateSchedule(job.id, { timeoutMs: null });
+
+    // THEN it reverts to null
+    expect(cleared!.timeoutMs).toBeNull();
+    expect(getSchedule(job.id)!.timeoutMs).toBeNull();
+  });
+});
+
 // ── listSchedules filters ───────────────────────────────────────────
 
 describe("listSchedules filters", () => {

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -316,6 +316,131 @@ describe("schedule_create with mode and routing", () => {
   });
 });
 
+// ── script timeout override ─────────────────────────────────────────
+
+describe("schedule_create / schedule_update timeout_ms", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("persists timeout_ms when creating a script schedule", async () => {
+    // GIVEN a script schedule created with a custom timeout
+    const result = await executeScheduleCreate(
+      {
+        name: "Slow job",
+        expression: "0 9 * * *",
+        message: "",
+        mode: "script",
+        script: "sleep 5",
+        timeout_ms: 120_000,
+      },
+      ctx,
+    );
+
+    // THEN the override is stored on the row
+    expect(result.isError).toBe(false);
+    const row = getRawDb()
+      .query("SELECT timeout_ms FROM cron_jobs LIMIT 1")
+      .get() as { timeout_ms: number | null };
+    expect(row.timeout_ms).toBe(120_000);
+  });
+
+  test("rejects an out-of-range timeout_ms on create", async () => {
+    // WHEN creating with a timeout below the minimum
+    const result = await executeScheduleCreate(
+      {
+        name: "Too short",
+        expression: "0 9 * * *",
+        message: "",
+        mode: "script",
+        script: "echo hi",
+        timeout_ms: 10,
+      },
+      ctx,
+    );
+
+    // THEN the tool returns a validation error and stores nothing
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("timeout_ms must be between");
+    const count = getRawDb()
+      .query("SELECT COUNT(*) AS n FROM cron_jobs")
+      .get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  test("updates and clears timeout_ms", async () => {
+    // GIVEN an existing script schedule
+    await executeScheduleCreate(
+      {
+        name: "Adjustable",
+        expression: "0 9 * * *",
+        message: "",
+        mode: "script",
+        script: "echo hi",
+        timeout_ms: 90_000,
+      },
+      ctx,
+    );
+    const { id } = getRawDb()
+      .query("SELECT id FROM cron_jobs LIMIT 1")
+      .get() as { id: string };
+
+    // WHEN the timeout is updated
+    const updated = await executeScheduleUpdate(
+      { job_id: id, timeout_ms: 5_000 },
+      ctx,
+    );
+
+    // THEN the new value is stored
+    expect(updated.isError).toBe(false);
+    const afterUpdate = getRawDb()
+      .query("SELECT timeout_ms FROM cron_jobs WHERE id = ?")
+      .get(id) as { timeout_ms: number | null };
+    expect(afterUpdate.timeout_ms).toBe(5_000);
+
+    // AND WHEN the timeout is cleared with null
+    const cleared = await executeScheduleUpdate(
+      { job_id: id, timeout_ms: null },
+      ctx,
+    );
+
+    // THEN the override reverts to null
+    expect(cleared.isError).toBe(false);
+    const afterClear = getRawDb()
+      .query("SELECT timeout_ms FROM cron_jobs WHERE id = ?")
+      .get(id) as { timeout_ms: number | null };
+    expect(afterClear.timeout_ms).toBeNull();
+  });
+
+  test("rejects an out-of-range timeout_ms on update", async () => {
+    // GIVEN an existing script schedule
+    await executeScheduleCreate(
+      {
+        name: "Guarded",
+        expression: "0 9 * * *",
+        message: "",
+        mode: "script",
+        script: "echo hi",
+      },
+      ctx,
+    );
+    const { id } = getRawDb()
+      .query("SELECT id FROM cron_jobs LIMIT 1")
+      .get() as { id: string };
+
+    // WHEN updating with a timeout above the maximum
+    const result = await executeScheduleUpdate(
+      { job_id: id, timeout_ms: 60 * 60 * 1000 },
+      ctx,
+    );
+
+    // THEN the tool returns a validation error
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("timeout_ms must be between");
+  });
+});
+
 // ── schedule_list ───────────────────────────────────────────────────
 
 describe("schedule_list tool", () => {

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -94,7 +94,7 @@ The `mode` parameter controls what happens when a schedule fires:
 
 - **execute** (default) - sends the schedule's message to a background assistant conversation for autonomous handling. The assistant processes the message as if the user sent it.
 - **notify** - sends a notification to the user via the notification pipeline. No assistant processing occurs.
-- **script** - runs the `script` field as a shell command directly. No LLM invoked, no conversation created. stdout/stderr are captured in the schedule run record. Exit code 0 = success, non-zero = error. Commands run in the workspace directory with a 60-second timeout.
+- **script** - runs the `script` field as a shell command directly. No LLM invoked, no conversation created. stdout/stderr are captured in the schedule run record. Exit code 0 = success, non-zero = error. Commands run in the workspace directory with a 60-second timeout by default. Override the timeout per schedule with `timeout_ms` (range 1000–1800000 ms) when a script needs more or less time; pass `timeout_ms: null` on update to revert to the default. The guardian can also adjust this from the /assistant/settings/schedules page.
 
 Use `notify` for simple reminders ("remind me to take medicine at 9am"), `execute` for tasks that need assistant action ("check my calendar at 8am and send me a digest"), and `script` for lightweight shell automations that don't need LLM involvement ("refresh a cache", "poll an API", "rotate logs").
 

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -71,6 +71,10 @@
           "retry_backoff_ms": {
             "type": "integer",
             "description": "Base backoff delay in milliseconds between retries. Exponential backoff is applied. Defaults to 60000."
+          },
+          "timeout_ms": {
+            "type": "integer",
+            "description": "For script mode: maximum time in milliseconds the shell command may run before it is killed. Defaults to 60000 (60s). Allowed range: 1000 to 1800000."
           }
         },
         "required": ["name"]
@@ -170,6 +174,10 @@
           "retry_backoff_ms": {
             "type": "integer",
             "description": "Base backoff delay in milliseconds between retries. Exponential backoff is applied. Defaults to 60000."
+          },
+          "timeout_ms": {
+            "type": ["integer", "null"],
+            "description": "For script mode: maximum time in milliseconds the shell command may run before it is killed (default 60000, range 1000 to 1800000). Pass null to clear a custom timeout and revert to the default."
           }
         },
         "required": ["job_id"]

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -186,6 +186,7 @@ import {
   migrateScheduleRetryPolicy,
   migrateScheduleReuseConversation,
   migrateScheduleScriptColumn,
+  migrateScheduleScriptTimeout,
   migrateScheduleWakeConversationId,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
@@ -470,6 +471,7 @@ export function initializeDb(): void {
     migrateMessagesClientMessageId,
     migrateLlmUsageEventsAddAssistantVersion,
     migrateAddMemoryV3Selections,
+    migrateScheduleScriptTimeout,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/269-schedule-script-timeout.ts
+++ b/assistant/src/memory/migrations/269-schedule-script-timeout.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleScriptTimeout(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN timeout_ms INTEGER`);
+  } catch {
+    /* Column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -255,6 +255,7 @@ export { migrateDropProviderConnectionStatus } from "./265-drop-provider-connect
 export { migrateMessagesClientMessageId } from "./266-messages-client-message-id.js";
 export { migrateLlmUsageEventsAddAssistantVersion } from "./267-llm-usage-events-add-assistant-version.js";
 export { migrateAddMemoryV3Selections } from "./268-add-memory-v3-selections.js";
+export { migrateScheduleScriptTimeout } from "./269-schedule-script-timeout.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -21,6 +21,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
   retryCount: integer("retry_count").notNull().default(0),
   maxRetries: integer("max_retries").notNull().default(3),
   retryBackoffMs: integer("retry_backoff_ms").notNull().default(60000),
+  timeoutMs: integer("timeout_ms"), // script-mode execution timeout override (ms); null = use default
   createdBy: text("created_by").notNull(), // 'agent' | 'user'
   mode: text("mode").notNull().default("execute"), // 'notify' | 'execute'
   routingIntent: text("routing_intent").notNull().default("all_channels"), // 'single_channel' | 'multi_channel' | 'all_channels'

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -392,7 +392,7 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "schedules/:id",
     method: "PATCH",
     policy: {
-      requiredScopes: ["settings.read"],
+      requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Update schedule",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -12,7 +12,10 @@ import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
 import { getConversation } from "../../memory/conversation-crud.js";
 import { normalizeScheduleSyntax } from "../../schedule/recurrence-types.js";
-import { runScript } from "../../schedule/run-script.js";
+import {
+  runScript,
+  validateScriptTimeoutMs,
+} from "../../schedule/run-script.js";
 import {
   cancelSchedule,
   completeScheduleRun,
@@ -60,6 +63,7 @@ function handleListSchedules(queryParams: Record<string, string>) {
       retryCount: j.retryCount,
       maxRetries: j.maxRetries,
       retryBackoffMs: j.retryBackoffMs,
+      timeoutMs: j.timeoutMs,
       description:
         j.syntax === "cron"
           ? describeCronExpression(j.cronExpression)
@@ -195,10 +199,19 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     "wakeConversationId",
     "maxRetries",
     "retryBackoffMs",
+    "timeoutMs",
   ] as const) {
     if (key in body) {
       updates[key] = body[key];
     }
+  }
+
+  if (updates.timeoutMs != null) {
+    if (typeof updates.timeoutMs !== "number") {
+      throw new BadRequestError("timeoutMs must be a number or null");
+    }
+    const timeoutError = validateScriptTimeoutMs(updates.timeoutMs);
+    if (timeoutError) throw new BadRequestError(timeoutError);
   }
 
   try {
@@ -399,6 +412,10 @@ export const ROUTES: RouteDefinition[] = [
       reuseConversation: z.boolean(),
       maxRetries: z.number().describe("Maximum retry attempts"),
       retryBackoffMs: z.number().describe("Retry backoff in milliseconds"),
+      timeoutMs: z
+        .number()
+        .nullable()
+        .describe("Script-mode execution timeout in ms; null = use default"),
     }),
     responseBody: z.object({
       schedules: z.array(z.unknown()).describe("Updated schedule list"),
@@ -459,7 +476,9 @@ async function handleRunScheduleNow(id: string) {
         { jobId: schedule.id, name: schedule.name },
         "Executing script schedule manually (run now)",
       );
-      const result = await runScript(schedule.script);
+      const result = await runScript(schedule.script, {
+        timeoutMs: schedule.timeoutMs ?? undefined,
+      });
       completeScheduleRun(runId, {
         status: result.exitCode === 0 ? "ok" : "error",
         output: result.stdout || undefined,

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -6,8 +6,16 @@ const log = getLogger("run-script");
 
 /** Maximum combined stdout + stderr captured (bytes). */
 const MAX_OUTPUT_BYTES = 10_000;
-/** Default timeout for script execution (ms). */
-const DEFAULT_TIMEOUT_MS = 60_000;
+/** Default timeout for script execution (ms) when a schedule sets no override. */
+export const DEFAULT_TIMEOUT_MS = 60_000;
+/** Smallest script timeout override a caller may set (ms). */
+export const MIN_SCRIPT_TIMEOUT_MS = 1_000;
+/**
+ * Largest script timeout override a caller may set (ms). Capped so a wedged
+ * script cannot block the scheduler tick indefinitely; mirrors the talk-mode
+ * budget in scheduler.ts.
+ */
+export const MAX_SCRIPT_TIMEOUT_MS = 30 * 60 * 1000;
 
 export interface ScriptResult {
   exitCode: number;
@@ -75,7 +83,9 @@ export async function runScript(
     ]);
     const stdout = truncate(stdoutStr);
     const timeoutMsg = `Script timed out after ${timeoutMs}ms`;
-    const stderr = truncate(stderrStr ? `${timeoutMsg}\n${stderrStr}` : timeoutMsg);
+    const stderr = truncate(
+      stderrStr ? `${timeoutMsg}\n${stderrStr}` : timeoutMsg,
+    );
     log.info(
       { command, timedOut: true, stdoutLen: stdout.length },
       "Script timed out",
@@ -97,4 +107,19 @@ export async function runScript(
 function truncate(text: string): string {
   if (text.length <= MAX_OUTPUT_BYTES) return text;
   return text.slice(0, MAX_OUTPUT_BYTES) + "\n... (truncated)";
+}
+
+/**
+ * Validate a caller-supplied script timeout override (ms). Returns an error
+ * message when the value is not a positive integer within the allowed bounds,
+ * or `null` when it is acceptable.
+ */
+export function validateScriptTimeoutMs(value: number): string | null {
+  if (!Number.isInteger(value)) {
+    return "timeout_ms must be an integer number of milliseconds";
+  }
+  if (value < MIN_SCRIPT_TIMEOUT_MS || value > MAX_SCRIPT_TIMEOUT_MS) {
+    return `timeout_ms must be between ${MIN_SCRIPT_TIMEOUT_MS} and ${MAX_SCRIPT_TIMEOUT_MS} (ms)`;
+  }
+  return null;
 }

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -47,6 +47,8 @@ export interface ScheduleJob {
   retryCount: number;
   maxRetries: number;
   retryBackoffMs: number;
+  /** Script-mode execution timeout override (ms); null = use the default. */
+  timeoutMs: number | null;
   createdBy: string;
   mode: ScheduleMode;
   routingIntent: RoutingIntent;
@@ -99,6 +101,7 @@ export function createSchedule(params: {
   reuseConversation?: boolean;
   maxRetries?: number;
   retryBackoffMs?: number;
+  timeoutMs?: number | null;
 }): ScheduleJob {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
@@ -134,6 +137,7 @@ export function createSchedule(params: {
   const reuseConversation = params.reuseConversation ?? !isOneShot;
   const maxRetries = params.maxRetries ?? 3;
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
+  const timeoutMs = params.timeoutMs ?? null;
 
   let nextRunAt: number;
   if (isOneShot) {
@@ -160,6 +164,7 @@ export function createSchedule(params: {
     retryCount: 0,
     maxRetries,
     retryBackoffMs,
+    timeoutMs,
     createdBy: params.createdBy ?? "agent",
     mode,
     routingIntent,
@@ -258,6 +263,7 @@ export function updateSchedule(
     wakeConversationId?: string | null;
     maxRetries?: number;
     retryBackoffMs?: number;
+    timeoutMs?: number | null;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -322,6 +328,7 @@ export function updateSchedule(
   if (updates.maxRetries !== undefined) set.maxRetries = updates.maxRetries;
   if (updates.retryBackoffMs !== undefined)
     set.retryBackoffMs = updates.retryBackoffMs;
+  if (updates.timeoutMs !== undefined) set.timeoutMs = updates.timeoutMs;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (
@@ -969,6 +976,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     retryCount: row.retryCount,
     maxRetries: row.maxRetries ?? 3,
     retryBackoffMs: row.retryBackoffMs ?? 60000,
+    timeoutMs: row.timeoutMs ?? null,
     createdBy: row.createdBy,
     mode: (row.mode ?? "execute") as ScheduleMode,
     routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -303,7 +303,9 @@ export async function runScheduleDueWorkOnce(
           { jobId: job.id, name: job.name, isOneShot },
           "Executing script schedule",
         );
-        const result: ScriptResult = await runScript(job.script);
+        const result: ScriptResult = await runScript(job.script, {
+          timeoutMs: job.timeoutMs ?? undefined,
+        });
         completeScheduleRun(runId, {
           status: result.exitCode === 0 ? "ok" : "error",
           output: result.stdout || undefined,

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -1,6 +1,7 @@
 import { formatIntegrationSummary } from "../../schedule/integration-status.js";
 import { validateRruleSetLines } from "../../schedule/recurrence-engine.js";
 import { normalizeScheduleSyntax } from "../../schedule/recurrence-types.js";
+import { validateScriptTimeoutMs } from "../../schedule/run-script.js";
 import type {
   RoutingIntent,
   ScheduleMode,
@@ -46,6 +47,14 @@ export async function executeScheduleCreate(
   const reuseConversation = input.reuse_conversation as boolean | undefined;
   const maxRetries = input.max_retries as number | undefined;
   const retryBackoffMs = input.retry_backoff_ms as number | undefined;
+  const timeoutMs = input.timeout_ms as number | undefined;
+
+  if (timeoutMs !== undefined) {
+    const timeoutError = validateScriptTimeoutMs(timeoutMs);
+    if (timeoutError) {
+      return { content: `Error: ${timeoutError}`, isError: true };
+    }
+  }
 
   if (!name || typeof name !== "string") {
     return {
@@ -134,6 +143,7 @@ export async function executeScheduleCreate(
         reuseConversation,
         maxRetries,
         retryBackoffMs,
+        timeoutMs,
       });
 
       const fireDate = formatLocalDate(job.nextRunAt);
@@ -214,6 +224,7 @@ export async function executeScheduleCreate(
       reuseConversation,
       maxRetries,
       retryBackoffMs,
+      timeoutMs,
     });
 
     const scheduleDescription =

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -4,6 +4,7 @@ import {
   normalizeScheduleSyntax,
   type ScheduleSyntax,
 } from "../../schedule/recurrence-types.js";
+import { validateScriptTimeoutMs } from "../../schedule/run-script.js";
 import type {
   RoutingIntent,
   ScheduleMode,
@@ -116,6 +117,20 @@ export async function executeScheduleUpdate(
     updates.retryBackoffMs = input.retry_backoff_ms;
   }
 
+  // Script execution timeout override (null clears it, reverting to default)
+  if (input.timeout_ms !== undefined) {
+    if (input.timeout_ms === null) {
+      updates.timeoutMs = null;
+    } else {
+      const timeoutMs = input.timeout_ms as number;
+      const timeoutError = validateScriptTimeoutMs(timeoutMs);
+      if (timeoutError) {
+        return { content: `Error: ${timeoutError}`, isError: true };
+      }
+      updates.timeoutMs = timeoutMs;
+    }
+  }
+
   // Auto-detect syntax when expression changes without explicit syntax
   if (input.expression !== undefined || input.syntax !== undefined) {
     const resolved = normalizeScheduleSyntax({
@@ -183,6 +198,7 @@ export async function executeScheduleUpdate(
         reuseConversation?: boolean;
         maxRetries?: number;
         retryBackoffMs?: number;
+        timeoutMs?: number | null;
       },
     );
 


### PR DESCRIPTION
Adds an optional per-schedule `timeout_ms` override for script-mode schedules so a script that needs more (or less) than the default 60s can run without changing the global default. The assistant can set it via `schedule_create`/`schedule_update` (range 1000–1800000 ms, `null` reverts to default), and the guardian can edit it inline from the /assistant/settings/schedules page; the column is nullable so existing schedules and older clients are unaffected.

---

- Requested by: @vargas@vellum.ai
- Session: https://app.devin.ai/sessions/8a0bf1d91bd5484c82c6101f4ec3e182

Requested by: @dvargas92495