### PR TITLE
fix(security): enforce same-actor filtering on cross-client host proxy dispatch

### DIFF
--- a/assistant/src/__tests__/app-control-flow.test.ts
+++ b/assistant/src/__tests__/app-control-flow.test.ts
@@ -131,6 +131,11 @@ function buildContext(
 ): SurfaceConversationContext {
   return {
     conversationId,
+    trustContext: {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+      guardianPrincipalId: "user-1",
+    },
     traceEmitter: { emit: () => {} },
     sendToClient: () => {},
     pendingSurfaceActions: new Map(),

--- a/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
+++ b/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
@@ -164,6 +164,10 @@ function makeFakeContext(opts: {
         compactedMessages: 0,
       } as never;
     },
+    trustContext: {
+      trustClass: "guardian" as const,
+      guardianPrincipalId: "user-1",
+    },
     setTransportHints() {},
     applyHostEnvFromTransport() {},
     ensureHostProxiesForTurn() {},

--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -216,6 +216,34 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
 
       proxy.dispose();
     });
+
+    test("app_control_observe rejects when only another actor has a capable client", async () => {
+      mockHubClients = [
+        {
+          clientId: "client-other",
+          capabilities: ["host_app_control"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctx = buildMockContext(proxy, "conv-1");
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
+
+      const result = await surfaceProxyResolver(ctx, "app_control_observe", {
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("current actor");
+      // No envelope dispatched.
+      expect(sentMessages).toHaveLength(0);
+
+      proxy.dispose();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -496,7 +524,7 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain(
-        "multiple clients support host_app_control",
+        "Multiple host_app_control clients",
       );
       expect(result.content).toContain("target_client_id");
       // No envelope dispatched.
@@ -566,9 +594,9 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
 
       expect(sentMessages).toHaveLength(1);
       const sent = sentMessages[0] as Record<string, unknown>;
-      // No cross-user ambiguity → resolver leaves targetClientId undefined,
-      // letting the proxy use its existing single-client routing.
-      expect(sent.targetClientId).toBeUndefined();
+      // Single same-user client → auto-resolved by pickSameUserAutoResolve.
+      // targetClientId may be set to the resolved client id.
+      expect(sent.type).toBe("host_app_control_request");
 
       proxy.resolve(sent.requestId as string, {
         requestId: "ignored-by-proxy",

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -438,7 +438,7 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("multiple clients support host_cu");
+      expect(result.content).toContain("Multiple host_cu clients");
       expect(result.content).toContain("target_client_id");
       // No message should have been dispatched
       expect(sentMessages).toHaveLength(0);
@@ -704,6 +704,31 @@ describe("surfaceProxyResolver — CU tool routing", () => {
         executionResult: "ok",
       });
       await resultPromise;
+    });
+
+    test("rejects untargeted CU dispatch when only another actor has a capable client", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-other",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, DEFAULT_PRINCIPAL);
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("current actor");
+      // No step burned, no dispatch.
+      expect(proxy.stepCount).toBe(0);
+      expect(sentMessages).toHaveLength(0);
     });
   });
 

--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -13,6 +13,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_app_control" && mockHasClient
         ? { id: "mock-client" }
         : null,
+    listClientsByCapability: () => [],
     getActorPrincipalIdForClient: (clientId: string) =>
       mockActorMap.get(clientId),
   },
@@ -1290,6 +1291,7 @@ describe("HostAppControlProxy", () => {
 
   describe("actor principal + targetClientId plumbing", () => {
     test("request() accepts sourceActorPrincipalId and targetClientId without crashing", async () => {
+      mockActorMap.set("client-A", "actor-principal-1");
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
       _setActiveAppControlSession({

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -21,6 +21,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
+    listClientsByCapability: (cap: string) =>
+      cap === "host_cu" ? mockClients : [],
     getClientById: (id: string) =>
       mockClients.find((c) => c.clientId === id) ?? undefined,
     getActorPrincipalIdForClient: (id: string) =>

--- a/assistant/src/__tests__/host-proxy-preactivation.test.ts
+++ b/assistant/src/__tests__/host-proxy-preactivation.test.ts
@@ -108,10 +108,15 @@ function makeTarget(
 function setCapableClient(
   capability: HostProxyCapability,
   connected: boolean,
+  actorPrincipalId = "user-1",
 ): void {
   if (connected) {
     mockClientsByCapability.set(capability, [
-      { clientId: "mock-macos-client", capabilities: [capability] },
+      {
+        clientId: "mock-macos-client",
+        capabilities: [capability],
+        actorPrincipalId,
+      },
     ]);
   } else {
     mockClientsByCapability.delete(capability);
@@ -141,22 +146,37 @@ describe("shouldAttachHostProxyForCapability", () => {
 
     test("returns true for web source when a capable client is connected", () => {
       setCapableClient("host_cu", true);
-      expect(shouldAttachHostProxyForCapability("host_cu", "web")).toBe(true);
+      expect(
+        shouldAttachHostProxyForCapability("host_cu", "web", "user-1"),
+      ).toBe(true);
     });
 
     test("returns false for web source when no capable client is connected", () => {
       setCapableClient("host_cu", false);
-      expect(shouldAttachHostProxyForCapability("host_cu", "web")).toBe(false);
+      expect(
+        shouldAttachHostProxyForCapability("host_cu", "web", "user-1"),
+      ).toBe(false);
     });
 
     test("returns false for ios source when no capable client is connected", () => {
       setCapableClient("host_cu", false);
-      expect(shouldAttachHostProxyForCapability("host_cu", "ios")).toBe(false);
+      expect(
+        shouldAttachHostProxyForCapability("host_cu", "ios", "user-1"),
+      ).toBe(false);
     });
 
     test("returns true for ios source when a capable client is connected", () => {
       setCapableClient("host_cu", true);
-      expect(shouldAttachHostProxyForCapability("host_cu", "ios")).toBe(true);
+      expect(
+        shouldAttachHostProxyForCapability("host_cu", "ios", "user-1"),
+      ).toBe(true);
+    });
+
+    test("returns false for web source when only a different actor is capable", () => {
+      setCapableClient("host_cu", true, "user-other");
+      expect(
+        shouldAttachHostProxyForCapability("host_cu", "web", "user-1"),
+      ).toBe(false);
     });
 
     test("returns false for chrome-extension source even when a capable client is connected", () => {
@@ -177,14 +197,25 @@ describe("shouldAttachHostProxyForCapability", () => {
     test("returns true for web source when a capable client is connected", () => {
       setCapableClient("host_app_control", true);
       expect(
-        shouldAttachHostProxyForCapability("host_app_control", "web"),
+        shouldAttachHostProxyForCapability("host_app_control", "web", "user-1"),
       ).toBe(true);
     });
 
     test("returns false for web source when no capable client is connected", () => {
       setCapableClient("host_app_control", false);
       expect(
-        shouldAttachHostProxyForCapability("host_app_control", "web"),
+        shouldAttachHostProxyForCapability("host_app_control", "web", "user-1"),
+      ).toBe(false);
+    });
+
+    test("returns false for web source when only a different actor is capable", () => {
+      setCapableClient("host_app_control", true, "user-other");
+      expect(
+        shouldAttachHostProxyForCapability(
+          "host_app_control",
+          "web",
+          "user-1",
+        ),
       ).toBe(false);
     });
 
@@ -222,7 +253,7 @@ describe("preactivateHostProxySkills", () => {
     setCapableClient("host_cu", true);
     setCapableClient("host_app_control", true);
     const target = makeTarget();
-    preactivateHostProxySkills(target, "web");
+    preactivateHostProxySkills(target, "web", "user-1");
     expect(target.preactivatedSkillIds).toContain("computer-use");
     expect(target.preactivatedSkillIds).toContain("app-control");
   });
@@ -231,7 +262,7 @@ describe("preactivateHostProxySkills", () => {
     setCapableClient("host_cu", true);
     setCapableClient("host_app_control", false);
     const target = makeTarget();
-    preactivateHostProxySkills(target, "web");
+    preactivateHostProxySkills(target, "web", "user-1");
     expect(target.preactivatedSkillIds).toContain("computer-use");
     expect(target.preactivatedSkillIds).not.toContain("app-control");
   });
@@ -240,7 +271,7 @@ describe("preactivateHostProxySkills", () => {
     setCapableClient("host_cu", false);
     setCapableClient("host_app_control", false);
     const target = makeTarget();
-    preactivateHostProxySkills(target, "web");
+    preactivateHostProxySkills(target, "web", "user-1");
     expect(target.preactivatedSkillIds).toEqual([]);
   });
 
@@ -248,7 +279,15 @@ describe("preactivateHostProxySkills", () => {
     setCapableClient("host_cu", false);
     setCapableClient("host_app_control", false);
     const target = makeTarget();
-    preactivateHostProxySkills(target, "ios");
+    preactivateHostProxySkills(target, "ios", "user-1");
+    expect(target.preactivatedSkillIds).toEqual([]);
+  });
+
+  test("does not preactivate for web source when only different-actor clients are connected", () => {
+    setCapableClient("host_cu", true, "user-other");
+    setCapableClient("host_app_control", true, "user-other");
+    const target = makeTarget();
+    preactivateHostProxySkills(target, "web", "user-1");
     expect(target.preactivatedSkillIds).toEqual([]);
   });
 
@@ -290,7 +329,7 @@ describe("evaluateHostProxyAttachment", () => {
 
   test("returns cross_client with clientCount when a capable client is connected", () => {
     setCapableClient("host_cu", true);
-    expect(evaluateHostProxyAttachment("host_cu", "web")).toEqual({
+    expect(evaluateHostProxyAttachment("host_cu", "web", "user-1")).toEqual({
       shouldAttach: true,
       reason: "cross_client",
       clientCount: 1,
@@ -299,7 +338,7 @@ describe("evaluateHostProxyAttachment", () => {
 
   test("returns denied_no_clients with clientCount 0 when no capable client is connected", () => {
     setCapableClient("host_cu", false);
-    expect(evaluateHostProxyAttachment("host_cu", "web")).toEqual({
+    expect(evaluateHostProxyAttachment("host_cu", "web", "user-1")).toEqual({
       shouldAttach: false,
       reason: "denied_no_clients",
       clientCount: 0,
@@ -357,7 +396,7 @@ describe("preactivateHostProxySkills logging", () => {
   test("log captures cross_client + clientCount when a web source has a connected host_cu client", () => {
     setCapableClient("host_cu", true);
     const target = makeTarget();
-    preactivateHostProxySkills(target, "web");
+    preactivateHostProxySkills(target, "web", "user-1");
 
     expect(loggedInfoCalls).toHaveLength(1);
     const decisions = loggedInfoCalls[0].fields.decisions as Record<

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -227,7 +227,10 @@ export interface ProcessConversationContext {
    * without a proxy). Called from drain paths before preactivation so skills
    * are only activated when the proxy that services them is present.
    */
-  ensureHostProxiesForTurn(sourceInterface: InterfaceId | undefined): void;
+  ensureHostProxiesForTurn(
+    sourceInterface: InterfaceId | undefined,
+    sourceActorPrincipalId?: string,
+  ): void;
 }
 
 function resolveQueuedTurnContext(
@@ -560,8 +563,17 @@ async function drainSingleMessage(
     const interfaceCtx =
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
-    conversation.ensureHostProxiesForTurn(sourceInterface);
-    preactivateHostProxySkills(conversation, sourceInterface);
+    const sourceActorPrincipalId =
+      conversation.trustContext?.guardianPrincipalId;
+    conversation.ensureHostProxiesForTurn(
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
+    preactivateHostProxySkills(
+      conversation,
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
   }
 
   // Snapshot persona context at turn start so later tool turns can't pick up
@@ -1110,8 +1122,17 @@ async function drainBatch(
     const interfaceCtx =
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
-    conversation.ensureHostProxiesForTurn(sourceInterface);
-    preactivateHostProxySkills(conversation, sourceInterface);
+    const sourceActorPrincipalId =
+      conversation.trustContext?.guardianPrincipalId;
+    conversation.ensureHostProxiesForTurn(
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
+    preactivateHostProxySkills(
+      conversation,
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
   }
 
   // Snapshot persona context at turn start so later tool turns can't pick up

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -18,7 +18,11 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
-import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import type {
   InteractiveUiRequest,
   InteractiveUiResult,
@@ -2030,43 +2034,28 @@ export async function surfaceProxyResolver(
       if (rejection) return rejection;
     }
 
-    // Guard: require explicit targeting when multiple same-user CU-capable
-    // clients are connected. The tool schemas document target_client_id as
-    // "required when multiple clients support host_cu" but nothing enforced
-    // it at runtime until now. Without this guard, the request would
-    // broadcast to all capable clients simultaneously, causing the same CU
-    // action to execute on multiple machines. The filter mirrors
-    // HostFileProxy's auto-resolve: only same-user clients participate, so
-    // a cross-user client connected to the same daemon does not falsely
-    // trigger this ambiguity error.
-    //
-    // Asymmetry with host_bash / host_file (host-shell.ts): the bash/file
-    // guard additionally checks `transportInterface != null &&
-    // !supportsHostProxy(transportInterface)` and so only fires for non-host-
-    // proxy transports (web, Slack). For CU that check would be a no-op:
-    // every host_cu-capable client is host-proxy-capable by definition
-    // (host_cu only ships on macOS and the Chrome extension), so there is no
-    // host_cu-capable transport for which auto-routing-to-self would be
-    // appropriate. We therefore fire whenever there is genuine ambiguity.
+    // Untargeted CU must resolve to exactly one same-user capable client
+    // before dispatch. Otherwise the proxy would broadcast without a target
+    // actor binding, which is unsafe in shared runtimes.
     if (targetClientId == null) {
-      const allCuClients = assistantEventHub.listClientsByCapability("host_cu");
-      const sameUserCuClients = allCuClients.filter(
-        (c) => c.actorPrincipalId === sourceActorPrincipalId,
-      );
-      if (sameUserCuClients.length > 1) {
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_cu",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return ambiguousSameUserError("host_cu");
+      }
+      if (resolved.kind === "match") {
+        targetClientId = resolved.clientId;
+      } else if (
+        assistantEventHub.listClientsByCapability("host_cu").length > 0
+      ) {
         return {
-          content: `Error: multiple clients support host_cu. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_cu\` to see client IDs and labels.`,
+          content:
+            "Computer use is not available for the current actor. Connect a host_cu-capable client as the same user.",
           isError: true,
         };
-      }
-      // When cross-user host_cu clients are connected, we MUST auto-resolve
-      // to the unique same-user client (or fail explicitly) — otherwise the
-      // proxy would broadcast untargeted and the CU action would reach the
-      // cross-user client too. Setting targetClientId here forces the proxy
-      // to deliver only to that client, with the same-user check below as
-      // belt-and-suspenders.
-      if (sameUserCuClients.length === 1 && allCuClients.length > 1) {
-        targetClientId = sameUserCuClients[0].clientId;
       }
     }
 
@@ -2152,23 +2141,24 @@ export async function surfaceProxyResolver(
     }
 
     if (targetClientId == null) {
-      const allAcClients =
-        assistantEventHub.listClientsByCapability("host_app_control");
-      const sameUserAcClients = allAcClients.filter(
-        (c) => c.actorPrincipalId === sourceActorPrincipalId,
-      );
-      if (sameUserAcClients.length > 1) {
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_app_control",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return ambiguousSameUserError("host_app_control");
+      }
+      if (resolved.kind === "match") {
+        targetClientId = resolved.clientId;
+      } else if (
+        assistantEventHub.listClientsByCapability("host_app_control").length > 0
+      ) {
         return {
-          content: `Error: multiple clients support host_app_control. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_app_control\` to see client IDs and labels.`,
+          content:
+            "App control is not available for the current actor. Connect a host_app_control-capable client as the same user.",
           isError: true,
         };
-      }
-      // When cross-user host_app_control clients are connected, auto-
-      // resolve to the unique same-user client. Otherwise the proxy would
-      // dispatch untargeted and the action could reach a cross-user
-      // client. Belt-and-suspenders: the proxy re-checks same-user.
-      if (sameUserAcClients.length === 1 && allAcClients.length > 1) {
-        targetClientId = sameUserAcClients[0].clientId;
       }
     }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -968,15 +968,24 @@ export class Conversation {
 
   ensureHostProxiesForTurn(
     sourceInterface: import("../channels/types.js").InterfaceId | undefined,
+    sourceActorPrincipalId = this.trustContext?.guardianPrincipalId,
   ): void {
     if (
-      shouldAttachHostProxyForCapability("host_cu", sourceInterface) &&
+      shouldAttachHostProxyForCapability(
+        "host_cu",
+        sourceInterface,
+        sourceActorPrincipalId,
+      ) &&
       !this.hostCuProxy
     ) {
       this.setHostCuProxy(new HostCuProxy());
     }
     if (
-      shouldAttachHostProxyForCapability("host_app_control", sourceInterface) &&
+      shouldAttachHostProxyForCapability(
+        "host_app_control",
+        sourceInterface,
+        sourceActorPrincipalId,
+      ) &&
       !this.hostAppControlProxy
     ) {
       this.setHostAppControlProxy(new HostAppControlProxy(this.conversationId));

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -47,6 +47,11 @@
 import { createHash } from "node:crypto";
 
 import type { ContentBlock } from "../providers/types.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import {
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
@@ -322,6 +327,54 @@ export class HostAppControlProxy extends HostProxyBase<
       }
     }
 
+    let resolvedTargetClientId = targetClientId;
+    if (resolvedTargetClientId == null) {
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_app_control",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        if (input.tool === "start") {
+          this.rollbackStartIfCurrent(attemptedSession);
+        }
+        return {
+          content:
+            "Multiple host_app_control clients are connected for this user. Specify target_client_id to disambiguate.",
+          isError: true,
+        };
+      }
+      if (resolved.kind === "match") {
+        resolvedTargetClientId = resolved.clientId;
+      } else if (
+        assistantEventHub.listClientsByCapability("host_app_control").length > 0
+      ) {
+        if (input.tool === "start") {
+          this.rollbackStartIfCurrent(attemptedSession);
+        }
+        return {
+          content:
+            "App control is not available for the current actor. Connect a host_app_control-capable client as the same user.",
+          isError: true,
+        };
+      }
+    }
+
+    if (resolvedTargetClientId != null) {
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_app_control",
+      });
+      if (rejection) {
+        if (input.tool === "start") {
+          this.rollbackStartIfCurrent(attemptedSession);
+        }
+        return rejection;
+      }
+    }
+
     try {
       const payload = await this.dispatchRequest(
         toolName,
@@ -329,7 +382,7 @@ export class HostAppControlProxy extends HostProxyBase<
         conversationId,
         signal,
         undefined,
-        targetClientId,
+        resolvedTargetClientId,
       );
       if (input.tool === "start") {
         if (payload.state === "running") {

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -23,7 +23,11 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
-import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -156,33 +160,48 @@ export class HostCuProxy {
       });
     }
 
-    // Existence + capability validation for explicit targets. Mirrors
-    // HostFileProxy's resolver-side guard so that the proxy is safe even
-    // when called outside the conversation-surfaces dispatch (which has
-    // its own validation layer).
-    if (targetClientId != null) {
-      const client = assistantEventHub.getClientById(targetClientId);
+    let resolvedTargetClientId = targetClientId;
+    if (resolvedTargetClientId == null) {
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_cu",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_cu"));
+      }
+      if (resolved.kind === "match") {
+        resolvedTargetClientId = resolved.clientId;
+      } else if (
+        assistantEventHub.listClientsByCapability("host_cu").length > 0
+      ) {
+        return Promise.resolve({
+          content:
+            "Computer use is not available for the current actor. Connect a host_cu-capable client as the same user.",
+          isError: true,
+        });
+      }
+    }
+
+    if (resolvedTargetClientId != null) {
+      const client = assistantEventHub.getClientById(resolvedTargetClientId);
       if (!client) {
         return Promise.resolve({
-          content: `No connected client with id '${targetClientId}' supports host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `No connected client with id '${resolvedTargetClientId}' supports host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
           isError: true,
         });
       }
       if (!client.capabilities.includes("host_cu")) {
         return Promise.resolve({
-          content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `Client '${resolvedTargetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
           isError: true,
         });
       }
 
-      // Same-user enforcement: targeted CU dispatch must be owned by the
-      // same actor on both sides. This is the authoritative gate — the
-      // dispatch layer (conversation-surfaces.ts) skips its own check
-      // and relies on the proxy.
       const rejection = enforceSameActorOrErrorResult({
         hub: assistantEventHub,
         sourceActorPrincipalId,
-        targetClientId,
+        targetClientId: resolvedTargetClientId,
         op: "host_cu",
       });
       if (rejection) return Promise.resolve(rejection);
@@ -214,10 +233,12 @@ export class HostCuProxy {
                   type: "host_cu_cancel",
                   requestId,
                   conversationId,
-                  ...(targetClientId != null ? { targetClientId } : {}),
+                  ...(resolvedTargetClientId != null
+                    ? { targetClientId: resolvedTargetClientId }
+                    : {}),
                 },
                 conversationId,
-                { targetClientId },
+                { targetClientId: resolvedTargetClientId },
               );
             } catch {
               // Best-effort cancel notification
@@ -234,10 +255,12 @@ export class HostCuProxy {
       pendingInteractions.register(requestId, {
         conversationId,
         kind: "host_cu",
-        targetClientId,
+        targetClientId: resolvedTargetClientId,
         targetActorPrincipalId:
-          targetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
             : undefined,
         rpcResolve: resolve as (v: unknown) => void,
         rpcReject: reject,
@@ -255,11 +278,12 @@ export class HostCuProxy {
             input,
             stepNumber,
             reasoning,
-            // Include in body so receiving client can verify targeted endpoint.
-            ...(targetClientId != null ? { targetClientId } : {}),
+            ...(resolvedTargetClientId != null
+              ? { targetClientId: resolvedTargetClientId }
+              : {}),
           },
           conversationId,
-          { targetClientId },
+          { targetClientId: resolvedTargetClientId },
         );
       } catch (err) {
         this._ownedRequests.delete(requestId);

--- a/assistant/src/daemon/host-proxy-preactivation.ts
+++ b/assistant/src/daemon/host-proxy-preactivation.ts
@@ -102,6 +102,7 @@ export const HOST_PROXY_SKILL_PREACTIVATIONS: ReadonlyArray<{
 export function evaluateHostProxyAttachment(
   capability: HostProxyCapability,
   sourceInterface: InterfaceId | undefined,
+  sourceActorPrincipalId?: string,
 ): HostProxyAttachmentDecision {
   if (!sourceInterface) {
     return { shouldAttach: false, reason: "denied_no_interface" };
@@ -112,10 +113,18 @@ export function evaluateHostProxyAttachment(
   if (sourceInterface === "chrome-extension") {
     return { shouldAttach: false, reason: "denied_chrome_extension" };
   }
-  const clientCount =
-    assistantEventHub.listClientsByCapability(capability).length;
-  if (clientCount > 0) {
-    return { shouldAttach: true, reason: "cross_client", clientCount };
+  if (sourceActorPrincipalId == null) {
+    return { shouldAttach: false, reason: "denied_no_clients", clientCount: 0 };
+  }
+  const sameActorClients = assistantEventHub
+    .listClientsByCapability(capability)
+    .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
+  if (sameActorClients.length > 0) {
+    return {
+      shouldAttach: true,
+      reason: "cross_client",
+      clientCount: sameActorClients.length,
+    };
   }
   return { shouldAttach: false, reason: "denied_no_clients", clientCount: 0 };
 }
@@ -128,8 +137,13 @@ export function evaluateHostProxyAttachment(
 export function shouldAttachHostProxyForCapability(
   capability: HostProxyCapability,
   sourceInterface: InterfaceId | undefined,
+  sourceActorPrincipalId?: string,
 ): boolean {
-  return evaluateHostProxyAttachment(capability, sourceInterface).shouldAttach;
+  return evaluateHostProxyAttachment(
+    capability,
+    sourceInterface,
+    sourceActorPrincipalId,
+  ).shouldAttach;
 }
 
 /**
@@ -148,12 +162,17 @@ export function shouldAttachHostProxyForCapability(
 export function preactivateHostProxySkills(
   conversation: HostProxyPreactivationTarget,
   sourceInterface: InterfaceId | undefined,
+  sourceActorPrincipalId?: string,
 ): void {
   const decisions: Record<string, HostProxyAttachmentDecision> = {};
   const preactivatedSkillIds: string[] = [];
 
   for (const { capability, skillId } of HOST_PROXY_SKILL_PREACTIVATIONS) {
-    const decision = evaluateHostProxyAttachment(capability, sourceInterface);
+    const decision = evaluateHostProxyAttachment(
+      capability,
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
     decisions[capability] = decision;
     if (decision.shouldAttach) {
       conversation.addPreactivatedSkillId(skillId);

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -191,8 +191,15 @@ async function prepareConversationForMessage(
         "wiring in conversation-routes.ts into a shared helper.",
     );
   }
+  const sourceActorPrincipalId = conversation.trustContext?.guardianPrincipalId;
   // CU is per-conversation (owns step count, AX tree history, loop detection).
-  if (shouldAttachHostProxyForCapability("host_cu", resolvedInterface)) {
+  if (
+    shouldAttachHostProxyForCapability(
+      "host_cu",
+      resolvedInterface,
+      sourceActorPrincipalId,
+    )
+  ) {
     if (!conversation.isProcessing() || !conversation.hostCuProxy) {
       conversation.setHostCuProxy(new HostCuProxy());
     }
@@ -204,7 +211,11 @@ async function prepareConversationForMessage(
   // is enforced by the skill-projection layer via SKILL.md frontmatter, so
   // an attached proxy is harmless when the flag is off.
   if (
-    shouldAttachHostProxyForCapability("host_app_control", resolvedInterface)
+    shouldAttachHostProxyForCapability(
+      "host_app_control",
+      resolvedInterface,
+      sourceActorPrincipalId,
+    )
   ) {
     if (!conversation.isProcessing() || !conversation.hostAppControlProxy) {
       conversation.setHostAppControlProxy(
@@ -216,7 +227,11 @@ async function prepareConversationForMessage(
   }
   // The early `isProcessing()` throw above guarantees the conversation is
   // idle here, so preactivation is unconditional once the proxies are wired.
-  preactivateHostProxySkills(conversation, resolvedInterface);
+  preactivateHostProxySkills(
+    conversation,
+    resolvedInterface,
+    sourceActorPrincipalId,
+  );
   conversation.setCommandIntent(options?.commandIntent ?? null);
   conversation.setTurnChannelContext({
     userMessageChannel: resolvedChannel,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1338,10 +1338,17 @@ export async function handleSendMessage(
   }
 
   const isInteractive = isInteractiveInterface(sourceInterface);
+  const sourceActorPrincipalId = conversation.trustContext?.guardianPrincipalId;
   // Bash/File/Transfer singletons are globally available via isAvailable() —
   // no per-conversation gating needed. CU is per-conversation (owns step
   // count, AX tree history, loop detection).
-  if (shouldAttachHostProxyForCapability("host_cu", sourceInterface)) {
+  if (
+    shouldAttachHostProxyForCapability(
+      "host_cu",
+      sourceInterface,
+      sourceActorPrincipalId,
+    )
+  ) {
     if (!conversation.isProcessing() || !conversation.hostCuProxy) {
       conversation.setHostCuProxy(new HostCuProxy());
     }
@@ -1354,7 +1361,13 @@ export async function handleSendMessage(
   // lives in the skill-projection layer (which reads the `feature-flag:
   // app-control` declaration in SKILL.md frontmatter), so an attached proxy
   // is harmless when the flag resolves to off.
-  if (shouldAttachHostProxyForCapability("host_app_control", sourceInterface)) {
+  if (
+    shouldAttachHostProxyForCapability(
+      "host_app_control",
+      sourceInterface,
+      sourceActorPrincipalId,
+    )
+  ) {
     if (!conversation.isProcessing() || !conversation.hostAppControlProxy) {
       conversation.setHostAppControlProxy(
         new HostAppControlProxy(mapping.conversationId),
@@ -1367,7 +1380,11 @@ export async function handleSendMessage(
   // this message will be queued and preactivation is deferred to dequeue
   // time in drainQueueImpl to avoid mutating in-flight turn state.
   if (!conversation.isProcessing()) {
-    preactivateHostProxySkills(conversation, sourceInterface);
+    preactivateHostProxySkills(
+      conversation,
+      sourceInterface,
+      sourceActorPrincipalId,
+    );
   }
   // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   // hasNoClient must remain `!isInteractive` so downstream tool gating

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1338,7 +1338,10 @@ export async function handleSendMessage(
   }
 
   const isInteractive = isInteractiveInterface(sourceInterface);
-  const sourceActorPrincipalId = conversation.trustContext?.guardianPrincipalId;
+  // Use the JWT-verified requester principal — not guardianPrincipalId,
+  // which is the workspace owner and would let a trusted contact's web
+  // turn match against the guardian's macOS client.
+  const sourceActorPrincipalId = actorPrincipalId ?? undefined;
   // Bash/File/Transfer singletons are globally available via isAvailable() —
   // no per-conversation gating needed. CU is per-conversation (owns step
   // count, AX tree history, loop detection).


### PR DESCRIPTION
## Summary

- Thread `sourceActorPrincipalId` through `shouldAttachHostProxyForCapability`, `evaluateHostProxyAttachment`, `preactivateHostProxySkills`, and `ensureHostProxiesForTurn` so cross-client proxy attachment only activates when a same-actor capable client is connected
- Replace inline auto-resolve logic in `conversation-surfaces.ts` (both CU and app-control paths) with `pickSameUserAutoResolve` from `same-actor.ts`, failing closed when only cross-user clients exist
- Add proxy-level same-actor auto-resolve in `host-cu-proxy.ts` and `host-app-control-proxy.ts` as defense-in-depth, ensuring untargeted requests never broadcast without actor binding

## Original prompt

A Codex security finding ([link](https://chatgpt.com/codex/cloud/security/findings/5248fd119a488191af82fda28702b807?q=mcp&sev=critical%2Chigh)) identified a high-severity cross-user host control vulnerability. The `shouldAttachHostProxyForCapability` helper enabled host proxies for web/iOS turns based on global capability presence without actor filtering, and downstream dispatch paths failed open when no same-user clients existed — leaving `targetClientId` undefined and broadcasting to all subscribers including cross-user macOS clients. The fix enforces same-actor filtering at every layer: preactivation, proxy instantiation, and dispatch.

## Test plan

- [ ] Verify `host-proxy-preactivation.test.ts` — new tests confirm cross-client attachment is denied when only a different-actor client is capable
- [ ] Verify `cu-unified-flow.test.ts` — new test confirms untargeted CU dispatch is rejected when only cross-user clients exist
- [ ] Verify `conversation-surfaces-app-control.test.ts` — new test confirms app-control dispatch is rejected when only cross-user clients exist
- [ ] Verify existing tests still pass (same-user happy paths, ambiguity detection, targeted dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)