### PR TITLE
refactor(assistant): remove dead currentTurnToolNames state

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -193,7 +193,6 @@ export interface EventHandlerState {
   readonly toolContentBlockToolNames: Map<number, string>;
   readonly directiveWarnings: string[];
   readonly toolUseIdToName: Map<string, string>;
-  currentTurnToolNames: string[];
   /** Sticky for the whole run: this turn created/refreshed an app. */
   appBuildToolUsedThisRun: boolean;
   /** Tracks whether the first text delta has been emitted this turn for activity state transitions. */
@@ -299,7 +298,6 @@ export function createEventHandlerState(): EventHandlerState {
     toolContentBlockToolNames: new Map(),
     directiveWarnings: [],
     toolUseIdToName: new Map(),
-    currentTurnToolNames: [],
     appBuildToolUsedThisRun: false,
     firstTextDeltaEmitted: false,
     firstThinkingDeltaEmitted: false,
@@ -761,7 +759,6 @@ export function handleToolUse(
   event: Extract<AgentEvent, { type: "tool_use" }>,
 ): void {
   state.toolUseIdToName.set(event.id, event.name);
-  state.currentTurnToolNames.push(event.name);
   if (event.name === "app_create" || event.name === "app_refresh") {
     state.appBuildToolUsedThisRun = true;
   }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2273,8 +2273,6 @@ export async function runAgentLoopImpl(
     const onCheckpoint = async (
       checkpoint: CheckpointInfo,
     ): Promise<CheckpointDecision> => {
-      state.currentTurnToolNames = [];
-
       if (ctx.canHandoffAtCheckpoint()) {
         return "handoff";
       }


### PR DESCRIPTION
Removes the orchestrator's `currentTurnToolNames` array, which has been write-only since #26315 dropped the browser_* tools and their `onCheckpoint` browser-flow reader — it was initialized, pushed to, and reset every checkpoint but never read. Deleting it is a no-behavior-change cleanup that shrinks the orchestrator-side per-turn state, part of the loop-state re-homing sequence following #32725.

Link to Devin session: https://app.devin.ai/sessions/7c1b9633322c4bf284eb6ed8525ce389
Requested by: @dvargas92495