### PR TITLE
fix(web): restrict local-mode Vite endpoints to loopback clients

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -125,7 +125,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(hatchMiddleware());
       server.middlewares.use(retireMiddleware());
       server.middlewares.use(guardianTokenMiddleware(env));
-      server.middlewares.use(gatewayProxyMiddleware());
+      server.middlewares.use(gatewayProxyMiddleware(lockfilePaths));
       server.middlewares.use(accountSpaFallback(server));
     },
   };
@@ -198,6 +198,8 @@ function lockfileMiddleware(
 ): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url !== "/assistant/__local/lockfile" && req.url !== "/__local/lockfile") return next();
+
+    if (rejectUnlessLoopback(req, res)) return;
 
     if (req.method === "GET") {
       handleGetLockfile(lockfilePaths, res);
@@ -344,6 +346,8 @@ function hatchMiddleware(): Connect.NextHandleFunction {
       return next();
     }
 
+    if (rejectUnlessLoopback(req, res)) return;
+
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.end();
@@ -451,6 +455,8 @@ function retireMiddleware(): Connect.NextHandleFunction {
       return next();
     }
 
+    if (rejectUnlessLoopback(req, res)) return;
+
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.end();
@@ -549,7 +555,7 @@ function handleRetire(assistantId: string, res: http.ServerResponse): void {
 }
 
 // ---------------------------------------------------------------------------
-// Guardian token middleware
+// Loopback guard
 // ---------------------------------------------------------------------------
 
 function isLoopbackAddr(addr: string): boolean {
@@ -559,6 +565,17 @@ function isLoopbackAddr(addr: string): boolean {
     return normalized.startsWith("127.");
   }
   return normalized === "::1";
+}
+
+function rejectUnlessLoopback(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): boolean {
+  if (isLoopbackAddr(req.socket.remoteAddress ?? "")) return false;
+  res.statusCode = 403;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ error: "Forbidden" }));
+  return true;
 }
 
 const GUARDIAN_TOKEN_PATTERN =
@@ -626,13 +643,7 @@ function guardianTokenMiddleware(
       return;
     }
 
-    const peer = req.socket.remoteAddress ?? "";
-    if (!isLoopbackAddr(peer)) {
-      res.statusCode = 403;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ error: "Forbidden" }));
-      return;
-    }
+    if (rejectUnlessLoopback(req, res)) return;
 
     const assistantId = decodeURIComponent(match[1]!);
     const tokenPath = resolveGuardianTokenPath(env, assistantId);
@@ -733,21 +744,58 @@ function guardianTokenMiddleware(
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
 
+function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
+  const ports = new Set<number>();
+  for (const candidate of lockfilePaths) {
+    try {
+      const raw = fs.readFileSync(candidate, "utf-8");
+      const data = JSON.parse(raw) as { assistants?: Array<{ gatewayUrl?: unknown }> };
+      const assistants = Array.isArray(data.assistants) ? data.assistants : [];
+      for (const assistant of assistants) {
+        if (!assistant || typeof assistant.gatewayUrl !== "string") continue;
+        try {
+          const parsed = new URL(assistant.gatewayUrl);
+          if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") continue;
+          const port = Number(parsed.port);
+          if (Number.isInteger(port) && port >= 1024 && port <= 65535) {
+            ports.add(port);
+          }
+        } catch {
+          continue;
+        }
+      }
+      if (ports.size > 0) return ports;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") return new Set<number>();
+    }
+  }
+  return ports;
+}
+
 /**
  * Connect middleware that proxies requests to local gateway ports.
  *
  * Matches `/__gateway/:port/*` and forwards to `http://127.0.0.1:{port}{rest}`.
  * Supports chunked transfer and SSE by piping without buffering.
  */
-function gatewayProxyMiddleware(): Connect.NextHandleFunction {
+function gatewayProxyMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
   return (req, res, next) => {
     const match = req.url?.match(GATEWAY_PATTERN);
     if (!match) return next();
+
+    if (rejectUnlessLoopback(req, res)) return;
 
     const port = parseInt(match[1]!, 10);
     if (port < 1024 || port > 65535) {
       res.statusCode = 400;
       res.end("Port must be between 1024 and 65535");
+      return;
+    }
+
+    const allowedPorts = readAllowedGatewayPorts(lockfilePaths);
+    if (!allowedPorts.has(port)) {
+      res.statusCode = 403;
+      res.end("Gateway port is not active in lockfile");
       return;
     }
 

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -744,24 +744,40 @@ function guardianTokenMiddleware(
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
 
+function addPortFromUrl(url: unknown, ports: Set<number>): void {
+  if (typeof url !== "string") return;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") return;
+    const port = Number(parsed.port);
+    if (Number.isInteger(port) && port >= 1024 && port <= 65535) {
+      ports.add(port);
+    }
+  } catch {
+    // malformed URL — skip
+  }
+}
+
 function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
   const ports = new Set<number>();
   for (const candidate of lockfilePaths) {
     try {
       const raw = fs.readFileSync(candidate, "utf-8");
-      const data = JSON.parse(raw) as { assistants?: Array<{ gatewayUrl?: unknown }> };
+      const data = JSON.parse(raw) as {
+        assistants?: Array<{
+          gatewayUrl?: unknown;
+          localUrl?: unknown;
+          resources?: { gatewayPort?: unknown };
+        }>;
+      };
       const assistants = Array.isArray(data.assistants) ? data.assistants : [];
       for (const assistant of assistants) {
-        if (!assistant || typeof assistant.gatewayUrl !== "string") continue;
-        try {
-          const parsed = new URL(assistant.gatewayUrl);
-          if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") continue;
-          const port = Number(parsed.port);
-          if (Number.isInteger(port) && port >= 1024 && port <= 65535) {
-            ports.add(port);
-          }
-        } catch {
-          continue;
+        if (!assistant) continue;
+        addPortFromUrl(assistant.gatewayUrl, ports);
+        addPortFromUrl(assistant.localUrl, ports);
+        const gp = assistant.resources?.gatewayPort;
+        if (typeof gp === "number" && Number.isInteger(gp) && gp >= 1024 && gp <= 65535) {
+          ports.add(gp);
         }
       }
       if (ports.size > 0) return ports;


### PR DESCRIPTION
## Summary
- Add `rejectUnlessLoopback` guard to all local-mode Vite middleware endpoints (lockfile, hatch, retire, gateway proxy) — blocks non-loopback callers with 403
- Add lockfile-derived port allowlist to gateway proxy — only forwards to ports belonging to active assistants, eliminating the arbitrary-port SSRF vector
- Refactor existing guardian token middleware to use the shared `rejectUnlessLoopback` helper

Codex finding: https://chatgpt.com/codex/cloud/security/findings/5481a363c26c8191a2b699285fdee260?q=mcp&sev=critical%2Chigh

## Original prompt
A Codex security finding flagged the local-mode Vite plugin as an auth bypass vector: with `host: true`, the lockfile and gateway proxy endpoints were reachable from the LAN without authentication. Since the gateway trusts loopback peers, requests forwarded by the Vite proxy bypassed JWT/scope/guardian auth. The fix adds loopback-only restrictions (matching the existing guardian token middleware pattern) and a lockfile-derived port allowlist to eliminate the SSRF primitive.

## Test plan
- [ ] Verify local dev still works: `VITE_LOCAL_MODE=1 bun run dev` from `apps/web`, confirm lockfile endpoint and gateway proxy work from the browser (loopback)
- [ ] Confirm non-loopback requests to `/__local/lockfile`, `/__local/hatch`, `/__local/retire`, and `/__gateway/<port>` return 403
- [ ] Confirm gateway proxy rejects ports not listed in the lockfile with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)