### PR TITLE
refactor(disk-pressure): unify REST response on canonical schema

### DIFF
--- a/apps/web/src/assistant/api.ts
+++ b/apps/web/src/assistant/api.ts
@@ -1,3 +1,8 @@
+import {
+  type DiskPressureStatusResponse,
+  DiskPressureStatusResponseSchema,
+} from "@vellumai/assistant-api";
+
 import { client } from "@/generated/api/client.gen";
 import {
   assistantsActivateCreate,
@@ -68,33 +73,6 @@ export interface AssistantHealthz {
 export type GetHealthzResult =
   | { ok: true; status: number; data: AssistantHealthz }
   | { ok: false; status: number; error: Record<string, unknown> };
-
-export type DiskPressureState = "disabled" | "ok" | "warning" | "critical" | "unknown";
-
-export type DiskPressureBlockedCapability =
-  | "agent-turns"
-  | "background-work"
-  | "remote-ingress";
-
-export interface DiskPressureStatus {
-  enabled: boolean;
-  state: DiskPressureState;
-  locked: boolean;
-  acknowledged: boolean;
-  overrideActive: boolean;
-  effectivelyLocked: boolean;
-  lockId: string | null;
-  usagePercent: number | null;
-  thresholdPercent: number;
-  path: string | null;
-  lastCheckedAt: string | null;
-  blockedCapabilities: DiskPressureBlockedCapability[];
-  error: string | null;
-}
-
-export interface DiskPressureStatusResponse {
-  status: DiskPressureStatus;
-}
 
 export type GetAssistantDiskPressureStatusResult =
   | { ok: true; status: number; data: DiskPressureStatusResponse }
@@ -286,7 +264,7 @@ export async function getAssistantDiskPressureStatus(
     return {
       ok: true,
       status: response.status,
-      data: data as unknown as DiskPressureStatusResponse,
+      data: DiskPressureStatusResponseSchema.parse(data),
     };
   }
 
@@ -321,7 +299,7 @@ export async function acknowledgeAssistantDiskPressure(
     return {
       ok: true,
       status: response.status,
-      data: data as unknown as DiskPressureStatusResponse,
+      data: DiskPressureStatusResponseSchema.parse(data),
     };
   }
 

--- a/apps/web/src/assistant/api.ts
+++ b/apps/web/src/assistant/api.ts
@@ -261,10 +261,19 @@ export async function getAssistantDiskPressureStatus(
   );
 
   if (response.ok) {
+    const parsed = DiskPressureStatusResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        status: response.status,
+        error: toErrorObject(parsed.error.message, response),
+      };
+    }
+
     return {
       ok: true,
       status: response.status,
-      data: DiskPressureStatusResponseSchema.parse(data),
+      data: parsed.data,
     };
   }
 
@@ -296,10 +305,19 @@ export async function acknowledgeAssistantDiskPressure(
   );
 
   if (response.ok) {
+    const parsed = DiskPressureStatusResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        status: response.status,
+        error: toErrorObject(parsed.error.message, response),
+      };
+    }
+
     return {
       ok: true,
       status: response.status,
-      data: DiskPressureStatusResponseSchema.parse(data),
+      data: parsed.data,
     };
   }
 

--- a/apps/web/src/assistant/disk-pressure.ts
+++ b/apps/web/src/assistant/disk-pressure.ts
@@ -1,4 +1,4 @@
-import type { DiskPressureStatus } from "@/assistant/api";
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
 
 export type DiskPressureMonitorMode =
   | "inactive"

--- a/apps/web/src/assistant/use-disk-pressure-monitor.ts
+++ b/apps/web/src/assistant/use-disk-pressure-monitor.ts
@@ -1,10 +1,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+
 import {
   acknowledgeAssistantDiskPressure,
   getAssistantDiskPressureStatus,
-  type DiskPressureStatus,
 } from "@/assistant/api";
 import {
   DISK_PRESSURE_POLL_INTERVAL_MS,

--- a/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
+++ b/apps/web/src/domains/chat/components/disk-pressure-banner.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, HardDrive } from "lucide-react";
 
 import { Button, Checkbox, Modal } from "@vellum/design-library";
 import { Notice } from "@vellum/design-library";
-import type { DiskPressureStatus } from "@/assistant/api";
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
 import { formatDiskPressureUsage } from "@/assistant/disk-pressure";
 
 export type DiskPressureBannerMode = "warning" | "acknowledgement-required" | "cleanup";

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -293,6 +293,10 @@ export {
   UserMessageEchoEventSchema,
 } from "./events/user-message-echo.js";
 export {
+  type DiskPressureStatusResponse,
+  DiskPressureStatusResponseSchema,
+} from "./responses/disk-pressure-status.js";
+export {
   type LlmContextResponse,
   LlmContextResponseSchema,
 } from "./responses/llm-context-response.js";

--- a/assistant/src/api/responses/disk-pressure-status.ts
+++ b/assistant/src/api/responses/disk-pressure-status.ts
@@ -1,0 +1,26 @@
+/**
+ * Wire contract for the disk-pressure REST endpoints
+ * (`GET /disk-pressure/status`, `POST /disk-pressure/acknowledge`,
+ * `POST /disk-pressure/override`). All three return the current
+ * snapshot wrapped as `{ status }`.
+ *
+ * Reuses the canonical `DiskPressureStatusSchema` defined alongside the
+ * `disk_pressure_status_changed` SSE event so the polled REST fetch and
+ * the streamed update share a single shape.
+ *
+ * Canonical wire-contract source. Assistant code imports the types
+ * directly from this file via relative paths; external consumers
+ * (web client, gateway, evals) import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+import { DiskPressureStatusSchema } from "../events/disk-pressure-status-changed.js";
+
+export const DiskPressureStatusResponseSchema = z.object({
+  status: DiskPressureStatusSchema,
+});
+
+export type DiskPressureStatusResponse = z.infer<
+  typeof DiskPressureStatusResponseSchema
+>;

--- a/assistant/src/runtime/routes/disk-pressure-routes.ts
+++ b/assistant/src/runtime/routes/disk-pressure-routes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { DiskPressureStatusResponseSchema } from "../../api/responses/disk-pressure-status.js";
 import {
   acknowledgeDiskPressureLock,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
@@ -9,28 +10,6 @@ import {
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { RouteError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
-
-const DiskPressureStatusSchema = z.object({
-  enabled: z.boolean(),
-  state: z.enum(["disabled", "ok", "warning", "critical", "unknown"]),
-  locked: z.boolean(),
-  acknowledged: z.boolean(),
-  overrideActive: z.boolean(),
-  effectivelyLocked: z.boolean(),
-  lockId: z.string().nullable(),
-  usagePercent: z.number().nullable(),
-  thresholdPercent: z.number(),
-  path: z.string().nullable(),
-  lastCheckedAt: z.string().nullable(),
-  blockedCapabilities: z.array(
-    z.enum(["agent-turns", "background-work", "remote-ingress"]),
-  ),
-  error: z.string().nullable(),
-});
-
-const DiskPressureActionResponseSchema = z.object({
-  status: DiskPressureStatusSchema,
-});
 
 const OverrideRequestSchema = z.object({
   confirmation: z.string(),
@@ -61,7 +40,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Return the current disk pressure status snapshot. When safe storage limits are disabled, returns a disabled status.",
     tags: ["disk-pressure"],
-    responseBody: DiskPressureActionResponseSchema,
+    responseBody: DiskPressureStatusResponseSchema,
     handler: () => statusResponse(),
   },
   {
@@ -76,7 +55,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Acknowledge the current disk pressure lock and enter cleanup mode without overriding assistant protections.",
     tags: ["disk-pressure"],
-    responseBody: DiskPressureActionResponseSchema,
+    responseBody: DiskPressureStatusResponseSchema,
     additionalResponses: {
       "409": { description: "No active lock or lock already acknowledged." },
     },
@@ -105,7 +84,7 @@ export const ROUTES: RouteDefinition[] = [
     description: `Override the current disk pressure lock only after confirming "${DISK_PRESSURE_OVERRIDE_CONFIRMATION}".`,
     tags: ["disk-pressure"],
     requestBody: OverrideRequestSchema,
-    responseBody: DiskPressureActionResponseSchema,
+    responseBody: DiskPressureStatusResponseSchema,
     additionalResponses: {
       "400": { description: "Confirmation phrase is invalid." },
       "409": { description: "No active lock or lock already overridden." },


### PR DESCRIPTION
Unifies the disk-pressure REST response on the canonical `DiskPressureStatusSchema` from `@vellumai/assistant-api` so the polled REST snapshot and the streamed `disk_pressure_status_changed` event share one source of truth — deleting the daemon's hand-mirrored route schema and the web client's parallel hand-rolled types plus its `as unknown as` casts. This is safe because the schema shape is byte-identical (the regenerated `assistant/openapi.yaml` is unchanged); only the source moves, and the web client now validates the payload through the shared strip-mode schema, which tolerates macOS↔platform version skew in both directions.

Link to Devin session: https://app.devin.ai/sessions/1e548ca652244faea565e4806a75dbc6
Requested by: @dvargas92495