### PR TITLE
feat(web/chat): add BubbleAttachments inline renderer for in-bubble attachments

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -1,0 +1,95 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+    }: {
+      attachment: { id: string };
+    }) => (
+      <div data-testid="preview-modal" data-attachment-id={attachment.id} />
+    ),
+  }),
+);
+
+import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
+
+import { BubbleAttachments } from "@/domains/chat/components/chat-attachments/bubble-attachments";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+const imageWithPreview: DisplayAttachment = {
+  id: "img-1",
+  filename: "photo.png",
+  mimeType: "image/png",
+  sizeBytes: 12_345,
+  previewUrl: "https://example.com/photo.png",
+};
+
+const pdf: DisplayAttachment = {
+  id: "pdf-1",
+  filename: "report.pdf",
+  mimeType: "application/pdf",
+  sizeBytes: 2_048,
+  previewUrl: null,
+};
+
+const imageWithoutPreview: DisplayAttachment = {
+  id: "img-2",
+  filename: "scan.jpg",
+  mimeType: "image/jpeg",
+  sizeBytes: 4_096,
+  previewUrl: null,
+};
+
+describe("BubbleAttachments", () => {
+  test("renders an image with a preview as a large inline preview without filename/size", () => {
+    const { getByRole, queryByText } = render(
+      <BubbleAttachments attachments={[imageWithPreview]} />,
+    );
+
+    const img = getByRole("button", { name: "photo.png" });
+    expect(img.getAttribute("src")).toBe("https://example.com/photo.png");
+    expect(queryByText("photo.png")).toBeNull();
+    expect(queryByText("12 KB")).toBeNull();
+  });
+
+  test("renders a non-image attachment as a square chip with filename and size", () => {
+    const { getByText } = render(<BubbleAttachments attachments={[pdf]} />);
+
+    expect(getByText("report.pdf")).toBeTruthy();
+    expect(getByText("2.0 KB")).toBeTruthy();
+  });
+
+  test("falls back to the square chip for an image without a preview", () => {
+    const { getByText } = render(
+      <BubbleAttachments attachments={[imageWithoutPreview]} />,
+    );
+
+    expect(getByText("scan.jpg")).toBeTruthy();
+  });
+
+  test("opens the preview modal when an attachment is clicked", () => {
+    const { getByRole, getByTestId } = render(
+      <BubbleAttachments attachments={[imageWithPreview]} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "photo.png" }));
+
+    expect(getByTestId("preview-modal").getAttribute("data-attachment-id")).toBe(
+      "img-1",
+    );
+  });
+
+  test("returns null for an empty attachments array", () => {
+    const { container } = render(<BubbleAttachments attachments={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -88,6 +88,22 @@ describe("BubbleAttachments", () => {
     );
   });
 
+  test("preserves the original attachment order for a mixed list", () => {
+    const { getByText, getByRole } = render(
+      <BubbleAttachments attachments={[pdf, imageWithPreview]} />,
+    );
+
+    const pdfEl = getByText("report.pdf");
+    const imgEl = getByRole("button", { name: "photo.png" });
+
+    // The pdf chip must appear before the image preview in document order,
+    // matching the input order [pdf, image].
+    expect(
+      pdfEl.compareDocumentPosition(imgEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   test("returns null for an empty attachments array", () => {
     const { container } = render(<BubbleAttachments attachments={[]} />);
     expect(container.innerHTML).toBe("");

--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,0 +1,96 @@
+
+import { useCallback, useState } from "react";
+import type { FC } from "react";
+
+import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
+
+import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
+
+interface BubbleAttachmentsProps {
+  attachments: DisplayAttachment[];
+  /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
+   *  attachment content when `previewUrl` is missing. */
+  assistantId?: string | null;
+}
+
+/**
+ * In-bubble attachment renderer for sent user messages. Image attachments with
+ * a usable `previewUrl` render as large inline previews; every other
+ * attachment (non-images, plus images whose preview is missing) renders as a
+ * compact {@link MessageAttachmentSquare} chip. Both kinds are clickable and
+ * open the full-screen {@link AttachmentPreviewModal}.
+ *
+ * Distinct from {@link MessageAttachments}, the legacy separate-strip renderer
+ * still used for assistant messages, which renders every attachment as a chip.
+ */
+export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
+  attachments,
+  assistantId,
+}) => {
+  const [previewAttachment, setPreviewAttachment] = useState<DisplayAttachment | null>(null);
+
+  const handleClose = useCallback(() => setPreviewAttachment(null), []);
+
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  const inlineImages: DisplayAttachment[] = [];
+  const chips: DisplayAttachment[] = [];
+  for (const att of attachments) {
+    const isInlineImage =
+      classifyAttachment(att.mimeType, att.filename) === "image" &&
+      att.previewUrl != null;
+    (isInlineImage ? inlineImages : chips).push(att);
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {inlineImages.map((att) => (
+          <img
+            key={att.id}
+            src={att.previewUrl ?? undefined}
+            alt={att.filename}
+            role="button"
+            aria-label={att.filename}
+            title={att.filename}
+            tabIndex={0}
+            onClick={() => setPreviewAttachment(att)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setPreviewAttachment(att);
+              }
+            }}
+            className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-cover"
+          />
+        ))}
+        {chips.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {chips.map((att) => (
+              <MessageAttachmentSquare
+                key={att.id}
+                filename={att.filename}
+                mimeType={att.mimeType}
+                sizeBytes={att.sizeBytes}
+                previewUrl={att.previewUrl}
+                onPreview={() => setPreviewAttachment(att)}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {previewAttachment && (
+        <AttachmentPreviewModal
+          open
+          onClose={handleClose}
+          attachment={previewAttachment}
+          assistantId={assistantId}
+        />
+      )}
+    </>
+  );
+};

--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -37,51 +37,47 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
     return null;
   }
 
-  const inlineImages: DisplayAttachment[] = [];
-  const chips: DisplayAttachment[] = [];
-  for (const att of attachments) {
-    const isInlineImage =
-      classifyAttachment(att.mimeType, att.filename) === "image" &&
-      att.previewUrl != null;
-    (isInlineImage ? inlineImages : chips).push(att);
-  }
-
   return (
     <>
       <div className="flex flex-col gap-2">
-        {inlineImages.map((att) => (
-          <img
-            key={att.id}
-            src={att.previewUrl ?? undefined}
-            alt={att.filename}
-            role="button"
-            aria-label={att.filename}
-            title={att.filename}
-            tabIndex={0}
-            onClick={() => setPreviewAttachment(att)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                setPreviewAttachment(att);
-              }
-            }}
-            className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-cover"
-          />
-        ))}
-        {chips.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {chips.map((att) => (
-              <MessageAttachmentSquare
+        {attachments.map((att) => {
+          const isInlineImage =
+            classifyAttachment(att.mimeType, att.filename) === "image" &&
+            att.previewUrl != null;
+
+          if (isInlineImage) {
+            return (
+              <img
                 key={att.id}
-                filename={att.filename}
-                mimeType={att.mimeType}
-                sizeBytes={att.sizeBytes}
-                previewUrl={att.previewUrl}
-                onPreview={() => setPreviewAttachment(att)}
+                src={att.previewUrl ?? undefined}
+                alt={att.filename}
+                role="button"
+                aria-label={att.filename}
+                title={att.filename}
+                tabIndex={0}
+                onClick={() => setPreviewAttachment(att)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setPreviewAttachment(att);
+                  }
+                }}
+                className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-cover"
               />
-            ))}
-          </div>
-        ) : null}
+            );
+          }
+
+          return (
+            <MessageAttachmentSquare
+              key={att.id}
+              filename={att.filename}
+              mimeType={att.mimeType}
+              sizeBytes={att.sizeBytes}
+              previewUrl={att.previewUrl}
+              onPreview={() => setPreviewAttachment(att)}
+            />
+          );
+        })}
       </div>
       {previewAttachment && (
         <AttachmentPreviewModal


### PR DESCRIPTION
## Summary
- Add BubbleAttachments: an in-bubble attachment renderer that shows image attachments as large inline previews and non-image files as compact MessageAttachmentSquare chips.
- Additive scaffolding for unifying user message text + attachments into one bubble; not yet wired into the transcript.

Part of plan: unify-message-attachments.md (PR 1 of 2)