### PR TITLE
[LUM-2027] Auto-collapse tool progress cards by default

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -77,7 +77,7 @@ function renderCard(
 }
 
 describe("ToolCallProgressCard — non-web tool group", () => {
-  test("renders the unified shell with the bash carousel header + step pill", () => {
+  test("renders the unified shell with the bash carousel header collapsed by default", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -86,22 +86,22 @@ describe("ToolCallProgressCard — non-web tool group", () => {
         input: { command: "git status" },
       }),
     ];
-    const { getAllByText, getByTestId, queryByText } = renderCard(toolCalls);
+    const { getByRole, getByText, getByTestId, queryByTestId, queryByText } = renderCard(toolCalls);
     // The unified card mounts the shared shell wrapper.
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
     // Title comes from `deriveStepLabel("bash")`, info from the `command`
-    // input. Title appears twice — once in the carousel header, once in
-    // the auto-expanded phase header (the body's phase-grouped layout
-    // collapses the single bash step into a "Working (bash)" phase
-    // section).
-    expect(getAllByText("Working (bash)").length).toBe(2);
-    expect(getAllByText("git status").length).toBeGreaterThanOrEqual(1);
+    // input. The expanded body is hidden by default, so only the header
+    // content is present on mount.
+    expect(getByText("Working (bash)")).toBeTruthy();
+    expect(getByText("git status")).toBeTruthy();
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+    expect(queryByTestId("tool-step-pill")).toBeNull();
     // Single-step cards suppress the count pill — it would just duplicate
     // the carousel title. Pill returns at 2+ steps.
     expect(queryByText("1 step")).toBeNull();
   });
 
-  test("auto-expands while loading so step rows are visible without a click", () => {
+  test("keeps loading step rows hidden until the user expands the card", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -110,9 +110,10 @@ describe("ToolCallProgressCard — non-web tool group", () => {
         input: { command: "git status" },
       }),
     ];
-    const { getAllByText } = renderCard(toolCalls);
-    // Title appears once in the header and once in the expanded body row.
-    expect(getAllByText("Working (bash)").length).toBeGreaterThanOrEqual(1);
+    const { getByRole, getByTestId, queryByTestId } = renderCard(toolCalls);
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+    fireEvent.click(getByRole("button", { name: /expand steps/i }));
+    expect(getByTestId("tool-step-pill")).toBeTruthy();
   });
 
   test("uses the loading indicator while any tool is running", () => {
@@ -146,7 +147,9 @@ describe("ToolCallProgressCard — tool step pill", () => {
         riskLevel: "high",
       }),
     ];
-    const { getByTestId } = renderCard(toolCalls);
+    const { getByTestId } = renderCard(toolCalls, {
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
     const pill = getByTestId("tool-step-pill");
     expect(pill).toBeTruthy();
     // Activity sentence wins over the terse command info (it also surfaces in
@@ -325,7 +328,9 @@ describe("ToolCallProgressCard — subagent_spawn filtering", () => {
         input: { command: "ls" },
       }),
     ];
-    const { getByTestId, queryByText } = renderCard(toolCalls);
+    const { getByTestId, queryByText } = renderCard(toolCalls, {
+      expandedCardIds: new Map([["tc-1", true]]),
+    });
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
     // Single non-spawn tool call → step pill suppressed (only fires at 2+).
     expect(queryByText(/^\d+ steps?$/)).toBeNull();
@@ -349,7 +354,7 @@ describe("ToolCallProgressCard — unknown-command nudge", () => {
       onOpenRuleEditor: () => {},
       onDismissUnknownNudge: () => {},
       // Force the body open so the nudge inside the expanded region is in
-      // the DOM regardless of the auto-collapse-on-completion behavior.
+      // the DOM regardless of the collapsed-by-default behavior.
       expandedCardIds: new Map([["tc-1", true]]),
     });
     expect(getByText("This command wasn't recognized.")).toBeTruthy();
@@ -426,7 +431,7 @@ describe("ToolCallProgressCard — unknown-command nudge", () => {
 });
 
 describe("ToolCallProgressCard — expansion derived from state", () => {
-  test("mounts expanded while loading", () => {
+  test("mounts collapsed while loading", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -436,10 +441,10 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
       }),
     ];
     const { getByRole } = renderCard(toolCalls);
-    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
   });
 
-  test("collapses automatically once the card reaches a terminal state", () => {
+  test("mounts collapsed once the card reaches a terminal state", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -454,7 +459,7 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
     expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
   });
 
-  test("auto-collapses on the loading → complete transition without a user toggle", () => {
+  test("stays collapsed on the loading → complete transition without a user toggle", () => {
     const expandedCardIds = new Map<string, boolean>();
     const running = [
       makeToolCall({
@@ -472,7 +477,7 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
         expandedCardIds={expandedCardIds}
       />,
     );
-    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
 
     const completed = [
       makeToolCall({
@@ -513,10 +518,7 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
         expandedCardIds={expandedCardIds}
       />,
     );
-    // Card mounts expanded; user collapses it manually.
-    fireEvent.click(getByRole("button", { name: /collapse steps/i }));
-    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
-    // User expands it back.
+    // Card mounts collapsed; user expands it manually.
     fireEvent.click(getByRole("button", { name: /expand steps/i }));
     expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
 
@@ -568,7 +570,7 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
     expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
   });
 
-  test("persisted expanded=true overrides the auto-collapse on completion", () => {
+  test("persisted expanded=true overrides the collapsed default on completion", () => {
     const expandedCardIds = new Map<string, boolean>([["tc-1", true]]);
     const toolCalls = [
       makeToolCall({
@@ -591,37 +593,18 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
     expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
   });
 
-  test("isStreaming=true keeps the card expanded after tools complete", () => {
-    // Tools finish before the assistant's final response — the card should
-    // stay expanded while `isStreaming` is true so the user sees the steps
-    // beside the streaming reply, not a prematurely-collapsed card.
+  test("persisted expanded=true overrides the collapsed default while loading", () => {
+    const expandedCardIds = new Map<string, boolean>([["tc-1", true]]);
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
         toolName: "bash",
-        status: "completed",
+        status: "running",
         input: { command: "ls" },
-        startedAt: 0,
-        completedAt: 1000,
       }),
     ];
-    const { getByRole } = renderCard(toolCalls, { isStreaming: true });
+    const { getByRole } = renderCard(toolCalls, { expandedCardIds });
     expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
-  });
-
-  test("isStreaming=false collapses the completed card (regression vs the previous case)", () => {
-    const toolCalls = [
-      makeToolCall({
-        id: "tc-1",
-        toolName: "bash",
-        status: "completed",
-        input: { command: "ls" },
-        startedAt: 0,
-        completedAt: 1000,
-      }),
-    ];
-    const { getByRole } = renderCard(toolCalls, { isStreaming: false });
-    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
   });
 });
 
@@ -701,6 +684,7 @@ describe("ToolCallProgressCard — leadingThinkingText", () => {
     ];
     const { getByText, getByText: getByText2 } = renderCard(toolCalls, {
       leadingThinkingText: "Let me check the directory first.",
+      expandedCardIds: new Map([["tc-1", true]]),
     });
     // The thinking text appears as a separate step row in the expanded body.
     expect(getByText("Let me check the directory first.")).toBeTruthy();

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx
@@ -213,6 +213,39 @@ describe("ToolCallProgressCard — web tool group regression", () => {
     // flow through the dedicated web-search card.
     expect(queryByTestId("tool-progress-card-shell")).toBeNull();
   });
+
+  test("web_search-only groups honor autoExpand through the shared shell", () => {
+    const expandedCardIds = new Map<string, boolean>();
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "web_search",
+        status: "running",
+        input: { query: "tigers" },
+      }),
+    ];
+    const { getByRole, rerender } = render(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+        autoExpand
+      />,
+    );
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+
+    rerender(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+        autoExpand={false}
+      />,
+    );
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
 });
 
 describe("ToolCallProgressCard — mixed group", () => {
@@ -605,6 +638,74 @@ describe("ToolCallProgressCard — expansion derived from state", () => {
     ];
     const { getByRole } = renderCard(toolCalls, { expandedCardIds });
     expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+  });
+
+  test("autoExpand opens the current loading card without persisting a user choice", () => {
+    const expandedCardIds = new Map<string, boolean>();
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls, {
+      expandedCardIds,
+      autoExpand: true,
+    });
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+    expect(expandedCardIds.size).toBe(0);
+  });
+
+  test("persisted collapse overrides autoExpand", () => {
+    const expandedCardIds = new Map<string, boolean>([["tc-1", false]]);
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole } = renderCard(toolCalls, {
+      expandedCardIds,
+      autoExpand: true,
+    });
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
+  });
+
+  test("collapses when autoExpand turns off and the user has not toggled", () => {
+    const expandedCardIds = new Map<string, boolean>();
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        toolName: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    const { getByRole, rerender } = render(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+        autoExpand
+      />,
+    );
+    expect(getByRole("button", { name: /collapse steps/i })).toBeTruthy();
+
+    rerender(
+      <ToolCallProgressCard
+        toolCalls={toolCalls}
+        expandedToolCallIds={new Set()}
+        onExpandChange={() => {}}
+        expandedCardIds={expandedCardIds}
+        autoExpand={false}
+      />,
+    );
+    expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
   });
 });
 

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -41,6 +41,12 @@ export interface ToolCallProgressCardProps {
    * explicitly expanded, `false` = user explicitly collapsed.
    */
   expandedCardIds: Map<string, boolean>;
+  /**
+   * Ephemeral parent-driven expansion for the currently active tool-call
+   * group. Unlike `expandedCardIds`, this is not persisted; explicit user
+   * toggles still win.
+   */
+  autoExpand?: boolean;
   onOpenRuleEditor?: (context: {
     toolName: string;
     riskLevel?: string;
@@ -87,6 +93,7 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
     toolCalls,
     pendingConfirmationToolCallId,
     leadingThinkingText,
+    autoExpand = false,
   } = props;
 
   const hasActiveConfirmation =
@@ -106,6 +113,12 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
   const cardData = useToolCallCardData(
     toolCalls,
     leadingThinkingText ?? null,
+  );
+  const cardId = toolCalls[0]?.id ?? null;
+  const expanded = useCardExpanded(
+    cardId,
+    props.expandedCardIds,
+    autoExpand,
   );
 
   // Confirmation short-circuit — render the inline approve/deny UI via the
@@ -127,10 +140,24 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
   // its mature rendering (carousel header, error chips). Mixed / non-web
   // groups fall through to the unified shell below.
   if (isPurelyWebGroup(toolCalls)) {
-    return <WebSearchView toolCalls={toolCalls} cardData={cardData} />;
+    return (
+      <WebSearchView
+        toolCalls={toolCalls}
+        cardData={cardData}
+        expanded={expanded.value}
+        onExpandChange={expanded.onChange}
+      />
+    );
   }
 
-  return <UnifiedToolCallProgressCard {...props} cardData={cardData} />;
+  return (
+    <UnifiedToolCallProgressCard
+      {...props}
+      cardData={cardData}
+      expanded={expanded.value}
+      onCardExpandChange={expanded.onChange}
+    />
+  );
 }
 
 /**
@@ -161,9 +188,13 @@ function isPurelyWebGroup(toolCalls: ChatMessageToolCall[]): boolean {
 function WebSearchView({
   toolCalls,
   cardData,
+  expanded,
+  onExpandChange,
 }: {
   toolCalls: ChatMessageToolCall[];
   cardData: ToolCallCardData;
+  expanded: boolean;
+  onExpandChange: (next: boolean) => void;
 }) {
   return (
     <WebSearchProgressCard
@@ -176,6 +207,8 @@ function WebSearchView({
       steps={cardData.steps as StepDescriptor[]}
       state={deriveWebShellState(toolCalls, cardData.state)}
       carouselItems={cardData.carouselItems}
+      expanded={expanded}
+      onExpandChange={onExpandChange}
     />
   );
 }
@@ -200,23 +233,22 @@ function deriveWebShellState(
  */
 function UnifiedToolCallProgressCard({
   toolCalls,
-  expandedCardIds,
   cardData,
+  expanded,
+  onCardExpandChange,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
-}: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
+}: ToolCallProgressCardProps & {
+  cardData: ToolCallCardData;
+  expanded: boolean;
+  onCardExpandChange: (next: boolean) => void;
+}) {
   const openToolDetail = useViewerStore.use.openToolDetail();
   // Drives the pill's active state — the pill whose detail drawer is currently
   // open renders selected. `null` when the drawer is closed or showing another
   // view, so no pill reads as active.
   const openToolDetailId = useViewerStore.use.activeToolDetail()?.toolCallId ?? null;
-  const cardId = toolCalls[0]?.id ?? null;
-  const expanded = useCardExpanded(
-    cardId,
-    expandedCardIds,
-  );
-
   const shellState: ToolProgressCardState = cardData.state;
 
   // Nudge rows need the raw call (riskLevel, allowlistOptions, …) which
@@ -230,8 +262,8 @@ function UnifiedToolCallProgressCard({
       currentStepTitle={cardData.currentStepTitle}
       currentStepInfo={cardData.currentStepInfo}
       stepCount={cardData.stepCount}
-      expanded={expanded.value}
-      onExpandChange={expanded.onChange}
+      expanded={expanded}
+      onExpandChange={onCardExpandChange}
     >
       <div className="flex w-full flex-col gap-3 px-3 pb-3">
         <PhaseGroupedStepList
@@ -265,7 +297,7 @@ function UnifiedToolCallProgressCard({
                     // which remounts the transcript and resets local expand
                     // state. Persisting the user's intent in `expandedCardIds`
                     // keeps the parent accordion open across that remount.
-                    expanded.onChange(true);
+                    onCardExpandChange(true);
                     openToolDetail({
                       toolCallId: tc.id,
                       toolName: tc.toolName,
@@ -298,9 +330,10 @@ function UnifiedToolCallProgressCard({
 
 /**
  * Drives the unified card's expand/collapse state. Tool progress cards default
- * collapsed in chat so ongoing tool activity stays compact; a user toggle (now
- * or in a previous mount, recorded in `expandedCardIds`) wins across state
- * transitions and remounts.
+ * collapsed in chat so past tool activity stays compact. The transcript can
+ * temporarily expand the current active group via `autoExpand`; a user toggle
+ * (now or in a previous mount, recorded in `expandedCardIds`) wins across
+ * state transitions and remounts.
  *
  * `localToggle` mirrors the map mutation so React re-renders on click —
  * mutating the map alone wouldn't trigger one.
@@ -308,6 +341,7 @@ function UnifiedToolCallProgressCard({
 function useCardExpanded(
   cardId: string | null,
   expandedCardIds: Map<string, boolean>,
+  autoExpand: boolean,
 ): { value: boolean; onChange: (next: boolean) => void } {
   const [localToggle, setLocalToggle] = useState<boolean | undefined>(
     undefined,
@@ -315,7 +349,7 @@ function useCardExpanded(
   const persisted =
     cardId != null ? expandedCardIds.get(cardId) : undefined;
   const userChoice = localToggle ?? persisted;
-  const value = userChoice ?? false;
+  const value = userChoice ?? autoExpand;
 
   const onChange = (next: boolean) => {
     setLocalToggle(next);

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -59,14 +59,6 @@ export interface ToolCallProgressCardProps {
   unknownNudgeToolCallIds?: Set<string>;
   onDismissUnknownNudge?: (toolCallId: string) => void;
   /**
-   * Whether the parent assistant message is currently streaming a response.
-   * Tools can finish before the assistant's final reply is complete; the
-   * card keeps itself expanded while either `isStreaming` is true or the
-   * tool group is still loading, so the user keeps seeing the steps next to
-   * the streaming reply instead of a prematurely-collapsed card.
-   */
-  isStreaming?: boolean;
-  /**
    * Optional leading "thinking" text segment that immediately preceded this
    * tool-call group in the message's `contentOrder`. When supplied the
    * unified card prepends a `thinking` step to the expanded body so the
@@ -213,7 +205,6 @@ function UnifiedToolCallProgressCard({
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
-  isStreaming,
 }: ToolCallProgressCardProps & { cardData: ToolCallCardData }) {
   const openToolDetail = useViewerStore.use.openToolDetail();
   // Drives the pill's active state — the pill whose detail drawer is currently
@@ -223,9 +214,7 @@ function UnifiedToolCallProgressCard({
   const cardId = toolCalls[0]?.id ?? null;
   const expanded = useCardExpanded(
     cardId,
-    cardData.state,
     expandedCardIds,
-    isStreaming ?? false,
   );
 
   const shellState: ToolProgressCardState = cardData.state;
@@ -308,21 +297,17 @@ function UnifiedToolCallProgressCard({
 }
 
 /**
- * Drives the unified card's expand/collapse state. Mirrors legacy behavior:
- * auto-expand while loading or while the parent message is still streaming
- * (tools can finish before the assistant's final response is complete),
- * auto-collapse on terminal state, but a user toggle (now or in a previous
- * mount, recorded in `expandedCardIds`) wins across state transitions and
- * remounts.
+ * Drives the unified card's expand/collapse state. Tool progress cards default
+ * collapsed in chat so ongoing tool activity stays compact; a user toggle (now
+ * or in a previous mount, recorded in `expandedCardIds`) wins across state
+ * transitions and remounts.
  *
  * `localToggle` mirrors the map mutation so React re-renders on click —
  * mutating the map alone wouldn't trigger one.
  */
 function useCardExpanded(
   cardId: string | null,
-  state: ToolCallCardData["state"],
   expandedCardIds: Map<string, boolean>,
-  isStreaming: boolean,
 ): { value: boolean; onChange: (next: boolean) => void } {
   const [localToggle, setLocalToggle] = useState<boolean | undefined>(
     undefined,
@@ -330,7 +315,7 @@ function useCardExpanded(
   const persisted =
     cardId != null ? expandedCardIds.get(cardId) : undefined;
   const userChoice = localToggle ?? persisted;
-  const value = userChoice ?? (state === "loading" || isStreaming);
+  const value = userChoice ?? false;
 
   const onChange = (next: boolean) => {
     setLocalToggle(next);
@@ -471,4 +456,3 @@ function ConfirmationView({
     </div>
   );
 }
-

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
@@ -93,6 +93,10 @@ export interface WebSearchProgressCardProps {
   steps: StepDescriptor[];
   /** Whether the card starts expanded. Uncontrolled by default. */
   defaultExpanded?: boolean;
+  /** Controlled expanded value. Pairs with `onExpandChange`. */
+  expanded?: boolean;
+  /** Notified when the user toggles the expand/collapse button. */
+  onExpandChange?: (next: boolean) => void;
   /**
    * Drives the header chrome:
    * - `"loading"` (default) → animated `ThreeDotIndicator` + rotating
@@ -131,6 +135,8 @@ export function WebSearchProgressCard({
   stepCount,
   steps,
   defaultExpanded = false,
+  expanded,
+  onExpandChange,
   state = "loading",
   carouselItems = EMPTY_CAROUSEL_ITEMS,
 }: WebSearchProgressCardProps) {
@@ -162,6 +168,8 @@ export function WebSearchProgressCard({
       currentStepInfo={headerInfo}
       stepCount={stepCount}
       defaultExpanded={defaultExpanded}
+      expanded={expanded}
+      onExpandChange={onExpandChange}
     >
       <div className="flex w-full flex-col gap-3 px-3 pb-3">
         <PhaseGroupedStepList

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -21,7 +21,19 @@ mock.module("@/domains/chat/components/surfaces/surface-router", () => ({
 mock.module(
   "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card",
   () => ({
-    ToolCallProgressCard: () => <div data-testid="tool-progress-card" />,
+    ToolCallProgressCard: ({
+      autoExpand,
+      toolCalls,
+    }: {
+      autoExpand?: boolean;
+      toolCalls: Array<{ id: string }>;
+    }) => (
+      <div
+        data-testid="tool-progress-card"
+        data-auto-expand={autoExpand ? "true" : "false"}
+        data-tool-call-ids={toolCalls.map((tc) => tc.id).join(",")}
+      />
+    ),
   }),
 );
 
@@ -246,5 +258,161 @@ describe("TranscriptMessageBody", () => {
 
     fireEvent.click(getByTitle("Inspect"));
     expect(inspectedIds).toEqual(["message-1"]);
+  });
+
+  test("auto-expands the latest interleaved tool-call group while the row is streaming", () => {
+    const { getByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m1",
+          role: "assistant",
+          content: "",
+          contentOrder: [{ type: "tool", id: "tc-1" }],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        isStreaming
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
+    ).toBe("true");
+  });
+
+  test("collapses an interleaved tool-call group once response text follows", () => {
+    const { getByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m1",
+          role: "assistant",
+          content: "",
+          contentOrder: [
+            { type: "tool", id: "tc-1" },
+            { type: "text", id: "0" },
+          ],
+          textSegments: [{ type: "text", content: "Done." }],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        isStreaming
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
+    ).toBe("false");
+  });
+
+  test("moves auto-expansion to a later interleaved tool-call group", () => {
+    const { getAllByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m1",
+          role: "assistant",
+          content: "",
+          contentOrder: [
+            { type: "tool", id: "tc-1" },
+            { type: "text", id: "0" },
+            { type: "tool", id: "tc-2" },
+          ],
+          textSegments: [{ type: "text", content: "Next I will check logs." }],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+            {
+              id: "tc-2",
+              toolName: "bash",
+              input: {},
+              status: "running",
+            },
+          ],
+        }}
+        isStreaming
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      getAllByTestId("tool-progress-card").map((el) =>
+        el.getAttribute("data-auto-expand"),
+      ),
+    ).toEqual(["false", "true"]);
+  });
+
+  test("auto-expands legacy tool-only streaming messages until content appears", () => {
+    const { getByTestId, rerender } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        isStreaming
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+    expect(
+      getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
+    ).toBe("true");
+
+    rerender(
+      <TranscriptMessageBody
+        message={{
+          id: "m1",
+          role: "assistant",
+          content: "Done.",
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        isStreaming
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+    expect(
+      getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
+    ).toBe("false");
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -221,6 +221,22 @@ function resolveSpawnedSubagentIds(
   return ids;
 }
 
+function shouldAutoExpandToolCallGroup({
+  isCurrentGroup,
+  isStreaming,
+  toolCalls,
+}: {
+  isCurrentGroup: boolean;
+  isStreaming: boolean;
+  toolCalls: ChatMessageToolCall[];
+}): boolean {
+  if (!isCurrentGroup) return false;
+  return (
+    isStreaming ||
+    toolCalls.some((toolCall) => toolCall.status === "running")
+  );
+}
+
 function latestMessageActivityTimestamp(
   message: DisplayMessage,
 ): number | undefined {
@@ -594,6 +610,11 @@ export function TranscriptMessageBody({
                       expandedToolCallIds={expandedToolCallIds}
                       onExpandChange={handleExpandChange}
                       expandedCardIds={expandedCardIds}
+                      autoExpand={shouldAutoExpandToolCallGroup({
+                        isCurrentGroup: gi === groups.length - 1,
+                        isStreaming,
+                        toolCalls,
+                      })}
                       onOpenRuleEditor={onOpenRuleEditor}
                       isSubmittingConfirmation={isSubmittingConfirmation}
                       onConfirmationSubmit={onConfirmationSubmit}
@@ -721,6 +742,9 @@ export function TranscriptMessageBody({
         : null,
     );
   }
+  const legacyToolCalls =
+    message.toolCalls?.filter((tc) => !isSuppressedUiTool(tc)) ?? [];
+  const hasVisibleLegacyContent = contentElements.some((el) => !!el);
 
   return (
     <div
@@ -732,13 +756,18 @@ export function TranscriptMessageBody({
       <div
         className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
       >
-        {message.toolCalls && message.toolCalls.filter((tc) => !isSuppressedUiTool(tc)).length > 0 && (
+        {legacyToolCalls.length > 0 && (
           <>
             <ToolCallProgressCard
-              toolCalls={message.toolCalls.filter((tc) => !isSuppressedUiTool(tc))}
+              toolCalls={legacyToolCalls}
               expandedToolCallIds={expandedToolCallIds}
               onExpandChange={handleExpandChange}
               expandedCardIds={expandedCardIds}
+              autoExpand={shouldAutoExpandToolCallGroup({
+                isCurrentGroup: !hasVisibleLegacyContent,
+                isStreaming,
+                toolCalls: legacyToolCalls,
+              })}
               onOpenRuleEditor={onOpenRuleEditor}
               isSubmittingConfirmation={isSubmittingConfirmation}
               onConfirmationSubmit={onConfirmationSubmit}
@@ -748,9 +777,7 @@ export function TranscriptMessageBody({
               onDismissUnknownNudge={onDismissUnknownNudge}
               leadingThinkingText={getLegacyLeadingThinkingText(message)}
             />
-            {renderInlineSubagentCards(
-              message.toolCalls.filter((tc) => !isSuppressedUiTool(tc)),
-            )}
+            {renderInlineSubagentCards(legacyToolCalls)}
           </>
         )}
         {(contentElements.some((el) => !!el) ||

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -601,7 +601,6 @@ export function TranscriptMessageBody({
                       pendingConfirmationToolCallId={pendingConfirmationToolCallId}
                       unknownNudgeToolCallIds={unknownNudgeToolCallIds}
                       onDismissUnknownNudge={onDismissUnknownNudge}
-                      isStreaming={isStreaming}
                       leadingThinkingText={getLeadingThinkingText(message, gi)}
                     />
                   )}
@@ -747,7 +746,6 @@ export function TranscriptMessageBody({
               pendingConfirmationToolCallId={pendingConfirmationToolCallId}
               unknownNudgeToolCallIds={unknownNudgeToolCallIds}
               onDismissUnknownNudge={onDismissUnknownNudge}
-              isStreaming={isStreaming}
               leadingThinkingText={getLegacyLeadingThinkingText(message)}
             />
             {renderInlineSubagentCards(


### PR DESCRIPTION
## Summary

Fixes LUM-2027.

- Defaults web chat tool-call/progress cards to collapsed, including while tools are running or the assistant response is still streaming.
- Keeps explicit user expansion/collapse choices persistent across remounts and state transitions.
- Removes the now-unused streaming-driven expansion prop from the transcript handoff.

## Root Cause

The unified web tool-call card derived its default expansion from `state === "loading" || isStreaming`, so active tool groups opened automatically and stayed open during response streaming.

## Validation

- `cd apps/web && bun test src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx`
- `cd apps/web && bun test src/domains/chat/transcript/transcript-message-body.test.tsx`
- `cd apps/web && bun run lint src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.test.tsx src/domains/chat/transcript/transcript-message-body.tsx`

Full `cd apps/web && bunx tsc --noEmit` is currently blocked by unrelated existing errors. With the local duplicate design-library React type tree removed, the remaining errors are in `src/domains/conversations/conversation-transforms.ts` and `src/domains/intelligence/components/plugins/plugin-row.tsx`, not in this PR's touched files.