### PR TITLE
fix(ci): don't report superseded web CI runs as failures

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -103,7 +103,7 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     needs: [lint, typecheck, test]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate results


### PR DESCRIPTION
## Summary
- Changed the `checks` aggregate job from `if: always()` to `if: ${{ !cancelled() }}` in the main web CI/CD workflow
- This prevents superseded runs (cancelled by `cancel-in-progress: true`) from being reported as failures — they show as "cancelled" instead, which the Slack notification handler already treats correctly (no ping)
- Real failures still aggregate and report correctly since `!cancelled()` still runs the job when sub-jobs fail

## Original prompt
Fix CI failures on main — the CI/CD Main Web workflow was reporting failures when runs were cancelled by `cancel-in-progress`. The tests were actually passing (201/201) but the jobs got cancelled mid-run by a newer commit push, and the `if: always()` checks job converted the `cancelled` status into a failure.