### PR TITLE
docs+code: address audit findings on the LUM-2091 event-bus refactor

### DIFF
--- a/apps/web/docs/CONVENTIONS.md
+++ b/apps/web/docs/CONVENTIONS.md
@@ -398,7 +398,7 @@ owns it.
 | `hooks/` | Cross-domain React hooks | `use-is-mobile.ts`, `use-visible-viewport.ts`, `use-feature-flag-bus-sync.ts` |
 | `utils/` | Pure utility functions (no side effects, no third-party SDKs) | `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts` |
 | `types/` | Cross-domain shared type definitions with no clear owning module. Types consumed by a single module live with that module. Types produced by a module live in the module that produces them — consumers use `import type`. | `window.d.ts`, `event-types.ts`, `conversation-types.ts` |
-| `lib/` | Third-party integrations and infrastructure wrappers (have side effects, configure SDK instances, manage lifecycle) | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `diagnostics.ts` (session ring buffer), `api-client.ts` (HeyAPI) |
+| `lib/` | Third-party SDK wrappers and app-internal infrastructure (registries, transports, interceptors). Side effects, module-level state, or lifecycle ownership. See [`lib/` vs `utils/`](#lib-vs-utils--where-does-my-code-go) below. | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `event-bus.ts` (pub/sub registry), `diagnostics.ts` (session ring buffer), `api-client.ts` (HeyAPI) |
 | `runtime/` | Framework adapters and native platform bridges | `route-adapter.ts`, `native-auth.ts`, `native-deep-link.ts`, `app-bridge.ts` |
 | `components/` | Cross-domain shared UI | `error-boundary.tsx`, `sign-in-gate.tsx`, `providers.tsx` |
 

--- a/apps/web/docs/EVENT_BUS.md
+++ b/apps/web/docs/EVENT_BUS.md
@@ -59,7 +59,7 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 
 | Event | Payload | Produced when |
 |---|---|---|
-| `sse.event` | `AssistantEvent` | Every event the bus-owned SSE connection sees. Consumers narrow on `payload.type` and filter on `payload.conversationId` themselves. |
+| `sse.event` | `AssistantEventEnvelope` | Every event the bus-owned SSE connection sees. The envelope carries transport metadata (`seq`, `conversationId`, `emittedAt`); subscribers narrow on `envelope.message.type` and filter on `envelope.conversationId` themselves. |
 | `sse.opened` | `{ assistantId; cause: "fresh" \| "error" \| "watchdog" \| "resume" }` | After each successful (re)open. `cause` lets consumers distinguish a fresh connection from a watchdog-driven recovery. |
 | `sse.closed` | `{ reason }` | Transport error on the SSE connection. Not published for intentional teardowns (hidden tab, reachability bounce). |
 | `app.resume` | `{ signal: "visibility" \| "app_state" \| "online" }` | Page visible, app foregrounded, or network came back online. |
@@ -79,8 +79,8 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 ## Subscribing
 
 In a React hook or component, use `useBusSubscription` from
-`@/hooks/use-bus-subscription.js`. It wraps `useEffect` + `subscribe`
-+ cleanup and stabilises the handler ref so inline arrows don't
+`@/hooks/use-bus-subscription`. It wraps `useEffect` + `subscribe` +
+cleanup and stabilises the handler ref so inline arrows don't
 re-register on every render.
 
 ```ts
@@ -92,9 +92,9 @@ useBusSubscription("app.resume", ({ signal }) => {
 ```
 
 In code outside the React tree (Zustand store bootstraps, route
-loaders, middleware), import `subscribe` from `@/lib/event-bus`
-directly and store the returned unsubscribe handle alongside the
-bootstrap's other teardown:
+loaders, middleware, services), import `subscribe` from
+`@/lib/event-bus` directly and store the returned unsubscribe
+handle alongside the bootstrap's other teardown:
 
 ```ts
 import { subscribe } from "@/lib/event-bus";
@@ -103,18 +103,6 @@ const unsubscribeResume = subscribe("app.resume", () => {
   refetchIfStale();
 });
 // Add unsubscribeResume() to the existing teardown closure.
-```
-
-For imperative call sites outside the React tree (Zustand store
-bootstraps, middleware, services), import `subscribe` from
-`@/lib/event-bus` directly:
-
-```ts
-import { subscribe } from "@/lib/event-bus";
-
-const unsubscribe = subscribe("app.resume", () => {
-  // ...
-});
 ```
 
 ## Publishing

--- a/apps/web/src/assistant/use-disk-pressure-monitor.ts
+++ b/apps/web/src/assistant/use-disk-pressure-monitor.ts
@@ -174,8 +174,8 @@ export function useDiskPressureMonitor({
     // Capacitor foreground, and `window.online`, so a single
     // subscription drives the focus-style refetch.
     const unsubResume = subscribe("app.resume", () => {
-        void refresh();
-      });
+      void refresh();
+    });
 
     return () => {
       window.clearInterval(intervalId);

--- a/apps/web/src/hooks/use-event-bus-init.ts
+++ b/apps/web/src/hooks/use-event-bus-init.ts
@@ -40,6 +40,13 @@ export function useEventBusInit({
   isAssistantActive,
 }: UseEventBusInitParams): void {
   useEffect(() => {
+    // Source helpers touch `document` / `window` at call time and
+    // document their "caller guards under SSR/Node" contract in their
+    // own JSDoc. `useEffect` already doesn't run during SSR render,
+    // but the guard makes the contract explicit and survives any
+    // future move to a non-React caller (e.g. invoking from a
+    // module-level bootstrap). Keep aligned with CONVENTIONS.md's
+    // "SSR/build-safe rendering" rule.
     if (typeof window === "undefined") return;
     const unsubscribers = [
       publishVisibilitySource(),

--- a/apps/web/src/lib/event-bus.test.ts
+++ b/apps/web/src/lib/event-bus.test.ts
@@ -220,9 +220,10 @@ describe("event-bus", () => {
     expect(() => unsub()).not.toThrow();
   });
 
-  test("publishing an unknown event name after reset is a no-op", () => {
-    expect(() =>
-      publish("app.offline", {}),
-    ).not.toThrow();
+  test("publishing after reset with no subscribers is a no-op", () => {
+    // Reset clears the handler registry; publishing into the empty
+    // Map resolves to a no-op (the `set` lookup returns undefined
+    // and the early-return fires).
+    expect(() => publish("app.offline", {})).not.toThrow();
   });
 });

--- a/apps/web/src/lib/event-bus.ts
+++ b/apps/web/src/lib/event-bus.ts
@@ -132,6 +132,11 @@ export type BusHandler<K extends BusEventName> = (
 ) => void;
 
 type AnyHandler = (payload: never) => void;
+// `let` (not `const`) because `__resetForTesting` reassigns to a
+// fresh Map rather than clearing in place. Any unsubscribe captured
+// before the reset closes over the *old* Map and harmlessly orphans
+// itself instead of mutating the new one — that's the property the
+// "unsubscribe-after-reset is a no-op" test relies on.
 let handlers: Map<BusEventName, Set<AnyHandler>> = new Map();
 
 /**
@@ -172,8 +177,10 @@ export function publish<K extends BusEventName>(
       (handler as (p: typeof payload) => void)(payload);
     } catch (err) {
       // One bad subscriber must not block downstream subscribers.
-      // Surface via console so the failure is debuggable without
-      // pulling Sentry into a primitive.
+      // Console-log rather than re-throw or call Sentry directly so
+      // the bus stays free of a hard dependency on the reporting
+      // layer (subscribers already log their own captures via Sentry
+      // when they care about it).
       console.error("[event-bus] handler threw", event, err);
     }
   }

--- a/apps/web/src/lib/event-bus.ts
+++ b/apps/web/src/lib/event-bus.ts
@@ -133,10 +133,11 @@ export type BusHandler<K extends BusEventName> = (
 
 type AnyHandler = (payload: never) => void;
 // `let` (not `const`) because `__resetForTesting` reassigns to a
-// fresh Map rather than clearing in place. Any unsubscribe captured
-// before the reset closes over the *old* Map and harmlessly orphans
-// itself instead of mutating the new one — that's the property the
-// "unsubscribe-after-reset is a no-op" test relies on.
+// fresh Map rather than clearing in place. After reset the module-
+// level `handlers` points to an empty Map, so any old unsubscribe
+// closure (which reads `handlers` through the binding, not by value)
+// sees `handlers.get(event) === undefined` and early-returns — that's
+// the property the "unsubscribe-after-reset is a no-op" test relies on.
 let handlers: Map<BusEventName, Set<AnyHandler>> = new Map();
 
 /**

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -321,8 +321,8 @@ export function setupAuthListeners(): () => void {
     );
 
   const unsubResume = subscribe("app.resume", () => {
-      void safeRefresh();
-    });
+    void safeRefresh();
+  });
   cleanups.push(unsubResume);
 
   if (typeof BroadcastChannel !== "undefined") {

--- a/apps/web/src/stores/organization-store.ts
+++ b/apps/web/src/stores/organization-store.ts
@@ -217,8 +217,8 @@ export function setupOrganizationStore(): () => void {
   };
 
   const unsubResume = subscribe("app.resume", () => {
-      refetchIfStale();
-    });
+    refetchIfStale();
+  });
 
   return () => {
     unsubStale();


### PR DESCRIPTION
Follow-up to #32844 (LUM-2091). An independent audit pass against the merged PR turned up six items the original review missed — three must-fix doc bugs, four code-side should-fix items, and a nit. Each is small; rolled into one PR.

## Doc fixes

**`CONVENTIONS.md` — directory table contradicted its own detailed definition.** The `lib/` row in the top-level table still said "Third-party integrations and infrastructure wrappers" while the detailed `lib/` vs `utils/` table below (rewritten in #32844) had been broadened to "Third-party SDK wrappers and app-internal infrastructure." Two sources of truth. Aligned the top-level row + added `event-bus.ts` to the examples list.

**`EVENT_BUS.md` — duplicated "Subscribing" paragraph.** Two consecutive blocks both explained the non-React `import { subscribe } from "@/lib/event-bus"` pattern with near-identical code samples. Merged.

**`EVENT_BUS.md` — wrong payload type listed for `sse.event`.** Table said `AssistantEvent`. Actual type is `AssistantEventEnvelope`. A reader narrowing on `payload.type` per the table would get a type error — the actual narrowing path is `envelope.message.type`. Fixed.

**`EVENT_BUS.md` — `.js` extension on a TS import path.** `@/hooks/use-bus-subscription.js` — no other doc in the repo uses `.js` aliases. Dropped.

## Code fixes

**Indentation drift on three `subscribe("app.resume", ...)` callbacks.** `auth-store.ts:323`, `organization-store.ts:219`, `use-disk-pressure-monitor.ts:176`. Inner block indented one level too deep — a leftover from collapsing the prior `useEventBusStore.getState().subscribe(...)` chain. Re-aligned.

**SSR guard in `useEventBusInit` had no explanatory comment.** The source helpers document a "caller guards under SSR/Node" contract; the guard in the hook satisfies that contract but read as dead code to a reviewer. Added a comment pointing at the contract.

**`let handlers` in `event-bus.ts` carried a non-obvious test invariant.** `__resetForTesting` reassigns to a fresh Map (rather than clearing in-place) so any unsubscribe captured before the reset closes over the old Map and harmlessly orphans itself — that's the property the "unsubscribe-after-reset is a no-op" test relies on. Adding the comment so the next reader doesn't change it to `const` and break the test.

**Rationale comment on the `console.error` fallback was overstated.** Claimed it kept Sentry out of "a primitive," but the bus's consumers (`sseService`, source helpers) all transitively pull Sentry. Reframed around dependency direction — the bus doesn't depend on the reporting layer; subscribers do their own captures.

## Test cleanup

**`event-bus.test.ts` — misleading test name.** Test titled "publishing an unknown event name after reset is a no-op" actually published a known event (`app.offline`). Renamed to describe what it's really testing — publishing into an empty registry.

## Out of scope (intentional)

- The `mock.module` process-global landmine that's now bitten three PRs in a row — separate test-infrastructure ticket.
- The `@vellumai/assistant-api` missing-exports issue — already filed as LUM-2092.
- Future-tense note about consolidating `runtime/event-sources/*` once the count grows past ~5 — premature today (N=5 reads fine); follow-up if/when N grows.

## Test plan

- [x] `bun test` across all bus + consumer files — 83/83 pass.
- [x] `bun run typecheck` — 208 errors, baseline unchanged.
- [ ] Manual: nothing to verify — pure doc / cosmetic code fixes.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_