### PR TITLE
fix: verify block mount paths and sources

### DIFF
--- a/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
+++ b/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
@@ -167,6 +167,117 @@ describe("block volume bootstrap scripts", () => {
     expect(result.stderr).not.toContain("remount,bind,ro");
   });
 
+  test("mount helper rejects dot-segment block roots", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_ROOT: "/mnt/..",
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:rw",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "VELLUM_BLOCK_ROOT must not contain . or .. path components",
+    );
+    expect(result.stderr).not.toContain("wait for block device");
+    expect(result.stderr).not.toContain("mkdir -p");
+  });
+
+  test("mount helper rejects dot-segment bind targets", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS:
+          "workspace:/workspace/../gateway-security:rw",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "bind target must not contain . or .. path components",
+    );
+    expect(result.stderr).not.toContain("wait for block device");
+    expect(result.stderr).not.toContain("mount --bind");
+  });
+
+  test("mount helper rejects existing block roots from the wrong source", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:rw",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED: "1",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET: "/mnt/test-root",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE: "/dev/wrong-block",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS: "rw,relatime",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "/mnt/test-root is mounted from /dev/wrong-block; expected /dev/test-block",
+    );
+    expect(result.stderr).not.toContain("mount --bind");
+    expect(result.stderr).not.toContain("exec true");
+  });
+
+  test("mount helper rejects existing bind targets from the wrong source", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:rw",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED: "1",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET: "/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE: "/mnt/test-root/other",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS: "rw,relatime",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "/workspace is mounted from /mnt/test-root/other; expected /mnt/test-root/workspace",
+    );
+    expect(result.stderr).not.toContain("exec true");
+  });
+
+  test("mount helper accepts matching existing bind targets", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:rw",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED: "1",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET: "/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE: "/dev/test-block",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_FSROOT: "/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS: "rw,relatime",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("/workspace is already mounted");
+    expect(result.stderr).not.toContain("mount --bind /mnt/test-root/workspace /workspace");
+    expect(result.stderr).toContain("DRY-RUN: exec true");
+  });
+
+  test("mount helper rejects stale read-only binds when rw is requested", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:rw",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED: "1",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET: "/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE: "/mnt/test-root/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS: "ro,relatime",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "/workspace is mounted with options ro,relatime; expected rw",
+    );
+    expect(result.stderr).not.toContain("exec true");
+  });
+
   test("init helper formats only devices with no filesystem", () => {
     const result = runScript(initScript);
 
@@ -252,6 +363,23 @@ describe("block volume bootstrap scripts", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("bind target must not be empty or /");
+    expect(result.stderr).not.toContain("findmnt --target");
+    expect(result.stderr).not.toContain("df -h");
+  });
+
+  test("resize helper rejects dot-segment evidence paths", () => {
+    const result = runScript(resizeScript, {
+      args: ["/workspace/.."],
+      env: {
+        VELLUM_BLOCK_DRY_RUN_BLKID_TYPE: "ext4",
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "bind target must not contain . or .. path components",
+    );
+    expect(result.stderr).not.toContain("resize2fs");
     expect(result.stderr).not.toContain("findmnt --target");
     expect(result.stderr).not.toContain("df -h");
   });

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-common.sh
@@ -70,6 +70,11 @@ block_normalize_absolute_non_root_path() {
   done
 
   [ -n "${path}" ] || block_die "${name} must not be empty or /"
+  case "${path}" in
+    */./*|*/../*|*/.|*/..)
+      block_die "${name} must not contain . or .. path components"
+      ;;
+  esac
   printf '%s\n' "${path}"
 }
 
@@ -137,18 +142,121 @@ block_ensure_dir() {
   block_run "mkdir -p ${path}" mkdir -p "${path}"
 }
 
-block_find_mountpoint() {
+block_find_mount_details() {
   target="$1"
+  BLOCK_MOUNT_SOURCE=""
+  BLOCK_MOUNT_OPTIONS=""
+  BLOCK_MOUNT_FSROOT=""
+
   if block_is_dry_run; then
     block_dry_run "findmnt --mountpoint ${target}"
+    if [ "${VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED:-}" != "1" ]; then
+      return 1
+    fi
+    if [ -n "${VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET:-}" ] &&
+      [ "${VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET}" != "${target}" ]; then
+      return 1
+    fi
+    BLOCK_MOUNT_SOURCE="${VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE:-}"
+    BLOCK_MOUNT_OPTIONS="${VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS:-}"
+    BLOCK_MOUNT_FSROOT="${VELLUM_BLOCK_DRY_RUN_FINDMNT_FSROOT:-}"
+    [ -n "${BLOCK_MOUNT_SOURCE}" ] || block_die "unable to determine mount source for ${target}"
+    [ -n "${BLOCK_MOUNT_OPTIONS}" ] || block_die "unable to determine mount options for ${target}"
+    return 0
+  fi
+
+  if ! findmnt --mountpoint "${target}" >/dev/null 2>&1; then
     return 1
   fi
-  findmnt --mountpoint "${target}" >/dev/null 2>&1
+
+  BLOCK_MOUNT_SOURCE="$(findmnt -rn -o SOURCE --mountpoint "${target}" 2>/dev/null || true)"
+  BLOCK_MOUNT_OPTIONS="$(findmnt -rn -o OPTIONS --mountpoint "${target}" 2>/dev/null || true)"
+  BLOCK_MOUNT_FSROOT="$(findmnt -rn -o FSROOT --mountpoint "${target}" 2>/dev/null || true)"
+  [ -n "${BLOCK_MOUNT_SOURCE}" ] || block_die "unable to determine mount source for ${target}"
+  [ -n "${BLOCK_MOUNT_OPTIONS}" ] || block_die "unable to determine mount options for ${target}"
+  return 0
+}
+
+block_sources_match() {
+  expected="$1"
+  actual="$2"
+  [ "${expected}" = "${actual}" ] && return 0
+  [ "${expected}[/]" = "${actual}" ] && return 0
+
+  if ! block_is_dry_run && command -v readlink >/dev/null 2>&1; then
+    expected_real="$(readlink -f "${expected}" 2>/dev/null || true)"
+    actual_real="$(readlink -f "${actual}" 2>/dev/null || true)"
+    if [ -n "${expected_real}" ] && [ -n "${actual_real}" ] &&
+      [ "${expected_real}" = "${actual_real}" ]; then
+      return 0
+    fi
+    if [ -n "${expected_real}" ] && [ "${expected_real}[/]" = "${actual}" ]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+block_mount_source_matches_device_fsroot() {
+  source_name="$1"
+  actual_source="$2"
+  actual_fsroot="$3"
+  expected_fsroot="/${source_name}"
+
+  if block_sources_match "${BLOCK_DEVICE}" "${actual_source}" &&
+    [ "${actual_fsroot}" = "${expected_fsroot}" ]; then
+    return 0
+  fi
+  if [ "${actual_source}" = "${BLOCK_DEVICE}[${expected_fsroot}]" ]; then
+    return 0
+  fi
+
+  if ! block_is_dry_run && command -v readlink >/dev/null 2>&1; then
+    device_real="$(readlink -f "${BLOCK_DEVICE}" 2>/dev/null || true)"
+    if [ -n "${device_real}" ] &&
+      [ "${actual_source}" = "${device_real}[${expected_fsroot}]" ]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+block_mount_options_include_mode() {
+  options="$1"
+  mode="$2"
+  case ",${options}," in
+    *",${mode},"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+block_verify_mount_source() {
+  target="$1"
+  expected_source="$2"
+  actual_source="$3"
+
+  if ! block_sources_match "${expected_source}" "${actual_source}"; then
+    block_die "${target} is mounted from ${actual_source}; expected ${expected_source}"
+  fi
+}
+
+block_verify_mount_mode() {
+  target="$1"
+  expected_mode="$2"
+  actual_options="$3"
+
+  if ! block_mount_options_include_mode "${actual_options}" "${expected_mode}"; then
+    block_die "${target} is mounted with options ${actual_options}; expected ${expected_mode}"
+  fi
 }
 
 block_mount_root() {
   block_ensure_dir "${BLOCK_ROOT}"
-  if block_find_mountpoint "${BLOCK_ROOT}"; then
+  if block_find_mount_details "${BLOCK_ROOT}"; then
+    block_verify_mount_source "${BLOCK_ROOT}" "${BLOCK_DEVICE}" "${BLOCK_MOUNT_SOURCE}"
+    block_verify_mount_mode "${BLOCK_ROOT}" "rw" "${BLOCK_MOUNT_OPTIONS}"
     block_log "${BLOCK_ROOT} is already mounted"
     return 0
   fi

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
@@ -14,7 +14,12 @@ block_mount_bind_spec() {
   block_ensure_dir "${source_path}"
   block_ensure_dir "${target}"
 
-  if block_find_mountpoint "${target}"; then
+  if block_find_mount_details "${target}"; then
+    if ! block_sources_match "${source_path}" "${BLOCK_MOUNT_SOURCE}" &&
+      ! block_mount_source_matches_device_fsroot "${source_name}" "${BLOCK_MOUNT_SOURCE}" "${BLOCK_MOUNT_FSROOT}"; then
+      block_die "${target} is mounted from ${BLOCK_MOUNT_SOURCE}; expected ${source_path}"
+    fi
+    block_verify_mount_mode "${target}" "${mode}" "${BLOCK_MOUNT_OPTIONS}"
     block_log "${target} is already mounted"
   else
     block_run "mount --bind ${source_path} ${target}" mount --bind "${source_path}" "${target}"
@@ -88,6 +93,7 @@ done
 [ "$#" -gt 0 ] || block_die "service command is required after --"
 
 block_validate_exec_env
+block_for_each_bind_spec "${VELLUM_BLOCK_BIND_SPECS:-}" :
 block_wait_for_device
 block_mount_root
 block_for_each_bind_spec "${VELLUM_BLOCK_BIND_SPECS:-}" block_mount_bind_spec

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-resize.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-resize.sh
@@ -9,7 +9,6 @@ block_print_resize_evidence() {
   path="$1"
   [ -n "${path}" ] || return 0
 
-  path="$(block_normalize_target_path "${path}")"
   block_run "findmnt --target ${path}" findmnt --target "${path}"
   block_run "df -h ${path}" df -h "${path}"
 }
@@ -23,6 +22,9 @@ if [ "$#" -gt 1 ]; then
 fi
 if [ "$#" -eq 1 ]; then
   evidence_path="$1"
+fi
+if [ -n "${evidence_path}" ]; then
+  evidence_path="$(block_normalize_target_path "${evidence_path}")"
 fi
 
 block_wait_for_device


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** Dot-segment paths could escape non-root validation, and existing mountpoints were accepted without source/mode checks.
**What was expected:** Block helpers reject parent-escaping paths and verify existing mounts match the expected device/source and access mode.
**What was found:** Inputs like /mnt/.. passed validation, and any pre-existing mountpoint was treated as success.