### PR TITLE
fix(web): match Figma spacing, height & icon chip on mobile context window sheet

### DIFF
--- a/apps/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/apps/web/src/domains/chat/components/context-window-indicator.tsx
@@ -146,14 +146,10 @@ function MobileSheetContent({
 }) {
   return (
     <>
-      <div className="flex flex-col items-center gap-5">
+      <div className="flex flex-col items-center gap-6">
         <span
           aria-hidden="true"
-          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl"
-          style={{
-            backgroundColor:
-              "color-mix(in oklab, var(--primary-base) 16%, transparent)",
-          }}
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-[var(--surface-active)]"
         >
           <Brain className="h-7 w-7 text-[var(--primary-base)]" />
         </span>
@@ -161,7 +157,7 @@ function MobileSheetContent({
         <BottomSheet.Title className="justify-center">Context Window</BottomSheet.Title>
 
         <div className="w-full px-2">
-          <div className="relative h-3 w-full overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]">
+          <div className="relative h-4 w-full overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]">
             <div
               className="h-full rounded-full transition-[width] duration-250 ease-out"
               style={{
@@ -172,7 +168,7 @@ function MobileSheetContent({
           </div>
         </div>
 
-        <div className="flex flex-col items-center gap-1.5">
+        <div className="flex flex-col items-center gap-2">
           <span className="text-body-large-default text-[var(--content-default)]">
             {percentage}% full
             {maxTokens != null && (
@@ -190,7 +186,7 @@ function MobileSheetContent({
       </div>
 
       {onClearContext && (
-        <BottomSheet.Footer className="justify-center pt-4">
+        <BottomSheet.Footer className="justify-center pt-6">
           <Button
             variant="outlined"
             fullWidth
@@ -294,11 +290,11 @@ export function ContextWindowIndicator({
             />
           </button>
         </BottomSheet.Trigger>
-        <BottomSheet.Content aria-describedby={undefined}>
+        <BottomSheet.Content aria-describedby={undefined} className="max-h-[85dvh]">
           <BottomSheet.Header className="sr-only">
             <BottomSheet.Title>Context Window</BottomSheet.Title>
           </BottomSheet.Header>
-          <BottomSheet.Body className="pt-0">
+          <BottomSheet.Body className="px-2 pt-8 pb-8">
             <MobileSheetContent
               percentage={percentage}
               ringColor={ringColor}


### PR DESCRIPTION
## Summary
- Increase mobile Context Window bottom sheet padding to 24px horizontal / 48px vertical and use a 24px gap between every element to match the Figma mock
- Taller progress bar (16px), 8px text-block gap, and max-h-[85dvh] so the content-hugging sheet is not clipped on short devices
- Neutral-gray icon chip (var(--surface-active)) at a 12px radius

Part of plan: ios-content-window-sheet-spacing.md (PR 1 of 1)