### PR TITLE
fix(acp): route ACP token injection through credential broker

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -171,7 +171,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-telegram.ts", // Telegram bot token management
       "daemon/handlers/config-vercel.ts", // Vercel API token management
       "runtime/routes/integrations/twilio.ts", // Twilio credential management (HTTP control-plane)
-      "acp/prepare-agent-env.ts", // shared helper injects CLAUDE_CODE_OAUTH_TOKEN into claude-agent-acp subprocess env (called by route + skill tool spawn paths)
       "security/token-manager.ts", // OAuth token refresh flow
       "tools/network/script-proxy/session-manager.ts", // proxy credential injection at runtime
       "calls/call-domain.ts", // caller identity resolution (user phone number lookup)

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -5,28 +5,120 @@
  * The route-level test in `runtime/routes/acp-routes.test.ts` covers the same
  * behavior through the HTTP handler; these tests pin the helper in isolation
  * so the contract is clear and a future refactor can't silently break it.
+ *
+ * Credential reads go through the credential broker (`serverUse`), so we
+ * mock the broker and metadata store rather than the raw secure-keys backend.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Stub the secure-keys backend BEFORE importing the helper. Bun's
-// `mock.module` is process-global and only takes effect for imports that
-// follow it — the dynamic import below ensures correctness.
-const secureKeyStore = new Map<string, string>();
+// ---------------------------------------------------------------------------
+// Stubs — wired BEFORE importing the helper via dynamic import.
+// ---------------------------------------------------------------------------
 
-mock.module("../../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => secureKeyStore.get(key),
+/** Simulates the credential metadata store. */
+const metadataStore = new Map<
+  string,
+  { allowedTools: string[]; usageDescription?: string }
+>();
+
+mock.module("../../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (service: string, field: string) => {
+    const key = `${service}/${field}`;
+    const entry = metadataStore.get(key);
+    if (!entry) return undefined;
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: entry.allowedTools,
+      allowedDomains: [],
+      usageDescription: entry.usageDescription,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    policy?: { allowedTools?: string[]; usageDescription?: string },
+  ) => {
+    const key = `${service}/${field}`;
+    const existing = metadataStore.get(key);
+    metadataStore.set(key, {
+      allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
+      usageDescription:
+        policy?.usageDescription ?? existing?.usageDescription,
+    });
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: metadataStore.get(key)!.allowedTools,
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+}));
+
+/**
+ * Simulates the credential broker's serverUse method. The vault stores
+ * plaintext values keyed by `service/field`; the broker enforces tool
+ * policy via the metadata store before passing the value to the callback.
+ */
+const vaultStore = new Map<string, string>();
+
+mock.module("../../tools/credentials/broker.js", () => ({
+  credentialBroker: {
+    serverUse: async <T>(request: {
+      service: string;
+      field: string;
+      toolName: string;
+      execute: (value: string) => Promise<T>;
+    }) => {
+      const key = `${request.service}/${request.field}`;
+      const meta = metadataStore.get(key);
+      if (!meta) {
+        return { success: false, reason: `No credential found for ${key}` };
+      }
+      if (!meta.allowedTools.includes(request.toolName)) {
+        return {
+          success: false,
+          reason: `Tool "${request.toolName}" not allowed`,
+        };
+      }
+      const value = vaultStore.get(key);
+      if (!value) {
+        return {
+          success: false,
+          reason: `No stored value for ${key}`,
+        };
+      }
+      const result = await request.execute(value);
+      return { success: true, result };
+    },
+  },
 }));
 
 const { prepareAgentEnv } = await import("../prepare-agent-env.js");
 
 beforeEach(() => {
-  secureKeyStore.clear();
+  metadataStore.clear();
+  vaultStore.clear();
 });
 
+// ---------------------------------------------------------------------------
+// Helper to seed a vault entry (simulates `assistant credentials set`).
+// ---------------------------------------------------------------------------
+
+function seedVaultToken(token: string): void {
+  vaultStore.set("acp/claude_oauth_token", token);
+}
+
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
-  test("injects CLAUDE_CODE_OAUTH_TOKEN from the secure store when agent.env has no override", async () => {
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-AAA");
+  test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker when agent.env has no override", async () => {
+    seedVaultToken("vault-AAA");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -34,6 +126,29 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     });
 
     expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-AAA");
+  });
+
+  test("auto-registers metadata with acp_spawn in allowedTools when none exists", async () => {
+    seedVaultToken("vault-auto-meta");
+
+    await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
+
+    const meta = metadataStore.get("acp/claude_oauth_token");
+    expect(meta).toBeDefined();
+    expect(meta!.allowedTools).toContain("acp_spawn");
+  });
+
+  test("adds acp_spawn to existing metadata that lacks it", async () => {
+    metadataStore.set("acp/claude_oauth_token", {
+      allowedTools: ["other_tool"],
+    });
+    seedVaultToken("vault-augment");
+
+    await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
+
+    const meta = metadataStore.get("acp/claude_oauth_token");
+    expect(meta!.allowedTools).toContain("acp_spawn");
+    expect(meta!.allowedTools).toContain("other_tool");
   });
 
   test("accepts CLAUDE_CODE_OAUTH_TOKEN from agent.env (config.json override) with no vault entry", async () => {
@@ -46,10 +161,8 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("config-BBB");
   });
 
-  test("agent.env override wins over the secure-store entry (precedence pin)", async () => {
-    // The config-supplied env wins so users can rotate per-workspace without
-    // racing the vault. Mirrors the route-level precedence test.
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-CCC");
+  test("agent.env override wins over the vault entry (precedence pin)", async () => {
+    seedVaultToken("vault-CCC");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -61,7 +174,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("preserves unrelated env vars on agent.env when injecting from the vault", async () => {
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-EEE");
+    seedVaultToken("vault-EEE");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -74,19 +187,13 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("throws FailedDependencyError when no token is provided from either route", async () => {
-    // secureKeyStore empty, no agent.env override — the preflight must throw
-    // so callers fail fast instead of spawning a zombie subprocess that the
-    // SDK rejects with 'Authentication required' after the first prompt.
     await expect(
       prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
     ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
   });
 
   test("gates on the resolved command BASENAME (alias to /custom/path/claude-agent-acp still gets the token)", async () => {
-    // A user-supplied `acp.agents.my-claude = { command: "/opt/.../claude-agent-acp" }`
-    // is the only realistic path that lands a non-bare basename here. The
-    // helper must still recognize it.
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-FFF");
+    seedVaultToken("vault-FFF");
 
     const prepared = await prepareAgentEnv({
       command: "/opt/bin/claude-agent-acp",
@@ -97,10 +204,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("does NOT mutate the caller's agentConfig", async () => {
-    // Callers pass `resolved.agent` which is shared state from the resolver's
-    // config cache. The helper must clone before mutating, otherwise repeated
-    // spawns would race on the same object.
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-GGG");
+    seedVaultToken("vault-GGG");
     const original = {
       command: "claude-agent-acp",
       args: [],
@@ -119,10 +223,6 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
 
 describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for codex-acp (no required env vars today)", async () => {
-    // codex-acp inherits auth from the underlying `codex` CLI binary
-    // (codex login / CODEX_API_KEY / OPENAI_API_KEY in process.env) — no
-    // ACP-level env injection. Pin that contract so a future change has
-    // to update this test explicitly.
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
       args: [],
@@ -132,7 +232,7 @@ describe("prepareAgentEnv — non-claude commands", () => {
   });
 
   test("returns the config unchanged for an unrecognized command basename", async () => {
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-HHH");
+    seedVaultToken("vault-HHH");
 
     const prepared = await prepareAgentEnv({
       command: "some-future-adapter",
@@ -140,7 +240,6 @@ describe("prepareAgentEnv — non-claude commands", () => {
       env: { FOO: "bar" },
     });
 
-    // No injection — basename gate skipped.
     expect(prepared.env).toEqual({ FOO: "bar" });
   });
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -138,9 +138,9 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(meta!.allowedTools).toContain("acp_spawn");
   });
 
-  test("adds acp_spawn to existing metadata that lacks it", async () => {
+  test("adds acp_spawn to metadata with empty allowedTools (default provisioning path)", async () => {
     metadataStore.set("acp/claude_oauth_token", {
-      allowedTools: ["other_tool"],
+      allowedTools: [],
     });
     seedVaultToken("vault-augment");
 
@@ -148,7 +148,20 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
 
     const meta = metadataStore.get("acp/claude_oauth_token");
     expect(meta!.allowedTools).toContain("acp_spawn");
-    expect(meta!.allowedTools).toContain("other_tool");
+  });
+
+  test("respects explicit tool policy that excludes acp_spawn", async () => {
+    metadataStore.set("acp/claude_oauth_token", {
+      allowedTools: ["other_tool"],
+    });
+    seedVaultToken("vault-restricted");
+
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
+
+    const meta = metadataStore.get("acp/claude_oauth_token");
+    expect(meta!.allowedTools).toEqual(["other_tool"]);
   });
 
   test("accepts CLAUDE_CODE_OAUTH_TOKEN from agent.env (config.json override) with no vault entry", async () => {

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -13,14 +13,49 @@
  *
  * The fix: have this single helper own injection + preflight, and have
  * every caller route through it before calling `manager.spawn`.
+ *
+ * Credential reads go through the credential broker (`serverUse`) so they
+ * are policy-gated (tool allowlist) and audit-logged. This keeps
+ * `prepare-agent-env.ts` off the secure-keys import allowlist — the broker
+ * owns the plaintext read boundary.
  */
 
 import { basename } from "node:path";
 
 import { FailedDependencyError } from "../runtime/routes/errors.js";
-import { credentialKey } from "../security/credential-key.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { credentialBroker } from "../tools/credentials/broker.js";
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
 import type { AcpAgentConfig } from "./types.js";
+
+const ACP_SPAWN_TOOL = "acp_spawn";
+
+/**
+ * Ensure the `acp/claude_oauth_token` credential has metadata that allows
+ * the `acp_spawn` tool to read it. This is a no-op when the user already
+ * provisioned with `--allowed-tools acp_spawn`. For credentials stored
+ * before the broker migration (or without explicit tool policy), this
+ * adds the policy on first use so the broker doesn't reject the read.
+ */
+function ensureAcpTokenPolicy(): void {
+  const meta = getCredentialMetadata("acp", "claude_oauth_token");
+  if (!meta) {
+    upsertCredentialMetadata("acp", "claude_oauth_token", {
+      allowedTools: [ACP_SPAWN_TOOL],
+      usageDescription:
+        "Claude OAuth token for ACP agent authentication",
+    });
+    return;
+  }
+  const tools = meta.allowedTools ?? [];
+  if (!tools.includes(ACP_SPAWN_TOOL)) {
+    upsertCredentialMetadata("acp", "claude_oauth_token", {
+      allowedTools: [...tools, ACP_SPAWN_TOOL],
+    });
+  }
+}
 
 /**
  * Returns a NEW config with any required credentials merged into `env`.
@@ -39,9 +74,8 @@ import type { AcpAgentConfig } from "./types.js";
  *   1. `acp.agents.<id>.env.CLAUDE_CODE_OAUTH_TOKEN` in `config.json` —
  *      the user-supplied env override on the resolved agent config.
  *   2. Secure store via CLI: `assistant credentials set --service acp \
- *        --field claude_oauth_token <token>` — written to the canonical
- *      `credential/{service}/{field}` key built by `credentialKey()`,
- *      used as fallback when (1) is unset.
+ *        --field claude_oauth_token <token>` — read through the
+ *      credential broker for policy enforcement and audit logging.
  * After resolution, this asserts the token is present (from either route)
  * before spawning. The "fail-fast" throw is symmetric with the existing
  * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
@@ -58,12 +92,15 @@ export async function prepareAgentEnv(
 
   if (commandBasename === "claude-agent-acp") {
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      const claudeToken = await getSecureKeyAsync(
-        credentialKey("acp", "claude_oauth_token"),
-      );
-      if (claudeToken) {
-        env.CLAUDE_CODE_OAUTH_TOKEN = claudeToken;
-      }
+      ensureAcpTokenPolicy();
+      await credentialBroker.serverUse<void>({
+        service: "acp",
+        field: "claude_oauth_token",
+        toolName: ACP_SPAWN_TOOL,
+        execute: async (token) => {
+          env.CLAUDE_CODE_OAUTH_TOKEN = token;
+        },
+      });
     }
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
       throw new FailedDependencyError(

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -34,10 +34,14 @@ const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
  * Ensure the `acp/claude_oauth_token` credential has metadata that allows
- * the `acp_spawn` tool to read it. This is a no-op when the user already
- * provisioned with `--allowed-tools acp_spawn`. For credentials stored
- * before the broker migration (or without explicit tool policy), this
- * adds the policy on first use so the broker doesn't reject the read.
+ * the `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ *
+ * - No metadata at all → create with `allowedTools: ["acp_spawn"]`.
+ * - Metadata exists with an empty `allowedTools` → default provisioning
+ *   path (user ran `credentials set` without `--allowed-tools`), add it.
+ * - Metadata exists with a non-empty `allowedTools` → explicit policy set
+ *   by the user/admin. Respect it even if `acp_spawn` is absent — the
+ *   broker will deny the read and the preflight will throw.
  */
 function ensureAcpTokenPolicy(): void {
   const meta = getCredentialMetadata("acp", "claude_oauth_token");
@@ -50,9 +54,9 @@ function ensureAcpTokenPolicy(): void {
     return;
   }
   const tools = meta.allowedTools ?? [];
-  if (!tools.includes(ACP_SPAWN_TOOL)) {
+  if (tools.length === 0) {
     upsertCredentialMetadata("acp", "claude_oauth_token", {
-      allowedTools: [...tools, ACP_SPAWN_TOOL],
+      allowedTools: [ACP_SPAWN_TOOL],
     });
   }
 }

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -5,9 +5,8 @@
  *  - POST /v1/acp/spawn — the three failure paths produced by
  *    `resolveAcpAgent` (acp_disabled, unknown_agent, binary_not_found).
  *  - POST /v1/acp/spawn (env injection) — CLAUDE_CODE_OAUTH_TOKEN is read
- *    from the secure store under the canonical
- *    `credential/acp/claude_oauth_token` key (built by `credentialKey()`)
- *    and merged into `agentConfig.env` ONLY for the `claude` agent.
+ *    from the credential broker (policy-gated + audited) and merged into
+ *    `agentConfig.env` ONLY for the `claude` agent.
  *  - DELETE /v1/acp/sessions?status=completed — the bulk-clear route that
  *    wipes terminal-state rows (completed/failed/cancelled) from
  *    `acp_session_history` while leaving running/initializing rows intact.
@@ -84,12 +83,83 @@ mock.module("../../acp/index.js", () => ({
   }),
 }));
 
-// Stub secure-keys so env-injection tests can plant a known token (or
-// absence). Driven via `secureKeyStore` per test in beforeEach.
-const secureKeyStore = new Map<string, string>();
+// Stub credential broker + metadata store so env-injection tests can plant
+// a known token (or absence) without touching the real credential store.
+// The broker mock mirrors the real serverUse policy: metadata must exist
+// and allowedTools must include the requesting tool.
+const vaultStore = new Map<string, string>();
+const metadataStore = new Map<
+  string,
+  { allowedTools: string[]; usageDescription?: string }
+>();
 
-mock.module("../../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => secureKeyStore.get(key),
+mock.module("../../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (service: string, field: string) => {
+    const key = `${service}/${field}`;
+    const entry = metadataStore.get(key);
+    if (!entry) return undefined;
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: entry.allowedTools,
+      allowedDomains: [],
+      usageDescription: entry.usageDescription,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    policy?: { allowedTools?: string[]; usageDescription?: string },
+  ) => {
+    const key = `${service}/${field}`;
+    const existing = metadataStore.get(key);
+    metadataStore.set(key, {
+      allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
+      usageDescription:
+        policy?.usageDescription ?? existing?.usageDescription,
+    });
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: metadataStore.get(key)!.allowedTools,
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+}));
+
+mock.module("../../tools/credentials/broker.js", () => ({
+  credentialBroker: {
+    serverUse: async <T>(request: {
+      service: string;
+      field: string;
+      toolName: string;
+      execute: (value: string) => Promise<T>;
+    }) => {
+      const key = `${request.service}/${request.field}`;
+      const meta = metadataStore.get(key);
+      if (!meta) {
+        return { success: false, reason: `No credential found for ${key}` };
+      }
+      if (!meta.allowedTools.includes(request.toolName)) {
+        return {
+          success: false,
+          reason: `Tool "${request.toolName}" not allowed`,
+        };
+      }
+      const value = vaultStore.get(key);
+      if (!value) {
+        return { success: false, reason: `No stored value for ${key}` };
+      }
+      const result = await request.execute(value);
+      return { success: true, result };
+    },
+  },
 }));
 
 import { eq } from "drizzle-orm";
@@ -113,7 +183,8 @@ beforeEach(() => {
   config.setConfig({});
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   capturedSpawns.length = 0;
-  secureKeyStore.clear();
+  vaultStore.clear();
+  metadataStore.clear();
 });
 
 // ---------------------------------------------------------------------------
@@ -186,29 +257,27 @@ describe("POST /v1/acp/spawn", () => {
 //
 // claude-agent-acp authenticates via CLAUDE_CODE_OAUTH_TOKEN. The route
 // accepts the token from two provisioning routes:
-//   1. Secure store under the canonical `credential/acp/claude_oauth_token`
-//      key (built by `credentialKey()`), populated by
-//      `assistant credentials set --service acp --field claude_oauth_token`.
+//   1. Credential broker (policy-gated + audited) reading from the secure
+//      store — provisioned via `assistant credentials set --service acp
+//      --field claude_oauth_token`.
 //   2. `acp.agents.claude.env.CLAUDE_CODE_OAUTH_TOKEN` in the user's
 //      config.json, surfaced on `resolved.agent.env` by the resolver.
-// After merging the secure-store value into `agentConfig.env`, the route
-// preflights for the token and throws `FailedDependencyError` if it is
-// still absent. The "fail-fast" behavior is symmetric with the existing
-// `binary_not_found` preflight and avoids the zombie-subprocess footgun
-// where claude-agent-acp launches, crashes on auth, and leaves the
-// caller with no useful signal.
+// After broker-mediated resolution, the route preflights for the token
+// and throws `FailedDependencyError` if it is still absent.
 //
 // These tests pin both the happy paths and the throw path so a future
 // drift in the key path, the env-override route, or the preflight check
 // fails the suite loudly.
 // ---------------------------------------------------------------------------
 
+/** Seed a vault entry to simulate `assistant credentials set`. */
+function seedVaultToken(token: string): void {
+  vaultStore.set("acp/claude_oauth_token", token);
+}
+
 describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
-  test("injects CLAUDE_CODE_OAUTH_TOKEN from credential/acp/claude_oauth_token for the claude agent", async () => {
-    secureKeyStore.set(
-      "credential/acp/claude_oauth_token",
-      "test-token-abc123",
-    );
+  test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker for the claude agent", async () => {
+    seedVaultToken("test-token-abc123");
 
     const handler = getSpawnHandler();
     await handler({
@@ -226,11 +295,7 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
     );
   });
 
-  test("accepts CLAUDE_CODE_OAUTH_TOKEN from acp.agents.claude.env (config.json override) without a secure-store entry", async () => {
-    // The user-supplied config.json env override is the first-priority
-    // provisioning route. resolveAcpAgent returns it on `resolved.agent.env`,
-    // which the route then preserves on `agentConfig.env`. The preflight
-    // should accept this path with no secure-store entry needed.
+  test("accepts CLAUDE_CODE_OAUTH_TOKEN from acp.agents.claude.env (config.json override) without a vault entry", async () => {
     config.setConfig({
       agents: {
         claude: {
@@ -256,12 +321,8 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
     );
   });
 
-  test("config.json env override wins over a secure-store token (precedence pin)", async () => {
-    // Codex review feedback (PR #31901 / P2): when a user explicitly sets
-    // CLAUDE_CODE_OAUTH_TOKEN under `acp.agents.<id>.env` (per-workspace,
-    // rotated, scoped credential, etc.), the secure-store value must NOT
-    // silently overwrite it. Vault is fallback, not override.
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-token-AAA");
+  test("config.json env override wins over a vault token (precedence pin)", async () => {
+    seedVaultToken("vault-token-AAA");
     config.setConfig({
       agents: {
         claude: {
@@ -288,11 +349,7 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
   });
 
   test("injects via command match for a user-defined agent id aliased to claude-agent-acp", async () => {
-    // Codex review feedback (PR #31901 / P2): gating is keyed off the
-    // resolved command (basename), not the agent id. A custom agent id
-    // pointing at claude-agent-acp still needs CLAUDE_CODE_OAUTH_TOKEN,
-    // so injection + preflight must fire regardless of the id string.
-    secureKeyStore.set("credential/acp/claude_oauth_token", "vault-token-zzz");
+    seedVaultToken("vault-token-zzz");
     config.setConfig({
       agents: {
         "my-claude": {
@@ -319,12 +376,6 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
   });
 
   test("throws FailedDependencyError when no CLAUDE_CODE_OAUTH_TOKEN is available from any source", async () => {
-    // secureKeyStore intentionally empty AND no agentConfig.env override —
-    // simulates a fresh install where the user hasn't provisioned a token
-    // via either route. Fail-fast preflight surfaces this immediately
-    // instead of letting claude-agent-acp launch, crash on auth, and leave
-    // a zombie subprocess behind.
-
     const handler = getSpawnHandler();
     await expect(
       handler({
@@ -339,14 +390,7 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
   });
 
   test("does NOT inject CLAUDE_CODE_OAUTH_TOKEN for agents whose command is not claude-agent-acp", async () => {
-    // Token-injection AND preflight are scoped to claude-agent-acp by
-    // command basename. A codex-acp spawn with the secure-store key set
-    // must still launch without that env var — and must not be blocked
-    // by claude's preflight.
-    secureKeyStore.set(
-      "credential/acp/claude_oauth_token",
-      "test-token-abc123",
-    );
+    seedVaultToken("test-token-abc123");
 
     const handler = getSpawnHandler();
     await handler({
@@ -362,28 +406,6 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
     expect(
       capturedSpawns[0]?.agentConfig.env?.CLAUDE_CODE_OAUTH_TOKEN,
     ).toBeUndefined();
-  });
-
-  test("does NOT pick up a token planted at the legacy non-`credential/` key path", async () => {
-    // Regression guard: the original implementation used the raw key
-    // "acp/claude/oauth_token". The fix routes through `credentialKey()`
-    // so the CLI (`assistant credentials set --service acp --field
-    // claude_oauth_token`) is the canonical provisioning path. Pin this
-    // by planting the token ONLY under the legacy key — the preflight
-    // should fail-fast because the canonical path is empty.
-    secureKeyStore.set("acp/claude/oauth_token", "legacy-token-should-miss");
-
-    const handler = getSpawnHandler();
-    await expect(
-      handler({
-        body: {
-          agent: "claude",
-          task: "do a thing",
-          conversationId: "conv-1",
-        },
-      }),
-    ).rejects.toThrow(/CLAUDE_CODE_OAUTH_TOKEN/);
-    expect(capturedSpawns).toHaveLength(0);
   });
 });
 

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -82,23 +82,83 @@ mock.module("../../util/logger.js", () => ({
     }),
 }));
 
-// Stub secure-keys so the `prepareAgentEnv` preflight finds a token without
-// the test having to populate the real OS keyring. Driven via `secureKeyStore`
-// per test in beforeEach; the default seeds a vault token so existing tests
-// (which assume claude spawns succeed) keep passing.
-//
-// The real module's other exports are spread in so transitive importers
-// (e.g. session-manager → pending-interactions → credential-routes, which
-// imports `getSecureKeyResultAsync`) still resolve at parse time. Bun's
-// `mock.module` is process-global and returns *exactly* the keys the factory
-// returns — without the spread, any consumer pulling a non-`getSecureKeyAsync`
-// export errors with "Export named '<X>' not found".
-const secureKeyStore = new Map<string, string>();
-const realSecureKeys = await import("../../security/secure-keys.js");
+// Stub credential broker + metadata store so `prepareAgentEnv` can resolve
+// tokens without the real OS keyring. Driven via `vaultStore` per test in
+// beforeEach; the default seeds a vault token so existing tests (which assume
+// claude spawns succeed) keep passing.
+const vaultStore = new Map<string, string>();
+const metadataStore = new Map<
+  string,
+  { allowedTools: string[]; usageDescription?: string }
+>();
 
-mock.module("../../security/secure-keys.js", () => ({
-  ...realSecureKeys,
-  getSecureKeyAsync: async (key: string) => secureKeyStore.get(key),
+mock.module("../../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (service: string, field: string) => {
+    const key = `${service}/${field}`;
+    const entry = metadataStore.get(key);
+    if (!entry) return undefined;
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: entry.allowedTools,
+      allowedDomains: [],
+      usageDescription: entry.usageDescription,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    policy?: { allowedTools?: string[]; usageDescription?: string },
+  ) => {
+    const key = `${service}/${field}`;
+    const existing = metadataStore.get(key);
+    metadataStore.set(key, {
+      allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
+      usageDescription:
+        policy?.usageDescription ?? existing?.usageDescription,
+    });
+    return {
+      credentialId: `cred-${key}`,
+      service,
+      field,
+      allowedTools: metadataStore.get(key)!.allowedTools,
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  },
+}));
+
+mock.module("../../tools/credentials/broker.js", () => ({
+  credentialBroker: {
+    serverUse: async <T>(request: {
+      service: string;
+      field: string;
+      toolName: string;
+      execute: (value: string) => Promise<T>;
+    }) => {
+      const key = `${request.service}/${request.field}`;
+      const meta = metadataStore.get(key);
+      if (!meta) {
+        return { success: false, reason: `No credential found for ${key}` };
+      }
+      if (!meta.allowedTools.includes(request.toolName)) {
+        return {
+          success: false,
+          reason: `Tool "${request.toolName}" not allowed`,
+        };
+      }
+      const value = vaultStore.get(key);
+      if (!value) {
+        return { success: false, reason: `No stored value for ${key}` };
+      }
+      const result = await request.execute(value);
+      return { success: true, result };
+    },
+  },
 }));
 
 // Stub session manager so we don't actually spawn child processes.
@@ -153,11 +213,9 @@ beforeEach(() => {
   // Default: vault has a claude token so the preflight in `prepareAgentEnv`
   // succeeds for tests that don't care about env injection. Env-injection
   // tests below clear/override this explicitly.
-  secureKeyStore.clear();
-  secureKeyStore.set(
-    "credential/acp/claude_oauth_token",
-    "default-test-token",
-  );
+  vaultStore.clear();
+  metadataStore.clear();
+  vaultStore.set("acp/claude_oauth_token", "default-test-token");
 });
 
 // ---------------------------------------------------------------------------
@@ -420,12 +478,10 @@ describe("executeAcpSpawn — per-agent resume hint", () => {
 // ---------------------------------------------------------------------------
 
 describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
-  test("injects CLAUDE_CODE_OAUTH_TOKEN from the secure store for the claude agent", async () => {
-    secureKeyStore.clear();
-    secureKeyStore.set(
-      "credential/acp/claude_oauth_token",
-      "tool-vault-token-abc",
-    );
+  test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker for the claude agent", async () => {
+    vaultStore.clear();
+    metadataStore.clear();
+    vaultStore.set("acp/claude_oauth_token", "tool-vault-token-abc");
     execScripts.set("npm ls", { error: new Error("npm not installed") });
     execScripts.set("npm view", { error: new Error("npm not installed") });
 
@@ -445,10 +501,8 @@ describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
   });
 
   test("accepts CLAUDE_CODE_OAUTH_TOKEN from config.json agent.env without a vault entry", async () => {
-    // Mirrors the route-level precedence test: a config.json env override
-    // is the first-priority provisioning route. The resolver surfaces it
-    // on `resolved.agent.env`, which the helper preserves.
-    secureKeyStore.clear();
+    vaultStore.clear();
+    metadataStore.clear();
     config.setConfig({
       agents: {
         claude: {
@@ -478,11 +532,8 @@ describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
   });
 
   test("returns isError when no token is available from either route (preflight throw mapped to tool result)", async () => {
-    // Both routes empty. The helper throws `FailedDependencyError`; the
-    // tool catches it and returns `{ isError: true, content: <msg> }`
-    // rather than letting it propagate (the tool boundary is a sync
-    // ToolExecutionResult, not an HTTP response).
-    secureKeyStore.clear();
+    vaultStore.clear();
+    metadataStore.clear();
 
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
@@ -491,7 +542,6 @@ describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
-    // Spawn was NEVER called — preflight fired before the subprocess started.
     expect(spawnMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Replace direct `getSecureKeyAsync` in `prepare-agent-env.ts` with `credentialBroker.serverUse()` for policy-gated, audit-logged credential reads
- Remove `acp/prepare-agent-env.ts` from the secure-keys import allowlist in the credential security invariants test
- Auto-register `allowedTools: ["acp_spawn"]` metadata for the ACP OAuth token on first use, preserving backward compatibility for existing installations

## Original prompt

A Codex security finding (high severity) identified that the ACP spawn route reads a Claude OAuth token directly from the secure credential store and injects it into a prompt-controlled subprocess environment, bypassing the credential broker's policy and audit layer. The fix routes the credential read through `credentialBroker.serverUse()` for tool-policy enforcement and audit logging, without changing the authorization scope on `acp/spawn`. The `acp_spawn` tool already has `risk: "high"` in its TOOLS.json manifest.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/8518afe5d9a08191a15f87f892cd833c