### PR TITLE
fix(auth): add settings.write policy to PUT config/llm/profiles route

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -72,7 +72,6 @@ describe("route policy coverage", () => {
     // registry had no entry for these endpoints, so `enforcePolicy`
     // returned allowed). Migration preserves behavior. Triage these
     // and assign real policies in a follow-up PR:
-    //   - PUT  config/llm/profiles/:name
     //   - PATCH/DELETE documents/:id/comments/:commentId
     //   - integrations/a2a/{config,invite/accept}
     //   - integrations/vercel/config
@@ -91,7 +90,6 @@ describe("route policy coverage", () => {
       "playground/seeded-conversations",
       "playground/seeded-conversations/:id",
       // C — pre-existing latent unprotected (follow-up audit owed)
-      "config/llm/profiles/:name",
       "documents/:id/comments/:commentId",
       "integrations/a2a/config",
       "integrations/a2a/invite/accept",

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1230,7 +1230,10 @@ export const ROUTES: RouteDefinition[] = [
     operationId: "config_llm_profiles_replace",
     endpoint: "config/llm/profiles/:name",
     method: "PUT",
-    policy: null,
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
     summary: "Replace an inference profile",
     description:
       "Replace the settings-UI-managed leaves of a single llm.profiles entry while preserving non-UI leaves.",


### PR DESCRIPTION
## Summary

- Add `settings.write` scope requirement and `ACTOR_PRINCIPALS` policy to the `config_llm_profiles_replace` route (PUT `/v1/config/llm/profiles/:name`)
- Previously this route had `policy: null` (unprotected), allowing any authenticated principal with only `settings.read` to replace inference profiles and create provider connections
- Matches the policy pattern used by `config_patch`, `config_set`, `config/embeddings:PUT`, `model:PUT`, and all other config-write routes

Codex finding: https://chatgpt.com/codex/cloud/security/findings/d83fce0a55e48191ac0a05f0bc45c34f

## Original prompt

A Codex security scanner flagged that the PUT route for replacing LLM inference profiles had no authorization policy, allowing a low-privilege JWT (e.g. `settings.read` only) to mutate profiles and create provider connections. The route's `policy: null` was an oversight during the refactoring that moved policies from a side-registry onto inline `RouteDefinition.policy` fields. The fix adds the standard `settings.write` + `ACTOR_PRINCIPALS` policy consistent with all other config-write routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)