### PR TITLE
fix(chat): tighten transcript message spacing to 8pt (VSpacing.sm)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -337,7 +337,7 @@ struct MessageListContentView: View, Equatable {
         // during any item insertion, which measures ALL children via sizeThatFits —
         // causing multi-minute hangs on long conversations. Do NOT remove the
         // .transaction modifier or wrap content mutations in withAnimation.
-        MessageTranscriptStack(spacing: VSpacing.md) {
+        MessageTranscriptStack(spacing: VSpacing.sm) {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage


### PR DESCRIPTION
## Summary
- Reduce the transcript LazyVStack inter-message gap from VSpacing.md (12pt) to VSpacing.sm (8pt) so consecutive messages (notably a user message and the following assistant reply) sit closer together, per Figma design feedback.

Part of plan: tighten-message-spacing.md (PR 1 of 1)