### PR TITLE
fix(security): add server-side destructive confirmation to CLI clear route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6242,8 +6242,8 @@ paths:
       operationId: conversations_cli_clear_post
       summary: Clear all conversations (CLI)
       description:
-        Tear down all active conversations and clear the database. The confirmation prompt is handled client-side
-        by the CLI.
+        "Tear down all active conversations and clear the database. Requires X-Confirm-Destructive:
+        clear-all-conversations."
       tags:
         - conversations
       responses:

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -497,6 +497,11 @@ Examples:
 
           const result = await cliIpcCall<{ cleared: number }>(
             "conversations_clear_cli",
+            {
+              headers: {
+                "x-confirm-destructive": "clear-all-conversations",
+              },
+            },
           );
 
           if (!result.ok) return exitFromIpcResult(result);

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -157,8 +157,15 @@ function handleExportCli({ body = {} }: RouteHandlerArgs) {
 // clear (CLI)
 // ---------------------------------------------------------------------------
 
-async function handleClearCli(_args: RouteHandlerArgs) {
-  // Tear down in-memory conversation state before DB clear.
+async function handleClearCli({ headers = {} }: RouteHandlerArgs) {
+  const confirm = headers["x-confirm-destructive"];
+  if (confirm !== "clear-all-conversations") {
+    throw new BadRequestError(
+      "POST /v1/conversations/cli/clear permanently deletes ALL conversations, messages, and memory. " +
+        "To confirm, set header X-Confirm-Destructive: clear-all-conversations",
+    );
+  }
+
   const cleared = await clearAllActive();
   log.info(
     { cleared },
@@ -387,7 +394,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Clear all conversations (CLI)",
     description:
       "Tear down all active conversations and clear the database. " +
-      "The confirmation prompt is handled client-side by the CLI.",
+      "Requires X-Confirm-Destructive: clear-all-conversations.",
     tags: ["conversations"],
     responseBody: z.object({
       cleared: z.number().int(),


### PR DESCRIPTION
## Summary

- Add server-side `X-Confirm-Destructive: clear-all-conversations` header validation to the `handleClearCli` route handler, matching the existing `DELETE /v1/conversations` pattern
- Update the CLI caller to send the confirmation header when invoking the IPC clear method
- Update the route description to document the header requirement

## Original prompt

A Codex security finding flagged the CLI conversation clear route (`POST /v1/conversations/cli/clear`) as missing server-side destructive confirmation. The primary authorization policy gap was already resolved by prior refactoring (#32549, #32675), but the clear handler still relied solely on a client-side CLI prompt — any IPC caller could bypass confirmation. This adds the same `x-confirm-destructive` header check used by the existing bulk delete route as defense-in-depth.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/bcada828f0fc81918bc0f09cb5d3ce1d?q=mcp&sev=critical%2Chigh