### PR TITLE
[codex] Fix app library sync and app-builder routing

### DIFF
--- a/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { AssistantEvent } from "@/types/event-types";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import {
@@ -140,6 +141,36 @@ describe("useAssistantResourceSync", () => {
         ]) as never,
       );
     });
+  });
+
+  test("invalidates app list queries on apps:list sync tag", async () => {
+    const queryClient = freshQueryClient();
+    let predicate:
+      | ((query: { queryKey: readonly unknown[] }) => boolean)
+      | undefined;
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      predicate = (
+        arg as {
+          predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+        }
+      ).predicate;
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.appsList]) as unknown as AssistantEvent);
+
+    await waitFor(() => {
+      expect(predicate).toBeDefined();
+    });
+    expect(
+      predicate!({
+        queryKey: appsGetQueryKey({ path: { assistant_id: "asst-1" } }),
+      }),
+    ).toBe(true);
+    expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
   });
 
   test("invalidates home-feed query on home_feed_updated", async () => {

--- a/apps/web/src/hooks/use-assistant-resource-sync.ts
+++ b/apps/web/src/hooks/use-assistant-resource-sync.ts
@@ -2,7 +2,7 @@
  * Bus consumer for assistant-level resource cache invalidation.
  *
  * Routes `sync_changed` tags (avatar, identity, config, sounds,
- * schedules) and discrete SSE events (`home_feed_updated`,
+ * schedules, apps) and discrete SSE events (`home_feed_updated`,
  * `relationship_state_updated`, `identity_changed`, `avatar_updated`)
  * into TanStack Query cache invalidations.
  *
@@ -39,7 +39,7 @@ import { SYNC_TAGS } from "@/lib/sync/types";
  * Subscribes to assistant-resource sync events via the event bus.
  *
  * Handles `sync_changed` tags for avatar, identity, config, sounds,
- * and schedules, plus discrete event types for home feed/state changes
+ * schedules, and apps, plus discrete event types for home feed/state changes
  * and identity/avatar pushes. These are all stateless invalidations —
  * no reconnect handling needed since the underlying `useQuery` hooks
  * refetch automatically when the query becomes stale.
@@ -89,6 +89,11 @@ export function useAssistantResourceSync(
                 queryKey: assistantScheduleRunsQueryKey(assistantId),
               });
               break;
+            case SYNC_TAGS.appsList:
+              void queryClient.invalidateQueries({
+                predicate: (query) => isAppsGetQueryKey(query.queryKey),
+              });
+              break;
           }
         }
         return;
@@ -121,4 +126,13 @@ export function useAssistantResourceSync(
         return;
     }
   });
+}
+
+function isAppsGetQueryKey(queryKey: readonly unknown[]): boolean {
+  const firstKeyPart = queryKey[0];
+  return (
+    firstKeyPart !== null &&
+    typeof firstKeyPart === "object" &&
+    (firstKeyPart as { _id?: unknown })._id === "appsGet"
+  );
 }

--- a/apps/web/src/lib/sync/types.ts
+++ b/apps/web/src/lib/sync/types.ts
@@ -4,6 +4,7 @@ export const SYNC_TAGS = {
   assistantConfig: "assistant:self:config",
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
+  appsList: "apps:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",

--- a/apps/web/src/lib/sync/web-sync-router.test.ts
+++ b/apps/web/src/lib/sync/web-sync-router.test.ts
@@ -44,6 +44,7 @@ function createHarness(opts: HarnessOptions = {}) {
     invalidateAssistantConfig: 0,
     invalidateAssistantSounds: 0,
     invalidateAssistantSchedules: 0,
+    invalidateApps: 0,
     scheduleConversationListRefetch: 0,
     refreshActiveConversationMessages: 0,
   };
@@ -62,6 +63,9 @@ function createHarness(opts: HarnessOptions = {}) {
     },
     invalidateAssistantSchedules: () => {
       calls.invalidateAssistantSchedules += 1;
+    },
+    invalidateApps: () => {
+      calls.invalidateApps += 1;
     },
     scheduleConversationListRefetch: () => {
       calls.scheduleConversationListRefetch += 1;
@@ -125,6 +129,20 @@ describe("createWebSyncRouter — self-echo drop", () => {
 
     expect(result.handledTags).toEqual([SYNC_TAGS.conversationsList]);
     expect(calls.scheduleConversationListRefetch).toBe(1);
+  });
+
+  test("dispatches app list sync tags", async () => {
+    const { router, calls } = createHarness();
+    const event: SyncChangedEvent = {
+      type: "sync_changed",
+      tags: [SYNC_TAGS.appsList],
+    };
+
+    const result = await router.dispatchSyncChanged(event);
+
+    expect(result.handledTags).toEqual([SYNC_TAGS.appsList]);
+    expect(result.unknownTags).toEqual([]);
+    expect(calls.invalidateApps).toBe(1);
   });
 
   test("metadata-only conversation tags do not refetch the full conversation list", async () => {

--- a/apps/web/src/lib/sync/web-sync-router.ts
+++ b/apps/web/src/lib/sync/web-sync-router.ts
@@ -25,6 +25,7 @@ export interface WebSyncRouterOptions {
   invalidateAssistantConfig: () => void;
   invalidateAssistantSounds: () => void;
   invalidateAssistantSchedules: () => void;
+  invalidateApps?: () => void;
   scheduleConversationListRefetch: () => void;
   refreshActiveConversationMessages: () => Promise<ActiveConversationMessagesRefreshResult>;
 }
@@ -68,6 +69,7 @@ export function createWebSyncRouter(
       SYNC_TAGS.assistantSchedules,
       options.invalidateAssistantSchedules,
     ),
+    registry.register(SYNC_TAGS.appsList, options.invalidateApps ?? (() => {})),
     registry.register(
       SYNC_TAGS.conversationsList,
       options.scheduleConversationListRefetch,

--- a/assistant/src/__tests__/app-builder-skill-instructions.test.ts
+++ b/assistant/src/__tests__/app-builder-skill-instructions.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, test } from "bun:test";
+
+describe("app-builder skill instructions", () => {
+  test("does not use blocking UI confirmation for optional profile switch", async () => {
+    const skillText = await readFile(
+      new URL("../config/bundled-skills/app-builder/SKILL.md", import.meta.url),
+      "utf8",
+    );
+    const preflightStart = skillText.indexOf("### 0. Preflight");
+    const preflightEnd = skillText.indexOf("### 1. Gather Requirements");
+    const preflight = skillText.slice(preflightStart, preflightEnd);
+
+    expect(preflight).not.toContain("assistant ui confirm --message");
+    expect(preflight).toContain("Do not call `assistant ui confirm`");
+    expect(preflight).toContain("Ask in normal conversation");
+    expect(preflight).toContain("blocking UI confirmation command");
+  });
+});

--- a/assistant/src/__tests__/app-builder-skill-instructions.test.ts
+++ b/assistant/src/__tests__/app-builder-skill-instructions.test.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
 
 describe("app-builder skill instructions", () => {
-  test("does not use blocking UI confirmation for optional profile switch", async () => {
+  test("uses non-CLI UI confirmation for optional profile switch", async () => {
     const skillText = await readFile(
       new URL("../config/bundled-skills/app-builder/SKILL.md", import.meta.url),
       "utf8",
@@ -12,8 +12,11 @@ describe("app-builder skill instructions", () => {
     const preflight = skillText.slice(preflightStart, preflightEnd);
 
     expect(preflight).not.toContain("assistant ui confirm --message");
-    expect(preflight).toContain("Do not call `assistant ui confirm`");
-    expect(preflight).toContain("Ask in normal conversation");
-    expect(preflight).toContain("blocking UI confirmation command");
+    expect(preflight).toContain("Use the `ui_show` tool");
+    expect(preflight).toContain('surface_type: "confirmation"');
+    expect(preflight).toContain("await_action: true");
+    expect(preflight).toContain(
+      "Do not call the shell command `assistant ui confirm`",
+    );
   });
 });

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -77,6 +77,24 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
     );
     expect((result[0].content[2] as { text: string }).text).toBe("Hello");
   });
+
+  test("app-backed active surface tells the model to load app-builder with the right argument", async () => {
+    const messages: Message[] = [userMsg("Edit this app")];
+    const { messages: result } = await applyRuntimeInjections(messages, {
+      activeSurface: {
+        surfaceId: "sf_1",
+        html: "<div>test</div>",
+        appId: "app-1",
+        appName: "Example App",
+        appFiles: [],
+      },
+      workspaceTopLevelContext: null,
+    });
+
+    const activeWorkspaceText = (result[0].content[0] as { text: string }).text;
+    expect(activeWorkspaceText).toContain('skill: "app-builder"');
+    expect(activeWorkspaceText).not.toContain('id: "app-builder"');
+  });
 });
 
 describe("applyRuntimeInjections — minimal mode skips workspace blocks", () => {

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ToolExecutor } from "../tools/executor.js";
@@ -70,6 +71,19 @@ import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function broadcastPayloads(): unknown[] {
+  return (broadcastSpy.mock.calls as unknown[][]).map(([payload]) => payload);
+}
+
+function expectAppChangeBroadcast(appId: string): void {
+  expect(broadcastPayloads()).toEqual(
+    expect.arrayContaining([
+      { type: "app_files_changed", appId },
+      { type: "sync_changed", tags: [SYNC_TAGS.appsList] },
+    ]) as never,
+  );
+}
 
 /** Build a minimal ToolSetupContext stub. */
 function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
@@ -167,11 +181,8 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_refresh", { app_id: "app-42" });
 
-      expect(broadcastSpy).toHaveBeenCalledTimes(1);
-      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
-        type: "app_files_changed",
-        appId: "app-42",
-      });
+      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expectAppChangeBroadcast("app-42");
     });
 
     test("calls updatePublishedAppDeployment", async () => {
@@ -262,6 +273,7 @@ describe("session-tool-setup app refresh side effects", () => {
         type: "app_files_changed",
         appId: "new-app-1",
       });
+      expectAppChangeBroadcast("new-app-1");
     });
 
     test("canonicalizes create_app skill_execute alias before hooks run", async () => {
@@ -293,6 +305,7 @@ describe("session-tool-setup app refresh side effects", () => {
         type: "app_files_changed",
         appId: "alias-app-1",
       });
+      expectAppChangeBroadcast("alias-app-1");
     });
 
     test("canonicalizes legacy computer_use_press_key skill_execute alias before dispatch", async () => {
@@ -403,6 +416,7 @@ describe("session-tool-setup app refresh side effects", () => {
         type: "app_files_changed",
         appId: "new-app-err",
       });
+      expectAppChangeBroadcast("new-app-err");
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -424,11 +438,8 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_delete", { app_id: "del-app-1" });
 
-      expect(broadcastSpy).toHaveBeenCalledTimes(1);
-      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
-        type: "app_files_changed",
-        appId: "del-app-1",
-      });
+      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expectAppChangeBroadcast("del-app-1");
     });
 
     test("skips side effects when app_delete result is an error", async () => {
@@ -480,7 +491,8 @@ describe("session-tool-setup app refresh side effects", () => {
         });
 
         expect(refreshSpy).toHaveBeenCalledTimes(1);
-        expect(broadcastSpy).toHaveBeenCalledTimes(1);
+        expect(broadcastSpy).toHaveBeenCalledTimes(2);
+        expectAppChangeBroadcast("skill-app");
         expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
       }
     });

--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -58,6 +58,74 @@ describe("Tool definition includes dynamic_page", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tool execution guard
+// ---------------------------------------------------------------------------
+
+describe("ui_show dynamic_page app substitute guard", () => {
+  test("rejects dynamic_page when the model labels it as an app build", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "JARVIS 1020 Test Counter",
+        activity: "Building the JARVIS 1020 Test Counter app",
+        data: {
+          html: "<button>Increment</button>",
+          preview: {
+            title: "JARVIS 1020 Test Counter",
+            subtitle: "Click INCREMENT to count up",
+          },
+        },
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        proxyToolResolver: async () => {
+          proxied = true;
+          return { content: "proxied", isError: false };
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('skill: "app-builder"');
+    expect(proxied).toBe(false);
+  });
+
+  test("allows transient non-app dynamic_page surfaces", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "My Slides",
+        data: {
+          html: "<h1>Hello</h1>",
+          preview: {
+            title: "Slides",
+            subtitle: "3 slides about Apple",
+          },
+        },
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        proxyToolResolver: async () => {
+          proxied = true;
+          return { content: "proxied", isError: false };
+        },
+      },
+    );
+
+    expect(result).toEqual({ content: "proxied", isError: false });
+    expect(proxied).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // UiSurfaceShowDynamicPage structure
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -135,13 +135,24 @@ assistant config get llm.activeProfile
 
 If the profile is already `quality-optimized`, skip the rest of this step and proceed to Step 1.
 
-**If the active profile is `balanced`, `cost-optimized`, or any non-quality profile, you MUST ask the user for permission before switching. Do NOT open an inference session without explicit user confirmation.** Ask in normal conversation, then stop and wait for the user's reply. Do not call `assistant ui confirm` or any other blocking UI confirmation command for this optional model-upgrade preflight; delayed confirmation surfaces block the build flow before the app work starts.
+**If the active profile is `balanced`, `cost-optimized`, or any non-quality profile, you MUST ask the user for permission before switching. Do NOT open an inference session without explicit user confirmation.** Use the `ui_show` tool to present an inline `confirmation` surface and wait for the action. Do not call the shell command `assistant ui confirm`; that CLI-mediated confirmation can block the build flow before the app work starts.
 
 ```
-The current model profile is `<profile>`. App building works best with `quality-optimized` because it makes better design decisions, writes cleaner components, and produces more visually polished results. Want me to switch for this build, or keep the current profile and build now?
+ui_show({
+  surface_type: "confirmation",
+  title: "Use quality model for this app?",
+  data: {
+    message: "The current model profile is `<profile>`. App building works best with `quality-optimized` because it makes better design decisions, writes cleaner components, and produces more visually polished results.",
+    detail: "Choose whether to switch for this build or keep the current profile and build now.",
+    confirmLabel: "Switch for this build",
+    cancelLabel: "Keep current profile"
+  },
+  display: "inline",
+  await_action: true
+})
 ```
 
-Wait for the user's answer before proceeding.
+If `ui_show` is unavailable or the current channel cannot render confirmation surfaces, ask the user directly in conversation as a fallback. Wait for the user's answer before proceeding.
 
 **Only if the user confirms**, open an inference session:
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -135,13 +135,13 @@ assistant config get llm.activeProfile
 
 If the profile is already `quality-optimized`, skip the rest of this step and proceed to Step 1.
 
-**If the active profile is `balanced`, `cost-optimized`, or any non-quality profile, you MUST ask the user for permission before switching. Do NOT open an inference session without explicit user confirmation.** Use `assistant ui confirm`:
+**If the active profile is `balanced`, `cost-optimized`, or any non-quality profile, you MUST ask the user for permission before switching. Do NOT open an inference session without explicit user confirmation.** Ask in normal conversation, then stop and wait for the user's reply. Do not call `assistant ui confirm` or any other blocking UI confirmation command for this optional model-upgrade preflight; delayed confirmation surfaces block the build flow before the app work starts.
 
 ```
-assistant ui confirm --message "App building works best with a high-quality model — it makes better design decisions, writes cleaner components, and produces more visually polished results. Switch to the quality profile for this build? (You can switch back after.)"
+The current model profile is `<profile>`. App building works best with `quality-optimized` because it makes better design decisions, writes cleaner components, and produces more visually polished results. Want me to switch for this build, or keep the current profile and build now?
 ```
 
-If `assistant ui confirm` isn't available on this binary, ask the user directly in conversation instead. **Either way, wait for the user's answer before proceeding.**
+Wait for the user's answer before proceeding.
 
 **Only if the user confirms**, open an inference session:
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -301,7 +301,7 @@ function injectActiveSurfaceContext(
     lines.push(
       `The user is viewing app "${ctx.appName ?? "Untitled"}" (app_id: "${ctx.appId}", slug: "${slug}") in workspace mode.`,
       "",
-      'PREREQUISITE: If `app_refresh` is not yet available, call `skill_load` with `id: "app-builder"` first to load it.',
+      'PREREQUISITE: If `app_refresh` is not yet available, call `skill_load` with `skill: "app-builder"` first to load it.',
       "",
       "RULES FOR WORKSPACE MODIFICATION:",
       `1. Use \`file_edit\` to make surgical changes to app files. The file path is \`${getAppDirPath(ctx.appId)}/<path>\`.`,

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -13,6 +13,7 @@ export const SYNC_TAGS = {
   assistantConfig: "assistant:self:config",
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
+  appsList: "apps:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -15,6 +15,7 @@ import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import {
+  publishAppsChanged,
   publishAvatarChanged,
   publishConfigChanged,
   publishIdentityChanged,
@@ -231,6 +232,7 @@ export class DaemonServer {
         refreshSurfacesForApp(conversation, appId, { fileChange: true });
       }
       broadcastMessage({ type: "app_files_changed", appId });
+      publishAppsChanged();
       void updatePublishedAppDeployment(appId);
     };
 

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -16,6 +16,7 @@ import { invalidatePageIndex } from "../memory/v2/page-index.js";
 import { getConceptsDir } from "../memory/v2/page-store.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
+import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -60,8 +61,13 @@ function notifyAppChanged(
   opts?: { fileChange?: boolean; status?: string },
 ): void {
   refreshSurfacesForApp(ctx, appId, opts);
-  broadcastMessage({ type: "app_files_changed", appId });
+  broadcastAppFilesChanged(appId);
   void updatePublishedAppDeployment(appId);
+}
+
+function broadcastAppFilesChanged(appId: string): void {
+  broadcastMessage({ type: "app_files_changed", appId });
+  publishAppsChanged();
 }
 
 // ── Registry ─────────────────────────────────────────────────────────
@@ -109,10 +115,7 @@ registerHook("app_create", (_name, _input, result, { ctx }) => {
       if (parsed.name) {
         void generateAppIcon(parsed.id, parsed.name, parsed.description)
           .then(() => {
-            broadcastMessage({
-              type: "app_files_changed",
-              appId: parsed.id!,
-            });
+            broadcastAppFilesChanged(parsed.id!);
           })
           .catch((err) => {
             log.warn(
@@ -130,14 +133,14 @@ registerHook("app_create", (_name, _input, result, { ctx }) => {
 registerHook("app_generate_icon", (_name, input) => {
   const appId = input.app_id as string | undefined;
   if (appId) {
-    broadcastMessage({ type: "app_files_changed", appId });
+    broadcastAppFilesChanged(appId);
   }
 });
 
 registerHook("app_delete", (_name, input) => {
   const appId = input.app_id as string | undefined;
   if (appId) {
-    broadcastMessage({ type: "app_files_changed", appId });
+    broadcastAppFilesChanged(appId);
   }
 });
 

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -180,6 +180,15 @@ mock.module("../notifications/emit-signal.js", () => ({
   },
 }));
 
+// app sync invalidation mock
+let publishAppsChangedCalls: Array<string | undefined> = [];
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishAppsChanged: (originClientId?: string) => {
+    publishAppsChangedCalls.push(originClientId);
+  },
+}));
+
 // findConversation mock
 type MockConversation = {
   processing: boolean;
@@ -302,6 +311,7 @@ function resetState() {
   releaseClaimCalls = 0;
   addMessageCalls = [];
   emitSignalCalls = [];
+  publishAppsChangedCalls = [];
   broadcastCalls = [];
   mockConversations = new Map();
   logWarnCalls = [];
@@ -461,6 +471,7 @@ describe("runProactiveArtifactJob", () => {
         type: "app_files_changed",
         appId: "app-123",
       });
+      expect(publishAppsChangedCalls).toEqual([undefined]);
 
       // Message injection: addMessage called with skipIndexing
       expect(addMessageCalls).toHaveLength(1);

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -31,6 +31,7 @@ import {
   extractText,
   getConfiguredProvider,
 } from "../providers/provider-send-message.js";
+import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { injectAuxAssistantMessage } from "./aux-message-injector.js";
 import {
@@ -160,6 +161,7 @@ export async function runProactiveArtifactJob(params: {
 
     if (artifactType === "app") {
       params.broadcastMessage({ type: "app_files_changed", appId: artifactId });
+      publishAppsChanged();
     }
 
     // ── Post-build message copy ─────────────────────────────────────

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -50,6 +50,7 @@ import { createSharedAppLink } from "../../memory/shared-app-links-store.js";
 import { computeContentId } from "../../util/content-id.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { publishAppsChanged } from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -62,6 +63,12 @@ const log = getLogger("app-management-routes");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function getOriginClientId(
+  headers: RouteHandlerArgs["headers"],
+): string | undefined {
+  return headers?.["x-vellum-client-id"]?.trim() || undefined;
+}
 
 function getSharedAppsDir(): string {
   return join(
@@ -566,14 +573,16 @@ async function handleImportBundle({ rawBody, headers }: RouteHandlerArgs) {
       "Request body is required — upload a .vbundle file",
     );
   }
-  return importBundle(rawBody, headers ?? {});
+  const result = await importBundle(rawBody, headers ?? {});
+  publishAppsChanged(getOriginClientId(headers));
+  return result;
 }
 
 function handleListSharedApps() {
   return { apps: listSharedApps() };
 }
 
-function handleForkSharedApp({ body }: RouteHandlerArgs) {
+function handleForkSharedApp({ body, headers }: RouteHandlerArgs) {
   if (!body?.uuid) {
     throw new BadRequestError("uuid is required");
   }
@@ -581,10 +590,11 @@ function handleForkSharedApp({ body }: RouteHandlerArgs) {
   if (!result.success) {
     throw new BadRequestError(result.error);
   }
+  publishAppsChanged(getOriginClientId(headers));
   return result;
 }
 
-async function handleInstallGalleryApp({ body }: RouteHandlerArgs) {
+async function handleInstallGalleryApp({ body, headers }: RouteHandlerArgs) {
   if (!body?.galleryAppId) {
     throw new BadRequestError("galleryAppId is required");
   }
@@ -592,6 +602,7 @@ async function handleInstallGalleryApp({ body }: RouteHandlerArgs) {
   if (!result.success) {
     throw new BadRequestError(result.error);
   }
+  publishAppsChanged(getOriginClientId(headers));
   return result;
 }
 
@@ -695,8 +706,9 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
   return { appId: app.id, dirName, name: app.name, html };
 }
 
-function handleDeleteApp({ pathParams }: RouteHandlerArgs) {
+function handleDeleteApp({ pathParams, headers }: RouteHandlerArgs) {
   deleteApp(pathParams?.id as string);
+  publishAppsChanged(getOriginClientId(headers));
   return { success: true };
 }
 

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -46,6 +46,10 @@ export function publishSchedulesChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.assistantSchedules], originClientId);
 }
 
+export function publishAppsChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
+}
+
 /**
  * Reasons that change the *shape* of the conversation list — a row is
  * added, removed, or its position changes. These require web clients to

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -128,7 +128,7 @@ export const skillLoadTool = {
   name: "skill_load",
 
   description:
-    "Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills.",
+    'Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills. For app, website, dashboard, game, calculator, tracker, visualization, or interactive tool requests, load `app-builder` with `skill: "app-builder"`.',
 
   category: "skills",
 

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -46,7 +46,7 @@ function proxyExecute(toolName: string) {
 export const uiShowTool = {
   name: "ui_show",
   description:
-    "Surface structured data or UI in the conversation. For long-form writing use the document skill; for interactive apps use the app-builder skill.\n\n" +
+    'Surface structured data or UI in the conversation. For long-form writing use the document skill. For interactive apps, dashboards, games, calculators, or durable tools, call `skill_load` with `skill: "app-builder"` and use the app-builder workflow; do not use `dynamic_page` as a substitute for a persistent app.\n\n' +
     "Surface types (data shapes):\n" +
     '- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "weather_forecast" (native weather widget), "task_progress" (live step tracker - update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] })\n' +
     '- table: { columns: [{ id, label }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -18,6 +18,11 @@ import type {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const APP_BUILDER_ARTIFACT_RE =
+  /\b(app|apps|application|applications|website|websites|site|sites|dashboard|dashboards|game|games|calculator|calculators|tracker|trackers|visualization|visualizations|visualisation|visualisations|tool|tools|utility|utilities|counter|counters)\b/i;
+const APP_BUILDER_BUILD_RE =
+  /\b(build|building|built|create|creating|created|make|making|made|generate|generating|generated)\b/i;
+
 /**
  * Forward execution to the connected macOS client via the request-bound
  * `proxyToolResolver`. Returns a structured error when no resolver is
@@ -29,6 +34,14 @@ function proxyExecute(toolName: string) {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> => {
+    if (toolName === "ui_show" && isDynamicPageAppSubstitute(input)) {
+      return {
+        content:
+          'Error: ui_show dynamic_page is for transient UI surfaces only. This request is building an app-like experience, so load the app-builder skill first with `skill_load` using `skill: "app-builder"`, then create a persistent Library app with the app-builder workflow.',
+        isError: true,
+      };
+    }
+
     if (!context.proxyToolResolver) {
       return {
         content: `No proxy resolver configured for proxy tool "${toolName}". This tool requires an external resolver (e.g. a connected macOS client).`,
@@ -39,6 +52,49 @@ function proxyExecute(toolName: string) {
   };
 }
 
+function isDynamicPageAppSubstitute(input: Record<string, unknown>): boolean {
+  if (input.surface_type !== "dynamic_page") {
+    return false;
+  }
+
+  const text = collectRoutingText(input).join(" ");
+  if (!APP_BUILDER_ARTIFACT_RE.test(text)) {
+    return false;
+  }
+
+  return APP_BUILDER_BUILD_RE.test(text) || /\b(app|application)\b/i.test(text);
+}
+
+function collectRoutingText(input: Record<string, unknown>): string[] {
+  const values: string[] = [];
+  addString(values, input.title);
+  addString(values, input.activity);
+
+  const data = asRecord(input.data);
+  if (data) {
+    const preview = asRecord(data.preview);
+    if (preview) {
+      addString(values, preview.title);
+      addString(values, preview.subtitle);
+      addString(values, preview.description);
+    }
+  }
+
+  return values;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function addString(values: string[], value: unknown): void {
+  if (typeof value === "string") {
+    values.push(value);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // ui_show
 // ---------------------------------------------------------------------------
@@ -46,7 +102,7 @@ function proxyExecute(toolName: string) {
 export const uiShowTool = {
   name: "ui_show",
   description:
-    'Surface structured data or UI in the conversation. For long-form writing use the document skill. For interactive apps, dashboards, games, calculators, or durable tools, call `skill_load` with `skill: "app-builder"` and use the app-builder workflow; do not use `dynamic_page` as a substitute for a persistent app.\n\n' +
+    'Surface structured data or UI in the conversation. For long-form writing use the document skill. For interactive apps, dashboards, games, calculators, or durable tools, call `skill_load` with `skill: "app-builder"` and use the app-builder workflow; do not use `dynamic_page` as a substitute for a persistent app. App-like `dynamic_page` calls are rejected.\n\n' +
     "Surface types (data shapes):\n" +
     '- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "weather_forecast" (native weather widget), "task_progress" (live step tracker - update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] })\n' +
     '- table: { columns: [{ id, label }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +


### PR DESCRIPTION
## Summary
- Add an `apps:list` sync invalidation tag and publish it after app create/refresh/delete/import/fork/install/source-change paths.
- Invalidate web `appsGet` queries when `apps:list` arrives so newly created apps appear in Library without a reload.
- Tighten app-builder routing hints, including the active app workspace `skill_load` argument and tool descriptions for app/dashboard/game/tool requests.

## Root Cause
New app writes were succeeding, but the daemon only emitted the legacy `app_files_changed` event. The web Library consumes canonical `sync_changed` invalidation tags, so its TanStack `appsGet` cache stayed stale. Separately, active app workspace guidance told the model to call `skill_load` with `id: "app-builder"`, but the tool schema requires `skill`, and generic UI guidance did not strongly route app-building requests to the app-builder skill.

## Validation
- `cd assistant && bun test src/__tests__/conversation-tool-setup-app-refresh.test.ts src/__tests__/conversation-runtime-workspace.test.ts`
- `cd assistant && bun test src/__tests__/skill-load-tool.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd apps/web && bun test src/hooks/use-assistant-resource-sync.test.tsx src/lib/sync/web-sync-router.test.ts`
- `cd apps/web && bunx tsc --noEmit` still fails on pre-existing duplicated React type errors under `@vellum/design-library`; none of the touched web sync files appear in that failure output.

Fixes JARVIS-1020
