### PR TITLE
fix(ci): split privileged web deploy from untrusted build

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -120,16 +120,25 @@ jobs:
           done
 
   # ── CD: build + publish the SPA to each environment's GCS bucket ──────────
-  # Runs only after every CI check passes (a `needs` dependency on a failed job
-  # skips this job automatically). One matrix leg per GitHub environment, all in
-  # parallel (fail-fast: false). Each leg builds under its own `environment:` so
-  # the env-scoped secrets and variables resolve to that environment.
-  # `production` gates here if it has required reviewers.
-  deploy:
-    name: Deploy SPA (${{ matrix.environment }})
+  # Split into two jobs so the privileged publish never shares a runner with
+  # repository/dependency-controlled build code. `build-and-package` runs the
+  # untrusted build (bun install/postinstall, openapi-ts, vite build) with NO
+  # cloud credentials and uploads the resulting `dist/` as an artifact. `deploy`
+  # then downloads that artifact into a fresh runner that holds the `id-token`
+  # OIDC permission and authenticates to GCP — so build code can no longer plant
+  # a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
+  # in the post-auth publish step and exfiltrate the short-lived GCP credentials.
+  #
+  # Both jobs run one matrix leg per GitHub environment (fail-fast: false) under
+  # their own `environment:` so the env-scoped secrets and variables resolve to
+  # that environment. `production` gates at `build-and-package` if it has
+  # required reviewers; `deploy` then inherits the gate via `needs`.
+  build-and-package:
+    name: Build SPA (${{ matrix.environment }})
     needs: [checks]
-    # workflow_dispatch has no branch filter, so guard `deploy` step explicitly to
-    # prevent accidental dispatch from feature branch.
+    # workflow_dispatch has no branch filter, so guard the CD chain explicitly to
+    # prevent accidental dispatch from a feature branch. `deploy` needs this job,
+    # so guarding here gates the whole chain.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
@@ -140,9 +149,10 @@ jobs:
       matrix:
         environment: [dev, staging, production]
     environment: ${{ matrix.environment }}
+    # No id-token: this job runs untrusted build code and must never hold cloud
+    # credentials.
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -187,6 +197,36 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 
+      # `path` is resolved from the workspace root and is NOT affected by the
+      # job's `working-directory` default, so it must be the full `apps/web/dist`.
+      - name: Upload SPA artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: web-dist-${{ matrix.environment }}
+          path: apps/web/dist
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy SPA (${{ matrix.environment }})
+    needs: [build-and-package]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, staging, production]
+    environment: ${{ matrix.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Download into workspace-root `dist/` (this job sets no working-directory
+      # default), matching the `dist/...` paths the publish step references.
+      - name: Download SPA artifact
+        uses: actions/download-artifact@95815c38cf15ff21684b820601a6c15f4d7f6513 # v4.2.1
+        with:
+          name: web-dist-${{ matrix.environment }}
+          path: dist
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
@@ -227,7 +267,7 @@ jobs:
 
   notify-web:
     name: Slack Notification (Web)
-    needs: [checks, deploy]
+    needs: [checks, build-and-package, deploy]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -240,9 +280,9 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.checks.result }}" == "failure" || "${{ needs.deploy.result }}" == "failure" ]]; then
+          if [[ "${{ needs.checks.result }}" == "failure" || "${{ needs.build-and-package.result }}" == "failure" || "${{ needs.deploy.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.checks.result }}" == "cancelled" || "${{ needs.deploy.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.checks.result }}" == "cancelled" || "${{ needs.build-and-package.result }}" == "cancelled" || "${{ needs.deploy.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
           elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
             STATUS="skipped"

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -120,154 +120,38 @@ jobs:
           done
 
   # ── CD: build + publish the SPA to each environment's GCS bucket ──────────
-  # Split into two jobs so the privileged publish never shares a runner with
-  # repository/dependency-controlled build code. `build-and-package` runs the
-  # untrusted build (bun install/postinstall, openapi-ts, vite build) with NO
-  # cloud credentials and uploads the resulting `dist/` as an artifact. `deploy`
-  # then downloads that artifact into a fresh runner that holds the `id-token`
-  # OIDC permission and authenticates to GCP — so build code can no longer plant
-  # a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
-  # in the post-auth publish step and exfiltrate the short-lived GCP credentials.
-  #
-  # Both jobs run one matrix leg per GitHub environment (fail-fast: false) under
-  # their own `environment:` so the env-scoped secrets and variables resolve to
-  # that environment. `production` gates at `build-and-package` if it has
-  # required reviewers; `deploy` then inherits the gate via `needs`.
-  build-and-package:
-    name: Build SPA (${{ matrix.environment }})
+  # Each environment is an independent instance of the `deploy-web-spa` reusable
+  # workflow (fail-fast: false), which internally splits an unprivileged build
+  # from the privileged GCP publish. Matrixing the *caller* — rather than the
+  # build/deploy jobs directly — keeps each environment independent: a failure
+  # building `dev` no longer skips `staging`/`production`, the way a matrixed
+  # `deploy: needs: [build-and-package]` would (GitHub treats a `needs` on a
+  # matrixed job as the aggregate of all its legs). The reusable workflow is
+  # where the build/publish trust boundary lives; see its header for details.
+  deploy:
+    name: Deploy SPA
     needs: [checks]
     # workflow_dispatch has no branch filter, so guard the CD chain explicitly to
-    # prevent accidental dispatch from a feature branch. `deploy` needs this job,
-    # so guarding here gates the whole chain.
+    # prevent accidental dispatch from a feature branch.
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/web
     strategy:
       fail-fast: false
       matrix:
         environment: [dev, staging, production]
-    environment: ${{ matrix.environment }}
-    # No id-token: this job runs untrusted build code and must never hold cloud
-    # credentials.
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: '1.3.11'
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Generate API clients
-        run: bun run openapi-ts
-
-      # Build per environment so the bundle bakes in this environment's public
-      # config — the Stripe publishable key differs per env (pk_test_ vs pk_live_)
-      # and the Sentry environment tag must match. Sources, per the GitHub config:
-      #   - VITE_SENTRY_DSN          repo-level variable (same for every env)
-      #   - VITE_SENTRY_ENVIRONMENT  per-environment variable (resolves via the
-      #                              job's `environment:`)
-      #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
-      #                              are public, so embedding them is expected
-      #   - VITE_APP_VERSION         commit SHA baked into the browser bundle
-      #                              for Sentry event release tagging.
-      #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
-      #                              and Sentry release side effects.
-      #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
-      #                              inlines it — it only authenticates the
-      #                              build-time source-map upload and is not
-      #                              emitted into dist/.
-      # The API base URL is not baked in: in the browser the client uses
-      # same-origin paths, so each bucket's origin reaches its own backend.
-      - name: Build
-        env:
-          VITE_PLATFORM_MODE: "true"
-          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
-          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
-          VITE_APP_VERSION: ${{ github.sha }}
-          SENTRY_UPLOAD_SOURCE_MAPS: "true"
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: bun run build
-
-      # `path` is resolved from the workspace root and is NOT affected by the
-      # job's `working-directory` default, so it must be the full `apps/web/dist`.
-      - name: Upload SPA artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: web-dist-${{ matrix.environment }}
-          path: apps/web/dist
-          if-no-files-found: error
-
-  deploy:
-    name: Deploy SPA (${{ matrix.environment }})
-    needs: [build-and-package]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [dev, staging, production]
-    environment: ${{ matrix.environment }}
+    # The caller's permissions are the ceiling for the reusable workflow; its
+    # build job narrows itself to `contents: read` while its deploy job uses
+    # `id-token: write`.
     permissions:
       contents: read
       id-token: write
-    steps:
-      # Download into workspace-root `dist/` (this job sets no working-directory
-      # default), matching the `dist/...` paths the publish step references.
-      - name: Download SPA artifact
-        uses: actions/download-artifact@95815c38cf15ff21684b820601a6c15f4d7f6513 # v4.2.1
-        with:
-          name: web-dist-${{ matrix.environment }}
-          path: dist
-
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-
-      - name: Publish SPA to GCS
-        env:
-          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-          TARGET_ENV: ${{ matrix.environment }}
-        run: |
-          set -euo pipefail
-          BUCKET="${PROJECT_ID}-assistant-spa"
-
-          if [ ! -f dist/index.html ]; then
-            echo "::error::dist/index.html not found — the build produced no output."
-            exit 1
-          fi
-
-          # 1. Upload everything EXCEPT index.html with a long immutable cache,
-          #    additive (no deletion) so clients that loaded the previous shell can
-          #    still fetch their lazy-loaded hashed chunks during the rollout.
-          #    index.html is excluded here so that a run cancelled before step 2
-          #    (e.g. superseded by concurrency.cancel-in-progress) can never leave
-          #    the entrypoint pinned with a year-long immutable cache.
-          gcloud storage rsync -r \
-            --exclude="^index\.html$" \
-            --cache-control="public, max-age=31536000, immutable" \
-            dist "gs://${BUCKET}"
-
-          # 2. Upload the HTML entrypoint last, with no-cache, so the new release
-          #    only goes live once its assets exist and is always revalidated.
-          gcloud storage cp \
-            --cache-control="no-cache, max-age=0, must-revalidate" \
-            dist/index.html "gs://${BUCKET}/index.html"
-
-          echo "Published SPA to gs://${BUCKET}/ (environment=${TARGET_ENV})"
+    uses: ./.github/workflows/deploy-web-spa.yaml
+    with:
+      environment: ${{ matrix.environment }}
+    secrets: inherit
 
   notify-web:
     name: Slack Notification (Web)
-    needs: [checks, build-and-package, deploy]
+    needs: [checks, deploy]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -280,9 +164,9 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.checks.result }}" == "failure" || "${{ needs.build-and-package.result }}" == "failure" || "${{ needs.deploy.result }}" == "failure" ]]; then
+          if [[ "${{ needs.checks.result }}" == "failure" || "${{ needs.deploy.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.checks.result }}" == "cancelled" || "${{ needs.build-and-package.result }}" == "cancelled" || "${{ needs.deploy.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.checks.result }}" == "cancelled" || "${{ needs.deploy.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
           elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
             STATUS="skipped"

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -8,6 +8,9 @@ on:
       - 'apps/web/**'
       - 'packages/design-library/**'
       - '.github/workflows/ci-main-web.yaml'
+      # The deploy/publish logic lives in this reusable workflow, so a change to
+      # it alone must still exercise the full web CI/CD pipeline.
+      - '.github/workflows/deploy-web-spa.yaml'
 
 # Serialize runs per branch and cancel any superseded in-flight run, so an
 # older commit's deploy can never finish after — and overwrite the bucket's

--- a/.github/workflows/deploy-web-spa.yaml
+++ b/.github/workflows/deploy-web-spa.yaml
@@ -1,0 +1,144 @@
+name: Deploy Web SPA (reusable)
+
+# Reusable workflow: build + publish the SPA for ONE GitHub environment.
+#
+# Split into two jobs so the privileged publish never shares a runner with
+# repository/dependency-controlled build code. `build-and-package` runs the
+# untrusted build (bun install/postinstall, openapi-ts, vite build) with NO
+# cloud credentials and uploads the resulting `dist/` as an artifact. `deploy`
+# then downloads that artifact into a fresh runner that holds the `id-token`
+# OIDC permission and authenticates to GCP — so build code can no longer plant
+# a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
+# in the post-auth publish step and exfiltrate the short-lived GCP credentials.
+#
+# The caller matrixes over environments (fail-fast: false), so each environment
+# is an independent instance of this workflow — a failure building `dev` never
+# blocks `staging`/`production`. `production` gates at `build-and-package` if it
+# has required reviewers; `deploy` then inherits the gate via `needs`.
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Target GitHub environment (dev | staging | production).
+        required: true
+        type: string
+
+jobs:
+  build-and-package:
+    name: Build SPA (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    environment: ${{ inputs.environment }}
+    # No id-token: this job runs untrusted build code and must never hold cloud
+    # credentials.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate API clients
+        run: bun run openapi-ts
+
+      # Build per environment so the bundle bakes in this environment's public
+      # config — the Stripe publishable key differs per env (pk_test_ vs pk_live_)
+      # and the Sentry environment tag must match. Sources, per the GitHub config:
+      #   - VITE_SENTRY_DSN          repo-level variable (same for every env)
+      #   - VITE_SENTRY_ENVIRONMENT  per-environment variable (resolves via the
+      #                              job's `environment:`)
+      #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
+      #                              are public, so embedding them is expected
+      #   - VITE_APP_VERSION         commit SHA baked into the browser bundle
+      #                              for Sentry event release tagging.
+      #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
+      #                              and Sentry release side effects.
+      #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
+      #                              inlines it — it only authenticates the
+      #                              build-time source-map upload and is not
+      #                              emitted into dist/.
+      # The API base URL is not baked in: in the browser the client uses
+      # same-origin paths, so each bucket's origin reaches its own backend.
+      - name: Build
+        env:
+          VITE_PLATFORM_MODE: "true"
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          VITE_APP_VERSION: ${{ github.sha }}
+          SENTRY_UPLOAD_SOURCE_MAPS: "true"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: bun run build
+
+      # `path` is resolved from the workspace root and is NOT affected by the
+      # job's `working-directory` default, so it must be the full `apps/web/dist`.
+      - name: Upload SPA artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: web-dist-${{ inputs.environment }}
+          path: apps/web/dist
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy SPA (${{ inputs.environment }})
+    needs: [build-and-package]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Download into workspace-root `dist/` (this job sets no working-directory
+      # default), matching the `dist/...` paths the publish step references.
+      - name: Download SPA artifact
+        uses: actions/download-artifact@95815c38cf15ff21684b820601a6c15f4d7f6513 # v4.2.1
+        with:
+          name: web-dist-${{ inputs.environment }}
+          path: dist
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Publish SPA to GCS
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          TARGET_ENV: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          BUCKET="${PROJECT_ID}-assistant-spa"
+
+          if [ ! -f dist/index.html ]; then
+            echo "::error::dist/index.html not found — the build produced no output."
+            exit 1
+          fi
+
+          # 1. Upload everything EXCEPT index.html with a long immutable cache,
+          #    additive (no deletion) so clients that loaded the previous shell can
+          #    still fetch their lazy-loaded hashed chunks during the rollout.
+          #    index.html is excluded here so that a run cancelled before step 2
+          #    (e.g. superseded by concurrency.cancel-in-progress) can never leave
+          #    the entrypoint pinned with a year-long immutable cache.
+          gcloud storage rsync -r \
+            --exclude="^index\.html$" \
+            --cache-control="public, max-age=31536000, immutable" \
+            dist "gs://${BUCKET}"
+
+          # 2. Upload the HTML entrypoint last, with no-cache, so the new release
+          #    only goes live once its assets exist and is always revalidated.
+          gcloud storage cp \
+            --cache-control="no-cache, max-age=0, must-revalidate" \
+            dist/index.html "gs://${BUCKET}/index.html"
+
+          echo "Published SPA to gs://${BUCKET}/ (environment=${TARGET_ENV})"


### PR DESCRIPTION
## Summary
- Closes a CI/CD trust-boundary issue in the web deploy: repository/dependency-controlled build code (`bun install`/`postinstall`, `openapi-ts`, `vite build`) previously ran in the **same job** that later authenticated to GCP (`id-token: write`) and invoked `gcloud`, so build code could persist a `$GITHUB_ENV`/`$GITHUB_PATH`/`BASH_ENV` hook (or a fake `gcloud`) that fires in the post-auth publish step and exfiltrates the short-lived GCP credentials.
- Splits build from publish via a new **`deploy-web-spa.yaml` reusable workflow**: an unprivileged `build-and-package` job (`contents: read`, no `id-token`) builds and uploads `dist` as a per-env artifact; a privileged `deploy` job (`id-token: write`) downloads it, authenticates, and publishes. No untrusted build code runs before auth.
- `ci-main-web.yaml` matrixes the **caller** over `[dev, staging, production]` (`fail-fast: false`) so each environment is an independent reusable-workflow instance — a single environment's build failure no longer skips deploy for the others (the regression a matrixed `deploy: needs: [build-and-package]` would introduce, since GitHub treats a `needs` on a matrixed job as the aggregate of all legs).
- Adds `.github/workflows/deploy-web-spa.yaml` to the caller's `push.paths` so changes to the deploy logic exercise the full pipeline.
- Validated with `actionlint` + YAML parse.

Both jobs bind to the GitHub environment to resolve per-environment config (build: Stripe/Sentry secrets & vars; deploy: `GCP_*` WIF config, matching every other privileged GCP job in this repo). A Codex review noted this could double-prompt for approval on `production` — but `production` has no required reviewers configured, so there's no approval gate and this is a no-op.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/00682e37b9048191894d91b9f6f71b36?sev=high%2Ccritical

## Original prompt
A Codex security scan (high / attack-path high) flagged that the web CD job in `ci-main-web.yaml` ran build/install code before GCP authentication and the `gcloud` publish step within one privileged job, letting a compromised build dependency or build script pivot through persisted runner state to reach short-lived GCP credentials and the SPA bucket. The task was to verify the finding still applied and apply the split-job remediation. Review feedback then drove two refinements: a reusable-workflow structure to preserve per-environment deploy independence, and adding the reusable workflow to the trigger path filters.