### PR TITLE
fix(ci): prevent command injection in manual CRX build workflow

### DIFF
--- a/.github/workflows/build-chrome-extension.yaml
+++ b/.github/workflows/build-chrome-extension.yaml
@@ -52,13 +52,20 @@ jobs:
       - name: Resolve version
         id: resolve-version
         working-directory: clients/chrome-extension
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          INPUT_VERSION="${{ inputs.version }}"
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           else
             VERSION=$(jq -r '.version' manifest.json)
           fi
+
+          if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){0,3}(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected digits with 1-4 dot-separated components and optional prerelease suffix."
+            exit 1
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using version: $VERSION"
 
@@ -82,8 +89,10 @@ jobs:
 
       - name: Verify manifest version
         working-directory: clients/chrome-extension
+        env:
+          EXPECTED_RAW: ${{ steps.resolve-version.outputs.version }}
         run: |
-          EXPECTED="${{ steps.resolve-version.outputs.version }}"
+          EXPECTED="$EXPECTED_RAW"
           # build.sh strips prerelease suffixes (e.g. "0.6.0-staging.3" -> "0.6.0")
           # to satisfy Chrome's version format requirement. Match that here.
           EXPECTED="${EXPECTED%%-*}"


### PR DESCRIPTION
## Summary

- Moves `inputs.version` from direct `${{ }}` interpolation in shell to safe `env:` indirection, preventing command injection in the "Resolve version" step
- Adds strict version format validation (semver-like regex) before writing to `$GITHUB_OUTPUT`
- Moves `steps.resolve-version.outputs.version` in the "Verify manifest version" step to an `env:` block, eliminating re-interpolation of potentially tainted step outputs while the CRX signing key is still on disk

## Original prompt

A Codex security finding identified a CI command injection vulnerability in the manual Chrome extension build workflow. The `workflow_dispatch` version input was directly interpolated into shell scripts, allowing crafted payloads to inject commands that could exfiltrate the CRX private signing key before cleanup. The fix uses GitHub Actions env indirection and input validation to block both injection vectors.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/1a0e0eecd2cc8191aac1ed5a3a3d0692?q=mcp&sev=critical%2Chigh