### PR TITLE
Assistant: add block-volume helpers to service images

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y \
     debootstrap \
     debian-archive-keyring \
     debconf \
+    e2fsprogs \
     ffmpeg \
     fonts-freefont-ttf \
     g++ \
@@ -112,11 +113,13 @@ RUN apt-get update && apt-get install -y \
     libxtst6 \
     lsof \
     make \
+    mount \
     openssl \
     procps \
     python3 \
     sqlite3 \
     sudo \
+    util-linux \
     unzip \
     uuid-runtime \
     vim \
@@ -179,7 +182,8 @@ RUN printf '%s\n' \
 RUN printf '%s\n' \
     '#!/usr/bin/env sh' \
     'set -eu' \
-    'if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then' \
+    '. /app/assistant/docker-kata-runtime-family.sh' \
+    'if ! vellum_is_kata_family_runtime; then' \
     '  exec /usr/bin/apt-get "$@"' \
     'fi' \
     'export DEBIAN_FRONTEND=noninteractive' \
@@ -194,7 +198,8 @@ RUN printf '%s\n' \
     printf '%s\n' \
     '#!/usr/bin/env sh' \
     'set -eu' \
-    'if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then' \
+    '. /app/assistant/docker-kata-runtime-family.sh' \
+    'if ! vellum_is_kata_family_runtime; then' \
     '  exec /usr/bin/apt "$@"' \
     'fi' \
     'export DEBIAN_FRONTEND=noninteractive' \
@@ -209,7 +214,8 @@ RUN printf '%s\n' \
     printf '%s\n' \
     '#!/usr/bin/env sh' \
     'set -eu' \
-    'if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then' \
+    '. /app/assistant/docker-kata-runtime-family.sh' \
+    'if ! vellum_is_kata_family_runtime; then' \
     '  exec /usr/bin/dpkg "$@"' \
     'fi' \
     'DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"' \
@@ -235,7 +241,16 @@ ENV IS_CONTAINERIZED=true
 # and the generated meet-join manifest from the builder stage.
 COPY --from=builder /app /app
 
-RUN chmod +x /app/assistant/docker-entrypoint.sh /app/assistant/docker-init-apt-root.sh /app/assistant/docker-kata-apt-env.sh
+COPY packages/block-volume-bootstrap/scripts/*.sh /usr/local/bin/
+
+RUN chmod +x \
+    /app/assistant/docker-entrypoint.sh \
+    /app/assistant/docker-init-apt-root.sh \
+    /app/assistant/docker-kata-apt-env.sh \
+    /app/assistant/docker-kata-runtime-family.sh \
+    /usr/local/bin/vellum-block-volume-common.sh \
+    /usr/local/bin/vellum-block-volume-init.sh \
+    /usr/local/bin/vellum-block-volume-mount.sh
 
 # Run the daemon + http server
 CMD ["/app/assistant/docker-entrypoint.sh"]

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -466,6 +466,8 @@ docker run --rm -p 3001:3001 \
 
 The image exposes port `3001` and bundles the `assistant` CLI binary.
 
+The image also includes the opt-in block-volume helper scripts used by vembda for Kata-family block-mode deployments. Default startup does not invoke them; vembda must wrap the service command explicitly. Assistant block mode uses `assistant-data:/data:rw;workspace:/workspace:rw;dockerd-data:/var/lib/docker:rw`. See [Kata Block-Mode Image Contract](../docs/kata-block-mode-image-contract.md).
+
 ## Troubleshooting
 
 ### Guardian and gateway-origin issues

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -6,9 +6,15 @@ set -eu
 chmod 1777 /tmp 2>/dev/null || true
 
 KATA_APT_INIT_PID=""
-if [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ] && [ -x /app/assistant/docker-init-apt-root.sh ]; then
+if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
+  . /app/assistant/docker-kata-runtime-family.sh
+else
+  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
+fi
+
+if vellum_is_kata_family_runtime && [ -x /app/assistant/docker-init-apt-root.sh ]; then
   export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
-  # Warm the chroot used by kata apt wrappers without blocking assistant readiness.
+  # Warm the chroot used by Kata-family apt wrappers without blocking assistant readiness.
   /app/assistant/docker-init-apt-root.sh &
   KATA_APT_INIT_PID="$!"
 fi

--- a/assistant/docker-init-apt-root.sh
+++ b/assistant/docker-init-apt-root.sh
@@ -10,7 +10,13 @@ LOCK_DIR="${DATA_ROOT}.rootfs-init.lock"
 LOCK_PID="${LOCK_DIR}/pid"
 HOST_PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 
-if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then
+if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
+  . /app/assistant/docker-kata-runtime-family.sh
+else
+  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
+fi
+
+if ! vellum_is_kata_family_runtime; then
   exit 0
 fi
 

--- a/assistant/docker-kata-apt-env.sh
+++ b/assistant/docker-kata-apt-env.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
-if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then
+if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
+  . /app/assistant/docker-kata-runtime-family.sh
+else
+  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
+fi
+
+if ! vellum_is_kata_family_runtime; then
   return 0 2>/dev/null || exit 0
 fi
 

--- a/assistant/docker-kata-runtime-family.sh
+++ b/assistant/docker-kata-runtime-family.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+vellum_is_kata_family_runtime() {
+  case "${VELLUM_SANDBOX_RUNTIME:-}" in
+    kata|firecracker|cloud-hypervisor)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/assistant/src/__tests__/kata-runtime-family.test.ts
+++ b/assistant/src/__tests__/kata-runtime-family.test.ts
@@ -1,0 +1,35 @@
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const runtimeFamilyScript = resolve(
+  repoRoot,
+  "assistant/docker-kata-runtime-family.sh",
+);
+
+function runRuntimePredicate(runtime: string) {
+  return Bun.spawnSync({
+    cmd: [
+      "sh",
+      "-c",
+      `. "${runtimeFamilyScript}"; VELLUM_SANDBOX_RUNTIME="$1"; vellum_is_kata_family_runtime`,
+      "runtime-family-test",
+      runtime,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("Kata-family runtime detection", () => {
+  test("treats kata, firecracker, and cloud-hypervisor as Kata-family runtimes", () => {
+    for (const runtime of ["kata", "firecracker", "cloud-hypervisor"]) {
+      expect(runRuntimePredicate(runtime).exitCode).toBe(0);
+    }
+  });
+
+  test("does not treat other sandbox runtimes as Kata-family runtimes", () => {
+    expect(runRuntimePredicate("gvisor").exitCode).not.toBe(0);
+    expect(runRuntimePredicate("").exitCode).not.toBe(0);
+  });
+});

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -141,7 +141,7 @@ describe("buildSanitizedEnv", () => {
     expect(env.LC_CTYPE).toBe("UTF-8");
   });
 
-  test("only includes Kata apt variables when sandbox runtime is kata", () => {
+  test("only includes Kata apt variables for Kata-family sandbox runtimes", () => {
     process.env.VELLUM_SANDBOX_RUNTIME = "gvisor";
     process.env.PATH = "/usr/bin";
     process.env.VELLUM_APT_DATA_ROOT = "/data/system";
@@ -162,6 +162,11 @@ describe("buildSanitizedEnv", () => {
       "/data/system/usr/local/lib",
     );
     expect(env.LD_LIBRARY_PATH.split(":")).not.toContain("/host/lib");
+
+    process.env.VELLUM_SANDBOX_RUNTIME = "cloud-hypervisor";
+    env = buildSanitizedEnv();
+    expect(env.VELLUM_APT_DATA_ROOT).toBe("/data/system");
+    expect(env.PATH.split(":")).toContain("/data/system/usr/bin");
   });
 
   test("defaults LANG and LC_ALL to UTF-8 when unset", () => {

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -69,6 +69,15 @@ export const KATA_SAFE_ENV_VARS = [
 export const KATA_INJECTED_ENV_VARS = ["LD_LIBRARY_PATH"] as const;
 
 const KATA_APT_DATA_ROOT = "/data/system";
+const KATA_FAMILY_SANDBOX_RUNTIMES = new Set([
+  "kata",
+  "firecracker",
+  "cloud-hypervisor",
+]);
+
+function isKataFamilyRuntime(runtime: string | undefined): boolean {
+  return runtime != null && KATA_FAMILY_SANDBOX_RUNTIMES.has(runtime);
+}
 
 function kataAptPaths(dataRoot: string): string[] {
   return [
@@ -118,7 +127,7 @@ function appendUniquePathEntries(
 
 export function buildSanitizedEnv(): Record<string, string> {
   const env: Record<string, string> = {};
-  const isKataRuntime = process.env.VELLUM_SANDBOX_RUNTIME === "kata";
+  const isKataRuntime = isKataFamilyRuntime(process.env.VELLUM_SANDBOX_RUNTIME);
   const safeEnvVars = isKataRuntime
     ? [...SAFE_ENV_VARS, ...KATA_SAFE_ENV_VARS]
     : SAFE_ENV_VARS;

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -33,6 +33,9 @@ WORKDIR /app/credential-executor
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    e2fsprogs \
+    mount \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bun binary from builder
@@ -55,6 +58,12 @@ RUN mkdir -p /ces-data && chown ces:ces /ces-data
 
 # Pre-create /ces-security for credential key storage (keys.enc, store.key)
 RUN mkdir -p /ces-security && chown ces:ces /ces-security
+
+COPY packages/block-volume-bootstrap/scripts/*.sh /usr/local/bin/
+RUN chmod +x \
+    /usr/local/bin/vellum-block-volume-common.sh \
+    /usr/local/bin/vellum-block-volume-init.sh \
+    /usr/local/bin/vellum-block-volume-mount.sh
 
 USER ces
 

--- a/credential-executor/README.md
+++ b/credential-executor/README.md
@@ -1,0 +1,9 @@
+# Credential Executor
+
+Credential Execution Service (CES) package for managed credential storage and authenticated command/API execution.
+
+## Docker
+
+The runtime image runs as non-root user `ces` (uid 1001) by default.
+
+The image includes the opt-in block-volume helper scripts used by vembda for Kata-family block-mode deployments. Default startup still runs as `ces` and does not invoke the helpers; vembda must wrap the service command explicitly. CES block mode uses `ces-data:/ces-data:rw;ces-security:/ces-security:rw;workspace:/workspace:ro`. See [Kata Block-Mode Image Contract](../docs/kata-block-mode-image-contract.md).

--- a/docs/kata-block-mode-image-contract.md
+++ b/docs/kata-block-mode-image-contract.md
@@ -1,0 +1,47 @@
+# Kata Block-Mode Image Contract
+
+Block mode is an opt-in deployment shape rendered by vembda. The service images do not auto-detect block storage, and their default `virtual_filesystem` startup paths do not source or execute the block-volume helpers.
+
+In block mode, vembda exposes the raw PVC block device to the relevant container and wraps the normal service command with one of the helper scripts installed at `/usr/local/bin/`:
+
+- `vellum-block-volume-init.sh` initializes the shared ext4 filesystem once.
+- `vellum-block-volume-mount.sh -- <service command...>` mounts the ext4 root, bind-mounts service subdirectories, optionally drops privileges, and then executes the service command.
+
+## Required Environment
+
+vembda must set these variables for containers that invoke the helpers:
+
+| Variable | Value |
+| --- | --- |
+| `VELLUM_FILESYSTEM_MODE` | `block` |
+| `VELLUM_BLOCK_DEVICE` | `/dev/assistant-data` |
+| `VELLUM_BLOCK_ROOT` | `/mnt/vellum-block-root` |
+| `VELLUM_BLOCK_BIND_SPECS` | Semicolon-separated `source:target:ro\|rw` bind specs for app containers |
+| `VELLUM_BLOCK_EXEC_UID` | Optional uid used by `vellum-block-volume-mount.sh` before exec |
+| `VELLUM_BLOCK_EXEC_GID` | Optional gid used by `vellum-block-volume-mount.sh` before exec |
+
+`VELLUM_BLOCK_BIND_SPECS` is not required for the init container. The helpers default `VELLUM_BLOCK_DEVICE` and `VELLUM_BLOCK_ROOT` to the values above, but vembda should render them explicitly so the pod spec is self-describing.
+
+## Expected Bind Specs
+
+| Service | `VELLUM_BLOCK_BIND_SPECS` |
+| --- | --- |
+| Assistant | `assistant-data:/data:rw;workspace:/workspace:rw;dockerd-data:/var/lib/docker:rw` |
+| Gateway | `workspace:/workspace:rw;gateway-security:/gateway-security:rw` |
+| CES | `ces-data:/ces-data:rw;ces-security:/ces-security:rw;workspace:/workspace:ro` |
+
+The init helper creates these top-level directories under `VELLUM_BLOCK_ROOT`: `assistant-data`, `workspace`, `gateway-security`, `ces-data`, `ces-security`, and `dockerd-data`. Assistant, workspace, gateway, and CES data are owned by `1001:1001`; Docker data is owned by `0:0`.
+
+## Security Boundary
+
+The block-volume helper does not provide cryptographic isolation between subdirectories. Any container with access to the raw block device can mount the entire ext4 filesystem, so vembda must not treat bind-mounted paths as a hard security boundary. Block mode is a storage-layout optimization for Kata-family isolation, not a substitute for per-service secrets ownership or separate security volumes where those are required.
+
+## Image Contents
+
+The assistant, gateway, and credential-executor runtime images include:
+
+- Executable `vellum-block-volume-init.sh` and `vellum-block-volume-mount.sh` in `/usr/local/bin/`.
+- `e2fsprogs` for `mkfs.ext4` and filesystem inspection.
+- `mount` and `util-linux` for `mount`, `findmnt`, and `setpriv`.
+
+The helper scripts are inert unless the container command explicitly invokes them. Normal image `CMD`, `USER`, and entrypoint behavior remains unchanged.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -34,8 +34,11 @@ WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
+    e2fsprogs \
     iproute2 \
+    mount \
     procps \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bun binary from builder
@@ -51,6 +54,12 @@ COPY --from=builder --chown=gateway:gateway /app/gateway /app
 COPY --from=builder --chown=gateway:gateway /app/packages /app/packages
 
 RUN mkdir -p /gateway-security && chown gateway:gateway /gateway-security
+
+COPY packages/block-volume-bootstrap/scripts/*.sh /usr/local/bin/
+RUN chmod +x \
+    /usr/local/bin/vellum-block-volume-common.sh \
+    /usr/local/bin/vellum-block-volume-init.sh \
+    /usr/local/bin/vellum-block-volume-mount.sh
 
 USER gateway
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -329,6 +329,8 @@ docker run --rm -p 7830:7830 \
 
 The image runs as non-root user `gateway` (uid 1001) and exposes port `7830`.
 
+The image also includes the opt-in block-volume helper scripts used by vembda for Kata-family block-mode deployments. Default startup still runs as `gateway` and does not invoke the helpers; vembda must wrap the service command explicitly. Gateway block mode uses `workspace:/workspace:rw;gateway-security:/gateway-security:rw`. See [Kata Block-Mode Image Contract](../docs/kata-block-mode-image-contract.md).
+
 The runtime base URL is derived from `RUNTIME_HTTP_PORT` as `http://localhost:${RUNTIME_HTTP_PORT}` (default port `7821`). The gateway internal base URL is always derived from `GATEWAY_PORT` as `http://127.0.0.1:${GATEWAY_PORT}` (default `7830`). Both hosts are hardcoded to localhost — the gateway and runtime must be co-located (e.g., same host, `--network host`, or Docker Compose with shared networking). Separate-host deployments are not currently supported.
 
 ## Development

--- a/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
+++ b/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
@@ -1,0 +1,140 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const initScript = resolve(
+  packageRoot,
+  "scripts/vellum-block-volume-init.sh",
+);
+const mountScript = resolve(
+  packageRoot,
+  "scripts/vellum-block-volume-mount.sh",
+);
+
+function runScript(
+  script: string,
+  {
+    args = [],
+    env = {},
+  }: { args?: string[]; env?: Record<string, string> } = {},
+) {
+  const result = Bun.spawnSync({
+    cmd: ["sh", script, ...args],
+    cwd: packageRoot,
+    env: {
+      PATH: process.env.PATH ?? "",
+      VELLUM_FILESYSTEM_MODE: "block",
+      VELLUM_BLOCK_DRY_RUN: "1",
+      VELLUM_BLOCK_DEVICE: "/dev/test-block",
+      VELLUM_BLOCK_ROOT: "/mnt/test-root",
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+  };
+}
+
+describe("block volume bootstrap scripts", () => {
+  test("mount helper parses bind specs and logs mount commands in order", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "bun", "run", "src/index.ts"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS:
+          "assistant-data:/data:rw;workspace:/workspace:ro",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain(
+      [
+        "DRY-RUN: wait for block device /dev/test-block",
+        "DRY-RUN: mkdir -p /mnt/test-root",
+        "DRY-RUN: findmnt --mountpoint /mnt/test-root",
+        "DRY-RUN: mount /dev/test-block /mnt/test-root",
+        "DRY-RUN: mkdir -p /mnt/test-root/assistant-data",
+        "DRY-RUN: mkdir -p /data",
+        "DRY-RUN: findmnt --mountpoint /data",
+        "DRY-RUN: mount --bind /mnt/test-root/assistant-data /data",
+        "DRY-RUN: mkdir -p /mnt/test-root/workspace",
+        "DRY-RUN: mkdir -p /workspace",
+        "DRY-RUN: findmnt --mountpoint /workspace",
+        "DRY-RUN: mount --bind /mnt/test-root/workspace /workspace",
+        "DRY-RUN: mount -o remount,bind,ro /workspace",
+        "DRY-RUN: exec bun run src/index.ts",
+      ].join("\n"),
+    );
+  });
+
+  test("mount helper logs setpriv execution when uid and gid are set", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "bun", "run", "src/managed-main.ts"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "ces-data:/ces-data:rw",
+        VELLUM_BLOCK_EXEC_UID: "1001",
+        VELLUM_BLOCK_EXEC_GID: "1001",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain(
+      "DRY-RUN: exec setpriv --reuid 1001 --regid 1001 --clear-groups -- bun run src/managed-main.ts",
+    );
+  });
+
+  test("mount helper rejects invalid bind specs", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:readonly",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("invalid bind mode 'readonly'");
+  });
+
+  test("init helper formats only devices with no filesystem", () => {
+    const result = runScript(initScript);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("DRY-RUN: blkid -o value -s TYPE /dev/test-block");
+    expect(result.stderr).toContain("DRY-RUN: mkfs.ext4 -F /dev/test-block");
+    expect(result.stderr).toContain("DRY-RUN: mount /dev/test-block /mnt/test-root");
+    expect(result.stderr).toContain("DRY-RUN: mkdir -p /mnt/test-root/assistant-data");
+    expect(result.stderr).toContain("DRY-RUN: chown 1001:1001 /mnt/test-root/workspace");
+    expect(result.stderr).toContain("DRY-RUN: chown 0:0 /mnt/test-root/dockerd-data");
+  });
+
+  test("init helper never formats a device with an existing ext4 filesystem", () => {
+    const result = runScript(initScript, {
+      env: {
+        VELLUM_BLOCK_DRY_RUN_BLKID_TYPE: "ext4",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("mkfs.ext4");
+    expect(result.stderr).toContain("already contains an ext4 filesystem");
+  });
+
+  test("init helper rejects non-ext4 existing filesystems before formatting", () => {
+    const result = runScript(initScript, {
+      env: {
+        VELLUM_BLOCK_DRY_RUN_BLKID_TYPE: "xfs",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "/dev/test-block contains unsupported filesystem 'xfs'; expected ext4",
+    );
+    expect(result.stderr).not.toContain("mkfs.ext4");
+  });
+});

--- a/packages/block-volume-bootstrap/package.json
+++ b/packages/block-volume-bootstrap/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vellumai/block-volume-bootstrap",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "test": "bun test __tests__/block-volume-bootstrap.test.ts"
+  }
+}

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env sh
+set -eu
+
+block_die() {
+  echo "vellum block volume: $*" >&2
+  exit 1
+}
+
+block_log() {
+  echo "vellum block volume: $*" >&2
+}
+
+block_is_dry_run() {
+  [ "${VELLUM_BLOCK_DRY_RUN:-}" = "1" ]
+}
+
+block_dry_run() {
+  if block_is_dry_run; then
+    echo "DRY-RUN: $*" >&2
+  fi
+}
+
+block_run() {
+  display="$1"
+  shift
+  if block_is_dry_run; then
+    block_dry_run "${display}"
+    return 0
+  fi
+  "$@"
+}
+
+block_require_value() {
+  name="$1"
+  value="$2"
+  [ -n "${value}" ] || block_die "${name} is required"
+}
+
+block_validate_mode_env() {
+  if [ "${VELLUM_FILESYSTEM_MODE:-}" != "block" ]; then
+    block_die "VELLUM_FILESYSTEM_MODE=block is required"
+  fi
+}
+
+block_validate_number() {
+  name="$1"
+  value="$2"
+  case "${value}" in
+    ''|*[!0-9]*)
+      block_die "${name} must be a numeric id"
+      ;;
+  esac
+}
+
+block_init_defaults() {
+  BLOCK_DEVICE="${VELLUM_BLOCK_DEVICE:-/dev/assistant-data}"
+  BLOCK_ROOT="${VELLUM_BLOCK_ROOT:-/mnt/vellum-block-root}"
+
+  case "${BLOCK_DEVICE}" in
+    /*) ;;
+    *) block_die "VELLUM_BLOCK_DEVICE must be an absolute path" ;;
+  esac
+
+  case "${BLOCK_ROOT}" in
+    ''|/) block_die "VELLUM_BLOCK_ROOT must not be empty or /" ;;
+    /*) ;;
+    *) block_die "VELLUM_BLOCK_ROOT must be an absolute path" ;;
+  esac
+
+  while [ "${BLOCK_ROOT}" != "/" ]; do
+    case "${BLOCK_ROOT}" in
+      */) BLOCK_ROOT="${BLOCK_ROOT%/}" ;;
+      *) break ;;
+    esac
+  done
+}
+
+block_validate_child_name() {
+  name="$1"
+  case "${name}" in
+    ''|'.'|'..'|/*|*/*|*[!A-Za-z0-9._-]*)
+      block_die "invalid block root child '${name}'"
+      ;;
+  esac
+}
+
+block_child_path() {
+  block_validate_child_name "$1"
+  printf '%s/%s\n' "${BLOCK_ROOT}" "$1"
+}
+
+block_validate_target_path() {
+  target="$1"
+  case "${target}" in
+    ''|/) block_die "bind target must not be empty or /" ;;
+    /*) ;;
+    *) block_die "bind target '${target}' must be an absolute path" ;;
+  esac
+}
+
+block_wait_for_device() {
+  timeout="${VELLUM_BLOCK_DEVICE_WAIT_TIMEOUT_SECONDS:-60}"
+  block_validate_number "VELLUM_BLOCK_DEVICE_WAIT_TIMEOUT_SECONDS" "${timeout}"
+
+  if block_is_dry_run; then
+    block_dry_run "wait for block device ${BLOCK_DEVICE}"
+    return 0
+  fi
+
+  elapsed=0
+  while [ ! -b "${BLOCK_DEVICE}" ]; do
+    if [ "${elapsed}" -ge "${timeout}" ]; then
+      block_die "timed out waiting for block device ${BLOCK_DEVICE}"
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+}
+
+block_ensure_dir() {
+  path="$1"
+  block_run "mkdir -p ${path}" mkdir -p "${path}"
+}
+
+block_find_mountpoint() {
+  target="$1"
+  if block_is_dry_run; then
+    block_dry_run "findmnt --mountpoint ${target}"
+    return 1
+  fi
+  findmnt --mountpoint "${target}" >/dev/null 2>&1
+}
+
+block_mount_root() {
+  block_ensure_dir "${BLOCK_ROOT}"
+  if block_find_mountpoint "${BLOCK_ROOT}"; then
+    block_log "${BLOCK_ROOT} is already mounted"
+    return 0
+  fi
+  block_run "mount ${BLOCK_DEVICE} ${BLOCK_ROOT}" mount "${BLOCK_DEVICE}" "${BLOCK_ROOT}"
+}
+
+block_parse_bind_spec() {
+  spec="$1"
+
+  case "${spec}" in
+    *:*:*) ;;
+    *)
+      block_die "invalid VELLUM_BLOCK_BIND_SPECS entry '${spec}'; expected source:target:ro|rw"
+      ;;
+  esac
+
+  BIND_SOURCE_NAME="${spec%%:*}"
+  rest="${spec#*:}"
+  BIND_TARGET="${rest%%:*}"
+  BIND_MODE="${rest#*:}"
+
+  case "${BIND_MODE}" in
+    *:*)
+      block_die "invalid VELLUM_BLOCK_BIND_SPECS entry '${spec}'; expected source:target:ro|rw"
+      ;;
+  esac
+
+  if [ "${BIND_SOURCE_NAME}" = "${spec}" ] || [ "${BIND_TARGET}" = "${rest}" ]; then
+    block_die "invalid VELLUM_BLOCK_BIND_SPECS entry '${spec}'; expected source:target:ro|rw"
+  fi
+
+  block_validate_child_name "${BIND_SOURCE_NAME}"
+  block_validate_target_path "${BIND_TARGET}"
+  case "${BIND_MODE}" in
+    ro|rw) ;;
+    *) block_die "invalid bind mode '${BIND_MODE}' in '${spec}'; expected ro or rw" ;;
+  esac
+}
+
+block_for_each_bind_spec() {
+  specs="$1"
+  callback="$2"
+  block_require_value "VELLUM_BLOCK_BIND_SPECS" "${specs}"
+
+  remaining="${specs}"
+  while :; do
+    case "${remaining}" in
+      *';'*)
+        spec="${remaining%%;*}"
+        remaining="${remaining#*;}"
+        ;;
+      *)
+        spec="${remaining}"
+        remaining=""
+        ;;
+    esac
+
+    [ -n "${spec}" ] || block_die "empty VELLUM_BLOCK_BIND_SPECS entry"
+    block_parse_bind_spec "${spec}"
+    "${callback}" "${BIND_SOURCE_NAME}" "${BIND_TARGET}" "${BIND_MODE}"
+
+    [ -n "${remaining}" ] || break
+  done
+}

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-init.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-init.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/vellum-block-volume-common.sh"
+
+block_detect_fs_type() {
+  if block_is_dry_run; then
+    block_dry_run "blkid -o value -s TYPE ${BLOCK_DEVICE}"
+    printf '%s\n' "${VELLUM_BLOCK_DRY_RUN_BLKID_TYPE:-}"
+    return 0
+  fi
+  blkid -o value -s TYPE "${BLOCK_DEVICE}" 2>/dev/null || true
+}
+
+block_prepare_top_level_dir() {
+  name="$1"
+  owner="$2"
+  path="$(block_child_path "${name}")"
+  block_ensure_dir "${path}"
+  block_run "chown ${owner} ${path}" chown "${owner}" "${path}"
+}
+
+block_validate_mode_env
+block_init_defaults
+block_wait_for_device
+
+fs_type="$(block_detect_fs_type)"
+case "${fs_type}" in
+  '')
+    block_run "mkfs.ext4 -F ${BLOCK_DEVICE}" mkfs.ext4 -F "${BLOCK_DEVICE}"
+    ;;
+  ext4)
+    block_log "${BLOCK_DEVICE} already contains an ext4 filesystem"
+    ;;
+  *)
+    block_die "${BLOCK_DEVICE} contains unsupported filesystem '${fs_type}'; expected ext4"
+    ;;
+esac
+
+block_mount_root
+
+block_prepare_top_level_dir "assistant-data" "1001:1001"
+block_prepare_top_level_dir "workspace" "1001:1001"
+block_prepare_top_level_dir "gateway-security" "1001:1001"
+block_prepare_top_level_dir "ces-data" "1001:1001"
+block_prepare_top_level_dir "ces-security" "1001:1001"
+block_prepare_top_level_dir "dockerd-data" "0:0"

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/vellum-block-volume-common.sh"
+
+block_mount_bind_spec() {
+  source_name="$1"
+  target="$2"
+  mode="$3"
+  source_path="$(block_child_path "${source_name}")"
+
+  block_ensure_dir "${source_path}"
+  block_ensure_dir "${target}"
+
+  if block_find_mountpoint "${target}"; then
+    block_log "${target} is already mounted"
+  else
+    block_run "mount --bind ${source_path} ${target}" mount --bind "${source_path}" "${target}"
+  fi
+
+  if [ "${mode}" = "ro" ]; then
+    block_run "mount -o remount,bind,ro ${target}" mount -o remount,bind,ro "${target}"
+  fi
+}
+
+block_join_command() {
+  joined=""
+  for arg in "$@"; do
+    joined="${joined}${joined:+ }${arg}"
+  done
+  printf '%s\n' "${joined}"
+}
+
+block_exec_service() {
+  uid="${VELLUM_BLOCK_EXEC_UID:-}"
+  gid="${VELLUM_BLOCK_EXEC_GID:-}"
+
+  if [ -n "${uid}" ]; then
+    block_validate_number "VELLUM_BLOCK_EXEC_UID" "${uid}"
+  fi
+  if [ -n "${gid}" ]; then
+    block_validate_number "VELLUM_BLOCK_EXEC_GID" "${gid}"
+  fi
+
+  command_display="$(block_join_command "$@")"
+  if [ -n "${uid}" ] || [ -n "${gid}" ]; then
+    setpriv_display="setpriv"
+    if [ -n "${uid}" ]; then
+      setpriv_display="${setpriv_display} --reuid ${uid}"
+    fi
+    if [ -n "${gid}" ]; then
+      setpriv_display="${setpriv_display} --regid ${gid} --clear-groups"
+    fi
+    setpriv_display="${setpriv_display} -- ${command_display}"
+
+    if block_is_dry_run; then
+      block_dry_run "exec ${setpriv_display}"
+      return 0
+    fi
+
+    if [ -n "${uid}" ] && [ -n "${gid}" ]; then
+      exec setpriv --reuid "${uid}" --regid "${gid}" --clear-groups -- "$@"
+    fi
+    if [ -n "${uid}" ]; then
+      exec setpriv --reuid "${uid}" -- "$@"
+    fi
+    exec setpriv --regid "${gid}" --clear-groups -- "$@"
+  fi
+
+  if block_is_dry_run; then
+    block_dry_run "exec ${command_display}"
+    return 0
+  fi
+  exec "$@"
+}
+
+block_validate_mode_env
+block_init_defaults
+
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--" ]; then
+    shift
+    break
+  fi
+  block_die "unexpected argument '$1'; service command must follow --"
+done
+
+[ "$#" -gt 0 ] || block_die "service command is required after --"
+
+block_wait_for_device
+block_mount_root
+block_for_each_bind_spec "${VELLUM_BLOCK_BIND_SPECS:-}" block_mount_bind_spec
+block_exec_service "$@"


### PR DESCRIPTION
## Summary
- Adds shared block-volume bootstrap helpers for raw ext4 PVC initialization and service bind mounts.
- Copies the helpers and required filesystem tools into assistant, gateway, and credential-executor images.
- Documents the Kata block-mode image contract and validates dry-run behavior.

Part of plan: single-ext4-volume-block-mode.md (PR A1 of 1)

## Smoke note
Ran focused unit and image smoke checks:
- `cd packages/block-volume-bootstrap && export PATH="$HOME/.bun/bin:$PATH"; bun test __tests__/block-volume-bootstrap.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/kata-runtime-family.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/terminal-tools.test.ts --grep "Kata apt variables"`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bunx tsc --noEmit`
- `sh -n packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh && sh -n packages/block-volume-bootstrap/scripts/vellum-block-volume-init.sh && sh -n packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh && sh -n assistant/docker-entrypoint.sh && sh -n assistant/docker-init-apt-root.sh && sh -n assistant/docker-kata-apt-env.sh && sh -n assistant/docker-kata-runtime-family.sh`
- `docker build -f assistant/Dockerfile -t vellum-assistant:block-smoke . && docker run --rm --entrypoint sh vellum-assistant:block-smoke -c 'test -x /usr/local/bin/vellum-block-volume-init.sh && test -x /usr/local/bin/vellum-block-volume-mount.sh && command -v mkfs.ext4 && command -v blkid && command -v mount && command -v findmnt && command -v setpriv'`
- `docker build -f gateway/Dockerfile -t vellum-gateway:block-smoke . && docker run --rm --entrypoint sh vellum-gateway:block-smoke -c 'test -x /usr/local/bin/vellum-block-volume-init.sh && test -x /usr/local/bin/vellum-block-volume-mount.sh && command -v mkfs.ext4 && command -v blkid && command -v mount && command -v findmnt && command -v setpriv'`
- `docker build -f credential-executor/Dockerfile -t vellum-credential-executor:block-smoke . && docker run --rm --entrypoint sh vellum-credential-executor:block-smoke -c 'test -x /usr/local/bin/vellum-block-volume-init.sh && test -x /usr/local/bin/vellum-block-volume-mount.sh && command -v mkfs.ext4 && command -v blkid && command -v mount && command -v findmnt && command -v setpriv'`