### PR TITLE
feat(chat): wire live-voice button + transcript surface into composer

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -9,20 +9,91 @@
  *   2. `@testing-library/react` `render` for HTML surface checks (placeholder,
  *      send/stop button, disabled attribute).
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import type { ChatAttachment } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
+import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import { INITIAL_TURN_STATE, type TurnState, useTurnStore } from "@/domains/chat/turn-store";
-
-import { ChatComposer, computeGhostSuffix, shouldSubmitOnEnter } from "@/domains/chat/components/chat-composer/chat-composer";
 
 let mockIsMobile = false;
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => mockIsMobile,
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
+
+// Live-voice integration mocks. The composer mounts `LiveVoiceButton` (which
+// self-gates on `voice-mode`) and reads `useLiveVoice()` for the transcript
+// surface + dictation mutual-exclusion. Both are mocked so the composer renders
+// in isolation: the flag via a mutable `mockVoiceMode`, and the session via a
+// mutable state + transcript bag. Defaults (flag off, idle, empty) keep the
+// existing HTML-surface assertions unchanged.
+let mockVoiceMode = false;
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: {
+      voiceMode: () => mockVoiceMode,
+    },
+  },
+}));
+
+// Local mirror of the live-voice session phases this test exercises. Kept as a
+// narrow union (not an import from the `voice` domain) so the `chat` test stays
+// free of cross-domain coupling — the composer only ever distinguishes idle
+// from non-idle, so the precise phase taxonomy is irrelevant here.
+type MockLiveVoiceState = "idle" | "connecting" | "listening";
+
+let mockLiveVoiceState: MockLiveVoiceState = "idle";
+let mockLivePartial = "";
+let mockLiveFinal = "";
+let mockLiveAssistant = "";
+const liveStartSpy = mock(
+  async (_assistantId: string, _conversationId?: string) => {},
+);
+const liveStopSpy = mock(async () => {});
+mock.module("@/domains/voice/live-voice/use-live-voice", () => ({
+  useLiveVoice: () => ({
+    state: mockLiveVoiceState,
+    partialTranscript: mockLivePartial,
+    finalTranscript: mockLiveFinal,
+    assistantTranscript: mockLiveAssistant,
+    inputAmplitude: 0,
+    error: null,
+    start: liveStartSpy,
+    stop: liveStopSpy,
+  }),
+}));
+
+// The real `VoiceInputButton` self-suppresses (returns null) unless the test
+// DOM exposes `MediaRecorder` + `getUserMedia`, which happy-dom does not. Mock
+// it with a probe that always renders and mirrors its `disabled` prop so the
+// composer's mutual-exclusion wiring is observable. The handle is mocked too.
+mock.module("@/domains/chat/components/voice-input-button", () => ({
+  VoiceInputButton: (props: { disabled?: boolean }) => (
+    <button
+      type="button"
+      aria-label="Start voice input"
+      disabled={props.disabled ?? false}
+    />
+  ),
+}));
+
+function resetLiveVoiceMocks() {
+  mockVoiceMode = false;
+  mockLiveVoiceState = "idle";
+  mockLivePartial = "";
+  mockLiveFinal = "";
+  mockLiveAssistant = "";
+  liveStartSpy.mockClear();
+  liveStopSpy.mockClear();
+}
+
+// Imported after the mocks so the component (and its transitive flag-store /
+// live-voice / voice-input-button imports) resolve against the mocked modules.
+const { ChatComposer, computeGhostSuffix, shouldSubmitOnEnter } = await import(
+  "@/domains/chat/components/chat-composer/chat-composer"
+);
 
 // ---------------------------------------------------------------------------
 // shouldSubmitOnEnter — keyboard policy
@@ -277,6 +348,7 @@ describe("computeGhostSuffix", () => {
 // ---------------------------------------------------------------------------
 
 afterEach(cleanup);
+beforeEach(resetLiveVoiceMocks);
 
 function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
   const { container } = render(
@@ -519,5 +591,142 @@ describe("Slash popup — SSR rendering", () => {
     // that the role="listbox" is absent when no slash input is active.
     const html = renderComposer({ input: "" });
     expect(html).not.toContain('role="listbox"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-voice integration
+//
+// The live-voice button is only mounted alongside the dictation button (same
+// `voiceInputRef`/`onVoiceTranscript` precondition) and self-gates on the
+// `voice-mode` flag. These tests render the *voice-enabled* variant so both
+// mic affordances are in play.
+// ---------------------------------------------------------------------------
+
+/** Render the composer with the dictation voice props supplied. */
+function renderVoiceComposer(
+  props: Partial<Parameters<typeof ChatComposer>[0]> = {},
+) {
+  return render(
+    <ChatComposer
+      input=""
+      setInput={() => {}}
+      onSubmit={() => {}}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      typingDisabled={false}
+      sendDisabled={false}
+      attachmentsUploadingCount={0}
+      canSendAttachments={false}
+      chatAttachments={[]}
+      onAddAttachmentFiles={() => {}}
+      onRemoveAttachment={() => {}}
+      onStopGenerating={() => {}}
+      assistantId="asst_test"
+      conversationId="conv_test"
+      voiceInputRef={createRef<VoiceInputButtonHandle>()}
+      onVoiceTranscript={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe("ChatComposer — live-voice integration", () => {
+  test("flag OFF: no live-voice button, dictation mic stays enabled", () => {
+    // GIVEN the voice-mode flag is disabled (default)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = false;
+
+    // WHEN the voice-enabled composer renders
+    const { queryByLabelText } = renderVoiceComposer();
+
+    // THEN the live-voice control is absent and dictation is unaffected
+    expect(queryByLabelText("Start voice mode")).toBeNull();
+    expect(queryByLabelText("Stop voice mode")).toBeNull();
+    const dictation = queryByLabelText(
+      "Start voice input",
+    ) as HTMLButtonElement | null;
+    expect(dictation).not.toBeNull();
+    expect(dictation?.disabled).toBe(false);
+  });
+
+  test("flag ON, idle: live-voice button present, dictation still enabled", () => {
+    // GIVEN the flag is on with no active session
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+
+    // WHEN the composer renders
+    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+
+    // THEN both mics are available and neither is forced disabled
+    expect(getByLabelText("Start voice mode")).toBeTruthy();
+    const dictation = queryByLabelText(
+      "Start voice input",
+    ) as HTMLButtonElement | null;
+    expect(dictation?.disabled).toBe(false);
+  });
+
+  test("active session disables dictation (mutual exclusion)", () => {
+    // GIVEN a live-voice session is listening
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders
+    const { getByLabelText } = renderVoiceComposer();
+
+    // THEN the live-voice control is a stop affordance and the dictation
+    // mic is disabled so the two capture flows can't run together
+    expect(getByLabelText("Stop voice mode")).toBeTruthy();
+    const dictation = getByLabelText(
+      "Start voice input",
+    ) as HTMLButtonElement;
+    expect(dictation.disabled).toBe(true);
+  });
+
+  test("active session surfaces user + assistant transcripts", () => {
+    // GIVEN a listening session with partial speech and a streaming reply
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+    mockLivePartial = "what is the";
+    mockLiveAssistant = "Let me check";
+
+    // WHEN the composer renders
+    const { getByLabelText } = renderVoiceComposer();
+
+    // THEN the transcript surface shows both sides of the turn
+    const surface = getByLabelText("Live voice transcript");
+    expect(surface.textContent).toContain("what is the");
+    expect(surface.textContent).toContain("Let me check");
+  });
+
+  test("active session stays stoppable even when the composer is busy", () => {
+    // GIVEN a live session AND the composer is otherwise disabled
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders with typingDisabled raised
+    const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
+
+    // THEN the stop control is still actionable and clicking it stops
+    const stop = getByLabelText("Stop voice mode") as HTMLButtonElement;
+    expect(stop.disabled).toBe(false);
+    fireEvent.click(stop);
+    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("flag ON but no transcript content: surface stays empty when idle", () => {
+    // GIVEN the flag is on but the session is idle
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+
+    // WHEN the composer renders
+    const { queryByLabelText } = renderVoiceComposer();
+
+    // THEN no transcript surface is rendered (idle = nothing to show)
+    expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 });

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -42,7 +42,7 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 // narrow union (not an import from the `voice` domain) so the `chat` test stays
 // free of cross-domain coupling — the composer only ever distinguishes idle
 // from non-idle, so the precise phase taxonomy is irrelevant here.
-type MockLiveVoiceState = "idle" | "connecting" | "listening";
+type MockLiveVoiceState = "idle" | "connecting" | "listening" | "failed";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
 let mockLivePartial = "";
@@ -79,12 +79,27 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
   ),
 }));
 
+// Dictation recording phase. The composer reads `useVoiceRecordingStore`
+// (cross-domain `voice` store) to derive its `isVoiceActive` signal. Mock it
+// via `mock.module` (rather than importing the store) so the `chat` test stays
+// free of cross-domain coupling, matching the live-voice mocks above. Only the
+// `.use.phase()` selector is consumed by the composer.
+let mockVoicePhase = "idle";
+mock.module("@/domains/voice/voice-recording-store", () => ({
+  useVoiceRecordingStore: {
+    use: {
+      phase: () => mockVoicePhase,
+    },
+  },
+}));
+
 function resetLiveVoiceMocks() {
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
   mockLivePartial = "";
   mockLiveFinal = "";
   mockLiveAssistant = "";
+  mockVoicePhase = "idle";
   liveStartSpy.mockClear();
   liveStopSpy.mockClear();
 }
@@ -727,6 +742,45 @@ describe("ChatComposer — live-voice integration", () => {
     const { queryByLabelText } = renderVoiceComposer();
 
     // THEN no transcript surface is rendered (idle = nothing to show)
+    expect(queryByLabelText("Live voice transcript")).toBeNull();
+  });
+
+  test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
+    // GIVEN the flag is on, no live session, but dictation is active.
+    // `processing` is one of the two phases that make the composer's
+    // `isVoiceActive` true (alongside `recording`); we use it because
+    // `recording` additionally spins up amplitude analysis (getUserMedia),
+    // which happy-dom doesn't provide — the mutual-exclusion signal is the
+    // same either way.
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+    mockVoicePhase = "processing";
+
+    // WHEN the composer renders
+    const { getByLabelText } = renderVoiceComposer();
+
+    // THEN the live-voice start affordance is disabled so it can't open a
+    // second mic/voice session alongside the dictation recorder
+    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(liveVoice.disabled).toBe(true);
+  });
+
+  test("failed live-voice state is inactive: dictation re-enabled, no transcript surface", () => {
+    // GIVEN the flag is on and a live-voice start attempt has failed
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "failed";
+
+    // WHEN the composer renders (dictation idle)
+    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+
+    // THEN dictation is treated as available again (failed = inactive)...
+    const dictation = getByLabelText(
+      "Start voice input",
+    ) as HTMLButtonElement;
+    expect(dictation.disabled).toBe(false);
+    // ...and the transcript surface is unmounted rather than left hanging
     expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 });

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -23,12 +23,15 @@ import {
   VoiceInputButton,
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
+import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
+import { useLiveVoice } from "@/domains/voice/live-voice/use-live-voice";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useAudioAmplitude } from "@/domains/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/voice/voice-recording-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 
 import { EMOJI_MIN_FILTER_LENGTH, EMOJI_TRIGGER_RE, useEmojiSearch, type EmojiEntry } from "@/domains/chat/components/chat-composer/emoji-catalog";
@@ -194,6 +197,12 @@ export interface ChatComposerProps {
   // assistant id used by AttachFileButton's disabled guard
   assistantId: string | null;
 
+  // Active conversation the live-voice session should attach to. Optional —
+  // when absent (e.g. the empty/new-conversation state) live voice still
+  // starts a fresh session for the assistant. The app-editing variant, which
+  // has no voice, leaves this undefined.
+  conversationId?: string | null;
+
   /**
    * Whether the currently-active inference model accepts image input.
    * When `false`, the AttachFileButton is disabled so users can't pick a
@@ -257,6 +266,7 @@ export function ChatComposer({
   onVoiceBeforeStart,
   onStopGenerating,
   assistantId,
+  conversationId,
   thresholdPickerSlot,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
@@ -280,6 +290,25 @@ export function ChatComposer({
   });
   const showVoiceInput =
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
+
+  // ---- Live voice (full-duplex conversation) ----------------------------
+  // Coexists with dictation: `LiveVoiceButton` self-gates on the `voice-mode`
+  // flag, but the transcript surface and the mutual-exclusion wiring below
+  // must also no-op when the flag is off so the composer is byte-identical for
+  // users without the flag. The live-voice button only appears alongside the
+  // dictation button (same `showVoiceInput` precondition + a non-null id).
+  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
+  const liveVoiceEligible = voiceMode && showVoiceInput && !!assistantId;
+  const {
+    state: liveVoiceState,
+    partialTranscript: liveVoicePartial,
+    finalTranscript: liveVoiceFinal,
+    assistantTranscript: liveVoiceAssistant,
+  } = useLiveVoice();
+  // Anything but idle counts as an active session; while active the dictation
+  // mic is disabled so the two capture flows never run at once.
+  const isLiveVoiceActive = liveVoiceEligible && liveVoiceState !== "idle";
+
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
   const isNative = useIsNativePlatform();
@@ -596,6 +625,28 @@ export function ChatComposer({
                 )}
               </div>
             )}
+            {isLiveVoiceActive && (
+              // Live-voice transcript surface — distinct from the dictation
+              // interim preview above, which only exists while the dictation
+              // recorder is running. Shows the user's partial/final speech and
+              // the streaming assistant reply for the in-flight turn.
+              <div
+                className="px-4 pb-1 space-y-0.5"
+                aria-label="Live voice transcript"
+                aria-live="polite"
+              >
+                {(liveVoicePartial || liveVoiceFinal) && (
+                  <p className="truncate text-[11px] text-[var(--content-secondary)]">
+                    {liveVoicePartial || liveVoiceFinal}
+                  </p>
+                )}
+                {liveVoiceAssistant && (
+                  <p className="truncate text-[11px] italic text-[var(--content-tertiary)]">
+                    {liveVoiceAssistant}
+                  </p>
+                )}
+              </div>
+            )}
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1">
                 {thresholdPickerSlot}
@@ -652,7 +703,10 @@ export function ChatComposer({
                       <VoiceInputButton
                         ref={voiceInputRef}
                         assistantId={assistantId}
-                        disabled={typingDisabled}
+                        // Mutual exclusion: an active live-voice session
+                        // disables the dictation mic so the two capture flows
+                        // never run simultaneously.
+                        disabled={typingDisabled || isLiveVoiceActive}
                         onTranscript={onVoiceTranscript}
                         onInterimTranscript={onVoiceInterimTranscript}
                         onError={onVoiceError}
@@ -661,6 +715,18 @@ export function ChatComposer({
                           voiceStreamRef.current = stream;
                           setVoiceStream(stream);
                         }}
+                      />
+                    )}
+                    {showVoiceInput && assistantId && (
+                      // Self-gates on the `voice-mode` flag (renders null when
+                      // off — no layout shift). The composer's busy/disabled
+                      // signal only gates the START path; an active session
+                      // stays stoppable even while the composer is otherwise
+                      // busy (see LiveVoiceButton).
+                      <LiveVoiceButton
+                        assistantId={assistantId}
+                        conversationId={conversationId ?? undefined}
+                        disabled={typingDisabled}
                       />
                     )}
                     {/* macOS parity: the send button is hidden during recording

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -305,9 +305,15 @@ export function ChatComposer({
     finalTranscript: liveVoiceFinal,
     assistantTranscript: liveVoiceAssistant,
   } = useLiveVoice();
-  // Anything but idle counts as an active session; while active the dictation
-  // mic is disabled so the two capture flows never run at once.
-  const isLiveVoiceActive = liveVoiceEligible && liveVoiceState !== "idle";
+  // Anything but idle/failed counts as an active session; while active the
+  // dictation mic is disabled so the two capture flows never run at once.
+  // `failed` is a retryable/inactive state in `useLiveVoice`/`LiveVoiceButton`,
+  // so we must treat it as inactive — otherwise dictation stays disabled and
+  // the (empty) transcript surface stays mounted after a failed start.
+  const isLiveVoiceActive =
+    liveVoiceEligible &&
+    liveVoiceState !== "idle" &&
+    liveVoiceState !== "failed";
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -723,10 +729,17 @@ export function ChatComposer({
                       // signal only gates the START path; an active session
                       // stays stoppable even while the composer is otherwise
                       // busy (see LiveVoiceButton).
+                      //
+                      // Mutual exclusion (reverse direction): while dictation is
+                      // active (`isVoiceActive`) we disable live voice so it
+                      // can't START a second mic/voice session alongside the
+                      // recorder. `LiveVoiceButton` only applies external
+                      // `disabled` to its START path, so an in-flight live-voice
+                      // session is never trapped by this.
                       <LiveVoiceButton
                         assistantId={assistantId}
                         conversationId={conversationId ?? undefined}
-                        disabled={typingDisabled}
+                        disabled={typingDisabled || isVoiceActive}
                       />
                     )}
                     {/* macOS parity: the send button is hidden during recording

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1345,6 +1345,7 @@ export function ChatRouteContent({
     onVoiceBeforeStart: handleVoiceBeforeStart,
     onStopGenerating: handleStopGenerating,
     assistantId,
+    conversationId: activeConversation?.conversationId,
     modelSupportsVision: activeModelSupportsVision,
     onRecallLastMessage: phase === "idle" ? () => {
       const content = startEditing();


### PR DESCRIPTION
## Summary
- Mount flag-gated LiveVoiceButton in the composer, mutually exclusive with dictation, surfacing live transcripts during a session

Part of plan: web-live-voice.md (PR 8 of 8)