### PR TITLE
feat(voice): add useLiveVoice session controller hook

### DIFF
--- a/apps/web/src/domains/voice/live-voice/live-voice-store.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-store.ts
@@ -1,0 +1,117 @@
+/**
+ * Zustand store holding the observable state of a single live-voice session.
+ *
+ * Web-app counterpart to the `@Observable` fields on the macOS
+ * `LiveVoiceChannelManager` (`clients/macos/.../LiveVoiceChannelManager.swift`).
+ * The {@link useLiveVoice} controller owns the session lifecycle and writes here
+ * through the actions; UI subscribes via per-field selectors so it only
+ * re-renders on the fields it reads.
+ *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
+ *
+ * **Primary API** — per-field selectors:
+ * ```ts
+ * const state = useLiveVoiceStore.use.state();
+ * ```
+ *
+ * **Non-React code** — use `.getState()` in callbacks, effects, handlers:
+ * ```ts
+ * const { state } = useLiveVoiceStore.getState();
+ * ```
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/guides/auto-generating-selectors}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase of the live-voice session. Mirrors the macOS
+ * `LiveVoiceChannelManager.State` enum 1:1.
+ *
+ * - `idle` — no session (or a finished one cleaned up).
+ * - `connecting` — minting a token / opening the socket, before `ready`.
+ * - `listening` — mic is capturing and streaming PCM to the server.
+ * - `transcribing` — push-to-talk released; waiting on the final transcript.
+ * - `thinking` — server is generating the assistant response.
+ * - `speaking` — TTS audio is queued/playing.
+ * - `ending` — graceful teardown in progress.
+ * - `failed` — the session failed; `error` carries the message.
+ */
+export type LiveVoiceSessionState =
+  | "idle"
+  | "connecting"
+  | "listening"
+  | "transcribing"
+  | "thinking"
+  | "speaking"
+  | "ending"
+  | "failed";
+
+export interface LiveVoiceState {
+  /** Current phase of the session lifecycle. */
+  state: LiveVoiceSessionState;
+  /** In-flight partial transcript of the user's current utterance. */
+  partialTranscript: string;
+  /** Last finalized user transcript. */
+  finalTranscript: string;
+  /** Accumulated assistant response text for the current turn. */
+  assistantTranscript: string;
+  /** Smoothed RMS mic amplitude in [0, 1] for UI / barge-in. */
+  inputAmplitude: number;
+  /** Human-readable error message when `state === "failed"`, `null` otherwise. */
+  error: string | null;
+}
+
+export interface LiveVoiceActions {
+  /** Replace the session phase. */
+  setState: (state: LiveVoiceSessionState) => void;
+  setPartialTranscript: (text: string) => void;
+  setFinalTranscript: (text: string) => void;
+  /** Append a delta to the accumulated assistant transcript. */
+  appendAssistantTranscript: (delta: string) => void;
+  /** Reset the assistant transcript ahead of a new response. */
+  clearAssistantTranscript: () => void;
+  setInputAmplitude: (amplitude: number) => void;
+  /** Transition to `failed` with a message. */
+  fail: (message: string) => void;
+  /** Reset every field back to the idle defaults. */
+  reset: () => void;
+}
+
+export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: LiveVoiceState = {
+  state: "idle",
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  error: null,
+};
+
+const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
+  ...INITIAL_STATE,
+
+  setState: (state) => set({ state }),
+  setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
+  setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
+  appendAssistantTranscript: (delta) =>
+    set((s) => ({ assistantTranscript: s.assistantTranscript + delta })),
+  clearAssistantTranscript: () => set({ assistantTranscript: "" }),
+  setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
+  fail: (message) => set({ state: "failed", error: message }),
+  reset: () => set({ ...INITIAL_STATE }),
+}));
+
+export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);

--- a/apps/web/src/domains/voice/live-voice/tts-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/tts-playback.test.ts
@@ -363,4 +363,50 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources.length).toBe(0);
     expect(player.isPlaying).toBe(false);
   });
+
+  // -------------------------------------------------------------------------
+  // dispose: release the underlying AudioContext (resource-leak guard)
+  // -------------------------------------------------------------------------
+
+  test("dispose() stops playback and closes the underlying context", async () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    expect(player.isPlaying).toBe(true);
+
+    await player.dispose();
+
+    // Every scheduled source was halted, the queue cleared, and the context
+    // released so it can't leak across repeated sessions.
+    expect(ctx.sources.every((s) => s.stopped)).toBe(true);
+    expect(ctx.closed).toBe(true);
+    expect(player.isPlaying).toBe(false);
+    expect(player.queuedCount).toBe(0);
+  });
+
+  test("dispose() is a no-op when no context was ever created", async () => {
+    // No enqueue, so the lazy context was never constructed: dispose must not
+    // throw and must not fabricate/close a context.
+    await player.dispose();
+    expect(ctx.closed).toBe(false);
+  });
+
+  test("dispose() is idempotent: repeat calls don't re-close the context", async () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+
+    await player.dispose();
+    ctx.closed = false; // detect any erroneous second close
+    await player.dispose();
+
+    expect(ctx.closed).toBe(false);
+  });
+
+  test("player is reusable after dispose() — the next enqueue recreates context", async () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    await player.dispose();
+
+    // A fresh enqueue lazily rebuilds a context and schedules normally.
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    expect(player.isPlaying).toBe(true);
+    expect(player.queuedCount).toBe(1);
+  });
 });

--- a/apps/web/src/domains/voice/live-voice/tts-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/tts-playback.ts
@@ -338,10 +338,13 @@ export class LiveVoiceAudioPlayer {
 
   /**
    * Release the underlying `AudioContext`. Implicitly stops playback first.
-   * The player can be reused afterwards — the next `enqueue` lazily recreates
-   * the context.
+   *
+   * Idempotent and safe to call when the context was never created or is
+   * already closed: only a context this player owns is closed, and the field is
+   * cleared before awaiting so re-entrant/repeat calls are no-ops. The player
+   * can be reused afterwards — the next `enqueue` lazily recreates the context.
    */
-  async close(): Promise<void> {
+  async dispose(): Promise<void> {
     this.stop();
     const context = this.context;
     this.context = null;

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Tests for the `useLiveVoice` session controller.
+ *
+ * The three merged primitives — client, capture, player — are replaced with
+ * hand-rolled fakes injected through `useLiveVoice`'s factory options, so no
+ * WebSocket, microphone, or AudioContext is touched. The fakes expose drivers
+ * (`emit`, `pushChunk`, `pushAmplitude`) so a test can drive a full turn and
+ * assert the state-machine transitions, barge-in, automatic ptt_release, and
+ * teardown.
+ *
+ * @jest-environment happy-dom
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+// The default client factory in use-live-voice statically imports the real
+// LiveVoiceChannelClient, which pulls in connection.ts -> the generated SDK.
+// Tests inject fake primitives, so we never construct the real client; mock the
+// connection module so importing the controller doesn't drag in the SDK client.
+mock.module("@/domains/voice/live-voice/connection", () => ({
+  mintLiveVoiceToken: mock(async () => ({
+    token: "tok",
+    expiresAt: "2026-06-01T00:05:00Z",
+  })),
+  buildLiveVoiceWsUrl: () => "wss://velay.vellum.ai/a/v1/live-voice",
+}));
+
+import type {
+  LiveVoiceChannelClient,
+  LiveVoiceClientError,
+  LiveVoiceClientEventMap,
+  LiveVoiceClientEventName,
+} from "@/domains/voice/live-voice/live-voice-client";
+import type {
+  LiveVoiceAudioCapture,
+  LiveVoiceAudioCaptureOptions,
+  LiveVoiceCaptureResult,
+} from "@/domains/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioPlayer } from "@/domains/voice/live-voice/tts-playback";
+
+// Import the controller + store *after* the connection mock is registered, so
+// the real connection.ts (which imports the generated SDK) never enters the
+// static import graph.
+const { useLiveVoice } = await import(
+  "@/domains/voice/live-voice/use-live-voice"
+);
+const { useLiveVoiceStore } = await import(
+  "@/domains/voice/live-voice/live-voice-store"
+);
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeClient {
+  connectArgs: { assistantId: string; conversationId?: string } | null = null;
+  sentAudio: ArrayBuffer[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  ended = false;
+  closed = false;
+
+  private handlers = new Map<
+    LiveVoiceClientEventName,
+    Set<(payload: never) => void>
+  >();
+
+  on<E extends LiveVoiceClientEventName>(
+    event: E,
+    handler: (payload: LiveVoiceClientEventMap[E]) => void,
+  ): () => void {
+    let set = this.handlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(event, set);
+    }
+    set.add(handler as (payload: never) => void);
+    return () => set?.delete(handler as (payload: never) => void);
+  }
+
+  async connect(args: {
+    assistantId: string;
+    conversationId?: string;
+  }): Promise<void> {
+    this.connectArgs = args;
+  }
+
+  sendAudio(pcm: ArrayBuffer): void {
+    this.sentAudio.push(pcm);
+  }
+  pttRelease(): void {
+    this.pttReleaseCount++;
+  }
+  interrupt(): void {
+    this.interruptCount++;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Drive a server event to the controller's subscribed handlers. */
+  emit<E extends LiveVoiceClientEventName>(
+    event: E,
+    payload: LiveVoiceClientEventMap[E],
+  ): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
+    }
+  }
+}
+
+class FakeCapture {
+  readonly onChunk: (buf: ArrayBuffer) => void;
+  readonly onAmplitude?: (amplitude: number) => void;
+
+  startCount = 0;
+  stopCount = 0;
+  shutdownCount = 0;
+  startResult: LiveVoiceCaptureResult = { ok: true };
+
+  constructor(options: LiveVoiceAudioCaptureOptions) {
+    this.onChunk = options.onChunk;
+    this.onAmplitude = options.onAmplitude;
+  }
+
+  async start(): Promise<LiveVoiceCaptureResult> {
+    this.startCount++;
+    return this.startResult;
+  }
+  async stop(): Promise<void> {
+    this.stopCount++;
+  }
+  async shutdown(): Promise<void> {
+    this.shutdownCount++;
+  }
+
+  /** Feed a captured PCM chunk to the controller. */
+  pushChunk(buf: ArrayBuffer): void {
+    this.onChunk(buf);
+  }
+  /** Feed an amplitude reading to the controller. */
+  pushAmplitude(amplitude: number): void {
+    this.onAmplitude?.(amplitude);
+  }
+}
+
+class FakePlayer {
+  enqueued: unknown[] = [];
+  stopCount = 0;
+  isPlaying = false;
+  private drainResolvers: Array<() => void> = [];
+
+  enqueue(chunk: unknown): void {
+    this.enqueued.push(chunk);
+    this.isPlaying = true;
+  }
+  stop(): void {
+    this.stopCount++;
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  async waitUntilDrained(): Promise<void> {
+    if (!this.isPlaying) return;
+    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
+  }
+
+  /** Simulate playback finishing naturally. */
+  finishPlayback(): void {
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  private resolveDrain(): void {
+    const resolvers = this.drainResolvers;
+    this.drainResolvers = [];
+    for (const resolve of resolvers) resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
+function pcmChunk(ms: number): ArrayBuffer {
+  const samples = Math.round((16000 * ms) / 1000);
+  return new Int16Array(samples).buffer;
+}
+
+function renderController() {
+  const client = new FakeClient();
+  const player = new FakePlayer();
+  let capture!: FakeCapture;
+
+  const view = renderHook(() =>
+    useLiveVoice({
+      createClient: () => client as unknown as LiveVoiceChannelClient,
+      createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
+      createCapture: (options) => {
+        capture = new FakeCapture(options);
+        return capture as unknown as LiveVoiceAudioCapture;
+      },
+    }),
+  );
+
+  return {
+    view,
+    client,
+    player,
+    getCapture: () => capture,
+  };
+}
+
+/** Start a session and drive it to the listening state (ready + capture). */
+async function startListening(h: ReturnType<typeof renderController>) {
+  await act(async () => {
+    await h.view.result.current.start("assistant-1", "conv-1");
+  });
+  // `ready` kicks off capture; await the microtask that resolves capture.start.
+  await act(async () => {
+    h.client.emit("ready", {
+      type: "ready",
+      seq: 1,
+      sessionId: "s1",
+      conversationId: "conv-1",
+    });
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+afterEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Full turn
+// ---------------------------------------------------------------------------
+
+describe("full turn", () => {
+  test("drives idle → connecting → listening → transcribing → thinking → speaking → idle", async () => {
+    const h = renderController();
+
+    expect(h.view.result.current.state).toBe("idle");
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+    });
+
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.getCapture().startCount).toBe(1);
+
+    // Captured audio is forwarded to the client.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+
+    // Partial then final transcript.
+    act(() => {
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
+    });
+    expect(h.view.result.current.partialTranscript).toBe("hel");
+
+    act(() => {
+      h.client.emit("sttFinal", { type: "stt_final", seq: 3, text: "hello" });
+    });
+    expect(h.view.result.current.finalTranscript).toBe("hello");
+    expect(h.view.result.current.partialTranscript).toBe("");
+    // Capture still running, so stt_final keeps us listening.
+    expect(h.view.result.current.state).toBe("listening");
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 4, turnId: "t1" });
+    });
+    expect(h.view.result.current.state).toBe("thinking");
+
+    act(() => {
+      h.client.emit("assistantTextDelta", {
+        type: "assistant_text_delta",
+        seq: 5,
+        text: "hi ",
+      });
+      h.client.emit("assistantTextDelta", {
+        type: "assistant_text_delta",
+        seq: 6,
+        text: "there",
+      });
+    });
+    expect(h.view.result.current.assistantTranscript).toBe("hi there");
+
+    act(() => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 7,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(h.player.enqueued).toHaveLength(1);
+
+    // tts_done stops capture and awaits playback drain, then returns to idle.
+    await act(async () => {
+      h.client.emit("ttsDone", { type: "tts_done", seq: 8, turnId: "t1" });
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.client.closed).toBe(true);
+    expect(h.getCapture().shutdownCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Barge-in
+// ---------------------------------------------------------------------------
+
+describe("barge-in", () => {
+  test("amplitude over threshold while speaking stops playback and interrupts", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(h.player.isPlaying).toBe(true);
+
+    act(() => {
+      h.getCapture().pushAmplitude(0.2); // over BARGE_IN_AMPLITUDE_THRESHOLD
+    });
+
+    expect(h.player.stopCount).toBe(1);
+    expect(h.client.interruptCount).toBe(1);
+    // Capture is still running, so barge-in returns us to listening.
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("interrupt is sent at most once per response", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.getCapture().pushAmplitude(0.2);
+      h.getCapture().pushAmplitude(0.25);
+    });
+
+    expect(h.client.interruptCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Automatic push-to-talk release on silence
+// ---------------------------------------------------------------------------
+
+describe("automatic ptt_release", () => {
+  test("speech followed by a silence window releases push-to-talk", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Speech: a chunk above the speech threshold accrues speech duration.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(200));
+    });
+    expect(h.client.pttReleaseCount).toBe(0);
+
+    // Silence: a chunk below the speech threshold for >= 1s triggers release.
+    act(() => {
+      h.getCapture().pushAmplitude(0.0);
+      h.getCapture().pushChunk(pcmChunk(1000));
+    });
+
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("silence without prior speech does not release", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.getCapture().pushAmplitude(0.0);
+      h.getCapture().pushChunk(pcmChunk(2000));
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure paths
+// ---------------------------------------------------------------------------
+
+describe("failure", () => {
+  test("error frame transitions to failed with the message and tears down", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      const err: LiveVoiceClientError = {
+        reason: "protocol-error",
+        message: "kaboom",
+      };
+      h.client.emit("error", err);
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(h.view.result.current.error).toBe("kaboom");
+    expect(h.client.closed).toBe(true);
+    expect(h.getCapture().shutdownCount).toBe(1);
+  });
+
+  test("busy frame fails the session", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("busy", {
+        type: "busy",
+        seq: 2,
+        activeSessionId: "other",
+      });
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(h.view.result.current.error).toBe(
+      "Another live-voice session is active.",
+    );
+  });
+
+  test("capture failure fails the session", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+    await act(async () => {
+      // The capture instance exists once start() ran; make its start fail.
+      h.getCapture().startResult = {
+        ok: false,
+        error: "permission-denied",
+      };
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(h.client.closed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+describe("teardown", () => {
+  test("stop() ends the session and releases mic, socket, and audio", async () => {
+    const h = renderController();
+    await startListening(h);
+    const capture = h.getCapture();
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    expect(h.client.ended).toBe(true);
+    expect(h.player.stopCount).toBeGreaterThanOrEqual(1);
+    expect(capture.shutdownCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("unmount releases mic, socket, and audio", async () => {
+    const h = renderController();
+    await startListening(h);
+    const capture = h.getCapture();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    expect(h.client.closed).toBe(true);
+    expect(h.player.stopCount).toBeGreaterThanOrEqual(1);
+    expect(capture.shutdownCount).toBe(1);
+  });
+
+  test("stop() with no active session resets to idle without throwing", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(h.view.result.current.state).toBe("idle");
+  });
+});

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
@@ -151,6 +151,7 @@ class FakeCapture {
 class FakePlayer {
   enqueued: unknown[] = [];
   stopCount = 0;
+  disposeCount = 0;
   isPlaying = false;
   private drainResolvers: Array<() => void> = [];
 
@@ -162,6 +163,10 @@ class FakePlayer {
     this.stopCount++;
     this.isPlaying = false;
     this.resolveDrain();
+  }
+  async dispose(): Promise<void> {
+    this.disposeCount++;
+    this.stop();
   }
   async waitUntilDrained(): Promise<void> {
     if (!this.isPlaying) return;
@@ -508,7 +513,9 @@ describe("teardown", () => {
     });
 
     expect(h.client.ended).toBe(true);
-    expect(h.player.stopCount).toBeGreaterThanOrEqual(1);
+    // dispose() releases the AudioContext (not just stop()); confirm capture is
+    // fully shut down too.
+    expect(h.player.disposeCount).toBeGreaterThanOrEqual(1);
     expect(capture.shutdownCount).toBe(1);
     expect(h.view.result.current.state).toBe("idle");
   });
@@ -523,7 +530,8 @@ describe("teardown", () => {
     });
 
     expect(h.client.closed).toBe(true);
-    expect(h.player.stopCount).toBeGreaterThanOrEqual(1);
+    // Unmount must dispose the player so the AudioContext is released.
+    expect(h.player.disposeCount).toBeGreaterThanOrEqual(1);
     expect(capture.shutdownCount).toBe(1);
   });
 

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.ts
@@ -1,0 +1,440 @@
+/**
+ * `useLiveVoice()` — session controller for the browser live-voice channel.
+ *
+ * Web-app counterpart to the macOS `LiveVoiceChannelManager`
+ * (`clients/macos/.../LiveVoiceChannelManager.swift`). It wires the three merged
+ * primitives — {@link LiveVoiceChannelClient} (transport), {@link
+ * LiveVoiceAudioCapture} (mic → PCM), {@link LiveVoiceAudioPlayer} (TTS
+ * playback) — into the session state machine and projects observable state into
+ * {@link useLiveVoiceStore}.
+ *
+ * The state machine is held in `useLiveVoiceStore`; this module owns the imperative
+ * glue (event wiring, barge-in, automatic push-to-talk release, teardown). One
+ * controller instance drives at most one session at a time; `start()` while a
+ * session is live is a no-op (matching the macOS guard).
+ *
+ * ## State transitions (full turn)
+ * `idle → connecting` (start) → `listening` (ready + capture started) →
+ * `transcribing` (ptt released) → `thinking` (server response) → `speaking`
+ * (tts_audio) → `idle` (tts_done drained + cleanup).
+ *
+ * ## Barge-in
+ * While `speaking`, a captured amplitude over {@link BARGE_IN_AMPLITUDE_THRESHOLD}
+ * stops playback and sends `interrupt` (once per response).
+ *
+ * ## Automatic push-to-talk release
+ * While `listening`, sustained speech (≥ {@link MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS})
+ * followed by {@link SILENCE_DURATION_BEFORE_RELEASE_MS} of silence releases
+ * push-to-talk and moves to `transcribing`.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+import {
+  LiveVoiceChannelClient,
+  type LiveVoiceClientError,
+} from "@/domains/voice/live-voice/live-voice-client";
+import {
+  LiveVoiceAudioCapture,
+  LIVE_VOICE_AUDIO_FORMAT,
+} from "@/domains/voice/live-voice/pcm-capture";
+import {
+  LiveVoiceAudioPlayer,
+  type TtsAudioChunk,
+} from "@/domains/voice/live-voice/tts-playback";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/voice/live-voice/live-voice-store";
+
+// ---------------------------------------------------------------------------
+// Thresholds (mirror the macOS LiveVoiceChannelManager defaults)
+// ---------------------------------------------------------------------------
+
+/** Mic amplitude (in [0, 1]) above which barge-in interrupts assistant speech. */
+const BARGE_IN_AMPLITUDE_THRESHOLD = 0.05;
+
+/** Mic amplitude above which a chunk counts as speech (for silence detection). */
+const SPEECH_AMPLITUDE_THRESHOLD = 0.03;
+
+/** Trailing silence (ms) after speech that triggers an automatic ptt_release. */
+const SILENCE_DURATION_BEFORE_RELEASE_MS = 1000;
+
+/** Minimum speech (ms) required before a silence window can trigger release. */
+const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface UseLiveVoiceResult {
+  /** Current session phase. */
+  state: LiveVoiceSessionState;
+  /** In-flight partial user transcript. */
+  partialTranscript: string;
+  /** Last finalized user transcript. */
+  finalTranscript: string;
+  /** Accumulated assistant response text for the current turn. */
+  assistantTranscript: string;
+  /** Smoothed mic amplitude in [0, 1]. */
+  inputAmplitude: number;
+  /** Failure message when `state === "failed"`, else `null`. */
+  error: string | null;
+  /** Start a session for `assistantId`, optionally attaching a conversation. */
+  start: (assistantId: string, conversationId?: string) => Promise<void>;
+  /** End the session and release the mic, socket, and audio context. */
+  stop: () => Promise<void>;
+}
+
+/** Injectable factories so tests can supply mock primitives. */
+export interface UseLiveVoiceOptions {
+  createClient?: () => LiveVoiceChannelClient;
+  createCapture?: (
+    options: ConstructorParameters<typeof LiveVoiceAudioCapture>[0],
+  ) => LiveVoiceAudioCapture;
+  createPlayer?: () => LiveVoiceAudioPlayer;
+}
+
+/**
+ * Mutable per-session bookkeeping that must not trigger re-renders. Lives in a
+ * ref alongside the active primitives; replaced wholesale on each `start()`.
+ */
+interface SessionContext {
+  client: LiveVoiceChannelClient;
+  capture: LiveVoiceAudioCapture;
+  player: LiveVoiceAudioPlayer;
+  /** Unsubscribe callbacks for the client event handlers. */
+  unsubscribes: Array<() => void>;
+  /** Monotonic id; a stale callback whose generation differs is ignored. */
+  generation: number;
+  captureRunning: boolean;
+  /** Whether the assistant has sent any TTS audio for the current response. */
+  responseAudioStarted: boolean;
+  /** Whether an interrupt was already sent for the current response. */
+  interruptSent: boolean;
+  /** Whether an automatic ptt_release is already in flight for this utterance. */
+  releaseInFlight: boolean;
+  /** Accumulated speech duration (ms) in the current utterance. */
+  speechMs: number;
+  /** Accumulated trailing silence (ms) after speech in the current utterance. */
+  silenceMs: number;
+}
+
+/** Number of bytes per Int16 PCM sample. */
+const BYTES_PER_SAMPLE = 2;
+
+/** Milliseconds of audio represented by a captured PCM chunk. */
+function chunkDurationMs(buf: ArrayBuffer): number {
+  const sampleCount = buf.byteLength / BYTES_PER_SAMPLE;
+  return (sampleCount / LIVE_VOICE_AUDIO_FORMAT.sampleRate) * 1000;
+}
+
+export function useLiveVoice(
+  options: UseLiveVoiceOptions = {},
+): UseLiveVoiceResult {
+  const state = useLiveVoiceStore.use.state();
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
+  const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  const error = useLiveVoiceStore.use.error();
+
+  const sessionRef = useRef<SessionContext | null>(null);
+
+  // Keep the factories in a ref so start()/stop() stay stable across renders
+  // even if callers pass inline option objects.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  /** Tear down the active session's primitives and clear the ref. */
+  const teardown = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+    // Bump the generation so any in-flight async callbacks become stale no-ops.
+    session.generation += 1;
+    for (const unsubscribe of session.unsubscribes) unsubscribe();
+    session.unsubscribes = [];
+    session.client.close();
+    session.player.stop();
+    void session.capture.shutdown();
+  }, []);
+
+  const stop = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) {
+      useLiveVoiceStore.getState().reset();
+      return;
+    }
+    sessionRef.current = null;
+    session.generation += 1;
+    useLiveVoiceStore.getState().setState("ending");
+    for (const unsubscribe of session.unsubscribes) unsubscribe();
+    session.unsubscribes = [];
+    session.client.end();
+    session.player.stop();
+    await session.capture.shutdown();
+    useLiveVoiceStore.getState().reset();
+  }, []);
+
+  const start = useCallback(
+    async (assistantId: string, conversationId?: string) => {
+      const current = sessionRef.current;
+      // A live session (anything but idle/failed) blocks a new start.
+      const phase = useLiveVoiceStore.getState().state;
+      if (current && phase !== "idle" && phase !== "failed") return;
+      if (current) teardown();
+
+      const store = useLiveVoiceStore.getState();
+      store.reset();
+      store.setState("connecting");
+
+      const opts = optionsRef.current;
+      const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
+      const player = (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
+
+      const session: SessionContext = {
+        client,
+        capture: undefined as unknown as LiveVoiceAudioCapture,
+        player,
+        unsubscribes: [],
+        generation: 0,
+        captureRunning: false,
+        responseAudioStarted: false,
+        interruptSent: false,
+        releaseInFlight: false,
+        speechMs: 0,
+        silenceMs: 0,
+      };
+
+      const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
+        onChunk: (buf) => handleChunk(session, buf),
+        onAmplitude: (amplitude) => handleAmplitude(session, amplitude),
+      });
+      session.capture = capture;
+      sessionRef.current = session;
+
+      const generation = session.generation;
+      const live = () =>
+        sessionRef.current === session && session.generation === generation;
+
+      session.unsubscribes.push(
+        client.on("ready", () => {
+          if (!live()) return;
+          void startCapture(session, teardown);
+        }),
+        client.on("sttPartial", (frame) => {
+          if (!live()) return;
+          const s = useLiveVoiceStore.getState();
+          s.setPartialTranscript(frame.text);
+          if (session.captureRunning) s.setState("listening");
+        }),
+        client.on("sttFinal", (frame) => {
+          if (!live()) return;
+          const s = useLiveVoiceStore.getState();
+          s.setFinalTranscript(frame.text);
+          s.setPartialTranscript("");
+          s.setState(session.captureRunning ? "listening" : "thinking");
+        }),
+        client.on("thinking", () => {
+          if (!live()) return;
+          // New response: reset the per-response transcript and barge-in flags.
+          session.responseAudioStarted = false;
+          session.interruptSent = false;
+          const s = useLiveVoiceStore.getState();
+          s.clearAssistantTranscript();
+          s.setState("thinking");
+        }),
+        client.on("assistantTextDelta", (frame) => {
+          if (!live() || frame.text.length === 0) return;
+          const s = useLiveVoiceStore.getState();
+          s.appendAssistantTranscript(frame.text);
+          const phase = s.state;
+          if (phase === "listening" || phase === "transcribing") {
+            s.setState("thinking");
+          }
+        }),
+        client.on("ttsAudio", (frame) => {
+          if (!live()) return;
+          beginAssistantAudioIfNeeded(session);
+          const chunk: TtsAudioChunk = {
+            dataBase64: frame.dataBase64,
+            sampleRate: frame.sampleRate,
+            mimeType: frame.mimeType,
+          };
+          session.player.enqueue(chunk);
+          useLiveVoiceStore.getState().setState("speaking");
+        }),
+        client.on("ttsDone", () => {
+          if (!live()) return;
+          void finishResponseAfterPlayback(session, teardown);
+        }),
+        client.on("archived", () => {
+          if (!live()) return;
+          // Persisted; nothing user-visible to do here.
+        }),
+        client.on("busy", () => {
+          if (!live()) return;
+          finishWithError(session, teardown, "Another live-voice session is active.");
+        }),
+        client.on("error", (err: LiveVoiceClientError) => {
+          if (!live()) return;
+          finishWithError(session, teardown, err.message);
+        }),
+        client.on("closed", () => {
+          // A transport close after a clean end()/teardown is expected; only an
+          // unexpected close while still attached needs cleanup.
+          if (!live()) return;
+          teardown();
+          useLiveVoiceStore.getState().reset();
+        }),
+      );
+
+      await client.connect({ assistantId, conversationId });
+    },
+    [teardown],
+  );
+
+  // Release everything if the consumer unmounts mid-session.
+  useEffect(() => () => teardown(), [teardown]);
+
+  return {
+    state,
+    partialTranscript,
+    finalTranscript,
+    assistantTranscript,
+    inputAmplitude,
+    error,
+    start,
+    stop,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Session helpers (operate on the session context; never re-render directly)
+// ---------------------------------------------------------------------------
+
+/** Open the mic and begin streaming PCM. Failure transitions to `failed`. */
+async function startCapture(
+  session: SessionContext,
+  teardown: () => void,
+): Promise<void> {
+  const generation = session.generation;
+  const result = await session.capture.start();
+  // A stop()/teardown that raced our await replaced or advanced the session.
+  if (session.generation !== generation) {
+    if (result.ok) void session.capture.stop();
+    return;
+  }
+  if (!result.ok) {
+    finishWithError(session, teardown, "Microphone capture could not start.");
+    return;
+  }
+  session.captureRunning = true;
+  const s = useLiveVoiceStore.getState();
+  if (s.state === "connecting") s.setState("listening");
+}
+
+/** Forward a captured PCM chunk to the server and drive silence detection. */
+function handleChunk(session: SessionContext, buf: ArrayBuffer): void {
+  if (!session.captureRunning) return;
+  session.client.sendAudio(buf);
+  updateAutomaticRelease(session, buf);
+}
+
+/** Apply the latest amplitude to the store and run barge-in detection. */
+function handleAmplitude(session: SessionContext, amplitude: number): void {
+  if (!session.captureRunning) return;
+  useLiveVoiceStore.getState().setInputAmplitude(amplitude);
+  if (amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD) {
+    interruptIfSpeaking(session);
+  }
+}
+
+/**
+ * Track speech / trailing-silence durations and auto-release push-to-talk once
+ * a real utterance is followed by a long-enough silence window.
+ */
+function updateAutomaticRelease(session: SessionContext, buf: ArrayBuffer): void {
+  if (useLiveVoiceStore.getState().state !== "listening") return;
+  const durationMs = chunkDurationMs(buf);
+  if (durationMs <= 0) return;
+
+  // The amplitude for this chunk was applied via onAmplitude; read it back so
+  // chunk-level speech/silence classification stays in sync with the UI value.
+  const amplitude = useLiveVoiceStore.getState().inputAmplitude;
+  if (amplitude >= SPEECH_AMPLITUDE_THRESHOLD) {
+    session.speechMs += durationMs;
+    session.silenceMs = 0;
+    return;
+  }
+  if (session.speechMs < MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS) {
+    session.speechMs = 0;
+    return;
+  }
+  session.silenceMs += durationMs;
+  if (session.silenceMs < SILENCE_DURATION_BEFORE_RELEASE_MS) return;
+  releasePushToTalk(session);
+}
+
+/** Stop forwarding audio and release push-to-talk; moves to `transcribing`. */
+function releasePushToTalk(session: SessionContext): void {
+  if (session.releaseInFlight || !session.captureRunning) return;
+  session.releaseInFlight = true;
+  session.captureRunning = false;
+  void session.capture.stop();
+  session.client.pttRelease();
+  const s = useLiveVoiceStore.getState();
+  if (s.state === "listening") s.setState("transcribing");
+  s.setInputAmplitude(0);
+}
+
+/** Barge-in: stop playback and interrupt the server once per response. */
+function interruptIfSpeaking(session: SessionContext): void {
+  if (useLiveVoiceStore.getState().state !== "speaking") return;
+  if (!session.player.isPlaying || session.interruptSent) return;
+  session.interruptSent = true;
+  session.player.stop();
+  session.client.interrupt();
+  const s = useLiveVoiceStore.getState();
+  s.setState(session.captureRunning ? "listening" : "idle");
+}
+
+/** First TTS frame of a response: reset playback flags for the new utterance. */
+function beginAssistantAudioIfNeeded(session: SessionContext): void {
+  if (session.responseAudioStarted) return;
+  session.responseAudioStarted = true;
+  session.interruptSent = false;
+}
+
+/**
+ * After `tts_done`, stop capturing then await playback drain before cleaning up
+ * and returning to `idle`. Stopping capture first prevents drain-window audio
+ * from being forwarded (mirrors the macOS ordering).
+ */
+async function finishResponseAfterPlayback(
+  session: SessionContext,
+  teardown: () => void,
+): Promise<void> {
+  const generation = session.generation;
+  session.responseAudioStarted = false;
+  session.captureRunning = false;
+  void session.capture.stop();
+
+  await session.player.waitUntilDrained();
+  if (session.generation !== generation) return;
+
+  useLiveVoiceStore.getState().setState("ending");
+  teardown();
+  useLiveVoiceStore.getState().reset();
+}
+
+/** Fail the session: tear down primitives and surface the message. */
+function finishWithError(
+  session: SessionContext,
+  teardown: () => void,
+  message: string,
+): void {
+  teardown();
+  useLiveVoiceStore.getState().fail(message);
+}

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.ts
@@ -156,7 +156,9 @@ export function useLiveVoice(
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
     session.client.close();
-    session.player.stop();
+    // dispose() stops playback *and* releases the AudioContext; a bare stop()
+    // would leak the context across repeated sessions until page unload.
+    void session.player.dispose();
     void session.capture.shutdown();
   }, []);
 
@@ -172,7 +174,8 @@ export function useLiveVoice(
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
     session.client.end();
-    session.player.stop();
+    // Release the AudioContext, not just the scheduled sources (see teardown).
+    await session.player.dispose();
     await session.capture.shutdown();
     useLiveVoiceStore.getState().reset();
   }, []);


### PR DESCRIPTION
## Summary
- Add useLiveVoice + live-voice store: state machine composing client/capture/playback with barge-in and teardown

Part of plan: web-live-voice.md (PR 6 of 8)