### PR TITLE
fix(voice): barge-in reachability, unmount store reset, composer state via store

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -24,11 +24,13 @@ mock.module("@/hooks/use-is-mobile", () => ({
 }));
 
 // Live-voice integration mocks. The composer mounts `LiveVoiceButton` (which
-// self-gates on `voice-mode`) and reads `useLiveVoice()` for the transcript
-// surface + dictation mutual-exclusion. Both are mocked so the composer renders
-// in isolation: the flag via a mutable `mockVoiceMode`, and the session via a
-// mutable state + transcript bag. Defaults (flag off, idle, empty) keep the
-// existing HTML-surface assertions unchanged.
+// self-gates on `voice-mode`) and reads live-voice session state via the
+// `useLiveVoiceStore` per-field selectors for the transcript surface +
+// dictation mutual-exclusion. Both are mocked so the composer renders in
+// isolation: the flag via a mutable `mockVoiceMode`, and the session via a
+// mutable state + transcript bag exposed through the store's `.use.*`
+// selectors. Defaults (flag off, idle, empty) keep the existing HTML-surface
+// assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -52,6 +54,20 @@ const liveStartSpy = mock(
   async (_assistantId: string, _conversationId?: string) => {},
 );
 const liveStopSpy = mock(async () => {});
+// The composer reads session state through the store's per-field selectors
+// (`useLiveVoiceStore.use.state()` etc.), so mock the store rather than the
+// `useLiveVoice` controller. `LiveVoiceButton` is the only `useLiveVoice`
+// consumer, and it is mocked separately below.
+mock.module("@/domains/voice/live-voice/live-voice-store", () => ({
+  useLiveVoiceStore: {
+    use: {
+      state: () => mockLiveVoiceState,
+      partialTranscript: () => mockLivePartial,
+      finalTranscript: () => mockLiveFinal,
+      assistantTranscript: () => mockLiveAssistant,
+    },
+  },
+}));
 mock.module("@/domains/voice/live-voice/use-live-voice", () => ({
   useLiveVoice: () => ({
     state: mockLiveVoiceState,

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -24,7 +24,7 @@ import {
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
-import { useLiveVoice } from "@/domains/voice/live-voice/use-live-voice";
+import { useLiveVoiceStore } from "@/domains/voice/live-voice/live-voice-store";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -299,12 +299,16 @@ export function ChatComposer({
   // dictation button (same `showVoiceInput` precondition + a non-null id).
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
   const liveVoiceEligible = voiceMode && showVoiceInput && !!assistantId;
-  const {
-    state: liveVoiceState,
-    partialTranscript: liveVoicePartial,
-    finalTranscript: liveVoiceFinal,
-    assistantTranscript: liveVoiceAssistant,
-  } = useLiveVoice();
+  // Read session state via the store's per-field selectors rather than mounting
+  // a second `useLiveVoice()` controller. The single controller instance lives
+  // in `LiveVoiceButton` (which drives start/stop + owns the unmount-teardown
+  // effect); the composer only ever *reads* the projected state, so two
+  // controllers with competing teardown effects on the same store would be a
+  // footgun. These atomic selectors re-render only on the fields they read.
+  const liveVoiceState = useLiveVoiceStore.use.state();
+  const liveVoicePartial = useLiveVoiceStore.use.partialTranscript();
+  const liveVoiceFinal = useLiveVoiceStore.use.finalTranscript();
+  const liveVoiceAssistant = useLiveVoiceStore.use.assistantTranscript();
   // Anything but idle/failed counts as an active session; while active the
   // dictation mic is disabled so the two capture flows never run at once.
   // `failed` is a retryable/inactive state in `useLiveVoice`/`LiveVoiceButton`,

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 
 // The default client factory in use-live-voice statically imports the real
 // LiveVoiceChannelClient, which pulls in connection.ts -> the generated SDK.
@@ -241,6 +241,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Unmount any still-mounted controller so its session teardown runs — with
+  // continuous listening a session stays live (mic open) until stop()/unmount,
+  // so without this the store/session would leak into the next test.
+  cleanup();
   useLiveVoiceStore.getState().reset();
 });
 
@@ -249,7 +253,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("full turn", () => {
-  test("drives idle → connecting → listening → transcribing → thinking → speaking → idle", async () => {
+  test("drives idle → connecting → listening → thinking → speaking → listening (continuous)", async () => {
     const h = renderController();
 
     expect(h.view.result.current.state).toBe("idle");
@@ -327,15 +331,17 @@ describe("full turn", () => {
     expect(h.view.result.current.state).toBe("speaking");
     expect(h.player.enqueued).toHaveLength(1);
 
-    // tts_done stops capture and awaits playback drain, then returns to idle.
+    // tts_done awaits playback drain, then resumes listening for the next turn
+    // (continuous conversation): the mic is NOT shut down and the socket stays
+    // open.
     await act(async () => {
       h.client.emit("ttsDone", { type: "tts_done", seq: 8, turnId: "t1" });
       h.player.finishPlayback();
       await Promise.resolve();
     });
-    expect(h.view.result.current.state).toBe("idle");
-    expect(h.client.closed).toBe(true);
-    expect(h.getCapture().shutdownCount).toBeGreaterThanOrEqual(1);
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
   });
 });
 
@@ -389,6 +395,60 @@ describe("barge-in", () => {
     });
 
     expect(h.client.interruptCount).toBe(1);
+  });
+
+  test("realistic turn: auto-release → speaking → barge-in resumes listening → second auto-release", async () => {
+    const h = renderController();
+    await startListening(h);
+    const capture = h.getCapture();
+
+    // --- Turn 1: speak, then go silent so push-to-talk auto-releases. ---
+    act(() => {
+      capture.pushAmplitude(0.1); // speech
+      capture.pushChunk(pcmChunk(200));
+      capture.pushAmplitude(0.0); // trailing silence
+      capture.pushChunk(pcmChunk(1000));
+    });
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+    // Forwarding is gated off after release, but the mic is still running.
+    const forwardedAfterRelease = h.client.sentAudio.length;
+
+    // Server thinks, then streams TTS — we move to speaking.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 4, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 5,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+
+    // The mic never stopped, so amplitude still flows while the assistant
+    // speaks: a loud reading interrupts (barge-in) and resumes listening.
+    act(() => {
+      capture.pushAmplitude(0.3); // over BARGE_IN_AMPLITUDE_THRESHOLD
+    });
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.player.stopCount).toBe(1);
+    expect(h.view.result.current.state).toBe("listening");
+    // Capture was never shut down across the whole turn.
+    expect(capture.shutdownCount).toBe(0);
+
+    // --- Turn 2: forwarding resumed, so a fresh utterance auto-releases too. ---
+    act(() => {
+      capture.pushAmplitude(0.1); // speech again
+      capture.pushChunk(pcmChunk(200));
+      capture.pushAmplitude(0.0); // silence
+      capture.pushChunk(pcmChunk(1000));
+    });
+    expect(h.client.pttReleaseCount).toBe(2);
+    expect(h.view.result.current.state).toBe("transcribing");
+    // The second utterance's PCM was forwarded after listening resumed.
+    expect(h.client.sentAudio.length).toBeGreaterThan(forwardedAfterRelease);
   });
 });
 
@@ -520,10 +580,12 @@ describe("teardown", () => {
     expect(h.view.result.current.state).toBe("idle");
   });
 
-  test("unmount releases mic, socket, and audio", async () => {
+  test("unmount releases mic, socket, and audio and resets the store to idle", async () => {
     const h = renderController();
     await startListening(h);
     const capture = h.getCapture();
+    // Sanity: a live session leaves the store non-idle before unmount.
+    expect(h.view.result.current.state).toBe("listening");
 
     act(() => {
       h.view.unmount();
@@ -533,6 +595,9 @@ describe("teardown", () => {
     // Unmount must dispose the player so the AudioContext is released.
     expect(h.player.disposeCount).toBeGreaterThanOrEqual(1);
     expect(capture.shutdownCount).toBe(1);
+    // Gap 2: teardown must reset the store so a mid-session unmount doesn't
+    // strand it in a non-idle phase (which would keep dictation disabled).
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
   });
 
   test("stop() with no active session resets to idle without throwing", async () => {

--- a/apps/web/src/domains/voice/live-voice/use-live-voice.ts
+++ b/apps/web/src/domains/voice/live-voice/use-live-voice.ts
@@ -13,19 +13,29 @@
  * controller instance drives at most one session at a time; `start()` while a
  * session is live is a no-op (matching the macOS guard).
  *
- * ## State transitions (full turn)
+ * ## State transitions (one turn of a continuous conversation)
  * `idle → connecting` (start) → `listening` (ready + capture started) →
  * `transcribing` (ptt released) → `thinking` (server response) → `speaking`
- * (tts_audio) → `idle` (tts_done drained + cleanup).
+ * (tts_audio) → `listening` (tts_done drained → resume for the next turn).
+ * The mic keeps capturing across the whole session; only `stop()`, teardown,
+ * an error, or a server `archived`/`closed` returns to `idle`/`failed`.
+ *
+ * ## Continuous listening
+ * The mic capture graph runs for the entire active session so amplitude keeps
+ * flowing for barge-in even while the assistant is thinking/speaking. What is
+ * gated per-turn is audio *forwarding* (`session.forwardingAudio`): captured
+ * PCM is only streamed to the server while forwarding is on. Push-to-talk
+ * release flips forwarding off (without stopping the mic); barge-in and
+ * end-of-response both flip it back on for the next utterance.
  *
  * ## Barge-in
  * While `speaking`, a captured amplitude over {@link BARGE_IN_AMPLITUDE_THRESHOLD}
- * stops playback and sends `interrupt` (once per response).
+ * stops playback, sends `interrupt` (once per response), and resumes listening.
  *
  * ## Automatic push-to-talk release
  * While `listening`, sustained speech (≥ {@link MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS})
  * followed by {@link SILENCE_DURATION_BEFORE_RELEASE_MS} of silence releases
- * push-to-talk and moves to `transcribing`.
+ * push-to-talk and moves to `transcribing` (mic stays open).
  */
 
 import { useCallback, useEffect, useRef } from "react";
@@ -107,7 +117,15 @@ interface SessionContext {
   unsubscribes: Array<() => void>;
   /** Monotonic id; a stale callback whose generation differs is ignored. */
   generation: number;
+  /** Whether the mic capture graph is running (open for the whole session). */
   captureRunning: boolean;
+  /**
+   * Whether captured PCM is currently streamed to the server. Gated per-turn:
+   * on while the user is speaking (`listening`), off after an automatic
+   * push-to-talk release, and flipped back on by barge-in / end-of-response.
+   * Amplitude keeps flowing regardless so barge-in works while not forwarding.
+   */
+  forwardingAudio: boolean;
   /** Whether the assistant has sent any TTS audio for the current response. */
   responseAudioStarted: boolean;
   /** Whether an interrupt was already sent for the current response. */
@@ -146,7 +164,16 @@ export function useLiveVoice(
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  /** Tear down the active session's primitives and clear the ref. */
+  /**
+   * Tear down the active session's primitives, clear the ref, and reset the
+   * store to idle.
+   *
+   * Resetting here keeps the store from getting stuck non-idle when the
+   * consumer unmounts mid-session (otherwise the composer would permanently
+   * disable dictation and keep the transcript surface mounted). Callers that
+   * need a terminal state other than `idle` (e.g. `finishWithError` → `failed`)
+   * set it *after* calling `teardown()`, so the reset can't clobber it.
+   */
   const teardown = useCallback(() => {
     const session = sessionRef.current;
     if (!session) return;
@@ -160,6 +187,7 @@ export function useLiveVoice(
     // would leak the context across repeated sessions until page unload.
     void session.player.dispose();
     void session.capture.shutdown();
+    useLiveVoiceStore.getState().reset();
   }, []);
 
   const stop = useCallback(async () => {
@@ -203,6 +231,7 @@ export function useLiveVoice(
         unsubscribes: [],
         generation: 0,
         captureRunning: false,
+        forwardingAudio: false,
         responseAudioStarted: false,
         interruptSent: false,
         releaseInFlight: false,
@@ -230,14 +259,18 @@ export function useLiveVoice(
           if (!live()) return;
           const s = useLiveVoiceStore.getState();
           s.setPartialTranscript(frame.text);
-          if (session.captureRunning) s.setState("listening");
+          // Only while still forwarding (the user's turn) does a partial keep
+          // us in `listening`; after ptt-release we're transcribing/thinking.
+          if (session.forwardingAudio) s.setState("listening");
         }),
         client.on("sttFinal", (frame) => {
           if (!live()) return;
           const s = useLiveVoiceStore.getState();
           s.setFinalTranscript(frame.text);
           s.setPartialTranscript("");
-          s.setState(session.captureRunning ? "listening" : "thinking");
+          // Forwarding ⇒ the user is still speaking (stay listening); otherwise
+          // ptt was released and the server is about to think.
+          s.setState(session.forwardingAudio ? "listening" : "thinking");
         }),
         client.on("thinking", () => {
           if (!live()) return;
@@ -270,7 +303,7 @@ export function useLiveVoice(
         }),
         client.on("ttsDone", () => {
           if (!live()) return;
-          void finishResponseAfterPlayback(session, teardown);
+          void finishResponseAfterPlayback(session);
         }),
         client.on("archived", () => {
           if (!live()) return;
@@ -286,10 +319,10 @@ export function useLiveVoice(
         }),
         client.on("closed", () => {
           // A transport close after a clean end()/teardown is expected; only an
-          // unexpected close while still attached needs cleanup.
+          // unexpected close while still attached needs cleanup. teardown()
+          // resets the store to idle.
           if (!live()) return;
           teardown();
-          useLiveVoiceStore.getState().reset();
         }),
       );
 
@@ -298,7 +331,9 @@ export function useLiveVoice(
     [teardown],
   );
 
-  // Release everything if the consumer unmounts mid-session.
+  // Release everything if the consumer unmounts mid-session. teardown() also
+  // resets the store to idle so a mid-session unmount doesn't strand it in a
+  // non-idle phase (which would keep dictation disabled via the composer).
   useEffect(() => () => teardown(), [teardown]);
 
   return {
@@ -334,18 +369,30 @@ async function startCapture(
     return;
   }
   session.captureRunning = true;
+  session.forwardingAudio = true;
   const s = useLiveVoiceStore.getState();
   if (s.state === "connecting") s.setState("listening");
 }
 
-/** Forward a captured PCM chunk to the server and drive silence detection. */
+/**
+ * Forward a captured PCM chunk to the server and drive silence detection.
+ *
+ * The mic stays open across the whole session, but PCM is only streamed while
+ * `forwardingAudio` is on (i.e. during the user's turn). Silence detection runs
+ * on the same gate so auto-release only fires while we are actually forwarding.
+ */
 function handleChunk(session: SessionContext, buf: ArrayBuffer): void {
-  if (!session.captureRunning) return;
+  if (!session.captureRunning || !session.forwardingAudio) return;
   session.client.sendAudio(buf);
   updateAutomaticRelease(session, buf);
 }
 
-/** Apply the latest amplitude to the store and run barge-in detection. */
+/**
+ * Apply the latest amplitude to the store and run barge-in detection.
+ *
+ * Runs whenever the mic is open — including while not forwarding — so a loud
+ * amplitude can interrupt the assistant mid-response (barge-in).
+ */
 function handleAmplitude(session: SessionContext, amplitude: number): void {
   if (!session.captureRunning) return;
   useLiveVoiceStore.getState().setInputAmplitude(amplitude);
@@ -380,27 +427,46 @@ function updateAutomaticRelease(session: SessionContext, buf: ArrayBuffer): void
   releasePushToTalk(session);
 }
 
-/** Stop forwarding audio and release push-to-talk; moves to `transcribing`. */
+/**
+ * Stop *forwarding* audio and release push-to-talk; moves to `transcribing`.
+ *
+ * The mic capture graph keeps running (so amplitude continues to flow for
+ * barge-in); only the per-turn forwarding gate is closed here.
+ */
 function releasePushToTalk(session: SessionContext): void {
-  if (session.releaseInFlight || !session.captureRunning) return;
+  if (session.releaseInFlight || !session.forwardingAudio) return;
   session.releaseInFlight = true;
-  session.captureRunning = false;
-  void session.capture.stop();
+  session.forwardingAudio = false;
   session.client.pttRelease();
   const s = useLiveVoiceStore.getState();
   if (s.state === "listening") s.setState("transcribing");
   s.setInputAmplitude(0);
 }
 
-/** Barge-in: stop playback and interrupt the server once per response. */
+/**
+ * Resume listening for the next utterance: re-open the forwarding gate, clear
+ * the per-utterance counters/flags, and move to `listening`. The mic is already
+ * running (continuous capture), so there is nothing to restart here.
+ */
+function resumeListening(session: SessionContext): void {
+  session.forwardingAudio = true;
+  session.releaseInFlight = false;
+  session.speechMs = 0;
+  session.silenceMs = 0;
+  useLiveVoiceStore.getState().setState("listening");
+}
+
+/**
+ * Barge-in: stop playback and interrupt the server once per response, then
+ * resume listening so the user's interrupting speech becomes the next turn.
+ */
 function interruptIfSpeaking(session: SessionContext): void {
   if (useLiveVoiceStore.getState().state !== "speaking") return;
   if (!session.player.isPlaying || session.interruptSent) return;
   session.interruptSent = true;
   session.player.stop();
   session.client.interrupt();
-  const s = useLiveVoiceStore.getState();
-  s.setState(session.captureRunning ? "listening" : "idle");
+  resumeListening(session);
 }
 
 /** First TTS frame of a response: reset playback flags for the new utterance. */
@@ -411,25 +477,28 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
 }
 
 /**
- * After `tts_done`, stop capturing then await playback drain before cleaning up
- * and returning to `idle`. Stopping capture first prevents drain-window audio
- * from being forwarded (mirrors the macOS ordering).
+ * After `tts_done`, await playback drain, then resume listening for the next
+ * turn — this is a continuous conversation, so the mic is never stopped here.
+ *
+ * Forwarding is suspended during the drain so playback audio captured by the
+ * (still-open) mic isn't streamed back to the server; `resumeListening` re-opens
+ * the gate once the assistant has finished speaking. A barge-in during the drain
+ * already flipped `forwardingAudio` back on and moved us to `listening`, so we
+ * leave that turn alone (only the still-`speaking` case resumes here).
  */
 async function finishResponseAfterPlayback(
   session: SessionContext,
-  teardown: () => void,
 ): Promise<void> {
   const generation = session.generation;
   session.responseAudioStarted = false;
-  session.captureRunning = false;
-  void session.capture.stop();
+  session.forwardingAudio = false;
 
   await session.player.waitUntilDrained();
   if (session.generation !== generation) return;
 
-  useLiveVoiceStore.getState().setState("ending");
-  teardown();
-  useLiveVoiceStore.getState().reset();
+  // A barge-in mid-drain already resumed listening; don't override its turn.
+  if (useLiveVoiceStore.getState().state !== "speaking") return;
+  resumeListening(session);
 }
 
 /** Fail the session: tear down primitives and surface the message. */


### PR DESCRIPTION
## Summary
- Keep mic capturing through the turn (gate forwarding) so barge-in works + resume listening
- Reset live-voice store on unmount so dictation re-enables
- Composer reads live-voice state via store selectors (single controller in the button)

Fixes self-review gaps for plan: web-live-voice.md