### PR TITLE
refactor(assistant): re-home the mid-loop budget gate into the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/agent-loop-exit-reason.test.ts
@@ -281,6 +281,64 @@ describe("AgentLoop exit-reason instrumentation", () => {
     expect(countExitEvents(events)).toBe(0);
   });
 
+  test("yields with 'budget' when the in-loop budget gate trips", async () => {
+    // GIVEN a provider that calls a tool (reaching a checkpoint) before it
+    // would continue with a text response.
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      textResponse("never reached"),
+    ]);
+    const toolExecutor = async () => ({ content: "ok", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // AND an effective context window so small that any real token estimate
+    // of the running history exceeds the mid-loop threshold.
+    // WHEN the loop checkpoints after the tool results land
+    const result = await loop.run([userMessage], () => {}, {
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+      }),
+    });
+
+    // THEN it yields for budget before issuing the next provider call.
+    expect(result.exitReason).toBe("budget");
+  });
+
+  test("does not yield for budget when overflow recovery is disabled", async () => {
+    // GIVEN the same tiny context window but overflow recovery disabled — the
+    // agent-wake configuration, which must never yield for budget.
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      textResponse("done"),
+    ]);
+    const toolExecutor = async () => ({ content: "ok", isError: false });
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    // WHEN the loop runs to completion
+    const result = await loop.run([userMessage], () => {}, {
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: false, safetyMarginRatio: 0 },
+      }),
+    });
+
+    // THEN it never yields for budget.
+    expect(result.exitReason).not.toBe("budget");
+  });
+
   test("emits 'error' when provider throws an unhandled error", async () => {
     const provider: Provider = {
       name: "broken",

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -239,8 +239,10 @@ describe("AgentLoop", () => {
     await loop.run([userMessage], collectEvents([]), {
       requestId: "req-1",
       callSite: "mainAgent",
-      effectiveMaxInputTokens: 1_000,
-      resolveEffectiveMaxInputTokens: () => maxInputTokens,
+      resolveContextWindow: () => ({
+        maxInputTokens,
+        overflowRecovery: { enabled: false, safetyMarginRatio: 0 },
+      }),
     });
 
     const secondCallMessages = calls[1].messages;

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -156,7 +156,9 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
     // and routing layers would short-circuit and silently drop both the
     // call-site config and the pinned override profile.
     expect(runArgs[0]!.options?.callSite).toBe("mainAgent");
-    expect(runArgs[0]!.options?.effectiveMaxInputTokens).toBe(150000);
+    expect(runArgs[0]!.options?.resolveContextWindow?.().maxInputTokens).toBe(
+      150000,
+    );
     // Sanity: the wake-source tag still propagates as requestId.
     expect(runArgs[0]!.options?.requestId).toBe("wake:scheduler");
   });
@@ -181,7 +183,9 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
     // maxTokens, effort, etc.). Otherwise the wake silently runs under
     // workspace defaults regardless of any per-call-site configuration.
     expect(runArgs[0]!.options?.callSite).toBe("mainAgent");
-    expect(runArgs[0]!.options?.effectiveMaxInputTokens).toBeGreaterThan(0);
+    expect(
+      runArgs[0]!.options?.resolveContextWindow?.().maxInputTokens,
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -355,7 +355,7 @@ interface CapturedAgentLoopRun {
   callSite: LLMCallSite | undefined;
   overrideProfile: string | undefined;
   resolvedOverrideProfile: string | undefined;
-  resolvedEffectiveMaxInputTokens: number | undefined;
+  resolvedMaxInputTokens: number | undefined;
 }
 
 let mutateBeforeResolveOverrideProfile: (() => void) | undefined;
@@ -374,8 +374,7 @@ function makeCtx(
       callSite: options?.callSite,
       overrideProfile: options?.overrideProfile,
       resolvedOverrideProfile: options?.resolveOverrideProfile?.(),
-      resolvedEffectiveMaxInputTokens:
-        options?.resolveEffectiveMaxInputTokens?.(),
+      resolvedMaxInputTokens: options?.resolveContextWindow?.().maxInputTokens,
     });
     return [
       ...messages,
@@ -664,7 +663,7 @@ describe("runAgentLoopImpl — per-conversation inferenceProfile", () => {
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0].overrideProfile).toBeUndefined();
     expect(captured[0].resolvedOverrideProfile).toBe("quality-optimized");
-    expect(captured[0].resolvedEffectiveMaxInputTokens).toBe(50000);
+    expect(captured[0].resolvedMaxInputTokens).toBe(50000);
     expect(ctx.currentTurnOverrideProfile).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -460,9 +460,37 @@ const asAgentLoopRun = (
       wrapped = {
         ...options,
         onCheckpoint: async (info) => {
+          // Handoff is offered first, mirroring the loop's ordering.
           const decision = await inner(info);
-          exitReason = decision === "continue" ? null : decision;
-          return decision;
+          if (decision !== "continue") {
+            exitReason = decision;
+            return decision;
+          }
+          // The mid-loop budget gate lives inside `AgentLoop.run`. Replicate
+          // it here — using the same formula and the stubbed estimator — so
+          // these orchestrator-escalation tests still drive the budget-yield
+          // path now that the orchestrator's `onCheckpoint` is handoff-only.
+          const contextWindow = options.resolveContextWindow?.();
+          if (contextWindow?.overflowRecovery.enabled) {
+            const { maxInputTokens, overflowRecovery } = contextWindow;
+            const safetyMargin =
+              info.history.length > 50
+                ? Math.max(overflowRecovery.safetyMarginRatio, 0.15)
+                : overflowRecovery.safetyMarginRatio;
+            const preflightBudget = Math.floor(
+              maxInputTokens * (1 - safetyMargin),
+            );
+            const estimated =
+              typeof mockEstimateTokens === "function"
+                ? mockEstimateTokens(info.history)
+                : mockEstimateTokens;
+            if (estimated > preflightBudget * 0.85) {
+              exitReason = "budget";
+              return "budget";
+            }
+          }
+          exitReason = null;
+          return "continue";
         },
       };
     }

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -573,9 +573,33 @@ const asAgentLoopRun = (
       wrapped = {
         ...options,
         onCheckpoint: async (info) => {
+          // Handoff is offered first, mirroring the loop's ordering.
           const decision = await inner(info);
-          exitReason = decision === "continue" ? null : decision;
-          return decision;
+          if (decision !== "continue") {
+            exitReason = decision;
+            return decision;
+          }
+          // The mid-loop budget gate lives inside `AgentLoop.run`. Replicate
+          // it here — using the same formula and the stubbed estimator — so
+          // these orchestrator-escalation tests still drive the budget-yield
+          // path now that the orchestrator's `onCheckpoint` is handoff-only.
+          const contextWindow = options.resolveContextWindow?.();
+          if (contextWindow?.overflowRecovery.enabled) {
+            const { maxInputTokens, overflowRecovery } = contextWindow;
+            const safetyMargin =
+              info.history.length > 50
+                ? Math.max(overflowRecovery.safetyMarginRatio, 0.15)
+                : overflowRecovery.safetyMarginRatio;
+            const preflightBudget = Math.floor(
+              maxInputTokens * (1 - safetyMargin),
+            );
+            if (mockEstimateTokens > preflightBudget * 0.85) {
+              exitReason = "budget";
+              return "budget";
+            }
+          }
+          exitReason = null;
+          return "continue";
         },
       };
     }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -9,6 +9,7 @@ import {
 import { calculateMaxToolResultChars } from "../context/tool-result-truncation.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { defaultEmptyResponseTerminal } from "../plugins/defaults/empty-response.js";
+import { defaultTokenEstimateTerminal } from "../plugins/defaults/token-estimate.js";
 import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error.js";
 import { defaultToolResultTruncateTerminal } from "../plugins/defaults/tool-result-truncate.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
@@ -16,6 +17,8 @@ import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {
   EmptyResponseArgs,
   EmptyResponseDecision,
+  EstimateArgs,
+  EstimateResult,
   LLMCallArgs,
   LLMCallResult,
   ToolErrorArgs,
@@ -42,6 +45,23 @@ import { getLogger } from "../util/logger.js";
 import { isRetryableNetworkError } from "../util/retry.js";
 
 const log = getLogger("agent-loop");
+
+/**
+ * Mid-loop yield threshold expressed as a fraction of the preflight budget.
+ * When the running token estimate crosses this fraction at a tool-use
+ * checkpoint, the loop yields (`exitReason = "budget"`) so the orchestrator
+ * can compact before the next provider call would risk a hard
+ * context-too-large rejection.
+ */
+const MID_LOOP_YIELD_THRESHOLD_RATIO = 0.85;
+
+/**
+ * Above this many in-context messages the budget gate raises the safety
+ * margin floor: long histories accumulate hard-to-estimate residue (tool
+ * results, media stubs), so a wider margin keeps the estimate conservative.
+ */
+const LONG_HISTORY_MESSAGE_THRESHOLD = 50;
+const LONG_HISTORY_SAFETY_MARGIN_FLOOR = 0.15;
 
 export interface AgentLoopConfig {
   maxTokens: number;
@@ -423,9 +443,24 @@ export interface AgentLoopRunOptions {
    * call-site named profile. Missing profile names silently fall through.
    */
   overrideProfile?: string;
-  effectiveMaxInputTokens?: number;
   resolveOverrideProfile?: () => string | undefined;
-  resolveEffectiveMaxInputTokens?: () => number | undefined;
+  /**
+   * Resolves the orchestrator's current effective context window for this
+   * conversation: the provider max-input-token ceiling plus the
+   * overflow-recovery config that drives the mid-loop budget gate. Resolved
+   * fresh per checkpoint so a mid-turn inference-profile change (which can
+   * shift both the ceiling and the margins) is reflected immediately.
+   *
+   * Drives two things: tool-result truncation reads `maxInputTokens`, and the
+   * mid-loop budget gate reads `overflowRecovery`. When absent, the loop
+   * falls back to `this.config.maxInputTokens` for truncation and skips the
+   * budget gate entirely (callers with no orchestrator-side compaction path,
+   * e.g. agent wakes, pass `overflowRecovery.enabled = false`).
+   */
+  resolveContextWindow?: () => {
+    maxInputTokens: number;
+    overflowRecovery: { enabled: boolean; safetyMarginRatio: number };
+  };
   /**
    * When true, the latest user message carries a volatile per-turn block
    * (e.g. a memory-v3 `<memory>` injection) that varies across otherwise
@@ -540,6 +575,35 @@ export class AgentLoop {
     return estimateToolsTokens(this.getResolvedTools(history));
   }
 
+  /**
+   * Estimate the total prompt tokens for the given history via the
+   * `tokenEstimate` plugin pipeline. The history and resolved-tool arrays are
+   * shallow-frozen so a misbehaving middleware that mutates its args (e.g.
+   * `args.history.push(...)`) cannot silently strip context from the loop's
+   * live `history`: TypeScript `readonly` does not prevent runtime mutation,
+   * but the frozen wrapper throws in strict mode.
+   */
+  private estimateTokens(
+    history: Message[],
+    turnContext: TurnContext,
+  ): Promise<EstimateResult> {
+    return runPipeline<EstimateArgs, EstimateResult>(
+      "tokenEstimate",
+      getMiddlewaresFor("tokenEstimate"),
+      defaultTokenEstimateTerminal,
+      {
+        history: Object.freeze([...history]) as Message[],
+        systemPrompt: this.systemPrompt,
+        tools: Object.freeze([
+          ...this.getResolvedTools(history),
+        ]) as ToolDefinition[],
+        providerName: getCalibrationProviderKey(this.provider),
+      },
+      turnContext,
+      DEFAULT_TIMEOUTS.tokenEstimate,
+    );
+  }
+
   async run(
     messages: Message[],
     onEvent: (event: AgentEvent) => void | Promise<void>,
@@ -552,9 +616,8 @@ export class AgentLoop {
       callSite,
       turnContext,
       overrideProfile,
-      effectiveMaxInputTokens,
       resolveOverrideProfile,
-      resolveEffectiveMaxInputTokens,
+      resolveContextWindow,
       mutableLatestUserMessage,
     } = options ?? {};
     const history = [...messages];
@@ -1249,8 +1312,7 @@ export class AgentLoop {
         // truncation strategy (e.g. a summariser) while the default
         // middleware preserves the historical tail-drop behaviour.
         const contextWindowTokens =
-          resolveEffectiveMaxInputTokens?.() ??
-          effectiveMaxInputTokens ??
+          resolveContextWindow?.().maxInputTokens ??
           this.config.maxInputTokens ??
           180_000;
         const maxChars = calculateMaxToolResultChars(contextWindowTokens);
@@ -1400,8 +1462,8 @@ export class AgentLoop {
         history.push({ role: "user", content: resultBlocks });
 
         // Invoke checkpoint callback after tool results are in history.
-        // The callback may be async — the mid-loop budget check delegates
-        // to the `tokenEstimate` plugin pipeline, which is asynchronous.
+        // Handoff is offered first so a queued message takes precedence over
+        // the mid-loop budget yield below.
         if (onCheckpoint) {
           const decision = await onCheckpoint({
             turnIndex: toolUseTurns - 1, // 0-based (toolUseTurns was already incremented)
@@ -1411,6 +1473,39 @@ export class AgentLoop {
           });
           if (decision !== "continue") {
             exitReason = decision;
+            break;
+          }
+        }
+
+        // Mid-loop budget gate: when overflow recovery is enabled, estimate
+        // the running context size and yield if it is approaching the
+        // preflight budget, letting the orchestrator compact before the next
+        // provider call would risk a hard context-too-large rejection. Keyed
+        // off the loop's own `history.length` (which reflects the messages
+        // actually in context this turn, including tool iterations) rather
+        // than the durable conversation count.
+        const contextWindow = resolveContextWindow?.();
+        if (contextWindow?.overflowRecovery.enabled) {
+          const { maxInputTokens, overflowRecovery } = contextWindow;
+          const safetyMargin =
+            history.length > LONG_HISTORY_MESSAGE_THRESHOLD
+              ? Math.max(
+                  overflowRecovery.safetyMarginRatio,
+                  LONG_HISTORY_SAFETY_MARGIN_FLOOR,
+                )
+              : overflowRecovery.safetyMarginRatio;
+          const preflightBudget = Math.floor(
+            maxInputTokens * (1 - safetyMargin),
+          );
+          const midLoopThreshold =
+            preflightBudget * MID_LOOP_YIELD_THRESHOLD_RATIO;
+          const estimated = await this.estimateTokens(history, turnCtx);
+          if (estimated > midLoopThreshold) {
+            rlog.warn(
+              { phase: "mid-loop", estimated, threshold: midLoopThreshold },
+              "Token estimate approaching budget — yielding for compaction",
+            );
+            exitReason = "budget";
             break;
           }
         }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -17,7 +17,6 @@ import type {
   AgentLoop,
   AgentLoopExitReason,
   CheckpointDecision,
-  CheckpointInfo,
 } from "../agent/loop.js";
 import { createAssistantMessage } from "../agent/message-types.js";
 import type {
@@ -254,15 +253,6 @@ function markHistoryStrippedBestEffort(
 
 const DISK_PRESSURE_ERROR_CODE = "DISK_SPACE_CRITICAL" as const;
 const DISK_PRESSURE_ERROR_CATEGORY = "disk_pressure";
-
-/**
- * Mid-loop yield threshold expressed as a fraction of the preflight
- * budget. When the running token estimate crosses this fraction at an
- * agent-loop checkpoint, the loop yields so the orchestrator can run a
- * compaction pass *before* the next provider call would risk a hard
- * rejection.
- */
-const MID_LOOP_YIELD_THRESHOLD_RATIO = 0.85;
 
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {
@@ -874,6 +864,25 @@ export async function runAgentLoopImpl(
       overflowRecovery,
       providerMaxTokens,
       preflightBudget: Math.floor(providerMaxTokens * (1 - safetyMargin)),
+    };
+  };
+  /**
+   * The agent loop's window into the orchestrator's current effective
+   * context window. The loop reads `maxInputTokens` for tool-result
+   * truncation and `overflowRecovery` for its mid-loop budget gate, applying
+   * the long-history safety-margin bump itself off its own running history.
+   * Resolved fresh on each access so a mid-turn profile change is reflected.
+   */
+  const resolveContextWindow = (): {
+    maxInputTokens: number;
+    overflowRecovery: { enabled: boolean; safetyMarginRatio: number };
+  } => {
+    refreshCurrentProfileState();
+    const { enabled, safetyMarginRatio } =
+      currentEffectiveContextWindow.overflowRecovery;
+    return {
+      maxInputTokens: currentEffectiveContextWindow.maxInputTokens,
+      overflowRecovery: { enabled, safetyMarginRatio },
     };
   };
 
@@ -2270,30 +2279,10 @@ export async function runAgentLoopImpl(
       await eventHandler({ type: "agent_loop_exit", reason });
     };
 
-    const onCheckpoint = async (
-      checkpoint: CheckpointInfo,
-    ): Promise<CheckpointDecision> => {
+    const onCheckpoint = async (): Promise<CheckpointDecision> => {
       if (ctx.canHandoffAtCheckpoint()) {
         return "handoff";
       }
-
-      // Mid-loop token budget check: estimate current context size and
-      // yield if we're approaching the preflight budget. This lets the
-      // conversation-agent-loop run compaction before the provider rejects.
-      if (overflowRecovery.enabled) {
-        const midLoopThreshold =
-          resolveCurrentContextBudget().preflightBudget *
-          MID_LOOP_YIELD_THRESHOLD_RATIO;
-        const estimated = await runTokenEstimatePipeline(checkpoint.history);
-        if (estimated > midLoopThreshold) {
-          rlog.warn(
-            { phase: "mid-loop", estimated, threshold: midLoopThreshold },
-            "Token estimate approaching budget — yielding for compaction",
-          );
-          return "budget";
-        }
-      }
-
       return "continue";
     };
 
@@ -2326,9 +2315,8 @@ export async function runAgentLoopImpl(
           callSite: turnCallSite,
           turnContext: loopTurnCtx,
           overrideProfile: turnOverrideProfile,
-          effectiveMaxInputTokens: resolveCurrentMaxInputTokens(),
           resolveOverrideProfile: resolveCurrentOverrideProfile,
-          resolveEffectiveMaxInputTokens: resolveCurrentMaxInputTokens,
+          resolveContextWindow,
           // memory-v3-live: the latest user message carries the volatile v3
           // `<memory>` block, so anchor the provider's long-TTL cache breakpoint
           // on the most recent stable message instead.

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -877,7 +877,14 @@ export async function wakeAgentForOpportunity(
             callSite,
             turnContext: wakeTurnContext,
             overrideProfile,
-            effectiveMaxInputTokens: effectiveContextWindow.maxInputTokens,
+            // Wake runs have no orchestrator-side mid-loop compaction path,
+            // so the budget gate stays disabled (`overflowRecovery.enabled =
+            // false`); `maxInputTokens` is still supplied for tool-result
+            // truncation.
+            resolveContextWindow: () => ({
+              maxInputTokens: effectiveContextWindow.maxInputTokens,
+              overflowRecovery: { enabled: false, safetyMarginRatio: 0 },
+            }),
           },
         ));
       } catch (err) {


### PR DESCRIPTION
Re-homes the mid-loop budget gate into the agent loop: the loop now estimates the running context via the `tokenEstimate` pipeline at each tool-use checkpoint and yields (`exitReason = "budget"`) when it approaches the preflight budget, instead of the orchestrator's `onCheckpoint` owning that decision. A single `resolveContextWindow` option replaces `effectiveMaxInputTokens`/`resolveEffectiveMaxInputTokens` — supplying both the truncation ceiling and the `overflowRecovery` config — so the loop takes exactly one context-window dependency and agent wakes opt out by passing `overflowRecovery.enabled = false`, preserving their no-budget-yield behavior.

---

- Requested by: @vargas
- Session: https://app.devin.ai/sessions/7c1b9633322c4bf284eb6ed8525ce389

Requested by: @dvargas92495