### PR TITLE
fix(chat): tighten spacing between user and assistant messages (8pt)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -337,7 +337,7 @@ struct MessageListContentView: View, Equatable {
         // during any item insertion, which measures ALL children via sizeThatFits —
         // causing multi-minute hangs on long conversations. Do NOT remove the
         // .transaction modifier or wrap content mutations in withAnimation.
-        MessageTranscriptStack(spacing: VSpacing.md) {
+        MessageTranscriptStack(spacing: VSpacing.sm) {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage


### PR DESCRIPTION
## Summary
Reduces the SwiftUI chat transcript's uniform inter-message vertical gap from `VSpacing.md` (12pt) to `VSpacing.sm` (8pt), so consecutive messages — notably a user-sent message and the following assistant reply — sit closer together. Implements the Figma red-comment feedback on the mobile chat mock (node 5322:6603, New-App): "the spacing between a user sent message and assistant message could be a little closer."

## Self-review result
PASS — 0 gaps across 3 fresh-eyes passes (plan faithfulness, repo integration, slop/reuse). No external reviewer feedback during execution.

## PRs merged into feature branch
- #32807: fix(chat): tighten transcript message spacing to 8pt (VSpacing.sm)

Part of plan: tighten-message-spacing.md