### PR TITLE
refactor(api-events): drop redundant daemon re-exports for disk-pressure/document-editor events

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -21,7 +21,6 @@ export * from "./message-types/computer-use.js";
 export * from "./message-types/contacts.js";
 export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
-export * from "./message-types/disk-pressure.js";
 export * from "./message-types/document-comments.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
@@ -51,6 +50,7 @@ export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
+import type { DiskPressureStatusChangedEvent } from "../api/events/disk-pressure-status-changed.js";
 import type { _AcpServerMessages } from "./message-types/acp.js";
 import type {
   _AppsClientMessages,
@@ -77,7 +77,6 @@ import type {
   _DiagnosticsClientMessages,
   _DiagnosticsServerMessages,
 } from "./message-types/diagnostics.js";
-import type { _DiskPressureServerMessages } from "./message-types/disk-pressure.js";
 import type { _DocumentCommentsServerMessages } from "./message-types/document-comments.js";
 import type {
   _DocumentsClientMessages,
@@ -216,7 +215,7 @@ export type ServerMessage =
   | _UpgradesServerMessages
   | _AcpServerMessages
   | _BookmarksServerMessages
-  | _DiskPressureServerMessages
+  | DiskPressureStatusChangedEvent
   | SubagentEvent;
 
 // === Contract schema ===

--- a/assistant/src/daemon/message-types/disk-pressure.ts
+++ b/assistant/src/daemon/message-types/disk-pressure.ts
@@ -1,5 +1,0 @@
-import type { DiskPressureStatusChangedEvent } from "../../api/events/disk-pressure-status-changed.js";
-
-export type { DiskPressureStatusChangedEvent };
-
-export type _DiskPressureServerMessages = DiskPressureStatusChangedEvent;

--- a/assistant/src/daemon/message-types/documents.ts
+++ b/assistant/src/daemon/message-types/documents.ts
@@ -2,8 +2,6 @@
 
 import type { DocumentEditorUpdateEvent } from "../../api/events/document-editor-update.js";
 
-export type { DocumentEditorUpdateEvent };
-
 // === Server → Client ===
 
 export interface DocumentEditorShow {


### PR DESCRIPTION
Follow-up to #32731: removes the redundant daemon-side re-exports of the now-canonical `DiskPressureStatusChangedEvent` and `DocumentEditorUpdateEvent`. The `message-types/disk-pressure.ts` file held only a pass-through re-export and a one-member alias, so it's deleted and the `ServerMessage` union references the canonical event directly; `documents.ts` drops its redundant `export type { DocumentEditorUpdateEvent }` while keeping the direct import for its local union. No consumer imported these types through the daemon barrel, so this is a pure dead-code cleanup with no behavioral change.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/1e548ca652244faea565e4806a75dbc6