### PR TITLE
fix(chat): show three-dot thinking indicator in avatar progress badge

### DIFF
--- a/apps/web/src/components/avatar/chat-avatar.tsx
+++ b/apps/web/src/components/avatar/chat-avatar.tsx
@@ -1,7 +1,7 @@
 import { motion, useReducedMotion } from "motion/react";
 import { useCallback, useMemo, useState, type CSSProperties } from "react";
 
-import { BusyIndicator } from "@/domains/chat/components/busy-indicator";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 import { isProgressBadgeEnabled } from "@/lib/feature-flags/progress-badge-flag";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { AnimatedAvatar } from "./animated-avatar";
@@ -18,25 +18,28 @@ export interface ChatAvatarProps {
 }
 
 /** Tunable badge geometry. Sizes scale with avatar size for visual consistency. */
-const BADGE_DOT_RATIO = 0.16; // dot diameter / avatar size — 56px avatar → ~9px dot
+const BADGE_DOT_RATIO = 0.1; // each dot diameter / avatar size — 56px avatar → ~6px dot
+const BADGE_GAP_RATIO = 0.05; // gap between dots / avatar size
 const BADGE_RING_RATIO = 0.04; // ring thickness / avatar size
 
 /**
- * Pulsing dot in the bottom-right corner of the avatar. Reuses
- * `BusyIndicator` for the pulse so the visual matches every other
- * "busy" affordance in the app (card-header status, tool-call chip).
+ * Pulsing three-dot "thinking" indicator in the bottom-right corner of the
+ * avatar. Reuses `ThreeDotIndicator` so the badge reads as the same typing
+ * affordance shown elsewhere in chat. A pill is wide enough to fit all three
+ * dots; a single round dot was too narrow to convey "thinking".
  *
- * A solid ring (same color as the surrounding chat surface) separates
- * the dot from the avatar background so it reads cleanly against either
- * a character avatar or a custom image.
+ * A solid ring (same color as the surrounding chat surface) separates the
+ * dots from the avatar background so they read cleanly against either a
+ * character avatar or a custom image.
  */
 function ProgressBadge({ size }: { size: number }) {
-  const dot = Math.max(6, Math.round(size * BADGE_DOT_RATIO));
+  const dot = Math.max(3, Math.round(size * BADGE_DOT_RATIO));
+  const gap = Math.max(2, Math.round(size * BADGE_GAP_RATIO));
   const ring = Math.max(1, Math.round(size * BADGE_RING_RATIO));
   return (
     <span
       aria-hidden="true"
-      className="absolute rounded-full"
+      className="absolute flex items-center justify-center rounded-full"
       style={{
         bottom: 0,
         right: 0,
@@ -44,7 +47,7 @@ function ProgressBadge({ size }: { size: number }) {
         backgroundColor: "var(--surface-base)",
       }}
     >
-      <BusyIndicator size={dot} />
+      <ThreeDotIndicator dotSize={dot} gap={gap} />
     </span>
   );
 }

--- a/apps/web/src/domains/chat/components/busy-indicator.test.tsx
+++ b/apps/web/src/domains/chat/components/busy-indicator.test.tsx
@@ -3,11 +3,11 @@
  *
  * The dot is a bare `<span>`, whose default `display: inline` makes the
  * CSS box model ignore `width`/`height`. Inside a flex parent the dot is
- * blockified and sizes correctly, but standalone (e.g. the avatar
- * `ProgressBadge`) it would collapse to 0×0 and never paint. The
- * `inline-block` class guarantees the dot lays out at its declared size
- * regardless of its parent's layout. Uses happy-dom via the bun:test
- * preload configured in `web/bunfig.toml`.
+ * blockified and sizes correctly, but standalone (outside a flex parent)
+ * it would collapse to 0×0 and never paint. The `inline-block` class
+ * guarantees the dot lays out at its declared size regardless of its
+ * parent's layout. Uses happy-dom via the bun:test preload configured in
+ * `web/bunfig.toml`.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";

--- a/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.test.tsx
@@ -2,10 +2,12 @@
  * Tests for `ThreeDotIndicator`.
  *
  * Verifies the indicator renders three evenly-sized dots that share the
- * legacy `busy-pulse` keyframe (matching the single-dot `BusyIndicator`
- * used by `ToolCallProgressCard`'s running state) with a 150ms stagger.
- * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`,
- * so inline `style` values are readable on the rendered DOM nodes.
+ * `busy-indicator` class (so they match the single-dot `BusyIndicator`
+ * pulse and inherit its reduced-motion override) with a 150ms stagger,
+ * and that `dotSize`/`gap` scale the indicator for tighter contexts like
+ * the avatar badge. Uses happy-dom via the bun:test preload configured in
+ * `web/bunfig.toml`, so inline `style` values are readable on the rendered
+ * DOM nodes.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -46,23 +48,47 @@ describe("ThreeDotIndicator", () => {
     expect(dots[2]!.style.animationDelay).toBe("300ms");
   });
 
-  test("each dot uses the busy-pulse keyframe (matches legacy BusyIndicator)", () => {
+  test("each dot carries the shared busy-indicator class (matches BusyIndicator + reduced-motion)", () => {
     const { container } = render(<ThreeDotIndicator />);
     const dots = getDots(container);
-    // happy-dom does not normalize the `animation` shorthand into
-    // longhand `animationName`; assert against the raw style attribute
-    // so the keyframe identifier is verified regardless of parser.
+    // The `busy-indicator` class supplies the `busy-pulse` animation and
+    // is the selector the `prefers-reduced-motion` override targets, so
+    // carrying it is what lets the dots stop animating under reduced motion.
     for (const dot of dots) {
-      expect(dot.getAttribute("style") ?? "").toContain("busy-pulse 1s");
+      expect(dot.className).toContain("busy-indicator");
     }
   });
 
-  test("wrapper accepts a custom className", () => {
+  test("dotSize and gap scale the indicator for tighter contexts", () => {
+    /**
+     * Tests that the avatar badge can shrink the indicator to fit a small
+     * pill via the `dotSize` and `gap` props.
+     */
+
+    // GIVEN a down-scaled indicator (avatar-badge sizing)
+    const { container } = render(<ThreeDotIndicator dotSize={5} gap={2} />);
+
+    // WHEN we read the wrapper and its dots
+    const wrapper = container.firstElementChild as HTMLElement;
+    const dots = getDots(container);
+
+    // THEN every dot lays out at the requested diameter
+    expect(dots).toHaveLength(3);
+    for (const dot of dots) {
+      expect(dot.style.width).toBe("5px");
+      expect(dot.style.height).toBe("5px");
+    }
+
+    // AND the wrapper uses the requested gap
+    expect(wrapper.style.gap).toBe("2px");
+  });
+
+  test("wrapper accepts a custom className and defaults to 3px gap", () => {
     const { container } = render(<ThreeDotIndicator className="ml-2" />);
     const wrapper = container.firstElementChild as HTMLElement;
     expect(wrapper.className).toContain("ml-2");
     // Base classes are still applied.
     expect(wrapper.className).toContain("inline-flex");
-    expect(wrapper.className).toContain("gap-[3px]");
+    expect(wrapper.style.gap).toBe("3px");
   });
 });

--- a/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.tsx
@@ -1,43 +1,51 @@
 
 /**
- * Three-dot pulsing indicator used in the web-search progress card header.
+ * Three-dot pulsing "thinking" indicator. Used in the web-search progress
+ * card header and as the assistant avatar's progress badge.
  *
- * Renders three evenly-sized 8px dots that pulse in opacity (1 → 0.3) and
- * scale (1 → 0.85) over 1s, staggered by 150ms each to produce a
- * left-to-right wave. This mirrors the legacy `BusyIndicator` primitive's
- * `busy-pulse` keyframe and `--primary-base` colour so the new card reads
- * consistently when shown alongside `ToolCallProgressCard` (which renders a
- * single `BusyIndicator` of the same diameter for its running state).
+ * Renders three evenly-sized dots that pulse in opacity (1 → 0.3) and scale
+ * (1 → 0.85) over 1s, staggered by 150ms each to produce a left-to-right
+ * wave. The dots carry the shared `busy-indicator` class so they use the
+ * same `busy-pulse` keyframe and `--primary-base` colour as the single-dot
+ * `BusyIndicator`, and — crucially — inherit its `prefers-reduced-motion`
+ * override (which targets the class, not the keyframe name). Per-dot
+ * `animationDelay` supplies the stagger; an inline longhand, so it survives
+ * the class's `animation` shorthand resetting delay to 0.
  *
- * Reduced-motion handling is inherited from the shared `busy-pulse`
- * keyframe override in the app theme CSS.
+ * `dotSize` and `gap` scale the indicator for tighter contexts (e.g. the
+ * avatar badge), defaulting to the 8px / 3px transcript sizing.
  */
 
 const DOT_COUNT = 3;
-const DOT_SIZE = 8;
+const DEFAULT_DOT_SIZE = 8;
+const DEFAULT_GAP = 3;
 const STAGGER_MS = 150;
 
 export function ThreeDotIndicator({
   className,
+  dotSize = DEFAULT_DOT_SIZE,
+  gap = DEFAULT_GAP,
   "data-testid": dataTestId,
 }: {
   className?: string;
+  dotSize?: number;
+  gap?: number;
   "data-testid"?: string;
 }) {
   return (
     <span
       aria-hidden="true"
       data-testid={dataTestId}
-      className={`inline-flex items-center gap-[3px]${className ? ` ${className}` : ""}`}
+      className={`inline-flex items-center${className ? ` ${className}` : ""}`}
+      style={{ gap }}
     >
       {Array.from({ length: DOT_COUNT }, (_, i) => (
         <span
           key={i}
-          className="shrink-0 rounded-full bg-[var(--primary-base)]"
+          className="busy-indicator shrink-0 rounded-full bg-[var(--primary-base)]"
           style={{
-            width: DOT_SIZE,
-            height: DOT_SIZE,
-            animation: "busy-pulse 1s ease-in-out infinite",
+            width: dotSize,
+            height: dotSize,
             animationDelay: `${i * STAGGER_MS}ms`,
           }}
         />


### PR DESCRIPTION
## Prompt / plan

The avatar progress badge (bottom-right of the assistant avatar) was reported as "too narrow, we don't see the three dots." It rendered a single round dot, which reads as a featureless blob rather than a recognizable "thinking" affordance.

Approach: render the existing three-dot indicator inside a pill wide enough to fit all three dots, scaling the geometry with avatar size.

## Changes

- `ProgressBadge` (`apps/web/src/components/avatar/chat-avatar.tsx`) now renders `ThreeDotIndicator` inside a flex pill instead of a single `BusyIndicator`. Geometry scales with avatar size: dot `≈size×0.10`, gap `≈size×0.05`, ring `≈size×0.04` (e.g. 56px avatar → 6px dots).
- `ThreeDotIndicator` gains optional `dotSize`/`gap` props (defaults unchanged at 8px/3px) so it can shrink for the small badge while keeping its existing transcript usage identical.
- `ThreeDotIndicator` dots now carry the shared `busy-indicator` class for the pulse instead of an inline `animation` shorthand. Per-dot stagger is supplied via inline `animationDelay` (longhand), which survives the class's shorthand reset.

## Reduced-motion fix (rolled in)

The pulse animation override lives in a `@media (prefers-reduced-motion: reduce)` block that targets the `.busy-indicator` **class**, not the `busy-pulse` keyframe name. `ThreeDotIndicator` previously animated via an inline `animation` style, so it bypassed that override and kept pulsing under reduced motion. Switching to the shared class makes all three dots honor reduced motion, matching the single-dot `BusyIndicator`. Inline styles cannot be overridden by stylesheet media queries (per the [CSS cascade origin/specificity rules](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Cascade)), which is exactly why the inline `animation` escaped the override.

## Test plan

- `bun run lint`, `bunx tsc --noEmit` — pass.
- `bun test` for `three-dot-indicator`, `busy-indicator`, and `web-search-progress-card` — pass. Tests updated to cover the new `dotSize`/`gap` props and the shared `busy-indicator` class (replacing the now-removed inline-animation assertion and the `gap-[3px]` class assertion, which is now an inline `gap` style).
- Visual check of the badge at avatar sizes 56 and 40 in both light and dark themes: three dots render in a pill, anchored bottom-right, with the surface-base ring separating them from the avatar.

## Root cause analysis

1. **How did the code get into this state?** The "thinking" indicator was moved from the transcript onto the avatar as a compact badge. To match the other "busy" affordances (tool-call chip, card-header status), the badge reused the single-dot `BusyIndicator`. A single dot inside a round chip cannot express "three dots," so once the chip was sized down it read as a plain dot.
2. **What decisions led to it?** Optimizing the badge for visual consistency with the single-dot busy affordance, rather than for the three-dot "typing/thinking" mental model the macOS client (`TypingIndicatorView`) already establishes.
3. **Warning signs missed?** An earlier fix had to make the badge visible at all; the follow-up "it's too narrow" report indicates the single-dot shape never matched the intended affordance. The separate reduced-motion gap was latent because `ThreeDotIndicator`'s docstring *claimed* it inherited the shared override, but it used an inline animation that silently bypassed it.
4. **Preventing recurrence?** Prefer the shared `busy-indicator` class over inline `animation` styles so reduced-motion (and any future keyframe tweak) applies uniformly. Keep docstring claims about inherited behavior verifiable by construction (i.e. actually use the class).
5. **AGENTS.md guideline?** Not warranted — a single durable convention ("animate via the `busy-indicator` class, not inline `animation`, so reduced-motion applies") is now encoded directly in `ThreeDotIndicator`'s docstring and its test, which is more discoverable and less likely to go stale than a repo-wide rule.

CLI verb checklist: N/A — no new IPC routes.

Link to Devin session: https://app.devin.ai/sessions/f872a9d3beb74d57b3c2da22ec44546b
Requested by: @dvargas92495