### PR TITLE
feat(web): add usePlatformGate hook and gate email/org on platform session

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -10,6 +10,7 @@ Read these before making changes:
 - **[`docs/STATE_MANAGEMENT.md`](./docs/STATE_MANAGEMENT.md)** — Zustand stores, atomic selectors, TanStack Query, the no-`useReducer` rule.
 - **[`docs/EVENT_BUS.md`](./docs/EVENT_BUS.md)** — Cross-domain push signals (SSE, app lifecycle, network). Single connection, typed events, no per-component `visibilitychange` handlers.
 - **[`docs/STYLE_GUIDE.md`](./docs/STYLE_GUIDE.md)** — Naming, imports, TypeScript, component authoring, formatting.
+- **[`docs/CONVENTIONS.md` — Platform gating](./docs/CONVENTIONS.md#platform-gating)** — The `usePlatformGate()` hook, the five user states (platform-hosted vs self-hosted × logged-in vs not), and when to gate/disable/hide platform-dependent UI surfaces.
 - **[`docs/CAPACITOR.md`](./docs/CAPACITOR.md)** — Capacitor / iOS patterns: lazy plugin imports, native auth, deep links, autogrowing textareas, streaming watchdogs, OS permission UI, capability detection, keyboard-only affordances. Mandatory reading if any code path you're touching might run inside the iOS WKWebView shell.
 - **[`docs/ELECTRON.md`](./docs/ELECTRON.md)** — Electron renderer patterns: `runtime/` wrapper modules for `window.vellum.*`, domain-owned bridge hooks, the three-file dance for new bridge surfaces. Read this if your change touches anything under `src/runtime/` that uses `window.vellum`.
 

--- a/apps/web/docs/CONVENTIONS.md
+++ b/apps/web/docs/CONVENTIONS.md
@@ -832,6 +832,69 @@ wrapping the SPA.
 
 ---
 
+## Platform gating
+
+The web app can run in three auth/hosting configurations that affect
+which UI surfaces are available:
+
+| Signal | Where | What it means |
+|--------|-------|---------------|
+| `isLocalMode()` | `src/lib/local-mode.ts` | `true` when `VITE_PLATFORM_MODE` is unset — the app is running against a local/self-hosted daemon, not the Vellum platform |
+| `hasPlatformSession` | `src/stores/auth-store.ts` | `true` when the user has a valid session with the Vellum platform (set asynchronously after probing the allauth session endpoint) |
+| `platformFeaturesInLocalMode` | feature flag store | Per-assistant flag (default `true`). When `false` in local mode, the API interceptor no-ops all platform client requests |
+
+### The five user states
+
+1. **Platform-hosted + logged in** — full access to everything
+2. **Platform-hosted + NOT logged in** — session expired; platform-dependent UI is *disabled* with a "log in" prompt
+3. **Self-hosted + platform features ON + logged in** — full access
+4. **Self-hosted + platform features ON + NOT logged in** — platform-dependent UI is *disabled*
+5. **Self-hosted + platform features OFF** — platform-dependent UI is *gated* (hidden entirely)
+
+### `usePlatformGate()` hook
+
+`src/hooks/use-platform-gate.ts` encapsulates the decision tree and
+returns one of three states:
+
+| Return value | Meaning | When |
+|-------------|---------|------|
+| `"full"` | Feature is fully functional | `hasPlatformSession` is `true` |
+| `"disabled"` | Show the UI but disable it (prompt re-login) | `hasPlatformSession` is `false`, platform features still enabled |
+| `"gated"` | Hide the UI entirely | Local mode AND `platformFeaturesInLocalMode` is `false` |
+
+Use this hook for any UI surface that depends on the Vellum platform
+API. The three actions map to concrete UI patterns:
+
+- **Full** — render normally.
+- **Disabled** — render the container/chrome but replace interactive
+  content with a `<Notice tone="info">` prompting platform login.
+  Disable platform API queries (`enabled: platformGate === "full"`).
+- **Gated** — don't render the component at all. If a parent container
+  (e.g. a settings card with a managed/your-own toggle) would be empty
+  without the gated content, render only the non-platform portion
+  without the toggle.
+
+### Daemon-owned endpoints routed through the platform proxy
+
+Many features use the platform API client but actually hit
+daemon-owned endpoints via `RuntimeProxyWildcardView` (the platform
+proxies `/v1/assistants/{id}/<path>` → daemon `/v1/<path>`). In local
+mode, the self-hosted ingress rewrite in `api-interceptors.ts` already
+reroutes these to the gateway directly — the
+`RUNTIME_PROXIED_FIRST_SEGMENTS` allowlist is skipped entirely in
+local mode. These features work in all five states with no gating
+needed. Examples: AI page (profiles, providers, models), Inspector,
+Home, Workspace, Contacts.
+
+### Organization store
+
+The organization store (`src/stores/organization-store.ts`) only
+fetches when `hasPlatformSession` is `true`. Organizations are a
+platform concept — in self-hosted mode the interceptor already strips
+the `Vellum-Organization-Id` header and uses bearer auth instead.
+
+---
+
 ## Testing
 
 - **Test framework:** [Bun's test runner](https://bun.sh/docs/test)

--- a/apps/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.test.tsx
@@ -22,6 +22,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
 import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import { useAuthStore } from "@/stores/auth-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 // The settings-card barrel re-exports toast surfaces; stub them so barrel
 // resolution doesn't pull the real toast module during the static render.
@@ -52,6 +53,7 @@ function makeSubscription(
 
 function renderCard(subscription: SubscriptionResponse): string {
   useAuthStore.setState({ hasPlatformSession: true });
+  useAssistantFeatureFlagStore.setState({ hasHydrated: true });
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });

--- a/apps/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.test.tsx
@@ -21,6 +21,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
 import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { useAuthStore } from "@/stores/auth-store";
 
 // The settings-card barrel re-exports toast surfaces; stub them so barrel
 // resolution doesn't pull the real toast module during the static render.
@@ -50,6 +51,7 @@ function makeSubscription(
 }
 
 function renderCard(subscription: SubscriptionResponse): string {
+  useAuthStore.setState({ hasPlatformSession: true });
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });

--- a/apps/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.test.tsx
@@ -21,8 +21,6 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
 import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
-import { useAuthStore } from "@/stores/auth-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 // The settings-card barrel re-exports toast surfaces; stub them so barrel
 // resolution doesn't pull the real toast module during the static render.
@@ -30,6 +28,13 @@ mock.module("@vellum/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },
   Toaster: () => null,
   ToastContent: () => null,
+}));
+
+// These tests exercise the subscription entitlement gate, not the platform
+// gate. Mock usePlatformGate to always return "full" so the managed email
+// form renders and the entitlement logic is reachable.
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => "full",
 }));
 
 const { EmailServiceCard } = await import("@/domains/settings/ai/ai-page");
@@ -52,8 +57,6 @@ function makeSubscription(
 }
 
 function renderCard(subscription: SubscriptionResponse): string {
-  useAuthStore.setState({ hasPlatformSession: true });
-  useAssistantFeatureFlagStore.setState({ hasHydrated: true });
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -75,6 +75,7 @@ import {
   visibleProfilesForPicker,
 } from "@/domains/settings/ai/profile-pickers";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { readSecret } from "@/domains/settings/ai/provider-connections-client";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 
@@ -940,8 +941,9 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
+  const platformGate = usePlatformGate();
   const [mode, setMode] = useState<ServiceMode>(
-    () => getLocalSetting(LS_EMAIL_MODE, "managed") as ServiceMode,
+    () => platformGate === "gated" ? "your-own" : getLocalSetting(LS_EMAIL_MODE, "managed") as ServiceMode,
   );
   const [byoProviderId, setByoProviderId] = useState<EmailByoProvider["id"]>(
     () =>
@@ -979,7 +981,7 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
   // anyway.
   const subscriptionQuery = useQuery({
     ...organizationsBillingSubscriptionRetrieveOptions(),
-    enabled: mode === "managed",
+    enabled: mode === "managed" && platformGate === "full",
   });
   const subscriptionData = subscriptionQuery.data;
   const entitlements = subscriptionData?.entitlements;
@@ -999,13 +1001,13 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     ...assistantsDomainsListOptions({
       path: { assistant_id: assistantId ?? "" },
     }),
-    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled,
+    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled && platformGate === "full",
   });
   const addressesQuery = useQuery({
     ...assistantsEmailAddressesListOptions({
       path: { assistant_id: assistantId ?? "" },
     }),
-    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled,
+    enabled: !!assistantId && mode === "managed" && !isExplicitlyNotEntitled && platformGate === "full",
   });
 
   const domain = domainsQuery.data?.results?.[0];
@@ -1016,7 +1018,7 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     ...assistantsEmailAddressesStatusRetrieveOptions({
       path: { assistant_id: assistantId ?? "", id: address?.id ?? "" },
     }),
-    enabled: !!assistantId && !!address?.id && mode === "managed",
+    enabled: !!assistantId && !!address?.id && mode === "managed" && platformGate === "full",
     refetchOnWindowFocus: false,
   });
 
@@ -1024,7 +1026,7 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     ...assistantsDomainsVerificationStatusRetrieveOptions({
       path: { assistant_id: assistantId ?? "", id: domain?.id ?? "" },
     }),
-    enabled: !!assistantId && !!domain?.id && mode === "managed",
+    enabled: !!assistantId && !!domain?.id && mode === "managed" && platformGate === "full",
     refetchInterval: (query) => {
       const st = query.state.data?.status;
       if (st === "verified" || st === "failed") return false;
@@ -1204,6 +1206,14 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     >
       {mode === "managed" ? (
         <div className="space-y-4">
+          {platformGate !== "full" ? (
+            <Notice tone="info">
+              {platformGate === "gated"
+                ? "Enable platform features to use managed email, or switch to Your Own."
+                : "Log in to the Vellum platform to manage email settings."}
+            </Notice>
+          ) : (
+          <>
           {subscriptionUnknown && (
             <Notice
               tone="warning"
@@ -1400,6 +1410,8 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
                 </p>
               )}
             </div>
+          )}
+          </>
           )}
         </div>
       ) : (

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -1196,6 +1196,70 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     [byoProviderId],
   );
 
+  const yourOwnContent = (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <label className="block text-body-small-default text-[var(--content-tertiary)]">
+          Provider
+        </label>
+        <Dropdown
+          value={byoProviderId}
+          onChange={(val) =>
+            setByoProviderId(val as EmailByoProvider["id"])
+          }
+          options={EMAIL_BYO_PROVIDERS.map((p) => ({
+            value: p.id,
+            label: p.displayName,
+          }))}
+        />
+      </div>
+
+      <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
+        <div className="flex flex-col gap-1">
+          <span>
+            Configure {selectedByoProvider.displayName} via the assistant
+            CLI: ask the assistant to run the{" "}
+            <code className="rounded bg-[var(--surface-active)] px-1 py-0.5 text-[12px]">
+              {selectedByoProvider.setupSkill}
+            </code>{" "}
+            skill. It walks you through storing the API key, detecting the
+            domain, and (optionally) wiring up an inbound webhook.
+          </span>
+          <a
+            href={selectedByoProvider.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
+          >
+            Open {selectedByoProvider.displayName}
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <SaveButton onClick={handleSaveMode} disabled={savingMode} />
+        {savingMode && (
+          <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
+        )}
+      </div>
+    </div>
+  );
+
+  if (platformGate === "gated") {
+    return (
+      <DetailCard
+        id="email"
+        title="Email"
+        subtitle="Configure how your assistant sends and receives email"
+      >
+        <div className="h-px bg-[var(--surface-active)]" />
+        <div className="mt-4">{yourOwnContent}</div>
+      </DetailCard>
+    );
+  }
+
   return (
     <ServiceCard
       id="email"
@@ -1206,11 +1270,9 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     >
       {mode === "managed" ? (
         <div className="space-y-4">
-          {platformGate !== "full" ? (
+          {platformGate === "disabled" ? (
             <Notice tone="info">
-              {platformGate === "gated"
-                ? "Enable platform features to use managed email, or switch to Your Own."
-                : "Log in to the Vellum platform to manage email settings."}
+              Log in to the Vellum platform to manage email settings.
             </Notice>
           ) : (
           <>
@@ -1414,56 +1476,7 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
           </>
           )}
         </div>
-      ) : (
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Provider
-            </label>
-            <Dropdown
-              value={byoProviderId}
-              onChange={(val) =>
-                setByoProviderId(val as EmailByoProvider["id"])
-              }
-              options={EMAIL_BYO_PROVIDERS.map((p) => ({
-                value: p.id,
-                label: p.displayName,
-              }))}
-            />
-          </div>
-
-          <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
-            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
-            <div className="flex flex-col gap-1">
-              <span>
-                Configure {selectedByoProvider.displayName} via the assistant
-                CLI: ask the assistant to run the{" "}
-                <code className="rounded bg-[var(--surface-active)] px-1 py-0.5 text-[12px]">
-                  {selectedByoProvider.setupSkill}
-                </code>{" "}
-                skill. It walks you through storing the API key, detecting the
-                domain, and (optionally) wiring up an inbound webhook.
-              </span>
-              <a
-                href={selectedByoProvider.docsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
-              >
-                Open {selectedByoProvider.displayName}
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <SaveButton onClick={handleSaveMode} disabled={savingMode} />
-            {savingMode && (
-              <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
-            )}
-          </div>
-        </div>
-      )}
+      ) : yourOwnContent}
     </ServiceCard>
   );
 }

--- a/apps/web/src/hooks/use-platform-gate.ts
+++ b/apps/web/src/hooks/use-platform-gate.ts
@@ -1,0 +1,17 @@
+import { useAuthStore } from "@/stores/auth-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { isLocalMode } from "@/lib/local-mode";
+
+export type PlatformGateState = "full" | "disabled" | "gated";
+
+export function usePlatformGate(): PlatformGateState {
+  const hasPlatformSession = useAuthStore.use.hasPlatformSession();
+  const platformFeaturesOff = useAssistantFeatureFlagStore(
+    (s) =>
+      (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
+  );
+
+  if (isLocalMode() && platformFeaturesOff) return "gated";
+  if (!hasPlatformSession) return "disabled";
+  return "full";
+}

--- a/apps/web/src/hooks/use-platform-gate.ts
+++ b/apps/web/src/hooks/use-platform-gate.ts
@@ -6,12 +6,16 @@ export type PlatformGateState = "full" | "disabled" | "gated";
 
 export function usePlatformGate(): PlatformGateState {
   const hasPlatformSession = useAuthStore.use.hasPlatformSession();
-  const platformFeaturesOff = useAssistantFeatureFlagStore(
-    (s) =>
-      (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
+  const { platformFeaturesOff, hasHydrated } = useAssistantFeatureFlagStore(
+    (s) => ({
+      platformFeaturesOff:
+        (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
+      hasHydrated: s.hasHydrated,
+    }),
   );
 
   if (isLocalMode() && platformFeaturesOff) return "gated";
+  if (isLocalMode() && !hasHydrated) return "disabled";
   if (!hasPlatformSession) return "disabled";
   return "full";
 }

--- a/apps/web/src/stores/organization-store.ts
+++ b/apps/web/src/stores/organization-store.ts
@@ -192,18 +192,21 @@ export function setupOrganizationStore(): () => void {
     }
   });
 
-  // 1. Auth transitions — login or user switch triggers org fetch.
+  // 1. Auth transitions — platform session triggers org fetch. Orgs are a
+  //    platform concept; skip the fetch when there's no platform session
+  //    (e.g. self-hosted/local mode with gateway-only auth).
   const unsubAuth = useAuthStore.subscribe((state, prevState) => {
     if (
-      state.isLoggedIn &&
-      (!prevState.isLoggedIn || state.user?.id !== prevState.user?.id)
+      state.hasPlatformSession &&
+      (!prevState.hasPlatformSession || state.user?.id !== prevState.user?.id)
     ) {
       useOrganizationStore.getState().fetchOrganizations();
     }
   });
 
-  // 2. App resume — refetch if stale.
+  // 2. App resume — refetch if stale and platform session is active.
   const refetchIfStale = () => {
+    if (!useAuthStore.getState().hasPlatformSession) return;
     const { status } = useOrganizationStore.getState();
     if (
       (status === "ready" || status === "error") &&


### PR DESCRIPTION
## Summary
- Adds a shared `usePlatformGate()` hook returning `"full" | "disabled" | "gated"` based on `hasPlatformSession` and `platformFeaturesInLocalMode` flag state
- Gates the AI page's managed email section: disables all platform queries and shows a contextual notice when no platform session or platform features are off
- Gates the organization store so it only fetches orgs when a platform session exists, preventing wasted requests in self-hosted/local mode

Part of the [Web UI Platform Decoupling](https://www.notion.so/3719035c57bd81ecba23eb1534c935a3) plan — implements the "Features Routed Through Platform Proxy" section.

## Test plan
- [ ] Verify managed email tab shows "Log in to the Vellum platform" notice when `hasPlatformSession` is false
- [ ] Verify managed email tab shows "Enable platform features" notice when platform features flag is off in local mode
- [ ] Verify "Your Own" email tab works in all states
- [ ] Verify org store doesn't fire `organizationsList()` in gateway-only auth mode
- [ ] Verify org store still fetches correctly in platform mode when session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)