### PR TITLE
fix(security): harden workspace entrypoint hooks

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -30,10 +30,10 @@ fi
 # and have the executable bit set. Scripts are sourced so env mutations
 # propagate to the daemon. Errors are logged but non-fatal.
 if [ -d /workspace/.entrypoint.d ]; then
+  wait_for_kata_apt_root
   for hook in /workspace/.entrypoint.d/*.sh; do
     [ ! -L "$hook" ] || continue
     [ -x "$hook" ] || continue
-    wait_for_kata_apt_root
     . "$hook" || echo "Warning: workspace hook $hook exited $?" >&2
   done
 fi

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -30,8 +30,10 @@ fi
 # and have the executable bit set. Scripts are sourced so env mutations
 # propagate to the daemon. Errors are logged but non-fatal.
 if [ -d /workspace/.entrypoint.d ]; then
-  wait_for_kata_apt_root
   for hook in /workspace/.entrypoint.d/*.sh; do
+    [ ! -L "$hook" ] || continue
+    [ -x "$hook" ] || continue
+    wait_for_kata_apt_root
     [ ! -L "$hook" ] || continue
     [ -x "$hook" ] || continue
     . "$hook" || echo "Warning: workspace hook $hook exited $?" >&2

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -25,14 +25,14 @@ if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi
 
-# Source executable scripts from /workspace/.entrypoint.d/ in lexicographic
-# order so an assistant can extend the daemon environment from its own
-# workspace volume — PATH additions, credential helpers, tooling symlinks.
-# Scripts are sourced so env mutations propagate to the daemon. Errors are
-# logged but non-fatal.
+# Source workspace entrypoint hooks from /workspace/.entrypoint.d/ in
+# lexicographic order. Hooks must be regular files (symlinks are rejected)
+# and have the executable bit set. Scripts are sourced so env mutations
+# propagate to the daemon. Errors are logged but non-fatal.
 if [ -d /workspace/.entrypoint.d ]; then
   for hook in /workspace/.entrypoint.d/*.sh; do
-    [ -r "$hook" ] || continue
+    [ ! -L "$hook" ] || continue
+    [ -x "$hook" ] || continue
     wait_for_kata_apt_root
     . "$hook" || echo "Warning: workspace hook $hook exited $?" >&2
   done


### PR DESCRIPTION
## Summary

- Reject symlinks in `/workspace/.entrypoint.d/` hook sourcing to prevent path traversal
- Require the executable bit (`-x`) instead of just readable (`-r`) to raise the bar for workspace-planted hooks
- Update comment to document the new validation requirements

Codex finding: https://chatgpt.com/codex/cloud/security/findings/f4097386188881918985b205bb006464

## Original prompt

A Codex security scan identified that the workspace entrypoint hook mechanism in `docker-entrypoint.sh` sources any readable `.sh` file from `/workspace/.entrypoint.d/` as root with no validation — no symlink rejection, no executable-bit check, no ownership verification. Since workspace writes are auto-approved low-risk operations, this creates a privilege escalation path. The hook feature (PR #30065) is deliberate and needed for tmux, credential helpers, and tooling persistence, so this PR hardens the mechanism rather than removing it: symlinks are now rejected and hooks must have the executable bit set.