### PR TITLE
fix(web): add loopback + active-assistant guards to retire endpoint

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -123,7 +123,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(configMiddleware(env));
       server.middlewares.use(lockfileMiddleware(lockfilePaths));
       server.middlewares.use(hatchMiddleware());
-      server.middlewares.use(retireMiddleware());
+      server.middlewares.use(retireMiddleware(lockfilePaths));
       server.middlewares.use(guardianTokenMiddleware(env));
       server.middlewares.use(gatewayProxyMiddleware());
       server.middlewares.use(accountSpaFallback(server));
@@ -442,7 +442,7 @@ function handleHatch(species: string, res: http.ServerResponse): void {
  * Transport: Vite dev middleware (child_process.spawn → CLI binary).
  * In Electron, replace with IPC call to main process: window.electronAPI.retireAssistant(assistantId). (LUM-2000)
  */
-function retireMiddleware(): Connect.NextHandleFunction {
+function retireMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (
       req.url !== "/assistant/__local/retire" &&
@@ -454,6 +454,14 @@ function retireMiddleware(): Connect.NextHandleFunction {
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.end();
+      return;
+    }
+
+    const peer = req.socket.remoteAddress ?? "";
+    if (!isLoopbackAddr(peer)) {
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "Forbidden" }));
       return;
     }
 
@@ -482,9 +490,48 @@ function retireMiddleware(): Connect.NextHandleFunction {
         return;
       }
 
+      const activeId = getActiveLocalAssistantId(lockfilePaths);
+      if (!activeId || assistantId !== activeId) {
+        res.statusCode = 403;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: "Forbidden" }));
+        return;
+      }
+
       handleRetire(assistantId, res);
     });
   };
+}
+
+function getActiveLocalAssistantId(lockfilePaths: string[]): string | undefined {
+  for (const candidate of lockfilePaths) {
+    try {
+      const raw = fs.readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw) as {
+        activeAssistant?: unknown;
+        assistants?: Array<Record<string, unknown>>;
+      };
+
+      if (typeof parsed.activeAssistant !== "string") {
+        return undefined;
+      }
+
+      const activeEntry = parsed.assistants?.find(
+        (a) => a?.assistantId === parsed.activeAssistant,
+      );
+      if (!activeEntry || activeEntry.cloud !== "local") {
+        return undefined;
+      }
+
+      return parsed.activeAssistant;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 const RETIRE_TIMEOUT_MS = 60_000;

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -9,6 +9,7 @@ import { SEEDS } from "../../cli/src/lib/environments/seeds";
 
 const PRODUCTION_ENVIRONMENT_NAME = "production";
 const CLI_PACKAGE_NAME = "@vellumai/cli";
+const LOCALHOST_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 let _resolvedCliPath: string | undefined;
 
@@ -459,6 +460,14 @@ function retireMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
 
     const peer = req.socket.remoteAddress ?? "";
     if (!isLoopbackAddr(peer)) {
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "Forbidden" }));
+      return;
+    }
+
+    const origin = req.headers.origin;
+    if (!origin || !LOCALHOST_ORIGIN_RE.test(origin)) {
       res.statusCode = 403;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ ok: false, error: "Forbidden" }));


### PR DESCRIPTION
## Summary

- Add loopback peer check to the `/__local/retire` middleware, blocking non-localhost requests before body parsing — mirrors the existing guard on `guardianTokenMiddleware`
- Add active-local-assistant validation: after parsing `assistantId`, verify it matches the lockfile's `activeAssistant` and that the entry is `cloud: "local"`, preventing retirement of arbitrary or non-local assistants
- Reuse the existing `isLoopbackAddr` utility instead of introducing a duplicate

Codex finding: https://chatgpt.com/codex/cloud/security/findings/7c0477e431088191aca3d0c860d81301?q=mcp&sev=critical%2Chigh

## Original prompt

A Codex security scan flagged the `/__local/retire` endpoint in the Vite local-mode plugin as unauthenticated — any POST with an `assistantId` would spawn `retire --yes` without loopback validation, auth, or CSRF protection. Since the Vite server listens on all interfaces (`host: true`), a LAN attacker could retire arbitrary assistants. The fix adds a loopback peer guard and restricts retirement to the currently active local assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)