### PR TITLE
fix: document CES block workspace env

### DIFF
--- a/credential-executor/README.md
+++ b/credential-executor/README.md
@@ -7,3 +7,10 @@ Credential Execution Service (CES) package for managed credential storage and au
 The runtime image runs as non-root user `ces` (uid 1001) by default.
 
 For Kata-family block-mode deployments, see the canonical [Kata Block-Mode Image Contract](../docs/kata-block-mode-image-contract.md). CES block mode uses the non-security bind specs `ces-data:/ces-data:rw;workspace:/workspace:ro`; `/ces-security` remains on a separate CES-owned security volume or equivalent platform-provisioned storage.
+
+The CES service container must also set:
+
+| Variable | Value | Purpose |
+| --- | --- | --- |
+| `VELLUM_WORKSPACE_DIR` | `/workspace` | Use the read-only workspace bind for command execution. |
+| `CREDENTIAL_SECURITY_DIR` | `/ces-security` | Keep credential security material on the separate CES security volume. |

--- a/docs/kata-block-mode-image-contract.md
+++ b/docs/kata-block-mode-image-contract.md
@@ -38,6 +38,19 @@ The init helper creates these top-level directories under `VELLUM_BLOCK_ROOT`: `
 
 When the init helper finds an existing ext4 filesystem, it runs `vellum-block-volume-resize.sh` before mounting the shared root. It must never run `mkfs.ext4` on a device that already has a filesystem.
 
+## CES Service Environment
+
+In addition to the helper environment and bind specs above, vembda must set these variables on the CES service container in block mode:
+
+| Variable | Value |
+| --- | --- |
+| `VELLUM_WORKSPACE_DIR` | `/workspace` |
+| `CREDENTIAL_SECURITY_DIR` | `/ces-security` |
+
+`VELLUM_WORKSPACE_DIR=/workspace` is required so managed CES command execution resolves its workspace root to the read-only workspace bind. Without this value, managed CES falls back to the legacy assistant data mount path (`/assistant-data-ro/.vellum/workspace` by default), which is not the block-mode workspace bind.
+
+`CREDENTIAL_SECURITY_DIR=/ces-security` keeps credential keys and stores on the separate CES-owned security volume described below. It must not point into the shared block volume.
+
 Gateway security material (`/gateway-security`), CES credential/security material (`/ces-security`), and other service-owned security storage must stay on separate service-owned volumes or equivalent platform-provisioned storage. They must not be initialized under, or bind-mounted from, the shared raw block volume.
 
 ## Security Boundary


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-ext4-volume-block-mode.md.

**Gap:** CES block-mode contract omitted the env needed to use the /workspace bind.
**What was expected:** vembda renders CES with VELLUM_WORKSPACE_DIR=/workspace and keeps credential security storage on the separate CES security volume.
**What was found:** The docs described the bind mount but not the service env required by CES workspace resolution.