### PR TITLE
fix(web/chat): gate interleaved user bubble to avoid empty styled box

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -504,6 +504,40 @@ describe("TranscriptMessageBody", () => {
     expect(bubble!.contains(surface)).toBe(false);
   });
 
+  test("omits the user bubble when an interleaved user message has no text or attachments", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u4",
+          role: "user",
+          content: "",
+          contentOrder: [{ type: "tool", id: "tc-1" }],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    // No visible text and no attachments: the empty surface-lift bubble must
+    // not render.
+    expect(
+      container.querySelector("[class*='bg-[var(--surface-lift)]']"),
+    ).toBeNull();
+    // Non-text elements (the tool-call card) still render.
+    expect(
+      container.querySelector("[data-testid='tool-progress-card']"),
+    ).not.toBeNull();
+  });
+
   test("auto-expands legacy tool-only streaming messages until content appears", () => {
     const { getByTestId, rerender } = render(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -700,6 +700,13 @@ export function TranscriptMessageBody({
           )
         : null;
 
+    // Mirrors the legacy user branch's `(hasVisibleLegacyText || hasAttachments)`
+    // gate: only render the surface-lift bubble when it would have visible
+    // content. Without this, an interleaved user message with no resolvable
+    // text, no fallback, and no attachments renders an empty padded box.
+    const hasVisibleInterleavedText =
+      interleavedTextElements.some((el) => !!el) || !!interleavedFallback;
+
     return (
       <div
         ref={wrapperRef}
@@ -712,16 +719,18 @@ export function TranscriptMessageBody({
         >
           {isUser ? (
             <>
-              <div className={userBubbleClass}>
-                {interleavedTextElements}
-                {interleavedFallback}
-                {hasAttachments && message.attachments ? (
-                  <BubbleAttachments
-                    attachments={message.attachments}
-                    assistantId={assistantId}
-                  />
-                ) : null}
-              </div>
+              {(hasVisibleInterleavedText || hasAttachments) && (
+                <div className={userBubbleClass}>
+                  {interleavedTextElements}
+                  {interleavedFallback}
+                  {hasAttachments && message.attachments ? (
+                    <BubbleAttachments
+                      attachments={message.attachments}
+                      assistantId={assistantId}
+                    />
+                  ) : null}
+                </div>
+              )}
               {/* Tool-call cards and surfaces stay outside the user bubble
                   (low-reachability for user messages, but kept for parity with
                   the assistant path). */}


### PR DESCRIPTION
## Summary
Mirror the legacy path's bubble guard in the interleaved render path: the user bubble (surface-lift bg + padding) now only renders when there is visible text or attachments, preventing a (latent) empty padded bubble. Non-text tool-call/surface elements still render outside the bubble.

Part of plan: unify-message-attachments.md (self-review remediation round 2)