### PR TITLE
fix(heartbeat): persist consecutive run counter across sleep/wake cycles

### DIFF
--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -56,6 +56,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
   markStaleRunningAsError: mockMarkStaleRunningAsError,
   countCompletedHeartbeatRuns: mock(() => 10),
+  countRecentConsecutiveRuns: mock(() => 0),
 }));
 
 mock.module("../schedule/recurrence-engine.js", () => ({

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -32,6 +32,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   markStaleRunningAsError: mockMarkStaleRunningAsError,
   listHeartbeatRuns: mockListHeartbeatRuns,
   countCompletedHeartbeatRuns: mockCountCompletedHeartbeatRuns,
+  countRecentConsecutiveRuns: mock(() => 0),
 }));
 
 // Mock config loader

--- a/assistant/src/background-wake/next-wake.test.ts
+++ b/assistant/src/background-wake/next-wake.test.ts
@@ -25,6 +25,7 @@ type MockSchedule = {
 
 let heartbeatConfig: MockHeartbeatConfig;
 let heartbeatNextRunAt: number | null;
+let heartbeatConsecutiveRunCapReached: boolean;
 let schedules: MockSchedule[];
 let computedCronNextRunAt: number;
 
@@ -39,7 +40,10 @@ mock.module("../heartbeat/heartbeat-service.js", () => ({
     getInstance: () =>
       heartbeatNextRunAt == null
         ? undefined
-        : { nextRunAt: heartbeatNextRunAt },
+        : {
+            nextRunAt: heartbeatNextRunAt,
+            isConsecutiveRunCapReached: heartbeatConsecutiveRunCapReached,
+          },
   },
 }));
 
@@ -70,6 +74,7 @@ describe("computeNextBackgroundWakeIntent", () => {
       maxConsecutiveRuns: 3,
     };
     heartbeatNextRunAt = null;
+    heartbeatConsecutiveRunCapReached = false;
     schedules = [];
     computedCronNextRunAt = NOW + 3_600_000;
   });
@@ -269,6 +274,31 @@ describe("computeNextBackgroundWakeIntent", () => {
     expect(second).not.toBeNull();
     expect(first!.computedAt).not.toBe(second!.computedAt);
     expect(first!.sourceGeneration).toBe(second!.sourceGeneration);
+  });
+
+  test("returns null when heartbeat consecutive run cap is reached and no schedules", () => {
+    heartbeatNextRunAt = NOW + 30_000;
+    heartbeatConsecutiveRunCapReached = true;
+
+    expect(computeNextBackgroundWakeIntent(NOW)).toBeNull();
+  });
+
+  test("returns schedule-only intent when heartbeat consecutive run cap is reached", () => {
+    heartbeatNextRunAt = NOW + 30_000;
+    heartbeatConsecutiveRunCapReached = true;
+    schedules = [
+      scheduleFixture({
+        id: "still-active",
+        nextRunAt: NOW + 60_000,
+      }),
+    ];
+
+    const intent = computeNextBackgroundWakeIntent(NOW);
+
+    expect(intent).not.toBeNull();
+    expect(intent!.reason).toBe("schedule");
+    expect(intent!.sourcePayload.heartbeat).toBeNull();
+    expect(intent!.sourcePayload.schedules).toHaveLength(1);
   });
 });
 

--- a/assistant/src/background-wake/next-wake.ts
+++ b/assistant/src/background-wake/next-wake.ts
@@ -95,7 +95,10 @@ function getHeartbeatWakeSource(now: number): HeartbeatWakeSource | null {
   const config = getConfig().heartbeat;
   if (!config.enabled) return null;
 
-  const serviceNextRunAt = HeartbeatService.getInstance()?.nextRunAt ?? null;
+  const service = HeartbeatService.getInstance();
+  if (service?.isConsecutiveRunCapReached) return null;
+
+  const serviceNextRunAt = service?.nextRunAt ?? null;
   let nextRunAt = serviceNextRunAt;
   const mode = config.cronExpression != null ? "cron" : "interval";
 

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -59,7 +59,8 @@ mock.module("../../util/platform.js", () => ({
   getEmbedWorkerPidPath: () =>
     join(workspaceDir ?? fallbackDir, "embed-worker.pid"),
   getWorkspaceDirDisplay: () => workspaceDir ?? fallbackDir,
-  getWorkspaceConfigPath: () => join(workspaceDir ?? fallbackDir, "config.json"),
+  getWorkspaceConfigPath: () =>
+    join(workspaceDir ?? fallbackDir, "config.json"),
   getWorkspaceSkillsDir: () => join(workspaceDir ?? fallbackDir, "skills"),
   getWorkspaceHooksDir: () => join(workspaceDir ?? fallbackDir, ".githooks"),
   getWorkspacePluginsDir: () => join(workspaceDir ?? fallbackDir, "plugins"),
@@ -194,6 +195,7 @@ mock.module("../heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: () => 0,
   markStaleRunningAsError: () => 0,
   countCompletedHeartbeatRuns: () => 10,
+  countRecentConsecutiveRuns: () => 0,
 }));
 
 // Stub the pre-first-message gate so tests can flip it on/off without

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -218,6 +218,37 @@ export function countCompletedHeartbeatRuns(): number {
 }
 
 /**
+ * Count the most recent consecutive heartbeat runs with status `ok`,
+ * walking backwards from newest. Stops at the first non-`ok` status
+ * (skipped, superseded, missed, error, timeout), which acts as a
+ * natural boundary for the consecutive-run counter. In-flight rows
+ * (`pending`, `running`) are skipped so they don't break the chain.
+ *
+ * Used to restore the in-memory consecutive-run counter on startup.
+ */
+export function countRecentConsecutiveRuns(maxToCheck: number): number {
+  const db = getDb();
+  const rows = db
+    .select({ status: heartbeatRuns.status })
+    .from(heartbeatRuns)
+    .orderBy(desc(heartbeatRuns.scheduledFor))
+    .limit(maxToCheck + 5)
+    .all();
+
+  let count = 0;
+  for (const row of rows) {
+    if (row.status === "ok") {
+      count++;
+    } else if (row.status === "pending" || row.status === "running") {
+      continue;
+    } else {
+      break;
+    }
+  }
+  return count;
+}
+
+/**
  * List heartbeat runs ordered by `scheduledFor` descending.
  */
 export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -180,9 +180,10 @@ export class HeartbeatService {
   /** Whether the consecutive-run cap has been reached. */
   get isConsecutiveRunCapReached(): boolean {
     const config = getConfig().heartbeat;
+    if (config.maxConsecutiveRuns == null) return false;
     return (
-      config.maxConsecutiveRuns != null &&
-      this._consecutiveRuns >= config.maxConsecutiveRuns
+      countRecentConsecutiveRuns(config.maxConsecutiveRuns) >=
+      config.maxConsecutiveRuns
     );
   }
 
@@ -281,12 +282,6 @@ export class HeartbeatService {
             );
           });
         }
-      }
-
-      if (config.maxConsecutiveRuns != null) {
-        this._consecutiveRuns = countRecentConsecutiveRuns(
-          config.maxConsecutiveRuns,
-        );
       }
     }
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -25,6 +25,7 @@ import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   completeHeartbeatRun,
   countCompletedHeartbeatRuns,
+  countRecentConsecutiveRuns,
   insertPendingHeartbeatRun,
   markStaleRunningAsError,
   markStaleRunsAsMissed,
@@ -75,30 +76,6 @@ export function isShallowProfile(): boolean {
 
 function getReengagementTimestampPath(): string {
   return join(getWorkspaceDir(), ".reengagement-ts");
-}
-
-function getConsecutiveRunsPath(): string {
-  return join(getWorkspaceDir(), ".heartbeat-consecutive-runs");
-}
-
-function loadPersistedConsecutiveRuns(): number {
-  const path = getConsecutiveRunsPath();
-  if (!existsSync(path)) return 0;
-  try {
-    const raw = readFileSync(path, "utf-8").trim();
-    const parsed = parseInt(raw, 10);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-  } catch {
-    return 0;
-  }
-}
-
-function persistConsecutiveRuns(count: number): void {
-  try {
-    writeFileSync(getConsecutiveRunsPath(), count.toString());
-  } catch {
-    // Best-effort; don't block the heartbeat.
-  }
 }
 
 function isReengagementCooldownElapsed(): boolean {
@@ -180,7 +157,7 @@ export class HeartbeatService {
   // Counter of consecutive auto-heartbeats since the last guardian message.
   // Reset by resetTimer (guardian message), reconfigure, and stop. Force runs
   // bypass the cap and do not increment.
-  private _consecutiveRuns = loadPersistedConsecutiveRuns();
+  private _consecutiveRuns = 0;
   // Bumped every time the counter is reset so an in-flight run that finishes
   // after a guardian message can detect the reset and skip its increment.
   private _resetGeneration = 0;
@@ -305,6 +282,12 @@ export class HeartbeatService {
           });
         }
       }
+
+      if (config.maxConsecutiveRuns != null) {
+        this._consecutiveRuns = countRecentConsecutiveRuns(
+          config.maxConsecutiveRuns,
+        );
+      }
     }
 
     if (config.cronExpression != null) {
@@ -387,7 +370,6 @@ export class HeartbeatService {
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
     this._consecutiveRuns = 0;
-    persistConsecutiveRuns(0);
     this._resetGeneration++;
     this.configEpoch++;
     if (this._pendingRunId) {
@@ -414,7 +396,6 @@ export class HeartbeatService {
     // Counter resets even when the timer is null so a guardian message during
     // a stopped window still clears the count.
     this._consecutiveRuns = 0;
-    persistConsecutiveRuns(0);
     this._resetGeneration++;
     if (!this.timer) return;
     if (this.cronMode) {
@@ -602,7 +583,6 @@ export class HeartbeatService {
       this._lastRunAt = Date.now();
       if (!force && this._resetGeneration === startGeneration) {
         this._consecutiveRuns++;
-        persistConsecutiveRuns(this._consecutiveRuns);
       }
       if (!this.cronMode) {
         this.scheduleNextRun(getConfig().heartbeat.intervalMs);

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -436,7 +436,6 @@ export class HeartbeatService {
 
   async stop(): Promise<void> {
     this._consecutiveRuns = 0;
-    persistConsecutiveRuns(0);
     this._resetGeneration++;
     this.stopped = true;
     if (this.timer) {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -77,6 +77,30 @@ function getReengagementTimestampPath(): string {
   return join(getWorkspaceDir(), ".reengagement-ts");
 }
 
+function getConsecutiveRunsPath(): string {
+  return join(getWorkspaceDir(), ".heartbeat-consecutive-runs");
+}
+
+function loadPersistedConsecutiveRuns(): number {
+  const path = getConsecutiveRunsPath();
+  if (!existsSync(path)) return 0;
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function persistConsecutiveRuns(count: number): void {
+  try {
+    writeFileSync(getConsecutiveRunsPath(), count.toString());
+  } catch {
+    // Best-effort; don't block the heartbeat.
+  }
+}
+
 function isReengagementCooldownElapsed(): boolean {
   const tsPath = getReengagementTimestampPath();
   if (!existsSync(tsPath)) return true;
@@ -156,7 +180,7 @@ export class HeartbeatService {
   // Counter of consecutive auto-heartbeats since the last guardian message.
   // Reset by resetTimer (guardian message), reconfigure, and stop. Force runs
   // bypass the cap and do not increment.
-  private _consecutiveRuns = 0;
+  private _consecutiveRuns = loadPersistedConsecutiveRuns();
   // Bumped every time the counter is reset so an in-flight run that finishes
   // after a guardian message can detect the reset and skip its increment.
   private _resetGeneration = 0;
@@ -174,6 +198,15 @@ export class HeartbeatService {
   /** Epoch-ms timestamp of the next scheduled heartbeat run. */
   get nextRunAt(): number | null {
     return this._nextRunAt;
+  }
+
+  /** Whether the consecutive-run cap has been reached. */
+  get isConsecutiveRunCapReached(): boolean {
+    const config = getConfig().heartbeat;
+    return (
+      config.maxConsecutiveRuns != null &&
+      this._consecutiveRuns >= config.maxConsecutiveRuns
+    );
   }
 
   async runManagedWakeIfDue(
@@ -354,6 +387,7 @@ export class HeartbeatService {
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
     this._consecutiveRuns = 0;
+    persistConsecutiveRuns(0);
     this._resetGeneration++;
     this.configEpoch++;
     if (this._pendingRunId) {
@@ -380,6 +414,7 @@ export class HeartbeatService {
     // Counter resets even when the timer is null so a guardian message during
     // a stopped window still clears the count.
     this._consecutiveRuns = 0;
+    persistConsecutiveRuns(0);
     this._resetGeneration++;
     if (!this.timer) return;
     if (this.cronMode) {
@@ -401,6 +436,7 @@ export class HeartbeatService {
 
   async stop(): Promise<void> {
     this._consecutiveRuns = 0;
+    persistConsecutiveRuns(0);
     this._resetGeneration++;
     this.stopped = true;
     if (this.timer) {
@@ -567,6 +603,7 @@ export class HeartbeatService {
       this._lastRunAt = Date.now();
       if (!force && this._resetGeneration === startGeneration) {
         this._consecutiveRuns++;
+        persistConsecutiveRuns(this._consecutiveRuns);
       }
       if (!this.cronMode) {
         this.scheduleNextRun(getConfig().heartbeat.intervalMs);

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -392,6 +392,11 @@ export class HeartbeatService {
     // a stopped window still clears the count.
     this._consecutiveRuns = 0;
     this._resetGeneration++;
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+      this._pendingRunId = null;
+    }
+    refreshBackgroundWakeIntentSoon("heartbeat-counter-reset");
     if (!this.timer) return;
     if (this.cronMode) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);


### PR DESCRIPTION
The `_consecutiveRuns` counter was in-memory only, so it reset to 0 on every daemon restart during managed wakes — the `maxConsecutiveRuns` cap was never enforced across sleep/wake cycles, and `getHeartbeatWakeSource()` always included heartbeat in the background wake intent regardless. This fix adds `countRecentConsecutiveRuns()` to query the `heartbeat_runs` DB table directly (counting recent consecutive `ok` rows backward from newest), uses it in `isConsecutiveRunCapReached` to exclude heartbeat from the wake intent when the cap is reached, and supersedes the pending DB run in `resetTimer()` so a guardian message breaks the consecutive-ok chain.

## Prompt / plan

Root cause: `private _consecutiveRuns = 0` reset on every daemon restart. Three-part fix:
1. Add `countRecentConsecutiveRuns()` to `heartbeat-run-store.ts` — queries recent rows from `heartbeat_runs` ordered by `scheduledFor DESC`, counts consecutive `ok` statuses, stops at any non-`ok` status (superseded, skipped, missed, error). Skips in-flight rows (`pending`/`running`).
2. Add `isConsecutiveRunCapReached` getter on `HeartbeatService` that calls the DB query directly, check it in `getHeartbeatWakeSource()` — return `null` when cap is reached so vembda doesn't schedule a wake for a heartbeat that would be skipped.
3. `resetTimer()` now supersedes the pending DB run and refreshes the background wake intent — this ensures a guardian message breaks the consecutive-ok chain in the DB, not just in memory.

### Root cause analysis
1. **How did the code get into this state?** The counter was added as in-memory state without considering that managed-wake restarts the daemon process.
2. **What mistakes led to it?** No persistence strategy for runtime state that must survive process restarts.
3. **Warning signs missed?** The `.reengagement-ts` file already solved an analogous persistence problem in the same service — the pattern existed but wasn't applied to this counter.
4. **Prevention?** Runtime counters that gate behavior across wake cycles should derive from persisted data (DB or file) rather than relying on in-memory state.

## Test plan

- 2 new tests in `next-wake.test.ts` verify heartbeat is excluded from wake intent when cap is reached (null result with no schedules; schedule-only intent with active schedules).
- All 59 related tests pass via pre-push hook.
- `bunx tsc --noEmit` and `bun run lint` clean.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/7c572bba11d544c4a323912e3a3ec572
