### PR TITLE
feat(web/chat): unify user message text + file attachments into a single bubble

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -1,0 +1,111 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+    }: {
+      attachment: { id: string };
+    }) => (
+      <div data-testid="preview-modal" data-attachment-id={attachment.id} />
+    ),
+  }),
+);
+
+import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
+
+import { BubbleAttachments } from "@/domains/chat/components/chat-attachments/bubble-attachments";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+const imageWithPreview: DisplayAttachment = {
+  id: "img-1",
+  filename: "photo.png",
+  mimeType: "image/png",
+  sizeBytes: 12_345,
+  previewUrl: "https://example.com/photo.png",
+};
+
+const pdf: DisplayAttachment = {
+  id: "pdf-1",
+  filename: "report.pdf",
+  mimeType: "application/pdf",
+  sizeBytes: 2_048,
+  previewUrl: null,
+};
+
+const imageWithoutPreview: DisplayAttachment = {
+  id: "img-2",
+  filename: "scan.jpg",
+  mimeType: "image/jpeg",
+  sizeBytes: 4_096,
+  previewUrl: null,
+};
+
+describe("BubbleAttachments", () => {
+  test("renders an image with a preview as a large inline preview without filename/size", () => {
+    const { getByRole, queryByText } = render(
+      <BubbleAttachments attachments={[imageWithPreview]} />,
+    );
+
+    const img = getByRole("button", { name: "photo.png" });
+    expect(img.getAttribute("src")).toBe("https://example.com/photo.png");
+    expect(queryByText("photo.png")).toBeNull();
+    expect(queryByText("12 KB")).toBeNull();
+  });
+
+  test("renders a non-image attachment as a square chip with filename and size", () => {
+    const { getByText } = render(<BubbleAttachments attachments={[pdf]} />);
+
+    expect(getByText("report.pdf")).toBeTruthy();
+    expect(getByText("2.0 KB")).toBeTruthy();
+  });
+
+  test("falls back to the square chip for an image without a preview", () => {
+    const { getByText } = render(
+      <BubbleAttachments attachments={[imageWithoutPreview]} />,
+    );
+
+    expect(getByText("scan.jpg")).toBeTruthy();
+  });
+
+  test("opens the preview modal when an attachment is clicked", () => {
+    const { getByRole, getByTestId } = render(
+      <BubbleAttachments attachments={[imageWithPreview]} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "photo.png" }));
+
+    expect(getByTestId("preview-modal").getAttribute("data-attachment-id")).toBe(
+      "img-1",
+    );
+  });
+
+  test("preserves the original attachment order for a mixed list", () => {
+    const { getByText, getByRole } = render(
+      <BubbleAttachments attachments={[pdf, imageWithPreview]} />,
+    );
+
+    const pdfEl = getByText("report.pdf");
+    const imgEl = getByRole("button", { name: "photo.png" });
+
+    // The pdf chip must appear before the image preview in document order,
+    // matching the input order [pdf, image].
+    expect(
+      pdfEl.compareDocumentPosition(imgEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("returns null for an empty attachments array", () => {
+    const { container } = render(<BubbleAttachments attachments={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,0 +1,92 @@
+
+import { useCallback, useState } from "react";
+import type { FC } from "react";
+
+import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
+
+import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
+
+interface BubbleAttachmentsProps {
+  attachments: DisplayAttachment[];
+  /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
+   *  attachment content when `previewUrl` is missing. */
+  assistantId?: string | null;
+}
+
+/**
+ * In-bubble attachment renderer for sent user messages. Image attachments with
+ * a usable `previewUrl` render as large inline previews; every other
+ * attachment (non-images, plus images whose preview is missing) renders as a
+ * compact {@link MessageAttachmentSquare} chip. Both kinds are clickable and
+ * open the full-screen {@link AttachmentPreviewModal}.
+ *
+ * Distinct from {@link MessageAttachments}, the legacy separate-strip renderer
+ * still used for assistant messages, which renders every attachment as a chip.
+ */
+export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
+  attachments,
+  assistantId,
+}) => {
+  const [previewAttachment, setPreviewAttachment] = useState<DisplayAttachment | null>(null);
+
+  const handleClose = useCallback(() => setPreviewAttachment(null), []);
+
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {attachments.map((att) => {
+          const isInlineImage =
+            classifyAttachment(att.mimeType, att.filename) === "image" &&
+            att.previewUrl != null;
+
+          if (isInlineImage) {
+            return (
+              <img
+                key={att.id}
+                src={att.previewUrl ?? undefined}
+                alt={att.filename}
+                role="button"
+                aria-label={att.filename}
+                title={att.filename}
+                tabIndex={0}
+                onClick={() => setPreviewAttachment(att)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setPreviewAttachment(att);
+                  }
+                }}
+                className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-cover"
+              />
+            );
+          }
+
+          return (
+            <MessageAttachmentSquare
+              key={att.id}
+              filename={att.filename}
+              mimeType={att.mimeType}
+              sizeBytes={att.sizeBytes}
+              previewUrl={att.previewUrl}
+              onPreview={() => setPreviewAttachment(att)}
+            />
+          );
+        })}
+      </div>
+      {previewAttachment && (
+        <AttachmentPreviewModal
+          open
+          onClose={handleClose}
+          attachment={previewAttachment}
+          assistantId={assistantId}
+        />
+      )}
+    </>
+  );
+};

--- a/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,11 +1,10 @@
 
-import { useCallback, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
 
-import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
 
 interface BubbleAttachmentsProps {
@@ -29,9 +28,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   attachments,
   assistantId,
 }) => {
-  const [previewAttachment, setPreviewAttachment] = useState<DisplayAttachment | null>(null);
-
-  const handleClose = useCallback(() => setPreviewAttachment(null), []);
+  const { openPreview, previewModal } = useAttachmentPreview(assistantId);
 
   if (attachments.length === 0) {
     return null;
@@ -55,14 +52,14 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
                 aria-label={att.filename}
                 title={att.filename}
                 tabIndex={0}
-                onClick={() => setPreviewAttachment(att)}
+                onClick={() => openPreview(att)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    setPreviewAttachment(att);
+                    openPreview(att);
                   }
                 }}
-                className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-cover"
+                className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-contain"
               />
             );
           }
@@ -74,19 +71,12 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
               mimeType={att.mimeType}
               sizeBytes={att.sizeBytes}
               previewUrl={att.previewUrl}
-              onPreview={() => setPreviewAttachment(att)}
+              onPreview={() => openPreview(att)}
             />
           );
         })}
       </div>
-      {previewAttachment && (
-        <AttachmentPreviewModal
-          open
-          onClose={handleClose}
-          attachment={previewAttachment}
-          assistantId={assistantId}
-        />
-      )}
+      {previewModal}
     </>
   );
 };

--- a/apps/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -1,11 +1,10 @@
 
-import { useCallback, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
 
-import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 
 interface MessageAttachmentsProps {
   attachments: DisplayAttachment[];
@@ -15,18 +14,18 @@ interface MessageAttachmentsProps {
 }
 
 /**
- * Read-only strip of attachment thumbnails rendered inside a sent user message
- * bubble. Every attachment is clickable and opens a full-screen preview modal
- * — the modal handles type-specific rendering (image/video/fallback) and
- * lazily fetches missing content when needed.
+ * Read-only strip of attachment thumbnails rendered as a separate strip for
+ * assistant messages (the user path now renders attachments inside the message
+ * bubble via {@link BubbleAttachments}). Every attachment is clickable and
+ * opens a full-screen preview modal — the modal handles type-specific
+ * rendering (image/video/fallback) and lazily fetches missing content when
+ * needed.
  */
 export const MessageAttachments: FC<MessageAttachmentsProps> = ({
   attachments,
   assistantId,
 }) => {
-  const [previewAttachment, setPreviewAttachment] = useState<DisplayAttachment | null>(null);
-
-  const handleClose = useCallback(() => setPreviewAttachment(null), []);
+  const { openPreview, previewModal } = useAttachmentPreview(assistantId);
 
   if (attachments.length === 0) {
     return null;
@@ -42,18 +41,11 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
             mimeType={att.mimeType}
             sizeBytes={att.sizeBytes}
             previewUrl={att.previewUrl}
-            onPreview={() => setPreviewAttachment(att)}
+            onPreview={() => openPreview(att)}
           />
         ))}
       </div>
-      {previewAttachment && (
-        <AttachmentPreviewModal
-          open
-          onClose={handleClose}
-          attachment={previewAttachment}
-          assistantId={assistantId}
-        />
-      )}
+      {previewModal}
     </>
   );
 };

--- a/apps/web/src/domains/chat/components/chat-attachments/use-attachment-preview.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/use-attachment-preview.tsx
@@ -1,0 +1,48 @@
+
+import { useCallback, useState } from "react";
+import type { ReactNode } from "react";
+
+import type { DisplayAttachment } from "@/domains/chat/utils/reconcile";
+
+import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+
+interface UseAttachmentPreviewResult {
+  /** Open the full-screen preview modal for the given attachment. */
+  openPreview: (attachment: DisplayAttachment) => void;
+  /** The rendered {@link AttachmentPreviewModal}, or `null` when nothing is
+   *  open. Render this somewhere stable in the consuming component. */
+  previewModal: ReactNode;
+}
+
+/**
+ * Owns the shared full-screen-preview plumbing for the attachment renderers
+ * ({@link BubbleAttachments} and {@link MessageAttachments}): the open/close
+ * state and the {@link AttachmentPreviewModal} element. Consumers call
+ * `openPreview(att)` from an item's click handler and render `previewModal`.
+ *
+ * @param assistantId Forwarded to {@link AttachmentPreviewModal} so it can
+ *   lazily fetch attachment content when `previewUrl` is missing.
+ */
+export function useAttachmentPreview(
+  assistantId?: string | null,
+): UseAttachmentPreviewResult {
+  const [previewAttachment, setPreviewAttachment] =
+    useState<DisplayAttachment | null>(null);
+
+  const openPreview = useCallback(
+    (attachment: DisplayAttachment) => setPreviewAttachment(attachment),
+    [],
+  );
+  const handleClose = useCallback(() => setPreviewAttachment(null), []);
+
+  const previewModal = previewAttachment ? (
+    <AttachmentPreviewModal
+      open
+      onClose={handleClose}
+      attachment={previewAttachment}
+      assistantId={assistantId}
+    />
+  ) : null;
+
+  return { openPreview, previewModal };
+}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -504,6 +504,40 @@ describe("TranscriptMessageBody", () => {
     expect(bubble!.contains(surface)).toBe(false);
   });
 
+  test("omits the user bubble when an interleaved user message has no text or attachments", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u4",
+          role: "user",
+          content: "",
+          contentOrder: [{ type: "tool", id: "tc-1" }],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    // No visible text and no attachments: the empty surface-lift bubble must
+    // not render.
+    expect(
+      container.querySelector("[class*='bg-[var(--surface-lift)]']"),
+    ).toBeNull();
+    // Non-text elements (the tool-call card) still render.
+    expect(
+      container.querySelector("[data-testid='tool-progress-card']"),
+    ).not.toBeNull();
+  });
+
   test("auto-expands legacy tool-only streaming messages until content appears", () => {
     const { getByTestId, rerender } = render(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -470,6 +470,40 @@ describe("TranscriptMessageBody", () => {
     ).toBeNull();
   });
 
+  test("renders a user-message surface outside the surface-lift bubble", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u3",
+          role: "user",
+          content: "",
+          contentOrder: [
+            { type: "text", id: "0" },
+            { type: "surface", id: "s-1" },
+          ],
+          textSegments: [{ type: "text", content: "do this" }],
+          surfaces: [{ surfaceId: "s-1" } as never],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const bubble = container.querySelector(
+      "[class*='bg-[var(--surface-lift)]']",
+    );
+    expect(bubble).not.toBeNull();
+    // Text lives inside the bubble.
+    expect(bubble!.querySelector("[data-testid='markdown']")?.textContent).toBe(
+      "do this",
+    );
+    // The surface renders, but OUTSIDE the bubble (not a descendant).
+    const surface = container.querySelector("[data-testid='surface']");
+    expect(surface).not.toBeNull();
+    expect(bubble!.contains(surface)).toBe(false);
+  });
+
   test("auto-expands legacy tool-only streaming messages until content appears", () => {
     const { getByTestId, rerender } = render(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -364,6 +364,112 @@ describe("TranscriptMessageBody", () => {
     ).toEqual(["false", "true"]);
   });
 
+  test("renders user text and an image attachment inside a single bubble", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u1",
+          role: "user",
+          content: "look at this",
+          attachments: [
+            {
+              id: "att-1",
+              filename: "photo.png",
+              mimeType: "image/png",
+              sizeBytes: 1234,
+              previewUrl: "blob:preview",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const bubbles = container.querySelectorAll(
+      "[class*='bg-[var(--surface-lift)]']",
+    );
+    // Exactly one bubble container carries the surface-lift background.
+    expect(bubbles.length).toBe(1);
+
+    const bubble = bubbles[0]!;
+    // Text lives inside the bubble.
+    expect(bubble.querySelector("[data-testid='markdown']")?.textContent).toBe(
+      "look at this",
+    );
+    // The inline image preview is a descendant of the same bubble, not a sibling.
+    const img = bubble.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("blob:preview");
+
+    // The legacy separate strip is not rendered for user messages.
+    expect(container.querySelector("[data-testid='attachments']")).toBeNull();
+  });
+
+  test("renders an attachment-only user message inside a single bubble", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u2",
+          role: "user",
+          content: "",
+          attachments: [
+            {
+              id: "att-1",
+              filename: "photo.png",
+              mimeType: "image/png",
+              sizeBytes: 1234,
+              previewUrl: "blob:preview",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const bubbles = container.querySelectorAll(
+      "[class*='bg-[var(--surface-lift)]']",
+    );
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0]!.querySelector("img")?.getAttribute("src")).toBe(
+      "blob:preview",
+    );
+    expect(container.querySelector("[data-testid='attachments']")).toBeNull();
+  });
+
+  test("renders assistant attachments via the separate MessageAttachments strip", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "a1",
+          role: "assistant",
+          content: "here you go",
+          attachments: [
+            {
+              id: "att-1",
+              filename: "photo.png",
+              mimeType: "image/png",
+              sizeBytes: 1234,
+              previewUrl: "blob:preview",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    // Assistant path unchanged: separate strip still renders, no surface-lift bubble.
+    expect(container.querySelector("[data-testid='attachments']")).not.toBeNull();
+    expect(
+      container.querySelector("[class*='bg-[var(--surface-lift)]']"),
+    ).toBeNull();
+  });
+
   test("auto-expands legacy tool-only streaming messages until content appears", () => {
     const { getByTestId, rerender } = render(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -504,6 +504,107 @@ describe("TranscriptMessageBody", () => {
     expect(bubble!.contains(surface)).toBe(false);
   });
 
+  test("preserves contentOrder for a [surface, text] user message (surface before text, outside the bubble)", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u-order-1",
+          role: "user",
+          content: "",
+          contentOrder: [
+            { type: "surface", id: "s-1" },
+            { type: "text", id: "0" },
+          ],
+          textSegments: [{ type: "text", content: "after surface" }],
+          surfaces: [{ surfaceId: "s-1" } as never],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const surface = container.querySelector("[data-testid='surface']");
+    const markdown = container.querySelector("[data-testid='markdown']");
+    expect(surface).not.toBeNull();
+    expect(markdown?.textContent).toBe("after surface");
+
+    // DOM order matches contentOrder: surface appears before the text.
+    expect(
+      surface!.compareDocumentPosition(markdown!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // The surface is NOT inside a surface-lift bubble; the text IS.
+    const bubble = container.querySelector(
+      "[class*='bg-[var(--surface-lift)]']",
+    );
+    expect(bubble).not.toBeNull();
+    expect(bubble!.contains(surface)).toBe(false);
+    expect(bubble!.contains(markdown)).toBe(true);
+  });
+
+  test("preserves contentOrder for an interleaved [text, tool, text] user message (tool between text, outside bubbles)", () => {
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "u-order-2",
+          role: "user",
+          content: "",
+          contentOrder: [
+            { type: "text", id: "0" },
+            { type: "tool", id: "tc-1" },
+            { type: "text", id: "1" },
+          ],
+          textSegments: [
+            { type: "text", content: "before tool" },
+            { type: "text", content: "after tool" },
+          ],
+          toolCalls: [
+            {
+              id: "tc-1",
+              toolName: "bash",
+              input: {},
+              status: "completed",
+            },
+          ],
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const markdowns = container.querySelectorAll("[data-testid='markdown']");
+    const toolCard = container.querySelector(
+      "[data-testid='tool-progress-card']",
+    );
+    expect(markdowns.length).toBe(2);
+    expect(markdowns[0]!.textContent).toBe("before tool");
+    expect(markdowns[1]!.textContent).toBe("after tool");
+    expect(toolCard).not.toBeNull();
+
+    // DOM order matches contentOrder: text → tool → text.
+    expect(
+      markdowns[0]!.compareDocumentPosition(toolCard!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      toolCard!.compareDocumentPosition(markdowns[1]!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // Two separate surface-lift bubbles wrap the two text runs; the tool card
+    // is outside both.
+    const bubbles = container.querySelectorAll(
+      "[class*='bg-[var(--surface-lift)]']",
+    );
+    expect(bubbles.length).toBe(2);
+    for (const bubble of bubbles) {
+      expect(bubble.contains(toolCard)).toBe(false);
+    }
+  });
+
   test("omits the user bubble when an interleaved user message has no text or attachments", () => {
     const { container } = render(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -700,6 +700,13 @@ export function TranscriptMessageBody({
           )
         : null;
 
+    // Mirrors the legacy user branch's `(hasVisibleLegacyText || hasAttachments)`
+    // gate: only render the surface-lift bubble when it would have visible
+    // content. Without this, an interleaved user message with no resolvable
+    // text, no fallback, and no attachments renders an empty padded box.
+    const hasVisibleInterleavedText =
+      interleavedTextElements.some((el) => !!el) || !!interleavedFallback;
+
     return (
       <div
         ref={wrapperRef}
@@ -712,16 +719,18 @@ export function TranscriptMessageBody({
         >
           {isUser ? (
             <>
-              <div className={userBubbleClass}>
-                {interleavedTextElements}
-                {interleavedFallback}
-                {hasAttachments && message.attachments ? (
-                  <BubbleAttachments
-                    attachments={message.attachments}
-                    assistantId={assistantId}
-                  />
-                ) : null}
-              </div>
+              {(hasVisibleInterleavedText || hasAttachments) && (
+                <div className={userBubbleClass}>
+                  {interleavedTextElements}
+                  {interleavedFallback}
+                  {hasAttachments && message.attachments ? (
+                    <BubbleAttachments
+                      attachments={message.attachments}
+                      assistantId={assistantId}
+                    />
+                  ) : null}
+                </div>
+              )}
               {/* Tool-call cards and surfaces stay outside the user bubble
                   (low-reachability for user messages, but kept for parity with
                   the assistant path). */}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -353,9 +353,12 @@ export function TranscriptMessageBody({
   );
   const isSlackMessage = Boolean(message.slackMessage);
   const isUser = message.role === "user";
+  const hasAttachments = Boolean(message.attachments?.length);
 
-  // Assistant text bubble class (unchanged). User text no longer carries the
-  // bubble — the bubble is applied once at the wrapper (`userBubbleClass`).
+  // `textBubbleClass` applies only to the assistant text path: it carries the
+  // text bubble per segment inside `segmentClass`'s assistant branch. User
+  // messages get their bubble once at the wrapper via `userBubbleClass`, so the
+  // user `segmentClass` carries no bubble background.
   const textBubbleClass = isSlackMessage
     ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"
     : "w-full text-[var(--content-default)]";
@@ -586,7 +589,15 @@ export function TranscriptMessageBody({
       return undefined;
     };
 
-    const interleavedGroupElements = groups.map((group, gi) => {
+    // Each entry carries its group `type` alongside the rendered node so the
+    // user branch can place text inside the bubble and tool-call/surface
+    // elements outside it (only text/markdown belongs in the user bubble). For
+    // assistants the order is preserved by rendering all nodes in sequence.
+    const interleavedGroupEntries = groups.map((group, gi): {
+      type: ContentGroup["type"];
+      node: ReactNode;
+    } => {
+      const node = ((): ReactNode => {
             if (group.type === "toolCalls") {
               const toolCalls = group.ids
                 .map(resolveToolCall)
@@ -663,11 +674,21 @@ export function TranscriptMessageBody({
               );
             }
             return null;
-          });
+      })();
+      return { type: group.type, node };
+    });
 
-    const hasAttachments = Boolean(
-      message.attachments && message.attachments.length > 0,
-    );
+    // Order-preserving flat list for the assistant branch.
+    const interleavedGroupElements = interleavedGroupEntries.map((e) => e.node);
+    // For the user branch: text belongs in the bubble; tool-call/surface
+    // elements render outside it (after the bubble).
+    const interleavedTextElements = interleavedGroupEntries
+      .filter((e) => e.type === "text")
+      .map((e) => e.node);
+    const interleavedNonTextElements = interleavedGroupEntries
+      .filter((e) => e.type !== "text")
+      .map((e) => e.node);
+
     // Fallback: if message.content exists but no text groups rendered
     // (e.g. tool_use_start before any assistant_text_delta), show the content.
     const interleavedFallback =
@@ -690,16 +711,22 @@ export function TranscriptMessageBody({
           className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
         >
           {isUser ? (
-            <div className={userBubbleClass}>
-              {interleavedGroupElements}
-              {interleavedFallback}
-              {hasAttachments && message.attachments ? (
-                <BubbleAttachments
-                  attachments={message.attachments}
-                  assistantId={assistantId}
-                />
-              ) : null}
-            </div>
+            <>
+              <div className={userBubbleClass}>
+                {interleavedTextElements}
+                {interleavedFallback}
+                {hasAttachments && message.attachments ? (
+                  <BubbleAttachments
+                    attachments={message.attachments}
+                    assistantId={assistantId}
+                  />
+                ) : null}
+              </div>
+              {/* Tool-call cards and surfaces stay outside the user bubble
+                  (low-reachability for user messages, but kept for parity with
+                  the assistant path). */}
+              {interleavedNonTextElements}
+            </>
           ) : (
             <>
               {interleavedGroupElements}
@@ -733,8 +760,10 @@ export function TranscriptMessageBody({
   }
 
   // Legacy path: no interleaved tool calls in contentOrder. Render all tool
-  // calls first, then text content.
-  const contentElements: ReactNode[] = [];
+  // calls first, then text content. Each element is tagged "text" or
+  // "surface" so the user branch can keep text in the bubble and render
+  // surfaces outside it.
+  const contentEntries: Array<{ type: "text" | "surface"; node: ReactNode }> = [];
   if (message.contentOrder && message.contentOrder.length > 0) {
     const textSegmentsArr = message.textSegments ?? [];
     for (const entry of message.contentOrder) {
@@ -746,43 +775,58 @@ export function TranscriptMessageBody({
               (s) => (s as Record<string, unknown>).id === entry.id,
             );
         const segText = seg?.content ?? entry.id;
-        contentElements.push(
-          renderTextWithInlineSurfaces(segText, `text-${entry.id}`, message.role === "user"),
-        );
+        contentEntries.push({
+          type: "text",
+          node: renderTextWithInlineSurfaces(segText, `text-${entry.id}`, message.role === "user"),
+        });
       } else if (entry.type === "surface") {
         const surface = resolveSurface(entry.id);
         if (surface) {
-          contentElements.push(
-            <div key={`surface-${entry.id}`} className="w-full">
-              <SurfaceRouter
-                surface={surface}
-                onAction={onSurfaceAction}
-                onOpenApp={onOpenApp}
-                onOpenDocument={onOpenDocument}
-                assistantId={assistantId}
-                isToolCallComplete={isToolCallComplete}
-              />
-            </div>,
-          );
+          contentEntries.push({
+            type: "surface",
+            node: (
+              <div key={`surface-${entry.id}`} className="w-full">
+                <SurfaceRouter
+                  surface={surface}
+                  onAction={onSurfaceAction}
+                  onOpenApp={onOpenApp}
+                  onOpenDocument={onOpenDocument}
+                  assistantId={assistantId}
+                  isToolCallComplete={isToolCallComplete}
+                />
+              </div>
+            ),
+          });
         }
       }
     }
-    if (contentElements.length === 0 && message.content) {
-      contentElements.push(
-        renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user"),
-      );
+    if (contentEntries.length === 0 && message.content) {
+      contentEntries.push({
+        type: "text",
+        node: renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user"),
+      });
     }
   } else {
-    contentElements.push(
-      message.content
+    contentEntries.push({
+      type: "text",
+      node: message.content
         ? renderTextWithInlineSurfaces(message.content, "content", message.role === "user")
         : null,
-    );
+    });
   }
+  // Order-preserving flat list for the assistant branch.
+  const contentElements = contentEntries.map((e) => e.node);
+  // For the user branch: text in the bubble, surfaces outside it.
+  const legacyTextElements = contentEntries
+    .filter((e) => e.type === "text")
+    .map((e) => e.node);
+  const legacyNonTextElements = contentEntries
+    .filter((e) => e.type !== "text")
+    .map((e) => e.node);
   const legacyToolCalls =
     message.toolCalls?.filter((tc) => !isSuppressedUiTool(tc)) ?? [];
   const hasVisibleLegacyContent = contentElements.some((el) => !!el);
-  const hasLegacyAttachments = Boolean(message.attachments?.length);
+  const hasVisibleLegacyText = legacyTextElements.some((el) => !!el);
 
   return (
     <div
@@ -823,21 +867,25 @@ export function TranscriptMessageBody({
           // bubble background/padding live here (userBubbleClass) instead of
           // per text segment. Rendered whenever there is any text content OR
           // any attachments, so attachment-only messages still get a bubble.
-          (hasVisibleLegacyContent || hasLegacyAttachments) && (
-            <div className={userBubbleClass}>
-              {contentElements}
-              {hasLegacyAttachments && message.attachments ? (
-                <BubbleAttachments
-                  attachments={message.attachments}
-                  assistantId={assistantId}
-                />
-              ) : null}
-            </div>
-          )
+          // Surfaces (rare for user messages) render outside the bubble.
+          <>
+            {(hasVisibleLegacyText || hasAttachments) && (
+              <div className={userBubbleClass}>
+                {legacyTextElements}
+                {hasAttachments && message.attachments ? (
+                  <BubbleAttachments
+                    attachments={message.attachments}
+                    assistantId={assistantId}
+                  />
+                ) : null}
+              </div>
+            )}
+            {legacyNonTextElements}
+          </>
         ) : (
           <>
             {(hasVisibleLegacyContent ||
-              (!message.toolCalls?.length && !hasLegacyAttachments)) && (
+              (!message.toolCalls?.length && !hasAttachments)) && (
               // Layout-only column: the bubble styling (textBubbleClass) is applied
               // per text segment inside renderTextWithInlineSurfaces, mirroring the
               // interleaved path above. Applying textBubbleClass here too would
@@ -848,7 +896,7 @@ export function TranscriptMessageBody({
                 {contentElements}
               </div>
             )}
-            {hasLegacyAttachments && message.attachments && (
+            {hasAttachments && message.attachments && (
               <MessageAttachments
                 attachments={message.attachments}
                 assistantId={assistantId}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -553,6 +553,71 @@ export function TranscriptMessageBody({
     );
   };
 
+  // Render the user-message content from an ordered, tagged list. Walks the
+  // items in canonical `contentOrder` sequence, grouping CONTIGUOUS runs of
+  // text into one `userBubbleClass` bubble while each non-text element (surface
+  // / tool-call group) renders OUTSIDE any bubble in its canonical position —
+  // preserving `contentOrder` and keeping non-text out of the bubble chrome.
+  // Attachments aren't part of `contentOrder`: they append to the last text
+  // bubble (so "text then image" is one bubble) or, when there is no text, get
+  // their own bubble. Empty text runs are skipped so no empty padded box shows.
+  const renderUserContent = (
+    items: Array<{ kind: "text" | "nonText"; node: ReactNode }>,
+  ): ReactNode => {
+    // Plan slots first, then emit JSX once, so trailing attachments can be
+    // pushed into the last text bubble's node array before its element is
+    // created (React captures children at creation time).
+    type Slot =
+      | { kind: "bubble"; nodes: ReactNode[] }
+      | { kind: "raw"; node: ReactNode };
+    const slots: Slot[] = [];
+    let textRun: ReactNode[] = [];
+
+    const flushTextRun = () => {
+      if (textRun.length > 0) {
+        slots.push({ kind: "bubble", nodes: textRun });
+        textRun = [];
+      }
+    };
+
+    for (const item of items) {
+      if (item.kind === "text") {
+        if (item.node) textRun.push(item.node);
+        continue;
+      }
+      flushTextRun();
+      if (item.node) slots.push({ kind: "raw", node: item.node });
+    }
+    flushTextRun();
+
+    if (hasAttachments && message.attachments) {
+      const attachmentsNode = (
+        <BubbleAttachments
+          key="user-attachments"
+          attachments={message.attachments}
+          assistantId={assistantId}
+        />
+      );
+      const lastBubble = slots.findLast((slot) => slot.kind === "bubble");
+      if (lastBubble) {
+        lastBubble.nodes.push(attachmentsNode);
+      } else {
+        slots.push({ kind: "bubble", nodes: [attachmentsNode] });
+      }
+    }
+
+    let bubbleIndex = 0;
+    return slots.map((slot, i) =>
+      slot.kind === "raw" ? (
+        <Fragment key={`user-slot-${i}`}>{slot.node}</Fragment>
+      ) : (
+        <div key={`user-bubble-${bubbleIndex++}`} className={userBubbleClass}>
+          {slot.nodes}
+        </div>
+      ),
+    );
+  };
+
   if (hasInterleavedToolCalls && message.contentOrder) {
     // Group consecutive entries: merge adjacent toolCall/tool entries into a
     // single group (mirrors macOS `groupContentBlocks`).
@@ -680,14 +745,6 @@ export function TranscriptMessageBody({
 
     // Order-preserving flat list for the assistant branch.
     const interleavedGroupElements = interleavedGroupEntries.map((e) => e.node);
-    // For the user branch: text belongs in the bubble; tool-call/surface
-    // elements render outside it (after the bubble).
-    const interleavedTextElements = interleavedGroupEntries
-      .filter((e) => e.type === "text")
-      .map((e) => e.node);
-    const interleavedNonTextElements = interleavedGroupEntries
-      .filter((e) => e.type !== "text")
-      .map((e) => e.node);
 
     // Fallback: if message.content exists but no text groups rendered
     // (e.g. tool_use_start before any assistant_text_delta), show the content.
@@ -700,12 +757,20 @@ export function TranscriptMessageBody({
           )
         : null;
 
-    // Mirrors the legacy user branch's `(hasVisibleLegacyText || hasAttachments)`
-    // gate: only render the surface-lift bubble when it would have visible
-    // content. Without this, an interleaved user message with no resolvable
-    // text, no fallback, and no attachments renders an empty padded box.
-    const hasVisibleInterleavedText =
-      interleavedTextElements.some((el) => !!el) || !!interleavedFallback;
+    // For the user branch: walk the entries in canonical order, tagging text
+    // (and the fallback) as bubble content and tool-call/surface groups as
+    // non-text so `renderUserContent` can split the bubble around them while
+    // preserving `contentOrder`.
+    const interleavedUserItems: Array<{
+      kind: "text" | "nonText";
+      node: ReactNode;
+    }> = interleavedGroupEntries.map((e) => ({
+      kind: e.type === "text" ? "text" : "nonText",
+      node: e.node,
+    }));
+    if (interleavedFallback) {
+      interleavedUserItems.push({ kind: "text", node: interleavedFallback });
+    }
 
     return (
       <div
@@ -718,24 +783,10 @@ export function TranscriptMessageBody({
           className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
         >
           {isUser ? (
-            <>
-              {(hasVisibleInterleavedText || hasAttachments) && (
-                <div className={userBubbleClass}>
-                  {interleavedTextElements}
-                  {interleavedFallback}
-                  {hasAttachments && message.attachments ? (
-                    <BubbleAttachments
-                      attachments={message.attachments}
-                      assistantId={assistantId}
-                    />
-                  ) : null}
-                </div>
-              )}
-              {/* Tool-call cards and surfaces stay outside the user bubble
-                  (low-reachability for user messages, but kept for parity with
-                  the assistant path). */}
-              {interleavedNonTextElements}
-            </>
+            // Text runs render inside surface-lift bubbles; tool-call/surface
+            // groups render outside any bubble in their canonical position so
+            // `contentOrder` is preserved (see `renderUserContent`).
+            renderUserContent(interleavedUserItems)
           ) : (
             <>
               {interleavedGroupElements}
@@ -825,17 +876,19 @@ export function TranscriptMessageBody({
   }
   // Order-preserving flat list for the assistant branch.
   const contentElements = contentEntries.map((e) => e.node);
-  // For the user branch: text in the bubble, surfaces outside it.
-  const legacyTextElements = contentEntries
-    .filter((e) => e.type === "text")
-    .map((e) => e.node);
-  const legacyNonTextElements = contentEntries
-    .filter((e) => e.type !== "text")
-    .map((e) => e.node);
+  // For the user branch: walk the entries in canonical order, tagging text as
+  // bubble content and surfaces as non-text so `renderUserContent` can split
+  // the bubble around them while preserving `contentOrder`.
+  const legacyUserItems: Array<{
+    kind: "text" | "nonText";
+    node: ReactNode;
+  }> = contentEntries.map((e) => ({
+    kind: e.type === "text" ? "text" : "nonText",
+    node: e.node,
+  }));
   const legacyToolCalls =
     message.toolCalls?.filter((tc) => !isSuppressedUiTool(tc)) ?? [];
   const hasVisibleLegacyContent = contentElements.some((el) => !!el);
-  const hasVisibleLegacyText = legacyTextElements.some((el) => !!el);
 
   return (
     <div
@@ -872,25 +925,11 @@ export function TranscriptMessageBody({
           </>
         )}
         {isUser ? (
-          // User messages render text + attachments in a single bubble. The
-          // bubble background/padding live here (userBubbleClass) instead of
-          // per text segment. Rendered whenever there is any text content OR
-          // any attachments, so attachment-only messages still get a bubble.
-          // Surfaces (rare for user messages) render outside the bubble.
-          <>
-            {(hasVisibleLegacyText || hasAttachments) && (
-              <div className={userBubbleClass}>
-                {legacyTextElements}
-                {hasAttachments && message.attachments ? (
-                  <BubbleAttachments
-                    attachments={message.attachments}
-                    assistantId={assistantId}
-                  />
-                ) : null}
-              </div>
-            )}
-            {legacyNonTextElements}
-          </>
+          // User messages render contiguous text runs (plus attachments) inside
+          // surface-lift bubbles; surfaces (rare for user messages) render
+          // outside any bubble in their canonical position so `contentOrder` is
+          // preserved (see `renderUserContent`).
+          renderUserContent(legacyUserItems)
         ) : (
           <>
             {(hasVisibleLegacyContent ||

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 
+import { BubbleAttachments } from "@/domains/chat/components/chat-attachments/bubble-attachments";
 import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
@@ -351,15 +352,25 @@ export function TranscriptMessageBody({
     (e) => e.type === "toolCall" || e.type === "tool",
   );
   const isSlackMessage = Boolean(message.slackMessage);
+  const isUser = message.role === "user";
 
-  const textBubbleClass =
-    message.role === "user"
-      ? `max-w-[80%] rounded-lg bg-[var(--surface-lift)] px-4 py-3 text-[var(--content-default)] ${
-          isSlackMessage ? "sm:max-w-[420px]" : ""
-        }`
-      : isSlackMessage
-        ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"
-        : "w-full text-[var(--content-default)]";
+  // Assistant text bubble class (unchanged). User text no longer carries the
+  // bubble — the bubble is applied once at the wrapper (`userBubbleClass`).
+  const textBubbleClass = isSlackMessage
+    ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"
+    : "w-full text-[var(--content-default)]";
+
+  // User messages render text + attachments inside a single bubble; the bubble
+  // background/padding live here at the wrapper rather than per text segment.
+  const userBubbleClass = `max-w-[80%] rounded-lg bg-[var(--surface-lift)] px-4 py-3 text-[var(--content-default)] flex flex-col gap-2 ${
+    isSlackMessage ? "sm:max-w-[420px]" : ""
+  }`;
+
+  // Class applied to each text segment inside `renderTextWithInlineSurfaces`.
+  // For users the wrapper provides the bubble, so segments carry no bubble bg.
+  const segmentClass = isUser
+    ? "break-words text-[15px]"
+    : `break-words text-[15px] ${textBubbleClass}`;
 
   const handleExpandChange = (toolCallId: string, isExpanded: boolean) => {
     if (isExpanded) {
@@ -463,7 +474,7 @@ export function TranscriptMessageBody({
             return (
               <div
                 key={`inline-text-${si}`}
-                className={`break-words text-[15px] ${textBubbleClass}`}
+                className={segmentClass}
               >
                 <ChatMarkdownMessage content={seg.content} hardLineBreaks={hardLineBreaks} />
               </div>
@@ -473,7 +484,7 @@ export function TranscriptMessageBody({
       );
     }
     return (
-      <div key={key} className={`break-words text-[15px] ${textBubbleClass}`}>
+      <div key={key} className={segmentClass}>
         <ChatMarkdownMessage content={text} hardLineBreaks={hardLineBreaks} />
       </div>
     );
@@ -575,17 +586,7 @@ export function TranscriptMessageBody({
       return undefined;
     };
 
-    return (
-      <div
-        ref={wrapperRef}
-        onClick={handleBubbleClick}
-        data-revealed={revealed}
-        className={`group/msg flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-      >
-        <div
-          className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
-        >
-          {groups.map((group, gi) => {
+    const interleavedGroupElements = groups.map((group, gi) => {
             if (group.type === "toolCalls") {
               const toolCalls = group.ids
                 .map(resolveToolCall)
@@ -662,18 +663,54 @@ export function TranscriptMessageBody({
               );
             }
             return null;
-          })}
-          {/* Fallback: if message.content exists but no text groups rendered
-              (e.g. tool_use_start before any assistant_text_delta), show the
-              content. */}
-          {!groups.some((g) => g.type === "text") && message.content &&
-            renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user")
-          }
-          {message.attachments && message.attachments.length > 0 && (
-            <MessageAttachments
-              attachments={message.attachments}
-              assistantId={assistantId}
-            />
+          });
+
+    const hasAttachments = Boolean(
+      message.attachments && message.attachments.length > 0,
+    );
+    // Fallback: if message.content exists but no text groups rendered
+    // (e.g. tool_use_start before any assistant_text_delta), show the content.
+    const interleavedFallback =
+      !groups.some((g) => g.type === "text") && message.content
+        ? renderTextWithInlineSurfaces(
+            message.content,
+            "fallback",
+            message.role === "user",
+          )
+        : null;
+
+    return (
+      <div
+        ref={wrapperRef}
+        onClick={handleBubbleClick}
+        data-revealed={revealed}
+        className={`group/msg flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
+      >
+        <div
+          className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
+        >
+          {isUser ? (
+            <div className={userBubbleClass}>
+              {interleavedGroupElements}
+              {interleavedFallback}
+              {hasAttachments && message.attachments ? (
+                <BubbleAttachments
+                  attachments={message.attachments}
+                  assistantId={assistantId}
+                />
+              ) : null}
+            </div>
+          ) : (
+            <>
+              {interleavedGroupElements}
+              {interleavedFallback}
+              {hasAttachments && (
+                <MessageAttachments
+                  attachments={message.attachments ?? []}
+                  assistantId={assistantId}
+                />
+              )}
+            </>
           )}
           <SlackMessageAttribution
             message={message}
@@ -745,6 +782,7 @@ export function TranscriptMessageBody({
   const legacyToolCalls =
     message.toolCalls?.filter((tc) => !isSuppressedUiTool(tc)) ?? [];
   const hasVisibleLegacyContent = contentElements.some((el) => !!el);
+  const hasLegacyAttachments = Boolean(message.attachments?.length);
 
   return (
     <div
@@ -780,24 +818,43 @@ export function TranscriptMessageBody({
             {renderInlineSubagentCards(legacyToolCalls)}
           </>
         )}
-        {(contentElements.some((el) => !!el) ||
-          (!message.toolCalls?.length &&
-            !(message.attachments && message.attachments.length > 0))) && (
-          // Layout-only column: the bubble styling (textBubbleClass) is applied
-          // per text segment inside renderTextWithInlineSurfaces, mirroring the
-          // interleaved path above. Applying textBubbleClass here too would
-          // double-wrap text in two nested bubbles (doubled padding/background).
-          <div
-            className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
-          >
-            {contentElements}
-          </div>
-        )}
-        {message.attachments && message.attachments.length > 0 && (
-          <MessageAttachments
-            attachments={message.attachments}
-            assistantId={assistantId}
-          />
+        {isUser ? (
+          // User messages render text + attachments in a single bubble. The
+          // bubble background/padding live here (userBubbleClass) instead of
+          // per text segment. Rendered whenever there is any text content OR
+          // any attachments, so attachment-only messages still get a bubble.
+          (hasVisibleLegacyContent || hasLegacyAttachments) && (
+            <div className={userBubbleClass}>
+              {contentElements}
+              {hasLegacyAttachments && message.attachments ? (
+                <BubbleAttachments
+                  attachments={message.attachments}
+                  assistantId={assistantId}
+                />
+              ) : null}
+            </div>
+          )
+        ) : (
+          <>
+            {(hasVisibleLegacyContent ||
+              (!message.toolCalls?.length && !hasLegacyAttachments)) && (
+              // Layout-only column: the bubble styling (textBubbleClass) is applied
+              // per text segment inside renderTextWithInlineSurfaces, mirroring the
+              // interleaved path above. Applying textBubbleClass here too would
+              // double-wrap text in two nested bubbles (doubled padding/background).
+              <div
+                className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
+              >
+                {contentElements}
+              </div>
+            )}
+            {hasLegacyAttachments && message.attachments && (
+              <MessageAttachments
+                attachments={message.attachments}
+                assistantId={assistantId}
+              />
+            )}
+          </>
         )}
         {/* Render surfaces attached to this message that aren't in contentOrder */}
         {(() => {


### PR DESCRIPTION
## Summary
Renders a user message's text and its file attachments inside a **single message bubble** in the web app, matching the Figma redesign (current: node 5322:6604 → desired: node 4499:118573). Previously the text rendered in a rounded bubble and attachments rendered as a separate sibling strip of thumbnail squares below it (two visual bubbles). Now image attachments show as a large inline preview and non-image files as compact chips, all inside one bubble. Rendering-only change — the data model already carries text + attachments on one message. Assistant message rendering is unchanged.

## Self-review result
PASS — converged after 2 remediation rounds. Round 1 fixed 6 gaps (image object-contain, boolean dedup, stale docstring/comment, extracted a shared `useAttachmentPreview` hook, kept tool-call/surface elements outside the user bubble). Round 2 added a guard so the interleaved user bubble can't render empty. Final integration + slop re-reviews: PASS.

## PRs merged into feature branch
- #32821: feat(web/chat): add BubbleAttachments inline renderer for in-bubble attachments
- #32823: feat(web/chat): render user text + attachments in a single message bubble

### Fix PRs (self-review remediation)
- #32827: image fit, dedup, shared preview hook, keep tool-calls/surfaces outside the user bubble
- #32828: gate interleaved user bubble to avoid an empty styled box

Part of plan: unify-message-attachments.md