### PR TITLE
fix(chat): render avatar progress badge that was invisible

### DIFF
--- a/apps/web/src/domains/chat/components/busy-indicator.test.tsx
+++ b/apps/web/src/domains/chat/components/busy-indicator.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for `BusyIndicator`.
+ *
+ * The dot is a bare `<span>`, whose default `display: inline` makes the
+ * CSS box model ignore `width`/`height`. Inside a flex parent the dot is
+ * blockified and sizes correctly, but standalone (e.g. the avatar
+ * `ProgressBadge`) it would collapse to 0×0 and never paint. The
+ * `inline-block` class guarantees the dot lays out at its declared size
+ * regardless of its parent's layout. Uses happy-dom via the bun:test
+ * preload configured in `web/bunfig.toml`.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { BusyIndicator } from "@/domains/chat/components/busy-indicator";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BusyIndicator", () => {
+  test("is block-level so its size applies outside a flex parent", () => {
+    /**
+     * Tests that the dot is block-level and carries its declared size,
+     * so it paints even when its parent is not a flex container.
+     */
+
+    // GIVEN a 6px busy indicator rendered with no flex parent
+    const { container } = render(<BusyIndicator size={6} />);
+
+    // WHEN we read the rendered dot element
+    const dot = container.firstElementChild as HTMLElement;
+
+    // THEN it is block-level so width/height are not ignored
+    expect(dot.className).toContain("inline-block");
+
+    // AND it lays out at the requested size
+    expect(dot.style.width).toBe("6px");
+    expect(dot.style.height).toBe("6px");
+  });
+
+  test("uses the shared busy-pulse keyframe", () => {
+    /**
+     * Tests that the dot keeps the shared pulse class so its animation
+     * matches every other busy affordance in the app.
+     */
+
+    // GIVEN a default busy indicator
+    const { container } = render(<BusyIndicator size={8} />);
+
+    // WHEN we read the rendered dot element
+    const dot = container.firstElementChild as HTMLElement;
+
+    // THEN it carries the shared busy-indicator pulse class
+    expect(dot.className).toContain("busy-indicator");
+  });
+});

--- a/apps/web/src/domains/chat/components/busy-indicator.tsx
+++ b/apps/web/src/domains/chat/components/busy-indicator.tsx
@@ -14,7 +14,7 @@ export function BusyIndicator({ size = 8 }: { size?: number }) {
   return (
     <span
       aria-hidden="true"
-      className="busy-indicator shrink-0 rounded-full"
+      className="busy-indicator inline-block shrink-0 rounded-full"
       style={{
         width: size,
         height: size,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1170,6 +1170,7 @@ export function ChatRouteContent({
           customImageUrl={avatarImageUrl}
           size={40}
           interactive
+          isProcessing={activeConversationIsProcessing}
         />
       ) : null,
     greeting: editingApp ? buildEditAppGreeting(editingApp) : emptyStateGreeting,


### PR DESCRIPTION
Fixes the avatar progress badge reporting `visible: true` via the debug API while never painting on screen, by passing `isProcessing` to the empty-state avatar and making the badge dot lay out at its real size. This restores the only visual signal that the assistant is processing once the `useProgressBadge` flag is on.

## Root cause analysis

**(a) How did the code get into this state?** The progress-badge feature (#32680) wired `isProcessing` into the transcript `ChatAvatar` but not the empty-state one, so the empty-state badge was never created. Separately, it reused `BusyIndicator` for the badge dot. `BusyIndicator` is a bare `<span>`, which defaults to `display: inline` — and [`width`/`height` do not apply to non-replaced inline elements](https://developer.mozilla.org/en-US/docs/Web/CSS/width). Its only prior caller wrapped it in a `flex` parent, where [flex items are blockified](https://www.w3.org/TR/css-flexbox-1/#flex-items), so the inline default never mattered. Inside the new non-flex `ProgressBadge` wrapper the dot stayed inline and collapsed to 0×0, so even when the badge mounted it painted nothing.

**(b) What mistakes or decisions led to it?** Two parallel render paths (empty-state vs transcript) were kept in sync by hand, so one was missed. And a primitive whose sizing silently depended on its parent's layout context was reused in a new context without that dependency.

**(c) Were there warning signs we missed?** The debug API deliberately reports the same `isProcessing && isProgressBadgeEnabled()` gate the component uses, so it reported `visible: true` — which masked the fact that the DOM node had no size. There was no test asserting the dot actually has dimensions.

**(d) What can we do to prevent recurrence?** A self-contained visual primitive shouldn't depend on its parent's `display` to size itself. `BusyIndicator` is now `inline-block` so it lays out at its declared size anywhere, and a regression test asserts that.

**(e) AGENTS.md change?** Not warranted. This is a narrow CSS-layout gotcha, not a project-wide rule; encoding "inline spans ignore width/height" as a durable rule would add noise that goes stale. The regression test is the right guard.

## Test plan

- `bunx tsc --noEmit` and `bun run lint` pass.
- New `busy-indicator.test.tsx` asserts the dot is block-level and sized; existing `three-dot-indicator` and `tool-call-chip` suites still pass (the chip already wraps the dot in a flex parent, so its rendering is unchanged).
- Reproduced locally via Playwright/CDP against the empty-state avatar with the `useProgressBadge` flag on: before, the badge span was absent / its dot measured 0×0 (`display: inline`); after, the dot measures ~6×6 (`display: inline-block`) and the pulsing badge is visible in the avatar's bottom-right.

Link to Devin session: https://app.devin.ai/sessions/4ecf21400f764b59ad1eecabd1535956
Requested by: @dvargas92495
