### PR TITLE
feat(assistant): proactive daily briefings via daily_briefing_configure tool

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 11 with recall occupying the existing slot", async () => {
+  test("should be exactly 12 with daily_briefing_configure added", async () => {
     await initializeTools();
     const allDefs = getAllToolDefinitions();
 
@@ -53,6 +53,7 @@ describe("always-loaded tool count", () => {
     const expectedNames = [
       "bash",
       "credential_store",
+      "daily_briefing_configure",
       "file_edit",
       "file_read",
       "file_write",
@@ -66,6 +67,6 @@ describe("always-loaded tool count", () => {
 
     expect(activeNames).toEqual(expectedNames);
     expect(activeNames.filter((name) => name === "recall")).toHaveLength(1);
-    expect(activeTools.length).toBe(11);
+    expect(activeTools.length).toBe(12);
   });
 });

--- a/assistant/src/__tests__/daily-briefing-configure.test.ts
+++ b/assistant/src/__tests__/daily-briefing-configure.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    memory: {},
+    daemon: { timezone: "America/New_York" },
+  }),
+}));
+
+import type { Database } from "bun:sqlite";
+
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { dailyBriefingConfigureTool } from "../tools/briefing/configure.js";
+import { BRIEFING_SCHEDULE_NAME } from "../tools/briefing/prompt.js";
+import type { ToolContext } from "../tools/types.js";
+
+initializeDb();
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+const guardianCtx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conversation",
+  trustClass: "guardian",
+};
+
+const untrustedCtx: ToolContext = {
+  ...guardianCtx,
+  trustClass: "trusted_contact",
+};
+
+beforeEach(() => {
+  getRawDb().run("DELETE FROM cron_runs");
+  getRawDb().run("DELETE FROM cron_jobs");
+});
+
+// ── guardian guard ───────────────────────────────────────────────────
+
+describe("trust guard", () => {
+  test("rejects non-guardian callers", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable" },
+      untrustedCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("guardian");
+  });
+});
+
+// ── status ───────────────────────────────────────────────────────────
+
+describe("action=status", () => {
+  test("reports no briefing configured when table is empty", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "status" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("No daily briefing");
+  });
+
+  test("reports schedule state after creation", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "status" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("enabled");
+    expect(result.content).toContain("0 9 * * *");
+  });
+});
+
+// ── enable ───────────────────────────────────────────────────────────
+
+describe("action=enable", () => {
+  test("creates a new schedule on first enable", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("created and enabled");
+    expect(result.content).toContain("09:00");
+  });
+
+  test("uses custom time when provided", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable", time: "07:30" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("07:30");
+  });
+
+  test("uses custom timezone when provided", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable", timezone: "Europe/London" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Europe/London");
+  });
+
+  test("re-enables a disabled schedule without creating a duplicate", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    await dailyBriefingConfigureTool.execute(
+      { action: "disable" },
+      guardianCtx,
+    );
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    // Should update, not create ("enabled" not "created")
+    expect(result.content).toContain("enabled");
+
+    // Exactly one schedule should exist
+    const rows = getRawDb()
+      .query(`SELECT COUNT(*) as c FROM cron_jobs WHERE name = ?`)
+      .get(BRIEFING_SCHEDULE_NAME) as { c: number };
+    expect(rows.c).toBe(1);
+  });
+
+  test("schedule is stored with correct name and mode", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const row = getRawDb()
+      .query(`SELECT * FROM cron_jobs WHERE name = ?`)
+      .get(BRIEFING_SCHEDULE_NAME) as Record<string, unknown> | null;
+    expect(row).not.toBeNull();
+    expect(row!.mode).toBe("execute");
+    expect(row!.enabled).toBe(1);
+    expect(row!.reuse_conversation).toBe(1);
+  });
+});
+
+// ── disable ──────────────────────────────────────────────────────────
+
+describe("action=disable", () => {
+  test("disables an enabled schedule", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "disable" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("disabled");
+
+    const row = getRawDb()
+      .query(`SELECT enabled FROM cron_jobs WHERE name = ?`)
+      .get(BRIEFING_SCHEDULE_NAME) as { enabled: number } | null;
+    expect(row!.enabled).toBe(0);
+  });
+
+  test("is a no-op when no schedule exists", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "disable" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("nothing to disable");
+  });
+
+  test("is a no-op when already disabled", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    await dailyBriefingConfigureTool.execute(
+      { action: "disable" },
+      guardianCtx,
+    );
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "disable" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("already disabled");
+  });
+});
+
+// ── set_time ─────────────────────────────────────────────────────────
+
+describe("action=set_time", () => {
+  test("updates delivery time on existing schedule", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "set_time", time: "08:00" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("08:00");
+
+    const row = getRawDb()
+      .query(`SELECT cron_expression FROM cron_jobs WHERE name = ?`)
+      .get(BRIEFING_SCHEDULE_NAME) as { cron_expression: string } | null;
+    expect(row!.cron_expression).toBe("0 8 * * *");
+  });
+
+  test("rejects missing time field", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "set_time" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("time is required");
+  });
+
+  test("rejects malformed time string", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "set_time", time: "9am" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid time");
+  });
+
+  test("rejects out-of-range hour", async () => {
+    await dailyBriefingConfigureTool.execute({ action: "enable" }, guardianCtx);
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "set_time", time: "25:00" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid time");
+  });
+
+  test("errors when no schedule exists yet", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "set_time", time: "08:00" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("enable");
+  });
+});

--- a/assistant/src/__tests__/daily-briefing-configure.test.ts
+++ b/assistant/src/__tests__/daily-briefing-configure.test.ts
@@ -104,6 +104,24 @@ describe("action=enable", () => {
     expect(result.content).toContain("07:30");
   });
 
+  test("rejects malformed time on enable", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable", time: "9am" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid time");
+  });
+
+  test("rejects out-of-range hour on enable", async () => {
+    const result = await dailyBriefingConfigureTool.execute(
+      { action: "enable", time: "25:00" },
+      guardianCtx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid time");
+  });
+
   test("uses custom timezone when provided", async () => {
     const result = await dailyBriefingConfigureTool.execute(
       { action: "enable", timezone: "Europe/London" },

--- a/assistant/src/tools/briefing/configure.ts
+++ b/assistant/src/tools/briefing/configure.ts
@@ -1,0 +1,218 @@
+import { RiskLevel } from "../../permissions/types.js";
+import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import {
+  createSchedule,
+  isValidCronExpression,
+  listSchedules,
+  updateSchedule,
+} from "../../schedule/schedule-store.js";
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "../types.js";
+import {
+  BRIEFING_DEFAULT_CRON,
+  BRIEFING_SCHEDULE_NAME,
+  DAILY_BRIEFING_PROMPT,
+} from "./prompt.js";
+
+type BriefingAction = "enable" | "disable" | "status" | "set_time";
+
+function parseCronFromTime(time: string): string | null {
+  const match = time.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  const hour = parseInt(match[1], 10);
+  const minute = parseInt(match[2], 10);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return `${minute} ${hour} * * *`;
+}
+
+function resolveTimezone(inputTz?: string): string {
+  if (inputTz) return inputTz;
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+function findBriefingSchedule() {
+  const all = listSchedules();
+  return all.find((j) => j.name === BRIEFING_SCHEDULE_NAME) ?? null;
+}
+
+function formatStatus(job: ReturnType<typeof findBriefingSchedule>): string {
+  if (!job) {
+    return "No daily briefing is configured. Use action=enable to set one up.";
+  }
+  const state = job.enabled ? "enabled" : "disabled";
+  const expr = job.expression ?? job.cronExpression ?? "(one-shot)";
+  const tz = job.timezone ?? "system timezone";
+  const lastRun = job.lastRunAt
+    ? new Date(job.lastRunAt).toLocaleString()
+    : "never";
+  const nextRun = job.nextRunAt
+    ? new Date(job.nextRunAt).toLocaleString()
+    : "not scheduled";
+  return [
+    `Daily Briefing: ${state}`,
+    `Schedule: ${expr} (${tz})`,
+    `Last run: ${lastRun}`,
+    `Next run: ${nextRun}`,
+  ].join("\n");
+}
+
+export const dailyBriefingConfigureTool = {
+  name: "daily_briefing_configure",
+  description:
+    "Configure the user's proactive daily briefing. The briefing fires on a recurring schedule, pulls recent memory and workspace context, composes a summary, and delivers it to all active channels (Slack, Telegram, macOS, etc.). Use action=enable to turn it on, action=disable to pause it, action=set_time to change delivery time (HH:MM format), or action=status to see the current configuration.",
+  category: "memory",
+  executionTarget: "sandbox",
+  defaultRiskLevel: RiskLevel.Low,
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      action: {
+        type: "string",
+        enum: ["enable", "disable", "status", "set_time"],
+        description:
+          "enable: create or activate the daily briefing. disable: pause it without deleting. set_time: change the delivery time (requires time field). status: show current configuration.",
+      },
+      time: {
+        type: "string",
+        description:
+          'Delivery time in HH:MM 24-hour format, e.g. "09:00" for 9 AM. Required for set_time; optional for enable (defaults to 09:00).',
+      },
+      timezone: {
+        type: "string",
+        description:
+          'IANA timezone name, e.g. "America/New_York". Defaults to the workspace timezone or the system timezone.',
+      },
+    },
+    required: ["action"],
+  },
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    if (isUntrustedTrustClass(context.trustClass)) {
+      return {
+        content:
+          "daily_briefing_configure is only available to the guardian — it creates and modifies scheduled jobs.",
+        isError: true,
+      };
+    }
+
+    const action = input.action as BriefingAction;
+    const rawTime = input.time as string | undefined;
+    const rawTz = input.timezone as string | undefined;
+
+    if (action === "status") {
+      return { content: formatStatus(findBriefingSchedule()), isError: false };
+    }
+
+    if (action === "set_time") {
+      if (!rawTime) {
+        return {
+          content: 'Error: time is required for set_time (e.g. "09:00").',
+          isError: true,
+        };
+      }
+      const cron = parseCronFromTime(rawTime);
+      if (!cron) {
+        return {
+          content: `Error: invalid time "${rawTime}". Use HH:MM 24-hour format, e.g. "09:00".`,
+          isError: true,
+        };
+      }
+      if (!isValidCronExpression(cron)) {
+        return {
+          content: `Error: derived cron expression "${cron}" is not valid.`,
+          isError: true,
+        };
+      }
+      const job = findBriefingSchedule();
+      if (!job) {
+        return {
+          content:
+            "No daily briefing exists yet. Use action=enable to create one first.",
+          isError: true,
+        };
+      }
+      const updated = updateSchedule(job.id, {
+        expression: cron,
+        cronExpression: cron,
+        timezone: resolveTimezone(rawTz),
+      });
+      if (!updated) {
+        return {
+          content: "Error: failed to update briefing schedule.",
+          isError: true,
+        };
+      }
+      return {
+        content: `Daily briefing updated. New delivery time: ${rawTime} (${updated.timezone ?? "system timezone"}). Next run: ${new Date(updated.nextRunAt).toLocaleString()}.`,
+        isError: false,
+      };
+    }
+
+    if (action === "disable") {
+      const job = findBriefingSchedule();
+      if (!job) {
+        return {
+          content: "No daily briefing is configured, so nothing to disable.",
+          isError: false,
+        };
+      }
+      if (!job.enabled) {
+        return {
+          content: "Daily briefing is already disabled.",
+          isError: false,
+        };
+      }
+      updateSchedule(job.id, { enabled: false });
+      return {
+        content: "Daily briefing disabled. Use action=enable to resume it.",
+        isError: false,
+      };
+    }
+
+    // action === "enable"
+    const timezone = resolveTimezone(rawTz);
+    const timeStr = rawTime ?? "09:00";
+    const cron = parseCronFromTime(timeStr) ?? BRIEFING_DEFAULT_CRON;
+
+    const existing = findBriefingSchedule();
+    if (existing) {
+      const updated = updateSchedule(existing.id, {
+        enabled: true,
+        expression: cron,
+        cronExpression: cron,
+        timezone,
+      });
+      return {
+        content: `Daily briefing enabled. Delivery: ${timeStr} (${timezone}). Next run: ${new Date(updated!.nextRunAt).toLocaleString()}.`,
+        isError: false,
+      };
+    }
+
+    // Create for the first time
+    const job = createSchedule({
+      name: BRIEFING_SCHEDULE_NAME,
+      syntax: "cron",
+      expression: cron,
+      timezone,
+      message: DAILY_BRIEFING_PROMPT,
+      mode: "execute",
+      enabled: true,
+      createdBy: "agent",
+      reuseConversation: true,
+      quiet: false,
+      maxRetries: 3,
+      retryBackoffMs: 60_000,
+    });
+
+    return {
+      content: `Daily briefing created and enabled. Delivery: ${timeStr} (${timezone}). First run: ${new Date(job.nextRunAt).toLocaleString()}.\n\nThe briefing will pull your recent memory and workspace context each morning, compose a summary, and send it to your active channels.`,
+      isError: false,
+    };
+  },
+} satisfies ToolDefinition;

--- a/assistant/src/tools/briefing/configure.ts
+++ b/assistant/src/tools/briefing/configure.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../../config/loader.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import {
@@ -28,8 +29,20 @@ function parseCronFromTime(time: string): string | null {
   return `${minute} ${hour} * * *`;
 }
 
+/**
+ * Resolve the timezone to use for the briefing schedule.
+ *
+ * Priority:
+ * 1. Explicit `timezone` argument passed by the agent.
+ * 2. `ui.userTimezone` — the timezone the user set in their profile.
+ * 3. `ui.detectedTimezone` — client-reported timezone (set on first login).
+ * 4. System timezone of the host process (last resort; may be UTC in containers).
+ */
 function resolveTimezone(inputTz?: string): string {
   if (inputTz) return inputTz;
+  const cfg = getConfig();
+  const configured = cfg.ui?.userTimezone ?? cfg.ui?.detectedTimezone;
+  if (configured) return configured;
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
@@ -83,7 +96,7 @@ export const dailyBriefingConfigureTool = {
       timezone: {
         type: "string",
         description:
-          'IANA timezone name, e.g. "America/New_York". Defaults to the workspace timezone or the system timezone.',
+          'IANA timezone name, e.g. "America/New_York". Defaults to ui.userTimezone, then ui.detectedTimezone, then system timezone.',
       },
     },
     required: ["action"],
@@ -175,7 +188,17 @@ export const dailyBriefingConfigureTool = {
       };
     }
 
-    // action === "enable"
+    // action === "enable" — validate time before writing anything
+    if (rawTime !== undefined) {
+      const cronCheck = parseCronFromTime(rawTime);
+      if (!cronCheck) {
+        return {
+          content: `Error: invalid time "${rawTime}". Use HH:MM 24-hour format, e.g. "09:00".`,
+          isError: true,
+        };
+      }
+    }
+
     const timezone = resolveTimezone(rawTz);
     const timeStr = rawTime ?? "09:00";
     const cron = parseCronFromTime(timeStr) ?? BRIEFING_DEFAULT_CRON;

--- a/assistant/src/tools/briefing/prompt.ts
+++ b/assistant/src/tools/briefing/prompt.ts
@@ -6,6 +6,11 @@
  * memory context (recent decisions, action items, workspace state) before the
  * agent processes the turn, so the briefing naturally draws on everything the
  * assistant knows about the user's work.
+ *
+ * Delivery: the agent is explicitly instructed to call
+ * `assistant notifications send` via the bash tool so the finished briefing
+ * reaches all active channels (Slack, Telegram, macOS push, etc.) rather than
+ * staying confined to the background conversation history.
  */
 export const DAILY_BRIEFING_PROMPT = `You are composing the user's proactive daily briefing. The memory context injected above contains recent decisions, action items, and workspace state — use it to surface what matters today.
 
@@ -32,7 +37,13 @@ Rules:
 - If memory context is sparse, say so briefly and recommend the user share more context.
 - End with a single encouraging sentence tied to the user's current work.
 
-After composing the briefing, send it as a notification so it reaches the user's active channels (Slack, Telegram, macOS, etc.).`;
+After composing the briefing text, deliver it to the user's active channels by running this bash command (substitute TITLE and BODY with your content — escape any double quotes inside BODY with backslash):
+
+\`\`\`bash
+assistant notifications send --title "Daily Briefing — <DATE>" --message "<BODY>" --source-event-name "briefing.daily"
+\`\`\`
+
+Do not skip this step. The bash call is what routes the briefing to Slack, Telegram, macOS, and other connected channels.`;
 
 /** Canonical name used to identify the briefing schedule in cron_jobs. */
 export const BRIEFING_SCHEDULE_NAME = "Daily Briefing";

--- a/assistant/src/tools/briefing/prompt.ts
+++ b/assistant/src/tools/briefing/prompt.ts
@@ -1,0 +1,41 @@
+/**
+ * Prompt template injected into the daily briefing schedule's `message` field.
+ *
+ * When the scheduler fires this job in "execute" mode, it boots a conversation
+ * with this text as the initial prompt. The agent runtime automatically injects
+ * memory context (recent decisions, action items, workspace state) before the
+ * agent processes the turn, so the briefing naturally draws on everything the
+ * assistant knows about the user's work.
+ */
+export const DAILY_BRIEFING_PROMPT = `You are composing the user's proactive daily briefing. The memory context injected above contains recent decisions, action items, and workspace state — use it to surface what matters today.
+
+Structure the briefing using this format:
+
+**Daily Briefing — {{DATE}}**
+
+**Action Items**
+Unresolved tasks, pending decisions, or commitments due today. Skip if none.
+
+**Progress**
+Notable completions or milestones from the past 24 hours. Skip if none.
+
+**On Your Radar**
+Anything flagged as important, upcoming, or worth watching. Skip if none.
+
+**Suggested Next Steps**
+2–3 concrete actions for today, ranked by impact.
+
+Rules:
+- Replace {{DATE}} with today's date (e.g. "Monday, June 2").
+- Keep each section to 3–5 bullets max. One sentence per bullet.
+- Omit sections that have nothing to report — do not write "Nothing to report."
+- If memory context is sparse, say so briefly and recommend the user share more context.
+- End with a single encouraging sentence tied to the user's current work.
+
+After composing the briefing, send it as a notification so it reaches the user's active channels (Slack, Telegram, macOS, etc.).`;
+
+/** Canonical name used to identify the briefing schedule in cron_jobs. */
+export const BRIEFING_SCHEDULE_NAME = "Daily Briefing";
+
+/** Default cron expression: 9 AM every day. */
+export const BRIEFING_DEFAULT_CRON = "0 9 * * *";

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -12,6 +12,7 @@ import {
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
 import { askQuestionTool } from "./ask-question/ask-question-tool.js";
+import { dailyBriefingConfigureTool } from "./briefing/configure.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
 import { runAuthenticatedCommandTool } from "./credential-execution/run-authenticated-command.js";
@@ -90,6 +91,7 @@ export const explicitTools: ToolDefinition[] = [
   // Always-explicit tools
   rememberTool,
   recallTool,
+  dailyBriefingConfigureTool,
   credentialStoreTool,
   notifyParentTool,
   askQuestionTool,


### PR DESCRIPTION
Adds a daily_briefing_configure tool that lets the assistant set up a recurring morning briefing for the user. When enabled, the scheduler boots a conversation each day, injects memory/workspace context, and the agent composes a structured summary (action items, progress, radar, next steps) delivered to all active channels (Slack, Telegram, macOS, etc.).

- assistant/src/tools/briefing/prompt.ts — DAILY_BRIEFING_PROMPT template and BRIEFING_SCHEDULE_NAME / BRIEFING_DEFAULT_CRON constants
- assistant/src/tools/briefing/configure.ts — daily_briefing_configure tool (guardian-only): actions enable / disable / status / set_time
- tool-manifest.ts — register daily_briefing_configure in explicitTools
- always-loaded-tools-guard — updated from 11 to 12 tools
- 16 tests covering trust guard, all four actions, and edge cases

The briefing is off by default. Users enable it with:
  "Set up my daily briefing at 9am"
and disable it with:
  "Turn off my morning briefing"

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
