### PR TITLE
fix(gateway): enforce scope checks on trust-rule routes

### DIFF
--- a/gateway/src/__tests__/trust-rules-route-auth.test.ts
+++ b/gateway/src/__tests__/trust-rules-route-auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const indexSource = readFileSync(
+  join(import.meta.dir, "..", "index.ts"),
+  "utf8",
+);
+
+function extractTrustRuleRouteObjects(): string[] {
+  const start = indexSource.indexOf("// ── Trust rules v3 ──");
+  const end = indexSource.indexOf("  ];", start);
+  const trustRuleRoutesSource = indexSource.slice(start, end);
+
+  return trustRuleRoutesSource
+    .split(/\n    \},\n/)
+    .filter((routeObject) => routeObject.includes("handleTrustRules"));
+}
+
+describe("trust rule route authorization", () => {
+  test("all trust rule routes use scoped settings authorization", () => {
+    const routeObjects = extractTrustRuleRouteObjects();
+
+    expect(routeObjects).toHaveLength(12);
+
+    for (const routeObject of routeObjects) {
+      expect(routeObject).toContain('auth: "edge-scoped"');
+      expect(routeObject).not.toContain('auth: "edge"');
+
+      const expectedScope = routeObject.includes("handleTrustRulesList")
+        ? 'scope: "settings.read"'
+        : 'scope: "settings.write"';
+      expect(routeObject).toContain(expectedScope);
+    }
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1327,7 +1327,8 @@ async function main() {
     {
       path: "/v1/trust-rules",
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req) => handleTrustRulesList(req),
     },
     {
@@ -1335,32 +1336,37 @@ async function main() {
       // the /:id catch-all regex so the literal path is matched first.
       path: "/v1/trust-rules/suggest",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => handleTrustRulesSuggest(req),
     },
     {
       path: "/v1/trust-rules",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => handleTrustRulesCreate(req),
     },
     {
       // Reset must be registered before the /:id catch-all regex
       path: /^\/v1\/trust-rules\/([^/]+)\/reset$/,
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesReset(req, params[0]),
     },
     {
       path: /^\/v1\/trust-rules\/([^/]+)$/,
       method: "PATCH",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesUpdate(req, params[0]),
     },
     {
       path: /^\/v1\/trust-rules\/([^/]+)$/,
       method: "DELETE",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesDelete(req, params[0]),
     },
 
@@ -1378,7 +1384,8 @@ async function main() {
     {
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/?$/,
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req) => handleTrustRulesList(req),
     },
     {
@@ -1386,32 +1393,37 @@ async function main() {
       // so the literal /suggest segment is matched first.
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/suggest\/?$/,
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => handleTrustRulesSuggest(req),
     },
     {
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/?$/,
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => handleTrustRulesCreate(req),
     },
     {
       // Reset must be registered before the /:id catch-all regex.
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/reset\/?$/,
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesReset(req, params[0]),
     },
     {
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/?$/,
       method: "PATCH",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesUpdate(req, params[0]),
     },
     {
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/?$/,
       method: "DELETE",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => handleTrustRulesDelete(req, params[0]),
     },
   ];


### PR DESCRIPTION
## Summary

- Changed all 12 trust-rule routes (both flat `/v1/trust-rules` and assistant-scoped `/v1/assistants/<id>/trust-rules`) from `auth: "edge"` to `auth: "edge-scoped"` with appropriate scope fields (`settings.read` for list, `settings.write` for mutations)
- Added a static source analysis test that verifies all trust-rule routes use scoped authorization

## Original prompt

A Codex security finding ([link](https://chatgpt.com/codex/cloud/security/findings/b29646b75e308191ae884298393c1f71?q=mcp&sev=critical%2Chigh)) identified that all trust-rule CRUD routes in the gateway used `auth: "edge"` instead of `auth: "edge-scoped"` with settings scopes. This meant any valid gateway JWT — even a low-privilege one without `settings.write` — could mutate trust rules, which control risk classification and permission prompting. The fix enforces the same scope pattern used by other settings routes in the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)