### PR TITLE
fix(streaming): harden transport-recovery reconcile + clarify burst-limiter scope

### DIFF
--- a/apps/web/src/domains/chat/streaming/reachability-burst-limiter.ts
+++ b/apps/web/src/domains/chat/streaming/reachability-burst-limiter.ts
@@ -1,5 +1,5 @@
 /**
- * Conversation-scoped reachability retry burst-limiter.
+ * Reachability retry burst-limiter.
  *
  * When the reachability probe flips to `"ready"` or `"retrying"`, we
  * want the bus to bounce its SSE connection so the conversation-scoped
@@ -10,6 +10,13 @@
  * Stateful (burst count + window start). Plain module, no React. The
  * caller drives it via `handleReachabilityPhase(phase)` from a
  * `useEffect` keyed on the probe phase.
+ *
+ * Scope: the budget is hook-instance-scoped (the caller creates one
+ * limiter per `useEventStream` mount via `useRef` lazy-init). It is
+ * NOT per-conversation — a conversation switch within the same hook
+ * instance keeps the existing budget. In practice this matches the
+ * 10s burst window: a budget burned on conversation A doesn't
+ * "follow" the user to conversation B beyond the rolling window.
  *
  * Side effects:
  *   - on success (within budget, `"ready"` phase): clears turn state

--- a/apps/web/src/domains/chat/streaming/reconcile-on-reopen.test.ts
+++ b/apps/web/src/domains/chat/streaming/reconcile-on-reopen.test.ts
@@ -16,10 +16,11 @@ mock.module("@/lib/diagnostics", () => ({
 
 const addBreadcrumbMock = mock(() => {});
 const captureMessageMock = mock(() => {});
+const captureExceptionMock = mock(() => {});
 mock.module("@sentry/react", () => ({
   addBreadcrumb: addBreadcrumbMock,
   captureMessage: captureMessageMock,
-  captureException: () => {},
+  captureException: captureExceptionMock,
 }));
 
 const { createReconcileOnReopen } = await import(
@@ -67,6 +68,7 @@ beforeEach(() => {
   recordDiagnosticMock.mockClear();
   addBreadcrumbMock.mockClear();
   captureMessageMock.mockClear();
+  captureExceptionMock.mockClear();
 });
 
 describe("reconcile-on-reopen — gating", () => {
@@ -201,5 +203,52 @@ describe("reconcile-on-reopen — transport recovery (watchdog / error)", () => 
 
     expect(addBreadcrumbMock).not.toHaveBeenCalled();
     expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("standalone reconcile rejection: logs to Sentry, does not run the loop, does not propagate", async () => {
+    // No sync router, so the code falls back to `reconcileActive()`.
+    // That fallback rejects; the handler must log + bail without
+    // touching `startReconciliationLoop` or surfacing an unhandled
+    // promise rejection.
+    const reconcileActive = mock(async () => {
+      throw new Error("daemon unreachable");
+    });
+    const { deps, startReconciliationLoop } = makeDeps({ reconcileActive });
+    const handler = createReconcileOnReopen(deps);
+
+    handler.handleSseOpened({ assistantId: "asst-1", cause: "watchdog" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reconcileActive).toHaveBeenCalledTimes(1);
+    expect(startReconciliationLoop).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("sync-router dispatchReconnect rejection: logs to Sentry, does not fall back to reconcileActive, does not run the loop", async () => {
+    const dispatchReconnect = mock(async () => {
+      throw new Error("sync router transport failed");
+    });
+    const reconcileActive = mock(async () => makeReconcileResult());
+    const { deps, startReconciliationLoop } = makeDeps({
+      reconcileActive,
+      syncRouterRef: {
+        current: { dispatchReconnect } as unknown as WebSyncRouter,
+      },
+    });
+    const handler = createReconcileOnReopen(deps);
+
+    handler.handleSseOpened({ assistantId: "asst-1", cause: "error" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(dispatchReconnect).toHaveBeenCalledTimes(1);
+    // The standalone fallback is in the SAME try block as the sync-
+    // router call; both await targets sit on the same try, so a sync-
+    // router rejection short-circuits before `reconcileActive` is
+    // reached. Important: the failure mode is "transport recovery
+    // failed", not "let's try the other path."
+    expect(reconcileActive).not.toHaveBeenCalled();
+    expect(startReconciliationLoop).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/domains/chat/streaming/reconcile-on-reopen.ts
+++ b/apps/web/src/domains/chat/streaming/reconcile-on-reopen.ts
@@ -100,10 +100,41 @@ async function runTransportRecoveryReconcile(
     cause,
   });
   const startedAt = Date.now();
-  const syncReconnectResult = await syncRouterRef.current?.dispatchReconnect();
-  const reconcileResult =
-    syncReconnectResult?.activeConversationMessages ??
-    (await deps.reconcileActive());
+  let reconcileResult: ActiveConversationMessagesRefreshResult;
+  // Both paths to the reconcile result can reject: the sync router's
+  // `dispatchReconnect()` and the standalone `reconcileActive()`
+  // fallback. Failure here is a transport-recovery failure — log it and
+  // bail. Without the catch, the rejection would surface as an
+  // unhandled promise rejection because the bus subscriber that calls
+  // us is `void`-firing this fn. The stale-epoch guard below would
+  // never run, and the bus's next reopen would have no idea anything
+  // went wrong.
+  try {
+    const syncReconnectResult =
+      await syncRouterRef.current?.dispatchReconnect();
+    reconcileResult =
+      syncReconnectResult?.activeConversationMessages ??
+      (await deps.reconcileActive());
+  } catch (err) {
+    recordDiagnostic("sse_post_reconnect_reconcile_failed", {
+      assistantId,
+      conversationId,
+      epoch,
+      cause,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    Sentry.captureException(err, {
+      level: "warning",
+      tags: {
+        context: "sse_transport_recovery",
+        cause,
+        platform: resolvePlatformTag(),
+      },
+      extra: { assistantId, conversationId, epoch },
+    });
+    return;
+  }
+
   // Stale-epoch guard: two close-together reopens can race — if a
   // newer sse.opened has bumped the epoch while we were awaiting,
   // this completion is for a superseded epoch and must not touch the
@@ -123,7 +154,13 @@ async function runTransportRecoveryReconcile(
   }
   deps.startReconciliationLoop(epoch);
   if (cause !== "watchdog") return;
-  recordWatchdogRescue(assistantId, conversationId, epoch, startedAt, reconcileResult);
+  recordWatchdogRescue(
+    assistantId,
+    conversationId,
+    epoch,
+    startedAt,
+    reconcileResult,
+  );
 }
 
 function recordWatchdogRescue(


### PR DESCRIPTION
## Summary

Two follow-ups Vex flagged on the LUM-2104 review (#32872):

1. **`runTransportRecoveryReconcile` had no error handling.** Both `dispatchReconnect()` (sync router) and `reconcileActive()` (standalone fallback) can reject. The function is `void`-fired from a bus subscriber, so rejections surfaced as unhandled promise rejections — the stale-epoch guard and Sentry rescue telemetry never ran, and the bus's next reopen had no idea anything failed. Pre-existing behavior (same in the old inline closure), but worth hardening now that the recovery path is its own module with a clear seam.

2. **Burst-limiter docstring framed the scope as "conversation-scoped"** but it's actually hook-instance-scoped. The caller creates one limiter per `useEventStream` mount via `useRef` lazy-init. A conversation switch within the same hook instance keeps the existing budget. In practice this matches the 10s burst window (a budget burned on conv A doesn't "follow" the user to conv B beyond the rolling window), but the docstring should describe what's true.

## Changes

**`reconcile-on-reopen.ts`** — Both awaits wrapped in a single `try` block. On error: `sse_post_reconnect_reconcile_failed` diagnostic + Sentry warning with the same `assistantId`/`conversationId`/`epoch`/`cause` extras the success path emits, then bail. No `startReconciliationLoop`, no watchdog rescue capture — those are only meaningful on success.

**`reconcile-on-reopen.test.ts`** — Two new tests:
- standalone `reconcileActive` rejection: logs to Sentry, doesn't run the loop, doesn't propagate.
- sync-router `dispatchReconnect` rejection: logs to Sentry, **does NOT fall back** to standalone (deliberate — failure mode is "transport recovery failed", not "try the other path"), doesn't run the loop.

**`reachability-burst-limiter.ts`** — Docstring updated: dropped the "conversation-scoped" framing from the heading; added an explicit "Scope" paragraph that contrasts hook-instance vs per-conversation.

## Test plan

- [x] `bun test src/domains/chat/streaming/` — 27/27 pass (was 25 + 2 new error-path tests)
- [x] `bunx tsc --noEmit` — clean on touched files
- [ ] Manual: induce a `dispatchReconnect()` failure during watchdog reconnect → no unhandled rejection in console, Sentry receives the warning.

## Audit-framed notes

- **Behavioral preservation**: success-path behavior is unchanged. Only the error path is newly defined — previously was an unhandled promise rejection, now it's a logged-and-bailed path.
- **Coupling**: the choice to NOT fall back from sync-router failure to standalone reconcile is deliberate and called out in the test name. If we ever want a try-the-other-path policy, that's a separate design decision and should land with its own test.
- **No new types, no new dependencies, no convention impact.**


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_