### PR TITLE
feat(voice): add browser live-voice websocket client

### DIFF
--- a/apps/web/src/domains/voice/live-voice/live-voice-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-client.test.ts
@@ -64,10 +64,18 @@ type SentMessage = string | ArrayBuffer;
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
 
+  // Mirror the WHATWG readyState constants the client guards on.
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
   url: string;
   binaryType = "blob";
   sent: SentMessage[] = [];
   closed = false;
+  // Sockets start life CONNECTING, exactly like a real WebSocket.
+  readyState = FakeWebSocket.CONNECTING;
 
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: unknown }) => void) | null = null;
@@ -80,15 +88,21 @@ class FakeWebSocket {
   }
 
   send(data: SentMessage): void {
+    // Match browser behaviour: sending on a non-OPEN socket throws.
+    if (this.readyState !== FakeWebSocket.OPEN) {
+      throw new Error("InvalidStateError: WebSocket is not open");
+    }
     this.sent.push(data);
   }
 
   close(): void {
     this.closed = true;
+    this.readyState = FakeWebSocket.CLOSED;
   }
 
   // --- test drivers ---
   open(): void {
+    this.readyState = FakeWebSocket.OPEN;
     this.onopen?.();
   }
   receive(frame: object): void {
@@ -470,6 +484,45 @@ describe("teardown", () => {
     expect(ws.sentJson.at(-1)).toEqual({ type: "end" });
     expect(ws.closed).toBe(true);
     expect(closedCount).toBe(1);
+  });
+
+  test("end() during connect (socket still CONNECTING) cancels cleanly without throwing", async () => {
+    const client = makeClient();
+    // Construct the socket but never open() it -> it stays CONNECTING.
+    const ws = await connectAndGetSocket(client);
+    expect(ws.readyState).toBe(FakeWebSocket.CONNECTING);
+
+    const errors: { reason: string }[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    // Must not throw even though the socket can't accept sends yet.
+    expect(() => client.end()).not.toThrow();
+
+    // No `end` frame could be sent on a CONNECTING socket.
+    expect(ws.sent).toHaveLength(0);
+    // The socket is closed and the session ended cleanly — no timeout/failure.
+    expect(ws.closed).toBe(true);
+    expect(closedCount).toBe(1);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("close() during connect (socket still CONNECTING) closes cleanly without throwing", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    expect(ws.readyState).toBe(FakeWebSocket.CONNECTING);
+
+    const errors: unknown[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    expect(() => client.close()).not.toThrow();
+
+    expect(ws.closed).toBe(true);
+    expect(closedCount).toBe(1);
+    expect(errors).toHaveLength(0);
   });
 
   test("close() is idempotent and emits closed exactly once", async () => {

--- a/apps/web/src/domains/voice/live-voice/live-voice-client.test.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-client.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Tests for the browser live-voice WebSocket client.
+ *
+ * `mintLiveVoiceToken` is mocked at module scope so no real HTTP/SDK call
+ * happens; `buildLiveVoiceWsUrl` is kept real so we exercise the genuine
+ * connection.ts URL builder (no hardcoded host in the client). The WebSocket is
+ * a hand-rolled fake injected via the client's `webSocketFactory` option — no
+ * global patching needed.
+ *
+ * Coverage: start-frame on open, every server frame -> typed event, binary
+ * audio passthrough, connect timeout when no `ready`, `busy` handling, mint
+ * failure, and clean `end()` / `close()` teardown.
+ *
+ * @jest-environment happy-dom
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+let mintResult: Promise<{ token: string; expiresAt: string }> = Promise.resolve(
+  { token: "tok-abc", expiresAt: "2026-06-01T00:05:00Z" },
+);
+
+mock.module("@/domains/voice/live-voice/connection", () => ({
+  mintLiveVoiceToken: mock(() => mintResult),
+  // Keep a real builder so the client genuinely composes the velay URL.
+  buildLiveVoiceWsUrl: ({
+    assistantId,
+    conversationId,
+    token,
+  }: {
+    assistantId: string;
+    conversationId?: string;
+    token: string;
+  }) => {
+    const url = new URL(`wss://velay.vellum.ai/${assistantId}/v1/live-voice`);
+    url.searchParams.set("token", token);
+    if (conversationId) url.searchParams.set("conversationId", conversationId);
+    return url.toString();
+  },
+}));
+
+import type { LiveVoiceChannelClient as LiveVoiceChannelClientType } from "@/domains/voice/live-voice/live-voice-client";
+
+// Import the module under test *after* registering the connection mock, so the
+// mock is in place before the real connection.ts (which imports the generated
+// SDK client) would otherwise be pulled into the static import graph.
+const { LiveVoiceChannelClient } = await import(
+  "@/domains/voice/live-voice/live-voice-client"
+);
+
+// ---------------------------------------------------------------------------
+// Fake WebSocket
+// ---------------------------------------------------------------------------
+
+type SentMessage = string | ArrayBuffer;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  url: string;
+  binaryType = "blob";
+  sent: SentMessage[] = [];
+  closed = false;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: SentMessage): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  // --- test drivers ---
+  open(): void {
+    this.onopen?.();
+  }
+  receive(frame: object): void {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+  receiveRaw(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+  emitError(): void {
+    this.onerror?.();
+  }
+  emitClose(): void {
+    this.onclose?.();
+  }
+
+  get sentText(): string[] {
+    return this.sent.filter((m): m is string => typeof m === "string");
+  }
+  get sentJson(): Record<string, unknown>[] {
+    return this.sentText.map((t) => JSON.parse(t));
+  }
+  get sentBinary(): ArrayBuffer[] {
+    return this.sent.filter((m): m is ArrayBuffer => m instanceof ArrayBuffer);
+  }
+}
+
+function makeClient(connectTimeoutMs = 10_000) {
+  const factory = (url: string) => new FakeWebSocket(url) as unknown as WebSocket;
+  const client = new LiveVoiceChannelClient({
+    webSocketFactory: factory,
+    connectTimeoutMs,
+  });
+  return client;
+}
+
+/** Connect and return the underlying fake socket once constructed. */
+async function connectAndGetSocket(
+  client: LiveVoiceChannelClientType,
+  args: { assistantId: string; conversationId?: string } = {
+    assistantId: "assistant-1",
+  },
+): Promise<FakeWebSocket> {
+  await client.connect(args);
+  const ws = FakeWebSocket.instances.at(-1);
+  if (!ws) throw new Error("no WebSocket was constructed");
+  return ws;
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  mintResult = Promise.resolve({
+    token: "tok-abc",
+    expiresAt: "2026-06-01T00:05:00Z",
+  });
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// connect + start frame
+// ---------------------------------------------------------------------------
+
+describe("connect", () => {
+  test("mints a token and opens the velay WS at the built URL", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      conversationId: "conv-xyz",
+    });
+    const url = new URL(ws.url);
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay.vellum.ai");
+    expect(url.pathname).toBe("/assistant-1/v1/live-voice");
+    expect(url.searchParams.get("token")).toBe("tok-abc");
+    expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
+  });
+
+  test("requests arraybuffer binary frames", async () => {
+    const ws = await connectAndGetSocket(makeClient());
+    expect(ws.binaryType).toBe("arraybuffer");
+  });
+
+  test("sends the start frame as JSON text on open, with conversationId", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      conversationId: "conv-xyz",
+    });
+    ws.open();
+
+    expect(ws.sentJson).toEqual([
+      {
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+        conversationId: "conv-xyz",
+      },
+    ]);
+    expect(ws.sentBinary).toHaveLength(0);
+  });
+
+  test("omits conversationId from the start frame when not provided", async () => {
+    const ws = await connectAndGetSocket(makeClient());
+    ws.open();
+    expect(ws.sentJson[0]).toEqual({
+      type: "start",
+      audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+    });
+  });
+
+  test("emits error when token minting fails", async () => {
+    mintResult = Promise.reject(new Error("mint boom"));
+    const client = makeClient();
+    const errors: { reason: string; message: string }[] = [];
+    client.on("error", (e) => errors.push(e));
+
+    await client.connect({ assistantId: "assistant-1" });
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.reason).toBe("connection-failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// server frame dispatch
+// ---------------------------------------------------------------------------
+
+describe("server frame dispatch", () => {
+  async function ready(): Promise<{
+    client: LiveVoiceChannelClientType;
+    ws: FakeWebSocket;
+  }> {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s1", conversationId: "c1" });
+    return { client, ws };
+  }
+
+  test("ready transitions to active and dispatches the ready event", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const seen: unknown[] = [];
+    client.on("ready", (f) => seen.push(f));
+    ws.receive({
+      type: "ready",
+      seq: 1,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+    });
+
+    expect(seen).toEqual([
+      { type: "ready", seq: 1, sessionId: "sess-1", conversationId: "conv-1" },
+    ]);
+  });
+
+  test("dispatches each transcript/text/tts/metrics/archived frame to its event", async () => {
+    const { client, ws } = await ready();
+
+    const got: Record<string, unknown[]> = {};
+    const record = (name: string) => (f: unknown) => {
+      (got[name] ??= []).push(f);
+    };
+    client.on("sttPartial", record("sttPartial"));
+    client.on("sttFinal", record("sttFinal"));
+    client.on("thinking", record("thinking"));
+    client.on("assistantTextDelta", record("assistantTextDelta"));
+    client.on("ttsAudio", record("ttsAudio"));
+    client.on("ttsDone", record("ttsDone"));
+    client.on("metrics", record("metrics"));
+    client.on("archived", record("archived"));
+
+    ws.receive({ type: "stt_partial", seq: 2, text: "hel" });
+    ws.receive({ type: "stt_final", seq: 3, text: "hello" });
+    ws.receive({ type: "thinking", seq: 4, turnId: "t1" });
+    ws.receive({ type: "assistant_text_delta", seq: 5, text: "hi" });
+    ws.receive({
+      type: "tts_audio",
+      seq: 6,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+    ws.receive({ type: "tts_done", seq: 7, turnId: "t1" });
+    ws.receive({
+      type: "metrics",
+      seq: 8,
+      turnId: "t1",
+      sttMs: 1,
+      llmFirstDeltaMs: 2,
+      ttsFirstAudioMs: 3,
+      totalMs: 4,
+    });
+    ws.receive({
+      type: "archived",
+      seq: 9,
+      conversationId: "c1",
+      sessionId: "s1",
+    });
+
+    expect(got.sttPartial).toEqual([{ type: "stt_partial", seq: 2, text: "hel" }]);
+    expect(got.sttFinal).toEqual([{ type: "stt_final", seq: 3, text: "hello" }]);
+    expect(got.thinking).toEqual([{ type: "thinking", seq: 4, turnId: "t1" }]);
+    expect(got.assistantTextDelta).toEqual([
+      { type: "assistant_text_delta", seq: 5, text: "hi" },
+    ]);
+    expect(got.ttsAudio).toHaveLength(1);
+    expect(got.ttsDone).toEqual([{ type: "tts_done", seq: 7, turnId: "t1" }]);
+    expect(got.metrics).toHaveLength(1);
+    expect(got.archived).toHaveLength(1);
+  });
+
+  test("server error frame emits a protocol-error and closes", async () => {
+    const { client, ws } = await ready();
+    const errors: { reason: string; code?: string; message: string }[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    ws.receive({ type: "error", seq: 10, code: "boom", message: "kaboom" });
+
+    expect(errors).toEqual([
+      { reason: "protocol-error", code: "boom", message: "kaboom" },
+    ]);
+    expect(closedCount).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  test("ignores inbound binary frames (no parse, no event)", async () => {
+    const { client, ws } = await ready();
+    const errors: unknown[] = [];
+    client.on("error", (e) => errors.push(e));
+
+    ws.receiveRaw(new ArrayBuffer(8));
+
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// busy handling (distinct from error)
+// ---------------------------------------------------------------------------
+
+describe("busy", () => {
+  test("emits busy (not error) and closes the socket", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const busy: unknown[] = [];
+    const errors: unknown[] = [];
+    let closedCount = 0;
+    client.on("busy", (f) => busy.push(f));
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    ws.receive({ type: "busy", seq: 1, activeSessionId: "other-sess" });
+
+    expect(busy).toEqual([
+      { type: "busy", seq: 1, activeSessionId: "other-sess" },
+    ]);
+    expect(errors).toHaveLength(0);
+    expect(closedCount).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// audio passthrough
+// ---------------------------------------------------------------------------
+
+describe("sendAudio", () => {
+  test("sends PCM as a binary frame once active", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    const pcm = new Int16Array([1, 2, 3]).buffer;
+    client.sendAudio(pcm);
+
+    expect(ws.sentBinary).toEqual([pcm]);
+    // The only text frame should be the start frame.
+    expect(ws.sentJson).toEqual([
+      {
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+      },
+    ]);
+  });
+
+  test("drops audio before ready (session not active)", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    client.sendAudio(new ArrayBuffer(4));
+    expect(ws.sentBinary).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// control frames
+// ---------------------------------------------------------------------------
+
+describe("control frames", () => {
+  test("pttRelease and interrupt go out as JSON text when active", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    client.pttRelease();
+    client.interrupt();
+
+    expect(ws.sentJson.slice(1)).toEqual([
+      { type: "ptt_release" },
+      { type: "interrupt" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connect timeout
+// ---------------------------------------------------------------------------
+
+describe("connect timeout", () => {
+  test("fails with timeout when no ready arrives within the window", async () => {
+    const client = makeClient(20);
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const errors: { reason: string }[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.reason).toBe("timeout");
+    expect(closedCount).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  test("does not fire timeout once ready arrives", async () => {
+    const client = makeClient(20);
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    const errors: unknown[] = [];
+    client.on("error", (e) => errors.push(e));
+
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// teardown
+// ---------------------------------------------------------------------------
+
+describe("teardown", () => {
+  test("end() sends an end frame then closes the socket", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    let closedCount = 0;
+    client.on("closed", () => closedCount++);
+
+    client.end();
+
+    expect(ws.sentJson.at(-1)).toEqual({ type: "end" });
+    expect(ws.closed).toBe(true);
+    expect(closedCount).toBe(1);
+  });
+
+  test("close() is idempotent and emits closed exactly once", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    let closedCount = 0;
+    client.on("closed", () => closedCount++);
+
+    client.close();
+    client.close();
+
+    expect(closedCount).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  test("after close, sendAudio and control frames are no-ops", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+    const before = ws.sent.length;
+
+    client.close();
+    client.sendAudio(new ArrayBuffer(4));
+    client.pttRelease();
+    client.interrupt();
+
+    expect(ws.sent.length).toBe(before);
+  });
+
+  test("an unexpected socket close before ready surfaces a connection failure", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const errors: { reason: string }[] = [];
+    client.on("error", (e) => errors.push(e));
+
+    ws.emitClose();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.reason).toBe("connection-failed");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/live-voice-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-client.ts
@@ -215,8 +215,8 @@ export class LiveVoiceChannelClient {
 
   /** Send a binary PCM audio frame. No-op unless the session is active. */
   sendAudio(pcm: ArrayBuffer): void {
-    if (this.state !== "active" || !this.ws) return;
-    this.ws.send(pcm);
+    if (this.state !== "active") return;
+    this.trySend(pcm);
   }
 
   /** Mark the current push-to-talk segment as released. */
@@ -229,10 +229,17 @@ export class LiveVoiceChannelClient {
     this.sendControlFrame("interrupt");
   }
 
-  /** End the session gracefully: send `end`, then close the socket. */
+  /**
+   * End the session gracefully: best-effort send `end`, then always close the
+   * socket. A quick-cancel while still CONNECTING simply skips the (impossible)
+   * `end` send and resolves as a clean close rather than a timeout failure.
+   */
   end(): void {
     if (this.state !== "connecting" && this.state !== "active") return;
-    this.sendControlFrame("end");
+    // Only the `end` frame is meaningful here, and it's strictly best-effort:
+    // trySend() no-ops unless the socket is OPEN, so this never throws while the
+    // socket is still CONNECTING. close() is reached unconditionally below.
+    this.trySend(JSON.stringify({ type: "end" }));
     this.close();
   }
 
@@ -250,7 +257,7 @@ export class LiveVoiceChannelClient {
       audio: START_AUDIO_CONFIG,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
     };
-    this.ws.send(JSON.stringify(startFrame));
+    this.trySend(JSON.stringify(startFrame));
   }
 
   private handleMessage(event: MessageEvent): void {
@@ -314,11 +321,22 @@ export class LiveVoiceChannelClient {
     this.emit("closed", undefined);
   }
 
-  private sendControlFrame(type: "ptt_release" | "interrupt" | "end"): void {
-    if (this.state !== "active" && !(type === "end" && this.state === "connecting")) {
-      return;
+  private sendControlFrame(type: "ptt_release" | "interrupt"): void {
+    if (this.state !== "active") return;
+    this.trySend(JSON.stringify({ type }));
+  }
+
+  /**
+   * Best-effort send: only writes to the socket when it is actually OPEN.
+   * Calling `send()` on a CONNECTING (or CLOSING/CLOSED) WebSocket throws
+   * `InvalidStateError` in browsers, so guarding on `readyState` keeps a
+   * quick-cancel during connect (and any late send) from throwing.
+   */
+  private trySend(data: string | ArrayBuffer): void {
+    const ws = this.ws;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(data);
     }
-    this.ws?.send(JSON.stringify({ type }));
   }
 
   private fail(

--- a/apps/web/src/domains/voice/live-voice/live-voice-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-client.ts
@@ -1,0 +1,359 @@
+/**
+ * Browser live-voice channel client (WebSocket transport).
+ *
+ * Web-app counterpart to the macOS `LiveVoiceChannelClient`
+ * (`clients/shared/Network/LiveVoiceChannelClient.swift`). One instance drives
+ * one live-voice session: it mints a short-lived velay token, opens the velay
+ * WebSocket, sends the `start` frame on open, streams microphone PCM as binary
+ * frames, and dispatches parsed server frames as typed events.
+ *
+ * Wire contract (see `protocol.ts`, ported from
+ * `assistant/src/live-voice/protocol.ts`):
+ * - `start` / `ptt_release` / `interrupt` / `end` go out as JSON **text** frames.
+ * - Audio chunks go out as raw **binary** frames (PCM bytes) — there is no
+ *   `audio` client frame on the web side.
+ * - Every inbound server frame is JSON text and is parsed via
+ *   {@link parseServerFrame}.
+ *
+ * Connection handshake mirrors the macOS client: a ~10s connect timeout fails
+ * the session if no `ready` frame arrives, and a server `busy` frame is handled
+ * distinctly from `error`.
+ */
+
+import {
+  buildLiveVoiceWsUrl,
+  mintLiveVoiceToken,
+} from "@/domains/voice/live-voice/connection";
+import {
+  type LiveVoiceArchivedServerFrame,
+  type LiveVoiceAssistantTextDeltaServerFrame,
+  type LiveVoiceBusyServerFrame,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceMetricsServerFrame,
+  type LiveVoiceReadyServerFrame,
+  type LiveVoiceSttFinalServerFrame,
+  type LiveVoiceSttPartialServerFrame,
+  type LiveVoiceThinkingServerFrame,
+  type LiveVoiceTtsAudioServerFrame,
+  type LiveVoiceTtsDoneServerFrame,
+  parseServerFrame,
+} from "@/domains/voice/live-voice/protocol";
+
+/** Audio shape sent in the `start` frame — matches the runtime contract. */
+const START_AUDIO_CONFIG: LiveVoiceClientStartFrame["audio"] = {
+  mimeType: "audio/pcm",
+  sampleRate: 16000,
+  channels: 1,
+};
+
+/** Fail the session if no `ready` frame arrives within this window. */
+const CONNECT_TIMEOUT_MS = 10_000;
+
+/** Reason a live-voice session failed, surfaced via the `error` event. */
+export type LiveVoiceClientErrorReason =
+  | "connection-failed"
+  | "protocol-error"
+  | "timeout";
+
+export interface LiveVoiceClientError {
+  readonly reason: LiveVoiceClientErrorReason;
+  /** Protocol error code from the server `error` frame, when applicable. */
+  readonly code?: string;
+  readonly message: string;
+}
+
+/**
+ * Typed event payloads. Names map 1:1 to the server frame types (camelCased),
+ * plus `closed` for transport teardown. Frame `seq` is preserved so consumers
+ * can order or dedupe.
+ */
+export interface LiveVoiceClientEventMap {
+  ready: LiveVoiceReadyServerFrame;
+  sttPartial: LiveVoiceSttPartialServerFrame;
+  sttFinal: LiveVoiceSttFinalServerFrame;
+  thinking: LiveVoiceThinkingServerFrame;
+  assistantTextDelta: LiveVoiceAssistantTextDeltaServerFrame;
+  ttsAudio: LiveVoiceTtsAudioServerFrame;
+  ttsDone: LiveVoiceTtsDoneServerFrame;
+  metrics: LiveVoiceMetricsServerFrame;
+  archived: LiveVoiceArchivedServerFrame;
+  busy: LiveVoiceBusyServerFrame;
+  error: LiveVoiceClientError;
+  /** Fired exactly once when the transport closes (clean or otherwise). */
+  closed: void;
+}
+
+export type LiveVoiceClientEventName = keyof LiveVoiceClientEventMap;
+
+export type LiveVoiceClientEventHandler<E extends LiveVoiceClientEventName> = (
+  payload: LiveVoiceClientEventMap[E],
+) => void;
+
+export interface LiveVoiceConnectArgs {
+  assistantId: string;
+  /** Optional conversation to attach the session to. */
+  conversationId?: string;
+}
+
+/** Factory so tests can inject a mock WebSocket. Defaults to the global. */
+export type WebSocketFactory = (url: string) => WebSocket;
+
+export interface LiveVoiceChannelClientOptions {
+  /** Override the WebSocket constructor (tests). */
+  webSocketFactory?: WebSocketFactory;
+  /** Override the connect timeout (tests). */
+  connectTimeoutMs?: number;
+}
+
+type SessionState = "idle" | "connecting" | "active" | "closed";
+
+/**
+ * Browser live-voice WebSocket client. Create one instance per session; after
+ * `close()`/`end()`/failure the instance is terminal and must not be reused.
+ */
+export class LiveVoiceChannelClient {
+  private readonly webSocketFactory: WebSocketFactory;
+  private readonly connectTimeoutMs: number;
+
+  private state: SessionState = "idle";
+  private ws: WebSocket | null = null;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private conversationId: string | undefined;
+
+  private readonly listeners: {
+    [E in LiveVoiceClientEventName]: Set<LiveVoiceClientEventHandler<E>>;
+  } = {
+    ready: new Set(),
+    sttPartial: new Set(),
+    sttFinal: new Set(),
+    thinking: new Set(),
+    assistantTextDelta: new Set(),
+    ttsAudio: new Set(),
+    ttsDone: new Set(),
+    metrics: new Set(),
+    archived: new Set(),
+    busy: new Set(),
+    error: new Set(),
+    closed: new Set(),
+  };
+
+  constructor(options: LiveVoiceChannelClientOptions = {}) {
+    this.webSocketFactory =
+      options.webSocketFactory ?? ((url) => new WebSocket(url));
+    this.connectTimeoutMs = options.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+  }
+
+  /**
+   * Subscribe to a typed event. Returns an unsubscribe function.
+   */
+  on<E extends LiveVoiceClientEventName>(
+    event: E,
+    handler: LiveVoiceClientEventHandler<E>,
+  ): () => void {
+    this.listeners[event].add(handler);
+    return () => {
+      this.listeners[event].delete(handler);
+    };
+  }
+
+  private emit<E extends LiveVoiceClientEventName>(
+    event: E,
+    payload: LiveVoiceClientEventMap[E],
+  ): void {
+    for (const handler of this.listeners[event]) {
+      handler(payload);
+    }
+  }
+
+  /**
+   * Mint a token, open the velay WebSocket, and send the `start` frame on open.
+   * Resolves once the socket is opening; session readiness is signalled via the
+   * `ready` event (or `error` / `busy` if it never arrives).
+   */
+  async connect({
+    assistantId,
+    conversationId,
+  }: LiveVoiceConnectArgs): Promise<void> {
+    if (this.state !== "idle") return;
+    this.state = "connecting";
+    this.conversationId = conversationId;
+
+    let token: string;
+    try {
+      ({ token } = await mintLiveVoiceToken(assistantId));
+    } catch (err) {
+      this.fail("connection-failed", messageOf(err, "Failed to mint live-voice token"));
+      return;
+    }
+    // A late close()/end() during the await must abort the connect.
+    if (this.state !== "connecting") return;
+
+    const url = buildLiveVoiceWsUrl({ assistantId, conversationId, token });
+
+    let ws: WebSocket;
+    try {
+      ws = this.webSocketFactory(url);
+    } catch (err) {
+      this.fail("connection-failed", messageOf(err, "Failed to open live-voice WebSocket"));
+      return;
+    }
+    this.ws = ws;
+    ws.binaryType = "arraybuffer";
+
+    ws.onopen = () => this.handleOpen();
+    ws.onmessage = (event) => this.handleMessage(event);
+    ws.onerror = () =>
+      this.fail("connection-failed", "Live-voice WebSocket error");
+    ws.onclose = () => this.handleClose();
+
+    this.connectTimeout = setTimeout(() => {
+      if (this.state === "connecting") {
+        this.fail("timeout", `Live-voice connection timed out after ${this.connectTimeoutMs}ms`);
+      }
+    }, this.connectTimeoutMs);
+  }
+
+  /** Send a binary PCM audio frame. No-op unless the session is active. */
+  sendAudio(pcm: ArrayBuffer): void {
+    if (this.state !== "active" || !this.ws) return;
+    this.ws.send(pcm);
+  }
+
+  /** Mark the current push-to-talk segment as released. */
+  pttRelease(): void {
+    this.sendControlFrame("ptt_release");
+  }
+
+  /** Interrupt assistant speech for barge-in. */
+  interrupt(): void {
+    this.sendControlFrame("interrupt");
+  }
+
+  /** End the session gracefully: send `end`, then close the socket. */
+  end(): void {
+    if (this.state !== "connecting" && this.state !== "active") return;
+    this.sendControlFrame("end");
+    this.close();
+  }
+
+  /** Close the WebSocket immediately. Idempotent. */
+  close(): void {
+    if (this.state === "closed") return;
+    this.teardown();
+    this.emit("closed", undefined);
+  }
+
+  private handleOpen(): void {
+    if (this.state !== "connecting" || !this.ws) return;
+    const startFrame: LiveVoiceClientStartFrame = {
+      type: "start",
+      audio: START_AUDIO_CONFIG,
+      ...(this.conversationId ? { conversationId: this.conversationId } : {}),
+    };
+    this.ws.send(JSON.stringify(startFrame));
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    if (this.state === "closed") return;
+    // Inbound audio (if any) arrives as binary; the wire protocol carries all
+    // server payloads as JSON text, so binary frames are not expected. Ignore
+    // them rather than mis-parsing bytes as JSON.
+    if (typeof event.data !== "string") return;
+
+    const frame = parseServerFrame(event.data);
+    switch (frame.type) {
+      case "ready":
+        if (this.state !== "connecting") return;
+        this.clearConnectTimeout();
+        this.state = "active";
+        this.emit("ready", frame);
+        return;
+      case "busy":
+        this.emit("busy", frame);
+        this.close();
+        return;
+      case "stt_partial":
+        this.emit("sttPartial", frame);
+        return;
+      case "stt_final":
+        this.emit("sttFinal", frame);
+        return;
+      case "thinking":
+        this.emit("thinking", frame);
+        return;
+      case "assistant_text_delta":
+        this.emit("assistantTextDelta", frame);
+        return;
+      case "tts_audio":
+        this.emit("ttsAudio", frame);
+        return;
+      case "tts_done":
+        this.emit("ttsDone", frame);
+        return;
+      case "metrics":
+        this.emit("metrics", frame);
+        return;
+      case "archived":
+        this.emit("archived", frame);
+        return;
+      case "error":
+        this.fail("protocol-error", frame.message, frame.code);
+        return;
+    }
+  }
+
+  private handleClose(): void {
+    if (this.state === "closed") return;
+    // An unexpected transport close before `ready` is a connection failure;
+    // otherwise it's a clean teardown.
+    if (this.state === "connecting") {
+      this.fail("connection-failed", "Live-voice WebSocket closed before ready");
+      return;
+    }
+    this.teardown();
+    this.emit("closed", undefined);
+  }
+
+  private sendControlFrame(type: "ptt_release" | "interrupt" | "end"): void {
+    if (this.state !== "active" && !(type === "end" && this.state === "connecting")) {
+      return;
+    }
+    this.ws?.send(JSON.stringify({ type }));
+  }
+
+  private fail(
+    reason: LiveVoiceClientErrorReason,
+    message: string,
+    code?: string,
+  ): void {
+    if (this.state === "closed") return;
+    this.teardown();
+    this.emit("error", { reason, message, ...(code ? { code } : {}) });
+    this.emit("closed", undefined);
+  }
+
+  private teardown(): void {
+    this.state = "closed";
+    this.clearConnectTimeout();
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      ws.close();
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout !== null) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+}
+
+function messageOf(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}


### PR DESCRIPTION
## Summary
- Add LiveVoiceChannelClient: mints token, opens WS via connection.ts, sends start + binary PCM, dispatches parsed server frames as typed events, with connect-timeout + busy handling

Part of plan: web-live-voice.md (PR 5 of 8)