### PR TITLE
JARVIS-1007: render single-newline breaks for assistant messages, style h4-h6

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -7,8 +7,19 @@ mock.module("@/domains/chat/components/chat-attachments/message-attachments", ()
 }));
 
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
-  ChatMarkdownMessage: ({ content }: { content: string }) => (
-    <div data-testid="markdown">{content}</div>
+  ChatMarkdownMessage: ({
+    content,
+    hardLineBreaks,
+  }: {
+    content: string;
+    hardLineBreaks?: boolean;
+  }) => (
+    <div
+      data-testid="markdown"
+      data-hard-line-breaks={hardLineBreaks ? "true" : "false"}
+    >
+      {content}
+    </div>
   ),
 }));
 
@@ -70,6 +81,28 @@ function renderMessage(
 }
 
 describe("TranscriptMessageBody", () => {
+  test("enables hard line breaks for assistant messages (JARVIS-1007)", () => {
+    const html = renderMessage({
+      id: "m1",
+      role: "assistant",
+      content: "line one\nline two",
+      timestamp: 1_000,
+    });
+
+    expect(html).toContain('data-hard-line-breaks="true"');
+  });
+
+  test("enables hard line breaks for user messages too", () => {
+    const html = renderMessage({
+      id: "m1",
+      role: "user",
+      content: "line one\nline two",
+      timestamp: 1_000,
+    });
+
+    expect(html).toContain('data-hard-line-breaks="true"');
+  });
+
   test("uses the latest tool completion as the message activity timestamp", () => {
     const html = renderMessage({
       id: "m1",

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -456,7 +456,10 @@ export function TranscriptMessageBody({
     (tc.toolName === "ui_show" || tc.toolName === "ui_update" || tc.toolName === "ui_dismiss");
   const messageTimestamp = latestMessageActivityTimestamp(message);
 
-  const renderTextWithInlineSurfaces = (text: string, key: string, hardLineBreaks: boolean) => {
+  // Hard line breaks are enabled for every transcript message regardless of
+  // role: single `\n`s in assistant output (not just user Shift+Enter input)
+  // should render as `<br>` rather than collapse to a space — see JARVIS-1007.
+  const renderTextWithInlineSurfaces = (text: string, key: string) => {
     const inlineSegments = parseInlineSurfaces(text);
     if (inlineSegments) {
       return (
@@ -481,7 +484,7 @@ export function TranscriptMessageBody({
                 key={`inline-text-${si}`}
                 className={segmentClass}
               >
-                <ChatMarkdownMessage content={seg.content} hardLineBreaks={hardLineBreaks} />
+                <ChatMarkdownMessage content={seg.content} hardLineBreaks />
               </div>
             );
           })}
@@ -490,7 +493,7 @@ export function TranscriptMessageBody({
     }
     return (
       <div key={key} className={segmentClass}>
-        <ChatMarkdownMessage content={text} hardLineBreaks={hardLineBreaks} />
+        <ChatMarkdownMessage content={text} hardLineBreaks />
       </div>
     );
   };
@@ -720,7 +723,7 @@ export function TranscriptMessageBody({
               if (!text) {
                 return null;
               }
-              return renderTextWithInlineSurfaces(text, `text-${gi}`, message.role === "user");
+              return renderTextWithInlineSurfaces(text, `text-${gi}`);
             }
             if (group.type === "surface") {
               const surface = resolveSurface(group.id);
@@ -752,11 +755,7 @@ export function TranscriptMessageBody({
     // (e.g. tool_use_start before any assistant_text_delta), show the content.
     const interleavedFallback =
       !groups.some((g) => g.type === "text") && message.content
-        ? renderTextWithInlineSurfaces(
-            message.content,
-            "fallback",
-            message.role === "user",
-          )
+        ? renderTextWithInlineSurfaces(message.content, "fallback")
         : null;
 
     // For the user branch: walk the entries in canonical order, tagging text
@@ -839,7 +838,7 @@ export function TranscriptMessageBody({
         const segText = seg?.content ?? entry.id;
         contentEntries.push({
           type: "text",
-          node: renderTextWithInlineSurfaces(segText, `text-${entry.id}`, message.role === "user"),
+          node: renderTextWithInlineSurfaces(segText, `text-${entry.id}`),
         });
       } else if (entry.type === "surface") {
         const surface = resolveSurface(entry.id);
@@ -865,14 +864,14 @@ export function TranscriptMessageBody({
     if (contentEntries.length === 0 && message.content) {
       contentEntries.push({
         type: "text",
-        node: renderTextWithInlineSurfaces(message.content, "fallback", message.role === "user"),
+        node: renderTextWithInlineSurfaces(message.content, "fallback"),
       });
     }
   } else {
     contentEntries.push({
       type: "text",
       node: message.content
-        ? renderTextWithInlineSurfaces(message.content, "content", message.role === "user")
+        ? renderTextWithInlineSurfaces(message.content, "content")
         : null,
     });
   }

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -93,6 +93,51 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("line2");
   });
 
+  test("hardLineBreaks leaves fenced code blocks verbatim (no trailing-space injection)", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "```js\nconst a = 1\nconst b = 2\n```",
+        hardLineBreaks: true,
+      }),
+    );
+
+    // The newline inside the code block must stay a bare newline — a blind
+    // string replace would harden it into "  \n", corrupting the code with
+    // trailing whitespace and/or a <br>.
+    expect(html).toContain("const a = 1\nconst b = 2");
+    expect(html).not.toContain("const a = 1  \n");
+    expect(html.match(/<code[\s\S]*?<\/code>/)?.[0]).not.toContain("<br");
+  });
+
+  test("hardLineBreaks does not break table parsing", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "| a | b |\n| - | - |\n| 1 | 2 |",
+        hardLineBreaks: true,
+      }),
+    );
+
+    // Row-separating newlines are structural, not prose text nodes, so the
+    // table still parses instead of collapsing into a <br>-laden paragraph.
+    expect(html).toContain("<table");
+    expect(html).not.toContain("<br");
+  });
+
+  test("h4-h6 render with bold typography instead of unstyled defaults", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "#### H4\n\n##### H5\n\n###### H6",
+      }),
+    );
+
+    expect(html).toContain("<h4");
+    expect(html).toContain("<h5");
+    expect(html).toContain("<h6");
+    // Every heading override restores bold weight on a canonical size token.
+    expect(html.match(/<h4[^>]*>/)?.[0]).toContain("!font-bold");
+    expect(html.match(/<h6[^>]*>/)?.[0]).toContain("!font-bold");
+  });
+
   test("monetary text is not mangled into math typography", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -192,6 +192,25 @@ function buildMarkdownComponents(
     ol: ({ children }) => (
       <ol className="mb-2 list-decimal pl-5 last:mb-0">{children}</ol>
     ),
+    // h4-h6 are rare in assistant output but must not fall through to
+    // unstyled browser defaults (a Tailwind reset strips their size/weight,
+    // leaving them indistinguishable from body text). Keep them bold on a
+    // descending body scale.
+    h4: ({ children }) => (
+      // typography: off-scale — bold weight override on canonical size
+
+      <h4 className="mb-1 mt-2 text-body-medium-default !font-bold first:mt-0">{children}</h4>
+    ),
+    h5: ({ children }) => (
+      // typography: off-scale — bold weight override on canonical size
+
+      <h5 className="mb-1 mt-2 text-body-small-default !font-bold first:mt-0">{children}</h5>
+    ),
+    h6: ({ children }) => (
+      // typography: off-scale — bold weight override on canonical size
+
+      <h6 className="mb-1 mt-2 text-body-small-default !font-bold text-[var(--content-secondary)] first:mt-0">{children}</h6>
+    ),
     li: ({ children }) => <li className="mb-0.5">{children}</li>,
     a: ({ href, children }) => <LinkComponent href={href}>{children}</LinkComponent>,
     code: ({ className, children, ...props }) => {
@@ -291,13 +310,15 @@ const CURRENCY_AMOUNT =
  */
 const structureParser = unified().use(remarkParse).use(remarkGfm);
 
-function escapeCurrencyDollars(content: string): string {
-  // Fast path: nothing that looks like `$<digit>` means no work to do.
-  if (!/\$\d/.test(content)) return content;
-
+/**
+ * Source offset ranges of every `text` node in `content`, in document order.
+ * Verbatim regions — inline code, fenced code, link/image destinations,
+ * autolinks — are non-`text` nodes, so they are excluded: a rewrite scoped to
+ * these ranges leaves them byte-for-byte intact. Shared by currency escaping
+ * and soft-break conversion so both stay confined to prose.
+ */
+function collectTextRanges(content: string): Array<[number, number]> {
   const tree = structureParser.parse(content);
-
-  // Source offset ranges of every text node, in document order.
   const ranges: Array<[number, number]> = [];
   const collect = (node: { type: string; position?: { start: { offset?: number }; end: { offset?: number } }; children?: unknown[] }) => {
     if (node.type === "text") {
@@ -315,35 +336,63 @@ function escapeCurrencyDollars(content: string): string {
     }
   };
   collect(tree as Parameters<typeof collect>[0]);
-  if (ranges.length === 0) return content;
+  return ranges;
+}
 
+/**
+ * Rebuild `content`, applying `rewrite` to each text-node slice while copying
+ * the verbatim gaps between them (code, links, …) untouched. `rewrite`
+ * receives the slice and its source start offset (for cross-boundary lookups).
+ */
+function rewriteTextSlices(
+  content: string,
+  ranges: Array<[number, number]>,
+  rewrite: (slice: string, start: number) => string,
+): string {
   let result = "";
   let cursor = 0;
   for (const [start, end] of ranges) {
     if (start < cursor) continue; // defensive: never reprocess overlapping spans
     result += content.slice(cursor, start); // verbatim gap (code, links, …)
-    const slice = content.slice(start, end);
-    result += slice.replace(CURRENCY_AMOUNT, (match, amount: string, offset: number) => {
-      const prev = offset > 0 ? slice[offset - 1] : start > 0 ? content[start - 1] : "";
-      if (prev === "$" || prev === "\\") return match;
-      return `\\$${amount}`;
-    });
+    result += rewrite(content.slice(start, end), start);
     cursor = end;
   }
   result += content.slice(cursor);
   return result;
 }
 
+function escapeCurrencyDollars(content: string): string {
+  // Fast path: nothing that looks like `$<digit>` means no work to do.
+  if (!/\$\d/.test(content)) return content;
+  const ranges = collectTextRanges(content);
+  if (ranges.length === 0) return content;
+  return rewriteTextSlices(content, ranges, (slice, start) =>
+    slice.replace(CURRENCY_AMOUNT, (match, amount: string, offset: number) => {
+      const prev = offset > 0 ? slice[offset - 1] : start > 0 ? content[start - 1] : "";
+      if (prev === "$" || prev === "\\") return match;
+      return `\\$${amount}`;
+    }),
+  );
+}
+
 /**
- * Convert lone newlines to CommonMark hard line breaks (two trailing
- * spaces before `\n`) so user-typed Shift+Enter breaks render as `<br>`.
- * Double-newlines (paragraph breaks) are left untouched.
+ * Convert lone newlines to CommonMark hard line breaks (two trailing spaces
+ * before `\n`) so single-`\n` breaks — common in both user-typed Shift+Enter
+ * input and assistant output — render as `<br>` instead of collapsing to a
+ * space.
+ *
+ * Like currency escaping, the rewrite is scoped to `text` nodes. A blind
+ * string replace would also append trailing spaces *inside fenced code blocks*
+ * (corrupting code) and to table-row source; confining it to prose avoids
+ * both. Paragraph breaks (`\n\n`) never appear within a single text node — a
+ * blank line terminates the block — so every `\n` reached here is a soft break
+ * safe to harden.
  */
-function preserveNewlines(text: string): string {
-  // Match runs of consecutive newlines. Single newlines become hard
-  // breaks; runs of 2+ are paragraph separators and stay untouched.
-  // Avoids lookbehind so it works on Safari/WKWebView < 16.4 (iOS 15+).
-  return text.replace(/\n+/g, (m) => (m.length === 1 ? "  \n" : m));
+function hardBreakNewlines(content: string): string {
+  if (!content.includes("\n")) return content;
+  const ranges = collectTextRanges(content);
+  if (ranges.length === 0) return content;
+  return rewriteTextSlices(content, ranges, (slice) => slice.replace(/\n/g, "  \n"));
 }
 
 export interface MarkdownMessageProps {
@@ -370,7 +419,7 @@ export function MarkdownMessage({
 }: MarkdownMessageProps) {
   const processed = useMemo(() => {
     const escaped = escapeCurrencyDollars(content);
-    return hardLineBreaks ? preserveNewlines(escaped) : escaped;
+    return hardLineBreaks ? hardBreakNewlines(escaped) : escaped;
   }, [content, hardLineBreaks]);
   const Link = linkComponent ?? DefaultLink;
   const components = useMemo(() => buildMarkdownComponents(Link), [Link]);


### PR DESCRIPTION
## What

Customer feedback (chris@devpartners.io): line breaks don't render in assistant responses, and basic markup (bold, headers) would be nice. This addresses the line-break gap and rounds out header support.

Rebased onto current main (which already carries the JARVIS-1006 currency work via #32861), so this diff is the 1007 changes only.

## Audit

The renderer (react-markdown + remark-gfm/remark-math) already supported more than the feedback implied:

- Bold / italic / strikethrough: already worked
- Headers `#`-`###`: already styled; `####`-`######` rendered unstyled (Tailwind reset strips browser defaults)
- Hard breaks via trailing two spaces: already worked (CommonMark-native)
- Single-newline hard breaks: enabled for user messages only, gated on `message.role === "user"`, so assistant output collapsed single newlines to a space

So the real gap behind "line breaks don't work" was assistant messages dropping single newlines, plus h4-h6 being indistinguishable from body text.

## Changes

1. Enable single-newline hard breaks for every transcript message, not just user messages. Matches ChatGPT / Claude.ai / Slack conversational rendering. File and surface markdown stay CommonMark-faithful (a `.md` file viewer should not force `<br>`).
2. Replace the blind `preserveNewlines` string replace with `hardBreakNewlines`, which reuses the JARVIS-1006 text-node-range walker so the conversion is confined to prose. The old version injected trailing spaces inside fenced code blocks (corrupting code) and into table-row source; scoping to text nodes leaves code, tables, links, and math byte-for-byte intact.
3. Style h4-h6 as bold headings instead of unstyled defaults.

`collectTextRanges` / `rewriteTextSlices` are extracted as shared helpers; currency escaping keeps identical behavior.

## Streaming caveat

Before this change a typical assistant message did zero preprocessing parses (currency fast-paths out, breaks were off). Now `hardBreakNewlines` runs one bare `remark-parse` per render when the content contains a newline, i.e. once per token during streaming. It is proportionate (roughly 10-20% on top of react-markdown's own full unified pipeline, which already re-parses every token), so not alarming, but it is a real new cost.

Potential follow-up if we want it tighter: merge currency-escape and break-hardening into a single parse/rewrite pass. Collect text ranges once and apply both transforms per slice, removing the second parse entirely. They are kept separate here only to keep currency provably untouched.

## Tests

- design-library markdown-message.test.tsx: added code-block-integrity, table-not-broken, and h4-h6 styling cases
- web transcript-message-body.test.tsx: added assertions that assistant and user messages both receive hard line breaks

Verified multi-line display math, inline math, and lists render correctly under hard breaks (no `<br>` leaks, KaTeX intact, list structure preserved).