### PR TITLE
fix(memory-v3): address Codex review (migrations, route scopes, reconcile)

### DIFF
--- a/assistant/src/memory/v3/__tests__/reconcile.test.ts
+++ b/assistant/src/memory/v3/__tests__/reconcile.test.ts
@@ -220,30 +220,55 @@ describe("reconcileTree", () => {
     expect(result.prunedCore).toEqual(["domain-a/gone"]);
   });
 
-  test("residual dangling ref triggers validation throw + restore", async () => {
+  test("out-of-band dangling page ref converges (prune pass)", async () => {
     // The current tree has only leaf-x. page-a references leaf-x (fine) PLUS a
-    // residual leaf path that exists in NEITHER prev nor current — so it is
-    // not a rename target and not a deleted-path drop, and survives the
-    // rewrite as a dangling ref. Validation must fail closed and restore.
+    // residual leaf path that exists in NEITHER prev nor current — an out-of-band
+    // ref a maintainer left when deleting a leaf file without a `prevLeaves`
+    // entry. v1 reconcile is a convergence/prune pass: it drops the dangling ref
+    // (the page keeps its surviving leaf, so no re-home is needed) instead of
+    // failing closed.
     await writeLeaf("domain-a/topic-x", { id: "leaf-x" });
     await writeCore(["domain-a/topic-x"]);
+    await seedAssignments();
     await writePageWithLeaves("page-a", [
       "domain-a/topic-x",
       "domain-a/residual",
     ]);
 
     const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+    const result = await reconcileTree({
+      prevLeaves: prev,
+      dataDir,
+      workspaceDir,
+    });
 
-    await expect(
-      reconcileTree({ prevLeaves: prev, dataDir, workspaceDir }),
-    ).rejects.toThrow(/validation failed/);
-
-    // Restored: page frontmatter reverted to its pre-reconcile state (both
-    // refs, including the residual one) and core.json reverted.
-    expect(await pageLeaves("page-a")).toEqual([
-      "domain-a/topic-x",
-      "domain-a/residual",
-    ]);
+    // Converged: the dangling residual ref is gone; the surviving leaf remains.
+    expect(await pageLeaves("page-a")).toEqual(["domain-a/topic-x"]);
     expect(await coreOf()).toEqual(["domain-a/topic-x"]);
+    // The out-of-band drop is not a reconciler-tracked delete (no prev entry),
+    // so it is not reported in `deleted`.
+    expect(result.deleted).toEqual([]);
+  });
+
+  test("page whose ONLY leaf dangles out-of-band is re-homed, not orphaned", async () => {
+    // page-a's sole leaf was deleted on disk with no `prevLeaves` entry. The
+    // convergence pass must re-home it onto a surviving leaf before dropping the
+    // dead ref, so the page is never left with zero leaves.
+    await writeLeaf("domain-a/topic-x", { id: "leaf-x" });
+    await writeCore([]);
+    await seedAssignments();
+    // page-a points only at a leaf absent from the tree (out-of-band delete).
+    await writePageWithLeaves("page-a", ["domain-a/gone"]);
+
+    // Only surviving leaf is sorted index 1 → re-home target.
+    const provider = stubProvider(() => [1]);
+
+    const prev: LeafRef[] = [{ id: "leaf-x", path: "domain-a/topic-x" }];
+    await reconcileTree({ prevLeaves: prev, dataDir, workspaceDir, provider });
+
+    const after = await pageLeaves("page-a");
+    expect(after).not.toContain("domain-a/gone"); // dangling ref dropped
+    expect(after).toEqual(["domain-a/topic-x"]); // re-homed onto the survivor
+    expect(after.length).toBeGreaterThanOrEqual(1); // never orphaned
   });
 });

--- a/assistant/src/memory/v3/reconcile.ts
+++ b/assistant/src/memory/v3/reconcile.ts
@@ -320,31 +320,60 @@ async function applyReconcile(args: ApplyArgs): Promise<ReconcileResult> {
     provider,
   } = args;
 
-  // 1. Re-home members of deleted leaves BEFORE dropping any refs, so a page
-  //    that loses its only leaf gains a surviving one (no orphan). We re-home
-  //    first, against the still-intact assignments, then drop the dead path.
+  // The set of leaf paths a ref may legitimately resolve to: the current tree
+  // plus every rename TARGET (a renamed leaf's new path is in `current`, but we
+  // include the map's values defensively). Any page ref or core entry that does
+  // NOT resolve into this set is dangling and must converge to a valid state.
+  const validPaths = new Set<LeafPath>(currentPaths);
+  for (const newPath of renames.values()) validPaths.add(newPath);
+
+  // A ref is "dangling" when, after rename resolution, it points outside the
+  // current tree. This covers BOTH reconciler-driven deletes (leaves in `prev`
+  // but not `current`) AND out-of-band deletes/renames a maintainer made on disk
+  // without a `prevLeaves` entry — the v1 convergence/prune case. We drop such
+  // refs in step 2; first (step 1) we re-home any page that would otherwise be
+  // orphaned so no page is left with zero leaves.
+  const isDangling = (resolved: LeafPath): boolean => !validPaths.has(resolved);
+
+  // 1. Re-home members of dangling leaves BEFORE dropping any refs, so a page
+  //    that would lose its only leaf gains a surviving one (no orphan). We
+  //    re-home first, against the still-intact assignments, then drop the dead
+  //    path. Reconciler-tracked deletes may carry a split directive; out-of-band
+  //    dangling leaves (discovered from page refs) re-home across the whole tree.
   const splitById = new Map<string, SplitDirective>(
     splits.map((s) => [s.fromId, s]),
   );
-  const deletedPaths = new Set<LeafPath>();
-  for (const leaf of deleted) {
-    deletedPaths.add(leaf.path);
+  const slugs = await listPages(workspaceDir);
 
-    const members = await pagesAssignedTo(workspaceDir, leaf.path);
-    if (members.length > 0) {
-      const split = leaf.id ? splitById.get(leaf.id) : undefined;
-      await rehomeMembers(workspaceDir, dataDir, members, split, provider);
+  // Collect every dangling leaf path: explicit deletes + any leaf referenced by
+  // a page that resolves outside the current tree.
+  const danglingLeafToMembers = new Map<LeafPath, Slug[]>();
+  for (const leaf of deleted) danglingLeafToMembers.set(leaf.path, []);
+  for (const slug of slugs) {
+    const page = await readPage(workspaceDir, slug);
+    if (!page) continue;
+    for (const ref of page.frontmatter.leaves ?? []) {
+      const resolved = renames.get(ref) ?? ref;
+      if (!isDangling(resolved)) continue;
+      const members = danglingLeafToMembers.get(ref) ?? [];
+      members.push(slug);
+      danglingLeafToMembers.set(ref, members);
     }
   }
 
-  // 2. Rewrite renamed paths and drop deleted paths from page frontmatter.
-  const slugs = await listPages(workspaceDir);
+  const deletedPaths = new Set<LeafPath>(danglingLeafToMembers.keys());
+  for (const [leafPath, members] of danglingLeafToMembers) {
+    if (members.length === 0) continue;
+    const id = deleted.find((l) => l.path === leafPath)?.id;
+    const split = id ? splitById.get(id) : undefined;
+    await rehomeMembers(workspaceDir, dataDir, members, split, provider);
+  }
+
+  // 2. Rewrite renamed paths and drop dangling paths from page frontmatter.
   for (const slug of slugs) {
     await rewritePageRefs(workspaceDir, slug, (leaves) =>
       dedupe(
-        leaves
-          .map((p) => renames.get(p) ?? p)
-          .filter((p) => !deletedPaths.has(p)),
+        leaves.map((p) => renames.get(p) ?? p).filter((p) => !isDangling(p)),
       ),
     );
   }
@@ -380,22 +409,6 @@ async function applyReconcile(args: ApplyArgs): Promise<ReconcileResult> {
     deleted: deleted.map((l) => l.path),
     prunedCore,
   };
-}
-
-/** Slugs whose `leaves:` frontmatter currently includes `leafPath`. */
-async function pagesAssignedTo(
-  workspaceDir: string,
-  leafPath: LeafPath,
-): Promise<Slug[]> {
-  const slugs = await listPages(workspaceDir);
-  const members: Slug[] = [];
-  for (const slug of slugs) {
-    const page = await readPage(workspaceDir, slug);
-    if (page && (page.frontmatter.leaves ?? []).includes(leafPath)) {
-      members.push(slug);
-    }
-  }
-  return members;
 }
 
 /**

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -272,8 +272,21 @@ export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndex
 // Route definitions (RouteHandlerArgs adapters over the handlers above)
 // ---------------------------------------------------------------------------
 
-const POLICY: RoutePolicy = {
+/** Read-only verbs (the `health` report) require only `settings.read`. */
+const READ_POLICY: RoutePolicy = {
   requiredScopes: ["settings.read"],
+  allowedPrincipalTypes: ACTOR_PRINCIPALS,
+};
+
+/**
+ * Mutating verbs require `settings.write`. `set-core --write`, `reconcile`, and
+ * `rebuild-index` write `core.json`, rewrite page frontmatter, and invalidate
+ * the live lanes, so a `settings.read`-only principal must not reach them.
+ * (`set-core` without `write` is a preview, but it shares this route, so the
+ * route as a whole is gated on write.)
+ */
+const WRITE_POLICY: RoutePolicy = {
+  requiredScopes: ["settings.write"],
   allowedPrincipalTypes: ACTOR_PRINCIPALS,
 };
 
@@ -281,7 +294,7 @@ export const ROUTES: RouteDefinition[] = [
   {
     operationId: "memory_v3_health",
     method: "POST",
-    policy: POLICY,
+    policy: READ_POLICY,
     endpoint: "memory/v3/health",
     handler: () => handleMemoryV3Health(),
     summary: "Print the v3 structural health report (read-only)",
@@ -290,7 +303,7 @@ export const ROUTES: RouteDefinition[] = [
   {
     operationId: "memory_v3_set_core",
     method: "POST",
-    policy: POLICY,
+    policy: WRITE_POLICY,
     endpoint: "memory/v3/set-core",
     handler: async ({ body = {} }: RouteHandlerArgs) => {
       try {
@@ -308,7 +321,7 @@ export const ROUTES: RouteDefinition[] = [
   {
     operationId: "memory_v3_reconcile",
     method: "POST",
-    policy: POLICY,
+    policy: WRITE_POLICY,
     endpoint: "memory/v3/reconcile",
     handler: () => handleMemoryV3Reconcile(),
     summary:
@@ -318,7 +331,7 @@ export const ROUTES: RouteDefinition[] = [
   {
     operationId: "memory_v3_rebuild_index",
     method: "POST",
-    policy: POLICY,
+    policy: WRITE_POLICY,
     endpoint: "memory/v3/rebuild-index",
     handler: () => handleMemoryV3RebuildIndex(),
     summary: "Invalidate the v3 lanes so the next turn rebuilds",

--- a/assistant/src/workspace/migrations/092-backfill-v3-leaves.ts
+++ b/assistant/src/workspace/migrations/092-backfill-v3-leaves.ts
@@ -1,9 +1,15 @@
-import { readFile } from "node:fs/promises";
+import * as fs from "node:fs";
 import { join } from "node:path";
 
-import { readPage, writePage } from "../../memory/v2/page-store.js";
-import type { LeafPath, Slug } from "../../memory/v3/types.js";
 import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * v3 leaf assignments and concept pages, addressed relative to the workspace.
+ */
+const ASSIGNMENTS_REL = join("memory", "v3", "data", "assignments.json");
+const CONCEPTS_REL = join("memory", "concepts");
+
+const FRONTMATTER_DELIMITER = "---";
 
 /**
  * Read the v3 slug -> leaf-path assignment map from the workspace data dir.
@@ -11,24 +17,102 @@ import type { WorkspaceMigration } from "./types.js";
  * Returns an empty map when `assignments.json` is absent (the v3 data dir was
  * never materialized for this workspace) so the migration is a clean no-op.
  */
-async function readAssignments(
-  workspaceDir: string,
-): Promise<Record<Slug, LeafPath[]>> {
-  const assignmentsPath = join(
-    workspaceDir,
-    "memory",
-    "v3",
-    "data",
-    "assignments.json",
-  );
+function readAssignments(workspaceDir: string): Record<string, string[]> {
+  const assignmentsPath = join(workspaceDir, ASSIGNMENTS_REL);
   let raw: string;
   try {
-    raw = await readFile(assignmentsPath, "utf8");
+    raw = fs.readFileSync(assignmentsPath, "utf8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
     throw err;
   }
-  return JSON.parse(raw) as Record<Slug, LeafPath[]>;
+  const parsed = JSON.parse(raw) as unknown;
+  return parsed && typeof parsed === "object"
+    ? (parsed as Record<string, string[]>)
+    : {};
+}
+
+interface SplitPage {
+  /** Raw YAML frontmatter block (between the `---` fences), without fences. */
+  frontmatter: string;
+  /** Everything after the closing frontmatter fence, verbatim. */
+  body: string;
+}
+
+/**
+ * Split a concept page into its YAML frontmatter block and body. Returns `null`
+ * when the file does not open with a `---` frontmatter fence (a page with no
+ * frontmatter, which we leave untouched).
+ *
+ * Inlined here rather than importing `../v2/page-store` — workspace migrations
+ * must stay self-contained (see AGENTS.md) so an append-only migration never
+ * shifts semantics when the runtime page parser evolves.
+ */
+function splitFrontmatter(content: string): SplitPage | null {
+  if (!content.startsWith(FRONTMATTER_DELIMITER)) return null;
+  const afterOpen = content.slice(FRONTMATTER_DELIMITER.length);
+  const closeMatch = afterOpen.match(/\r?\n---[ \t]*(?:\r?\n|$)/);
+  if (!closeMatch || closeMatch.index === undefined) return null;
+  const frontmatter = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  return { frontmatter, body };
+}
+
+/**
+ * Locate a top-level `leaves:` field in the frontmatter lines: the index of its
+ * key line plus the (exclusive) index after any indented block-sequence items
+ * that belong to it. Returns `null` when no `leaves:` key is present.
+ *
+ * A line-shaped scan (rather than a YAML parse) keeps the migration free of an
+ * npm dependency, as AGENTS.md requires; leaf frontmatter is flat key/value so
+ * the only nesting is a `leaves:` block sequence (`  - path`).
+ */
+function findLeavesField(
+  lines: string[],
+): { start: number; end: number; nonEmpty: boolean } | null {
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^leaves:[ \t]*(.*)$/.exec(lines[i]);
+    if (!m) continue;
+    const inline = m[1].trim();
+    if (inline.length > 0) {
+      // Inline form: `leaves: [a, b]` (non-empty) or `leaves: []` (empty).
+      return { start: i, end: i + 1, nonEmpty: inline !== "[]" };
+    }
+    // Block form: consume following indented lines (`  - item`) as the value.
+    let end = i + 1;
+    let nonEmpty = false;
+    while (end < lines.length && /^[ \t]+\S/.test(lines[end])) {
+      if (/^[ \t]+-[ \t]+\S/.test(lines[end])) nonEmpty = true;
+      end++;
+    }
+    return { start: i, end, nonEmpty };
+  }
+  return null;
+}
+
+/**
+ * Splice a non-empty `leaves:` block sequence into the frontmatter, replacing
+ * any existing (empty) `leaves:` field in place so we never leave a duplicate
+ * key. Leaf paths are simple slugs (`domain/topic`) that need no quoting; we
+ * still defensively quote any value containing YAML-significant characters.
+ */
+function withLeaves(frontmatter: string, leaves: string[]): string {
+  const quote = (v: string): string =>
+    /[:#[\]{}",&*!|>%@`]/.test(v) ? JSON.stringify(v) : v;
+  const block = ["leaves:", ...leaves.map((l) => `  - ${quote(l)}`)];
+
+  const lines = frontmatter.replace(/\s+$/, "").split(/\r?\n/);
+  // Drop a leading empty line so a previously blank frontmatter doesn't yield
+  // a stray newline at the top.
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
+
+  const existing = findLeavesField(lines);
+  if (existing) {
+    lines.splice(existing.start, existing.end - existing.start, ...block);
+  } else {
+    lines.push(...block);
+  }
+  return lines.join("\n");
 }
 
 /**
@@ -36,35 +120,46 @@ async function readAssignments(
  *
  * v3 routing persists a slug -> leaf-path map at
  * `<workspace>/memory/v3/data/assignments.json`. Concept pages gained an
- * optional `leaves` frontmatter field (`ConceptPageFrontmatterSchema`), but
- * existing pages predate it. This one-time migration copies each slug's
- * assignment into the matching page's frontmatter.
+ * optional `leaves` frontmatter field, but existing pages predate it. This
+ * one-time migration copies each slug's assignment into the matching page's
+ * frontmatter.
  *
  * Idempotent: pages that already carry a non-empty `leaves` are left untouched
  * (never clobbered). A missing `assignments.json` or a slug with no matching
- * page is a no-op — neither throws.
+ * page is a no-op — neither throws. All read/write logic is inlined (built-ins
+ * only) so the migration stays self-contained per AGENTS.md.
  */
 export const backfillV3LeavesMigration: WorkspaceMigration = {
   id: "092-backfill-v3-leaves",
   description: "Backfill v3 leaf assignments into concept-page frontmatter",
 
-  async run(workspaceDir: string): Promise<void> {
-    const assignments = await readAssignments(workspaceDir);
+  run(workspaceDir: string): void {
+    const assignments = readAssignments(workspaceDir);
+    const conceptsDir = join(workspaceDir, CONCEPTS_REL);
 
     for (const [slug, leaves] of Object.entries(assignments)) {
-      if (!leaves || leaves.length === 0) continue;
+      if (!Array.isArray(leaves) || leaves.length === 0) continue;
 
-      const page = await readPage(workspaceDir, slug);
-      if (!page) continue;
+      const file = join(conceptsDir, `${slug}.md`);
+      let content: string;
+      try {
+        content = fs.readFileSync(file, "utf8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw err;
+      }
 
-      const existing = page.frontmatter.leaves;
-      if (existing && existing.length > 0) continue;
+      const split = splitFrontmatter(content);
+      if (!split) continue; // No frontmatter fence — leave the page untouched.
+      // Never clobber a page that already declares non-empty leaves.
+      const existing = findLeavesField(split.frontmatter.split(/\r?\n/));
+      if (existing?.nonEmpty) continue;
 
-      await writePage(workspaceDir, {
-        slug: page.slug,
-        frontmatter: { ...page.frontmatter, leaves: [...leaves] },
-        body: page.body,
-      });
+      const rebuilt = `${FRONTMATTER_DELIMITER}\n${withLeaves(
+        split.frontmatter,
+        leaves,
+      )}\n${FRONTMATTER_DELIMITER}\n${split.body}`;
+      fs.writeFileSync(file, rebuilt, "utf8");
     }
   },
 

--- a/assistant/src/workspace/migrations/093-backfill-leaf-ids.ts
+++ b/assistant/src/workspace/migrations/093-backfill-leaf-ids.ts
@@ -2,12 +2,10 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import { join, relative } from "node:path";
 
-import { parse, stringify } from "yaml";
-
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
-const log = getLogger("workspace-migration-092-backfill-leaf-ids");
+const log = getLogger("workspace-migration-093-backfill-leaf-ids");
 
 /** v3 leaf files live under this path relative to the workspace dir. */
 const LEAVES_REL = join("memory", "v3", "data", "leaves");
@@ -62,10 +60,31 @@ function collectLeafFiles(dir: string): string[] {
 }
 
 /**
+ * True when the frontmatter already declares a non-empty top-level `id:` field.
+ * A line-shaped check (rather than a YAML parse) keeps the migration free of an
+ * npm `yaml` dependency, as AGENTS.md requires — leaf frontmatter is simple
+ * flat key/value, so a `^id:` scan is sufficient and durable.
+ */
+function hasStableId(frontmatter: string): boolean {
+  for (const line of frontmatter.split(/\r?\n/)) {
+    const m = /^id:[ \t]*(.*)$/.exec(line);
+    if (!m) continue;
+    return m[1].trim().replace(/^["']|["']$/g, "").length > 0;
+  }
+  return false;
+}
+
+/**
  * Backfill a stable `id` into the frontmatter of `file` if it lacks one.
  * Returns `true` when the file was rewritten. Idempotent: a leaf that already
  * has an `id` is left untouched. The id is keyed off the leaf's path relative
  * to the leaves root so it is stable across machines and re-runs.
+ *
+ * Frontmatter is edited as text (the `id:` line is prepended to the existing
+ * block) rather than parsed/re-serialized through a YAML library: workspace
+ * migrations must stay self-contained with no npm deps (AGENTS.md), and a
+ * text splice also preserves the rest of the human-authored frontmatter
+ * verbatim (key order, comments, formatting).
  */
 function backfillLeaf(leavesDir: string, file: string): boolean {
   const content = fs.readFileSync(file, "utf8");
@@ -75,26 +94,15 @@ function backfillLeaf(leavesDir: string, file: string): boolean {
     return false;
   }
 
-  let data: Record<string, unknown>;
-  try {
-    const parsed = parse(split.frontmatter) as unknown;
-    data =
-      parsed && typeof parsed === "object"
-        ? (parsed as Record<string, unknown>)
-        : {};
-  } catch (err) {
-    log.warn({ err, file }, "Failed to parse leaf frontmatter; skipping");
-    return false;
-  }
-
-  if (typeof data.id === "string" && data.id.length > 0) {
+  if (hasStableId(split.frontmatter)) {
     return false; // Already has a stable id — idempotent skip.
   }
 
   const relPath = relative(leavesDir, file);
-  data.id = stableIdForPath(relPath);
-
-  const newFrontmatter = stringify(data).replace(/\n$/, "");
+  const idLine = `id: ${stableIdForPath(relPath)}`;
+  const existing = split.frontmatter.replace(/^\s+|\s+$/g, "");
+  const newFrontmatter =
+    existing.length > 0 ? `${idLine}\n${existing}` : idLine;
   const rebuilt = `${FRONTMATTER_DELIMITER}\n${newFrontmatter}\n${FRONTMATTER_DELIMITER}\n${split.body}`;
   fs.writeFileSync(file, rebuilt, "utf8");
   return true;


### PR DESCRIPTION
## Summary
Address all four Codex review comments on the memory-v3 self-maintenance branch (3× P1, 1× P2), each verified against the actual code/docs:

- **P1 — migration 092 self-containment** (AGENTS.md): dropped the `../v2/page-store` import; inlined string-based frontmatter read/splice using only `node:fs`/`node:path` (also preserves page bytes verbatim instead of schema round-tripping).
- **P1 — migration 093 no npm deps** (AGENTS.md): removed the `yaml` package; detect/insert the `id:` line as text via the file's own `splitFrontmatter`. Fixed logger module name 092→093.
- **P1 — route write-scope**: split the shared `RoutePolicy` — `health` keeps `settings.read`; `set-core`/`reconcile`/`rebuild-index` now require `settings.write`.
- **P2 — reconcile convergence**: the v1 prune pass now drops page refs to ANY leaf absent from the current tree (re-homing a page first if it was its only leaf, never orphaned), instead of tripping `validateNoDangling` on an out-of-band leaf deletion.

## Tests
Replaced the "residual dangling ref throws" reconcile test (it encoded the bug) with two: out-of-band ref converges, and a sole-leaf-dangling page is re-homed. Migration 092/093 tests green.

## Verification
`bunx tsc --noEmit` clean; `generate:openapi --check` up to date; 092 (6), 093 (6), reconcile (6), memory-v3 CLI — all green.

Part of plan: memory-v3-self-maintenance.md (Codex review fixes)