### PR TITLE
fix(voice): worklet build + Safari AudioContext + EMA + audio-module slop cleanup

### DIFF
--- a/apps/web/src/domains/voice/audio-context.ts
+++ b/apps/web/src/domains/voice/audio-context.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared `AudioContext` constructor helper for the voice domain.
+ *
+ * Safari only exposes the prefixed `webkitAudioContext`, so every Web Audio
+ * call site needs the `AudioContext ?? webkitAudioContext` fallback. This
+ * centralizes that fallback so capture/playback (and any future voice audio
+ * code) don't each hand-roll their own copy.
+ *
+ * Note: `sound-manager.ts` and `use-push-to-talk.ts` predate this helper and
+ * still inline the same fallback; they can adopt this in a follow-up.
+ */
+
+/** Window augmented with Safari's prefixed AudioContext constructor. */
+export type AudioContextWindow = typeof globalThis & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+/**
+ * Resolve the available `AudioContext` constructor, falling back to Safari's
+ * prefixed `webkitAudioContext`. Returns `undefined` when neither exists, so
+ * feature-detection sites can branch without constructing a context.
+ */
+export function getAudioContextCtor(): typeof AudioContext | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.AudioContext ?? (window as AudioContextWindow).webkitAudioContext;
+}
+
+/**
+ * Construct an `AudioContext`, falling back to Safari's prefixed
+ * `webkitAudioContext`. Throws if neither constructor is available (callers
+ * that may run before user gesture / on unsupported platforms should feature
+ * detect first).
+ */
+export function createAudioContext(options?: AudioContextOptions): AudioContext {
+  const Ctor = getAudioContextCtor();
+  if (!Ctor) {
+    throw new Error("Web Audio API is not available in this environment");
+  }
+  return new Ctor(options);
+}

--- a/apps/web/src/domains/voice/live-voice/live-voice-client.ts
+++ b/apps/web/src/domains/voice/live-voice/live-voice-client.ts
@@ -29,6 +29,7 @@ import {
   type LiveVoiceAssistantTextDeltaServerFrame,
   type LiveVoiceBusyServerFrame,
   type LiveVoiceClientStartFrame,
+  LIVE_VOICE_AUDIO_FORMAT,
   type LiveVoiceMetricsServerFrame,
   type LiveVoiceReadyServerFrame,
   type LiveVoiceSttFinalServerFrame,
@@ -38,13 +39,6 @@ import {
   type LiveVoiceTtsDoneServerFrame,
   parseServerFrame,
 } from "@/domains/voice/live-voice/protocol";
-
-/** Audio shape sent in the `start` frame — matches the runtime contract. */
-const START_AUDIO_CONFIG: LiveVoiceClientStartFrame["audio"] = {
-  mimeType: "audio/pcm",
-  sampleRate: 16000,
-  channels: 1,
-};
 
 /** Fail the session if no `ready` frame arrives within this window. */
 const CONNECT_TIMEOUT_MS = 10_000;
@@ -254,7 +248,7 @@ export class LiveVoiceChannelClient {
     if (this.state !== "connecting" || !this.ws) return;
     const startFrame: LiveVoiceClientStartFrame = {
       type: "start",
-      audio: START_AUDIO_CONFIG,
+      audio: LIVE_VOICE_AUDIO_FORMAT,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
     };
     this.trySend(JSON.stringify(startFrame));

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.test.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
-  downsampleToInt16,
   isSupported,
   LIVE_VOICE_AUDIO_FORMAT,
   LiveVoiceAudioCapture,
@@ -122,28 +121,6 @@ describe("LIVE_VOICE_AUDIO_FORMAT", () => {
       sampleRate: 16000,
       channels: 1,
     });
-  });
-});
-
-describe("downsampleToInt16", () => {
-  test("converts a known Float32 input to signed 16-bit at 16kHz (no resample)", () => {
-    // inputRate === target: 1:1, exercises just the Float32 -> Int16 scaling.
-    const input = new Float32Array([0, 1, -1, 0.5, -0.5]);
-    const pcm = downsampleToInt16(input, 16000);
-    expect(Array.from(pcm)).toEqual([0, 32767, -32768, 16383, -16384]);
-  });
-
-  test("clamps out-of-range samples to the Int16 bounds", () => {
-    const pcm = downsampleToInt16(new Float32Array([2.0, -2.0]), 16000);
-    expect(Array.from(pcm)).toEqual([32767, -32768]);
-  });
-
-  test("decimates a 32kHz buffer to half the samples", () => {
-    const input = new Float32Array([1, 0, 1, 0, 1, 0, 1, 0]);
-    const pcm = downsampleToInt16(input, 32000);
-    // ratio 2 -> 4 output samples, taking every other input (the 1s).
-    expect(pcm.length).toBe(4);
-    expect(Array.from(pcm)).toEqual([32767, 32767, 32767, 32767]);
   });
 });
 

--- a/apps/web/src/domains/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-capture.ts
@@ -18,44 +18,32 @@
  * pre-prompt on Capacitor iOS).
  */
 
-/** Output audio contract — must match the runtime `start` frame. */
-export const LIVE_VOICE_AUDIO_FORMAT = {
-  mimeType: "audio/pcm",
-  sampleRate: 16000,
-  channels: 1,
-} as const;
+// Import the worklet as a Vite-bundled, *transpiled* classic script asset and
+// get its URL. The `?worker&url` suffix is the robust form: it makes Vite
+// compile the worklet entry (TS -> JS, IIFE, dependencies inlined) and emit it
+// as a standalone asset, then hand us the hashed URL to pass to `addModule()`.
+//
+// A bare `new URL("./pcm-downsample-worklet.ts", import.meta.url)` does NOT
+// work for this: Vite treats it as a static asset and copies the file verbatim,
+// so production ships a raw `.ts` file that an `AudioWorklet` cannot parse (TS
+// syntax, wrong MIME type) — i.e. the feature would be dead in prod. The dev
+// server tolerates on-the-fly TS, which is why this only bites a real build.
+// https://vite.dev/guide/worker#import-with-query-suffixes
+import WORKLET_MODULE_URL from "./pcm-downsample-worklet.ts?worker&url";
+
+import { createAudioContext, getAudioContextCtor } from "@/domains/voice/audio-context";
+import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/voice/live-voice/protocol";
+
+// Re-exported for capture consumers (e.g. use-live-voice.ts) so they don't need
+// to reach into the protocol module. Canonical definition lives in protocol.ts.
+export { LIVE_VOICE_AUDIO_FORMAT };
 
 // Matches `use-audio-amplitude.ts` (and the macOS AudioEngineController):
-// 0.5/0.5 EMA, scaled by 14 and clamped to 1.0.
+// EMA with alpha 0.5, scaled by 14 and clamped to 1.0.
 const AMPLITUDE_SMOOTHING = 0.5;
 const AMPLITUDE_SCALE = 14.0;
 
 const WORKLET_PROCESSOR_NAME = "pcm-downsample";
-
-/**
- * Converts a Float32 mono buffer (sampled at `inputRate`) to 16 kHz signed
- * 16-bit PCM via linear decimation. Shared by the AudioWorklet processor and
- * its tests so the conversion math has a single, directly-testable home.
- */
-export function downsampleToInt16(input: Float32Array, inputRate: number): Int16Array {
-  const ratio = inputRate / LIVE_VOICE_AUDIO_FORMAT.sampleRate;
-  const outLength = Math.max(0, Math.floor(input.length / ratio));
-  const pcm = new Int16Array(outLength);
-  let pos = 0;
-  for (let i = 0; i < outLength; i++) {
-    const sample = input[Math.floor(pos)] ?? 0;
-    // Clamp to [-1, 1] then scale to the signed 16-bit range. The asymmetric
-    // 0x8000 / 0x7fff factors map -1.0 -> -32768 and +1.0 -> +32767.
-    const clamped = sample < -1 ? -1 : sample > 1 ? 1 : sample;
-    pcm[i] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
-    pos += ratio;
-  }
-  return pcm;
-}
-// Vite rewrites this into a bundled worklet asset URL at build time, mirroring
-// the `new URL(..., import.meta.url)` worker pattern.
-// https://vite.dev/guide/assets#new-url-url-import-meta-url
-const WORKLET_MODULE_URL = new URL("./pcm-downsample-worklet.ts", import.meta.url);
 
 /** Reason a capture failed to start, mapped from `getUserMedia` DOMExceptions. */
 export type LiveVoiceCaptureError =
@@ -85,12 +73,15 @@ export interface LiveVoiceAudioCaptureOptions {
  * platform branch here. Returns false only when an API is genuinely absent.
  */
 export function isSupported(): boolean {
+  // Safari exposes only the prefixed `webkitAudioContext`; resolve via the same
+  // fallback as `createAudioContext` so we don't gate out a supported browser.
+  const Ctor = getAudioContextCtor();
   return (
     typeof navigator !== "undefined" &&
     !!navigator.mediaDevices?.getUserMedia &&
-    typeof AudioContext !== "undefined" &&
+    !!Ctor &&
     // AudioWorklet is present on a constructed context's `audioWorklet`.
-    "audioWorklet" in AudioContext.prototype
+    "audioWorklet" in Ctor.prototype
   );
 }
 
@@ -170,9 +161,9 @@ export class LiveVoiceAudioCapture {
     this.stream = stream;
 
     try {
-      const context = new AudioContext();
+      const context = createAudioContext();
       this.context = context;
-      await context.audioWorklet.addModule(WORKLET_MODULE_URL.href);
+      await context.audioWorklet.addModule(WORKLET_MODULE_URL);
 
       if (cancelled()) {
         await this.teardown();
@@ -229,7 +220,8 @@ export class LiveVoiceAudioCapture {
     }
     const rawRMS = Math.sqrt(sumSquares / samples.length);
     this.smoothedAmplitude =
-      AMPLITUDE_SMOOTHING * rawRMS + AMPLITUDE_SMOOTHING * this.smoothedAmplitude;
+      AMPLITUDE_SMOOTHING * rawRMS +
+      (1 - AMPLITUDE_SMOOTHING) * this.smoothedAmplitude;
     this.onAmplitude(Math.min(this.smoothedAmplitude * AMPLITUDE_SCALE, 1.0));
   }
 

--- a/apps/web/src/domains/voice/live-voice/pcm-downsample-worklet.ts
+++ b/apps/web/src/domains/voice/live-voice/pcm-downsample-worklet.ts
@@ -6,16 +6,18 @@
  * each chunk to the main thread.
  *
  * The output contract — `audio/pcm`, 16000 Hz, mono, signed 16-bit LE — matches
- * what the live-voice runtime `start` frame declares. Keep it in sync with the
- * `TARGET_SAMPLE_RATE` consumed by `pcm-capture.ts`.
+ * what the live-voice runtime `start` frame declares.
  *
- * This file is loaded as a classic AudioWorklet module (not bundled with the
- * app graph). It runs on the audio render thread, so it only references the
+ * This file runs on the audio render thread, so it only references the
  * `AudioWorkletProcessor` globals available there — no DOM, no app imports.
+ * That isolation is why `TARGET_SAMPLE_RATE` is hardcoded here rather than
+ * imported: it MUST stay in sync with the canonical `LIVE_VOICE_AUDIO_FORMAT`
+ * in `protocol.ts` (`sampleRate: 16000`).
  *
  * Reference: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor
  */
 
+// Mirror of LIVE_VOICE_AUDIO_FORMAT.sampleRate in protocol.ts (see docblock).
 const TARGET_SAMPLE_RATE = 16000;
 
 // AudioWorkletGlobalScope globals. They are not in the default DOM lib, so
@@ -43,12 +45,10 @@ declare const AudioWorkletProcessor: {
  * the nearest source sample. Good enough for speech; the runtime STT is robust
  * to mild aliasing and this avoids an FIR filter on the audio thread.
  *
- * The per-sample Float32 -> Int16 conversion math is mirrored by the pure,
- * unit-tested `downsampleToInt16` helper in `pcm-capture.ts`. This processor
- * keeps its own copy because it must also carry the fractional read position
- * (`readPos`) across render quanta — which a stateless helper cannot — and
- * because it cannot import DOM-coupled main-thread code onto the audio thread.
- * Keep the two in sync.
+ * The decimation loop + Float32 -> Int16 conversion lives only here (it carries
+ * the fractional read position across render quanta, which a stateless helper
+ * cannot, and the audio thread can't import app code). Its output is exercised
+ * directly by the cross-quantum tests in `pcm-capture.test.ts`.
  */
 class PcmDownsampleProcessor extends AudioWorkletProcessor {
   private readonly ratio = sampleRate / TARGET_SAMPLE_RATE;

--- a/apps/web/src/domains/voice/live-voice/protocol.ts
+++ b/apps/web/src/domains/voice/live-voice/protocol.ts
@@ -27,6 +27,22 @@ export interface LiveVoiceAudioConfig {
   readonly channels: 1;
 }
 
+/**
+ * Canonical client capture/upload audio contract — the single source of truth
+ * shared by the capture pipeline (`pcm-capture.ts`) and the `start` frame's
+ * `audio` config (`live-voice-client.ts`). Mirrors the runtime contract in
+ * `assistant/src/live-voice/protocol.ts`.
+ *
+ * The AudioWorklet (`pcm-downsample-worklet.ts`) cannot import app modules
+ * (audio-thread isolation), so it hardcodes the same `16000` — keep its
+ * `TARGET_SAMPLE_RATE` in sync with this.
+ */
+export const LIVE_VOICE_AUDIO_FORMAT: LiveVoiceAudioConfig = {
+  mimeType: "audio/pcm",
+  sampleRate: 16000,
+  channels: 1,
+};
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;

--- a/apps/web/src/domains/voice/live-voice/tts-playback.test.ts
+++ b/apps/web/src/domains/voice/live-voice/tts-playback.test.ts
@@ -205,7 +205,6 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources[0]!.buffer!.sampleRate).toBe(24000);
 
     expect(player.isPlaying).toBe(true);
-    expect(player.queuedCount).toBe(2);
   });
 
   test("never schedules in the past after the queue lags currentTime", () => {
@@ -217,17 +216,17 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources[1]!.startedAt).toBe(5);
   });
 
-  test("queuedCount decrements as sources finish and isPlaying clears", () => {
+  test("isPlaying stays true until the last source finishes", () => {
     player.enqueue(chunk(new Array(12000).fill(1)));
     player.enqueue(chunk(new Array(12000).fill(1)));
-    expect(player.queuedCount).toBe(2);
-
-    ctx.sources[0]!.finish();
-    expect(player.queuedCount).toBe(1);
     expect(player.isPlaying).toBe(true);
 
+    // First of two buffers finishing leaves playback active.
+    ctx.sources[0]!.finish();
+    expect(player.isPlaying).toBe(true);
+
+    // The last buffer finishing clears playback.
     ctx.sources[1]!.finish();
-    expect(player.queuedCount).toBe(0);
     expect(player.isPlaying).toBe(false);
   });
 
@@ -239,7 +238,6 @@ describe("LiveVoiceAudioPlayer", () => {
 
     expect(ctx.sources.every((s) => s.stopped)).toBe(true);
     expect(ctx.sources.every((s) => s.disconnected)).toBe(true);
-    expect(player.queuedCount).toBe(0);
     expect(player.isPlaying).toBe(false);
   });
 
@@ -279,20 +277,6 @@ describe("LiveVoiceAudioPlayer", () => {
     const promise = player.waitUntilDrained();
     player.stop();
     await expect(promise).resolves.toBeUndefined();
-  });
-
-  test("subscribe() reports state transitions", () => {
-    const seen: Array<{ isPlaying: boolean; queuedCount: number }> = [];
-    player.subscribe((s) => seen.push({ ...s }));
-
-    // Immediate emit on subscribe.
-    expect(seen[0]).toEqual({ isPlaying: false, queuedCount: 0 });
-
-    player.enqueue(chunk(new Array(24000).fill(1)));
-    expect(seen.at(-1)).toEqual({ isPlaying: true, queuedCount: 1 });
-
-    player.stop();
-    expect(seen.at(-1)).toEqual({ isPlaying: false, queuedCount: 0 });
   });
 
   test("drops empty/malformed chunks without scheduling", () => {
@@ -380,7 +364,6 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources.every((s) => s.stopped)).toBe(true);
     expect(ctx.closed).toBe(true);
     expect(player.isPlaying).toBe(false);
-    expect(player.queuedCount).toBe(0);
   });
 
   test("dispose() is a no-op when no context was ever created", async () => {
@@ -407,6 +390,5 @@ describe("LiveVoiceAudioPlayer", () => {
     // A fresh enqueue lazily rebuilds a context and schedules normally.
     player.enqueue(chunk(new Array(24000).fill(1)));
     expect(player.isPlaying).toBe(true);
-    expect(player.queuedCount).toBe(1);
   });
 });

--- a/apps/web/src/domains/voice/live-voice/tts-playback.ts
+++ b/apps/web/src/domains/voice/live-voice/tts-playback.ts
@@ -34,6 +34,8 @@
  * owns its own `AudioContext` lifecycle.
  */
 
+import { createAudioContext } from "@/domains/voice/audio-context";
+
 /** A single TTS audio frame as delivered by the live-voice channel. */
 export interface TtsAudioChunk {
   /**
@@ -78,12 +80,6 @@ function base64ToArrayBuffer(dataBase64: string): ArrayBuffer {
   return bytes.buffer;
 }
 
-/** Observer notified whenever `isPlaying` or `queuedCount` changes. */
-export type PlaybackObserver = (state: {
-  isPlaying: boolean;
-  queuedCount: number;
-}) => void;
-
 /**
  * Minimal structural type for the `AudioContext` surface this player uses.
  * Declared locally so tests can supply a lightweight mock without depending on
@@ -110,15 +106,8 @@ export interface AudioContextLike {
 /** Factory for the `AudioContext`. Overridable in tests. */
 export type AudioContextFactory = () => AudioContextLike;
 
-const defaultAudioContextFactory: AudioContextFactory = () => {
-  // Safari only exposes the prefixed constructor, matching the fallback used
-  // by SoundManager and use-push-to-talk elsewhere in the voice domain.
-  const Ctor =
-    window.AudioContext ||
-    (window as unknown as { webkitAudioContext?: typeof AudioContext })
-      .webkitAudioContext;
-  return new Ctor() as unknown as AudioContextLike;
-};
+const defaultAudioContextFactory: AudioContextFactory = () =>
+  createAudioContext() as unknown as AudioContextLike;
 
 /**
  * Decode base64-encoded little-endian 16-bit PCM into normalized Float32
@@ -158,10 +147,7 @@ export class LiveVoiceAudioPlayer {
    */
   private playheadTime = 0;
 
-  private observers = new Set<PlaybackObserver>();
-
   private playingState = false;
-  private queuedCountState = 0;
 
   /** Resolvers for in-flight `waitUntilDrained()` promises. */
   private drainResolvers: Array<() => void> = [];
@@ -181,23 +167,6 @@ export class LiveVoiceAudioPlayer {
   /** Whether any audio is currently scheduled or playing. */
   get isPlaying(): boolean {
     return this.playingState;
-  }
-
-  /** Number of buffers currently scheduled (playing or pending). */
-  get queuedCount(): number {
-    return this.queuedCountState;
-  }
-
-  /**
-   * Subscribe to playback-state changes. Returns an unsubscribe function.
-   * The observer is invoked immediately with the current state.
-   */
-  subscribe(observer: PlaybackObserver): () => void {
-    this.observers.add(observer);
-    observer({ isPlaying: this.playingState, queuedCount: this.queuedCountState });
-    return () => {
-      this.observers.delete(observer);
-    };
   }
 
   /**
@@ -298,7 +267,7 @@ export class LiveVoiceAudioPlayer {
       this.handleSourceEnded(source);
     };
 
-    this.setState(true, this.activeSources.size);
+    this.playingState = true;
   }
 
   /**
@@ -321,7 +290,7 @@ export class LiveVoiceAudioPlayer {
     }
     this.activeSources.clear();
     this.playheadTime = 0;
-    this.setState(false, 0);
+    this.playingState = false;
     this.resolveDrain();
   }
 
@@ -364,10 +333,8 @@ export class LiveVoiceAudioPlayer {
     source.disconnect();
     if (this.activeSources.size === 0) {
       this.playheadTime = 0;
-      this.setState(false, 0);
+      this.playingState = false;
       this.resolveDrain();
-    } else {
-      this.setState(true, this.activeSources.size);
     }
   }
 
@@ -375,16 +342,5 @@ export class LiveVoiceAudioPlayer {
     const resolvers = this.drainResolvers;
     this.drainResolvers = [];
     for (const resolve of resolvers) resolve();
-  }
-
-  private setState(isPlaying: boolean, queuedCount: number): void {
-    if (isPlaying === this.playingState && queuedCount === this.queuedCountState) {
-      return;
-    }
-    this.playingState = isPlaying;
-    this.queuedCountState = queuedCount;
-    for (const observer of this.observers) {
-      observer({ isPlaying, queuedCount });
-    }
   }
 }

--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -8,9 +8,29 @@
  * Reference: https://github.com/nicedoc/happy-dom/wiki/GlobalRegistrator
  */
 
+import { plugin, type BunPlugin } from "bun";
+
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 GlobalRegistrator.register();
+
+// Vite asset-URL query suffixes (`?worker&url`, `?url`, `?worker`) aren't
+// understood by Bun's resolver. Production builds rely on Vite to turn these
+// imports into emitted-asset URLs (e.g. the live-voice AudioWorklet); in tests
+// we only need the import to resolve, so map any such specifier to a stub
+// default export (the URL string). Tests that exercise the asset drive it
+// through their own mocks rather than fetching the real URL.
+const viteAssetUrlStub: BunPlugin = {
+  name: "vite-asset-url-stub",
+  setup(build) {
+    build.onLoad({ filter: /\?(worker&url|url|worker)$/ }, (args) => ({
+      contents: `export default ${JSON.stringify(args.path)};`,
+      loader: "js",
+    }));
+  },
+};
+
+plugin(viteAssetUrlStub);
 
 // Tests default to platform mode (matching CI/CD builds). Individual tests
 // that need local mode should mock isLocalMode() instead.


### PR DESCRIPTION
## Summary
- Verify/repair AudioWorklet production bundling; shared createAudioContext (Safari fallback) used by capture + playback; correct EMA; single audio-format source; remove unused player observer API; dedupe downsample math

Fixes self-review gaps for plan: web-live-voice.md