### PR TITLE
feat(web): publish AssistantEventEnvelope on the event bus

### DIFF
--- a/apps/web/src/assistant/use-disk-pressure-monitor.ts
+++ b/apps/web/src/assistant/use-disk-pressure-monitor.ts
@@ -209,7 +209,8 @@ export function useDiskPressureMonitor({
   // Complements the polling interval and resume-refresh above so
   // status changes are reflected immediately without waiting for
   // the next poll tick.
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
     if (event.type !== "disk_pressure_status_changed") return;
     applyStatusEvent(event.status);
   });

--- a/apps/web/src/domains/chat/hooks/use-document-comment-events.ts
+++ b/apps/web/src/domains/chat/hooks/use-document-comment-events.ts
@@ -11,7 +11,7 @@
 
 import { useCallback, useEffect, useRef } from "react";
 
-import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -48,15 +48,16 @@ export function useDocumentCommentEvents({
   surfaceId,
   enabled,
   onCommentsChanged,
-}: UseDocumentCommentEventsOptions): (event: AssistantEvent) => void {
+}: UseDocumentCommentEventsOptions): (envelope: AssistantEventEnvelope) => void {
   const callbackRef = useRef(onCommentsChanged);
   useEffect(() => {
     callbackRef.current = onCommentsChanged;
   }, [onCommentsChanged]);
 
   return useCallback(
-    (event: AssistantEvent) => {
+    (envelope: AssistantEventEnvelope) => {
       if (!enabled) return;
+      const event = envelope.message;
 
       switch (event.type) {
         case "document_comment_created":

--- a/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 import { useRef, type MutableRefObject } from "react";
 
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { AssistantEvent } from "@/types/event-types";
 import type { ChatEventStream } from "@/lib/streaming/stream-transport";
 import {
@@ -60,10 +61,15 @@ function renderEventStream(
 
 function publishDelta(conversationId: string): void {
   useEventBusStore.getState().publish("sse.event", {
-    type: "assistant_text_delta",
+    id: "evt-1",
     conversationId,
-    delta: "hi",
-  } as unknown as AssistantEvent);
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: "assistant_text_delta",
+      conversationId,
+      delta: "hi",
+    },
+  } as unknown as AssistantEventEnvelope);
 }
 
 beforeEach(() => {
@@ -113,9 +119,13 @@ describe("useEventStream — conversation-switch filtering", () => {
     const handler = mock(() => {});
     renderEventStream("conv-A", handler);
     useEventBusStore.getState().publish("sse.event", {
-      type: "sync_changed",
-      tags: ["assistant:self:identity"],
-    } as unknown as AssistantEvent);
+      id: "evt-sync",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "sync_changed",
+        tags: ["assistant:self:identity"],
+      },
+    } as unknown as AssistantEventEnvelope);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -129,9 +139,13 @@ describe("useEventStream — conversation-switch filtering", () => {
     const handler = mock(() => {});
     renderEventStream("conv-A", handler);
     useEventBusStore.getState().publish("sse.event", {
-      type: "assistant_text_delta",
-      delta: "should be rejected",
-    } as unknown as AssistantEvent);
+      id: "evt-no-conv",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "assistant_text_delta",
+        delta: "should be rejected",
+      },
+    } as unknown as AssistantEventEnvelope);
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -139,10 +153,15 @@ describe("useEventStream — conversation-switch filtering", () => {
     const handler = mock(() => {});
     renderEventStream("conv-A", handler);
     useEventBusStore.getState().publish("sse.event", {
-      type: "message_complete",
+      id: "evt-msg",
       conversationId: "conv-A",
-      messageId: "m1",
-    } as unknown as AssistantEvent);
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "message_complete",
+        conversationId: "conv-A",
+        messageId: "m1",
+      },
+    } as unknown as AssistantEventEnvelope);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -150,10 +169,15 @@ describe("useEventStream — conversation-switch filtering", () => {
     const handler = mock(() => {});
     renderEventStream("conv-A", handler);
     useEventBusStore.getState().publish("sse.event", {
-      type: "tool_call",
+      id: "evt-tool",
       conversationId: "conv-B",
-      toolName: "bash",
-    } as unknown as AssistantEvent);
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "tool_call",
+        conversationId: "conv-B",
+        toolName: "bash",
+      },
+    } as unknown as AssistantEventEnvelope);
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-conversation-filter.test.tsx
@@ -67,9 +67,9 @@ function publishDelta(conversationId: string): void {
     message: {
       type: "assistant_text_delta",
       conversationId,
-      delta: "hi",
+      text: "hi",
     },
-  } as unknown as AssistantEventEnvelope);
+  } as AssistantEventEnvelope);
 }
 
 beforeEach(() => {
@@ -125,7 +125,7 @@ describe("useEventStream — conversation-switch filtering", () => {
         type: "sync_changed",
         tags: ["assistant:self:identity"],
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -143,9 +143,9 @@ describe("useEventStream — conversation-switch filtering", () => {
       emittedAt: new Date().toISOString(),
       message: {
         type: "assistant_text_delta",
-        delta: "should be rejected",
+        text: "should be rejected",
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -161,11 +161,11 @@ describe("useEventStream — conversation-switch filtering", () => {
         conversationId: "conv-A",
         messageId: "m1",
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  test("a tool_call event for another conversation is dropped even when the active conversation has no current SSE epoch yet", () => {
+  test("a conversation-scoped event for another conversation is dropped even when the active conversation has no current SSE epoch yet", () => {
     const handler = mock(() => {});
     renderEventStream("conv-A", handler);
     useEventBusStore.getState().publish("sse.event", {
@@ -173,11 +173,11 @@ describe("useEventStream — conversation-switch filtering", () => {
       conversationId: "conv-B",
       emittedAt: new Date().toISOString(),
       message: {
-        type: "tool_call",
+        type: "assistant_text_delta",
         conversationId: "conv-B",
-        toolName: "bash",
+        text: "should be dropped",
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
@@ -87,9 +87,9 @@ function publishDelta(conversationId: string): void {
     message: {
       type: "assistant_text_delta",
       conversationId,
-      delta: `delta-${Math.random().toString(36).slice(2, 6)}`,
+      text: `delta-${Math.random().toString(36).slice(2, 6)}`,
     },
-  } as unknown as AssistantEventEnvelope);
+  } as AssistantEventEnvelope);
 }
 
 beforeEach(() => {
@@ -245,7 +245,7 @@ describe("useEventStream — rapid conversation switch stress", () => {
         type: "sync_changed",
         tags: ["assistant:self:identity"],
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     act(() => {
       rerender({ key: "conv-B" });
     });
@@ -256,7 +256,7 @@ describe("useEventStream — rapid conversation switch stress", () => {
         type: "sync_changed",
         tags: ["assistant:self:avatar"],
       },
-    } as unknown as AssistantEventEnvelope);
+    } as AssistantEventEnvelope);
     expect(captured).toHaveLength(2);
     expect((captured[0]!.event as { type: string }).type).toBe("sync_changed");
     expect((captured[1]!.event as { type: string }).type).toBe("sync_changed");

--- a/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-event-stream-rapid-switch.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { act } from "react";
 import { useRef, type MutableRefObject } from "react";
 
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { AssistantEvent } from "@/types/event-types";
 import type { ChatEventStream } from "@/lib/streaming/stream-transport";
 import {
@@ -80,10 +81,15 @@ function renderEventStreamWithCapture(
 
 function publishDelta(conversationId: string): void {
   useEventBusStore.getState().publish("sse.event", {
-    type: "assistant_text_delta",
+    id: `evt-${Math.random().toString(36).slice(2, 6)}`,
     conversationId,
-    delta: `delta-${Math.random().toString(36).slice(2, 6)}`,
-  } as unknown as AssistantEvent);
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: "assistant_text_delta",
+      conversationId,
+      delta: `delta-${Math.random().toString(36).slice(2, 6)}`,
+    },
+  } as unknown as AssistantEventEnvelope);
 }
 
 beforeEach(() => {
@@ -233,16 +239,24 @@ describe("useEventStream — rapid conversation switch stress", () => {
       observeKey,
     );
     useEventBusStore.getState().publish("sse.event", {
-      type: "sync_changed",
-      tags: ["assistant:self:identity"],
-    } as unknown as AssistantEvent);
+      id: "evt-sync-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "sync_changed",
+        tags: ["assistant:self:identity"],
+      },
+    } as unknown as AssistantEventEnvelope);
     act(() => {
       rerender({ key: "conv-B" });
     });
     useEventBusStore.getState().publish("sse.event", {
-      type: "sync_changed",
-      tags: ["assistant:self:avatar"],
-    } as unknown as AssistantEvent);
+      id: "evt-sync-2",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "sync_changed",
+        tags: ["assistant:self:avatar"],
+      },
+    } as unknown as AssistantEventEnvelope);
     expect(captured).toHaveLength(2);
     expect((captured[0]!.event as { type: string }).type).toBe("sync_changed");
     expect((captured[1]!.event as { type: string }).type).toBe("sync_changed");

--- a/apps/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-event-stream.ts
@@ -221,9 +221,9 @@ export function useEventStream({
     const presence: ChatEventStream = { cancel: () => {} };
     streamRef.current = presence;
 
-    const unsubEvent = bus.subscribe("sse.event", (event) => {
-      const eventConversationId = (event as { conversationId?: string })
-        .conversationId;
+    const unsubEvent = bus.subscribe("sse.event", (envelope) => {
+      const event = envelope.message;
+      const eventConversationId = envelope.conversationId;
       // Two-stage filter to prevent cross-conversation event leakage.
       // The bus opens a single unfiltered SSE connection, so every
       // event for every conversation flows through this subscriber.

--- a/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
+++ b/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
@@ -54,23 +54,28 @@ function publishInteractionResolved(payload: {
 }) {
   act(() => {
     useEventBusStore.getState().publish("sse.event", {
-      type: "interaction_resolved",
-      requestId: payload.requestId,
+      id: `evt-${payload.requestId}`,
       conversationId: payload.conversationId,
-      state: payload.state,
-      // Cast through the daemon-mirrored union; tests intentionally feed
-      // both user-facing and host-proxy kinds.
-      kind: (payload.kind ?? "confirmation") as
-        | "confirmation"
-        | "secret"
-        | "question"
-        | "acp_confirmation"
-        | "host_bash"
-        | "host_file"
-        | "host_cu"
-        | "host_browser"
-        | "host_app_control"
-        | "host_transfer",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "interaction_resolved",
+        requestId: payload.requestId,
+        conversationId: payload.conversationId,
+        state: payload.state,
+        // Cast through the daemon-mirrored union; tests intentionally feed
+        // both user-facing and host-proxy kinds.
+        kind: (payload.kind ?? "confirmation") as
+          | "confirmation"
+          | "secret"
+          | "question"
+          | "acp_confirmation"
+          | "host_bash"
+          | "host_file"
+          | "host_cu"
+          | "host_browser"
+          | "host_app_control"
+          | "host_transfer",
+      },
     });
   });
 }

--- a/apps/web/src/domains/conversations/use-attention-tracking.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking.ts
@@ -205,8 +205,9 @@ export function useAttentionTracking({
   // silently-ignored by default instead of accidentally clearing
   // processing state.
   // -------------------------------------------------------------------------
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
     if (!assistantId) return;
+    const event = envelope.message;
     if (event.type !== "interaction_resolved") return;
     if (!USER_FACING_INTERACTION_KINDS.has(event.kind)) return;
     const key = event.conversationId;

--- a/apps/web/src/domains/conversations/use-conversation-sync.test.tsx
+++ b/apps/web/src/domains/conversations/use-conversation-sync.test.tsx
@@ -6,7 +6,7 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import {
   conversationGroupsQueryKey,
 } from "@/domains/conversations/conversation-queries";
-import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { Conversation } from "@/types/conversation-types";
 import { conversationsQueryKey } from "@/lib/sync/query-tags";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types";
@@ -68,10 +68,11 @@ function syncEvent(tags: string[]): SyncChangedEvent {
 }
 
 function emit(event: SyncChangedEvent): void {
-  // SyncChangedEvent is structurally assignable to AssistantSyncChangedEvent
-  // (which only adds an optional conversationId field), so this cast is safe.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  useEventBusStore.getState().publish("sse.event", event as any);
+  useEventBusStore.getState().publish("sse.event", {
+    id: "evt-1",
+    emittedAt: new Date().toISOString(),
+    message: event,
+  } as AssistantEventEnvelope);
 }
 
 function emitOpened(
@@ -304,10 +305,15 @@ describe("useConversationSync", () => {
       wrapper: createWrapper(queryClient),
     });
     useEventBusStore.getState().publish("sse.event", {
-      type: "conversation_title_updated",
+      id: "evt-title",
       conversationId: "conv-1",
-      title: "New Title",
-    } as unknown as AssistantEvent);
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "conversation_title_updated",
+        conversationId: "conv-1",
+        title: "New Title",
+      },
+    } as AssistantEventEnvelope);
     await waitFor(() => {
       const cached = queryClient.getQueryData<Conversation[]>(
         conversationsQueryKey("asst-1"),

--- a/apps/web/src/domains/conversations/use-conversation-sync.ts
+++ b/apps/web/src/domains/conversations/use-conversation-sync.ts
@@ -65,8 +65,9 @@ export function useConversationSync(
     };
   }, [assistantId, isAssistantActive]);
 
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
     if (!assistantId || !isAssistantActive) return;
+    const event = envelope.message;
 
     switch (event.type) {
       case "sync_changed":

--- a/apps/web/src/domains/settings/hooks/use-settings-sync.ts
+++ b/apps/web/src/domains/settings/hooks/use-settings-sync.ts
@@ -30,8 +30,9 @@ export function useSettingsSync(): void {
   // assistant switch.
   const registry = useMemoizedRegistry(queryClient, assistantId);
 
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
     if (!registry) return;
+    const event = envelope.message;
     if (event.type === "sync_changed") {
       void registry.dispatch(event);
     }

--- a/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { AssistantEvent } from "@/types/event-types";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import {
@@ -39,7 +40,11 @@ function syncEvent(tags: string[]): SyncChangedEvent {
 }
 
 function emit(event: AssistantEvent): void {
-  useEventBusStore.getState().publish("sse.event", event);
+  useEventBusStore.getState().publish("sse.event", {
+    id: "evt-1",
+    emittedAt: new Date().toISOString(),
+    message: event,
+  } as AssistantEventEnvelope);
 }
 
 beforeEach(() => {

--- a/apps/web/src/hooks/use-assistant-resource-sync.ts
+++ b/apps/web/src/hooks/use-assistant-resource-sync.ts
@@ -50,8 +50,9 @@ export function useAssistantResourceSync(
 ): void {
   const queryClient = useQueryClient();
 
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
     if (!assistantId || !isAssistantActive) return;
+    const event = envelope.message;
 
     switch (event.type) {
       case "sync_changed":

--- a/apps/web/src/hooks/use-document-editor-sync.ts
+++ b/apps/web/src/hooks/use-document-editor-sync.ts
@@ -21,7 +21,8 @@ import { useViewerStore } from "@/stores/viewer-store";
  * store is global and document surface ids are globally unique.
  */
 export function useDocumentEditorSync(): void {
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
     if (event.type !== "document_editor_update") return;
     useViewerStore
       .getState()

--- a/apps/web/src/hooks/use-event-bus-init.test.tsx
+++ b/apps/web/src/hooks/use-event-bus-init.test.tsx
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
-import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import {
   __resetEventBusForTesting,
   useEventBusStore,
 } from "@/stores/event-bus-store";
 
-type EventHandler = (event: AssistantEvent) => void;
+type EventHandler = (envelope: AssistantEventEnvelope) => void;
 type ReconnectHandler = (cause: "error" | "watchdog") => void;
 
 let activeOnEvent: EventHandler | null = null;
@@ -138,12 +138,16 @@ describe("useEventBusInit — SSE ownership", () => {
         isAssistantActive: true,
       }),
     );
-    const event: AssistantEvent = {
-      type: "avatar_updated",
-      avatarPath: "/tmp/avatar.png",
+    const envelope: AssistantEventEnvelope = {
+      id: "evt-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "avatar_updated",
+        avatarPath: "/tmp/avatar.png",
+      },
     };
-    activeOnEvent!(event);
-    expect(handler).toHaveBeenCalledWith(event);
+    activeOnEvent!(envelope);
+    expect(handler).toHaveBeenCalledWith(envelope);
   });
 
   test("publishes sse.opened with cause=fresh on first open", () => {

--- a/apps/web/src/hooks/use-event-bus-init.ts
+++ b/apps/web/src/hooks/use-event-bus-init.ts
@@ -217,8 +217,8 @@ export function useEventBusInit({
       const stream = subscribeChatEvents(
         capturedAssistantId,
         null,
-        (event) => {
-          useEventBusStore.getState().publish("sse.event", event);
+        (envelope) => {
+          useEventBusStore.getState().publish("sse.event", envelope);
         },
         (err) => {
           current = null;

--- a/apps/web/src/hooks/use-feature-flag-bus-sync.test.tsx
+++ b/apps/web/src/hooks/use-feature-flag-bus-sync.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
 import {
   assistantFlagValuesQueryKey,
@@ -33,10 +34,11 @@ function syncEvent(tags: string[]): SyncChangedEvent {
 }
 
 function emit(event: SyncChangedEvent): void {
-  // SyncChangedEvent is structurally assignable to AssistantSyncChangedEvent
-  // (which only adds an optional conversationId field), so this cast is safe.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  useEventBusStore.getState().publish("sse.event", event as any);
+  useEventBusStore.getState().publish("sse.event", {
+    id: "evt-1",
+    emittedAt: new Date().toISOString(),
+    message: event,
+  } as AssistantEventEnvelope);
 }
 
 function emitOpened(

--- a/apps/web/src/hooks/use-feature-flag-bus-sync.ts
+++ b/apps/web/src/hooks/use-feature-flag-bus-sync.ts
@@ -36,8 +36,9 @@ export function useFeatureFlagBusSync(
 ): void {
   const queryClient = useQueryClient();
 
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
     if (!assistantId || !isAssistantActive) return;
+    const event = envelope.message;
     if (event.type !== "sync_changed") return;
     for (const tag of event.tags) {
       if (tag === SYNC_TAGS.featureFlagsClient) {

--- a/apps/web/src/hooks/use-notification-intent-sync.ts
+++ b/apps/web/src/hooks/use-notification-intent-sync.ts
@@ -33,7 +33,8 @@ import { useConversationStore } from "@/stores/conversation-store";
 export function useNotificationIntentSync(
   assistantId: string | null,
 ): void {
-  useBusSubscription("sse.event", (event) => {
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
     if (event.type !== "notification_intent") return;
 
     // Guardian-scoped notifications are for devices bound to that

--- a/apps/web/src/lib/streaming/event-parser.test.ts
+++ b/apps/web/src/lib/streaming/event-parser.test.ts
@@ -2,8 +2,18 @@ import { describe, expect, test } from "bun:test";
 
 import type { DiskPressureStatus } from "@vellumai/assistant-api";
 
+import type { AssistantEvent } from "@/types/event-types";
 import { parseAssistantEvent } from "@/lib/streaming/event-parser";
 import { SYNC_TAGS } from "@/lib/sync/types";
+
+/**
+ * Convenience wrapper: extracts the inner event from the envelope
+ * returned by `parseAssistantEvent`. Most tests only care about the
+ * inner event, not the envelope metadata.
+ */
+function parseEvent(data: Record<string, unknown>): AssistantEvent {
+  return parseAssistantEvent(data).message as AssistantEvent;
+}
 
 describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
@@ -11,7 +21,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses assistant_text_delta with messageId and conversationId", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_text_delta",
       text: "Hello",
       messageId: "msg-1",
@@ -26,7 +36,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses assistant_text_delta with only required text field", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_text_delta",
       text: "",
     });
@@ -38,7 +48,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown assistant_text_delta event when text field is missing", () => {
     const data = { type: "assistant_text_delta", conversationId: "conv-1" };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "assistant_text_delta",
@@ -48,7 +58,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from assistant_text_delta", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_text_delta",
       text: "Hi",
       legacyField: "x",
@@ -64,7 +74,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses message_complete with messageId and conversationId", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_complete",
       messageId: "msg-1",
       conversationId: "conversation-1",
@@ -77,12 +87,12 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses message_complete with no fields", () => {
-    const event = parseAssistantEvent({ type: "message_complete" });
+    const event = parseEvent({ type: "message_complete" });
     expect(event).toEqual({ type: "message_complete" });
   });
 
   test("parses message_complete with attachments", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_complete",
       messageId: "msg-1",
       attachments: [
@@ -111,7 +121,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses message_complete with source aux", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_complete",
       conversationId: "conv-1",
       messageId: "msg-aux",
@@ -126,7 +136,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses message_complete with attachmentWarnings", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_complete",
       messageId: "msg-1",
       attachmentWarnings: ["truncated to 4MB"],
@@ -146,7 +156,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       attachments: [{ filename: "missing-mime.txt" }],
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "message_complete",
@@ -161,7 +171,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       source: "unexpected",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "message_complete",
@@ -175,7 +185,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses generation_handoff with required queuedCount", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "generation_handoff",
       conversationId: "conv-1",
       queuedCount: 2,
@@ -197,7 +207,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       messageId: "msg-1",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "generation_handoff",
@@ -211,7 +221,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses generation_cancelled with conversationId", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "generation_cancelled",
       conversationId: "conv-1",
     });
@@ -222,7 +232,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses generation_cancelled without conversationId", () => {
-    const event = parseAssistantEvent({ type: "generation_cancelled" });
+    const event = parseEvent({ type: "generation_cancelled" });
     expect(event).toEqual({ type: "generation_cancelled" });
   });
 
@@ -231,7 +241,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses document_comment_created with full comment payload", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_created",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -270,7 +280,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses document_comment_created without optional anchor/thread fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_created",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -306,7 +316,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       surfaceId: "surface-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "document_comment_created",
       data,
@@ -328,7 +338,7 @@ describe("parseAssistantEvent", () => {
         updatedAt: 0,
       },
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "document_comment_created",
       data,
@@ -337,7 +347,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from document_comment_created", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_created",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -373,7 +383,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses document_comment_resolved with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_resolved",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -396,7 +406,7 @@ describe("parseAssistantEvent", () => {
       surfaceId: "surface-1",
       commentId: "c-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "document_comment_resolved",
       data,
@@ -405,7 +415,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from document_comment_resolved", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_resolved",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -427,7 +437,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses document_comment_reopened with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_reopened",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -447,7 +457,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       surfaceId: "surface-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "document_comment_reopened",
       data,
@@ -456,7 +466,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from document_comment_reopened", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_reopened",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -476,7 +486,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses document_comment_deleted with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_deleted",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -496,7 +506,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       commentId: "c-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "document_comment_deleted",
       data,
@@ -505,7 +515,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from document_comment_deleted", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "document_comment_deleted",
       conversationId: "conv-1",
       surfaceId: "surface-1",
@@ -525,7 +535,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses message_queued with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_queued",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -545,7 +555,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       requestId: "req-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "message_queued",
       data,
@@ -554,7 +564,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from message_queued", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_queued",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -574,7 +584,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses message_dequeued with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_dequeued",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -591,7 +601,7 @@ describe("parseAssistantEvent", () => {
       type: "message_dequeued",
       requestId: "req-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "message_dequeued",
       data,
@@ -600,7 +610,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from message_dequeued", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_dequeued",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -618,7 +628,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses message_queued_deleted with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_queued_deleted",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -635,7 +645,7 @@ describe("parseAssistantEvent", () => {
       type: "message_queued_deleted",
       conversationId: "conv-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "message_queued_deleted",
       data,
@@ -644,7 +654,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from message_queued_deleted", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_queued_deleted",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -662,7 +672,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses message_request_complete with required fields and runStillActive", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_request_complete",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -677,7 +687,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses message_request_complete without optional runStillActive", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_request_complete",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -694,7 +704,7 @@ describe("parseAssistantEvent", () => {
       type: "message_request_complete",
       conversationId: "conv-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "message_request_complete",
       data,
@@ -703,7 +713,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from message_request_complete", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_request_complete",
       conversationId: "conv-1",
       requestId: "req-1",
@@ -723,7 +733,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses compaction_circuit_open with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "compaction_circuit_open",
       conversationId: "conv-1",
       reason: "3_consecutive_failures",
@@ -744,7 +754,7 @@ describe("parseAssistantEvent", () => {
       reason: "unexplained",
       openUntil: 1_700_000_000_000,
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "compaction_circuit_open",
       data,
@@ -758,7 +768,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       reason: "3_consecutive_failures",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "compaction_circuit_open",
       data,
@@ -767,7 +777,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses compaction_circuit_closed with required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "compaction_circuit_closed",
       conversationId: "conv-1",
     });
@@ -779,7 +789,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown compaction_circuit_closed when conversationId is missing", () => {
     const data = { type: "compaction_circuit_closed" };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "compaction_circuit_closed",
       data,
@@ -791,7 +801,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses home_feed_updated with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "home_feed_updated",
       updatedAt: "2026-05-29T15:00:00.000Z",
       newItemCount: 3,
@@ -805,7 +815,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown home_feed_updated when updatedAt is missing", () => {
     const data = { type: "home_feed_updated", newItemCount: 3 };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "home_feed_updated",
       data,
@@ -818,7 +828,7 @@ describe("parseAssistantEvent", () => {
       updatedAt: "2026-05-29T15:00:00.000Z",
       newItemCount: "many",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "home_feed_updated",
       data,
@@ -837,7 +847,7 @@ describe("parseAssistantEvent", () => {
       state: "approved",
       kind: "confirmation",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "interaction_resolved",
       data,
@@ -845,7 +855,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from interaction_resolved", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "interaction_resolved",
       requestId: "req-1",
       conversationId: "conv-1",
@@ -867,7 +877,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses error with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "error",
       message: "Your balance has run out",
       code: "PROVIDER_BILLING",
@@ -888,7 +898,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses error with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "error",
       message: "Too many requests",
     });
@@ -900,7 +910,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown error when message is missing", () => {
     const data = { type: "error", code: "rate_limit_exceeded" };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "error",
       data,
@@ -908,7 +918,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from error", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "error",
       message: "boom",
       surpriseField: "boom",
@@ -924,7 +934,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses conversation_error with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "conversation_error",
       conversationId: "conv-1",
       code: "PROVIDER_INVALID_KEY",
@@ -949,7 +959,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses conversation_error with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "conversation_error",
       conversationId: "conv-2",
       code: "PROVIDER_RATE_LIMIT",
@@ -972,7 +982,7 @@ describe("parseAssistantEvent", () => {
       code: "UNKNOWN",
       userMessage: "Something went wrong.",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_error",
       data,
@@ -988,7 +998,7 @@ describe("parseAssistantEvent", () => {
       userMessage: "Rate limited",
       retryable: true,
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_error",
       data,
@@ -997,7 +1007,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from conversation_error", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "conversation_error",
       conversationId: "conv-5",
       code: "UNKNOWN",
@@ -1015,7 +1025,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses interaction_resolved with explicit conversationId", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "interaction_resolved",
       requestId: "req-1",
       conversationId: "conv-1",
@@ -1032,7 +1042,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("interaction_resolved with an invalid state degrades to unknown", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "interaction_resolved",
       requestId: "req-3",
       conversationId: "conv-3",
@@ -1043,7 +1053,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("interaction_resolved without a requestId degrades to unknown", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "interaction_resolved",
       conversationId: "conv-4",
       state: "cancelled",
@@ -1053,7 +1063,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown event for unrecognized type", () => {
     const data = { type: "some_future_event", foo: "bar" };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "some_future_event",
@@ -1062,7 +1072,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses sync_changed tags", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "sync_changed",
       tags: [
         SYNC_TAGS.assistantAvatar,
@@ -1082,7 +1092,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown for sync_changed without a tags array", () => {
     const data = { type: "sync_changed", tag: SYNC_TAGS.assistantAvatar };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "sync_changed",
@@ -1095,7 +1105,7 @@ describe("parseAssistantEvent", () => {
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar, 42],
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "sync_changed",
@@ -1104,7 +1114,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses sync_changed with originClientId", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
       originClientId: "client-abc",
@@ -1117,7 +1127,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("omits originClientId from sync_changed when absent", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
     });
@@ -1131,7 +1141,7 @@ describe("parseAssistantEvent", () => {
   test("preserves originClientId verbatim and rejects invalid values", () => {
     // GIVEN a non-empty originClientId — the canonical schema keeps it
     // verbatim; the daemon stamps a clean header value, so no trimming.
-    const verbatim = parseAssistantEvent({
+    const verbatim = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
       originClientId: "client-xyz",
@@ -1144,7 +1154,7 @@ describe("parseAssistantEvent", () => {
 
     // AND an empty originClientId fails the schema's min-length guard, so
     // the whole event falls through to unknown rather than being parsed.
-    const empty = parseAssistantEvent({
+    const empty = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
       originClientId: "",
@@ -1152,7 +1162,7 @@ describe("parseAssistantEvent", () => {
     expect(empty.type).toBe("unknown");
 
     // AND a non-string originClientId likewise fails validation.
-    const nonString = parseAssistantEvent({
+    const nonString = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
       originClientId: 42,
@@ -1161,7 +1171,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses assistant_activity_state idle", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_activity_state",
       conversationId: "conv-1",
       activityVersion: 7,
@@ -1182,7 +1192,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses assistant_activity_state thinking with statusText", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_activity_state",
       conversationId: "conv-1",
       activityVersion: 3,
@@ -1206,7 +1216,7 @@ describe("parseAssistantEvent", () => {
     // Disk-pressure block path emits idle with error_terminal but no
     // follow-up message_complete. The web handler must treat this as
     // terminal so the loading indicator clears.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_activity_state",
       conversationId: "conv-1",
       activityVersion: 1,
@@ -1233,7 +1243,7 @@ describe("parseAssistantEvent", () => {
       anchor: "global",
       reason: "message_complete",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "assistant_activity_state",
@@ -1251,7 +1261,7 @@ describe("parseAssistantEvent", () => {
       anchor: "global",
       reason: "made_up_reason",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "assistant_activity_state",
@@ -1261,7 +1271,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses open_url", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "open_url",
       url: "https://example.com/oauth",
       title: "Connect Google",
@@ -1281,7 +1291,7 @@ describe("parseAssistantEvent", () => {
       title: "Connect Google",
       conversationId: "conv-1",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "open_url",
@@ -1292,7 +1302,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown open_url event when url is empty string", () => {
     const data = { type: "open_url", url: "", conversationId: "conv-1" };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "open_url",
@@ -1302,7 +1312,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses navigate_settings", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "navigate_settings",
       tab: "Integrations",
     });
@@ -1314,7 +1324,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown navigate_settings event when tab is missing", () => {
     const data = { type: "navigate_settings" };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "navigate_settings",
@@ -1342,7 +1352,7 @@ describe("parseAssistantEvent", () => {
     test("parses a critical status verbatim with no conversationId", () => {
       // GIVEN a fully-populated critical disk-pressure snapshot
       // WHEN parsed
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "disk_pressure_status_changed",
         status: criticalStatus,
       });
@@ -1358,7 +1368,7 @@ describe("parseAssistantEvent", () => {
     test("parses the warning state (added by canonicalization)", () => {
       // GIVEN a snapshot in the `warning` state — a value the legacy web
       // type omitted but the daemon contract has always emitted.
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "disk_pressure_status_changed",
         status: { ...criticalStatus, state: "warning" },
       });
@@ -1384,7 +1394,7 @@ describe("parseAssistantEvent", () => {
         blockedCapabilities: [],
         error: null,
       };
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "disk_pressure_status_changed",
         status,
       });
@@ -1396,7 +1406,7 @@ describe("parseAssistantEvent", () => {
 
     test("strips unknown fields (strip-mode) on the event and status", () => {
       // GIVEN unknown fields on both the event and the nested status
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "disk_pressure_status_changed",
         conversationId: "conv-should-be-stripped",
         status: { ...criticalStatus, futureField: "ignored" },
@@ -1418,14 +1428,14 @@ describe("parseAssistantEvent", () => {
         },
       };
       // THEN the schema rejects it and the parser yields an unknown event.
-      const event = parseAssistantEvent(data);
+      const event = parseEvent(data);
       expect(event.type).toBe("unknown");
     });
 
     test("falls through to unknown for a flat (statusless) payload", () => {
       // GIVEN a flat payload with status fields hoisted to the top level —
       // a shape the daemon never emits (it always nests under `status`).
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "disk_pressure_status_changed",
         ...criticalStatus,
       });
@@ -1437,7 +1447,7 @@ describe("parseAssistantEvent", () => {
   describe("document_editor_update", () => {
     test("parses a conversation-scoped editor update", () => {
       // GIVEN an inner message carrying its own conversationId
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "document_editor_update",
         conversationId: "conv-1",
         surfaceId: "surface-1",
@@ -1455,7 +1465,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("strips unknown fields (strip-mode)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "document_editor_update",
         conversationId: "conv-1",
         surfaceId: "surface-1",
@@ -1475,7 +1485,7 @@ describe("parseAssistantEvent", () => {
     test("falls through to unknown when conversationId is missing", () => {
       // GIVEN a payload lacking the required conversationId — the parser
       // never grafts the envelope routing key onto a canonical event.
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "document_editor_update",
         surfaceId: "surface-1",
         markdown: "body",
@@ -1487,7 +1497,7 @@ describe("parseAssistantEvent", () => {
 
   describe("turn_profile_auto_routed", () => {
     test("parses an auto-routed profile notification", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "turn_profile_auto_routed",
         conversationId: "conv-1",
         profile: "quality-optimized",
@@ -1504,7 +1514,7 @@ describe("parseAssistantEvent", () => {
     test("strips the legacy conversationKey field (strip-mode)", () => {
       // GIVEN a payload still carrying the legacy conversationKey field
       // the daemon no longer emits
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "turn_profile_auto_routed",
         conversationId: "conv-1",
         profile: "quality-optimized",
@@ -1521,7 +1531,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("falls through to unknown when profileLabel is missing", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "turn_profile_auto_routed",
         conversationId: "conv-1",
         profile: "quality-optimized",
@@ -1532,7 +1542,7 @@ describe("parseAssistantEvent", () => {
 
   describe("tool_result", () => {
     test("keeps daemon risk* option names (canonical schema does not rename)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "bash",
         result: "ok",
@@ -1578,7 +1588,7 @@ describe("parseAssistantEvent", () => {
       // valid Minimatch trust rule patterns. The consumer deliberately does
       // not feed them into the save path; the schema keeps them as a
       // separate field so that distinction survives on the wire.
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "bash",
         result: "ok",
@@ -1597,7 +1607,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("leaves risk option fields undefined when absent", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "remember",
         result: "saved",
@@ -1614,7 +1624,7 @@ describe("parseAssistantEvent", () => {
       // The daemon emits `riskAllowlistOptions`, not the un-prefixed
       // `allowlistOptions` (that field is reserved for confirmation_request).
       // An unknown key is silently dropped by the strip-mode schema.
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "bash",
         result: "ok",
@@ -1628,7 +1638,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("propagates messageId (anchor protocol)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "bash",
         result: "ok",
@@ -1642,7 +1652,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("messageId is undefined when absent (legacy daemon stream)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_result",
         toolName: "bash",
         result: "ok",
@@ -1660,7 +1670,7 @@ describe("parseAssistantEvent", () => {
         result: "ok",
         messageId: 42,
       };
-      const event = parseAssistantEvent(data);
+      const event = parseEvent(data);
       expect(event).toEqual({
         type: "unknown",
         rawType: "tool_result",
@@ -1671,7 +1681,7 @@ describe("parseAssistantEvent", () => {
 
   describe("tool_use_start", () => {
     test("propagates messageId (anchor protocol)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_use_start",
         toolName: "bash",
         input: { command: "ls" },
@@ -1686,7 +1696,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("messageId is undefined when absent (legacy daemon stream)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "tool_use_start",
         toolName: "bash",
         input: {},
@@ -1700,7 +1710,7 @@ describe("parseAssistantEvent", () => {
 
   describe("assistant_turn_start", () => {
     test("parses with required messageId", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "assistant_turn_start",
         messageId: "asst-msg-42",
         conversationId: "conv-1",
@@ -1713,7 +1723,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("conversationId is optional", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "assistant_turn_start",
         messageId: "asst-msg-42",
       });
@@ -1730,14 +1740,14 @@ describe("parseAssistantEvent", () => {
       // worth surfacing to the reducer. Falling back to `unknown` keeps the
       // chat reducer's "saw an event we didn't know how to handle" branch
       // visible in dev mode rather than silently producing a no-op event.
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "assistant_turn_start",
       });
       expect(event.type).toBe("unknown");
     });
 
     test("drops to unknown when messageId is non-string", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "assistant_turn_start",
         messageId: 42,
       });
@@ -1749,7 +1759,7 @@ describe("parseAssistantEvent", () => {
     test("parses with all fields", () => {
       // GIVEN a user_message_echo carrying the full optional set
       // WHEN parsed
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "user_message_echo",
         text: "hello",
         conversationId: "conv-1",
@@ -1771,7 +1781,7 @@ describe("parseAssistantEvent", () => {
     test("parses with only the required text — synthetic echo shape", () => {
       // GIVEN a synthetic echo (surface-action prompt) with no ids
       // WHEN parsed
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "user_message_echo",
         text: "do the thing",
       });
@@ -1787,7 +1797,7 @@ describe("parseAssistantEvent", () => {
     test("drops to unknown when text is missing — text is the payload", () => {
       // GIVEN an echo missing its required `text`
       // WHEN parsed
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "user_message_echo",
         conversationId: "conv-1",
       });
@@ -1798,7 +1808,7 @@ describe("parseAssistantEvent", () => {
     test("drops to unknown when an unexpected field is present", () => {
       // GIVEN an echo with an extra field the strict schema rejects
       // WHEN parsed
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "user_message_echo",
         text: "hi",
         unexpected: true,
@@ -1813,7 +1823,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses ui_surface_show with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_show",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -1846,7 +1856,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses ui_surface_show with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_show",
       conversationId: "conv-2",
       surfaceId: "s-2",
@@ -1869,7 +1879,7 @@ describe("parseAssistantEvent", () => {
       surfaceType: "card",
       data: {},
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "ui_surface_show",
       data,
@@ -1877,7 +1887,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from ui_surface_show", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_show",
       conversationId: "conv-4",
       surfaceId: "s-4",
@@ -1899,7 +1909,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses ui_surface_update with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_update",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -1919,7 +1929,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       surfaceId: "s-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "ui_surface_update",
       data,
@@ -1928,7 +1938,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from ui_surface_update", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_update",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -1948,7 +1958,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses ui_surface_dismiss with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_dismiss",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -1965,7 +1975,7 @@ describe("parseAssistantEvent", () => {
       type: "ui_surface_dismiss",
       conversationId: "conv-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "ui_surface_dismiss",
       data,
@@ -1974,7 +1984,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from ui_surface_dismiss", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_dismiss",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -1992,7 +2002,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses ui_surface_complete with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_complete",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -2009,7 +2019,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses ui_surface_complete with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_complete",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -2029,7 +2039,7 @@ describe("parseAssistantEvent", () => {
       conversationId: "conv-1",
       surfaceId: "s-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "ui_surface_complete",
       data,
@@ -2038,7 +2048,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from ui_surface_complete", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "ui_surface_complete",
       conversationId: "conv-1",
       surfaceId: "s-1",
@@ -2054,7 +2064,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses notification_intent with deep-link metadata", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "notification_intent",
       deliveryId: "del-1",
       sourceEventName: "chat.assistant_turn_complete",
@@ -2073,7 +2083,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("notification_intent preserves targetGuardianPrincipalId and silent", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "notification_intent",
       sourceEventName: "guardian.question",
       title: "Guardian check-in",
@@ -2089,7 +2099,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("notification_intent without title falls through to unknown", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "notification_intent",
       sourceEventName: "chat.assistant_turn_complete",
       body: "missing title",
@@ -2108,7 +2118,7 @@ describe("parseAssistantEvent", () => {
       body: "Body",
       deepLinkMetadata: "not-an-object",
     };
-    const event = parseAssistantEvent(data);
+    const event = parseEvent(data);
     expect(event).toEqual({
       type: "unknown",
       rawType: "notification_intent",
@@ -2117,7 +2127,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("notification_intent strips unknown top-level fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "notification_intent",
       sourceEventName: "chat.assistant_turn_complete",
       title: "Hello",
@@ -2134,7 +2144,7 @@ describe("parseAssistantEvent", () => {
 
   describe("usage_update", () => {
     test("parses usage_update with all required fields", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "usage_update",
         conversationId: "conv-1",
         inputTokens: 100,
@@ -2170,7 +2180,7 @@ describe("parseAssistantEvent", () => {
         totalOutputTokens: 50,
         estimatedCost: 0.0021,
       };
-      const event = parseAssistantEvent(data);
+      const event = parseEvent(data);
       expect(event).toEqual({
         type: "unknown",
         rawType: "usage_update",
@@ -2180,7 +2190,7 @@ describe("parseAssistantEvent", () => {
     });
 
     test("strips unknown top-level fields (e.g. legacy cachedInputTokens)", () => {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "usage_update",
         conversationId: "conv-1",
         inputTokens: 100,
@@ -2210,7 +2220,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses identity_changed with all required fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "identity_changed",
       name: "ApolloBot",
       role: "sidekick",
@@ -2237,7 +2247,7 @@ describe("parseAssistantEvent", () => {
       // emoji omitted
       home: "kubernetes",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "identity_changed",
       data,
@@ -2253,7 +2263,7 @@ describe("parseAssistantEvent", () => {
       emoji: "🦖",
       home: "kubernetes",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "identity_changed",
       data,
@@ -2265,7 +2275,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses avatar_updated with avatarPath", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "avatar_updated",
       avatarPath: "/home/.vellum/avatar.png",
     });
@@ -2277,7 +2287,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown avatar_updated when avatarPath is missing", () => {
     const data = { type: "avatar_updated" };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "avatar_updated",
       data,
@@ -2296,7 +2306,7 @@ describe("parseAssistantEvent", () => {
       "reordered",
       "seen_changed",
     ] as const) {
-      const event = parseAssistantEvent({
+      const event = parseEvent({
         type: "conversation_list_invalidated",
         reason,
       });
@@ -2306,7 +2316,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown conversation_list_invalidated when reason is missing", () => {
     const data = { type: "conversation_list_invalidated" };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_list_invalidated",
       data,
@@ -2318,7 +2328,7 @@ describe("parseAssistantEvent", () => {
       type: "conversation_list_invalidated",
       reason: "evicted",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_list_invalidated",
       data,
@@ -2330,7 +2340,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses conversation_title_updated with conversationId and title", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "conversation_title_updated",
       conversationId: "conv-1",
       title: "New Title",
@@ -2347,7 +2357,7 @@ describe("parseAssistantEvent", () => {
       type: "conversation_title_updated",
       title: "Orphan title",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_title_updated",
       data,
@@ -2359,7 +2369,7 @@ describe("parseAssistantEvent", () => {
       type: "conversation_title_updated",
       conversationId: "conv-1",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "conversation_title_updated",
       data,
@@ -2372,7 +2382,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses secret_request with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "secret_request",
       requestId: "sr-1",
       service: "github",
@@ -2403,7 +2413,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses secret_request with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "secret_request",
       requestId: "sr-2",
       service: "openai",
@@ -2426,7 +2436,7 @@ describe("parseAssistantEvent", () => {
       field: "api_key",
       label: "Missing service",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "secret_request",
       data,
@@ -2434,7 +2444,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from secret_request", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "secret_request",
       requestId: "sr-4",
       service: "openai",
@@ -2456,7 +2466,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses confirmation_request with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "confirmation_request",
       requestId: "cr-1",
       toolName: "bash",
@@ -2519,7 +2529,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses confirmation_request with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "confirmation_request",
       requestId: "cr-2",
       toolName: "write_file",
@@ -2548,7 +2558,7 @@ describe("parseAssistantEvent", () => {
       allowlistOptions: [],
       scopeOptions: [],
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "confirmation_request",
       data,
@@ -2556,7 +2566,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from confirmation_request", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "confirmation_request",
       requestId: "cr-4",
       toolName: "bash",
@@ -2582,7 +2592,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses contact_request with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "contact_request",
       requestId: "ctc-1",
       channel: "email",
@@ -2603,7 +2613,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses contact_request with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "contact_request",
       requestId: "ctc-2",
     });
@@ -2615,7 +2625,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown contact_request when requestId is missing", () => {
     const data = { type: "contact_request", channel: "email" };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "contact_request",
       data,
@@ -2623,7 +2633,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from contact_request", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "contact_request",
       requestId: "ctc-3",
       surpriseField: "boom",
@@ -2639,7 +2649,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses question_request with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "question_request",
       requestId: "qr-1",
       questions: [
@@ -2680,7 +2690,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses question_request with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "question_request",
       requestId: "qr-2",
       questions: [{ id: "q1", question: "Continue?", options: [] }],
@@ -2703,7 +2713,7 @@ describe("parseAssistantEvent", () => {
       question: "Continue?",
       options: [],
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "question_request",
       data,
@@ -2711,7 +2721,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("strips unknown fields from question_request", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "question_request",
       requestId: "qr-4",
       questions: [{ id: "q1", question: "?", options: [] }],
@@ -2733,7 +2743,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses subagent_spawned with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_spawned",
       subagentId: "sa-1",
       parentConversationId: "conv-1",
@@ -2754,7 +2764,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses subagent_spawned with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_spawned",
       subagentId: "sa-2",
       parentConversationId: "conv-2",
@@ -2777,7 +2787,7 @@ describe("parseAssistantEvent", () => {
       label: "Research",
       objective: "Find weather data",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_spawned",
       data,
@@ -2793,7 +2803,7 @@ describe("parseAssistantEvent", () => {
       objective: "Find weather data",
       surpriseField: "boom",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_spawned",
       data,
@@ -2805,7 +2815,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses subagent_status_changed with all fields", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_status_changed",
       subagentId: "sa-1",
       status: "completed",
@@ -2821,7 +2831,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses subagent_status_changed with required fields only", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_status_changed",
       subagentId: "sa-2",
       status: "running",
@@ -2834,7 +2844,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("accepts subagent_status_changed with `aborted` terminal status", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_status_changed",
       subagentId: "sa-3",
       status: "aborted",
@@ -2852,7 +2862,7 @@ describe("parseAssistantEvent", () => {
       subagentId: "sa-4",
       status: "bogus",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_status_changed",
       data,
@@ -2866,7 +2876,7 @@ describe("parseAssistantEvent", () => {
       status: "running",
       surpriseField: "boom",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_status_changed",
       data,
@@ -2878,7 +2888,7 @@ describe("parseAssistantEvent", () => {
   // ---------------------------------------------------------------------
 
   test("parses subagent_event wrapping an inner event", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_event",
       conversationId: "conv-1",
       subagentId: "sa-1",
@@ -2899,7 +2909,7 @@ describe("parseAssistantEvent", () => {
   });
 
   test("parses subagent_event with an inner tool_use_start envelope", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "subagent_event",
       conversationId: "conv-2",
       subagentId: "sa-2",
@@ -2929,7 +2939,7 @@ describe("parseAssistantEvent", () => {
       subagentId: "sa-3",
       event: { type: "assistant_text_delta", text: "hi" },
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_event",
       data,
@@ -2944,7 +2954,7 @@ describe("parseAssistantEvent", () => {
       event: { type: "assistant_text_delta", text: "hi" },
       surpriseField: "boom",
     };
-    expect(parseAssistantEvent(data)).toEqual({
+    expect(parseEvent(data)).toEqual({
       type: "unknown",
       rawType: "subagent_event",
       data,
@@ -2955,7 +2965,7 @@ describe("parseAssistantEvent", () => {
 
 describe("envelope format parsing", () => {
   test("flat payloads pass through unchanged", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "assistant_text_delta",
       text: "Hello from envelope",
       messageId: "msg-env-1",
@@ -2968,7 +2978,7 @@ describe("envelope format parsing", () => {
   });
 
   test("envelope shape uses message.type over top-level type", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "wrapper",
       message: {
         type: "assistant_text_delta",
@@ -2985,7 +2995,7 @@ describe("envelope format parsing", () => {
   });
 
   test("envelope shape supports sync_changed", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "wrapper",
       message: {
         type: "sync_changed",
@@ -3006,7 +3016,7 @@ describe("envelope format parsing", () => {
   });
 
   test("flat message_complete works when no envelope message field is present", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "message_complete",
       messageId: "msg-flat",
     });
@@ -3018,7 +3028,7 @@ describe("envelope format parsing", () => {
   });
 
   test("flat sync_changed works when no envelope message field is present", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantSounds],
     });
@@ -3030,7 +3040,7 @@ describe("envelope format parsing", () => {
   });
 
   test("non-object message field is ignored (falls back to flat)", () => {
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       type: "error",
       message: "This is a string, not an envelope",
       code: "test_error",
@@ -3048,7 +3058,7 @@ describe("envelope format parsing", () => {
     // inner message. When the inner omits it, the parser does NOT rescue the
     // event with the envelope-level routing key — it falls through to unknown.
     // This is the drift `@vellumai/assistant-api` exists to prevent.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       conversationId: "conv-from-envelope",
       message: {
         type: "document_editor_update",
@@ -3063,7 +3073,7 @@ describe("envelope format parsing", () => {
   test("a conversation-scoped event reads its own inner conversationId", () => {
     // When the inner message carries its own conversationId, the canonical
     // schema reads it directly; the envelope-level routing key is never used.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       conversationId: "envelope-conv",
       message: {
         type: "document_editor_update",
@@ -3083,7 +3093,7 @@ describe("envelope format parsing", () => {
     // relationship_state_updated is a global event whose strict wire schema
     // doesn't declare conversationId. Stamping the envelope-derived value
     // onto it is the drift `@vellumai/assistant-api` exists to prevent.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       conversationId: "should-be-ignored",
       message: {
         type: "relationship_state_updated",
@@ -3107,7 +3117,7 @@ describe("envelope format parsing", () => {
     // `@vellumai/assistant-api` exists to prevent. Downstream routing
     // that needs conversation scope reads the envelope at the SSE
     // pipe, not from the typed event.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       conversationId: "conv-from-envelope",
       message: {
         type: "open_url",
@@ -3126,7 +3136,7 @@ describe("envelope format parsing", () => {
     // sets conversationId on the inner message, the schema validates,
     // and the typed event carries it through. The envelope value plays
     // no role.
-    const event = parseAssistantEvent({
+    const event = parseEvent({
       conversationId: "envelope-conv",
       message: {
         type: "open_url",

--- a/apps/web/src/lib/streaming/event-parser.ts
+++ b/apps/web/src/lib/streaming/event-parser.ts
@@ -11,7 +11,10 @@
  */
 
 import type { AssistantEvent } from "@/types/event-types";
-import { AssistantEventSchema } from "@vellumai/assistant-api";
+import {
+  AssistantEventSchema,
+  type AssistantEventEnvelope,
+} from "@vellumai/assistant-api";
 import { unknownEvent } from "@/lib/streaming/parse-helpers";
 
 /**
@@ -82,11 +85,35 @@ export function parseAssistantEvent(
   // requires (including `conversationId` for conversation-scoped
   // events), so the envelope-level routing key never needs grafting on.
   const schemaResult = AssistantEventSchema.safeParse(inner);
-  if (schemaResult.success) return schemaResult.data as AssistantEvent;
+  if (schemaResult.success) {
+    return schemaResult.data as AssistantEvent;
+  }
 
   // Unrecognised payload. Stamp the envelope conversationId onto the
   // fallback so per-conversation subscribers can still route it.
   const merged = mergeEnvelopeConversationId(inner, envelopeConversationId);
   const rawType = typeof merged.type === "string" ? merged.type : "";
   return unknownEvent(rawType, merged);
+}
+
+/**
+ * Parse a raw SSE payload into a full `AssistantEventEnvelope`.
+ * Extracts envelope metadata (`id`, `conversationId`, `seq`,
+ * `emittedAt`) from the raw data and delegates inner-event parsing
+ * to `parseAssistantEvent`.
+ */
+export function parseAssistantEventEnvelope(
+  data: Record<string, unknown>,
+): AssistantEventEnvelope {
+  const event = parseAssistantEvent(data);
+  return {
+    id: typeof data.id === "string" ? data.id : "",
+    conversationId:
+      typeof data.conversationId === "string"
+        ? data.conversationId
+        : undefined,
+    seq: typeof data.seq === "number" ? data.seq : undefined,
+    emittedAt: typeof data.emittedAt === "string" ? data.emittedAt : "",
+    message: event,
+  } as AssistantEventEnvelope;
 }

--- a/apps/web/src/lib/streaming/event-parser.ts
+++ b/apps/web/src/lib/streaming/event-parser.ts
@@ -2,110 +2,53 @@
  * SSE event parsing for the assistant chat stream.
  *
  * Exports `parseAssistantEvent`, which takes a raw SSE payload and
- * returns a typed `AssistantEvent`. The parser unwraps the
- * envelope/flat shape and validates the inner message against the
- * canonical `AssistantEventSchema` from `@vellumai/assistant-api`,
- * which is the source of truth for every wire event. Anything the
- * union doesn't recognise becomes an `UnknownEvent` so callers can
- * safely ignore it without crashing.
+ * returns a typed `AssistantEventEnvelope`. The primary path validates
+ * the full envelope (metadata + inner message) against
+ * `AssistantEventEnvelopeSchema` from `@vellumai/assistant-api`.
+ * Payloads that don't match (unknown event types, legacy flat shapes)
+ * are wrapped in an envelope with an `UnknownEvent` message so callers
+ * can safely ignore them without crashing.
  */
 
 import type { AssistantEvent } from "@/types/event-types";
 import {
+  AssistantEventEnvelopeSchema,
   AssistantEventSchema,
   type AssistantEventEnvelope,
 } from "@vellumai/assistant-api";
 import { unknownEvent } from "@/lib/streaming/parse-helpers";
 
 /**
- * Unwrap envelope-shape payloads `{ message: { type, ...fields }, conversationId }`
- * into the inner event. Flat-shape payloads `{ type, ...fields }` pass
- * through unchanged.
+ * Parse a raw SSE payload into a typed `AssistantEventEnvelope`.
  *
- * Pure unwrap: the envelope-level `conversationId` (SSE routing key)
- * is NOT merged onto the inner message. Canonical schemas that don't
- * declare `conversationId` stay strict; the routing key is only folded
- * back in via `mergeEnvelopeConversationId` when building the
- * `UnknownEvent` fallback.
- */
-function unwrapEnvelope(data: Record<string, unknown>): {
-  inner: Record<string, unknown>;
-  envelopeConversationId: string | undefined;
-} {
-  const message = data.message;
-  if (
-    message &&
-    typeof message === "object" &&
-    !Array.isArray(message) &&
-    typeof (message as Record<string, unknown>).type === "string"
-  ) {
-    return {
-      inner: message as Record<string, unknown>,
-      envelopeConversationId:
-        typeof data.conversationId === "string"
-          ? data.conversationId
-          : undefined,
-    };
-  }
-  return { inner: data, envelopeConversationId: undefined };
-}
-
-/**
- * Merge the envelope-level `conversationId` onto the inner data when
- * the inner doesn't already declare one. Applied only when building the
- * `UnknownEvent` fallback, so per-conversation SSE subscribers can
- * still route an unrecognised payload by its envelope scope. Canonical
- * events never go through this — they declare the fields they require,
- * so the envelope routing key never leaks onto a parsed event.
- */
-function mergeEnvelopeConversationId(
-  inner: Record<string, unknown>,
-  envelopeConversationId: string | undefined,
-): Record<string, unknown> {
-  if (envelopeConversationId && typeof inner.conversationId !== "string") {
-    return { ...inner, conversationId: envelopeConversationId };
-  }
-  return inner;
-}
-
-/**
- * Parse a raw SSE payload into a typed `AssistantEvent`. Owns envelope
- * unwrap and canonical-schema dispatch. Tolerant of unknown event
- * types — returns an `UnknownEvent` for anything unrecognised so
- * callers can safely ignore it without crashing.
+ * Primary path: `AssistantEventEnvelopeSchema.safeParse` validates the
+ * full envelope in one shot. Fallback: extract the inner event (from
+ * `data.message` if envelope-shaped, or `data` itself if flat), try the
+ * inner schema, and wrap the result in a synthetic envelope.
  */
 export function parseAssistantEvent(
   data: Record<string, unknown>,
-): AssistantEvent {
-  const { inner, envelopeConversationId } = unwrapEnvelope(data);
-
-  // The discriminated union in `@vellumai/assistant-api` is the source
-  // of truth for every wire event. The schema sees the pure inner
-  // message (no envelope merge): every schema declares the fields it
-  // requires (including `conversationId` for conversation-scoped
-  // events), so the envelope-level routing key never needs grafting on.
-  const schemaResult = AssistantEventSchema.safeParse(inner);
-  if (schemaResult.success) {
-    return schemaResult.data as AssistantEvent;
+): AssistantEventEnvelope {
+  const envelopeResult = AssistantEventEnvelopeSchema.safeParse(data);
+  if (envelopeResult.success) {
+    return envelopeResult.data;
   }
 
-  // Unrecognised payload. Stamp the envelope conversationId onto the
-  // fallback so per-conversation subscribers can still route it.
-  const merged = mergeEnvelopeConversationId(inner, envelopeConversationId);
-  const rawType = typeof merged.type === "string" ? merged.type : "";
-  return unknownEvent(rawType, merged);
-}
+  // Determine the inner payload: envelope-wrapped or flat shape.
+  const msg = data.message;
+  const inner =
+    msg &&
+    typeof msg === "object" &&
+    !Array.isArray(msg) &&
+    typeof (msg as Record<string, unknown>).type === "string"
+      ? (msg as Record<string, unknown>)
+      : data;
 
-/**
- * Parse a raw SSE payload into a full `AssistantEventEnvelope`.
- * Extracts envelope metadata (`id`, `conversationId`, `seq`,
- * `emittedAt`) from the raw data and delegates inner-event parsing
- * to `parseAssistantEvent`.
- */
-export function parseAssistantEventEnvelope(
-  data: Record<string, unknown>,
-): AssistantEventEnvelope {
-  const event = parseAssistantEvent(data);
+  const innerResult = AssistantEventSchema.safeParse(inner);
+  const event: AssistantEvent = innerResult.success
+    ? (innerResult.data as AssistantEvent)
+    : unknownEvent(typeof inner.type === "string" ? inner.type : "", inner);
+
   return {
     id: typeof data.id === "string" ? data.id : "",
     conversationId:

--- a/apps/web/src/lib/streaming/stream-transport.ts
+++ b/apps/web/src/lib/streaming/stream-transport.ts
@@ -9,8 +9,9 @@
 
 import { client } from "@/generated/api/client.gen";
 import { SDK_BASE_OPTIONS } from "@/utils/api-errors";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import { parseAssistantEvent } from "@/lib/streaming/event-parser";
-import type { AssistantEvent } from "@/types/event-types";
+
 import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import {
@@ -117,7 +118,7 @@ const STREAM_IDLE_TIMEOUT_MS = 45_000;
 export function subscribeChatEvents(
   assistantId: string,
   conversationId: string | null | undefined,
-  onEvent: (event: AssistantEvent) => void,
+  onEvent: (envelope: AssistantEventEnvelope) => void,
   onError: (err: Error) => void,
   options: ChatEventStreamOptions = {},
 ): ChatEventStream {
@@ -290,9 +291,22 @@ export function subscribeChatEvents(
           // envelope-conversationId stamping. This handler is the
           // transport — keep it thin.
           const parsed = parseAssistantEvent(data);
+
+          const envelope = {
+            id: typeof data.id === "string" ? data.id : "",
+            conversationId:
+              typeof data.conversationId === "string"
+                ? data.conversationId
+                : undefined,
+            seq: typeof data.seq === "number" ? data.seq : undefined,
+            emittedAt:
+              typeof data.emittedAt === "string" ? data.emittedAt : "",
+            message: parsed,
+          } as AssistantEventEnvelope;
+
           pushSseEvent(sseDebugClientId, parsed);
           try {
-            onEvent(parsed);
+            onEvent(envelope);
           } catch {
             // Callback errors should not trigger stream reconnect
           }

--- a/apps/web/src/lib/streaming/stream-transport.ts
+++ b/apps/web/src/lib/streaming/stream-transport.ts
@@ -10,7 +10,7 @@
 import { client } from "@/generated/api/client.gen";
 import { SDK_BASE_OPTIONS } from "@/utils/api-errors";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
-import { parseAssistantEventEnvelope } from "@/lib/streaming/event-parser";
+import { parseAssistantEvent } from "@/lib/streaming/event-parser";
 
 import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
@@ -286,7 +286,7 @@ export function subscribeChatEvents(
             reconnectCount = 0;
           }
 
-          const envelope = parseAssistantEventEnvelope(data);
+          const envelope = parseAssistantEvent(data);
 
           pushSseEvent(sseDebugClientId, envelope.message);
           try {

--- a/apps/web/src/lib/streaming/stream-transport.ts
+++ b/apps/web/src/lib/streaming/stream-transport.ts
@@ -10,7 +10,7 @@
 import { client } from "@/generated/api/client.gen";
 import { SDK_BASE_OPTIONS } from "@/utils/api-errors";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
-import { parseAssistantEvent } from "@/lib/streaming/event-parser";
+import { parseAssistantEventEnvelope } from "@/lib/streaming/event-parser";
 
 import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
@@ -286,25 +286,9 @@ export function subscribeChatEvents(
             reconnectCount = 0;
           }
 
-          // `parseAssistantEvent` owns the full path: envelope/flat
-          // unwrap, canonical-schema dispatch, legacy-event coercion, and
-          // envelope-conversationId stamping. This handler is the
-          // transport — keep it thin.
-          const parsed = parseAssistantEvent(data);
+          const envelope = parseAssistantEventEnvelope(data);
 
-          const envelope = {
-            id: typeof data.id === "string" ? data.id : "",
-            conversationId:
-              typeof data.conversationId === "string"
-                ? data.conversationId
-                : undefined,
-            seq: typeof data.seq === "number" ? data.seq : undefined,
-            emittedAt:
-              typeof data.emittedAt === "string" ? data.emittedAt : "",
-            message: parsed,
-          } as AssistantEventEnvelope;
-
-          pushSseEvent(sseDebugClientId, parsed);
+          pushSseEvent(sseDebugClientId, envelope.message);
           try {
             onEvent(envelope);
           } catch {

--- a/apps/web/src/stores/event-bus-store.test.ts
+++ b/apps/web/src/stores/event-bus-store.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import {
   __resetEventBusForTesting,
   useEventBusStore,
 } from "@/stores/event-bus-store";
 
-function avatarEvent(): AssistantEvent {
-  return { type: "avatar_updated", avatarPath: "/tmp/avatar.png" };
+function avatarEnvelope(): AssistantEventEnvelope {
+  return {
+    id: "evt-1",
+    emittedAt: new Date().toISOString(),
+    message: { type: "avatar_updated", avatarPath: "/tmp/avatar.png" },
+  };
 }
 
 beforeEach(() => {
@@ -23,10 +27,10 @@ describe("event-bus-store", () => {
     const bus = useEventBusStore.getState();
     const handler = mock(() => {});
     bus.subscribe("sse.event", handler);
-    const event = avatarEvent();
-    bus.publish("sse.event", event);
+    const envelope = avatarEnvelope();
+    bus.publish("sse.event", envelope);
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith(event);
+    expect(handler).toHaveBeenCalledWith(envelope);
   });
 
   test("publish delivers to every active subscriber", () => {
@@ -44,10 +48,10 @@ describe("event-bus-store", () => {
     const bus = useEventBusStore.getState();
     const handler = mock(() => {});
     const unsubscribe = bus.subscribe("sse.event", handler);
-    bus.publish("sse.event", avatarEvent());
+    bus.publish("sse.event", avatarEnvelope());
     expect(handler).toHaveBeenCalledTimes(1);
     unsubscribe();
-    bus.publish("sse.event", avatarEvent());
+    bus.publish("sse.event", avatarEnvelope());
     expect(handler).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/stores/event-bus-store.ts
+++ b/apps/web/src/stores/event-bus-store.ts
@@ -21,7 +21,7 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
-import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 /**
  * Source of a synthetic `"app.resume"` event.
@@ -49,12 +49,11 @@ export type AppHiddenSignal = "visibility" | "app_state";
 export interface BusEventMap {
   /**
    * Re-broadcast of an SSE event received on the bus-owned
-   * assistant-scoped `/v1/events` connection. Subscribers narrow on
-   * `payload.type`. Conversation-scoped consumers must filter on
-   * `event.conversationId` themselves — the bus delivers every
-   * event the underlying stream sees.
+   * assistant-scoped `/v1/events` connection. The envelope carries
+   * transport metadata (`seq`, `conversationId`, `emittedAt`);
+   * subscribers read the semantic event from `envelope.message`.
    */
-  "sse.event": AssistantEvent;
+  "sse.event": AssistantEventEnvelope;
   /**
    * The bus-owned SSE connection just opened (or reopened). Carries the
    * `cause` of the (re)open so consumers can distinguish a fresh


### PR DESCRIPTION
Switches the event bus payload from bare `AssistantEvent` to `AssistantEventEnvelope`, giving subscribers typed access to envelope metadata (`seq`, `conversationId`, `id`, `emittedAt`). This unblocks B7.3 (client-side gap detection) from reading `seq` off the bus without casts or raw-payload interception.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/23bd280e47b645a39d2433185a906bc7
