### PR TITLE
fix(web): gate Developer settings page behind settingsDeveloperNav flag

### DIFF
--- a/apps/web/src/domains/settings/pages/developer-page.tsx
+++ b/apps/web/src/domains/settings/pages/developer-page.tsx
@@ -20,8 +20,9 @@ type DeveloperTabId = (typeof ALL_TABS)[number]["id"];
 export function DeveloperPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
+  const hasHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
 
-  if (!settingsDeveloperNav) {
+  if (hasHydrated && !settingsDeveloperNav) {
     return <Navigate replace to={routes.settings.general} />;
   }
 

--- a/apps/web/src/domains/settings/pages/developer-page.tsx
+++ b/apps/web/src/domains/settings/pages/developer-page.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
-import { useSearchParams } from "react-router";
+import { Navigate, useSearchParams } from "react-router";
 
 import { AssistantLifecyclePanel } from "@/domains/settings/components/panels/assistant-lifecycle-panel";
 import { EnvironmentConfigPanel } from "@/domains/settings/components/panels/environment-config-panel";
 import { FeatureFlagsPanel } from "@/domains/settings/components/panels/feature-flags-panel";
 import { SentryTestingPanel } from "@/domains/settings/components/panels/sentry-testing-panel";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { cn } from "@/utils/misc";
+import { routes } from "@/utils/routes";
 
 const ALL_TABS = [
   { id: "feature-flags", label: "Feature Flags" },
@@ -17,6 +19,11 @@ type DeveloperTabId = (typeof ALL_TABS)[number]["id"];
 
 export function DeveloperPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
+
+  if (!settingsDeveloperNav) {
+    return <Navigate replace to={routes.settings.general} />;
+  }
 
   const activeTab: DeveloperTabId = useMemo(() => {
     const tabParam = searchParams.get("tab");


### PR DESCRIPTION
## Summary

- Add a `settingsDeveloperNav` feature flag guard to `DeveloperPage` that redirects to general settings when the flag is disabled
- Prevents direct URL navigation to `/assistant/settings/developer` by unauthenticated-for-developer users, closing the UI path for persisting security-sensitive assistant feature flag overrides

Codex finding: https://chatgpt.com/codex/cloud/security/findings/e2d47cf37bfc8191944335f5d6ec357a?q=mcp&sev=critical%2Chigh

## Original prompt

A Codex security finding flagged that the Developer settings page was directly reachable by any authenticated user via URL, even though the sidebar entry was hidden behind the `settingsDeveloperNav` flag. The page exposes the feature flag panel which now persists assistant-scoped flag toggles to the gateway, allowing non-developer users to enable security-sensitive features like `auto-analyze` (full tool access without user approval) and `app-control` (raw input/screenshot automation). The fix adds a route-level guard matching the existing sidebar gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)