### PR TITLE
fix(runtime): close path traversal in domain verification-status route

### DIFF
--- a/assistant/src/runtime/routes/domain-routes.ts
+++ b/assistant/src/runtime/routes/domain-routes.ts
@@ -18,6 +18,16 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
+interface DomainListResponse {
+  results: {
+    id: string;
+    subdomain?: string;
+    domain?: string;
+    created_at?: string;
+    created?: string;
+  }[];
+}
+
 async function requireClient(): Promise<VellumPlatformClient> {
   const client = await VellumPlatformClient.create();
   if (!client) {
@@ -31,6 +41,25 @@ async function requireClient(): Promise<VellumPlatformClient> {
     );
   }
   return client;
+}
+
+async function fetchDomains(
+  client: VellumPlatformClient,
+): Promise<DomainListResponse> {
+  const response = await client.fetch(
+    `/v1/assistants/${client.platformAssistantId}/domains/`,
+  );
+
+  if (!response.ok) {
+    const respBody = (await response.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const detail = respBody.detail ?? `HTTP ${response.status}`;
+    throw new RouteError(String(detail), "LIST_FAILED", response.status);
+  }
+
+  return (await response.json()) as DomainListResponse;
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────
@@ -107,33 +136,7 @@ async function handleDomainStatus(_args: RouteHandlerArgs) {
   const client = await requireClient();
   const apexDomain = getApexDomain();
 
-  const response = await client.fetch(
-    `/v1/assistants/${client.platformAssistantId}/domains/`,
-  );
-
-  if (!response.ok) {
-    const respBody = (await response.json().catch(() => ({}))) as Record<
-      string,
-      unknown
-    >;
-    const detail = respBody.detail ?? `HTTP ${response.status}`;
-    throw new RouteError(
-      String(detail),
-      "LIST_FAILED",
-      response.status,
-    );
-  }
-
-  const data = (await response.json()) as {
-    results: {
-      id: string;
-      subdomain?: string;
-      domain?: string;
-      created_at?: string;
-      created?: string;
-    }[];
-  };
-
+  const data = await fetchDomains(client);
   const domains = data.results ?? [];
 
   // Sync subdomain to config if not already cached
@@ -164,8 +167,15 @@ async function handleDomainVerificationStatus({
   }
   const client = await requireClient();
 
+  const { results } = await fetchDomains(client);
+  if (!results?.some((d) => d.id === domain_id)) {
+    throw new BadRequestError(
+      "domain_id is not registered for this assistant",
+    );
+  }
+
   const response = await client.fetch(
-    `/v1/assistants/${client.platformAssistantId}/domains/${domain_id}/verification-status/`,
+    `/v1/assistants/${client.platformAssistantId}/domains/${encodeURIComponent(domain_id)}/verification-status/`,
   );
 
   if (!response.ok) {

--- a/assistant/src/runtime/routes/domain-routes.ts
+++ b/assistant/src/runtime/routes/domain-routes.ts
@@ -12,13 +12,17 @@ import {
   setNestedValue,
 } from "../../config/loader.js";
 import { VellumPlatformClient } from "../../platform/client.js";
+import { getLogger } from "../../util/logger.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, RouteError, UnauthorizedError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
+const log = getLogger("domain-routes");
+
 // ── Helpers ───────────────────────────────────────────────────────────
 
 interface DomainListResponse {
+  next?: string | null;
   results: {
     id: string;
     subdomain?: string;
@@ -167,7 +171,13 @@ async function handleDomainVerificationStatus({
   }
   const client = await requireClient();
 
-  const { results } = await fetchDomains(client);
+  const { results, next } = await fetchDomains(client);
+  if (next) {
+    log.error(
+      { extra: { domain_id, next } },
+      "Domain list is paginated; ownership check may produce false negatives",
+    );
+  }
   if (!results?.some((d) => d.id === domain_id)) {
     throw new BadRequestError(
       "domain_id is not registered for this assistant",


### PR DESCRIPTION
## Summary

- Extract `fetchDomains` helper from `handleDomainStatus` to reuse the domain-listing platform call
- Add domain ownership validation in `handleDomainVerificationStatus` — reject `domain_id` values not registered for this assistant
- Apply `encodeURIComponent` to `domain_id` before interpolating into the platform API path, preventing path traversal via `../`, `?`, or `#` characters

## Original prompt

A Codex security finding ([link](https://chatgpt.com/codex/cloud/security/findings/162ffd1db1888191a6d94fb6b5e36da3?q=mcp&sev=critical%2Chigh)) identified `POST /v1/domain/verification-status` as an unscoped platform API proxy. The handler accepted caller-controlled `domain_id` and interpolated it directly into an authenticated platform API path without encoding or ownership validation. While the original access-control gaps (missing daemon route policy and gateway IPC policy entry) were already fixed by later refactors, the path traversal and missing ownership check remained. This PR closes those two remaining vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)