### PR TITLE
docs(plugins): match TL;DR step 2 to experimental README + give each default plugin a package.json

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -41,7 +41,7 @@ wired surface.
 ## TL;DR
 
 1. Create a directory `<workspaceDir>/plugins/my-plugin/`.
-2. Give the manifest a `name` and `version`.
+2. Drop a `package.json` with a `name` and a `peerDependencies["@vellumai/plugin-api"]` semver range.
 3. Add a `register.ts` that builds a `Plugin` object and passes it to
    `registerPlugin()` as an import-time side effect.
 4. Hang middleware, tools, routes, skills, or injectors off the `Plugin`

--- a/assistant/src/__tests__/circuit-breaker-pipeline.test.ts
+++ b/assistant/src/__tests__/circuit-breaker-pipeline.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the `circuitBreaker` plugin pipeline.
  *
- * The default plugin (`plugins/defaults/circuit-breaker.ts`) replaces the
+ * The default plugin (`plugins/defaults/circuit-breaker/register.ts`) replaces the
  * inline compaction circuit-breaker logic that previously lived in
  * `daemon/conversation-agent-loop.ts`. These tests exercise the default
  * plugin through the pipeline runner and assert the threshold (3 consecutive
@@ -31,7 +31,7 @@ import {
   COMPACTION_CIRCUIT_COOLDOWN_MS,
   COMPACTION_CIRCUIT_FAILURE_THRESHOLD,
   defaultCircuitBreakerPlugin,
-} from "../plugins/defaults/circuit-breaker.js";
+} from "../plugins/defaults/circuit-breaker/register.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/compaction-pipeline.test.ts
+++ b/assistant/src/__tests__/compaction-pipeline.test.ts
@@ -20,7 +20,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   DEFAULT_COMPACTION_PLUGIN_NAME,
   defaultCompactionTerminal,
-} from "../plugins/defaults/compaction.js";
+} from "../plugins/defaults/compaction/register.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
   type CompactionArgs,

--- a/assistant/src/__tests__/compaction-timeout-recovery.test.ts
+++ b/assistant/src/__tests__/compaction-timeout-recovery.test.ts
@@ -27,7 +27,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   COMPACTION_CIRCUIT_FAILURE_THRESHOLD,
   defaultCircuitBreakerPlugin,
-} from "../plugins/defaults/circuit-breaker.js";
+} from "../plugins/defaults/circuit-breaker/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -65,7 +65,7 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import { parentAlias } from "../messaging/providers/slack/render-transcript.js";
-import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors/register.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { applyRuntimeInjections } from "../daemon/conversation-runtime-assembly.js";
-import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors/register.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,

--- a/assistant/src/__tests__/empty-response-pipeline.test.ts
+++ b/assistant/src/__tests__/empty-response-pipeline.test.ts
@@ -22,7 +22,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   defaultEmptyResponsePlugin,
   defaultEmptyResponseTerminal,
-} from "../plugins/defaults/empty-response.js";
+} from "../plugins/defaults/empty-response/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/history-repair-pipeline.test.ts
+++ b/assistant/src/__tests__/history-repair-pipeline.test.ts
@@ -24,7 +24,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   defaultHistoryRepairPlugin,
   defaultHistoryRepairTerminal,
-} from "../plugins/defaults/history-repair.js";
+} from "../plugins/defaults/history-repair/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/injector-background-turn.test.ts
+++ b/assistant/src/__tests__/injector-background-turn.test.ts
@@ -23,7 +23,7 @@ mock.module("../config/loader.js", () => ({
 import {
   DEFAULT_INJECTOR_ORDER,
   defaultInjectorsPlugin,
-} from "../plugins/defaults/injectors.js";
+} from "../plugins/defaults/injectors/register.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -45,7 +45,7 @@ mock.module("../config/loader.js", () => ({
 const { applyRuntimeInjections, composeInjectorChain } =
   await import("../daemon/conversation-runtime-assembly.js");
 const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
-  await import("../plugins/defaults/injectors.js");
+  await import("../plugins/defaults/injectors/register.js");
 import {
   getInjectors,
   registerPlugin,

--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_INJECTOR_ORDER,
   defaultInjectorsPlugin,
   DISK_PRESSURE_WARNING_PROMPT,
-} from "../plugins/defaults/injectors.js";
+} from "../plugins/defaults/injectors/register.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,

--- a/assistant/src/__tests__/injector-document-comments.test.ts
+++ b/assistant/src/__tests__/injector-document-comments.test.ts
@@ -9,7 +9,7 @@ mock.module("../documents/document-comments-store.js", () => ({
 }));
 
 const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
-  await import("../plugins/defaults/injectors.js");
+  await import("../plugins/defaults/injectors/register.js");
 import type { Injector, TurnContext } from "../plugins/types.js";
 
 function findInjector(name: string): Injector {

--- a/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
+++ b/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
@@ -30,7 +30,7 @@ mock.module("../memory/pkb/pkb-search.js", () => ({
 const { applyRuntimeInjections } =
   await import("../daemon/conversation-runtime-assembly.js");
 const { defaultInjectorsPlugin } =
-  await import("../plugins/defaults/injectors.js");
+  await import("../plugins/defaults/injectors/register.js");
 const { registerPlugin, resetPluginRegistryForTests } =
   await import("../plugins/registry.js");
 import type { TurnContext } from "../plugins/types.js";

--- a/assistant/src/__tests__/llm-call-pipeline.test.ts
+++ b/assistant/src/__tests__/llm-call-pipeline.test.ts
@@ -14,7 +14,7 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import type { TrustContext } from "../daemon/trust-context.js";
-import { defaultLlmCallPlugin } from "../plugins/defaults/llm-call.js";
+import { defaultLlmCallPlugin } from "../plugins/defaults/llm-call/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -29,7 +29,7 @@ import {
   type DefaultMemoryRetrievalDeps,
   defaultMemoryRetrievalPlugin,
   runDefaultMemoryRetrieval,
-} from "../plugins/defaults/memory-retrieval.js";
+} from "../plugins/defaults/memory-retrieval/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/memory-v2-static-injector.test.ts
+++ b/assistant/src/__tests__/memory-v2-static-injector.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors/register.js";
 import type { Injector, TurnContext } from "../plugins/types.js";
 
 function findInjector(name: string): Injector {

--- a/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
+++ b/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
@@ -36,7 +36,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   defaultOverflowReduceMiddleware,
   defaultOverflowReducePlugin,
-} from "../plugins/defaults/overflow-reduce.js";
+} from "../plugins/defaults/overflow-reduce/register.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/persistence-pipeline.test.ts
+++ b/assistant/src/__tests__/persistence-pipeline.test.ts
@@ -34,7 +34,7 @@ import { initializeDb } from "../memory/db-init.js";
 import {
   defaultPersistencePlugin,
   defaultPersistenceTerminal,
-} from "../plugins/defaults/persistence.js";
+} from "../plugins/defaults/persistence/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/title-generate-pipeline.test.ts
+++ b/assistant/src/__tests__/title-generate-pipeline.test.ts
@@ -36,7 +36,7 @@ mock.module("../memory/conversation-title-service.js", () => ({
   queueGenerateConversationTitle: queueGenerateConversationTitleMock,
 }));
 
-import { defaultTitleGenerateTerminal } from "../plugins/defaults/title-generate.js";
+import { defaultTitleGenerateTerminal } from "../plugins/defaults/title-generate/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/token-estimate-pipeline.test.ts
+++ b/assistant/src/__tests__/token-estimate-pipeline.test.ts
@@ -33,7 +33,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   defaultTokenEstimatePlugin,
   defaultTokenEstimateTerminal,
-} from "../plugins/defaults/token-estimate.js";
+} from "../plugins/defaults/token-estimate/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/tool-error-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-error-pipeline.test.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_TOOL_ERROR_NUDGE_TEXT,
   defaultToolErrorPlugin,
   defaultToolErrorTerminal,
-} from "../plugins/defaults/tool-error.js";
+} from "../plugins/defaults/tool-error/register.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/__tests__/tool-execute-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-execute-pipeline.test.ts
@@ -139,7 +139,7 @@ mock.module("../security/token-manager.js", () => ({
 
 // ── Imports — after mock.module so the executor under test picks them up ──
 import { PermissionPrompter } from "../permissions/prompter.js";
-import { defaultToolExecutePlugin } from "../plugins/defaults/tool-execute.js";
+import { defaultToolExecutePlugin } from "../plugins/defaults/tool-execute/register.js";
 import {
   getMiddlewaresFor,
   registerPlugin,

--- a/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
@@ -27,7 +27,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import {
   defaultToolResultTruncatePlugin,
   defaultToolResultTruncateTerminal,
-} from "../plugins/defaults/tool-result-truncate.js";
+} from "../plugins/defaults/tool-result-truncate/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -8,9 +8,9 @@ import {
 } from "../context/token-estimator.js";
 import { calculateMaxToolResultChars } from "../context/tool-result-truncation.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
-import { defaultEmptyResponseTerminal } from "../plugins/defaults/empty-response.js";
-import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error.js";
-import { defaultToolResultTruncateTerminal } from "../plugins/defaults/tool-result-truncate.js";
+import { defaultEmptyResponseTerminal } from "../plugins/defaults/empty-response/register.js";
+import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error/register.js";
+import { defaultToolResultTruncateTerminal } from "../plugins/defaults/tool-result-truncate/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {
@@ -1020,7 +1020,7 @@ export class AgentLoop {
         // The actual decision (nudge vs. accept vs. error) is delegated to
         // the `emptyResponse` plugin pipeline. The pipeline returns a
         // decision; the loop carries out the side-effect (pushing the nudge
-        // or surfacing the error). See `plugins/defaults/empty-response.ts`
+        // or surfacing the error). See `plugins/defaults/empty-response/register.ts`
         // for the default decision logic.
         const hasVisibleText = response.content.some(
           (block) => block.type === "text" && block.text.trim().length > 0,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -41,7 +41,7 @@ import {
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
-import { defaultPersistenceTerminal } from "../plugins/defaults/persistence.js";
+import { defaultPersistenceTerminal } from "../plugins/defaults/persistence/register.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -96,17 +96,17 @@ import {
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type { UserPromptSubmitContext } from "../plugin-api/types.js";
-import { defaultCompactionTerminal } from "../plugins/defaults/compaction.js";
-import { defaultHistoryRepairTerminal } from "../plugins/defaults/history-repair.js";
+import { defaultCompactionTerminal } from "../plugins/defaults/compaction/register.js";
+import { defaultHistoryRepairTerminal } from "../plugins/defaults/history-repair/register.js";
 import {
   asDefaultGraphPayload,
   type DefaultMemoryRetrievalDeps,
   type GraphMemoryPayload,
   runDefaultMemoryRetrieval,
-} from "../plugins/defaults/memory-retrieval.js";
-import { defaultPersistenceTerminal } from "../plugins/defaults/persistence.js";
-import { defaultTitleGenerateTerminal } from "../plugins/defaults/title-generate.js";
-import { defaultTokenEstimateTerminal } from "../plugins/defaults/token-estimate.js";
+} from "../plugins/defaults/memory-retrieval/register.js";
+import { defaultPersistenceTerminal } from "../plugins/defaults/persistence/register.js";
+import { defaultTitleGenerateTerminal } from "../plugins/defaults/title-generate/register.js";
+import { defaultTokenEstimateTerminal } from "../plugins/defaults/token-estimate/register.js";
 import { DEFAULT_TIMEOUTS, runHook, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {
@@ -290,7 +290,7 @@ function formatDiskPressureBlockedMessage(): string {
 //
 // The circuit-breaker behavior (3 consecutive summary-LLM failures trips a
 // 1-hour cooldown) is now implemented by the `circuitBreaker` plugin
-// pipeline. The default plugin (`plugins/defaults/circuit-breaker.ts`)
+// pipeline. The default plugin (`plugins/defaults/circuit-breaker/register.ts`)
 // replicates the legacy threshold/cooldown constants and event-emission
 // semantics exactly — it operates on the `consecutiveCompactionFailures` /
 // `compactionCircuitOpenUntil` fields the conversation still owns so the
@@ -413,7 +413,7 @@ async function isCompactionCircuitOpen(ctx: {
  * paths don't silently reset the 3-strike counter.
  *
  * The default plugin handles threshold-based tripping and cooldown reset;
- * see `plugins/defaults/circuit-breaker.ts` for the canonical semantics.
+ * see `plugins/defaults/circuit-breaker/register.ts` for the canonical semantics.
  */
 export async function trackCompactionOutcome(
   ctx: {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -490,7 +490,7 @@ export function buildSubagentStatusBlock(
 }
 
 // The `<active_subagents>` block is emitted by the `subagent-status` default
-// injector (`plugins/defaults/injectors.ts`) as an `append-user-tail`
+// injector (`plugins/defaults/injectors/register.ts`) as an `append-user-tail`
 // placement. Use {@link applyRuntimeInjections} with
 // `options.subagentStatusBlock` set, or drive the injector chain directly
 // via `collectInjectorBlocks`.
@@ -533,7 +533,7 @@ export function readNowScratchpad(): string | null {
 
 /**
  * The `<NOW.md>` block is emitted by the `now-md` default injector
- * (`plugins/defaults/injectors.ts`) as an `after-memory-prefix` placement.
+ * (`plugins/defaults/injectors/register.ts`) as an `after-memory-prefix` placement.
  * Use {@link applyRuntimeInjections} with `options.nowScratchpad` set.
  */
 

--- a/assistant/src/plugins/defaults/circuit-breaker/package.json
+++ b/assistant/src/plugins/defaults/circuit-breaker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-circuit-breaker",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in circuit-breaker pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/circuit-breaker/register.ts
+++ b/assistant/src/plugins/defaults/circuit-breaker/register.ts
@@ -32,8 +32,9 @@
  * container; the key is attached to the log record via the pipeline runner.
  */
 
-import { registerPlugin } from "../registry.js";
-import { type Plugin, PluginExecutionError } from "../types.js";
+import { registerPlugin } from "../../registry.js";
+import { type Plugin, PluginExecutionError } from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Consecutive failures required to trip the breaker. Matches the legacy
@@ -53,8 +54,8 @@ export const COMPACTION_CIRCUIT_COOLDOWN_MS = 60 * 60 * 1000;
  */
 export const defaultCircuitBreakerPlugin: Plugin = {
   manifest: {
-    name: "default-circuit-breaker",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
 
   middleware: {

--- a/assistant/src/plugins/defaults/compaction/package.json
+++ b/assistant/src/plugins/defaults/compaction/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-compaction",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in compaction pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/compaction/register.ts
+++ b/assistant/src/plugins/defaults/compaction/register.ts
@@ -2,11 +2,11 @@
  * Default `compaction` plugin.
  *
  * Delegates to the orchestrator's existing
- * {@link import("../../context/window-manager.js").ContextWindowManager}
+ * {@link import("../../../context/window-manager.js").ContextWindowManager}
  * instance. No behavior change relative to the pre-plugin call site — the
  * plugin only exists so custom plugins registered in later PRs can observe
  * arguments, short-circuit to a different summary, or post-process the
- * {@link import("../../context/window-manager.js").ContextWindowResult}
+ * {@link import("../../../context/window-manager.js").ContextWindowResult}
  * before the orchestrator consumes it.
  *
  * Lookup: the default middleware reads `ctx.contextWindowManager` from the
@@ -23,9 +23,9 @@ import type {
   ContextWindowCompactOptions,
   ContextWindowManager,
   ContextWindowResult,
-} from "../../context/window-manager.js";
-import type { Message } from "../../providers/types.js";
-import { registerPlugin } from "../registry.js";
+} from "../../../context/window-manager.js";
+import type { Message } from "../../../providers/types.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type CompactionArgs,
   type CompactionResult,
@@ -33,7 +33,8 @@ import {
   type Plugin,
   PluginExecutionError,
   type TurnContext,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Name under which the default plugin registers. Exposed so tests and later
@@ -110,8 +111,8 @@ const defaultCompactionMiddleware: Middleware<
  */
 export const defaultCompactionPlugin: Plugin = {
   manifest: {
-    name: DEFAULT_COMPACTION_PLUGIN_NAME,
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     compaction: defaultCompactionMiddleware,

--- a/assistant/src/plugins/defaults/empty-response/package.json
+++ b/assistant/src/plugins/defaults/empty-response/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-empty-response",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in empty-response pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/empty-response/register.ts
+++ b/assistant/src/plugins/defaults/empty-response/register.ts
@@ -39,14 +39,15 @@
  * declared in one place only.
  */
 
-import { registerPlugin } from "../registry.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type EmptyResponseArgs,
   type EmptyResponseResult,
   type Middleware,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Canonical nudge text. Must stay verbatim so a plugin that wraps the
@@ -93,8 +94,8 @@ const passthrough: Middleware<EmptyResponseArgs, EmptyResponseResult> = async (
 /** Singleton plugin — the registry rejects duplicate registrations by name. */
 export const defaultEmptyResponsePlugin: Plugin = {
   manifest: {
-    name: "default-empty-response",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     emptyResponse: passthrough,

--- a/assistant/src/plugins/defaults/history-repair/package.json
+++ b/assistant/src/plugins/defaults/history-repair/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-history-repair",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in history-repair pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/history-repair/register.ts
+++ b/assistant/src/plugins/defaults/history-repair/register.ts
@@ -23,15 +23,16 @@
  * in `daemon/conversation-agent-loop.ts`.
  */
 
-import { repairHistory } from "../../daemon/history-repair.js";
-import { registerPlugin } from "../registry.js";
+import { repairHistory } from "../../../daemon/history-repair.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type HistoryRepairArgs,
   type HistoryRepairResult,
   type Middleware,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Terminal handler for the `historyRepair` pipeline. Exported so tests can
@@ -52,8 +53,8 @@ const passthrough: Middleware<HistoryRepairArgs, HistoryRepairResult> = async (
 
 export const defaultHistoryRepairPlugin: Plugin = {
   manifest: {
-    name: "default-history-repair",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     historyRepair: passthrough,

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -13,34 +13,34 @@
  *   production-parity state (e.g. `conversation-agent-loop.test.ts`); those
  *   call {@link resetPluginRegistryAndRegisterDefaults}.
  *
- * Each `defaults/<name>.ts` module self-registers at module load via a local
+ * Each `defaults/<name>/register.ts` module self-registers at module load via a local
  * side effect. Importing this aggregator (or any individual default file)
  * populates the registry — the self-registration is idempotent, and so are
  * {@link registerDefaultPlugins} and {@link resetPluginRegistryAndRegisterDefaults}.
  * Per-file self-registration is what keeps registration attached to each
  * file's own already-initialized plugin identifier, so importing
  * `defaults/index.ts` mid-cycle (e.g. through the
- * `memory-retrieval.ts` → … → `pipeline.ts` → `defaults/index.ts`
+ * `memory-retrieval/register.ts` → … → `pipeline.ts` → `defaults/index.ts`
  * chain) does not trip a TDZ.
  */
 
 import { memoryV3ShadowPlugin } from "../../memory/v3/shadow-plugin.js";
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
 import { type Plugin, PluginExecutionError } from "../types.js";
-import { defaultCircuitBreakerPlugin } from "./circuit-breaker.js";
-import { defaultCompactionPlugin } from "./compaction.js";
-import { defaultEmptyResponsePlugin } from "./empty-response.js";
-import { defaultHistoryRepairPlugin } from "./history-repair.js";
-import { defaultInjectorsPlugin } from "./injectors.js";
-import { defaultLlmCallPlugin } from "./llm-call.js";
-import { defaultMemoryRetrievalPlugin } from "./memory-retrieval.js";
-import { defaultOverflowReducePlugin } from "./overflow-reduce.js";
-import { defaultPersistencePlugin } from "./persistence.js";
-import { defaultTitleGeneratePlugin } from "./title-generate.js";
-import { defaultTokenEstimatePlugin } from "./token-estimate.js";
-import { defaultToolErrorPlugin } from "./tool-error.js";
-import { defaultToolExecutePlugin } from "./tool-execute.js";
-import { defaultToolResultTruncatePlugin } from "./tool-result-truncate.js";
+import { defaultCircuitBreakerPlugin } from "./circuit-breaker/register.js";
+import { defaultCompactionPlugin } from "./compaction/register.js";
+import { defaultEmptyResponsePlugin } from "./empty-response/register.js";
+import { defaultHistoryRepairPlugin } from "./history-repair/register.js";
+import { defaultInjectorsPlugin } from "./injectors/register.js";
+import { defaultLlmCallPlugin } from "./llm-call/register.js";
+import { defaultMemoryRetrievalPlugin } from "./memory-retrieval/register.js";
+import { defaultOverflowReducePlugin } from "./overflow-reduce/register.js";
+import { defaultPersistencePlugin } from "./persistence/register.js";
+import { defaultTitleGeneratePlugin } from "./title-generate/register.js";
+import { defaultTokenEstimatePlugin } from "./token-estimate/register.js";
+import { defaultToolErrorPlugin } from "./tool-error/register.js";
+import { defaultToolExecutePlugin } from "./tool-execute/register.js";
+import { defaultToolResultTruncatePlugin } from "./tool-result-truncate/register.js";
 
 /**
  * Full set of first-party default plugins. Used by

--- a/assistant/src/plugins/defaults/injectors/package.json
+++ b/assistant/src/plugins/defaults/injectors/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-injectors",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in injectors pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/injectors/register.ts
+++ b/assistant/src/plugins/defaults/injectors/register.ts
@@ -48,13 +48,13 @@
 
 import { resolve } from "node:path";
 
-import { getConfig } from "../../config/loader.js";
-import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
-import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
-import { listComments } from "../../documents/document-comments-store.js";
-import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
-import { getLogger } from "../../util/logger.js";
-import { registerPlugin } from "../registry.js";
+import { getConfig } from "../../../config/loader.js";
+import { getInContextPkbPaths } from "../../../daemon/pkb-context-tracker.js";
+import { buildPkbReminder } from "../../../daemon/pkb-reminder-builder.js";
+import { listComments } from "../../../documents/document-comments-store.js";
+import { searchPkbFiles } from "../../../memory/pkb/pkb-search.js";
+import { getLogger } from "../../../util/logger.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type InjectionBlock,
   type Injector,
@@ -62,7 +62,8 @@ import {
   PluginExecutionError,
   type TurnContext,
   type TurnInjectionInputs,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 const pkbReminderLog = getLogger("pkb-reminder");
 
@@ -686,8 +687,8 @@ const threadFocusInjector: Injector = {
  */
 export const defaultInjectorsPlugin: Plugin = {
   manifest: {
-    name: "default-injectors",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   injectors: [
     diskPressureWarningInjector,

--- a/assistant/src/plugins/defaults/llm-call/package.json
+++ b/assistant/src/plugins/defaults/llm-call/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-llm-call",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in llm-call pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/llm-call/register.ts
+++ b/assistant/src/plugins/defaults/llm-call/register.ts
@@ -20,13 +20,14 @@
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 15).
  */
 
-import { registerPlugin } from "../registry.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type LLMCallArgs,
   type LLMCallResult,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * The default LLM-call plugin. Its `llmCall` middleware is a passthrough that
@@ -40,8 +41,8 @@ import {
  */
 export const defaultLlmCallPlugin: Plugin = {
   manifest: {
-    name: "default-llm-call",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     llmCall: async function defaultLlmCall(

--- a/assistant/src/plugins/defaults/memory-retrieval/package.json
+++ b/assistant/src/plugins/defaults/memory-retrieval/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-memory-retrieval",
+  "version": "0.0.1",
+  "description": "First-party default plugin wrapping the assistant's built-in memory-retrieval pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/memory-retrieval/register.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/register.ts
@@ -24,22 +24,23 @@
  * milestone.
  */
 
-import type { AssistantConfig } from "../../config/schema.js";
+import type { AssistantConfig } from "../../../config/schema.js";
 import {
   readNowScratchpad,
   readPkbContext,
-} from "../../daemon/conversation-runtime-assembly.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
-import type { ConversationGraphMemory } from "../../memory/graph/conversation-graph-memory.js";
-import type { Message } from "../../providers/types.js";
-import { registerPlugin } from "../registry.js";
+} from "../../../daemon/conversation-runtime-assembly.js";
+import type { ServerMessage } from "../../../daemon/message-protocol.js";
+import type { ConversationGraphMemory } from "../../../memory/graph/conversation-graph-memory.js";
+import type { Message } from "../../../providers/types.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type MemoryArgs,
   type MemoryResult,
   type Middleware,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Discriminator the agent loop uses to narrow `MemoryResult.memoryGraphBlocks`
@@ -188,8 +189,8 @@ const defaultMemoryRetrievalMiddleware: Middleware<MemoryArgs, MemoryResult> =
  */
 export const defaultMemoryRetrievalPlugin: Plugin = {
   manifest: {
-    name: "default-memory-retrieval",
-    version: "0.0.1",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     memoryRetrieval: defaultMemoryRetrievalMiddleware,

--- a/assistant/src/plugins/defaults/overflow-reduce/package.json
+++ b/assistant/src/plugins/defaults/overflow-reduce/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-overflow-reduce",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in overflow-reduce pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/overflow-reduce/register.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce/register.ts
@@ -23,20 +23,21 @@
  * → (for the forced-compaction tier only) nested `compaction` pipeline.
  */
 
-import type { ContextWindowCompactOptions } from "../../context/window-manager.js";
+import type { ContextWindowCompactOptions } from "../../../context/window-manager.js";
 import {
   createInitialReducerState,
   reduceContextOverflow,
   type ReducerState,
-} from "../../daemon/context-overflow-reducer.js";
-import { registerPlugin } from "../registry.js";
+} from "../../../daemon/context-overflow-reducer.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Middleware,
   type OverflowReduceArgs,
   type OverflowReduceResult,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Default middleware — implements the historical tier-loop semantics.
@@ -154,8 +155,8 @@ export const defaultOverflowReduceMiddleware: Middleware<
  */
 export const defaultOverflowReducePlugin: Plugin = {
   manifest: {
-    name: "default-overflow-reduce",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     overflowReduce: defaultOverflowReduceMiddleware,

--- a/assistant/src/plugins/defaults/persistence/package.json
+++ b/assistant/src/plugins/defaults/persistence/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-persistence",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in persistence pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/persistence/register.ts
+++ b/assistant/src/plugins/defaults/persistence/register.ts
@@ -44,16 +44,17 @@ import {
   reserveMessage,
   updateMessageContent,
   updateMessageMetadata,
-} from "../../memory/conversation-crud.js";
-import { syncMessageToDisk } from "../../memory/conversation-disk-view.js";
-import { registerPlugin } from "../registry.js";
+} from "../../../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../../../memory/conversation-disk-view.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Middleware,
   type PersistArgs,
   type PersistResult,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Terminal handler for the `persistence` pipeline. Exported so tests can
@@ -117,8 +118,8 @@ const passthrough: Middleware<PersistArgs, PersistResult> = async (
 
 export const defaultPersistencePlugin: Plugin = {
   manifest: {
-    name: "default-persistence",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     persistence: passthrough,

--- a/assistant/src/plugins/defaults/title-generate/package.json
+++ b/assistant/src/plugins/defaults/title-generate/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-title-generate",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in title-generate pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/title-generate/register.ts
+++ b/assistant/src/plugins/defaults/title-generate/register.ts
@@ -17,14 +17,15 @@
  * by the time {@link bootstrapPlugins} runs.
  */
 
-import { queueGenerateConversationTitle } from "../../memory/conversation-title-service.js";
-import { registerPlugin } from "../registry.js";
+import { queueGenerateConversationTitle } from "../../../memory/conversation-title-service.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Plugin,
   PluginExecutionError,
   type TitleArgs,
   type TitleResult,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Invoke the title-generation service with the provided arguments. Used as
@@ -62,8 +63,8 @@ export async function defaultTitleGenerateTerminal(
  */
 export const defaultTitleGeneratePlugin: Plugin = {
   manifest: {
-    name: "default-title-generate",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
 };
 

--- a/assistant/src/plugins/defaults/token-estimate/package.json
+++ b/assistant/src/plugins/defaults/token-estimate/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-token-estimate",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in token-estimate pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/token-estimate/register.ts
+++ b/assistant/src/plugins/defaults/token-estimate/register.ts
@@ -14,7 +14,7 @@
  * provider-native `countTokens` override) participate normally.
  *
  * The terminal delegates to
- * {@link import("../../context/token-estimator.js").estimatePromptTokens estimatePromptTokens},
+ * {@link import("../../../context/token-estimator.js").estimatePromptTokens estimatePromptTokens},
  * which applies the EWMA calibration correction recorded from past provider
  * responses. Preflight + mid-loop checks must use the calibrated estimate —
  * the calibrated value keeps the overflow gate consistent with the
@@ -29,15 +29,16 @@
 import {
   estimatePromptTokens,
   estimateToolsTokens,
-} from "../../context/token-estimator.js";
-import { registerPlugin } from "../registry.js";
+} from "../../../context/token-estimator.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type EstimateArgs,
   type EstimateResult,
   type Middleware,
   type Plugin,
   PluginExecutionError,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Terminal handler for the `tokenEstimate` pipeline. Computes the tool token
@@ -70,8 +71,8 @@ const passthrough: Middleware<EstimateArgs, EstimateResult> = async (
  */
 export const defaultTokenEstimatePlugin: Plugin = {
   manifest: {
-    name: "default-token-estimate",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     tokenEstimate: passthrough,

--- a/assistant/src/plugins/defaults/tool-error/package.json
+++ b/assistant/src/plugins/defaults/tool-error/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-tool-error",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in tool-error pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/tool-error/register.ts
+++ b/assistant/src/plugins/defaults/tool-error/register.ts
@@ -23,14 +23,15 @@
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 19).
  */
 
-import { registerPlugin } from "../registry.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Middleware,
   type Plugin,
   PluginExecutionError,
   type ToolErrorArgs,
   type ToolErrorDecision,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Canonical nudge text. Kept as a module-level constant so tests and future
@@ -88,8 +89,8 @@ const defaultToolErrorMiddleware: Middleware<ToolErrorArgs, ToolErrorDecision> =
  */
 export const defaultToolErrorPlugin: Plugin = {
   manifest: {
-    name: "default-tool-error",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     toolError: defaultToolErrorMiddleware,

--- a/assistant/src/plugins/defaults/tool-execute/package.json
+++ b/assistant/src/plugins/defaults/tool-execute/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-tool-execute",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in tool-execute pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/tool-execute/register.ts
+++ b/assistant/src/plugins/defaults/tool-execute/register.ts
@@ -29,14 +29,15 @@
  *   canonical terminator regardless of which third parties load.
  */
 
-import { registerPlugin } from "../registry.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Middleware,
   type Plugin,
   PluginExecutionError,
   type ToolExecuteArgs,
   type ToolExecuteResult,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Passthrough middleware — forwards the call to `next`. Named so the
@@ -56,8 +57,8 @@ const defaultToolExecute: Middleware<ToolExecuteArgs, ToolExecuteResult> =
  */
 export const defaultToolExecutePlugin: Plugin = {
   manifest: {
-    name: "default-tool-execute",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     toolExecute: defaultToolExecute,

--- a/assistant/src/plugins/defaults/tool-result-truncate/package.json
+++ b/assistant/src/plugins/defaults/tool-result-truncate/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-tool-result-truncate",
+  "version": "1.0.0",
+  "description": "First-party default plugin wrapping the assistant's built-in tool-result-truncate pipeline with a passthrough implementation.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/tool-result-truncate/register.ts
+++ b/assistant/src/plugins/defaults/tool-result-truncate/register.ts
@@ -15,15 +15,16 @@
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 17).
  */
 
-import { truncateToolResultText } from "../../context/tool-result-truncation.js";
-import { registerPlugin } from "../registry.js";
+import { truncateToolResultText } from "../../../context/tool-result-truncation.js";
+import { registerPlugin } from "../../registry.js";
 import {
   type Middleware,
   type Plugin,
   PluginExecutionError,
   type ToolResultTruncateArgs,
   type ToolResultTruncateResult,
-} from "../types.js";
+} from "../../types.js";
+import pkg from "./package.json" with { type: "json" };
 
 /**
  * Terminal handler for the `toolResultTruncate` pipeline. Exported so tests
@@ -53,8 +54,8 @@ const passthrough: Middleware<
  */
 export const defaultToolResultTruncatePlugin: Plugin = {
   manifest: {
-    name: "default-tool-result-truncate",
-    version: "1.0.0",
+    name: pkg.name,
+    version: pkg.version,
   },
   middleware: {
     toolResultTruncate: passthrough,


### PR DESCRIPTION
Continues the plugins.md ↔ experimental README consolidation: `plugins.md` TL;DR step 2 now mirrors the experimental README — a plugin declares its manifest via a `package.json` (`name` + `peerDependencies["@vellumai/plugin-api"]`). To make that guidance true for first-party plugins, each of the 14 defaults moves into its own `defaults/<name>/` dir with a `register.ts` + a `package.json`, and derives its `manifest` from `pkg.name`/`pkg.version` (bun bundles the JSON import into the `--compile` binary, so the compiled-daemon path is unaffected).

This is a structural refactor with no behavior change: package names stay unscoped (`default-<name>`) so registry names, dedupe, and name-asserting tests are byte-identical; the `register.ts`-stripping toward full file-based discovery is intentionally left for later PRs.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/59e1d9bfdd584bcb9571addbcd80a056