### PR TITLE
fix: hide block root before service exec

### DIFF
--- a/docs/kata-block-mode-image-contract.md
+++ b/docs/kata-block-mode-image-contract.md
@@ -5,7 +5,7 @@ Block mode is an opt-in deployment shape rendered by vembda. The service images 
 In block mode, vembda exposes the raw PVC block device to the relevant container and wraps the normal service command with one of the helper scripts installed at `/usr/local/bin/`:
 
 - `vellum-block-volume-init.sh` initializes the shared ext4 filesystem once.
-- `vellum-block-volume-mount.sh -- <service command...>` mounts the ext4 root, bind-mounts service subdirectories, optionally drops privileges, and then executes the service command.
+- `vellum-block-volume-mount.sh -- <service command...>` mounts the ext4 root, bind-mounts service subdirectories, unmounts the staging root, optionally drops privileges, and then executes the service command.
 - `vellum-block-volume-resize.sh [bind-path]` verifies the raw device is ext4, runs `resize2fs`, and optionally prints `findmnt` and `df -h` evidence for a bind path after resize.
 
 ## Required Environment
@@ -45,6 +45,8 @@ Gateway security material (`/gateway-security`), CES credential/security materia
 The block-volume helper does not provide cryptographic isolation between subdirectories. Any container with access to the raw block device can mount the entire ext4 filesystem, so vembda must not treat bind-mounted paths as a hard security boundary. Block mode is a storage-layout optimization for Kata-family isolation, not a substitute for per-service secrets ownership or separate security volumes.
 
 Block-mode app containers that invoke `vellum-block-volume-mount.sh` must start the helper as root so it can mount the raw block device and bind targets. For images that normally run as a non-root user, vembda must set `VELLUM_BLOCK_EXEC_UID=1001` and `VELLUM_BLOCK_EXEC_GID=1001` so the helper drops to that user before executing the service command.
+
+After service bind mounts are established, `vellum-block-volume-mount.sh` unmounts `VELLUM_BLOCK_ROOT` before executing the service. App processes must use their declared bind targets and must not rely on the staging root remaining available.
 
 ## Resize Flow
 

--- a/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
+++ b/packages/block-volume-bootstrap/__tests__/block-volume-bootstrap.test.ts
@@ -71,6 +71,7 @@ describe("block volume bootstrap scripts", () => {
         "DRY-RUN: findmnt --mountpoint /workspace",
         "DRY-RUN: mount --bind /mnt/test-root/workspace /workspace",
         "DRY-RUN: mount -o remount,bind,ro /workspace",
+        "DRY-RUN: umount /mnt/test-root",
         "DRY-RUN: exec bun run src/index.ts",
       ].join("\n"),
     );
@@ -107,6 +108,22 @@ describe("block volume bootstrap scripts", () => {
     expect(result.stderr).toContain(
       "DRY-RUN: exec setpriv --reuid 1001 --regid 1001 --clear-groups -- bun run src/managed-main.ts",
     );
+  });
+
+  test("mount helper hides the staging root before service exec", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "bun", "run", "src/index.ts"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:ro",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const hideRootIndex = result.stderr.indexOf("DRY-RUN: umount /mnt/test-root");
+    const execIndex = result.stderr.indexOf("DRY-RUN: exec bun run src/index.ts");
+    expect(hideRootIndex).toBeGreaterThan(-1);
+    expect(execIndex).toBeGreaterThan(-1);
+    expect(hideRootIndex).toBeLessThan(execIndex);
   });
 
   test("mount helper rejects uid-only privilege drops", () => {
@@ -256,6 +273,25 @@ describe("block volume bootstrap scripts", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain("/workspace is already mounted");
     expect(result.stderr).not.toContain("mount --bind /mnt/test-root/workspace /workspace");
+    expect(result.stderr).toContain("DRY-RUN: exec true");
+  });
+
+  test("mount helper repairs matching read-write binds when read-only is requested", () => {
+    const result = runScript(mountScript, {
+      args: ["--", "true"],
+      env: {
+        VELLUM_BLOCK_BIND_SPECS: "workspace:/workspace:ro",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_MOUNTED: "1",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_TARGET: "/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_SOURCE: "/mnt/test-root/workspace",
+        VELLUM_BLOCK_DRY_RUN_FINDMNT_OPTIONS: "rw,relatime",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("/workspace is mounted rw; remounting ro");
+    expect(result.stderr).not.toContain("mount --bind /mnt/test-root/workspace /workspace");
+    expect(result.stderr).toContain("DRY-RUN: mount -o remount,bind,ro /workspace");
     expect(result.stderr).toContain("DRY-RUN: exec true");
   });
 

--- a/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
+++ b/packages/block-volume-bootstrap/scripts/vellum-block-volume-mount.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 block_mount_bind_spec() {
   source_name="$1"
   target="$2"
-  mode="$3"
+  requested_mode="$3"
   source_path="$(block_child_path "${source_name}")"
 
   block_ensure_dir "${source_path}"
@@ -19,15 +19,27 @@ block_mount_bind_spec() {
       ! block_mount_source_matches_device_fsroot "${source_name}" "${BLOCK_MOUNT_SOURCE}" "${BLOCK_MOUNT_FSROOT}"; then
       block_die "${target} is mounted from ${BLOCK_MOUNT_SOURCE}; expected ${source_path}"
     fi
-    block_verify_mount_mode "${target}" "${mode}" "${BLOCK_MOUNT_OPTIONS}"
-    block_log "${target} is already mounted"
+    if [ "${requested_mode}" = "rw" ]; then
+      block_verify_mount_mode "${target}" "rw" "${BLOCK_MOUNT_OPTIONS}"
+      block_log "${target} is already mounted"
+    elif block_mount_options_include_mode "${BLOCK_MOUNT_OPTIONS}" "ro"; then
+      block_log "${target} is already mounted"
+    elif block_mount_options_include_mode "${BLOCK_MOUNT_OPTIONS}" "rw"; then
+      block_log "${target} is mounted rw; remounting ro"
+    else
+      block_verify_mount_mode "${target}" "ro" "${BLOCK_MOUNT_OPTIONS}"
+    fi
   else
     block_run "mount --bind ${source_path} ${target}" mount --bind "${source_path}" "${target}"
   fi
 
-  if [ "${mode}" = "ro" ]; then
+  if [ "${requested_mode}" = "ro" ]; then
     block_run "mount -o remount,bind,ro ${target}" mount -o remount,bind,ro "${target}"
   fi
+}
+
+block_hide_root_before_exec() {
+  block_run "umount ${BLOCK_ROOT}" umount "${BLOCK_ROOT}"
 }
 
 block_join_command() {
@@ -97,4 +109,5 @@ block_for_each_bind_spec "${VELLUM_BLOCK_BIND_SPECS:-}" :
 block_wait_for_device
 block_mount_root
 block_for_each_bind_spec "${VELLUM_BLOCK_BIND_SPECS:-}" block_mount_bind_spec
+block_hide_root_before_exec
 block_exec_service "$@"


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** The shared block root stayed accessible after bind setup, and repairable partial read-only bind mounts were rejected.
**What was expected:** App containers cannot bypass bind specs via the staging root, and interrupted `ro` bind setup is repaired idempotently.
**What was found:** Services could traverse `VELLUM_BLOCK_ROOT`, and matching-source `rw` binds were rejected before `ro` remount repair.