### PR TITLE
[codex] Record gateway chat activity for idle sleep

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -119,6 +119,58 @@ describe("runtime proxy handler", () => {
     expect(capturedBody).toBe('{"message":"hello"}');
   });
 
+  test("notifies platform activity for assistant-scoped chat message posts", async () => {
+    const recordActivity = mock(async () => undefined);
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ accepted: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createRuntimeProxyHandler(makeConfig(), {
+      recordActivity,
+    });
+    const req = new Request(
+      "http://localhost:7830/v1/assistants/test-assistant/messages/",
+      {
+        method: "POST",
+        body: JSON.stringify({ content: "hello" }),
+        headers: { "content-type": "application/json" },
+      },
+    );
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(recordActivity).toHaveBeenCalledTimes(1);
+    expect(recordActivity).toHaveBeenCalledWith({
+      assistantId: "test-assistant",
+      method: "POST",
+      path: "/v1/assistants/test-assistant/messages/",
+    });
+  });
+
+  test("does not notify platform activity for chat message reads", async () => {
+    const recordActivity = mock(async () => undefined);
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ messages: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createRuntimeProxyHandler(makeConfig(), {
+      recordActivity,
+    });
+    const req = new Request(
+      "http://localhost:7830/v1/assistants/test-assistant/messages/",
+    );
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(recordActivity).not.toHaveBeenCalled();
+  });
+
   test("relays upstream status code", async () => {
     fetchMock = mock(async () => {
       return new Response("Not Found", { status: 404 });

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -27,7 +27,53 @@ const log = getLogger("runtime-proxy");
  */
 const WEBHOOK_PATH_RE = /^\/webhooks\//;
 
-export function createRuntimeProxyHandler(config: GatewayConfig) {
+type RecordActivityHook = (activity: {
+  assistantId: string;
+  method: string;
+  path: string;
+}) => void | Promise<void>;
+
+interface RuntimeProxyHandlerOptions {
+  recordActivity?: RecordActivityHook;
+}
+
+const CHAT_MESSAGE_ACTIVITY_RE =
+  /^\/v1\/assistants\/([^/]+)\/messages(?:\/.*)?\/?$/;
+
+function chatMessageActivityAssistantId(
+  method: string,
+  pathname: string,
+): string | null {
+  if (method !== "POST") return null;
+  const match = CHAT_MESSAGE_ACTIVITY_RE.exec(pathname);
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+function notifyActivity(
+  hook: RecordActivityHook | undefined,
+  activity: { assistantId: string; method: string; path: string },
+): void {
+  if (!hook) return;
+
+  try {
+    void Promise.resolve(hook(activity)).catch((err) => {
+      log.debug(
+        { err, ...activity },
+        "Failed to notify platform of chat activity",
+      );
+    });
+  } catch (err) {
+    log.debug(
+      { err, ...activity },
+      "Failed to notify platform of chat activity",
+    );
+  }
+}
+
+export function createRuntimeProxyHandler(
+  config: GatewayConfig,
+  options: RuntimeProxyHandlerOptions = {},
+) {
   return async (req: Request, clientIp?: string): Promise<Response> => {
     const start = performance.now();
     const url = new URL(req.url);
@@ -83,6 +129,18 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       );
     } else {
       exchangeToken = mintServiceToken();
+    }
+
+    const activityAssistantId = chatMessageActivityAssistantId(
+      req.method,
+      url.pathname,
+    );
+    if (activityAssistantId) {
+      notifyActivity(options.recordActivity, {
+        assistantId: activityAssistantId,
+        method: req.method,
+        path: url.pathname,
+      });
     }
 
     // The daemon uses flat /v1/... paths. Rewrite any legacy

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -480,7 +480,9 @@ async function main() {
   const handleListBackups = createListBackupsHandler(backupDeps);
   const handleCreateBackup = createBackupSnapshotHandler(backupDeps);
 
-  const handleRuntimeProxy = createRuntimeProxyHandler(config);
+  const handleRuntimeProxy = createRuntimeProxyHandler(config, {
+    recordActivity: () => notifyRecordActivity(),
+  });
 
   // Helper to reject when an integration isn't configured
   const requireConfigured = (
@@ -1761,9 +1763,9 @@ async function main() {
   // ── Slack Socket Mode lifecycle ──
   let slackSocketClient: SlackSocketModeClient | null = null;
 
-  /** Fire-and-forget: notify the platform of inbound Slack activity so the
-   *  idle-sleep timer is reset for this assistant.
-   *  Throttled to at most one outbound POST per 30 seconds. */
+  /** Fire-and-forget: notify the platform of inbound user activity so the
+   * idle-sleep timer is reset for this assistant.
+   * Throttled to at most one outbound POST per 30 seconds. */
   let lastRecordActivityTs = 0;
   async function notifyRecordActivity(): Promise<void> {
     if (!arePlatformFeaturesEnabled()) {
@@ -1807,7 +1809,7 @@ async function main() {
     } catch (err) {
       log.debug(
         { err },
-        "Failed to notify platform of Slack activity for idle sleep",
+        "Failed to notify platform of inbound activity for idle sleep",
       );
     }
   }


### PR DESCRIPTION
Closing this draft. We confirmed normal hosted web chat is hitting Django/vembda, so the activity fix belongs in the platform/vembda path rather than the assistant gateway runtime proxy.

The likely root cause is vembda's multi-key Redis Lua activity write: it works locally on single-node Redis, but can fail under clustered Valkey/CROSSSLOT and get swallowed by the existing best-effort activity logging, leaving chat successful while Last Activity remains `Unknown`. The platform PR is being reworked for that path instead.