### PR TITLE
docs(plugins): align plugins.md and experimental README intros + TL;DR

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -1,4 +1,4 @@
-# Plugin authoring guide
+# Plugins
 
 > **Note:** This guide documents the **legacy** plugin architecture — the
 > in-tree `register.ts` + middleware-pipeline system. We are converging on
@@ -10,16 +10,13 @@
 > differ is the next piece of consolidation work. New plugins should target
 > the modern schema.
 
-Plugins let you extend the assistant by hooking middleware into named
-runtime pipelines, contributing tools/routes/skills, and injecting
-system-prompt content. This guide is the authoritative reference for how
-plugins are structured, registered, and executed — everything the code
-actually enforces.
+Plugins extend the assistant's default capabilities using hooks, tools,
+skills, and more.
 
-For a worked minimal example, see
-[`assistant/examples/plugins/echo/`](../examples/plugins/echo/README.md).
-That plugin observes every pipeline and logs to stderr, and is the fastest
-way to see the system in action.
+If you're authoring a plugin against the current convention, this file is
+your map. Read [`examples/plugins/echo/`](../examples/plugins/echo/README.md)
+alongside, it's the canonical reference implementation and exercises every
+wired surface.
 
 ## Table of contents
 
@@ -44,9 +41,9 @@ way to see the system in action.
 ## TL;DR
 
 1. Create a directory `<workspaceDir>/plugins/my-plugin/`.
-2. Add a `register.ts` that builds a `Plugin` object and passes it to
+2. Give the manifest a `name` and `version`.
+3. Add a `register.ts` that builds a `Plugin` object and passes it to
    `registerPlugin()` as an import-time side effect.
-3. Give the manifest a `name` and `version`.
 4. Hang middleware, tools, routes, skills, or injectors off the `Plugin`
    object.
 5. Restart the assistant — the loader scans `<workspaceDir>/plugins/*` and

--- a/experimental/plugins/README.md
+++ b/experimental/plugins/README.md
@@ -1,20 +1,28 @@
 # Plugins
 
-Plugins extend the assistant's default capabilibilities using hooks, tools, skills, and more.
+Plugins extend the assistant's default capabilities using hooks, tools,
+skills, and more.
 
-If you're authoring a plugin against the current convention, this file
-is your map. Read [`simple-memory/`](./simple-memory/) alongside, it's
-the canonical reference implementation and exercises every wired
-surface.
+If you're authoring a plugin against the current convention, this file is
+your map. Read [`simple-memory/`](./simple-memory/) alongside, it's the
+canonical reference implementation and exercises every wired surface.
 
-> Note: This README is meant to be _human-readable_ and is meant to be reviewed by other contributors,
-> so that API conventions can be made intentionally.
+## Table of contents
+
+- [TL;DR](#tldr)
+- [What a plugin can contribute today](#what-a-plugin-can-contribute-today)
+- [Directory layout](#directory-layout)
+- [Manifest](#manifest--packagejson)
+- [Public API surface](#public-api-surface--vellumaiplugin-api)
+- [Hooks](#hooks)
+- [Tools](#tools)
+- [Conventions](#conventions)
 
 ---
 
 ## TL;DR
 
-1. Create a directory `<root>/my-plugin/`.
+1. Create a directory `<workspaceDir>/plugins/my-plugin/`.
 2. Drop a `package.json` with a `name` and a `peerDependencies["@vellumai/plugin-api"]` semver range.
 3. Add `hooks/<name>.ts` files (default export = hook function).
 4. Add `tools/<name>.ts` files (default export = tool definition).
@@ -256,12 +264,12 @@ export default {
 Every field on a plugin tool is optional — the loader fills documented
 defaults when an author omits a field:
 
-| Field              | Default                                                                |
-| ------------------ | ---------------------------------------------------------------------- |
-| `description`      | `""`                                                                   |
-| `defaultRiskLevel` | `"medium"` (prompt-then-allow on first invocation)                     |
-| `input_schema`     | `{ type: "object", properties: {}, additionalProperties: false }`      |
-| `execute`          | Returns an error result naming the tool as unimplemented                |
+| Field              | Default                                                           |
+| ------------------ | ----------------------------------------------------------------- |
+| `description`      | `""`                                                              |
+| `defaultRiskLevel` | `"medium"` (prompt-then-allow on first invocation)                |
+| `input_schema`     | `{ type: "object", properties: {}, additionalProperties: false }` |
+| `execute`          | Returns an error result naming the tool as unimplemented          |
 
 `export default {}` is therefore a valid (if useless) tool — broken
 individual tools never block plugin load; misconfigurations surface at


### PR DESCRIPTION
First consolidation pass to converge the legacy plugin guide (`assistant/docs/plugins.md`) and the modern schema (`experimental/plugins/README.md`) toward a shared shape, so remaining differences read as the next consolidation work.

---

- Requested by: @dvargasfuertes
- Session: https://app.devin.ai/sessions/59e1d9bfdd584bcb9571addbcd80a056

Requested by: @dvargas92495