### PR TITLE
feat(web): gate chat-adjacent platform features with usePlatformGate

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -22,6 +22,7 @@ import { LazyBoundary } from "@/components/lazy-boundary";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { useAuthStore } from "@/stores/auth-store";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { adminUrl, routes } from "@/utils/routes";
 import { ThemeToggle } from "@/components/theme-toggle";
 
@@ -125,6 +126,7 @@ function PreferencesMenuContent({
   const navigate = useNavigate();
   const logout = useAuthStore.use.logout();
   const user = useAuthStore.use.user();
+  const platformGate = usePlatformGate();
 
   return (
     <>
@@ -150,14 +152,16 @@ function PreferencesMenuContent({
         }}
       />
 
-      <PanelItem
-        icon={MessageSquareText}
-        label="Share Feedback"
-        onSelect={() => {
-          onClose();
-          onShareFeedback();
-        }}
-      />
+      {platformGate === "full" && (
+        <PanelItem
+          icon={MessageSquareText}
+          label="Share Feedback"
+          onSelect={() => {
+            onClose();
+            onShareFeedback();
+          }}
+        />
+      )}
 
       {user?.isStaff ? (
         <PanelItem

--- a/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -36,6 +36,7 @@ import { reportError } from "@/utils/error-report";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import { isPointerCoarse } from "@/utils/pointer";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { DoctorAvatar } from "@/domains/settings/components/panels/doctor-avatar";
 import {
   type ChatEntry,
@@ -468,6 +469,7 @@ export function DoctorPanel({
   const [pendingApproval, setPendingApproval] = useState(false);
   const [pendingBackup, setPendingBackup] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const platformGate = usePlatformGate();
   const [thinking, setThinking] = useState(false);
   const [selectedHistorySessionId, setSelectedHistorySessionId] = useState<
     string | null
@@ -1005,13 +1007,15 @@ export function DoctorPanel({
           >
             Beta
           </Tag>
-          <button
-            type="button"
-            onClick={() => setFeedbackOpen(true)}
-            className="cursor-pointer text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
-          >
-            Share Feedback
-          </button>
+          {platformGate === "full" && (
+            <button
+              type="button"
+              onClick={() => setFeedbackOpen(true)}
+              className="cursor-pointer text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
+            >
+              Share Feedback
+            </button>
+          )}
         </div>
 
         {isSessionActive && (

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -23,6 +23,7 @@ import {
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { isLocalMode } from "@/lib/local-mode";
 import {
   applyThemePreference,
@@ -137,6 +138,7 @@ export function GeneralPage() {
   const multiPlatformAssistant = useAssistantFeatureFlagStore.use.multiPlatformAssistant();
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
+  const platformGate = usePlatformGate();
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;
 
@@ -166,7 +168,7 @@ export function GeneralPage() {
         />
       </DetailCard>
 
-      {isLoggedIn && <ProfileCard assistant={platformAssistant} />}
+      {isLoggedIn && platformGate === "full" && <ProfileCard assistant={platformAssistant} />}
 
       {assistant && (
         <ResizeCard


### PR DESCRIPTION
## Summary
- Gate **ProfileCard** (handle editor + domain display) on `platformGate === "full"` in the General settings page — the entire card is hidden when the user lacks a platform session or platform features are off
- Gate **Share Feedback** menu item in the preferences menu and doctor panel — hidden when platform gate is not "full" since `feedbackCreate` is a platform-only API
- **Slack channel footer** confirmed as needing no changes (purely read-only, no platform API calls)

## Original prompt
Continuing the Web UI Platform Decoupling plan, the user asked to implement the "Chat-Adjacent Platform Features" section from the Notion doc. This section covers ProfileCard (handle editor, domain display), Share Feedback modal, and Slack channel footer. The goal is to apply the `usePlatformGate()` hook (built in the previous PR) to hide platform-dependent UI surfaces when the user doesn't have a platform session or has platform features disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)