### PR TITLE
fix: reject root-equivalent block paths

### DIFF
--- a/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
+++ b/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
@@ -76,6 +76,23 @@ describe("block volume bootstrap scripts", () => {
     );
   });
 
+  test("mount helper normalizes trailing slashes on bind targets", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace///:ro",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("DRY-RUN: mkdir -p /workspace");
+    expect(result.stderr).toContain(
+      "DRY-RUN: mount --bind /mnt/test-root/workspace /workspace",
+    );
+    expect(result.stderr).toContain("DRY-RUN: mount -o remount,bind,ro /workspace");
+    expect(result.stderr).not.toContain("/workspace///");
+  });
+
   test("mount helper logs setpriv execution when uid and gid are set", () => {
     const result = runScript(mountScript, {
       args: ["--", "bun", "run", "src/managed-main.ts"],
@@ -136,6 +153,20 @@ describe("block volume bootstrap scripts", () => {
     expect(result.stderr).toContain("invalid bind mode 'readonly'");
   });
 
+  test("mount helper rejects slash-only bind targets", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:////:ro",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("bind target must not be empty or /");
+    expect(result.stderr).not.toContain("mount --bind");
+    expect(result.stderr).not.toContain("remount,bind,ro");
+  });
+
   test("init helper formats only devices with no filesystem", () => {
     const result = runScript(initScript);
 
@@ -148,6 +179,33 @@ describe("block volume bootstrap scripts", () => {
     expect(result.stderr).not.toContain("/mnt/test-root/gateway-security");
     expect(result.stderr).not.toContain("/mnt/test-root/ces-security");
     expect(result.stderr).toContain("DRY-RUN: chown 0:0 /mnt/test-root/dockerd-data");
+  });
+
+  test("init helper normalizes trailing slashes on block root", () => {
+    const result = runScript(initScript, {
+      env: {
+        VELLUM_BLOCK_ROOT: "/mnt/test-root///",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("DRY-RUN: mkdir -p /mnt/test-root");
+    expect(result.stderr).toContain("DRY-RUN: mount /dev/test-block /mnt/test-root");
+    expect(result.stderr).toContain("DRY-RUN: mkdir -p /mnt/test-root/workspace");
+    expect(result.stderr).not.toContain("/mnt/test-root///");
+  });
+
+  test("init helper rejects slash-only block roots", () => {
+    const result = runScript(initScript, {
+      env: {
+        VELLUM_BLOCK_ROOT: "////",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("VELLUM_BLOCK_ROOT must not be empty or /");
+    expect(result.stderr).not.toContain("wait for block device");
+    expect(result.stderr).not.toContain("mkdir -p");
   });
 
   test("resize helper grows ext4 and prints requested bind path evidence", () => {
@@ -168,6 +226,34 @@ describe("block volume bootstrap scripts", () => {
         "DRY-RUN: df -h /workspace",
       ].join("\n"),
     );
+  });
+
+  test("resize helper normalizes trailing slashes on evidence paths", () => {
+    const result = runScript(resizeScript, {
+      args: ["/workspace///"],
+      env: {
+        VELLUM_BLOCK_DRY_RUN_BLKID_TYPE: "ext4",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("DRY-RUN: findmnt --target /workspace");
+    expect(result.stderr).toContain("DRY-RUN: df -h /workspace");
+    expect(result.stderr).not.toContain("/workspace///");
+  });
+
+  test("resize helper rejects slash-only evidence paths", () => {
+    const result = runScript(resizeScript, {
+      args: ["////"],
+      env: {
+        VELLUM_BLOCK_DRY_RUN_BLKID_TYPE: "ext4",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("bind target must not be empty or /");
+    expect(result.stderr).not.toContain("findmnt --target");
+    expect(result.stderr).not.toContain("df -h");
   });
 
   test("resize helper rejects non-ext4 filesystems", () => {

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
@@ -52,6 +52,27 @@ block_validate_number() {
   esac
 }
 
+block_normalize_absolute_non_root_path() {
+  name="$1"
+  path="$2"
+
+  case "${path}" in
+    '') block_die "${name} must not be empty or /" ;;
+    /*) ;;
+    *) block_die "${name} must be an absolute path" ;;
+  esac
+
+  while :; do
+    case "${path}" in
+      */) path="${path%/}" ;;
+      *) break ;;
+    esac
+  done
+
+  [ -n "${path}" ] || block_die "${name} must not be empty or /"
+  printf '%s\n' "${path}"
+}
+
 block_detect_fs_type() {
   if block_is_dry_run; then
     block_dry_run "blkid -o value -s TYPE ${BLOCK_DEVICE}"
@@ -70,18 +91,7 @@ block_init_defaults() {
     *) block_die "VELLUM_BLOCK_DEVICE must be an absolute path" ;;
   esac
 
-  case "${BLOCK_ROOT}" in
-    ''|/) block_die "VELLUM_BLOCK_ROOT must not be empty or /" ;;
-    /*) ;;
-    *) block_die "VELLUM_BLOCK_ROOT must be an absolute path" ;;
-  esac
-
-  while [ "${BLOCK_ROOT}" != "/" ]; do
-    case "${BLOCK_ROOT}" in
-      */) BLOCK_ROOT="${BLOCK_ROOT%/}" ;;
-      *) break ;;
-    esac
-  done
+  BLOCK_ROOT="$(block_normalize_absolute_non_root_path "VELLUM_BLOCK_ROOT" "${BLOCK_ROOT}")"
 }
 
 block_validate_child_name() {
@@ -98,13 +108,9 @@ block_child_path() {
   printf '%s/%s\n' "${BLOCK_ROOT}" "$1"
 }
 
-block_validate_target_path() {
+block_normalize_target_path() {
   target="$1"
-  case "${target}" in
-    ''|/) block_die "bind target must not be empty or /" ;;
-    /*) ;;
-    *) block_die "bind target '${target}' must be an absolute path" ;;
-  esac
+  block_normalize_absolute_non_root_path "bind target" "${target}"
 }
 
 block_wait_for_device() {
@@ -175,7 +181,7 @@ block_parse_bind_spec() {
   fi
 
   block_validate_child_name "${BIND_SOURCE_NAME}"
-  block_validate_target_path "${BIND_TARGET}"
+  BIND_TARGET="$(block_normalize_target_path "${BIND_TARGET}")"
   case "${BIND_MODE}" in
     ro|rw) ;;
     *) block_die "invalid bind mode '${BIND_MODE}' in '${spec}'; expected ro or rw" ;;

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-resize.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-resize.sh
@@ -9,7 +9,7 @@ block_print_resize_evidence() {
   path="$1"
   [ -n "${path}" ] || return 0
 
-  block_validate_target_path "${path}"
+  path="$(block_normalize_target_path "${path}")"
   block_run "findmnt --target ${path}" findmnt --target "${path}"
   block_run "df -h ${path}" df -h "${path}"
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** Slash-only block root and bind/evidence paths could resolve to `/`.
**What was expected:** Helper validation rejects root-equivalent paths before mkdir, mount, remount, resize evidence, or chown operations.
**What was found:** Inputs like `////` bypassed exact `/` checks.