### PR TITLE
fix: use repo context for gateway image builds

### DIFF
--- a/clients/macos/vellum-assistant/AppleContainer/LocalImageBuilder.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/LocalImageBuilder.swift
@@ -122,7 +122,7 @@ enum LocalImageBuilder {
             case .gateway:
                 return ServiceBuildConfig(
                     service: service,
-                    context: repoRoot.appendingPathComponent("gateway"),
+                    context: repoRoot,
                     dockerfile: repoRoot.appendingPathComponent("gateway/Dockerfile"),
                     tag: ref.fullReference
                 )

--- a/clients/macos/vellum-assistantTests/LocalImageBuilderTests.swift
+++ b/clients/macos/vellum-assistantTests/LocalImageBuilderTests.swift
@@ -89,9 +89,9 @@ final class LocalImageBuilderTests: XCTestCase {
         XCTAssertEqual(assistant.dockerfile.lastPathComponent, "Dockerfile")
         XCTAssertTrue(assistant.dockerfile.path.contains("assistant"))
 
-        // Gateway: context=repoRoot/gateway, dockerfile=repoRoot/gateway/Dockerfile
+        // Gateway: context=repoRoot, dockerfile=repoRoot/gateway/Dockerfile
         let gateway = byService[.gateway]!
-        XCTAssertEqual(gateway.context, root.appendingPathComponent("gateway"))
+        XCTAssertEqual(gateway.context, root)
         XCTAssertEqual(gateway.dockerfile.lastPathComponent, "Dockerfile")
         XCTAssertTrue(gateway.dockerfile.path.contains("gateway"))
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -318,7 +318,7 @@ On `SIGTERM` the gateway enters drain mode: `/readyz` begins returning `503` so 
 
 ```bash
 # Build
-docker build -t vellum-gateway:local gateway
+docker build -f gateway/Dockerfile -t vellum-gateway:local .
 
 # Run (pass required env vars)
 docker run --rm -p 7830:7830 \

--- a/scripts/dockerhub-publish.sh
+++ b/scripts/dockerhub-publish.sh
@@ -103,7 +103,7 @@ build_context_for() {
   case "$1" in
     assistant)            echo "." ;;
     credential-executor)  echo "." ;;
-    gateway)              echo "gateway" ;;
+    gateway)              echo "." ;;
   esac
 }
 

--- a/scripts/gcr-publish.ts
+++ b/scripts/gcr-publish.ts
@@ -89,7 +89,7 @@ const SERVICE_CONFIG: Record<Service, ServiceConfig> = {
   },
   gateway: {
     imageEnvVar: "GATEWAY_IMAGE_NAME",
-    context: "gateway",
+    context: ".",
     dockerfile: "gateway/Dockerfile",
     featureFlagSync: {
       src: "meta/feature-flags/feature-flag-registry.json",

--- a/scripts/staging-docker-upload.ts
+++ b/scripts/staging-docker-upload.ts
@@ -97,7 +97,7 @@ const SERVICE_CONFIG: Record<Service, ServiceConfig> = {
   },
   gateway: {
     imageEnvVar: "GATEWAY_IMAGE_NAME",
-    context: "gateway",
+    context: ".",
     dockerfile: "gateway/Dockerfile",
     featureFlagSync: {
       src: "meta/feature-flags/feature-flag-registry.json",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** Gateway Dockerfile now copies the shared block-volume package but some build paths still used gateway/ as context.
**What was expected:** Gateway image builds use a context containing packages/block-volume-bootstrap.
**What was found:** macOS local builder and publish scripts could not see the shared package from gateway/ context.