### PR TITLE
fix(streaming): catch the resume-path reconcile rejection in reconcile-on-reopen

### DIFF
--- a/apps/web/src/domains/chat/streaming/reconcile-on-reopen.test.ts
+++ b/apps/web/src/domains/chat/streaming/reconcile-on-reopen.test.ts
@@ -109,6 +109,29 @@ describe("reconcile-on-reopen — resume cause", () => {
     expect(reconcileActive).toHaveBeenCalledTimes(1);
     expect(startReconciliationLoop).toHaveBeenCalledWith(1);
   });
+
+  test("reconcile rejection: logs to Sentry, does NOT block the loop start, does not propagate", async () => {
+    // Resume path is parallel-fire by design — the loop is the
+    // primary catch-up mechanism, so a one-shot reconcile failure
+    // shouldn't stop it from running. The catch just logs the
+    // rejection instead of letting it surface as an unhandled
+    // promise rejection.
+    const reconcileActive = mock(async () => {
+      throw new Error("daemon timeout");
+    });
+    const { deps, startReconciliationLoop } = makeDeps({ reconcileActive });
+    const handler = createReconcileOnReopen(deps);
+
+    handler.handleSseOpened({ assistantId: "asst-1", cause: "resume" });
+
+    // Loop start is synchronous and unconditional.
+    expect(startReconciliationLoop).toHaveBeenCalledWith(1);
+
+    // Let the rejected promise settle so the .catch fires.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("reconcile-on-reopen — transport recovery (watchdog / error)", () => {

--- a/apps/web/src/domains/chat/streaming/reconcile-on-reopen.ts
+++ b/apps/web/src/domains/chat/streaming/reconcile-on-reopen.ts
@@ -80,8 +80,32 @@ export function createReconcileOnReopen(
         void runTransportRecoveryReconcile(deps, epoch, cause);
         return;
       }
-      // `"resume"` and any future non-fresh cause.
-      void deps.reconcileActive();
+      // `"resume"` and any future non-fresh cause. Reconcile and
+      // loop-start fire in parallel: the loop's polling is the
+      // primary catch-up mechanism, so we don't gate it on the
+      // best-effort one-shot reconcile. A rejected reconcile gets
+      // logged + dropped — without the `.catch` it would surface
+      // as an unhandled promise rejection (same shape as the
+      // transport-recovery hardening in this module, just with
+      // parallel-fire instead of sequential).
+      void deps.reconcileActive().catch((err) => {
+        recordDiagnostic("sse_post_reconnect_reconcile_failed", {
+          assistantId,
+          conversationId,
+          epoch,
+          cause,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        Sentry.captureException(err, {
+          level: "warning",
+          tags: {
+            context: "sse_resume_reconcile",
+            cause,
+            platform: resolvePlatformTag(),
+          },
+          extra: { assistantId, conversationId, epoch },
+        });
+      });
       deps.startReconciliationLoop(epoch);
     },
   };


### PR DESCRIPTION
## Summary

Finishes the error-handling pass on `reconcile-on-reopen.ts` that started in #32891. Vex flagged this as a non-blocking follow-up: the `"resume"` cause's `void deps.reconcileActive()` is fire-and-forget without error handling, so a rejection surfaces as an unhandled promise rejection — same shape as the watchdog/error path I just fixed.

After this PR, the entire module is error-safe, not just half of it.

## What this does

Wraps `deps.reconcileActive()` in the resume path with `.catch()` that:
- Records `sse_post_reconnect_reconcile_failed` diagnostic (same name + context as the transport-recovery path for log uniformity).
- Captures the exception to Sentry at `warning` level with `context: "sse_resume_reconcile"` tag (distinct from the transport-recovery `"sse_transport_recovery"` so dashboards can split the two).

**Deliberately preserves the parallel-fire semantics** instead of converting to sequential `await`-then-loop:

```ts
void deps.reconcileActive().catch((err) => { /* log */ });
deps.startReconciliationLoop(epoch);
```

The loop start is the primary catch-up mechanism on resume; a one-shot reconcile failure shouldn't stop polling from running. This is a different shape from the transport-recovery path (which DOES gate the loop on reconcile success, because there it's the rescue) — the asymmetry is intentional and documented in code.

## Test plan

- [x] `bun test src/domains/chat/streaming/reconcile-on-reopen.test.ts` — 11/11 pass (was 10 + 1 new).
- [x] New test verifies: loop start still called synchronously with bumped epoch even when reconcileActive rejects, Sentry receives one captureException once the rejection settles.
- [x] `bunx tsc --noEmit` clean on touched files.

## Audit-framed notes

- **Behavioral preservation**: loop-start behavior unchanged. Only the previously-implicit "unhandled rejection if reconcile fails" path is now explicitly logged-and-dropped.
- **No new dependencies, no new types, no convention impact.**
- **Asymmetry with transport-recovery path is by design**, called out in the inline comment.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZ4p8AkqDQMSavHvWfioe)_