### PR TITLE
fix: centralize Kata runtime shell detection

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -6,11 +6,7 @@ set -eu
 chmod 1777 /tmp 2>/dev/null || true
 
 KATA_APT_INIT_PID=""
-if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
-  . /app/assistant/docker-kata-runtime-family.sh
-else
-  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
-fi
+. /app/assistant/docker-kata-runtime-family.sh
 
 if vellum_is_kata_family_runtime && [ -x /app/assistant/docker-init-apt-root.sh ]; then
   export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"

--- a/assistant/docker-init-apt-root.sh
+++ b/assistant/docker-init-apt-root.sh
@@ -10,11 +10,7 @@ LOCK_DIR="${DATA_ROOT}.rootfs-init.lock"
 LOCK_PID="${LOCK_DIR}/pid"
 HOST_PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 
-if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
-  . /app/assistant/docker-kata-runtime-family.sh
-else
-  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
-fi
+. /app/assistant/docker-kata-runtime-family.sh
 
 if ! vellum_is_kata_family_runtime; then
   exit 0

--- a/assistant/docker-kata-apt-env.sh
+++ b/assistant/docker-kata-apt-env.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env sh
 
-if [ -r /app/assistant/docker-kata-runtime-family.sh ]; then
-  . /app/assistant/docker-kata-runtime-family.sh
-else
-  vellum_is_kata_family_runtime() { [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ]; }
-fi
+. /app/assistant/docker-kata-runtime-family.sh
 
 if ! vellum_is_kata_family_runtime; then
   return 0 2>/dev/null || exit 0


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** Shell fallback runtime checks could miss cloud-hypervisor.
**What was expected:** Kata-family runtime membership is consistent across shell startup paths.
**What was found:** Inline fallback logic only recognized kata if the shared helper was unavailable.