### PR TITLE
fix(macos): detect existing self-signed codesign certs and use SHA hash

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -310,6 +310,16 @@ if [ -z "${SIGN_IDENTITY:-}" ]; then
                 | sed 's/.*"\(.*\)"/\1/' || true)
         fi
 
+        # Fall back to an existing self-signed "Vellum Local Development" cert.
+        # These are CSSMERR_TP_NOT_TRUSTED so `-v` hides them; query without
+        # `-v` and use the SHA-1 hash (not the name) to avoid the "ambiguous"
+        # error when duplicate certs exist.
+        if [ -z "$SIGN_IDENTITY" ]; then
+            SIGN_IDENTITY=$(security find-identity -p codesigning 2>/dev/null \
+                | grep "Vellum Local Development" | grep -v "valid identities" | head -1 \
+                | awk '{print $2}' || true)
+        fi
+
         # No valid certificate found — create a self-signed one for local dev.
         # macOS 26+ requires a non-empty codeSigningID for apps that claim
         # security-sensitive entitlements (virtualization, audio-input, etc.).
@@ -395,12 +405,14 @@ CERTEOF
                 fi
                 rm -rf "$_CERT_DIR"
             fi
-            # Pick up the newly-created (or previously-created) cert.
-            # Self-signed certs show as CSSMERR_TP_NOT_TRUSTED which
-            # _valid_codesign_identities excludes, so query without -v.
+            # Pick up the newly-created (or previously-created) cert by SHA-1
+            # hash. Self-signed certs show as CSSMERR_TP_NOT_TRUSTED which
+            # _valid_codesign_identities excludes, so query without -v. Using
+            # the hash (not the name) avoids "ambiguous" errors if duplicate
+            # certs with the same CN exist in the keychain.
             SIGN_IDENTITY=$(security find-identity -p codesigning 2>/dev/null \
                 | grep "$_CERT_CN" | grep -v "valid identities" | head -1 \
-                | sed 's/.*"\(.*\)"/\1/' || true)
+                | awk '{print $2}' || true)
         fi
     fi
 


### PR DESCRIPTION
## Summary
- `build.sh` used `security find-identity -v` which hides untrusted self-signed certs, so every build created a new duplicate "Vellum Local Development" cert
- After enough duplicates accumulate, `codesign` fails with "ambiguous" and the build breaks
- Adds a fallback check without `-v` to find existing self-signed certs before the creation block
- Uses SHA-1 hash instead of cert name for `SIGN_IDENTITY` to avoid ambiguity with duplicates

## Test plan
- [ ] Run `./build.sh build` twice — second run should NOT create a new cert
- [ ] Delete all certs, run `./build.sh build` — should create exactly one cert and sign successfully
- [ ] Run `vel up` from platform repo — macOS build should detect existing cert and skip creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)