### PR TITLE
refactor(web): extract event-bus signal sources into runtime/event-sources/ (LUM-2069)

### DIFF
--- a/apps/web/docs/EVENT_BUS.md
+++ b/apps/web/docs/EVENT_BUS.md
@@ -125,11 +125,59 @@ useEventBusStore.getState().publish("reachability.retry-requested", {});
    `event-bus-store.ts`. Keep the JSDoc on the field — it's how
    consumers learn when the event fires.
 2. Add the producer. SSE-derived events go in `use-event-bus-init.ts`'s
-   SSE effect. DOM-derived events go in its lifecycle effect.
+   SSE effect. Host-environment signals (DOM, Capacitor, Electron)
+   go in a new file under `runtime/event-sources/` — see
+   "Adding a new signal source" below.
 3. Add subscribers where needed via `useBusSubscription` (React) or
    `subscribeBus` (stores / non-React).
 4. Test the producer (publish round-trip in `use-event-bus-init.test.tsx`
    or `event-bus-store.test.ts`) and at least one consumer.
+
+## Adding a new signal source
+
+A *signal source* is the bridge between a host-environment event
+(DOM visibility, `window.online`, Capacitor `appStateChange`, Electron
+`powerMonitor`, deep links) and the bus. Each one lives in its own
+file under `runtime/event-sources/`. The shape is intentionally
+narrow:
+
+```ts
+export function publishMySignalSource(bus: EventBusPublisher): () => void {
+  // ...attach listener, publish via `bus.publish(...)`...
+  return () => {
+    // ...detach listener...
+  };
+}
+```
+
+Rules:
+
+1. **One source per file.** New host-environment signal → new file
+   in `runtime/event-sources/`. Don't add another `if` branch to
+   `useEventBusInit`'s lifecycle effect.
+2. **Accept `EventBusPublisher`, never the full store.** Sources
+   only publish — never subscribe. The `Pick<EventBusActions, "publish">`
+   type keeps the surface narrow and makes the helper trivial to
+   stub with `{ publish: mock() }`.
+3. **No-op off-platform.** If the source is platform-conditioned
+   (Capacitor-only, Electron-only), early-return a no-op
+   unsubscribe. `useEventBusInit` calls every source unconditionally.
+4. **Synchronous return.** Even lazy plugin imports (Capacitor) must
+   return the unsubscribe synchronously — use an internal
+   `cancelled` flag if the listener registration is async.
+   See `capacitor-app-state.ts` for the pattern.
+5. **Colocated unit test.** Test in isolation with a
+   `{ publish: mock() }` stub — don't reach for the integration
+   test in `use-event-bus-init.test.tsx`. The integration test is
+   for SSE-policy behavior, not source wiring.
+6. **Wire it in.** Add a single line to `useEventBusInit`'s Effect 1:
+   ```ts
+   const unsubscribers = [
+     publishVisibilitySource(bus),
+     // ...
+     publishMySignalSource(bus),
+   ];
+   ```
 
 ## Conventions
 

--- a/apps/web/src/hooks/use-event-bus-init.test.tsx
+++ b/apps/web/src/hooks/use-event-bus-init.test.tsx
@@ -48,30 +48,6 @@ mock.module("@/assistant/lifecycle-service", () => ({
   },
 }));
 
-// Capture the deep-link subscription callback so tests can fire
-// "live" links. Allow each test to seed the drain return value.
-type DeepLink =
-  | { kind: "send"; message: string }
-  | { kind: "openThread"; threadId: string }
-  | { kind: "unknown"; url: string };
-let activeDeepLinkCallback: ((link: DeepLink) => void) | null = null;
-let pendingDeepLinksFixture: DeepLink[] = [];
-const subscribeToDeepLinksMock = mock((cb: (link: DeepLink) => void) => {
-  activeDeepLinkCallback = cb;
-  return () => {
-    activeDeepLinkCallback = null;
-  };
-});
-const drainPendingDeepLinksMock = mock(async (): Promise<DeepLink[]> => {
-  const drained = pendingDeepLinksFixture;
-  pendingDeepLinksFixture = [];
-  return drained;
-});
-mock.module("@/runtime/deep-links", () => ({
-  drainPendingDeepLinks: drainPendingDeepLinksMock,
-  subscribeToDeepLinks: subscribeToDeepLinksMock,
-}));
-
 const { useEventBusInit } = await import("@/hooks/use-event-bus-init");
 
 beforeEach(() => {
@@ -80,13 +56,9 @@ beforeEach(() => {
   activeOnError = null;
   activeOnReconnect = null;
   lastSubscribeArgs = null;
-  activeDeepLinkCallback = null;
-  pendingDeepLinksFixture = [];
   cancelMock.mockClear();
   subscribeChatEventsMock.mockClear();
   checkAssistantMock.mockClear();
-  subscribeToDeepLinksMock.mockClear();
-  drainPendingDeepLinksMock.mockClear();
 });
 
 afterEach(() => {
@@ -540,144 +512,7 @@ describe("useEventBusInit — SSE ownership", () => {
   });
 });
 
-describe("useEventBusInit — DOM event sources", () => {
-  test("publishes app.online and app.resume{signal:'online'} on window online", () => {
-    const onlineHandler = mock(() => {});
-    const resumeHandler = mock(() => {});
-    useEventBusStore.getState().subscribe("app.online", onlineHandler);
-    useEventBusStore.getState().subscribe("app.resume", resumeHandler);
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-    window.dispatchEvent(new Event("online"));
-    expect(onlineHandler).toHaveBeenCalledTimes(1);
-    expect(resumeHandler).toHaveBeenCalledWith({ signal: "online" });
-  });
-
-  test("publishes app.offline on window offline", () => {
-    const offlineHandler = mock(() => {});
-    useEventBusStore.getState().subscribe("app.offline", offlineHandler);
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-    window.dispatchEvent(new Event("offline"));
-    expect(offlineHandler).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("useEventBusInit — deep links", () => {
-  test("publishes deeplink.send for live `send` links via the wrapper subscription", () => {
-    const handler = mock(() => {});
-    useEventBusStore.getState().subscribe("deeplink.send", handler);
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    activeDeepLinkCallback?.({ kind: "send", message: "hi" });
-
-    expect(handler).toHaveBeenCalledWith({ message: "hi" });
-  });
-
-  test("publishes deeplink.openThread for live `openThread` links", () => {
-    const handler = mock(() => {});
-    useEventBusStore.getState().subscribe("deeplink.openThread", handler);
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    activeDeepLinkCallback?.({ kind: "openThread", threadId: "abc" });
-
-    expect(handler).toHaveBeenCalledWith({ threadId: "abc" });
-  });
-
-  test("publishes deeplink.unknown for parser-fallback links", () => {
-    const handler = mock(() => {});
-    useEventBusStore.getState().subscribe("deeplink.unknown", handler);
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    activeDeepLinkCallback?.({ kind: "unknown", url: "javascript:alert(1)" });
-
-    expect(handler).toHaveBeenCalledWith({ url: "javascript:alert(1)" });
-  });
-
-  test("drains the pending buffer at mount and publishes each link in order", async () => {
-    const sendHandler = mock(() => {});
-    const threadHandler = mock(() => {});
-    useEventBusStore.getState().subscribe("deeplink.send", sendHandler);
-    useEventBusStore.getState().subscribe("deeplink.openThread", threadHandler);
-    pendingDeepLinksFixture = [
-      { kind: "send", message: "one" },
-      { kind: "openThread", threadId: "thread-1" },
-    ];
-
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    // Drain is awaited; let the microtasks settle.
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(sendHandler).toHaveBeenCalledWith({ message: "one" });
-    expect(threadHandler).toHaveBeenCalledWith({ threadId: "thread-1" });
-  });
-
-  test("subscribes BEFORE draining so a link arriving mid-drain isn't lost", async () => {
-    // Trace the subscribe-before-drain order: `subscribeToDeepLinks`
-    // must be called before `drainPendingDeepLinks` so a link that
-    // lands in the in-flight window between the two calls still
-    // reaches the renderer.
-    renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    expect(subscribeToDeepLinksMock).toHaveBeenCalled();
-    expect(drainPendingDeepLinksMock).toHaveBeenCalled();
-    const subscribeOrder =
-      subscribeToDeepLinksMock.mock.invocationCallOrder[0]!;
-    const drainOrder = drainPendingDeepLinksMock.mock.invocationCallOrder[0]!;
-    expect(subscribeOrder).toBeLessThan(drainOrder);
-  });
-
-  test("unsubscribes on unmount so live links stop firing into the bus", () => {
-    const handler = mock(() => {});
-    useEventBusStore.getState().subscribe("deeplink.send", handler);
-    const { unmount } = renderHook(() =>
-      useEventBusInit({
-        assistantId: null,
-        isAssistantActive: false,
-      }),
-    );
-
-    unmount();
-
-    // After unmount, the captured callback is cleared by the
-    // unsubscribe-noop returned by `subscribeToDeepLinks`. Verify
-    // by attempting to fire — should not deliver.
-    activeDeepLinkCallback?.({ kind: "send", message: "post-unmount" });
-    expect(handler).not.toHaveBeenCalled();
-  });
-});
+// Per-source wiring is covered by colocated unit tests under
+// `runtime/event-sources/`. The integration suite here focuses on
+// SSE-policy interactions (teardown on hidden, dedup windows, cause
+// tagging) — the only thing `useEventBusInit` itself still owns.

--- a/apps/web/src/hooks/use-event-bus-init.ts
+++ b/apps/web/src/hooks/use-event-bus-init.ts
@@ -32,19 +32,16 @@
  */
 import { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
-import type { PluginListenerHandle } from "@capacitor/core";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { subscribeChatEvents } from "@/lib/streaming/stream-transport";
 import type { ChatEventStream } from "@/lib/streaming/stream-transport";
-import {
-  drainPendingDeepLinks,
-  subscribeToDeepLinks,
-  type DeepLink,
-} from "@/runtime/deep-links";
-import { subscribeToPowerEvents } from "@/runtime/power-events";
+import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
+import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
+import { publishElectronDeepLinksSource } from "@/runtime/event-sources/electron-deep-links";
+import { publishElectronPowerSource } from "@/runtime/event-sources/electron-power";
+import { publishWindowOnlineSource } from "@/runtime/event-sources/window-online";
 import { useEventBusStore } from "@/stores/event-bus-store";
-import { isNativePlatform } from "@/runtime/native-auth";
 
 interface UseEventBusInitParams {
   /** Resolved assistant id, or `null` when not yet loaded. */
@@ -60,127 +57,27 @@ export function useEventBusInit({
   isAssistantActive,
 }: UseEventBusInitParams): void {
   // -------------------------------------------------------------------------
-  // Effect 1: DOM + Capacitor lifecycle event sources
+  // Effect 1: signal sources publish into the bus
+  //
+  // Each helper in `runtime/event-sources/` wires one host-environment
+  // event source (DOM visibility, network online/offline, Capacitor
+  // app state, Electron powerMonitor, Electron deep links) and returns
+  // its own unsubscribe. New signal sources land as a new file there,
+  // not as another branch here — see the "Adding a new signal source"
+  // section in `apps/web/docs/EVENT_BUS.md`.
   // -------------------------------------------------------------------------
   useEffect(() => {
     if (typeof window === "undefined") return;
-
     const bus = useEventBusStore.getState();
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        bus.publish("app.hidden", { signal: "visibility" });
-      } else {
-        bus.publish("app.resume", { signal: "visibility" });
-      }
-    };
-    const handleOnline = () => {
-      bus.publish("app.online", {});
-      bus.publish("app.resume", { signal: "online" });
-    };
-    const handleOffline = () => {
-      bus.publish("app.offline", {});
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-
-    let appStateHandle: PluginListenerHandle | null = null;
-    let appStateCancelled = false;
-    if (isNativePlatform()) {
-      import("@capacitor/app")
-        .then(({ App }) =>
-          App.addListener("appStateChange", ({ isActive }) => {
-            if (isActive) {
-              bus.publish("app.resume", { signal: "app_state" });
-            } else {
-              bus.publish("app.hidden", { signal: "app_state" });
-            }
-          }),
-        )
-        .then((registered) => {
-          if (appStateCancelled) {
-            void registered.remove();
-            return;
-          }
-          appStateHandle = registered;
-        })
-        .catch((err) => {
-          Sentry.captureException(err, {
-            level: "warning",
-            tags: { context: "event_bus_capacitor_init" },
-          });
-        });
-    }
-
-    // Electron host: subscribe to `powerMonitor` via the runtime
-    // wrapper. The bridge fans every system-level event in as a
-    // typed bus event. Off Electron the wrapper is a no-op and the
-    // unsubscribe-noop is returned — no effect on web / iOS.
-    const unsubPower = subscribeToPowerEvents(({ kind }) => {
-      switch (kind) {
-        case "suspend":
-          bus.publish("power.suspend", {});
-          break;
-        case "resume":
-          bus.publish("power.resume", {});
-          break;
-        case "lock":
-          bus.publish("power.lock", {});
-          break;
-        case "unlock":
-          bus.publish("power.unlock", {});
-          break;
-        case "active":
-          bus.publish("power.active", {});
-          break;
-      }
-    });
-
-    // Electron host: deep-link bridge. Subscribe-then-drain order
-    // matters — a link arriving between drain completion and
-    // subscription would be lost otherwise. Subscribe first, drain
-    // second; any in-flight link is delivered via `onLink` and the
-    // drained buffer carries the pre-renderer-ready backlog. The
-    // bus delivers handlers in registration order so duplicate
-    // delivery (live link also enqueued in main between subscribe
-    // and drain) is consumer's problem if it ever happens — the
-    // current main-side implementation buffers + broadcasts, so
-    // drain after subscribe sees no duplicates in practice.
-    const publishDeepLink = (link: DeepLink) => {
-      switch (link.kind) {
-        case "send":
-          bus.publish("deeplink.send", { message: link.message });
-          break;
-        case "openThread":
-          bus.publish("deeplink.openThread", { threadId: link.threadId });
-          break;
-        case "unknown":
-          bus.publish("deeplink.unknown", { url: link.url });
-          break;
-      }
-    };
-    const unsubDeepLinks = subscribeToDeepLinks(publishDeepLink);
-    void drainPendingDeepLinks()
-      .then((pending) => {
-        for (const link of pending) publishDeepLink(link);
-      })
-      .catch((err) => {
-        Sentry.captureException(err, {
-          level: "warning",
-          tags: { context: "deep_link_drain" },
-        });
-      });
-
+    const unsubscribers = [
+      publishVisibilitySource(bus),
+      publishWindowOnlineSource(bus),
+      publishCapacitorAppStateSource(bus),
+      publishElectronPowerSource(bus),
+      publishElectronDeepLinksSource(bus),
+    ];
     return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-      appStateCancelled = true;
-      void appStateHandle?.remove();
-      unsubPower();
-      unsubDeepLinks();
+      for (const unsub of unsubscribers) unsub();
     };
   }, []);
 

--- a/apps/web/src/runtime/event-sources/capacitor-app-state.test.ts
+++ b/apps/web/src/runtime/event-sources/capacitor-app-state.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type AppStatePayload = { isActive: boolean };
+type AppStateHandler = (payload: AppStatePayload) => void;
+
+let isNative = true;
+const isNativePlatformMock = mock(() => isNative);
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: isNativePlatformMock,
+}));
+
+let activeHandler: AppStateHandler | null = null;
+const handleRemoveMock = mock(async () => {});
+let addListenerResolver: ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
+let addListenerRejecter: ((err: Error) => void) | null = null;
+let pendingAddListenerPromise: Promise<{ remove: typeof handleRemoveMock }> | null =
+  null;
+
+const addListenerMock = mock(
+  (_event: "appStateChange", handler: AppStateHandler) => {
+    activeHandler = handler;
+    pendingAddListenerPromise = new Promise<{ remove: typeof handleRemoveMock }>(
+      (resolve, reject) => {
+        addListenerResolver = resolve;
+        addListenerRejecter = reject;
+      },
+    );
+    return pendingAddListenerPromise;
+  },
+);
+
+mock.module("@capacitor/app", () => ({
+  App: {
+    addListener: addListenerMock,
+  },
+}));
+
+const captureExceptionMock = mock(() => {});
+mock.module("@sentry/browser", () => ({
+  captureException: captureExceptionMock,
+}));
+
+const { publishCapacitorAppStateSource } = await import(
+  "@/runtime/event-sources/capacitor-app-state"
+);
+import type {
+  BusEventName,
+  BusEventPayload,
+} from "@/stores/event-bus-store";
+
+const makePublisher = () => ({
+  publish: mock(
+    <K extends BusEventName>(_event: K, _payload: BusEventPayload<K>) => {},
+  ),
+});
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
+const resolveAddListener = async () => {
+  // The dynamic `import("@capacitor/app")` and its `.then` chain each
+  // queue a microtask, so the source's `addListenerMock` call lags
+  // synchronous test code. Flush before resolving the pending promise,
+  // then flush again so the `.then` that stores the `handle` runs.
+  await flushMicrotasks();
+  addListenerResolver?.({ remove: handleRemoveMock });
+  await flushMicrotasks();
+};
+
+beforeEach(() => {
+  isNative = true;
+  activeHandler = null;
+  addListenerResolver = null;
+  addListenerRejecter = null;
+  pendingAddListenerPromise = null;
+  isNativePlatformMock.mockClear();
+  addListenerMock.mockClear();
+  handleRemoveMock.mockClear();
+  captureExceptionMock.mockClear();
+});
+
+describe("publishCapacitorAppStateSource", () => {
+  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
+    isNative = false;
+    const bus = makePublisher();
+
+    const unsubscribe = publishCapacitorAppStateSource(bus);
+    unsubscribe();
+
+    expect(addListenerMock).not.toHaveBeenCalled();
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  test("publishes app.resume(signal:'app_state') when isActive flips true", async () => {
+    const bus = makePublisher();
+    publishCapacitorAppStateSource(bus);
+
+    await resolveAddListener();
+    activeHandler!({ isActive: true });
+
+    expect(bus.publish).toHaveBeenCalledWith("app.resume", {
+      signal: "app_state",
+    });
+  });
+
+  test("publishes app.hidden(signal:'app_state') when isActive flips false", async () => {
+    const bus = makePublisher();
+    publishCapacitorAppStateSource(bus);
+
+    await resolveAddListener();
+    activeHandler!({ isActive: false });
+
+    expect(bus.publish).toHaveBeenCalledWith("app.hidden", {
+      signal: "app_state",
+    });
+  });
+
+  test("returned unsubscribe removes the listener once it resolves", async () => {
+    const unsubscribe = publishCapacitorAppStateSource(makePublisher());
+
+    await resolveAddListener();
+    expect(handleRemoveMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
+    const unsubscribe = publishCapacitorAppStateSource(makePublisher());
+
+    // Unsubscribe is called first — internal `cancelled` flag must
+    // catch the late `.then` and remove the listener.
+    unsubscribe();
+    await resolveAddListener();
+
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a lazy-import failure to Sentry instead of throwing", async () => {
+    publishCapacitorAppStateSource(makePublisher());
+
+    await flushMicrotasks();
+    const err = new Error("plugin missing");
+    addListenerRejecter?.(err);
+    await flushMicrotasks();
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(err, {
+      level: "warning",
+      tags: { context: "event_bus_capacitor_init" },
+    });
+  });
+});

--- a/apps/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/apps/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -1,0 +1,62 @@
+import * as Sentry from "@sentry/browser";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { isNativePlatform } from "@/runtime/native-auth";
+import type { EventBusPublisher } from "@/stores/event-bus-store";
+
+/**
+ * Capacitor iOS shell's `App.appStateChange` →
+ * `app.resume(signal: "app_state")` on active, `app.hidden(signal:
+ * "app_state")` on inactive. Off Capacitor iOS the function is a no-op
+ * (`isNativePlatform()` returns false) — web and Electron get their
+ * lifecycle signals from `publishVisibilitySource` / `publishWindowOnlineSource`
+ * / `publishElectronPowerSource` instead.
+ *
+ * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
+ * "lazy-import rule"): Capacitor plugins are Proxy objects whose
+ * `.then` trap hangs an outer `await` indefinitely if the Proxy
+ * crosses a Promise-resolution context. The dynamic import inside
+ * the helper keeps the Proxy out of any async return.
+ *
+ * The sync return + internal `cancelled` flag covers the case where
+ * the caller unsubscribes before the import resolves: we mark
+ * cancelled, the import-resolution path checks it and removes the
+ * just-registered listener.
+ */
+export function publishCapacitorAppStateSource(
+  bus: EventBusPublisher,
+): () => void {
+  if (!isNativePlatform()) return () => undefined;
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  import("@capacitor/app")
+    .then(({ App }) =>
+      App.addListener("appStateChange", ({ isActive }) => {
+        if (isActive) {
+          bus.publish("app.resume", { signal: "app_state" });
+        } else {
+          bus.publish("app.hidden", { signal: "app_state" });
+        }
+      }),
+    )
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err) => {
+      Sentry.captureException(err, {
+        level: "warning",
+        tags: { context: "event_bus_capacitor_init" },
+      });
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+  };
+}

--- a/apps/web/src/runtime/event-sources/dom-visibility.test.ts
+++ b/apps/web/src/runtime/event-sources/dom-visibility.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
+import type {
+  BusEventName,
+  BusEventPayload,
+} from "@/stores/event-bus-store";
+
+const makePublisher = () => ({
+  publish: mock(
+    <K extends BusEventName>(_event: K, _payload: BusEventPayload<K>) => {},
+  ),
+});
+
+const setVisibilityState = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+afterEach(() => {
+  setVisibilityState("visible");
+});
+
+describe("publishVisibilitySource", () => {
+  test("publishes app.hidden(signal:'visibility') when document becomes hidden", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishVisibilitySource(bus);
+
+    setVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(bus.publish).toHaveBeenCalledWith("app.hidden", {
+      signal: "visibility",
+    });
+    unsubscribe();
+  });
+
+  test("publishes app.resume(signal:'visibility') when document becomes visible", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishVisibilitySource(bus);
+
+    setVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(bus.publish).toHaveBeenCalledWith("app.resume", {
+      signal: "visibility",
+    });
+    unsubscribe();
+  });
+
+  test("removes the listener on unsubscribe", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishVisibilitySource(bus);
+    unsubscribe();
+
+    setVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/runtime/event-sources/dom-visibility.ts
+++ b/apps/web/src/runtime/event-sources/dom-visibility.ts
@@ -1,0 +1,32 @@
+import type { EventBusPublisher } from "@/stores/event-bus-store";
+
+/**
+ * `document.visibilitychange` → `app.resume(signal: "visibility")` on
+ * visible, `app.hidden(signal: "visibility")` on hidden. The cross-domain
+ * bus is the consumer; SSE policy (in `useEventBusInit`'s Effect 2)
+ * teardowns on hidden and reopens on resume.
+ *
+ * The Capacitor iOS shell fires `appStateChange` too, which the bus
+ * sees through `publishCapacitorAppStateSource` with `signal: "app_state"`.
+ * Consumers that want to dedup between the two collapse them on their
+ * own — the bus delivers every signal it sees.
+ *
+ * Browser-only; the caller is responsible for not invoking this in an
+ * environment without `document` (SSR / Node). `useEventBusInit` guards
+ * with `typeof window === "undefined"`.
+ */
+export function publishVisibilitySource(
+  bus: EventBusPublisher,
+): () => void {
+  const handler = () => {
+    if (document.visibilityState === "hidden") {
+      bus.publish("app.hidden", { signal: "visibility" });
+    } else {
+      bus.publish("app.resume", { signal: "visibility" });
+    }
+  };
+  document.addEventListener("visibilitychange", handler);
+  return () => {
+    document.removeEventListener("visibilitychange", handler);
+  };
+}

--- a/apps/web/src/runtime/event-sources/electron-deep-links.test.ts
+++ b/apps/web/src/runtime/event-sources/electron-deep-links.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type DeepLink =
+  | { kind: "send"; message: string }
+  | { kind: "openThread"; threadId: string }
+  | { kind: "unknown"; url: string };
+
+let activeCallback: ((link: DeepLink) => void) | null = null;
+let pendingFixture: DeepLink[] = [];
+let drainError: Error | null = null;
+const unsubscribeMock = mock(() => {
+  activeCallback = null;
+});
+const subscribeToDeepLinksMock = mock((cb: (link: DeepLink) => void) => {
+  activeCallback = cb;
+  return unsubscribeMock;
+});
+const drainPendingDeepLinksMock = mock(async (): Promise<DeepLink[]> => {
+  if (drainError) throw drainError;
+  const drained = pendingFixture;
+  pendingFixture = [];
+  return drained;
+});
+
+mock.module("@/runtime/deep-links", () => ({
+  drainPendingDeepLinks: drainPendingDeepLinksMock,
+  subscribeToDeepLinks: subscribeToDeepLinksMock,
+}));
+
+const captureExceptionMock = mock(() => {});
+mock.module("@sentry/browser", () => ({
+  captureException: captureExceptionMock,
+}));
+
+const { publishElectronDeepLinksSource } = await import(
+  "@/runtime/event-sources/electron-deep-links"
+);
+import type {
+  BusEventName,
+  BusEventPayload,
+} from "@/stores/event-bus-store";
+
+const makePublisher = () => ({
+  publish: mock(
+    <K extends BusEventName>(_event: K, _payload: BusEventPayload<K>) => {},
+  ),
+});
+
+beforeEach(() => {
+  activeCallback = null;
+  pendingFixture = [];
+  drainError = null;
+  subscribeToDeepLinksMock.mockClear();
+  drainPendingDeepLinksMock.mockClear();
+  unsubscribeMock.mockClear();
+  captureExceptionMock.mockClear();
+});
+
+describe("publishElectronDeepLinksSource", () => {
+  test("maps each DeepLink kind onto its typed bus event for live links", () => {
+    const bus = makePublisher();
+    publishElectronDeepLinksSource(bus);
+
+    activeCallback!({ kind: "send", message: "hi" });
+    activeCallback!({ kind: "openThread", threadId: "t-1" });
+    activeCallback!({ kind: "unknown", url: "javascript:alert(1)" });
+
+    expect(bus.publish.mock.calls).toEqual([
+      ["deeplink.send", { message: "hi" }],
+      ["deeplink.openThread", { threadId: "t-1" }],
+      ["deeplink.unknown", { url: "javascript:alert(1)" }],
+    ]);
+  });
+
+  test("subscribes BEFORE draining — covers the in-flight race", async () => {
+    publishElectronDeepLinksSource(makePublisher());
+
+    expect(subscribeToDeepLinksMock).toHaveBeenCalled();
+    expect(drainPendingDeepLinksMock).toHaveBeenCalled();
+    const subscribeOrder =
+      subscribeToDeepLinksMock.mock.invocationCallOrder[0]!;
+    const drainOrder = drainPendingDeepLinksMock.mock.invocationCallOrder[0]!;
+    expect(subscribeOrder).toBeLessThan(drainOrder);
+  });
+
+  test("publishes drained links once the drain promise settles", async () => {
+    pendingFixture = [
+      { kind: "send", message: "one" },
+      { kind: "openThread", threadId: "thread-1" },
+    ];
+    const bus = makePublisher();
+
+    publishElectronDeepLinksSource(bus);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(bus.publish.mock.calls).toEqual([
+      ["deeplink.send", { message: "one" }],
+      ["deeplink.openThread", { threadId: "thread-1" }],
+    ]);
+  });
+
+  test("reports a drain failure to Sentry instead of propagating", async () => {
+    drainError = new Error("ipc transport failed");
+    const bus = makePublisher();
+
+    publishElectronDeepLinksSource(bus);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(drainError, {
+      level: "warning",
+      tags: { context: "deep_link_drain" },
+    });
+  });
+
+  test("returns the subscribe-side unsubscribe so cleanup detaches the live bridge", () => {
+    const unsubscribe = publishElectronDeepLinksSource(makePublisher());
+
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+    unsubscribe();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/runtime/event-sources/electron-deep-links.ts
+++ b/apps/web/src/runtime/event-sources/electron-deep-links.ts
@@ -1,0 +1,66 @@
+import * as Sentry from "@sentry/browser";
+
+import {
+  drainPendingDeepLinks,
+  subscribeToDeepLinks,
+  type DeepLink,
+} from "@/runtime/deep-links";
+import type { EventBusPublisher } from "@/stores/event-bus-store";
+
+/**
+ * Electron `vellum://` deep-link bridge → typed bus events:
+ * `deeplink.send { message }` / `deeplink.openThread { threadId }`
+ * / `deeplink.unknown { url }`.
+ *
+ * Two surfaces because deep links can arrive BEFORE the renderer
+ * exists (OS launches the app via a `vellum://` click → `open-url`
+ * fires before `whenReady`):
+ *
+ *   - **Subscribe** for live links via the runtime wrapper.
+ *   - **Drain** the main-side buffer for links that arrived during
+ *     startup (pre-renderer-ready backlog).
+ *
+ * Subscribe-then-drain order is load-bearing: a link landing between
+ * drain completion and subscription would be lost otherwise. The
+ * helper subscribes synchronously and fires the drain in the
+ * background. Duplicate delivery is prevented main-side: pending
+ * buffering only happens when `subscribers.size === 0` at the moment
+ * of arrival (see `apps/macos/src/main/deep-links.ts`). Once a
+ * subscriber is registered, in-flight links go via broadcast only,
+ * and `drainPendingDeepLinks` returns the pre-subscribe backlog.
+ *
+ * Off Electron the wrappers are no-ops and the returned unsubscribe
+ * drops through cleanly.
+ */
+export function publishElectronDeepLinksSource(
+  bus: EventBusPublisher,
+): () => void {
+  const publishDeepLink = (link: DeepLink): void => {
+    switch (link.kind) {
+      case "send":
+        bus.publish("deeplink.send", { message: link.message });
+        break;
+      case "openThread":
+        bus.publish("deeplink.openThread", { threadId: link.threadId });
+        break;
+      case "unknown":
+        bus.publish("deeplink.unknown", { url: link.url });
+        break;
+    }
+  };
+
+  const unsubscribe = subscribeToDeepLinks(publishDeepLink);
+
+  void drainPendingDeepLinks()
+    .then((pending) => {
+      for (const link of pending) publishDeepLink(link);
+    })
+    .catch((err) => {
+      Sentry.captureException(err, {
+        level: "warning",
+        tags: { context: "deep_link_drain" },
+      });
+    });
+
+  return unsubscribe;
+}

--- a/apps/web/src/runtime/event-sources/electron-power.test.ts
+++ b/apps/web/src/runtime/event-sources/electron-power.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type PowerEvent = { kind: "suspend" | "resume" | "lock" | "unlock" | "active" };
+let activeCallback: ((event: PowerEvent) => void) | null = null;
+const unsubscribeMock = mock(() => {
+  activeCallback = null;
+});
+const subscribeToPowerEventsMock = mock(
+  (cb: (event: PowerEvent) => void) => {
+    activeCallback = cb;
+    return unsubscribeMock;
+  },
+);
+
+mock.module("@/runtime/power-events", () => ({
+  subscribeToPowerEvents: subscribeToPowerEventsMock,
+}));
+
+const { publishElectronPowerSource } = await import(
+  "@/runtime/event-sources/electron-power"
+);
+import type {
+  BusEventName,
+  BusEventPayload,
+} from "@/stores/event-bus-store";
+
+const makePublisher = () => ({
+  publish: mock(
+    <K extends BusEventName>(_event: K, _payload: BusEventPayload<K>) => {},
+  ),
+});
+
+beforeEach(() => {
+  activeCallback = null;
+  subscribeToPowerEventsMock.mockClear();
+  unsubscribeMock.mockClear();
+});
+
+describe("publishElectronPowerSource", () => {
+  test("maps every PowerEventKind onto its typed bus event", () => {
+    const bus = makePublisher();
+    publishElectronPowerSource(bus);
+
+    activeCallback!({ kind: "suspend" });
+    activeCallback!({ kind: "resume" });
+    activeCallback!({ kind: "lock" });
+    activeCallback!({ kind: "unlock" });
+    activeCallback!({ kind: "active" });
+
+    expect(bus.publish.mock.calls).toEqual([
+      ["power.suspend", {}],
+      ["power.resume", {}],
+      ["power.lock", {}],
+      ["power.unlock", {}],
+      ["power.active", {}],
+    ]);
+  });
+
+  test("returns the runtime-wrapper unsubscribe so cleanup tears the bridge down", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishElectronPowerSource(bus);
+
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+    unsubscribe();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/runtime/event-sources/electron-power.ts
+++ b/apps/web/src/runtime/event-sources/electron-power.ts
@@ -1,0 +1,37 @@
+import { subscribeToPowerEvents } from "@/runtime/power-events";
+import type { EventBusPublisher } from "@/stores/event-bus-store";
+
+/**
+ * Electron main-process `powerMonitor` → five typed bus events:
+ * `power.suspend` / `power.resume` / `power.lock` / `power.unlock`
+ * / `power.active`. Off Electron the runtime wrapper is a no-op and
+ * the returned unsubscribe-noop drops through cleanly — web / iOS
+ * get their resume signals from `app.resume` instead.
+ *
+ * The renderer wrapper is the platform gate; this helper is just the
+ * narrow mapping from `kind` → typed bus event so consumers don't
+ * have to switch on `kind` themselves.
+ */
+export function publishElectronPowerSource(
+  bus: EventBusPublisher,
+): () => void {
+  return subscribeToPowerEvents(({ kind }) => {
+    switch (kind) {
+      case "suspend":
+        bus.publish("power.suspend", {});
+        break;
+      case "resume":
+        bus.publish("power.resume", {});
+        break;
+      case "lock":
+        bus.publish("power.lock", {});
+        break;
+      case "unlock":
+        bus.publish("power.unlock", {});
+        break;
+      case "active":
+        bus.publish("power.active", {});
+        break;
+    }
+  });
+}

--- a/apps/web/src/runtime/event-sources/window-online.test.ts
+++ b/apps/web/src/runtime/event-sources/window-online.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { publishWindowOnlineSource } from "@/runtime/event-sources/window-online";
+import type {
+  BusEventName,
+  BusEventPayload,
+} from "@/stores/event-bus-store";
+
+const makePublisher = () => ({
+  publish: mock(
+    <K extends BusEventName>(_event: K, _payload: BusEventPayload<K>) => {},
+  ),
+});
+
+describe("publishWindowOnlineSource", () => {
+  test("publishes BOTH app.online and app.resume(signal:'online') on window online", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishWindowOnlineSource(bus);
+
+    window.dispatchEvent(new Event("online"));
+
+    expect(bus.publish).toHaveBeenCalledWith("app.online", {});
+    expect(bus.publish).toHaveBeenCalledWith("app.resume", {
+      signal: "online",
+    });
+    unsubscribe();
+  });
+
+  test("publishes app.offline on window offline (no resume)", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishWindowOnlineSource(bus);
+
+    window.dispatchEvent(new Event("offline"));
+
+    expect(bus.publish).toHaveBeenCalledWith("app.offline", {});
+    const resumeCalls = bus.publish.mock.calls.filter(
+      ([name]) => name === "app.resume",
+    );
+    expect(resumeCalls).toHaveLength(0);
+    unsubscribe();
+  });
+
+  test("removes both listeners on unsubscribe", () => {
+    const bus = makePublisher();
+    const unsubscribe = publishWindowOnlineSource(bus);
+    unsubscribe();
+
+    window.dispatchEvent(new Event("online"));
+    window.dispatchEvent(new Event("offline"));
+
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/runtime/event-sources/window-online.ts
+++ b/apps/web/src/runtime/event-sources/window-online.ts
@@ -1,0 +1,28 @@
+import type { EventBusPublisher } from "@/stores/event-bus-store";
+
+/**
+ * `window.online` / `window.offline` → `app.online` + `app.resume(signal: "online")`
+ * / `app.offline`. The online event publishes BOTH a discrete
+ * `app.online` (for consumers that only care about reachability flips)
+ * AND an `app.resume` (for consumers that want a single "we're back"
+ * channel covering visibility, app-state, and online).
+ *
+ * Browser-only; same SSR guard as `publishVisibilitySource`.
+ */
+export function publishWindowOnlineSource(
+  bus: EventBusPublisher,
+): () => void {
+  const onOnline = () => {
+    bus.publish("app.online", {});
+    bus.publish("app.resume", { signal: "online" });
+  };
+  const onOffline = () => {
+    bus.publish("app.offline", {});
+  };
+  window.addEventListener("online", onOnline);
+  window.addEventListener("offline", onOffline);
+  return () => {
+    window.removeEventListener("online", onOnline);
+    window.removeEventListener("offline", onOffline);
+  };
+}

--- a/apps/web/src/stores/event-bus-store.ts
+++ b/apps/web/src/stores/event-bus-store.ts
@@ -177,6 +177,15 @@ export interface EventBusActions {
 
 export type EventBusStore = EventBusState & EventBusActions;
 
+/**
+ * Narrowed bus surface for signal-source helpers (`runtime/event-sources/`).
+ * Sources only ever publish — they should not subscribe to the bus to
+ * derive their own signals. Pass `EventBusPublisher` instead of the
+ * full store/actions to keep the principle of least authority and to
+ * keep the helpers easy to test with a `{ publish: mock() }` stub.
+ */
+export type EventBusPublisher = Pick<EventBusActions, "publish">;
+
 const useEventBusStoreBase = create<EventBusStore>()(() => ({
   _version: 1,
 


### PR DESCRIPTION
## Summary

`useEventBusInit` was a 337-line file mixing two unrelated concerns: a
signal-source registry (DOM visibility, network online, Capacitor app
state, Electron powerMonitor, Electron deep links) and the SSE-policy
state machine (open/teardown/dedup/cause-tagging). This PR pulls the
signal-source registry out.

Each host-environment signal source now lives in its own file under
`apps/web/src/runtime/event-sources/` and accepts a narrowed
`EventBusPublisher = Pick<EventBusActions, "publish">`. `useEventBusInit`'s
Effect 1 is a 12-line orchestrator that calls each helper and aggregates
the returned unsubscribes.

Effect 2 (SSE policy) is intentionally not extracted in this PR — it's
the only thing left in the hook, and it's genuinely orchestration. A
follow-up will lift it into a non-React `sseService` paralleling
`lifecycleService`.

- `runtime/event-sources/dom-visibility.ts`
- `runtime/event-sources/window-online.ts`
- `runtime/event-sources/capacitor-app-state.ts`
- `runtime/event-sources/electron-power.ts`
- `runtime/event-sources/electron-deep-links.ts`

Each helper has a colocated unit test that exercises the publish
contract with a `{ publish: mock() }` stub.

## Why `runtime/`, not `lib/`?

CONVENTIONS.md is explicit: `lib/` is for third-party SDK wrappers
(Sentry, HeyAPI, allauth), `runtime/` is for host-environment adapters
with no third-party SDK dependency. The five helpers either wrap a
`runtime/*` bridge (`power-events`, `deep-links`) or sit directly on
DOM / `window` APIs — they're runtime-shaped. The one third-party
import (`@capacitor/app`) stays lazy for the original
Proxy-trap-on-await reason and is gated on `isNativePlatform()`.

The initial pass landed in `lib/event-sources/`. The audit caught the
mismatch and this PR has the move applied.

## Audit-framed notes

- The integration suite in `use-event-bus-init.test.tsx` dropped its
  `— DOM event sources` and `— deep links` describe blocks. Those
  cases are fully covered by the colocated unit tests; the
  integration test now focuses on SSE-policy behavior, which is the
  only thing `useEventBusInit` itself still owns.
- `EVENT_BUS.md` gains an `## Adding a new signal source` section
  documenting the helper contract: one file per source, narrow
  publisher type, no-op off platform, synchronous unsubscribe even
  behind lazy imports, colocated unit test.
- The deep-link docstring previously said "delivered via the live
  path AND the drained buffer, but main's `subscriberCount` model
  prevents the duplicate" — the actual main-side model only buffers
  when `subscribers.size === 0` at the moment of arrival, so once a
  subscriber is registered duplicates aren't possible (not just
  "prevented"). Docstring reconciled to match.
- The `Sentry` import in `use-event-bus-init.ts` is still in use
  (SSE-error breadcrumb in Effect 2). No dead imports left after the
  extraction.
- No new `.cross-domain-allowlist.json` entries needed; no barrel
  files; tests colocated.

## File sizes

- `use-event-bus-init.ts`: 337 → 234 lines (Effect 1 collapsed from
  ~120 lines to ~25; Effect 2 untouched).
- Each new helper: 28–66 lines.

## Test plan

- [x] `bun test src/runtime/event-sources/` — 19 unit tests pass.
- [x] `bun test src/hooks/use-event-bus-init.test.tsx` — 26
  remaining integration tests pass (after deleting redundant blocks).
- [x] `bun test src/stores/event-bus-store.test.ts` — passes.
- [x] `bun run typecheck` — no new errors from this PR (206 total,
  matches main).
- [ ] Manual: cold-launch macOS app via `vellum://` URL → renderer
  receives the deep link via the drained-buffer path.
- [ ] Manual: foreground/background the macOS app → SSE bounces on
  `app.hidden` / `app.resume` as before.
- [ ] Manual: sleep/wake the Mac while the renderer stays visible
  (tray-resident) → SSE bounces on `power.resume`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_