### PR TITLE
feat(voice): add live-voice websocket protocol types and parser

### DIFF
--- a/apps/web/src/domains/voice/live-voice/protocol.test.ts
+++ b/apps/web/src/domains/voice/live-voice/protocol.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseServerFrame,
+  type LiveVoiceServerFrame,
+} from "@/domains/voice/live-voice/protocol";
+
+describe("parseServerFrame", () => {
+  const frames: LiveVoiceServerFrame[] = [
+    { type: "ready", seq: 1, sessionId: "s1", conversationId: "c1" },
+    { type: "busy", seq: 2, activeSessionId: "s9" },
+    { type: "stt_partial", seq: 3, text: "hel" },
+    { type: "stt_final", seq: 4, text: "hello" },
+    { type: "thinking", seq: 5, turnId: "t1" },
+    { type: "assistant_text_delta", seq: 6, text: "hi" },
+    {
+      type: "tts_audio",
+      seq: 7,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    },
+    { type: "tts_done", seq: 8, turnId: "t1" },
+    {
+      type: "metrics",
+      seq: 9,
+      turnId: "t1",
+      sttMs: 120,
+      llmFirstDeltaMs: 200,
+      ttsFirstAudioMs: null,
+      totalMs: null,
+    },
+    {
+      type: "archived",
+      seq: 10,
+      conversationId: "c1",
+      sessionId: "s1",
+      turnId: "t1",
+      role: "assistant",
+      attachmentId: "a1",
+      attachmentIds: ["a1", "a2"],
+      warning: { code: "w", message: "warn" },
+    },
+    { type: "error", seq: 11, code: "boom", message: "bad" },
+  ];
+
+  for (const frame of frames) {
+    test(`round-trips ${frame.type} frame`, () => {
+      const result = parseServerFrame(JSON.stringify(frame));
+      expect(result).toEqual(frame);
+    });
+  }
+
+  test("returns invalid_json for malformed JSON", () => {
+    const result = parseServerFrame("{not json");
+    expect(result).toEqual({
+      type: "error",
+      code: "invalid_json",
+      message: expect.any(String),
+    });
+  });
+
+  test("returns invalid_json for non-object JSON", () => {
+    for (const raw of ["42", '"str"', "null", "[]"]) {
+      expect(parseServerFrame(raw)).toEqual({
+        type: "error",
+        code: "invalid_json",
+        message: expect.any(String),
+      });
+    }
+  });
+
+  test("returns invalid_json for unknown frame type", () => {
+    const result = parseServerFrame(
+      JSON.stringify({ type: "made_up", seq: 1 }),
+    );
+    expect(result).toEqual({
+      type: "error",
+      code: "invalid_json",
+      message: expect.any(String),
+    });
+  });
+
+  test("returns invalid_json for missing type", () => {
+    const result = parseServerFrame(JSON.stringify({ seq: 1, text: "x" }));
+    expect(result).toEqual({
+      type: "error",
+      code: "invalid_json",
+      message: expect.any(String),
+    });
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/protocol.ts
+++ b/apps/web/src/domains/voice/live-voice/protocol.ts
@@ -1,0 +1,224 @@
+/**
+ * Live-voice WebSocket wire protocol.
+ *
+ * Web-app port of the runtime contract defined in
+ * `assistant/src/live-voice/protocol.ts`. Field names and shapes mirror that
+ * module exactly so the browser client and daemon agree on the wire format.
+ *
+ * Pure module: no DOM / WebSocket imports.
+ *
+ * ## Framing
+ *
+ * - Client control frames ({@link LiveVoiceClientFrame}) are sent as JSON text
+ *   frames.
+ * - Audio chunks are sent as raw BINARY WebSocket frames (PCM bytes), NOT as
+ *   JSON — there is no `audio` client frame on the web side.
+ * - Every server frame ({@link LiveVoiceServerFrame}) is JSON text and carries a
+ *   monotonically increasing `seq` number.
+ */
+
+// ---------------------------------------------------------------------------
+// Client frames (text/JSON control frames; audio goes over binary frames)
+// ---------------------------------------------------------------------------
+
+export interface LiveVoiceAudioConfig {
+  readonly mimeType: "audio/pcm";
+  readonly sampleRate: number;
+  readonly channels: 1;
+}
+
+export interface LiveVoiceClientStartFrame {
+  readonly type: "start";
+  readonly conversationId?: string;
+  readonly audio: LiveVoiceAudioConfig;
+}
+
+export interface LiveVoiceClientPttReleaseFrame {
+  readonly type: "ptt_release";
+}
+
+export interface LiveVoiceClientInterruptFrame {
+  readonly type: "interrupt";
+}
+
+export interface LiveVoiceClientEndFrame {
+  readonly type: "end";
+}
+
+export type LiveVoiceClientFrame =
+  | LiveVoiceClientStartFrame
+  | LiveVoiceClientPttReleaseFrame
+  | LiveVoiceClientInterruptFrame
+  | LiveVoiceClientEndFrame;
+
+// ---------------------------------------------------------------------------
+// Server frames (text/JSON; every frame carries `seq`)
+// ---------------------------------------------------------------------------
+
+const LIVE_VOICE_SERVER_FRAME_TYPES = [
+  "ready",
+  "busy",
+  "stt_partial",
+  "stt_final",
+  "thinking",
+  "assistant_text_delta",
+  "tts_audio",
+  "tts_done",
+  "metrics",
+  "archived",
+  "error",
+] as const;
+
+type LiveVoiceServerFrameType = (typeof LIVE_VOICE_SERVER_FRAME_TYPES)[number];
+
+interface LiveVoiceServerFrameBase {
+  readonly type: LiveVoiceServerFrameType;
+  readonly seq: number;
+}
+
+export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "ready";
+  readonly sessionId: string;
+  readonly conversationId: string;
+}
+
+export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "busy";
+  readonly activeSessionId: string;
+}
+
+export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_partial";
+  readonly text: string;
+}
+
+export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_final";
+  readonly text: string;
+}
+
+export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "thinking";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceAssistantTextDeltaServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "assistant_text_delta";
+  readonly text: string;
+}
+
+export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_audio";
+  readonly mimeType: string;
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "metrics";
+  readonly turnId: string;
+  readonly sttMs: number | null;
+  readonly llmFirstDeltaMs: number | null;
+  readonly ttsFirstAudioMs: number | null;
+  readonly totalMs: number | null;
+}
+
+export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "archived";
+  readonly conversationId: string;
+  readonly sessionId: string;
+  readonly turnId?: string;
+  readonly role?: "user" | "assistant";
+  readonly attachmentId?: string;
+  readonly attachmentIds?: string[];
+  readonly warning?: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "error";
+  readonly code: string;
+  readonly message: string;
+}
+
+export type LiveVoiceServerFrame =
+  | LiveVoiceReadyServerFrame
+  | LiveVoiceBusyServerFrame
+  | LiveVoiceSttPartialServerFrame
+  | LiveVoiceSttFinalServerFrame
+  | LiveVoiceThinkingServerFrame
+  | LiveVoiceAssistantTextDeltaServerFrame
+  | LiveVoiceTtsAudioServerFrame
+  | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceMetricsServerFrame
+  | LiveVoiceArchivedServerFrame
+  | LiveVoiceErrorServerFrame;
+
+/**
+ * Error frame returned by {@link parseServerFrame} when the raw payload cannot
+ * be JSON-parsed or lacks a recognized `type` discriminator.
+ */
+export interface LiveVoiceInvalidJsonFrame {
+  readonly type: "error";
+  readonly code: "invalid_json";
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function isLiveVoiceServerFrameType(
+  value: unknown,
+): value is LiveVoiceServerFrameType {
+  return (
+    typeof value === "string" &&
+    (LIVE_VOICE_SERVER_FRAME_TYPES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Parse a raw text frame received from the server into a typed
+ * {@link LiveVoiceServerFrame}.
+ *
+ * Returns a {@link LiveVoiceInvalidJsonFrame} (`code: "invalid_json"`) when the
+ * payload is not valid JSON, is not an object, or carries an unknown/missing
+ * `type` discriminator.
+ */
+export function parseServerFrame(
+  raw: string,
+): LiveVoiceServerFrame | LiveVoiceInvalidJsonFrame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      type: "error",
+      code: "invalid_json",
+      message: "Live voice server frame is not valid JSON",
+    };
+  }
+
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    !isLiveVoiceServerFrameType((parsed as { type?: unknown }).type)
+  ) {
+    return {
+      type: "error",
+      code: "invalid_json",
+      message: "Live voice server frame has missing or unknown type",
+    };
+  }
+
+  return parsed as LiveVoiceServerFrame;
+}


### PR DESCRIPTION
## Summary
- Port live-voice WS wire protocol (client/server frames) to the web app with a frame parser

Part of plan: web-live-voice.md (PR 2 of 8)