### PR TITLE
fix(web): hide "Open in New Window" in conversation actions on native iOS

### DIFF
--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -24,6 +24,11 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
+let mockIsNativePlatform = false;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => mockIsNativePlatform,
+}));
+
 // Mock design library compound components that require browser APIs (portals,
 // Radix floating-ui) so renderToStaticMarkup can produce testable HTML.
 const passthrough = ({ children, ...props }: Record<string, unknown>) =>
@@ -96,6 +101,7 @@ import {
 
 beforeEach(() => {
   mockIsMobile = false;
+  mockIsNativePlatform = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -292,6 +298,38 @@ describe("ConversationActionsMenu — mobile panel details", () => {
     expect(html).toContain("Move to");
     expect(html).toContain("Work");
     expect(html).toContain("Remove from group");
+  });
+
+  test("hides Open in New Window on native iOS bottom sheet", () => {
+    mockIsMobile = true;
+    mockIsNativePlatform = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        variant="header"
+        onOpenInNewWindow={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).not.toContain("Open in new window");
+    expect(html).not.toContain("Open in New Window");
+    // Other actions remain.
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+
+  test("shows Open in New Window on web bottom sheet", () => {
+    mockIsMobile = true;
+    mockIsNativePlatform = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        variant="header"
+        onOpenInNewWindow={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain("Open in new window");
   });
 
   test("variant header renders header-order items on mobile", () => {

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -27,6 +27,7 @@ import {
 } from "@vellum/design-library";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isNativePlatform } from "@/runtime/native-auth";
 
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
@@ -264,14 +265,15 @@ export function renderConversationMenuItems({
       </Primitive.Item>
     ) : null;
 
-  const openInNewWindowItem = onOpenInNewWindow ? (
-    <Primitive.Item
-      leftIcon={<ExternalLink size={14} />}
-      onSelect={onOpenInNewWindow}
-    >
-      {variant === "header" ? "Open in new window" : "Open in New Window"}
-    </Primitive.Item>
-  ) : null;
+  const openInNewWindowItem =
+    onOpenInNewWindow && !isNativePlatform() ? (
+      <Primitive.Item
+        leftIcon={<ExternalLink size={14} />}
+        onSelect={onOpenInNewWindow}
+      >
+        {variant === "header" ? "Open in new window" : "Open in New Window"}
+      </Primitive.Item>
+    ) : null;
 
   const inspectItem = onInspect ? (
     <Primitive.Item leftIcon={<Microscope size={14} />} onSelect={onInspect}>
@@ -518,16 +520,17 @@ function renderConversationMenuItemsAsPanelItems({
         })
       : null;
 
-  const openInNewWindowItem = onOpenInNewWindow
-    ? buildPanelItem({
-        key: "open-in-new-window",
-        icon: ExternalLink,
-        label:
-          variant === "header" ? "Open in new window" : "Open in New Window",
-        run: onOpenInNewWindow,
-        onClose,
-      })
-    : null;
+  const openInNewWindowItem =
+    onOpenInNewWindow && !isNativePlatform()
+      ? buildPanelItem({
+          key: "open-in-new-window",
+          icon: ExternalLink,
+          label:
+            variant === "header" ? "Open in new window" : "Open in New Window",
+          run: onOpenInNewWindow,
+          onClose,
+        })
+      : null;
 
   const inspectItem = onInspect
     ? buildPanelItem({


### PR DESCRIPTION
## Summary
- Gate the conversation-actions "Open in New Window" item on !isNativePlatform() so it is hidden in the native iOS (Capacitor) app, where opening a new browser window is meaningless
- Applied in both the mobile bottom-sheet and desktop dropdown renderers; web/desktop/mobile-web unchanged
- Added tests covering hidden-on-native and shown-on-web

Part of plan: conversation-actions-sheet-ios.md (PR 1 of 1)