### PR TITLE
feat(voice): add live-voice ws connection + token-exchange client

### DIFF
--- a/apps/web/src/domains/voice/live-voice/connection.test.ts
+++ b/apps/web/src/domains/voice/live-voice/connection.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the live-voice WS connection + token-exchange client.
+ *
+ * Two surfaces under test:
+ *   - `mintLiveVoiceToken` — must POST `/v1/auth/live-voice-token/` through
+ *     the credentialed platform `client` (which attaches session cookie +
+ *     CSRF + org header via the interceptor). We spy on `client.post` rather
+ *     than `mock.module`-ing the whole SDK, matching the pattern in
+ *     `domains/chat/inspector/compaction-trail-fetch.test.ts`.
+ *   - `buildLiveVoiceWsUrl` — must produce the cloud velay URL with the
+ *     `assistantId` in the path, a URL-encoded `?token=`, the `wss` scheme,
+ *     and `conversationId` propagated only when supplied.
+ *
+ * @jest-environment happy-dom
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { client } from "@/generated/api/client.gen";
+
+import {
+  buildLiveVoiceWsUrl,
+  LiveVoiceTokenError,
+  mintLiveVoiceToken,
+} from "./connection";
+
+// ---------------------------------------------------------------------------
+// mintLiveVoiceToken
+// ---------------------------------------------------------------------------
+
+type CapturedPostOptions = {
+  url: string;
+  body?: Record<string, unknown>;
+};
+
+let captured: CapturedPostOptions | null = null;
+let nextPostResult: { data: unknown; error: unknown; response: Response };
+const originalPost = client.post;
+
+beforeEach(() => {
+  captured = null;
+  nextPostResult = {
+    data: { token: "tok-abc", expiresAt: "2026-06-01T00:05:00Z" },
+    error: null,
+    response: new Response(null, { status: 200 }),
+  };
+  client.post = mock(async (options: CapturedPostOptions) => {
+    captured = options;
+    return nextPostResult;
+  }) as typeof client.post;
+});
+
+afterEach(() => {
+  client.post = originalPost;
+});
+
+describe("mintLiveVoiceToken", () => {
+  test("POSTs the documented mint endpoint with the assistantId body", async () => {
+    await mintLiveVoiceToken("assistant-1");
+
+    expect(captured).not.toBeNull();
+    expect(captured!.url).toBe("/v1/auth/live-voice-token/");
+    expect(captured!.body).toEqual({ assistantId: "assistant-1" });
+  });
+
+  test("returns { token, expiresAt } from the response", async () => {
+    const result = await mintLiveVoiceToken("assistant-1");
+    expect(result).toEqual({
+      token: "tok-abc",
+      expiresAt: "2026-06-01T00:05:00Z",
+    });
+  });
+
+  test("throws LiveVoiceTokenError with the HTTP status on non-OK", async () => {
+    nextPostResult = {
+      data: null,
+      error: { detail: "forbidden" },
+      response: new Response(null, { status: 403 }),
+    };
+
+    try {
+      await mintLiveVoiceToken("assistant-1");
+      throw new Error("expected mintLiveVoiceToken to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LiveVoiceTokenError);
+      expect((err as LiveVoiceTokenError).status).toBe(403);
+    }
+  });
+
+  test("throws LiveVoiceTokenError(0) when the body is malformed", async () => {
+    nextPostResult = {
+      data: { token: "tok-abc" }, // missing expiresAt
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+
+    try {
+      await mintLiveVoiceToken("assistant-1");
+      throw new Error("expected mintLiveVoiceToken to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LiveVoiceTokenError);
+      expect((err as LiveVoiceTokenError).status).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLiveVoiceWsUrl
+// ---------------------------------------------------------------------------
+
+describe("buildLiveVoiceWsUrl", () => {
+  test("builds the cloud velay URL with assistantId path + wss scheme + ?token=", () => {
+    const url = new URL(
+      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
+    );
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay.vellum.ai");
+    expect(url.pathname).toBe("/assistant-1/v1/live-voice");
+    expect(url.searchParams.get("token")).toBe("tok-abc");
+    expect(url.searchParams.has("conversationId")).toBe(false);
+  });
+
+  test("URL-encodes tokens containing reserved characters", () => {
+    const token = "a/b+c=d e";
+    const raw = buildLiveVoiceWsUrl({ assistantId: "assistant-1", token });
+    // The encoded form must round-trip back to the original token.
+    expect(new URL(raw).searchParams.get("token")).toBe(token);
+    // And the raw string must not carry the unencoded reserved chars.
+    expect(raw).not.toContain("token=a/b+c=d e");
+  });
+
+  test("appends conversationId as an additional query param when provided", () => {
+    const url = new URL(
+      buildLiveVoiceWsUrl({
+        assistantId: "assistant-1",
+        conversationId: "conv-xyz",
+        token: "tok-abc",
+      }),
+    );
+    expect(url.searchParams.get("token")).toBe("tok-abc");
+    expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/connection.ts
+++ b/apps/web/src/domains/voice/live-voice/connection.ts
@@ -1,0 +1,136 @@
+/**
+ * Live-voice WebSocket connection + token-exchange client.
+ *
+ * Live voice streams audio to velay (`velay.vellum.ai`), which is cross-origin
+ * from the `platform.vellum.ai` SPA. A same-origin cookie WS upgrade is NOT
+ * viable: velay does no user auth, and the channel gateway only accepts a
+ * local actor edge JWT. So the browser must first mint a short-lived,
+ * org+assistant-scoped WS token from the platform and pass it to velay as a
+ * `?token=` query param.
+ *
+ * ---------------------------------------------------------------------------
+ * Mint-endpoint contract (the backend plan must match this verbatim)
+ * ---------------------------------------------------------------------------
+ *
+ *   POST /v1/auth/live-voice-token/
+ *     Auth:     Django SessionAuthentication — session cookie + CSRF
+ *               (`X-CSRFToken`) + `Vellum-Organization-Id`, all attached
+ *               automatically by the platform HeyAPI client interceptor.
+ *               Do NOT hand-roll an `Authorization` header.
+ *     Request:  { assistantId: string }
+ *     Response: { token: string; expiresAt: string }   // expiresAt is ISO-8601
+ *
+ * The endpoint scopes the minted token to the caller's active org and the
+ * requested assistant; velay validates it on the WS upgrade.
+ *
+ * No generated SDK function exists for this route yet (the OpenAPI regen
+ * hasn't picked it up — the backend endpoint is a separate plan). We call
+ * `client.post` directly with the URL, matching sibling hand-rolled platform
+ * fetchers (e.g. `domains/chat/inspector/compaction-trail-fetch.ts`). Routing
+ * through the platform `client` is what attaches the session cookie + CSRF +
+ * `Vellum-Organization-Id` via the request interceptor.
+ */
+
+import { client } from "@/generated/api/client.gen";
+import { assertHasResponse, SDK_BASE_OPTIONS } from "@/utils/api-errors";
+
+/** Production velay host (no scheme). Overridable via `VITE_VELAY_HOST`. */
+const DEFAULT_VELAY_HOST = "velay.vellum.ai";
+
+export interface LiveVoiceToken {
+  token: string;
+  /** ISO-8601 timestamp after which the token is no longer accepted by velay. */
+  expiresAt: string;
+}
+
+export class LiveVoiceTokenError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "LiveVoiceTokenError";
+    this.status = status;
+  }
+}
+
+/**
+ * Type guard for the mint endpoint's wire shape. `client.post` is typed but
+ * the body is `unknown` on the wire — narrow defensively rather than trusting
+ * the generic.
+ */
+function isLiveVoiceToken(value: unknown): value is LiveVoiceToken {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.token === "string" && typeof v.expiresAt === "string";
+}
+
+/**
+ * Mint a short-lived, org+assistant-scoped live-voice WS token.
+ *
+ * POSTs `/v1/auth/live-voice-token/` through the credentialed platform client
+ * so the session cookie, CSRF token, and `Vellum-Organization-Id` ride along
+ * automatically (see the module doc comment for the contract).
+ */
+export async function mintLiveVoiceToken(
+  assistantId: string,
+): Promise<LiveVoiceToken> {
+  const { data, error, response } = await client.post<LiveVoiceToken, unknown>({
+    ...SDK_BASE_OPTIONS,
+    url: "/v1/auth/live-voice-token/",
+    body: { assistantId },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to mint live-voice token");
+  if (!response.ok) {
+    throw new LiveVoiceTokenError(
+      response.status,
+      `Live-voice token request failed (HTTP ${response.status})`,
+    );
+  }
+  if (!isLiveVoiceToken(data)) {
+    throw new LiveVoiceTokenError(0, "Live-voice token response was malformed");
+  }
+  return data;
+}
+
+/** Resolve the velay host (no scheme), honouring the build-time override. */
+function getVelayHost(): string {
+  return import.meta.env.VITE_VELAY_HOST || DEFAULT_VELAY_HOST;
+}
+
+export interface BuildLiveVoiceWsUrlArgs {
+  assistantId: string;
+  /** Optional conversation to attach the live-voice session to. */
+  conversationId?: string;
+  /** Short-lived token from {@link mintLiveVoiceToken}. */
+  token: string;
+}
+
+/**
+ * Build the velay live-voice WebSocket URL for the cloud path:
+ *
+ *   wss://<velayHost>/<assistantId>/v1/live-voice?token=<token>[&conversationId=<id>]
+ *
+ * The token is URL-encoded. `conversationId` is appended as an additional
+ * query param only when provided.
+ *
+ * TODO(self-hosted): when `getSelfHostedIngressUrl()` (see
+ * `@/lib/self-hosted/connection`) returns a local gateway URL, live voice
+ * should instead connect to that gateway over plain WS
+ * (`ws://localhost:{port}/...`) authenticated with a `Bearer` actor token,
+ * rather than to velay with a minted query token. Not implemented — cloud is
+ * the target for this plan, so this builder is cloud-only for now.
+ */
+export function buildLiveVoiceWsUrl({
+  assistantId,
+  conversationId,
+  token,
+}: BuildLiveVoiceWsUrlArgs): string {
+  const host = getVelayHost();
+  const url = new URL(`wss://${host}/${assistantId}/v1/live-voice`);
+  url.searchParams.set("token", token);
+  if (conversationId) {
+    url.searchParams.set("conversationId", conversationId);
+  }
+  return url.toString();
+}

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -20,6 +20,11 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   /** When set, the app runs in platform (cloud-hosted) mode. Unset = local mode. */
   readonly VITE_PLATFORM_MODE?: string;
+  /**
+   * Override for the live-voice velay host (no scheme), e.g. `velay.dev.vellum.ai`.
+   * Defaults to `velay.vellum.ai` when unset. See `domains/voice/live-voice/connection.ts`.
+   */
+  readonly VITE_VELAY_HOST?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add live-voice WS URL builder (velay, ?token=) and short-lived token mint client (cookie+CSRF via existing HTTP client)

Part of plan: web-live-voice.md (PR 1 of 8)