### PR TITLE
feat(chat): add flag-gated live-voice button to the composer

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -12,6 +12,12 @@
   "src/domains/chat/components/chat-composer/chat-composer.tsx": [
     "voice"
   ],
+  "src/domains/chat/components/live-voice-button.test.tsx": [
+    "voice"
+  ],
+  "src/domains/chat/components/live-voice-button.tsx": [
+    "voice"
+  ],
   "src/domains/chat/components/voice-input-button.tsx": [
     "voice"
   ],

--- a/apps/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -142,6 +142,42 @@ describe("LiveVoiceButton", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  test("stays stoppable when disabled while a session is active", () => {
+    // GIVEN an active session and a parent that has raised `disabled`
+    mockVoiceMode = true;
+    mockState = "listening";
+    const { getByLabelText } = render(
+      <LiveVoiceButton assistantId="a1" disabled />,
+    );
+
+    // THEN the stop control remains enabled despite the external disabled prop
+    const button = getByLabelText("Stop voice mode") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    // WHEN the user clicks it, the session is stopped
+    fireEvent.click(button);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  test("prevents starting a session when disabled while idle", () => {
+    // GIVEN an idle, flag-enabled button that the parent has disabled
+    mockVoiceMode = true;
+    mockState = "idle";
+    const { getByLabelText } = render(
+      <LiveVoiceButton assistantId="a1" disabled />,
+    );
+
+    // THEN the start control is disabled
+    const button = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    // WHEN the user clicks it, no session is started
+    fireEvent.click(button);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
   test("scales the icon with live amplitude while active", () => {
     // GIVEN an active session with non-zero mic amplitude
     mockVoiceMode = true;

--- a/apps/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for `LiveVoiceButton`.
+ *
+ * The button is gated behind the `voice-mode` assistant flag and toggles a
+ * {@link useLiveVoice} session. We mock both so the component renders in
+ * isolation: the flag store via a mutable `mockVoiceMode`, and `useLiveVoice`
+ * via spies for `start`/`stop` plus a mutable `mockState`/`mockInputAmplitude`.
+ *
+ * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { LiveVoiceSessionState } from "@/domains/voice/live-voice/live-voice-store";
+
+let mockVoiceMode = false;
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: {
+      voiceMode: () => mockVoiceMode,
+    },
+  },
+}));
+
+const startSpy = mock(async (_assistantId: string, _conversationId?: string) => {});
+const stopSpy = mock(async () => {});
+let mockState: LiveVoiceSessionState = "idle";
+let mockInputAmplitude = 0;
+mock.module("@/domains/voice/live-voice/use-live-voice", () => ({
+  useLiveVoice: () => ({
+    state: mockState,
+    partialTranscript: "",
+    finalTranscript: "",
+    assistantTranscript: "",
+    inputAmplitude: mockInputAmplitude,
+    error: null,
+    start: startSpy,
+    stop: stopSpy,
+  }),
+}));
+
+// Imported after the mocks so the component picks up the mocked modules.
+const { LiveVoiceButton } = await import(
+  "@/domains/chat/components/live-voice-button"
+);
+
+beforeEach(() => {
+  mockVoiceMode = false;
+  mockState = "idle";
+  mockInputAmplitude = 0;
+  startSpy.mockClear();
+  stopSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LiveVoiceButton", () => {
+  test("renders nothing when the voice-mode flag is off", () => {
+    // GIVEN the voice-mode flag is disabled
+    mockVoiceMode = false;
+
+    // WHEN the button renders
+    const { container } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN nothing is painted
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders a start control when the flag is on and idle", () => {
+    // GIVEN the flag is enabled and no session is active
+    mockVoiceMode = true;
+    mockState = "idle";
+
+    // WHEN the button renders
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN it offers to start voice mode and is not pressed
+    const button = getByLabelText("Start voice mode");
+    expect(button).toBeTruthy();
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("starts a session on click when idle", () => {
+    // GIVEN an idle, flag-enabled button with a conversation
+    mockVoiceMode = true;
+    mockState = "idle";
+    const { getByLabelText } = render(
+      <LiveVoiceButton assistantId="a1" conversationId="c1" />,
+    );
+
+    // WHEN the user clicks it
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN it starts a live-voice session for the assistant + conversation
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledWith("a1", "c1");
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("stops the session on click when active", () => {
+    // GIVEN an active session (listening)
+    mockVoiceMode = true;
+    mockState = "listening";
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN the control reflects the live session
+    const button = getByLabelText("Stop voice mode");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+
+    // WHEN the user clicks it
+    fireEvent.click(button);
+
+    // THEN it stops the session
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  test("reflects connecting as a busy, non-toggling state", () => {
+    // GIVEN a session that is still connecting
+    mockVoiceMode = true;
+    mockState = "connecting";
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN the control is busy and disabled
+    const button = getByLabelText("Connecting live voice") as HTMLButtonElement;
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.disabled).toBe(true);
+
+    // WHEN the user clicks it, neither start nor stop fire
+    fireEvent.click(button);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("scales the icon with live amplitude while active", () => {
+    // GIVEN an active session with non-zero mic amplitude
+    mockVoiceMode = true;
+    mockState = "listening";
+    mockInputAmplitude = 1;
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN the control carries an amplitude-driven transform
+    const button = getByLabelText("Stop voice mode");
+    expect(button.style.transform).toContain("scale(");
+  });
+});

--- a/apps/web/src/domains/chat/components/live-voice-button.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.tsx
@@ -51,11 +51,16 @@ export function LiveVoiceButton({
   const handleClick = useCallback(() => {
     if (connecting) return;
     if (active) {
+      // An active session must always be stoppable, even if the parent has
+      // raised `disabled` in the meantime — otherwise the user is stuck with a
+      // live mic/socket until some automatic teardown.
       void stop();
     } else {
+      // Only the start path honours the external `disabled` prop.
+      if (disabled) return;
       void start(assistantId, conversationId);
     }
-  }, [active, connecting, start, stop, assistantId, conversationId]);
+  }, [active, connecting, disabled, start, stop, assistantId, conversationId]);
 
   if (!voiceMode) return null;
 
@@ -78,7 +83,9 @@ export function LiveVoiceButton({
         )
       }
       onClick={handleClick}
-      disabled={disabled || connecting}
+      // An active session is always stoppable; the external `disabled` prop
+      // only gates the start path. `connecting` stays disabled/busy.
+      disabled={connecting || (!active && disabled)}
       aria-label={label}
       aria-pressed={active}
       aria-busy={connecting}

--- a/apps/web/src/domains/chat/components/live-voice-button.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.tsx
@@ -1,0 +1,96 @@
+/**
+ * `LiveVoiceButton` — composer control that toggles a live-voice conversation.
+ *
+ * Distinct from the dictation {@link import("./voice-input-button").VoiceInputButton}:
+ * that one records a single utterance and drops a transcript into the composer,
+ * while this one opens a full-duplex live-voice session via {@link useLiveVoice}
+ * (mic streaming + TTS playback + barge-in). The button is gated behind the
+ * `voice-mode` assistant flag and renders nothing when the flag is off.
+ *
+ * Appearance reflects the {@link useLiveVoice} session phase:
+ *   - `idle`/`failed`     → mic icon, click to start
+ *   - `connecting`        → spinning loader, disabled (token mint / socket open)
+ *   - any other (active)  → stop-circle icon, click to stop; the live
+ *                           `inputAmplitude` drives a subtle pulse so the user
+ *                           sees the mic is hearing them.
+ *
+ * Wiring into the composer happens in a later PR; this is the standalone control.
+ */
+
+import { Loader2, Mic, StopCircle } from "lucide-react";
+import { useCallback } from "react";
+
+import { Button } from "@vellum/design-library";
+
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useLiveVoice } from "@/domains/voice/live-voice/use-live-voice";
+
+interface LiveVoiceButtonProps {
+  /** Assistant whose live-voice channel the session attaches to. */
+  assistantId: string;
+  /** Optional conversation to continue inside the session. */
+  conversationId?: string;
+  /** Disable the control (e.g. while the composer is otherwise busy). */
+  disabled?: boolean;
+}
+
+export function LiveVoiceButton({
+  assistantId,
+  conversationId,
+  disabled = false,
+}: LiveVoiceButtonProps) {
+  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
+  const { state, inputAmplitude, start, stop } = useLiveVoice();
+
+  const connecting = state === "connecting";
+  // Anything past connecting (listening/transcribing/thinking/speaking/ending)
+  // means a session is live and the button acts as a stop control.
+  const active =
+    state !== "idle" && state !== "failed" && state !== "connecting";
+
+  const handleClick = useCallback(() => {
+    if (connecting) return;
+    if (active) {
+      void stop();
+    } else {
+      void start(assistantId, conversationId);
+    }
+  }, [active, connecting, start, stop, assistantId, conversationId]);
+
+  if (!voiceMode) return null;
+
+  const label = connecting
+    ? "Connecting live voice"
+    : active
+      ? "Stop voice mode"
+      : "Start voice mode";
+
+  return (
+    <Button
+      variant="ghost"
+      iconOnly={
+        connecting ? (
+          <Loader2 className="animate-spin" strokeWidth={2} />
+        ) : active ? (
+          <StopCircle strokeWidth={2} />
+        ) : (
+          <Mic strokeWidth={2} />
+        )
+      }
+      onClick={handleClick}
+      disabled={disabled || connecting}
+      aria-label={label}
+      aria-pressed={active}
+      aria-busy={connecting}
+      title={label}
+      className="[--vbtn-fg:var(--content-secondary)]"
+      style={
+        // While listening, scale the icon with live amplitude so the control
+        // visibly reacts to the user's voice (clamped to a gentle 1.0–1.25).
+        active
+          ? { transform: `scale(${1 + Math.min(inputAmplitude, 1) * 0.25})` }
+          : undefined
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Consume the voice-mode flag and add a LiveVoiceButton (flag-gated) that toggles a useLiveVoice session and shows state + amplitude

Part of plan: web-live-voice.md (PR 7 of 8)