### PR TITLE
fix(web): hide "Open in New Window" in conversation actions on native iOS

### DIFF
--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -24,6 +24,11 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
+let mockIsNativePlatform = false;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => mockIsNativePlatform,
+}));
+
 // Mock design library compound components that require browser APIs (portals,
 // Radix floating-ui) so renderToStaticMarkup can produce testable HTML.
 const passthrough = ({ children, ...props }: Record<string, unknown>) =>
@@ -96,6 +101,7 @@ import {
 
 beforeEach(() => {
   mockIsMobile = false;
+  mockIsNativePlatform = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -292,6 +298,38 @@ describe("ConversationActionsMenu — mobile panel details", () => {
     expect(html).toContain("Move to");
     expect(html).toContain("Work");
     expect(html).toContain("Remove from group");
+  });
+
+  test("hides Open in New Window on native iOS bottom sheet", () => {
+    mockIsMobile = true;
+    mockIsNativePlatform = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        variant="header"
+        onOpenInNewWindow={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).not.toContain("Open in new window");
+    expect(html).not.toContain("Open in New Window");
+    // Other actions remain.
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+
+  test("shows Open in New Window on web bottom sheet", () => {
+    mockIsMobile = true;
+    mockIsNativePlatform = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        variant="header"
+        onOpenInNewWindow={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain("Open in new window");
   });
 
   test("variant header renders header-order items on mobile", () => {

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -26,6 +26,7 @@ mock.module("@/hooks/use-is-mobile", () => ({
 
 let mockIsNativePlatform = false;
 mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: () => mockIsNativePlatform,
   isNativePlatform: () => mockIsNativePlatform,
 }));
 

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -27,7 +27,7 @@ import {
 } from "@vellum/design-library";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { isNativePlatform } from "@/runtime/native-auth";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
@@ -266,7 +266,7 @@ export function renderConversationMenuItems({
     ) : null;
 
   const openInNewWindowItem =
-    onOpenInNewWindow && !isNativePlatform() ? (
+    onOpenInNewWindow ? (
       <Primitive.Item
         leftIcon={<ExternalLink size={14} />}
         onSelect={onOpenInNewWindow}
@@ -446,7 +446,11 @@ function renderConversationMenuItemsAsPanelItems({
   onRefresh,
   variant = "sidebar",
   onClose,
-}: ConversationMenuItemsProps & { onClose: () => void }): ReactNode {
+  isNativePlatform = false,
+}: ConversationMenuItemsProps & {
+  onClose: () => void;
+  isNativePlatform?: boolean;
+}): ReactNode {
   const showMoveToGroup =
     onMoveToGroup && moveToGroups && moveToGroups.length > 0;
 
@@ -521,7 +525,7 @@ function renderConversationMenuItemsAsPanelItems({
       : null;
 
   const openInNewWindowItem =
-    onOpenInNewWindow && !isNativePlatform()
+    onOpenInNewWindow && !isNativePlatform
       ? buildPanelItem({
           key: "open-in-new-window",
           icon: ExternalLink,
@@ -669,6 +673,7 @@ export function ConversationActionsMenu({
   ...itemProps
 }: ConversationActionsMenuProps) {
   const isMobile = useIsMobile();
+  const isNativePlatform = useIsNativePlatform();
   const [open, setOpen] = useState(false);
 
   const defaultTrigger = (
@@ -700,6 +705,7 @@ export function ConversationActionsMenu({
             {renderConversationMenuItemsAsPanelItems({
               ...itemProps,
               onClose: () => setOpen(false),
+              isNativePlatform,
             })}
           </BottomSheet.Body>
         </BottomSheet.Content>

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -27,6 +27,7 @@ import {
 } from "@vellum/design-library";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isNativePlatform } from "@/runtime/native-auth";
 
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
@@ -264,14 +265,15 @@ export function renderConversationMenuItems({
       </Primitive.Item>
     ) : null;
 
-  const openInNewWindowItem = onOpenInNewWindow ? (
-    <Primitive.Item
-      leftIcon={<ExternalLink size={14} />}
-      onSelect={onOpenInNewWindow}
-    >
-      {variant === "header" ? "Open in new window" : "Open in New Window"}
-    </Primitive.Item>
-  ) : null;
+  const openInNewWindowItem =
+    onOpenInNewWindow && !isNativePlatform() ? (
+      <Primitive.Item
+        leftIcon={<ExternalLink size={14} />}
+        onSelect={onOpenInNewWindow}
+      >
+        {variant === "header" ? "Open in new window" : "Open in New Window"}
+      </Primitive.Item>
+    ) : null;
 
   const inspectItem = onInspect ? (
     <Primitive.Item leftIcon={<Microscope size={14} />} onSelect={onInspect}>
@@ -518,16 +520,17 @@ function renderConversationMenuItemsAsPanelItems({
         })
       : null;
 
-  const openInNewWindowItem = onOpenInNewWindow
-    ? buildPanelItem({
-        key: "open-in-new-window",
-        icon: ExternalLink,
-        label:
-          variant === "header" ? "Open in new window" : "Open in New Window",
-        run: onOpenInNewWindow,
-        onClose,
-      })
-    : null;
+  const openInNewWindowItem =
+    onOpenInNewWindow && !isNativePlatform()
+      ? buildPanelItem({
+          key: "open-in-new-window",
+          icon: ExternalLink,
+          label:
+            variant === "header" ? "Open in new window" : "Open in New Window",
+          run: onOpenInNewWindow,
+          onClose,
+        })
+      : null;
 
   const inspectItem = onInspect
     ? buildPanelItem({


### PR DESCRIPTION
## Summary
Hides the "Open in New Window" action from the Conversation Actions menu/bottom-sheet when running in the native iOS (Capacitor) app, where opening a new browser window is meaningless. Gated on `isNativePlatform()` in both the mobile bottom-sheet and desktop dropdown renderers of `conversation-actions-menu.tsx`; web/desktop/mobile-web are unchanged.

Note: the item's 16px text already matches the Figma mock via `PanelItem`'s existing `max-md:text-body-large-default`, so no text change was needed.

## Self-review result
Skipped (`--skip-review`).

## PRs merged into feature branch
- #32824: fix(web): hide "Open in New Window" in conversation actions on native iOS

Part of plan: conversation-actions-sheet-ios.md