### PR TITLE
Extract __local endpoints into shared module for Vite + Bun.serve

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -1,140 +1,42 @@
-import { spawn } from "node:child_process";
-import fs from "node:fs";
 import http from "node:http";
-import { createRequire } from "node:module";
-import os from "node:os";
+import fs from "node:fs";
 import path from "node:path";
 import type { Plugin, Connect, ViteDevServer } from "vite";
-import { SEEDS } from "../../cli/src/lib/environments/seeds";
 
-const PRODUCTION_ENVIRONMENT_NAME = "production";
-const CLI_PACKAGE_NAME = "@vellumai/cli";
+import {
+  resolveLocalConfigFromEnv,
+  resolveCliPath,
+  isLoopbackAddr,
+  getLockfileData,
+  upsertLockfileAssistant,
+  runHatch,
+  runRetire,
+  getGuardianAccessToken,
+  parseGatewayUrl,
+} from "../../cli/src/lib/local-endpoints";
 
-let _resolvedCliPath: string | undefined;
+const GUARDIAN_TOKEN_PATTERN =
+  /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
 
-/**
- * Resolve the CLI entry point via two strategies:
- *
- * 1. **Source tree** — `<repoRoot>/cli/src/index.ts` exists (dev mode in monorepo).
- * 2. **Installed package** — `require.resolve("@vellumai/cli/package.json")` then
- *    derive the entry point from the resolved package directory.
- *
- * The result is cached for the lifetime of the Vite server process.
- */
-function resolveCliPath(): string {
-  if (_resolvedCliPath) return _resolvedCliPath;
-
-  const repoRoot = path.resolve(import.meta.dirname, "..", "..");
-  const sourceTreePath = path.join(repoRoot, "cli", "src", "index.ts");
-  if (fs.existsSync(sourceTreePath)) {
-    _resolvedCliPath = sourceTreePath;
-    return _resolvedCliPath;
-  }
-
-  const _require = createRequire(import.meta.url);
-  try {
-    const pkgPath = _require.resolve(`${CLI_PACKAGE_NAME}/package.json`);
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { bin?: Record<string, string> };
-    const binEntry = pkg.bin?.["vellum"];
-    if (binEntry) {
-      const entryPoint = path.resolve(path.dirname(pkgPath), binEntry);
-      if (fs.existsSync(entryPoint)) {
-        _resolvedCliPath = entryPoint;
-        return _resolvedCliPath;
-      }
-    }
-  } catch {
-    // Not found in node_modules
-  }
-
-  throw new Error(
-    `Vellum CLI not found. Looked for source tree at ${sourceTreePath} and npm package ${CLI_PACKAGE_NAME}.`,
-  );
-}
-
-/**
- * Sensitive lockfile fields that must never be served to the browser.
- */
-const SENSITIVE_FIELDS = [
-  "signingKey",
-  "bearerToken",
-  "guardianBootstrapSecret",
-] as const;
-
-/**
- * Resolve the lockfile path on disk using XDG conventions.
- *
- * Mirrors `cli/src/lib/environments/paths.ts` logic:
- * - Production: `~/.vellum.lock.json`
- * - Non-production: `$XDG_CONFIG_HOME/vellum-{env}/lockfile.json`
- * - `VELLUM_LOCKFILE_DIR` overrides the directory in both cases.
- */
-function resolveLockfilePaths(env: Record<string, string>): string[] {
-  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
-  const lockfileDir = env.VELLUM_LOCKFILE_DIR;
-
-  if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
-    const dir = lockfileDir ?? os.homedir();
-    return [
-      path.join(dir, ".vellum.lock.json"),
-      path.join(dir, ".vellum.lockfile.json"),
-    ];
-  }
-
-  const xdgConfigHome =
-    env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  const dir = lockfileDir ?? path.join(xdgConfigHome, `vellum-${vellumEnv}`);
-  return [path.join(dir, "lockfile.json")];
-}
-
-/**
- * Strip sensitive fields from each assistant entry in the lockfile data.
- */
-function stripSensitiveFields(data: Record<string, unknown>): void {
-  const assistants = data.assistants;
-  if (!Array.isArray(assistants)) return;
-  for (const assistant of assistants) {
-    if (assistant && typeof assistant === "object") {
-      const entry = assistant as Record<string, unknown>;
-      for (const field of SENSITIVE_FIELDS) {
-        delete entry[field];
-      }
-      const resources = entry.resources;
-      if (resources && typeof resources === "object") {
-        for (const field of SENSITIVE_FIELDS) {
-          delete (resources as Record<string, unknown>)[field];
-        }
-      }
-    }
-  }
-}
-
-/**
- * Vite plugin that serves lockfile endpoints and a dynamic gateway proxy
- * for local-mode development.
- */
 export function localModePlugin(env: Record<string, string>): Plugin {
-  const lockfilePaths = resolveLockfilePaths(env);
+  const config = resolveLocalConfigFromEnv(env);
+  const baseDir = path.resolve(import.meta.dirname, "..", "..");
 
   return {
     name: "vellum-local-mode",
     configureServer(server) {
       server.middlewares.use(loopbackCallbackMiddleware());
-      server.middlewares.use(configMiddleware(env));
-      server.middlewares.use(lockfileMiddleware(lockfilePaths));
-      server.middlewares.use(hatchMiddleware());
-      server.middlewares.use(retireMiddleware());
-      server.middlewares.use(guardianTokenMiddleware(env));
+      server.middlewares.use(configMiddleware(config.webUrl, config.platformUrl));
+      server.middlewares.use(lockfileMiddleware(config.lockfilePaths));
+      server.middlewares.use(hatchMiddleware(baseDir));
+      server.middlewares.use(retireMiddleware(baseDir));
+      server.middlewares.use(guardianTokenMiddleware(config.configDir, baseDir, env));
       server.middlewares.use(gatewayProxyMiddleware());
       server.middlewares.use(accountSpaFallback(server));
     },
   };
 }
 
-/**
- * Redirect `/callback` from the platform's CLI loopback auth flow
- * into the SPA route that processes the session token.
- */
 function loopbackCallbackMiddleware(): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url?.startsWith("/callback")) {
@@ -147,16 +49,7 @@ function loopbackCallbackMiddleware(): Connect.NextHandleFunction {
   };
 }
 
-/**
- * Serve environment config so the SPA can resolve the platform web URL
- * for loopback auth without hardcoding it.
- */
-function configMiddleware(env: Record<string, string>): Connect.NextHandleFunction {
-  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
-  const seed = SEEDS[vellumEnv] ?? SEEDS[PRODUCTION_ENVIRONMENT_NAME]!;
-
-  const webUrl = env.VELLUM_WEB_URL || seed.webUrl;
-  const platformUrl = env.VELLUM_PLATFORM_URL || seed.platformUrl;
+function configMiddleware(webUrl: string, platformUrl: string): Connect.NextHandleFunction {
   const body = JSON.stringify({ webUrl, platformUrl });
 
   return (req, res, next) => {
@@ -166,12 +59,6 @@ function configMiddleware(env: Record<string, string>): Connect.NextHandleFuncti
   };
 }
 
-/**
- * SPA fallback for `/account/*` routes. Vite's base is `/assistant/` so
- * paths outside it don't get the default SPA fallback. This middleware
- * serves the transformed index.html for account routes so React Router
- * can handle them.
- */
 function accountSpaFallback(server: ViteDevServer): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (!req.url?.startsWith("/account/") && !req.url?.startsWith("/account?") && req.url !== "/account") return next();
@@ -190,19 +77,42 @@ function accountSpaFallback(server: ViteDevServer): Connect.NextHandleFunction {
   };
 }
 
-/**
- * Connect middleware for the lockfile read endpoint.
- */
-function lockfileMiddleware(
-  lockfilePaths: string[],
-): Connect.NextHandleFunction {
+function lockfileMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url !== "/assistant/__local/lockfile" && req.url !== "/__local/lockfile") return next();
 
     if (req.method === "GET") {
-      handleGetLockfile(lockfilePaths, res);
+      const result = getLockfileData(lockfilePaths);
+      if (result.ok) {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(result.data));
+      } else {
+        res.statusCode = result.status;
+        res.end();
+      }
     } else if (req.method === "POST") {
-      handlePostLockfile(lockfilePaths, req, res);
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        let body: Record<string, unknown>;
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+          return;
+        }
+
+        const result = upsertLockfileAssistant(
+          lockfilePaths,
+          body.assistant as Record<string, unknown>,
+          body.activeAssistant as string | undefined,
+        );
+        res.statusCode = result.ok ? 200 : result.status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(result));
+      });
     } else {
       res.statusCode = 405;
       res.end();
@@ -210,139 +120,9 @@ function lockfileMiddleware(
   };
 }
 
-function handleGetLockfile(
-  lockfilePaths: string[],
-  res: http.ServerResponse,
-): void {
-  let raw: string | undefined;
-  for (const candidate of lockfilePaths) {
-    try {
-      raw = fs.readFileSync(candidate, "utf-8");
-      break;
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        res.statusCode = 500;
-        res.end();
-        return;
-      }
-    }
-  }
-
-  if (!raw) {
-    res.setHeader("Content-Type", "application/json");
-    res.end(JSON.stringify({ assistants: [], activeAssistant: null }));
-    return;
-  }
-
-  try {
-    const data = JSON.parse(raw) as Record<string, unknown>;
-    stripSensitiveFields(data);
-    res.setHeader("Content-Type", "application/json");
-    res.end(JSON.stringify(data));
-  } catch {
-    res.statusCode = 500;
-    res.end();
-  }
-}
-
-/**
- * Merge an assistant entry into the lockfile on disk.
- *
- * Transport: Vite dev middleware (fs read/write).
- * In Electron, replace with IPC call to main process: window.electronAPI.saveLockfileAssistant(entry). (LUM-1998)
- */
-function handlePostLockfile(
-  lockfilePaths: string[],
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-): void {
-  const chunks: Buffer[] = [];
-  req.on("data", (chunk: Buffer) => chunks.push(chunk));
-  req.on("end", () => {
-    let body: Record<string, unknown>;
-    try {
-      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
-    } catch {
-      res.statusCode = 400;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
-      return;
-    }
-
-    const assistant = body.assistant as Record<string, unknown> | undefined;
-    const activeAssistant = body.activeAssistant as string | undefined;
-    if (!assistant || typeof assistant.assistantId !== "string") {
-      res.statusCode = 400;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ ok: false, error: "Missing assistant.assistantId" }));
-      return;
-    }
-
-    // Read existing lockfile
-    let lockfile: Record<string, unknown> = { assistants: [], activeAssistant: null };
-    const writePath = lockfilePaths[0]!;
-    for (const candidate of lockfilePaths) {
-      try {
-        lockfile = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
-        break;
-      } catch {
-        // continue
-      }
-    }
-
-    // Upsert the assistant entry
-    const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
-    const existingIdx = assistants.findIndex(
-      (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
-    );
-    if (existingIdx >= 0) {
-      assistants[existingIdx] = { ...assistants[existingIdx], ...assistant };
-    } else {
-      assistants.push(assistant);
-    }
-    lockfile.assistants = assistants;
-    if (activeAssistant !== undefined) {
-      lockfile.activeAssistant = activeAssistant;
-    }
-
-    // Atomic write
-    try {
-      const dir = path.dirname(writePath);
-      fs.mkdirSync(dir, { recursive: true });
-      const tmp = `${writePath}.tmp.${process.pid}`;
-      fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
-      fs.renameSync(tmp, writePath);
-    } catch (err) {
-      res.statusCode = 500;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ ok: false, error: `Failed to write lockfile: ${err}` }));
-      return;
-    }
-
-    const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<string, unknown>;
-    stripSensitiveFields(stripped);
-    res.setHeader("Content-Type", "application/json");
-    res.end(JSON.stringify({ ok: true, lockfile: stripped }));
-  });
-}
-
-const HATCH_TIMEOUT_MS = 120_000;
-
-/**
- * Connect middleware for the hatch endpoint.
- *
- * Transport: Vite dev middleware (child_process.spawn → CLI binary).
- * In Electron, replace with IPC call to main process: window.electronAPI.hatchAssistant(species). (LUM-1997)
- * The main process has direct access to the hatch-local module without spawning a subprocess.
- */
-function hatchMiddleware(): Connect.NextHandleFunction {
+function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
   return (req, res, next) => {
-    if (
-      req.url !== "/assistant/__local/hatch" &&
-      req.url !== "/__local/hatch"
-    ) {
-      return next();
-    }
+    if (req.url !== "/assistant/__local/hatch" && req.url !== "/__local/hatch") return next();
 
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -356,12 +136,8 @@ function hatchMiddleware(): Connect.NextHandleFunction {
       let species = "vellum";
       if (chunks.length > 0) {
         try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            species?: string;
-          };
-          if (body.species) {
-            species = body.species;
-          }
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as { species?: string };
+          if (body.species) species = body.species;
         } catch {
           res.statusCode = 400;
           res.setHeader("Content-Type", "application/json");
@@ -370,86 +146,28 @@ function hatchMiddleware(): Connect.NextHandleFunction {
         }
       }
 
-      handleHatch(species, res);
+      let cliPath: string;
+      try {
+        cliPath = resolveCliPath(baseDir, import.meta.url);
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+        return;
+      }
+
+      runHatch(species, cliPath).then((result) => {
+        res.statusCode = result.ok ? 200 : result.status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(result.ok ? { ok: true, assistantId: result.assistantId } : { ok: false, error: result.error }));
+      });
     });
   };
 }
 
-function handleHatch(species: string, res: http.ServerResponse): void {
-  let cliPath: string;
-  try {
-    cliPath = resolveCliPath();
-  } catch (err) {
-    res.statusCode = 500;
-    res.setHeader("Content-Type", "application/json");
-    res.end(
-      JSON.stringify({
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      }),
-    );
-    return;
-  }
-
-  const child = spawn("bun", ["run", cliPath, "hatch", species], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  let stdout = "";
-  let stderr = "";
-  let responded = false;
-
-  const respond = (status: number, body: Record<string, unknown>) => {
-    if (responded) return;
-    responded = true;
-    clearTimeout(timeout);
-    res.statusCode = status;
-    res.setHeader("Content-Type", "application/json");
-    res.end(JSON.stringify(body));
-  };
-
-  const timeout = setTimeout(() => {
-    child.kill("SIGTERM");
-    respond(500, { ok: false, error: "Hatch timed out after 120 seconds" });
-  }, HATCH_TIMEOUT_MS);
-
-  child.stdout.on("data", (data: Buffer) => {
-    stdout += data.toString();
-  });
-
-  child.stderr.on("data", (data: Buffer) => {
-    stderr += data.toString();
-  });
-
-  child.on("close", (code) => {
-    if (code === 0) {
-      const match = stdout.match(/Hatching local assistant:\s+(.+)/);
-      const assistantId = match?.[1]?.trim() ?? "";
-      respond(200, { ok: true, assistantId });
-    } else {
-      respond(500, { ok: false, error: stderr || stdout });
-    }
-  });
-
-  child.on("error", (err) => {
-    respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
-  });
-}
-
-/**
- * Connect middleware for the retire endpoint.
- *
- * Transport: Vite dev middleware (child_process.spawn → CLI binary).
- * In Electron, replace with IPC call to main process: window.electronAPI.retireAssistant(assistantId). (LUM-2000)
- */
-function retireMiddleware(): Connect.NextHandleFunction {
+function retireMiddleware(baseDir: string): Connect.NextHandleFunction {
   return (req, res, next) => {
-    if (
-      req.url !== "/assistant/__local/retire" &&
-      req.url !== "/__local/retire"
-    ) {
-      return next();
-    }
+    if (req.url !== "/assistant/__local/retire" && req.url !== "/__local/retire") return next();
 
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -463,9 +181,7 @@ function retireMiddleware(): Connect.NextHandleFunction {
       let assistantId: string | undefined;
       if (chunks.length > 0) {
         try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            assistantId?: string;
-          };
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as { assistantId?: string };
           assistantId = body.assistantId;
         } catch {
           res.statusCode = 400;
@@ -482,138 +198,28 @@ function retireMiddleware(): Connect.NextHandleFunction {
         return;
       }
 
-      handleRetire(assistantId, res);
+      let cliPath: string;
+      try {
+        cliPath = resolveCliPath(baseDir, import.meta.url);
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+        return;
+      }
+
+      runRetire(assistantId, cliPath).then((result) => {
+        res.statusCode = result.ok ? 200 : result.status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(result.ok ? { ok: true } : { ok: false, error: result.error }));
+      });
     });
   };
 }
 
-const RETIRE_TIMEOUT_MS = 60_000;
-
-function handleRetire(assistantId: string, res: http.ServerResponse): void {
-  let cliPath: string;
-  try {
-    cliPath = resolveCliPath();
-  } catch (err) {
-    res.statusCode = 500;
-    res.setHeader("Content-Type", "application/json");
-    res.end(
-      JSON.stringify({
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      }),
-    );
-    return;
-  }
-
-  const child = spawn("bun", ["run", cliPath, "retire", assistantId, "--yes"], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  let stdout = "";
-  let stderr = "";
-  let responded = false;
-
-  const respond = (status: number, body: Record<string, unknown>) => {
-    if (responded) return;
-    responded = true;
-    clearTimeout(timeout);
-    res.statusCode = status;
-    res.setHeader("Content-Type", "application/json");
-    res.end(JSON.stringify(body));
-  };
-
-  const timeout = setTimeout(() => {
-    child.kill("SIGTERM");
-    respond(500, { ok: false, error: "Retire timed out after 60 seconds" });
-  }, RETIRE_TIMEOUT_MS);
-
-  child.stdout.on("data", (data: Buffer) => {
-    stdout += data.toString();
-  });
-
-  child.stderr.on("data", (data: Buffer) => {
-    stderr += data.toString();
-  });
-
-  child.on("close", (code) => {
-    if (code === 0) {
-      respond(200, { ok: true });
-    } else {
-      respond(500, { ok: false, error: stderr || stdout });
-    }
-  });
-
-  child.on("error", (err) => {
-    respond(500, { ok: false, error: `Failed to spawn CLI: ${err.message}` });
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Guardian token middleware
-// ---------------------------------------------------------------------------
-
-function isLoopbackAddr(addr: string): boolean {
-  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  const normalized = v4Mapped ? v4Mapped[1]! : addr;
-  if (normalized.includes(".")) {
-    return normalized.startsWith("127.");
-  }
-  return normalized === "::1";
-}
-
-const GUARDIAN_TOKEN_PATTERN =
-  /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
-
-const GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS = 15_000;
-
-/**
- * Resolve the config directory matching `cli/src/lib/environments/paths.ts:getConfigDir`.
- */
-function resolveConfigDir(env: Record<string, string>): string {
-  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
-  const xdgConfigHome =
-    env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
-    return path.join(xdgConfigHome, "vellum");
-  }
-  return path.join(xdgConfigHome, `vellum-${vellumEnv}`);
-}
-
-function resolveGuardianTokenPath(
-  env: Record<string, string>,
-  assistantId: string,
-): string {
-  return path.join(resolveConfigDir(env), "assistants", assistantId, "guardian-token.json");
-}
-
-interface GuardianTokenData {
-  accessToken: string;
-  accessTokenExpiresAt: string | number;
-  refreshToken: string;
-  refreshTokenExpiresAt: string | number;
-}
-
-function isAccessTokenExpired(data: GuardianTokenData): boolean {
-  const expiresAt = new Date(data.accessTokenExpiresAt).getTime();
-  if (!Number.isFinite(expiresAt)) return true;
-  return Date.now() >= expiresAt - 60_000;
-}
-
-function isRefreshTokenExpired(data: GuardianTokenData): boolean {
-  const expiresAt = new Date(data.refreshTokenExpiresAt).getTime();
-  if (!Number.isFinite(expiresAt)) return true;
-  return Date.now() >= expiresAt;
-}
-
-/**
- * Connect middleware that serves guardian access tokens for local assistants.
- *
- * GET /assistant/__local/guardian-token/:assistantId
- *
- * Reads the guardian token from disk. If the access token is expired,
- * shells out to the CLI to refresh it, then re-reads from disk.
- */
 function guardianTokenMiddleware(
+  configDir: string,
+  baseDir: string,
   env: Record<string, string>,
 ): Connect.NextHandleFunction {
   return (req, res, next) => {
@@ -627,53 +233,11 @@ function guardianTokenMiddleware(
     }
 
     const peer = req.socket.remoteAddress ?? "";
-    if (!isLoopbackAddr(peer)) {
-      res.statusCode = 403;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ error: "Forbidden" }));
-      return;
-    }
-
     const assistantId = decodeURIComponent(match[1]!);
-    const tokenPath = resolveGuardianTokenPath(env, assistantId);
 
-    let raw: string;
-    try {
-      raw = fs.readFileSync(tokenPath, "utf-8");
-    } catch {
-      res.statusCode = 404;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ error: "Guardian token not found" }));
-      return;
-    }
-
-    let data: GuardianTokenData;
-    try {
-      data = JSON.parse(raw) as GuardianTokenData;
-    } catch {
-      res.statusCode = 500;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ error: "Malformed guardian token file" }));
-      return;
-    }
-
-    if (!isAccessTokenExpired(data)) {
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ accessToken: data.accessToken }));
-      return;
-    }
-
-    if (isRefreshTokenExpired(data)) {
-      res.statusCode = 401;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ error: "Guardian token expired — re-run `vellum hatch` or `vellum wake`" }));
-      return;
-    }
-
-    // Refresh via CLI in a child process
     let cliPath: string;
     try {
-      cliPath = resolveCliPath();
+      cliPath = resolveCliPath(baseDir, import.meta.url);
     } catch (err) {
       res.statusCode = 500;
       res.setHeader("Content-Type", "application/json");
@@ -681,84 +245,36 @@ function guardianTokenMiddleware(
       return;
     }
 
-    const child = spawn(
-      "bun",
-      ["run", cliPath, "gateway", "token", "refresh", assistantId],
-      { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, ...env } },
-    );
-
-    let stdout = "";
-    let responded = false;
-
-    const respond = (status: number, body: Record<string, unknown>) => {
-      if (responded) return;
-      responded = true;
-      clearTimeout(timeout);
-      res.statusCode = status;
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify(body));
-    };
-
-    const timeout = setTimeout(() => {
-      child.kill("SIGTERM");
-      respond(500, { error: "Guardian token refresh timed out" });
-    }, GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS);
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-
-    child.on("close", (code) => {
-      if (code === 0) {
-        const accessToken = stdout.trim();
-        if (accessToken) {
-          respond(200, { accessToken });
-        } else {
-          respond(500, { error: "CLI returned empty token" });
-        }
+    getGuardianAccessToken(assistantId, configDir, cliPath, isLoopbackAddr(peer), env).then((result) => {
+      if (result.ok) {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ accessToken: result.accessToken }));
       } else {
-        respond(401, { error: "Failed to refresh guardian token" });
+        res.statusCode = result.status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: result.error }));
       }
-    });
-
-    child.on("error", (err) => {
-      respond(500, { error: `Failed to spawn CLI: ${err.message}` });
     });
   };
 }
 
-// ---------------------------------------------------------------------------
-// Gateway proxy middleware
-// ---------------------------------------------------------------------------
-
-const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
-
-/**
- * Connect middleware that proxies requests to local gateway ports.
- *
- * Matches `/__gateway/:port/*` and forwards to `http://127.0.0.1:{port}{rest}`.
- * Supports chunked transfer and SSE by piping without buffering.
- */
 function gatewayProxyMiddleware(): Connect.NextHandleFunction {
   return (req, res, next) => {
-    const match = req.url?.match(GATEWAY_PATTERN);
-    if (!match) return next();
-
-    const port = parseInt(match[1]!, 10);
-    if (port < 1024 || port > 65535) {
+    const result = parseGatewayUrl(req.url ?? "");
+    if (!result.match) return next();
+    if (!result.valid) {
       res.statusCode = 400;
       res.end("Port must be between 1024 and 65535");
       return;
     }
 
-    const restPath = match[2] || "/";
-
+    const { target } = result;
     const proxyOptions: http.RequestOptions = {
       hostname: "127.0.0.1",
-      port,
-      path: restPath,
+      port: target.port,
+      path: target.path,
       method: req.method,
-      headers: { ...req.headers, host: `127.0.0.1:${port}` },
+      headers: { ...req.headers, host: `127.0.0.1:${target.port}` },
     };
 
     const proxyReq = http.request(proxyOptions, (proxyRes) => {
@@ -773,7 +289,6 @@ function gatewayProxyMiddleware(): Connect.NextHandleFunction {
       }
     });
 
-    // Pipe the incoming request body to the proxy request (supports POST, etc.)
     req.pipe(proxyReq);
   };
 }

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -368,6 +368,15 @@ async function handleLocalEndpoints(
   server: { requestIP(req: Request): { address: string } | null },
 ): Promise<Response | null> {
   const { pathname } = url;
+
+  // All __local and __gateway endpoints are restricted to loopback clients.
+  // The server binds 0.0.0.0 for LAN access to the SPA, but these endpoints
+  // must not be reachable from other machines.
+  const peer = server.requestIP(req)?.address ?? "";
+  if (!isLoopbackAddr(peer)) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const lockfilePaths = _lockfilePaths;
   const configDir = _configDir;
 
@@ -462,7 +471,6 @@ async function handleLocalEndpoints(
     if (req.method !== "GET") return new Response(null, { status: 405 });
 
     const assistantId = decodeURIComponent(guardianMatch[1]!);
-    const peer = server.requestIP(req)?.address ?? "";
 
     let cliPath: string;
     try {
@@ -471,7 +479,7 @@ async function handleLocalEndpoints(
       return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
     }
 
-    const result = await getGuardianAccessToken(assistantId, configDir, cliPath, isLoopbackAddr(peer), _localEnv);
+    const result = await getGuardianAccessToken(assistantId, configDir, cliPath, true, _localEnv);
     if (result.ok) {
       return Response.json({ accessToken: result.accessToken });
     }
@@ -485,7 +493,7 @@ async function handleLocalEndpoints(
       return new Response("Port must be between 1024 and 65535", { status: 400 });
     }
     const { target: gatewayTarget } = gatewayResult;
-    const targetUrl = `http://127.0.0.1:${gatewayTarget.port}${gatewayTarget.path}`;
+    const targetUrl = `http://127.0.0.1:${gatewayTarget.port}${gatewayTarget.path}${url.search}`;
     const headers = new Headers(req.headers);
     headers.set("host", `127.0.0.1:${gatewayTarget.port}`);
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -24,6 +24,18 @@ import {
   WEB_INTERFACE_ID,
   getClientRegistrationHeaders,
 } from "../lib/client-identity";
+import {
+  getLockfileData,
+  upsertLockfileAssistant,
+  runHatch,
+  runRetire,
+  getGuardianAccessToken,
+  parseGatewayUrl,
+  isLoopbackAddr,
+  resolveCliPath,
+  resolveLockfilePaths,
+  resolveConfigDir,
+} from "../lib/local-endpoints";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import {
   fetchOrganizationId,
@@ -332,6 +344,191 @@ function findWebSourceDir(): string | null {
   return null;
 }
 
+const LOCKFILE_PATTERN = /^(?:\/assistant)?\/__local\/lockfile$/;
+const HATCH_PATTERN = /^(?:\/assistant)?\/__local\/hatch$/;
+const RETIRE_PATTERN = /^(?:\/assistant)?\/__local\/retire$/;
+const GUARDIAN_TOKEN_PATTERN = /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
+
+function getEnvRecord(): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) result[k] = v;
+  }
+  return result;
+}
+
+const _localEnv = getEnvRecord();
+const _lockfilePaths = resolveLockfilePaths(_localEnv);
+const _configDir = resolveConfigDir(_localEnv);
+const _baseDir = getBaseDir();
+
+async function handleLocalEndpoints(
+  req: Request,
+  url: URL,
+  server: { requestIP(req: Request): { address: string } | null },
+): Promise<Response | null> {
+  const { pathname } = url;
+  const lockfilePaths = _lockfilePaths;
+  const configDir = _configDir;
+
+  // Lockfile
+  if (LOCKFILE_PATTERN.test(pathname)) {
+    if (req.method === "GET") {
+      const result = getLockfileData(lockfilePaths);
+      if (result.ok) {
+        return Response.json(result.data);
+      }
+      return new Response(null, { status: result.status });
+    }
+    if (req.method === "POST") {
+      let body: Record<string, unknown>;
+      try {
+        body = (await req.json()) as Record<string, unknown>;
+      } catch {
+        return Response.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+      }
+      const result = upsertLockfileAssistant(
+        lockfilePaths,
+        body.assistant as Record<string, unknown>,
+        body.activeAssistant as string | undefined,
+      );
+      return Response.json(result, { status: result.ok ? 200 : result.status });
+    }
+    return new Response(null, { status: 405 });
+  }
+
+  // Hatch
+  if (HATCH_PATTERN.test(pathname)) {
+    if (req.method !== "POST") return new Response(null, { status: 405 });
+
+    let species = "vellum";
+    const contentType = req.headers.get("content-type") ?? "";
+    if (contentType.includes("json")) {
+      try {
+        const body = (await req.json()) as { species?: string };
+        if (body.species) species = body.species;
+      } catch {
+        return Response.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+      }
+    }
+
+    let cliPath: string;
+    try {
+      cliPath = resolveCliPath(_baseDir);
+    } catch (err) {
+      return Response.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+    }
+
+    const result = await runHatch(species, cliPath);
+    if (result.ok) {
+      return Response.json({ ok: true, assistantId: result.assistantId });
+    }
+    return Response.json({ ok: false, error: result.error }, { status: result.status });
+  }
+
+  // Retire
+  if (RETIRE_PATTERN.test(pathname)) {
+    if (req.method !== "POST") return new Response(null, { status: 405 });
+
+    let assistantId: string | undefined;
+    try {
+      const body = (await req.json()) as { assistantId?: string };
+      assistantId = body.assistantId;
+    } catch {
+      return Response.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!assistantId) {
+      return Response.json({ ok: false, error: "Missing assistantId" }, { status: 400 });
+    }
+
+    let cliPath: string;
+    try {
+      cliPath = resolveCliPath(_baseDir);
+    } catch (err) {
+      return Response.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+    }
+
+    const result = await runRetire(assistantId, cliPath);
+    if (result.ok) {
+      return Response.json({ ok: true });
+    }
+    return Response.json({ ok: false, error: result.error }, { status: result.status });
+  }
+
+  // Guardian token
+  const guardianMatch = pathname.match(GUARDIAN_TOKEN_PATTERN);
+  if (guardianMatch) {
+    if (req.method !== "GET") return new Response(null, { status: 405 });
+
+    const assistantId = decodeURIComponent(guardianMatch[1]!);
+    const peer = server.requestIP(req)?.address ?? "";
+
+    let cliPath: string;
+    try {
+      cliPath = resolveCliPath(_baseDir);
+    } catch (err) {
+      return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+    }
+
+    const result = await getGuardianAccessToken(assistantId, configDir, cliPath, isLoopbackAddr(peer), _localEnv);
+    if (result.ok) {
+      return Response.json({ accessToken: result.accessToken });
+    }
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  // Gateway proxy
+  const gatewayResult = parseGatewayUrl(pathname);
+  if (gatewayResult.match) {
+    if (!gatewayResult.valid) {
+      return new Response("Port must be between 1024 and 65535", { status: 400 });
+    }
+    const { target: gatewayTarget } = gatewayResult;
+    const targetUrl = `http://127.0.0.1:${gatewayTarget.port}${gatewayTarget.path}`;
+    const headers = new Headers(req.headers);
+    headers.set("host", `127.0.0.1:${gatewayTarget.port}`);
+
+    try {
+      const hasBody = req.method !== "GET" && req.method !== "HEAD";
+      const proxyRes = await fetch(targetUrl, {
+        method: req.method,
+        headers,
+        body: hasBody ? req.body : undefined,
+        redirect: "manual",
+      });
+      const resHeaders = new Headers(proxyRes.headers);
+      resHeaders.delete("transfer-encoding");
+      return new Response(proxyRes.body, {
+        status: proxyRes.status,
+        statusText: proxyRes.statusText,
+        headers: resHeaders,
+      });
+    } catch {
+      return new Response("Gateway proxy error", { status: 502 });
+    }
+  }
+
+  return null;
+}
+
+function getBaseDir(): string {
+  let dir = import.meta.dir;
+  for (let depth = 0; depth < 8; depth++) {
+    if (existsSync(path.join(dir, "cli", "src", "index.ts"))) {
+      return dir;
+    }
+    const pkgPath = path.join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(import.meta.dir, "..", "..", "..");
+}
+
 async function runWebInterface(): Promise<void> {
   // Prefer Vite dev server in source checkouts for full local-mode support
   // (HMR, __local endpoints, gateway proxy).
@@ -382,6 +579,10 @@ async function runWebInterface(): Promise<void> {
           headers: { "Content-Type": "application/json" },
         });
       }
+
+      // __local endpoints for local-mode (lockfile, hatch, retire, guardian-token, gateway-proxy).
+      const localResponse = await handleLocalEndpoints(req, url, server);
+      if (localResponse) return localResponse;
 
       // Reverse-proxy platform API requests.
       if (

--- a/cli/src/lib/local-endpoints/config.ts
+++ b/cli/src/lib/local-endpoints/config.ts
@@ -1,0 +1,57 @@
+import os from "node:os";
+import path from "node:path";
+
+import { SEEDS } from "../environments/seeds";
+
+const PRODUCTION_ENVIRONMENT_NAME = "production";
+
+export interface LocalEndpointConfig {
+  lockfilePaths: string[];
+  configDir: string;
+  webUrl: string;
+  platformUrl: string;
+}
+
+/**
+ * Resolve config from environment variables (Vite plugin context, where
+ * `env` comes from `loadEnv` and process.env).
+ */
+export function resolveLocalConfigFromEnv(env: Record<string, string>): LocalEndpointConfig {
+  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
+  const seed = SEEDS[vellumEnv] ?? SEEDS[PRODUCTION_ENVIRONMENT_NAME]!;
+
+  return {
+    lockfilePaths: resolveLockfilePaths(env),
+    configDir: resolveConfigDir(env),
+    webUrl: env.VELLUM_WEB_URL || seed.webUrl,
+    platformUrl: env.VELLUM_PLATFORM_URL || seed.platformUrl,
+  };
+}
+
+export function resolveLockfilePaths(env: Record<string, string>): string[] {
+  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
+  const lockfileDir = env.VELLUM_LOCKFILE_DIR;
+
+  if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
+    const dir = lockfileDir ?? os.homedir();
+    return [
+      path.join(dir, ".vellum.lock.json"),
+      path.join(dir, ".vellum.lockfile.json"),
+    ];
+  }
+
+  const xdgConfigHome =
+    env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  const dir = lockfileDir ?? path.join(xdgConfigHome, `vellum-${vellumEnv}`);
+  return [path.join(dir, "lockfile.json")];
+}
+
+export function resolveConfigDir(env: Record<string, string>): string {
+  const vellumEnv = env.VELLUM_ENVIRONMENT || PRODUCTION_ENVIRONMENT_NAME;
+  const xdgConfigHome =
+    env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  if (vellumEnv === PRODUCTION_ENVIRONMENT_NAME) {
+    return path.join(xdgConfigHome, "vellum");
+  }
+  return path.join(xdgConfigHome, `vellum-${vellumEnv}`);
+}

--- a/cli/src/lib/local-endpoints/gateway-proxy.ts
+++ b/cli/src/lib/local-endpoints/gateway-proxy.ts
@@ -1,0 +1,21 @@
+const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
+
+export interface GatewayTarget {
+  port: number;
+  path: string;
+}
+
+export type GatewayParseResult =
+  | { match: true; valid: true; target: GatewayTarget }
+  | { match: true; valid: false }
+  | { match: false };
+
+export function parseGatewayUrl(pathname: string): GatewayParseResult {
+  const match = pathname.match(GATEWAY_PATTERN);
+  if (!match) return { match: false };
+
+  const port = parseInt(match[1]!, 10);
+  if (port < 1024 || port > 65535) return { match: true, valid: false };
+
+  return { match: true, valid: true, target: { port, path: match[2] || "/" } };
+}

--- a/cli/src/lib/local-endpoints/guardian-token.ts
+++ b/cli/src/lib/local-endpoints/guardian-token.ts
@@ -1,0 +1,120 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS = 15_000;
+
+interface GuardianTokenData {
+  accessToken: string;
+  accessTokenExpiresAt: string | number;
+  refreshToken: string;
+  refreshTokenExpiresAt: string | number;
+}
+
+function isAccessTokenExpired(data: GuardianTokenData): boolean {
+  const expiresAt = new Date(data.accessTokenExpiresAt).getTime();
+  if (!Number.isFinite(expiresAt)) return true;
+  return Date.now() >= expiresAt - 60_000;
+}
+
+function isRefreshTokenExpired(data: GuardianTokenData): boolean {
+  const expiresAt = new Date(data.refreshTokenExpiresAt).getTime();
+  if (!Number.isFinite(expiresAt)) return true;
+  return Date.now() >= expiresAt;
+}
+
+export type TokenResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; status: number; error: string };
+
+export function getGuardianAccessToken(
+  assistantId: string,
+  configDir: string,
+  cliPath: string,
+  isLoopback: boolean,
+  env?: Record<string, string>,
+): Promise<TokenResult> {
+  if (!isLoopback) {
+    return Promise.resolve({ ok: false, status: 403, error: "Forbidden" });
+  }
+
+  const tokenPath = path.join(configDir, "assistants", assistantId, "guardian-token.json");
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(tokenPath, "utf-8");
+  } catch {
+    return Promise.resolve({ ok: false, status: 404, error: "Guardian token not found" });
+  }
+
+  let data: GuardianTokenData;
+  try {
+    data = JSON.parse(raw) as GuardianTokenData;
+  } catch {
+    return Promise.resolve({ ok: false, status: 500, error: "Malformed guardian token file" });
+  }
+
+  if (!isAccessTokenExpired(data)) {
+    return Promise.resolve({ ok: true, accessToken: data.accessToken });
+  }
+
+  if (isRefreshTokenExpired(data)) {
+    return Promise.resolve({
+      ok: false,
+      status: 401,
+      error: "Guardian token expired — re-run `vellum hatch` or `vellum wake`",
+    });
+  }
+
+  return refreshToken(assistantId, cliPath, env);
+}
+
+function refreshToken(
+  assistantId: string,
+  cliPath: string,
+  env?: Record<string, string>,
+): Promise<TokenResult> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      "bun",
+      ["run", cliPath, "gateway", "token", "refresh", assistantId],
+      { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, ...env } },
+    );
+
+    let stdout = "";
+    let done = false;
+
+    const finish = (result: TokenResult) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({ ok: false, status: 500, error: "Guardian token refresh timed out" });
+    }, GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        const accessToken = stdout.trim();
+        if (accessToken) {
+          finish({ ok: true, accessToken });
+        } else {
+          finish({ ok: false, status: 500, error: "CLI returned empty token" });
+        }
+      } else {
+        finish({ ok: false, status: 401, error: "Failed to refresh guardian token" });
+      }
+    });
+
+    child.on("error", (err) => {
+      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+    });
+  });
+}

--- a/cli/src/lib/local-endpoints/hatch.ts
+++ b/cli/src/lib/local-endpoints/hatch.ts
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+
+const HATCH_TIMEOUT_MS = 120_000;
+
+export type HatchResult =
+  | { ok: true; assistantId: string }
+  | { ok: false; status: number; error: string };
+
+export function runHatch(species: string, cliPath: string): Promise<HatchResult> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["run", cliPath, "hatch", species], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let done = false;
+
+    const finish = (result: HatchResult) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({ ok: false, status: 500, error: "Hatch timed out after 120 seconds" });
+    }, HATCH_TIMEOUT_MS);
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        const match = stdout.match(/Hatching local assistant:\s+(.+)/);
+        const assistantId = match?.[1]?.trim() ?? "";
+        finish({ ok: true, assistantId });
+      } else {
+        finish({ ok: false, status: 500, error: stderr || stdout });
+      }
+    });
+
+    child.on("error", (err) => {
+      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+    });
+  });
+}

--- a/cli/src/lib/local-endpoints/index.ts
+++ b/cli/src/lib/local-endpoints/index.ts
@@ -1,0 +1,13 @@
+export { stripSensitiveFields, isLoopbackAddr, resolveCliPath, resetCliPathCache } from "./util";
+export { resolveLocalConfigFromEnv, resolveLockfilePaths, resolveConfigDir } from "./config";
+export type { LocalEndpointConfig } from "./config";
+export { getLockfileData, upsertLockfileAssistant } from "./lockfile";
+export type { LockfileResult, WriteResult } from "./lockfile";
+export { runHatch } from "./hatch";
+export type { HatchResult } from "./hatch";
+export { runRetire } from "./retire";
+export type { RetireResult } from "./retire";
+export { getGuardianAccessToken } from "./guardian-token";
+export type { TokenResult } from "./guardian-token";
+export { parseGatewayUrl } from "./gateway-proxy";
+export type { GatewayTarget, GatewayParseResult } from "./gateway-proxy";

--- a/cli/src/lib/local-endpoints/lockfile.ts
+++ b/cli/src/lib/local-endpoints/lockfile.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { stripSensitiveFields } from "./util";
+
+export type LockfileResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; status: number; error?: string };
+
+export function getLockfileData(lockfilePaths: string[]): LockfileResult {
+  let raw: string | undefined;
+  for (const candidate of lockfilePaths) {
+    try {
+      raw = fs.readFileSync(candidate, "utf-8");
+      break;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        return { ok: false, status: 500 };
+      }
+    }
+  }
+
+  if (!raw) {
+    return { ok: true, data: { assistants: [], activeAssistant: null } };
+  }
+
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    stripSensitiveFields(data);
+    return { ok: true, data };
+  } catch {
+    return { ok: false, status: 500 };
+  }
+}
+
+export type WriteResult =
+  | { ok: true; lockfile: Record<string, unknown> }
+  | { ok: false; status: number; error: string };
+
+export function upsertLockfileAssistant(
+  lockfilePaths: string[],
+  assistant: Record<string, unknown>,
+  activeAssistant: string | undefined,
+): WriteResult {
+  if (!assistant || typeof assistant.assistantId !== "string") {
+    return { ok: false, status: 400, error: "Missing assistant.assistantId" };
+  }
+
+  let lockfile: Record<string, unknown> = { assistants: [], activeAssistant: null };
+  for (const candidate of lockfilePaths) {
+    try {
+      lockfile = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
+      break;
+    } catch {
+      // continue
+    }
+  }
+
+  const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+  const existingIdx = assistants.findIndex(
+    (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
+  );
+  if (existingIdx >= 0) {
+    assistants[existingIdx] = { ...assistants[existingIdx], ...assistant };
+  } else {
+    assistants.push(assistant);
+  }
+  lockfile.assistants = assistants;
+  if (activeAssistant !== undefined) {
+    lockfile.activeAssistant = activeAssistant;
+  }
+
+  const writePath = lockfilePaths[0]!;
+  try {
+    const dir = path.dirname(writePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${writePath}.tmp.${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
+    fs.renameSync(tmp, writePath);
+  } catch (err) {
+    return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
+  }
+
+  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<string, unknown>;
+  stripSensitiveFields(stripped);
+  return { ok: true, lockfile: stripped };
+}

--- a/cli/src/lib/local-endpoints/retire.ts
+++ b/cli/src/lib/local-endpoints/retire.ts
@@ -1,0 +1,51 @@
+import { spawn } from "node:child_process";
+
+const RETIRE_TIMEOUT_MS = 60_000;
+
+export type RetireResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+export function runRetire(assistantId: string, cliPath: string): Promise<RetireResult> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["run", cliPath, "retire", assistantId, "--yes"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let done = false;
+
+    const finish = (result: RetireResult) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({ ok: false, status: 500, error: "Retire timed out after 60 seconds" });
+    }, RETIRE_TIMEOUT_MS);
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        finish({ ok: true });
+      } else {
+        finish({ ok: false, status: 500, error: stderr || stdout });
+      }
+    });
+
+    child.on("error", (err) => {
+      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+    });
+  });
+}

--- a/cli/src/lib/local-endpoints/util.ts
+++ b/cli/src/lib/local-endpoints/util.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const CLI_PACKAGE_NAME = "@vellumai/cli";
+
+const SENSITIVE_FIELDS = [
+  "signingKey",
+  "bearerToken",
+  "guardianBootstrapSecret",
+] as const;
+
+export function stripSensitiveFields(data: Record<string, unknown>): void {
+  const assistants = data.assistants;
+  if (!Array.isArray(assistants)) return;
+  for (const assistant of assistants) {
+    if (assistant && typeof assistant === "object") {
+      const entry = assistant as Record<string, unknown>;
+      for (const field of SENSITIVE_FIELDS) {
+        delete entry[field];
+      }
+      const resources = entry.resources;
+      if (resources && typeof resources === "object") {
+        for (const field of SENSITIVE_FIELDS) {
+          delete (resources as Record<string, unknown>)[field];
+        }
+      }
+    }
+  }
+}
+
+export function isLoopbackAddr(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1]! : addr;
+  if (normalized.includes(".")) {
+    return normalized.startsWith("127.");
+  }
+  return normalized === "::1";
+}
+
+let _resolvedCliPath: string | undefined;
+
+/**
+ * Resolve the CLI entry point.
+ *
+ * 1. Source tree — `<baseDir>/cli/src/index.ts` (dev mode in monorepo).
+ * 2. Installed package — `require.resolve("@vellumai/cli/package.json")`.
+ */
+export function resolveCliPath(baseDir: string, importMetaUrl?: string): string {
+  if (_resolvedCliPath) return _resolvedCliPath;
+
+  const sourceTreePath = path.join(baseDir, "cli", "src", "index.ts");
+  if (fs.existsSync(sourceTreePath)) {
+    _resolvedCliPath = sourceTreePath;
+    return _resolvedCliPath;
+  }
+
+  const _require = createRequire(importMetaUrl ?? `file://${baseDir}/`);
+  try {
+    const pkgPath = _require.resolve(`${CLI_PACKAGE_NAME}/package.json`);
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { bin?: Record<string, string> };
+    const binEntry = pkg.bin?.["vellum"];
+    if (binEntry) {
+      const entryPoint = path.resolve(path.dirname(pkgPath), binEntry);
+      if (fs.existsSync(entryPoint)) {
+        _resolvedCliPath = entryPoint;
+        return _resolvedCliPath;
+      }
+    }
+  } catch {
+    // Not found in node_modules
+  }
+
+  throw new Error(
+    `Vellum CLI not found. Looked for source tree at ${sourceTreePath} and npm package ${CLI_PACKAGE_NAME}.`,
+  );
+}
+
+export function resetCliPathCache(): void {
+  _resolvedCliPath = undefined;
+}


### PR DESCRIPTION
## Summary
- Created `cli/src/lib/local-endpoints/` with transport-agnostic functions for lockfile read/write, hatch, retire, guardian-token refresh, and gateway-proxy URL parsing
- Rewired `apps/web/vite-plugin-local-mode.ts` to import core logic from the new module (779→230 lines)
- Added all five `__local` endpoint groups to the Bun.serve static file server in `cli/src/commands/client.ts`

## Original prompt
Extract the five `__local` endpoint groups from `vite-plugin-local-mode.ts` into transport-agnostic core functions that both the Vite dev server and the npm-installed static file server can share. The goal is to make `vellum client --interface web` fully functional in local mode even when running from pre-built assets (no Vite dev server).