### PR TITLE
test(web): drop LUM-2092 workaround mocks from use-event-bus-init.test.tsx

### DIFF
--- a/apps/web/src/hooks/use-event-bus-init.test.tsx
+++ b/apps/web/src/hooks/use-event-bus-init.test.tsx
@@ -10,25 +10,9 @@ import {
 } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
+import { sseService } from "@/assistant/sse-service";
+import { useEventBusInit } from "@/hooks/use-event-bus-init";
 import { __resetForTesting } from "@/lib/event-bus";
-
-// `mock.module` for `stream-transport` + `lifecycle-service` is a
-// workaround for a pre-existing main-branch issue: the import chain
-// `sseService → lifecycleService → assistant/api` references
-// `DiskPressureStatusResponseSchema`, which is mid-migration to
-// `@vellumai/assistant-api` and not yet exported there. Without the
-// mocks the module load throws before any test runs. When the
-// canonical package catches up, drop both mocks — they're not part
-// of the hook's actual contract.
-mock.module("@/lib/streaming/stream-transport", () => ({
-  subscribeChatEvents: () => ({ cancel: () => {} }),
-}));
-mock.module("@/assistant/lifecycle-service", () => ({
-  lifecycleService: { checkAssistant: async () => {} },
-}));
-
-const { sseService } = await import("@/assistant/sse-service");
-const { useEventBusInit } = await import("@/hooks/use-event-bus-init");
 
 const detachMock = mock(() => {});
 const attachSpy = spyOn(sseService, "attach").mockImplementation(


### PR DESCRIPTION
Closes LUM-2092 — the ticket described "missing exports on `@vellumai/assistant-api`" that have since been added by parallel PRs (#32701, #32726, #32728, #32731, #32743, #32748, #32792).

`use-event-bus-init.test.tsx` had two `mock.module` blocks plus a comment block explaining they were a workaround for the (then-missing) `DiskPressureStatusResponseSchema` export. The exports exist now; `bun run typecheck` is clean against `@vellumai/assistant-api`; the mocks were dead weight.

Removed:
- The two `mock.module` blocks for `@/lib/streaming/stream-transport` and `@/assistant/lifecycle-service`.
- The workaround-pointer comment.
- The `await import(...)` dance — was only needed to ensure mocks were set before the import. Static imports work now.

The `spyOn(sseService, "attach")` assertion stays — per-object spy, not a process-global `mock.module`, so it doesn't leak across test files.

Net diff: −16 lines, +2 lines. 64/64 tests pass.

## Test plan

- [x] `bun test src/hooks/use-event-bus-init.test.tsx` — 3/3 pass.
- [x] `bun test` across the bus + source-helper + sse-service files — 64/64.
- [ ] CI on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_