### PR TITLE
fix(web): match Figma divider/remove spacing on file-attachment chip

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
@@ -102,7 +102,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
         </span>
       </div>
       {onRemove ? (
-        <>
+        <div className="flex shrink-0 items-center gap-2">
           <div className="h-8 w-px shrink-0 bg-[var(--border-disabled)]" />
           <Button
             variant="ghost"
@@ -114,7 +114,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
             }}
             aria-label={`Remove ${filename}`}
           />
-        </>
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary
- Wrap the file-attachment chip's divider and remove button in an 8px (gap-2) group so the divider-to-× spacing matches Figma node 4499-117763 (was 12px)
- Remove Button is untouched; text-to-divider gap stays 12px

Part of plan: file-attachment-chip-mock.md (PR 1 of 1)