### PR TITLE
fix(web): split zustand selector in usePlatformGate to avoid infinite loop

### DIFF
--- a/apps/web/src/hooks/use-platform-gate.ts
+++ b/apps/web/src/hooks/use-platform-gate.ts
@@ -6,13 +6,11 @@ export type PlatformGateState = "full" | "disabled" | "gated";
 
 export function usePlatformGate(): PlatformGateState {
   const hasPlatformSession = useAuthStore.use.hasPlatformSession();
-  const { platformFeaturesOff, hasHydrated } = useAssistantFeatureFlagStore(
-    (s) => ({
-      platformFeaturesOff:
-        (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
-      hasHydrated: s.hasHydrated,
-    }),
+  const platformFeaturesOff = useAssistantFeatureFlagStore(
+    (s) =>
+      (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
   );
+  const hasHydrated = useAssistantFeatureFlagStore((s) => s.hasHydrated);
 
   if (isLocalMode() && platformFeaturesOff) return "gated";
   if (isLocalMode() && !hasHydrated) return "disabled";


### PR DESCRIPTION
## Summary
- Split the Zustand selector in `usePlatformGate` from a single object-returning selector into two primitive-returning selectors
- Fixes an infinite re-render loop when opening Preferences — the object selector created a new reference on every `getSnapshot` call, which React's `useSyncExternalStore` interpreted as changed state

## Original prompt
The Preferences menu was crashing with "Maximum update depth exceeded" and a warning that `getSnapshot` results should be cached. The root cause was a Zustand selector in `usePlatformGate` that returned a new object on every call, breaking referential equality for `useSyncExternalStore`. The fix splits it into two selectors that each return a boolean primitive.