### PR TITLE
refactor(subagents): give subagent-detail a real response schema

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -41,7 +41,6 @@ import {
 import { useViewerStore } from "@/stores/viewer-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useSubagentStore, type SubagentTimelineEvent } from "@/domains/chat/subagent-store";
-import type { SubagentStatus } from "@vellumai/assistant-api";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -835,10 +834,9 @@ export function ChatPage() {
       let eventCounter = 0;
       const events: SubagentTimelineEvent[] = [];
 
-      for (const evt of detail.events ?? []) {
-        const rawType = typeof evt.type === "string" ? evt.type : "unknown";
+      for (const evt of detail.events) {
         let type: SubagentTimelineEvent["type"];
-        switch (rawType) {
+        switch (evt.type) {
           case "text":
           case "assistant_text_delta":
             type = "text";
@@ -857,14 +855,7 @@ export function ChatPage() {
             continue;
         }
 
-        const content =
-          typeof evt.content === "string"
-            ? evt.content
-            : typeof evt.text === "string"
-              ? evt.text
-              : typeof evt.result === "string"
-                ? evt.result
-                : "";
+        const content = evt.content;
 
         if (type === "text" && content === "") continue;
 
@@ -879,15 +870,15 @@ export function ChatPage() {
           id: `detail-${++eventCounter}`,
           type,
           content,
-          toolName: typeof evt.toolName === "string" ? evt.toolName : undefined,
-          isError: typeof evt.isError === "boolean" ? evt.isError : undefined,
-          timestamp: typeof evt.timestamp === "number" ? evt.timestamp : Date.now(),
+          toolName: evt.toolName,
+          isError: evt.isError,
+          timestamp: Date.now(),
         });
       }
 
       useSubagentStore.getState().loadDetail({
         subagentId,
-        status: (detail.status as SubagentStatus) || undefined,
+        status: detail.status,
         objective: detail.objective,
         inputTokens: detail.usage?.inputTokens,
         outputTokens: detail.usage?.outputTokens,

--- a/apps/web/src/utils/fetch-subagent-detail.ts
+++ b/apps/web/src/utils/fetch-subagent-detail.ts
@@ -1,43 +1,18 @@
 /**
  * Fetch subagent execution detail from the daemon.
  *
- * The daemon route schema declares `events: z.array(z.unknown())` so the
- * generated SDK types events as `Array<unknown>`. This module defines the
- * known runtime shape and casts to it.
+ * The response is validated at the network boundary against the canonical
+ * `SubagentDetailResponseSchema`, so consumers receive a typed, trusted
+ * shape instead of the SDK's pre-schema `unknown` events.
  */
 
 import * as Sentry from "@sentry/browser";
+import {
+  SubagentDetailResponseSchema,
+  type SubagentDetailResponse,
+} from "@vellumai/assistant-api";
 
 import { subagentsByIdGet } from "@/generated/daemon/sdk.gen";
-
-// ---------------------------------------------------------------------------
-// Types — mirrors `parseSubagentMessages()` in the daemon's
-// subagents-routes.ts. Kept here because this fetch wrapper is the sole
-// consumer and the SDK's `z.unknown()` erases the real shape.
-// ---------------------------------------------------------------------------
-
-export interface SubagentEvent {
-  type: string;
-  content: string;
-  toolName?: string;
-  isError?: boolean;
-  messageId?: string;
-  text?: string;
-  result?: string;
-  timestamp?: number;
-}
-
-export interface SubagentDetailResponse {
-  subagentId: string;
-  objective: string;
-  status?: string;
-  usage?: {
-    inputTokens: number;
-    outputTokens: number;
-    estimatedCost: number;
-  };
-  events: SubagentEvent[];
-}
 
 export async function fetchSubagentDetail(
   assistantId: string,
@@ -53,7 +28,14 @@ export async function fetchSubagentDetail(
     if (!response || !response.ok || !data) {
       return null;
     }
-    return data as unknown as SubagentDetailResponse;
+    const parsed = SubagentDetailResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      Sentry.captureException(parsed.error, {
+        tags: { operation: "fetchSubagentDetail" },
+      });
+      return null;
+    }
+    return parsed.data;
   } catch (err) {
     Sentry.captureException(err, { tags: { operation: "fetchSubagentDetail" } });
     return null;

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17671,6 +17671,15 @@ paths:
                     type: string
                   objective:
                     type: string
+                  status:
+                    type: string
+                    enum:
+                      - pending
+                      - running
+                      - awaiting_input
+                      - completed
+                      - failed
+                      - aborted
                   usage:
                     type: object
                     properties:
@@ -17687,11 +17696,25 @@ paths:
                     additionalProperties: false
                   events:
                     type: array
-                    items: {}
-                    description: Subagent event objects
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        content:
+                          type: string
+                        toolName:
+                          type: string
+                        isError:
+                          type: boolean
+                        messageId:
+                          type: string
+                      required:
+                        - type
+                        - content
+                      additionalProperties: false
                 required:
                   - subagentId
-                  - objective
                   - events
                 additionalProperties: false
       parameters:

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -330,6 +330,12 @@ export {
   type MemoryV3SelectionRow,
   MemoryV3SelectionRowSchema,
 } from "./responses/memory-v3-selection-log.js";
+export {
+  type SubagentDetailEvent,
+  SubagentDetailEventSchema,
+  type SubagentDetailResponse,
+  SubagentDetailResponseSchema,
+} from "./responses/subagent-detail.js";
 
 /**
  * Canonical SSE event schema for the assistant runtime.

--- a/assistant/src/api/responses/subagent-detail.ts
+++ b/assistant/src/api/responses/subagent-detail.ts
@@ -1,0 +1,48 @@
+/**
+ * Wire contract for the subagent-detail REST endpoint
+ * (`GET /subagents/:id`). Returns a subagent's objective, live status,
+ * cumulative usage, and the reconstructed event history parsed from its
+ * stored message rows.
+ *
+ * Reuses the canonical `SubagentStatusSchema` and `SubagentUsageStatsSchema`
+ * defined alongside the `subagent_status_changed` SSE event so the polled
+ * REST detail and the streamed status update share one status/usage shape.
+ *
+ * Canonical wire-contract source. Assistant code imports the types
+ * directly from this file via relative paths; external consumers
+ * (web client, gateway, evals) import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+import {
+  SubagentStatusSchema,
+  SubagentUsageStatsSchema,
+} from "../events/subagent-status-changed.js";
+
+/**
+ * A single reconstructed event in a subagent's history. Built from the
+ * subagent conversation's stored message rows (assistant text, tool calls,
+ * tool results), so `type` is an open string rather than a closed enum.
+ */
+export const SubagentDetailEventSchema = z.object({
+  type: z.string(),
+  content: z.string(),
+  toolName: z.string().optional(),
+  isError: z.boolean().optional(),
+  messageId: z.string().optional(),
+});
+
+export type SubagentDetailEvent = z.infer<typeof SubagentDetailEventSchema>;
+
+export const SubagentDetailResponseSchema = z.object({
+  subagentId: z.string(),
+  objective: z.string().optional(),
+  status: SubagentStatusSchema.optional(),
+  usage: SubagentUsageStatsSchema.optional(),
+  events: z.array(SubagentDetailEventSchema),
+});
+
+export type SubagentDetailResponse = z.infer<
+  typeof SubagentDetailResponseSchema
+>;

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -7,6 +7,7 @@
  */
 import { z } from "zod";
 
+import { SubagentDetailResponseSchema } from "../../api/responses/subagent-detail.js";
 import {
   getMessages,
   type MessageRow,
@@ -251,18 +252,7 @@ export const ROUTES: RouteDefinition[] = [
         description: "Parent conversation ID (required)",
       },
     ],
-    responseBody: z.object({
-      subagentId: z.string(),
-      objective: z.string(),
-      usage: z
-        .object({
-          inputTokens: z.number(),
-          outputTokens: z.number(),
-          estimatedCost: z.number(),
-        })
-        .optional(),
-      events: z.array(z.unknown()).describe("Subagent event objects"),
-    }),
+    responseBody: SubagentDetailResponseSchema,
     handler: ({ pathParams, queryParams }) => {
       const conversationId = queryParams?.conversationId;
       if (!conversationId) {
@@ -270,9 +260,12 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       const manager = getSubagentManager();
-      manager.getState(pathParams!.id);
+      const state = manager.getState(pathParams!.id);
 
-      return getSubagentDetail(pathParams!.id, conversationId);
+      return {
+        ...getSubagentDetail(pathParams!.id, conversationId),
+        status: state?.status,
+      };
     },
   },
 


### PR DESCRIPTION
Replaces the `events: z.array(z.unknown())` erasure on `GET /subagents/:id` with a canonical `SubagentDetailResponseSchema` in `@vellumai/assistant-api`, so the generated SDK type carries the real event shape and the web fetch wrapper can drop its hand-rolled mirror interfaces plus the `as unknown as` cast in favor of validating the response with `safeParse`. Also fixes a latent bug where the handler fetched `manager.getState(id)` and discarded it while the web invented a `status?` field the route never returned — the handler now returns that status, making the field real.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/1e548ca652244faea565e4806a75dbc6