### PR TITLE
[ATL-647] fix(evals): scope eval-pod OCI runtime MITM rewrite to opted-in container

### DIFF
--- a/evals/docker/eval-pod/vellum-evals-runtime/README.md
+++ b/evals/docker/eval-pod/vellum-evals-runtime/README.md
@@ -1,8 +1,9 @@
 # vellum-evals-runtime
 
-A thin OCI runtime wrapper around `runc`, configured as the **default-runtime** of
-the inner dockerd inside the privileged eval-pod. Its sole job is to mutate the
-OCI `config.json` of every container the inner dockerd creates so that:
+A thin OCI runtime wrapper around `runc`, registered as a **named (non-default)
+runtime** of the inner dockerd inside the privileged eval-pod. The eval
+orchestrator selects it for the **single run/species container** it hatches, and
+only that opted-in container gets its OCI `config.json` mutated so that:
 
 1. The container's process environment has our three TLS-CA env vars set:
    - `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/recording-ca.pem`
@@ -14,9 +15,16 @@ OCI `config.json` of every container the inner dockerd creates so that:
    inherits the eval-pod's netns, where iptables NAT redirects `:443 → :8443`
    into mitmproxy.
 
-Together these three changes mean every assistant species container (Vellum,
-Hermes, OpenClaw, …) is born trusting our recording CA and routes outbound
-TLS through mitmproxy, **without any code changes on the species side**.
+Together these three changes mean the run/species container (Vellum, Hermes,
+OpenClaw, …) is born trusting our recording CA and routes outbound TLS through
+mitmproxy, **without any code changes on the species side**.
+
+The wrapper is opt-in per container: it only applies these mutations when the
+spec carries the `ai.vellum.evals.mitm` OCI annotation. Every other container
+the inner dockerd creates — recording sidecars, sub-containers the agent spins
+up, anything launched with `--network=none` or `--network container:<target>` —
+is left byte-for-byte untouched and keeps its own network namespace and trust
+store. See [Scope](#scope-why-not-default-runtime).
 
 ## Lifecycle
 
@@ -27,8 +35,9 @@ containerd-shim
         │  1. detect `create` subcommand
         │  2. find --bundle dir
         │  3. read <bundle>/config.json
-        │  4. mutate (env + mount + drop netns)
-        │  5. write back
+        │  4. opted in? (ai.vellum.evals.mitm annotation) — if not, pass through
+        │  5. mutate (env + mount + drop netns)
+        │  6. write back
         │
         └── exec /usr/bin/runc create --bundle /var/lib/docker/.../bundle <cid>
               │ (real runc reads the now-mutated config and creates the container)
@@ -38,15 +47,16 @@ containerd-shim
 
 The wrapper exits the moment it `exec`s real runc. It does **not** run for the
 lifetime of the container. All non-`create` subcommands (`start`, `state`,
-`kill`, `delete`, ...) pass through to real runc unchanged.
+`kill`, `delete`, ...) — and every `create` for a container that is **not**
+opted in — pass through to real runc unchanged.
 
 ## How dockerd is told to use it
 
-The eval-pod's inner dockerd is started with this `daemon.json`:
+The eval-pod's inner dockerd registers the wrapper as a **named** runtime but
+leaves the stock `runc` as the default, so untouched containers run normally:
 
 ```json
 {
-  "default-runtime": "vellum-evals-runtime",
   "runtimes": {
     "vellum-evals-runtime": {
       "path": "/usr/local/bin/vellum-evals-runtime"
@@ -55,7 +65,43 @@ The eval-pod's inner dockerd is started with this `daemon.json`:
 }
 ```
 
+The orchestrator then selects the runtime **and** sets the opt-in annotation on
+the run/species container only:
+
+```sh
+docker run \
+  --runtime vellum-evals-runtime \
+  --annotation ai.vellum.evals.mitm=1 \
+  <species-image> ...
+```
+
+`--annotation` passes the key through to the OCI spec's `.annotations`
+([docker run reference](https://docs.docker.com/reference/cli/docker/container/run/));
+the wrapper reads it to decide whether to mutate. `--runtime` is the primary
+scoping; the annotation is the in-binary fail-safe.
+
 (The eval-pod Dockerfile + start.sh that set this up ship in a follow-up PR.)
+
+## Scope (why not default-runtime)
+
+The wrapper is **not** the dockerd `default-runtime`, and the network-namespace
+drop is **not** applied to every container. Doing so was a container-isolation
+regression: the inner dockerd creates more than just the species container
+(recording sidecars, sub-containers the agent itself launches, etc.). Forcing
+*all* of them to share the eval-pod netns means an untrusted eval/species
+container could:
+
+- reach pod-local `localhost` services it should never see,
+- contend for or listen on the same ports as sidecars, and
+- with `CAP_NET_RAW`, observe or interfere with sibling/sidecar traffic.
+
+It also overrode explicit isolation requests (`--network=none`,
+`--network container:<target>`, custom bridge networks) silently.
+
+Scoping the runtime to a single opted-in container confines the MITM plumbing to
+exactly the container whose egress we need to record, and lets every other
+container keep the network isolation it asked for. The orchestrator opts in via
+`--runtime` + `--annotation` — no species-image changes required.
 
 ## Configuration
 
@@ -107,6 +153,7 @@ straight into the eval-pod image with no Go toolchain or libc needed.
 go test ./...
 ```
 
-Tests exercise (a) the pure spec-mutation function with table-driven inputs
-and (b) the arg-parser + on-disk rewrite path against a tempdir-hosted
-synthetic bundle. No runc, no docker, no network — all hermetic.
+Tests exercise (a) the pure spec-mutation function with table-driven inputs,
+(b) the opt-in gate that scopes the rewrite to annotated containers, and
+(c) the arg-parser + on-disk rewrite path against a tempdir-hosted synthetic
+bundle. No runc, no docker, no network — all hermetic.

--- a/evals/docker/eval-pod/vellum-evals-runtime/README.md
+++ b/evals/docker/eval-pod/vellum-evals-runtime/README.md
@@ -88,7 +88,7 @@ The wrapper is **not** the dockerd `default-runtime`, and the network-namespace
 drop is **not** applied to every container. Doing so was a container-isolation
 regression: the inner dockerd creates more than just the species container
 (recording sidecars, sub-containers the agent itself launches, etc.). Forcing
-*all* of them to share the eval-pod netns means an untrusted eval/species
+_all_ of them to share the eval-pod netns means an untrusted eval/species
 container could:
 
 - reach pod-local `localhost` services it should never see,

--- a/evals/docker/eval-pod/vellum-evals-runtime/main.go
+++ b/evals/docker/eval-pod/vellum-evals-runtime/main.go
@@ -1,15 +1,27 @@
 // Package main: vellum-evals-runtime — a thin OCI runtime wrapper.
 //
-// Configured as the inner dockerd's default-runtime inside the privileged
-// eval-pod. Every container the inner dockerd creates is born with our
-// recording CA trusted and its egress passing through the pod-netns
-// iptables NAT that redirects to mitmproxy.
+// Registered as a named (non-default) runtime of the inner dockerd inside
+// the privileged eval-pod. The eval orchestrator selects it for the single
+// run/species container with:
+//
+//	docker run --runtime vellum-evals-runtime \
+//	  --annotation ai.vellum.evals.mitm=1 ...
+//
+// Only that opted-in container is rewritten so it trusts our recording CA
+// and inherits the pod netns where iptables NAT redirects to mitmproxy.
+// Every other container the inner dockerd creates keeps its own network
+// namespace and default trust store. Scoping it this way (rather than as
+// the dockerd default-runtime) is a security boundary: untrusted eval /
+// species containers and their sidecars must not be silently forced into
+// the shared pod netns.
 //
 // Lifecycle: this binary is invoked once per `docker run` (containerd-shim
 // invokes it with arguments matching the runc CLI). On the `create`
-// subcommand we read the OCI config.json from the bundle dir, mutate it
-// in place, and then exec the real runc. All other subcommands
-// (start, state, kill, delete, ...) are a pure pass-through.
+// subcommand we read the OCI config.json from the bundle dir and, only if
+// the container is opted in (see mitmOptIn), mutate it in place; then we
+// exec the real runc. All other subcommands (start, state, kill, delete,
+// ...) — and every container that is not opted in — are a pure
+// pass-through.
 //
 // The wrapper exits the moment it execs runc — it does NOT live for the
 // lifetime of the container. Networking/TLS interception is the job of
@@ -105,6 +117,12 @@ func detectSubcommand(args []string) string {
 // mutateCreateBundle finds the bundle dir from args (defaulting to cwd)
 // and rewrites <bundle>/config.json with the CA + mount + netns
 // mutations from mutate.go.
+//
+// The rewrite is scoped to the single run/species container the
+// orchestrator opted in via the mitmOptInAnnotation. Any container without
+// that annotation is left byte-for-byte untouched so its network isolation
+// and trust store survive — this is what keeps the wrapper from collapsing
+// every container into the shared pod netns.
 func mutateCreateBundle(args []string) error {
 	bundleDir, err := findBundleDir(args)
 	if err != nil {
@@ -114,6 +132,9 @@ func mutateCreateBundle(args []string) error {
 	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", configPath, err)
+	}
+	if !mitmOptIn(raw) {
+		return nil
 	}
 	caHost := os.Getenv(envCAHostPath)
 	if caHost == "" {

--- a/evals/docker/eval-pod/vellum-evals-runtime/main_test.go
+++ b/evals/docker/eval-pod/vellum-evals-runtime/main_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+// optInConfigJSON is a minimal OCI config.json that carries the MITM opt-in
+// annotation, so mutateCreateBundle treats it as the run/species container.
+const optInConfigJSON = `{
+		"annotations": {"ai.vellum.evals.mitm": "1"},
+		"process": {"env": ["PATH=/usr/bin"]},
+		"linux": {"namespaces": [{"type": "network"}, {"type": "pid"}]}
+	}`
+
 // ---- detectSubcommand ----
 
 func TestDetectSubcommand(t *testing.T) {
@@ -95,11 +103,7 @@ func TestFindBundleDir_FlagWithoutValue(t *testing.T) {
 func TestMutateCreateBundle_RewritesConfigJSON(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	input := `{
-		"process": {"env": ["PATH=/usr/bin"]},
-		"linux": {"namespaces": [{"type": "network"}, {"type": "pid"}]}
-	}`
-	if err := os.WriteFile(configPath, []byte(input), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte(optInConfigJSON), 0o644); err != nil {
 		t.Fatalf("seed write: %v", err)
 	}
 
@@ -132,6 +136,42 @@ func TestMutateCreateBundle_RewritesConfigJSON(t *testing.T) {
 	}
 }
 
+// TestMutateCreateBundle_SkipsWhenNotOptedIn is the security-critical case:
+// a container the orchestrator did NOT opt in must be left byte-for-byte
+// untouched, so its own network namespace and trust store survive.
+func TestMutateCreateBundle_SkipsWhenNotOptedIn(t *testing.T) {
+	// GIVEN a config.json that requests its own network namespace but carries
+	// no MITM opt-in annotation
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	input := `{
+		"process": {"env": ["PATH=/usr/bin"]},
+		"linux": {"namespaces": [{"type": "network"}, {"type": "pid"}]}
+	}`
+	if err := os.WriteFile(configPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	// WHEN the runtime processes the create bundle
+	args := []string{"create", "--bundle", dir, "test-container"}
+	if err := mutateCreateBundle(args); err != nil {
+		t.Fatalf("mutateCreateBundle errored: %v", err)
+	}
+
+	// THEN the file is unchanged: the network namespace and default trust
+	// store are preserved (no CA env vars, no CA mount injected)
+	out, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read after mutate: %v", err)
+	}
+	if string(out) != input {
+		t.Errorf("non-opted-in config should be byte-identical; got:\n%s", out)
+	}
+	if containsBytes(out, "recording-ca.pem") {
+		t.Error("CA must not be injected into a container that did not opt in")
+	}
+}
+
 func TestMutateCreateBundle_MissingConfigErrors(t *testing.T) {
 	dir := t.TempDir()
 	args := []string{"create", "--bundle", dir, "test-container"}
@@ -144,7 +184,7 @@ func TestMutateCreateBundle_MissingConfigErrors(t *testing.T) {
 func TestMutateCreateBundle_RespectsCAHostPathEnv(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	if err := os.WriteFile(configPath, []byte(`{}`), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"annotations": {"ai.vellum.evals.mitm": "1"}}`), 0o644); err != nil {
 		t.Fatalf("seed write: %v", err)
 	}
 

--- a/evals/docker/eval-pod/vellum-evals-runtime/mutate.go
+++ b/evals/docker/eval-pod/vellum-evals-runtime/mutate.go
@@ -5,6 +5,13 @@
 // runc, is born already trusting our recording CA and sharing the parent
 // (pod) network namespace.
 //
+// MutateConfig is unconditional: it always applies all three mutations to
+// whatever spec it is handed. The decision of *which* containers to rewrite
+// is a separate policy concern (mitmOptIn) enforced on the create path in
+// main.go — only the single run/species container the orchestrator opts in
+// is mutated, so sidecars and other containers keep their own network
+// namespace and default trust store.
+//
 // Three mutations, applied in order:
 //  1. Append three CA env vars to .process.env
 //     (NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, SSL_CERT_FILE)
@@ -25,6 +32,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -32,6 +40,16 @@ const (
 	// CA is bind-mounted. Hardcoded by convention so HTTP libraries can be
 	// pointed at it via env vars below.
 	CAContainerPath = "/etc/ssl/certs/recording-ca.pem"
+
+	// mitmOptInAnnotation is the OCI annotation key that authorizes the
+	// create-time spec rewrite. The eval orchestrator sets it (via
+	// `docker run --annotation ai.vellum.evals.mitm=1`) on the single
+	// run/species container that should be MITM'd. Its absence is the
+	// fail-safe default: any container without it is left byte-for-byte
+	// untouched, preserving its own network namespace and trust store.
+	// Reverse-domain notation per the OCI annotation guidance:
+	// https://github.com/opencontainers/image-spec/blob/main/annotations.md
+	mitmOptInAnnotation = "ai.vellum.evals.mitm"
 )
 
 // caEnvVars are the three env vars our HTTP-library-of-choice ecosystems
@@ -42,8 +60,35 @@ var caEnvVars = []string{
 	"SSL_CERT_FILE=" + CAContainerPath,       // openssl-based fallbacks (curl, Go, Ruby)
 }
 
+// mitmOptIn reports whether the OCI spec carries the opt-in annotation that
+// authorizes the MITM rewrite. A container is opted in only when the
+// orchestrator explicitly set mitmOptInAnnotation to a truthy value
+// ("1" or "true", case-insensitive). A decode failure or a missing/false
+// annotation yields false: the fail-safe default is to leave the container
+// untouched. This gate is what scopes the wrapper to the run/species
+// container even if it is ever (mis-)registered as the inner dockerd's
+// default-runtime.
+func mitmOptIn(configJSON []byte) bool {
+	var spec struct {
+		Annotations map[string]string `json:"annotations"`
+	}
+	if err := json.Unmarshal(configJSON, &spec); err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(spec.Annotations[mitmOptInAnnotation])) {
+	case "1", "true":
+		return true
+	default:
+		return false
+	}
+}
+
 // MutateConfig takes the raw bytes of an OCI config.json, applies the three
 // mutations described in the package doc, and returns the new bytes.
+//
+// MutateConfig does not itself check the opt-in annotation — callers must
+// gate on mitmOptIn first (see mutateCreateBundle). Keeping the check out of
+// this function keeps the mutation logic pure and table-testable.
 //
 // caHostPath is the absolute path on the host (eval-pod) filesystem where
 // the recording CA PEM lives. The eval-pod startup script is responsible

--- a/evals/docker/eval-pod/vellum-evals-runtime/mutate_test.go
+++ b/evals/docker/eval-pod/vellum-evals-runtime/mutate_test.go
@@ -457,3 +457,43 @@ func TestMutateConfig_RealisticConfig(t *testing.T) {
 		t.Errorf("process.noNewPrivileges lost: %v", process["noNewPrivileges"])
 	}
 }
+
+// ---- opt-in gate (mitmOptIn) ----
+
+// TestMitmOptIn verifies the create-path gate: only a spec whose
+// ai.vellum.evals.mitm annotation is truthy authorizes the rewrite; every
+// other shape (missing annotation, false/empty value, no annotations block,
+// invalid JSON) is treated as "not opted in" so the container is left alone.
+func TestMitmOptIn(t *testing.T) {
+	// GIVEN a table of OCI config.json shapes and the opt-in verdict each
+	// should produce
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"annotation = 1", `{"annotations": {"ai.vellum.evals.mitm": "1"}}`, true},
+		{"annotation = true", `{"annotations": {"ai.vellum.evals.mitm": "true"}}`, true},
+		{"annotation = TRUE (case-insensitive)", `{"annotations": {"ai.vellum.evals.mitm": "TRUE"}}`, true},
+		{"annotation = true with whitespace", `{"annotations": {"ai.vellum.evals.mitm": " true "}}`, true},
+		{"annotation = 0", `{"annotations": {"ai.vellum.evals.mitm": "0"}}`, false},
+		{"annotation = false", `{"annotations": {"ai.vellum.evals.mitm": "false"}}`, false},
+		{"annotation empty string", `{"annotations": {"ai.vellum.evals.mitm": ""}}`, false},
+		{"different annotation key", `{"annotations": {"other.key": "1"}}`, false},
+		{"annotations block absent", `{"process": {"env": []}}`, false},
+		{"empty spec", `{}`, false},
+		{"invalid JSON", `{ not json`, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// WHEN we evaluate the opt-in gate against the spec bytes
+			got := mitmOptIn([]byte(c.in))
+
+			// THEN the verdict matches the fail-safe expectation
+			if got != c.want {
+				t.Errorf("mitmOptIn(%s) = %v; want %v", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scopes the eval-pod `vellum-evals-runtime` OCI wrapper so it only rewrites the single run/species container the orchestrator opts in (via the `ai.vellum.evals.mitm` OCI annotation, set with `docker run --runtime vellum-evals-runtime --annotation ai.vellum.evals.mitm=1`) instead of dropping the network namespace from every container the inner dockerd creates. This restores network-namespace isolation for untrusted eval/species containers, their recording sidecars, and agent-spawned sub-containers — which were previously forced into the shared eval-pod netns even when they requested `--network=none` or `--network container:<target>`.

The wrapper is now registered as a named (non-default) runtime so stock `runc` stays the dockerd default, and an in-binary opt-in gate (`mitmOptIn`) makes the rewrite fail-safe even if the runtime is ever mis-registered as `default-runtime`. `--annotation` values are passed straight through to the OCI spec's `.annotations` ([docker run reference](https://docs.docker.com/reference/cli/docker/container/run/)).

Closes ATL-647

## Root cause analysis

- **How it got here:** the wrapper was introduced as the inner dockerd's `default-runtime` so MITM recording would be species-agnostic. Applying the three mutations (CA env + CA mount + drop netns) to *every* container was the simplest way to guarantee uniform egress capture with zero species-side changes.
- **The decision that caused it:** optimizing for "uniform, zero-touch" interception meant the netns drop ran unconditionally on every `create`, silently overriding any container's own network choice (`--network=none`, `--network container:X`, custom bridge). Isolation was traded away for uniformity without scoping.
- **Warning signs missed:** the test suite asserted the netns was dropped, but there was no test asserting non-target containers *kept* their isolation; the README described "every container" as the intended behavior, so the over-reach read as by-design rather than as a regression.
- **Prevention:** runtime-level mutations that weaken an isolation boundary must be opt-in per container (default-deny), never a blanket dockerd default. This PR adds the missing "stays isolated when not opted in" test so the property is now guarded.
- **AGENTS.md:** no new rule needed — the durable rationale lives in the wrapper's README "Scope (why not default-runtime)" section, which is closer to the code and less likely to go stale than a repo-wide guideline.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/fbb436855d9240598acc23972353d25f
