### PR TITLE
feat(web): Vite onboarding parity — hosting/privacy polish + API-key step

### DIFF
--- a/apps/web/src/domains/contacts/components/generate-invite-link-dialog.tsx
+++ b/apps/web/src/domains/contacts/components/generate-invite-link-dialog.tsx
@@ -142,7 +142,7 @@ export function GenerateInviteLinkDialog({
                   type="button"
                   onClick={() => handleCopy(inviteUrl)}
                   aria-label="Copy invite link"
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[var(--border-default)] hover:bg-[var(--surface-hover)]"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[var(--border-base)] hover:bg-[var(--surface-hover)]"
                 >
                   {copied ? (
                     <Check className="h-4 w-4" />

--- a/apps/web/src/domains/onboarding/components/onboarding-layout.tsx
+++ b/apps/web/src/domains/onboarding/components/onboarding-layout.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
+import { PortalContainerProvider } from "@vellum/design-library/utils/portal-container";
 import { CreatureFooter } from "./creature-footer";
 
 /**
@@ -12,14 +13,27 @@ import { CreatureFooter } from "./creature-footer";
  * the viewport (e.g. ToolSelectionScreen on iPhone 13 mini) become scrollable
  * instead of clipping the Continue button off-screen. The CreatureFooter sits
  * outside the scroll container so it stays at the viewport bottom.
+ *
+ * Overlay components (e.g. the provider Dropdown menu) portal into the
+ * trailing at-origin element below — outside the centered, animated content
+ * column. Without it the Dropdown renders inline and its position:fixed menu
+ * anchors to the column's containing block (created by the column's transform
+ * animation) instead of the viewport, landing far off to the side.
  */
 export function OnboardingLayout({ children }: { children: ReactNode }) {
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
+    null,
+  );
+
   return (
     <div className="relative flex h-full flex-col bg-[var(--surface-base)]">
       <div className="flex-1 overflow-y-auto">
-        {children}
+        <PortalContainerProvider container={portalContainer}>
+          {children}
+        </PortalContainerProvider>
       </div>
       <CreatureFooter />
+      <div ref={setPortalContainer} />
     </div>
   );
 }

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -88,7 +88,7 @@ export function ApiKeyScreen() {
           </div>
 
           {requiresKey && (
-            <div className="flex flex-col gap-1.5">
+            <div className="flex flex-col gap-3">
               <Input
                 type="password"
                 label={`${entry.displayName} API Key`}

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { Button } from "@vellum/design-library/components/button";
+import { Dropdown } from "@vellum/design-library/components/dropdown";
+import { Input } from "@vellum/design-library/components/input";
+import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import {
+  DEFAULT_ONBOARDING_PROVIDER,
+  onboardingProvider,
+  ONBOARDING_PROVIDERS,
+  type OnboardingProviderId,
+} from "@/domains/onboarding/provider-catalog";
+import {
+  peekPendingProviderKey,
+  setPendingProviderKey,
+} from "@/domains/onboarding/provider-key";
+import { routes } from "@/utils/routes";
+
+export function ApiKeyScreen() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const hosting = searchParams.get("hosting");
+
+  const pending = peekPendingProviderKey();
+  const [provider, setProvider] = useState<OnboardingProviderId>(
+    pending?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
+  );
+  const [apiKey, setApiKey] = useState(pending?.key ?? "");
+
+  const entry = onboardingProvider(provider) ?? DEFAULT_ONBOARDING_PROVIDER;
+  const requiresKey = entry.requiresKey;
+  const canContinue = !requiresKey || apiKey.trim().length > 0;
+
+  const onContinue = () => {
+    if (!canContinue) return;
+    setPendingProviderKey({
+      provider,
+      key: requiresKey ? apiKey.trim() : "",
+    });
+    void navigate(
+      hosting
+        ? `${routes.onboarding.privacy}?hosting=${hosting}`
+        : routes.onboarding.privacy,
+    );
+  };
+
+  const onBack = () => {
+    void navigate(routes.onboarding.hosting);
+  };
+
+  return (
+    <OnboardingLayout>
+      <div className="mx-auto flex w-full max-w-xl flex-col items-center px-6 py-16 text-[var(--content-default)]">
+        <h1
+          className="text-3xl font-semibold tracking-tight"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
+        >
+          Connect a Model Provider
+        </h1>
+        <p
+          className="mt-3 text-center text-body-medium-lighter text-[var(--content-tertiary)]"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+        >
+          Enter an API key to connect your model provider.
+        </p>
+
+        <div
+          className="mt-10 flex w-full flex-col gap-4"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+        >
+          <div className="flex flex-col gap-1">
+            <label className="text-body-small-default text-[var(--content-tertiary)]">
+              Provider
+            </label>
+            <Dropdown
+              aria-label="Provider"
+              value={provider}
+              onChange={(v) => {
+                setProvider(v as OnboardingProviderId);
+                setApiKey("");
+              }}
+              options={ONBOARDING_PROVIDERS.map((p) => ({
+                value: p.id,
+                label: p.displayName,
+              }))}
+            />
+          </div>
+
+          {requiresKey && (
+            <div className="flex flex-col gap-1.5">
+              <Input
+                type="password"
+                label={`${entry.displayName} API Key`}
+                placeholder={entry.apiKeyPlaceholder ?? "Enter your API key"}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                fullWidth
+              />
+              {entry.docsUrl && (
+                <a
+                  href={entry.docsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="self-start text-body-small-default text-[var(--content-default)] underline"
+                >
+                  Get an API key here
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div
+          className="mt-8 flex w-full flex-col gap-2"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+        >
+          <Button
+            variant="primary"
+            size="regular"
+            fullWidth
+            disabled={!canContinue}
+            onClick={onContinue}
+            className="h-11 text-base"
+          >
+            Continue
+          </Button>
+          <Button
+            variant="outlined"
+            size="regular"
+            fullWidth
+            onClick={onBack}
+            className="h-11 text-base"
+          >
+            Back
+          </Button>
+        </div>
+      </div>
+    </OnboardingLayout>
+  );
+}

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -98,14 +98,17 @@ export function ApiKeyScreen() {
                 fullWidth
               />
               {entry.docsUrl && (
-                <a
-                  href={entry.docsUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="self-start text-body-small-default text-[var(--content-default)] underline"
-                >
-                  Get an API key here
-                </a>
+                <p className="self-start text-body-medium-lighter text-[var(--content-tertiary)]">
+                  Don't have it?{" "}
+                  <a
+                    href={entry.docsUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--content-default)] underline"
+                  >
+                    Get an API key here
+                  </a>
+                </p>
               )}
             </div>
           )}

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -22,11 +22,12 @@ export function ApiKeyScreen() {
   const [searchParams] = useSearchParams();
   const hosting = searchParams.get("hosting");
 
-  const pending = peekPendingProviderKey();
   const [provider, setProvider] = useState<OnboardingProviderId>(
-    pending?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
+    () => peekPendingProviderKey()?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
   );
-  const [apiKey, setApiKey] = useState(pending?.key ?? "");
+  const [apiKey, setApiKey] = useState(
+    () => peekPendingProviderKey()?.key ?? "",
+  );
 
   const entry = onboardingProvider(provider) ?? DEFAULT_ONBOARDING_PROVIDER;
   const requiresKey = entry.requiresKey;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -20,6 +20,7 @@ import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-lay
 import { extractErrorMessage } from "@/utils/api-errors";
 import { isLocalMode, hatchLocalAssistant, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection, getLocalGatewayUrl } from "@/lib/local-mode";
 import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
+import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import {
   readAiDataConsent,
@@ -84,7 +85,6 @@ export type HatchGateDecision =
 export function decideHatchGate(input: {
   isAuthLoading: boolean;
   isLoggedIn: boolean;
-  isLocalMode: boolean;
   isReplay: boolean;
   onboardingCompleted: boolean;
   tosAccepted: boolean;
@@ -96,7 +96,9 @@ export function decideHatchGate(input: {
   if (input.onboardingCompleted && !input.isReplay) {
     return { kind: "redirect", to: routes.assistant };
   }
-  if (input.isLocalMode) return { kind: "proceed" };
+  // Consent (incl. local mode): the privacy screen is now shown for every
+  // hosting option, so require it for local hatches too. The privacy screen
+  // persists tosAccepted/aiDataConsent and marks the in-memory consent signal.
   const persistedConsent = input.tosAccepted && input.aiDataConsentAccepted;
   if (!input.cameFromPrivacyScreen && !persistedConsent) {
     return { kind: "redirect", to: getOnboardingEntrypoint() };
@@ -153,7 +155,6 @@ export function HatchingScreen() {
     const decision = decideHatchGate({
       isAuthLoading,
       isLoggedIn,
-      isLocalMode: isLocalMode(),
       isReplay,
       onboardingCompleted: readOnboardingCompleted(),
       tosAccepted: readTosAccepted(),
@@ -286,6 +287,19 @@ export function HatchingScreen() {
             readyPollTimer = null;
           }
           if (cancelled) return;
+
+          // Apply the model-provider key collected on the API-key step to the
+          // freshly hatched assistant. Non-blocking on failure — onboarding
+          // proceeds and the user can fix it in Settings.
+          if (result.assistantId) {
+            try {
+              await applyPendingProviderKey(result.assistantId);
+            } catch (err) {
+              Sentry.captureException(err, {
+                tags: { context: "onboarding_apply_provider_key" },
+              });
+            }
+          }
 
           handleHatchReady();
         } catch {

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -7,7 +7,7 @@ import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-lay
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useAuthStore } from "@/stores/auth-store";
-import { routes } from "@/utils/routes";
+import { docsUrl, routes } from "@/utils/routes";
 
 type HostingMode = "vellum-cloud" | "local" | "docker";
 
@@ -71,6 +71,10 @@ export function HostingScreen() {
     }
   };
 
+  const onBack = () => {
+    void navigate(routes.onboarding.welcome);
+  };
+
   return (
     <OnboardingLayout>
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 pt-16 text-[var(--content-default)]">
@@ -88,7 +92,7 @@ export function HostingScreen() {
         </p>
 
         <div
-          className="mt-10 flex w-full flex-col gap-3"
+          className="mt-10 grid w-full auto-rows-fr gap-3"
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
         >
           {options.map((opt) => (
@@ -104,7 +108,7 @@ export function HostingScreen() {
         </div>
 
         <div
-          className="mt-8 w-full max-w-sm"
+          className="mt-8 flex w-full flex-col gap-2"
           style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
         >
           <Button
@@ -116,7 +120,26 @@ export function HostingScreen() {
           >
             Continue
           </Button>
+          <Button
+            variant="outlined"
+            size="regular"
+            fullWidth
+            className="h-11 text-base"
+            onClick={onBack}
+          >
+            Back
+          </Button>
         </div>
+
+        <a
+          href={docsUrl(routes.docs.hostingOptions)}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-6 text-body-medium-default text-[var(--content-default)] underline"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.6s both" }}
+        >
+          Need help choosing?
+        </a>
       </div>
     </OnboardingLayout>
   );
@@ -143,7 +166,7 @@ function HostingCard({
       } ${
         selected && !option.disabled
           ? "border-[var(--primary-base)] bg-[var(--primary-base)]/5"
-          : "border-[var(--border-default)] bg-transparent"
+          : "border-[var(--border-element)] bg-transparent"
       }`}
     >
       {option.icon}
@@ -167,7 +190,7 @@ function HostingCard({
           className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 ${
             selected
               ? "border-[var(--primary-base)]"
-              : "border-[var(--border-default)]"
+              : "border-[var(--border-element)]"
           }`}
         >
           {selected && (

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useAuthStore } from "@/stores/auth-store";
@@ -65,9 +66,12 @@ export function HostingScreen() {
     if (selected === "vellum-cloud") {
       clearGatewayToken();
       setSelfHostedConnection(null);
+      // Cloud is managed — drop any provider key staged from a prior
+      // Local/Docker visit so it can't leak into a later local hatch.
+      setPendingProviderKey(null);
       void navigate(routes.onboarding.privacy);
     } else {
-      void navigate(`${routes.onboarding.hatching}?hosting=${selected}`);
+      void navigate(`${routes.onboarding.apiKey}?hosting=${selected}`);
     }
   };
 

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -60,13 +60,6 @@ function SettingRow({
   );
 }
 
-// Consent checkboxes use the primary fill (not the green positive fill the
-// shared Checkbox defaults to) so they read as the screen's action color,
-// distinct from the green preference toggles above. Overridden locally to
-// avoid changing the shared design-library checkbox everywhere.
-const CONSENT_CHECKBOX_CLASS =
-  "[&_button[data-state=checked]]:bg-[var(--primary-base)]";
-
 export function PrivacyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -218,7 +211,6 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setAiDataConsent(next === true)}
             label={aiConsentLabel}
             aria-label="I agree to the AI Data Sharing Policy"
-            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 
@@ -228,7 +220,6 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setTosAccepted(next === true)}
             label={tosLabel}
             aria-label="I agree to the Terms of Service and Privacy Policy"
-            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -60,6 +60,13 @@ function SettingRow({
   );
 }
 
+// Consent checkboxes use the primary fill (not the green positive fill the
+// shared Checkbox defaults to) so they read as the screen's action color,
+// distinct from the green preference toggles above. Overridden locally to
+// avoid changing the shared design-library checkbox everywhere.
+const CONSENT_CHECKBOX_CLASS =
+  "[&_button[data-state=checked]]:bg-[var(--primary-base)]";
+
 export function PrivacyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -207,6 +214,7 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setAiDataConsent(next === true)}
             label={aiConsentLabel}
             aria-label="I agree to the AI Data Sharing Policy"
+            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 
@@ -216,6 +224,7 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setTosAccepted(next === true)}
             label={tosLabel}
             aria-label="I agree to the Terms of Service and Privacy Policy"
+            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -60,6 +60,14 @@ function SettingRow({
   );
 }
 
+// Consent checkboxes mirror the primary button: the checked fill uses
+// --primary-base and the check uses --content-inset (the on-primary
+// foreground). This stays correct in every theme — dark fill + white check in
+// light mode, white fill + dark check in dark mode — whereas the design
+// library's hardcoded white check vanishes on the near-white dark-mode fill.
+const CONSENT_CHECKBOX_CLASS =
+  "[&_button[data-state=checked]]:bg-[var(--primary-base)] [&_svg]:text-[var(--content-inset)]";
+
 export function PrivacyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -211,6 +219,7 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setAiDataConsent(next === true)}
             label={aiConsentLabel}
             aria-label="I agree to the AI Data Sharing Policy"
+            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 
@@ -220,6 +229,7 @@ export function PrivacyScreen() {
             onCheckedChange={(next) => setTosAccepted(next === true)}
             label={tosLabel}
             aria-label="I agree to the Terms of Service and Privacy Policy"
+            className={CONSENT_CHECKBOX_CLASS}
           />
         </div>
 

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -111,16 +111,20 @@ export function PrivacyScreen() {
         variant,
       });
     }
-    void navigate(
-      isReplay
-        ? `${routes.onboarding.hatching}?replay=1`
-        : routes.onboarding.hatching,
-    );
+    // Preserve the hosting param (Local/Docker need it so hatching runs the
+    // local hatch instead of a platform hatch).
+    const hostingParam = searchParams.get("hosting");
+    const params = new URLSearchParams();
+    if (hostingParam) params.set("hosting", hostingParam);
+    if (isReplay) params.set("replay", "1");
+    const qs = params.toString();
+    void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
   }, [
     isNative,
     isReplay,
     navigate,
     preferredFunnelVariant,
+    searchParams,
     setShareAnalytics,
     setShareDiagnostics,
     shareAnalytics,

--- a/apps/web/src/domains/onboarding/provider-catalog.ts
+++ b/apps/web/src/domains/onboarding/provider-catalog.ts
@@ -1,0 +1,85 @@
+// Trimmed model-provider catalog for the onboarding "Connect a Model Provider"
+// step. Ported from the daemon/macOS catalog
+// (clients/shared/Resources/llm-provider-catalog.json), limited to the
+// providers the web daemon client supports (see ConnectionProvider in
+// domains/settings) and to the fields the onboarding UI needs.
+
+export type OnboardingProviderId =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "ollama"
+  | "fireworks"
+  | "openrouter"
+  | "openai-compatible";
+
+export interface OnboardingProvider {
+  readonly id: OnboardingProviderId;
+  readonly displayName: string;
+  /** Placeholder for the API-key input; null for keyless providers. */
+  readonly apiKeyPlaceholder: string | null;
+  /** "Get an API key here" docs URL; null when the provider has none. */
+  readonly docsUrl: string | null;
+  /** Whether an API key is required before the user can continue. */
+  readonly requiresKey: boolean;
+}
+
+export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
+  {
+    id: "anthropic",
+    displayName: "Anthropic",
+    apiKeyPlaceholder: "sk-ant-api03-...",
+    docsUrl: "https://console.anthropic.com/settings/keys",
+    requiresKey: true,
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    apiKeyPlaceholder: "sk-proj-...",
+    docsUrl: "https://platform.openai.com/api-keys",
+    requiresKey: true,
+  },
+  {
+    id: "gemini",
+    displayName: "Google Gemini",
+    apiKeyPlaceholder: "AIza...",
+    docsUrl: "https://aistudio.google.com/apikey",
+    requiresKey: true,
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama",
+    apiKeyPlaceholder: null,
+    docsUrl: "https://ollama.com/download",
+    requiresKey: false,
+  },
+  {
+    id: "fireworks",
+    displayName: "Fireworks",
+    apiKeyPlaceholder: "fw_...",
+    docsUrl: "https://fireworks.ai/account/api-keys",
+    requiresKey: true,
+  },
+  {
+    id: "openrouter",
+    displayName: "OpenRouter",
+    apiKeyPlaceholder: "sk-or-v1-...",
+    docsUrl: "https://openrouter.ai/keys",
+    requiresKey: true,
+  },
+  {
+    id: "openai-compatible",
+    displayName: "OpenAI-compatible",
+    apiKeyPlaceholder: "Your provider's API key",
+    docsUrl: null,
+    requiresKey: true,
+  },
+];
+
+export const DEFAULT_ONBOARDING_PROVIDER = ONBOARDING_PROVIDERS[0];
+
+export function onboardingProvider(
+  id: string,
+): OnboardingProvider | undefined {
+  return ONBOARDING_PROVIDERS.find((p) => p.id === id);
+}

--- a/apps/web/src/domains/onboarding/provider-key.test.ts
+++ b/apps/web/src/domains/onboarding/provider-key.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  consumePendingProviderKey,
+  peekPendingProviderKey,
+  setPendingProviderKey,
+} from "@/domains/onboarding/provider-key";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("pending provider key", () => {
+  test("round-trips provider + key through sessionStorage", () => {
+    setPendingProviderKey({ provider: "anthropic", key: "sk-ant-test" });
+    expect(peekPendingProviderKey()).toEqual({
+      provider: "anthropic",
+      key: "sk-ant-test",
+    });
+  });
+
+  test("peek is non-destructive, consume clears it (consume-once)", () => {
+    setPendingProviderKey({ provider: "openai", key: "sk-proj-test" });
+
+    expect(peekPendingProviderKey()?.provider).toBe("openai");
+    // Still present after peek.
+    expect(peekPendingProviderKey()?.provider).toBe("openai");
+
+    expect(consumePendingProviderKey()?.provider).toBe("openai");
+    // Gone after consume.
+    expect(peekPendingProviderKey()).toBeNull();
+    expect(consumePendingProviderKey()).toBeNull();
+  });
+
+  test("setting null clears any pending key", () => {
+    setPendingProviderKey({ provider: "gemini", key: "AIza-test" });
+    setPendingProviderKey(null);
+    expect(peekPendingProviderKey()).toBeNull();
+  });
+
+  test("keyless providers store an empty key", () => {
+    setPendingProviderKey({ provider: "ollama", key: "" });
+    expect(consumePendingProviderKey()).toEqual({ provider: "ollama", key: "" });
+  });
+});

--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -1,0 +1,109 @@
+import { client } from "@/generated/api/client.gen";
+import type { OnboardingProviderId } from "@/domains/onboarding/provider-catalog";
+
+// Model-provider API key collected during onboarding. Held in sessionStorage
+// (consume-once) between the API-key step and the post-hatch application, then
+// written to the freshly hatched assistant. Mirrors the macOS flow, which
+// holds the key in-memory and POSTs it to the daemon once the assistant is up.
+
+const PENDING_KEY_STORAGE = "onboarding.providerKey";
+
+export interface PendingProviderKey {
+  provider: OnboardingProviderId;
+  /** Empty for keyless providers (e.g. Ollama). */
+  key: string;
+}
+
+export function setPendingProviderKey(value: PendingProviderKey | null): void {
+  try {
+    if (value === null) {
+      sessionStorage.removeItem(PENDING_KEY_STORAGE);
+      return;
+    }
+    sessionStorage.setItem(PENDING_KEY_STORAGE, JSON.stringify(value));
+  } catch {
+    // Storage unavailable (private mode / quota) — degrade silently.
+  }
+}
+
+export function peekPendingProviderKey(): PendingProviderKey | null {
+  try {
+    const raw = sessionStorage.getItem(PENDING_KEY_STORAGE);
+    if (!raw) return null;
+    return JSON.parse(raw) as PendingProviderKey;
+  } catch {
+    return null;
+  }
+}
+
+export function consumePendingProviderKey(): PendingProviderKey | null {
+  const value = peekPendingProviderKey();
+  try {
+    sessionStorage.removeItem(PENDING_KEY_STORAGE);
+  } catch {
+    // ignore
+  }
+  return value;
+}
+
+// Daemon wrappers via the generated client. Duplicated minimally here rather
+// than importing domains/settings/ai/provider-connections-client (cross-domain
+// imports are ESLint-gated in apps/web).
+
+async function writeApiKeySecret(
+  assistantId: string,
+  provider: OnboardingProviderId,
+  value: string,
+): Promise<void> {
+  const result = await client.post({
+    url: "/v1/assistants/{assistant_id}/secrets/",
+    path: { assistant_id: assistantId },
+    body: { type: "api_key", name: provider, value },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!result.response?.ok) {
+    throw Object.assign(new Error("Failed to write provider secret"), {
+      status: result.response?.status,
+    });
+  }
+}
+
+async function createProviderConnection(
+  assistantId: string,
+  provider: OnboardingProviderId,
+  hasKey: boolean,
+): Promise<void> {
+  const auth = hasKey
+    ? { type: "api_key", credential: `credential/${provider}/api_key` }
+    : { type: "none" };
+  const result = await client.post({
+    url: "/v1/assistants/{assistant_id}/inference/provider-connections",
+    path: { assistant_id: assistantId },
+    body: { name: provider, provider, auth },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!result.response?.ok) {
+    throw Object.assign(new Error("Failed to create provider connection"), {
+      status: result.response?.status,
+    });
+  }
+}
+
+/**
+ * Apply the API key collected during onboarding to the freshly hatched local
+ * assistant: store the secret (when a key was entered) and create the provider
+ * connection so the daemon can use it. Consumes the pending key; no-op when
+ * nothing was collected (e.g. Vellum Cloud, which skips the API-key step).
+ */
+export async function applyPendingProviderKey(
+  assistantId: string,
+): Promise<void> {
+  const pending = consumePendingProviderKey();
+  if (!pending) return;
+  const trimmed = pending.key.trim();
+  const hasKey = trimmed.length > 0;
+  if (hasKey) {
+    await writeApiKeySecret(assistantId, pending.provider, trimmed);
+  }
+  await createProviderConnection(assistantId, pending.provider, hasKey);
+}

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -886,7 +886,7 @@ export function ProviderEditorContent({
 
         {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
         {authType === "oauth_subscription" && (
-          <div className="space-y-3 rounded-lg border border-[var(--border-default)] p-4">
+          <div className="space-y-3 rounded-lg border border-[var(--border-base)] p-4">
             <Typography
               variant="body-small-default"
               as="p"

--- a/apps/web/src/domains/settings/components/assistant-picker.tsx
+++ b/apps/web/src/domains/settings/components/assistant-picker.tsx
@@ -33,7 +33,7 @@ export function AssistantPicker() {
               className={`flex items-center justify-between gap-4 rounded-lg border px-4 py-3 ${
                 isActive
                   ? "border-[var(--border-focus)] bg-[var(--surface-lift)]"
-                  : "border-[var(--border-default)] bg-[var(--surface-default)]"
+                  : "border-[var(--border-base)] bg-[var(--surface-default)]"
               }`}
             >
               <div className="flex min-w-0 items-center gap-3">

--- a/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -199,7 +199,7 @@ function AssistantListCard({
               className={`flex items-center justify-between gap-4 rounded-lg border px-4 py-3 ${
                 isActive
                   ? "border-[var(--border-focus)] bg-[var(--surface-lift)]"
-                  : "border-[var(--border-default)] bg-[var(--surface-default)]"
+                  : "border-[var(--border-base)] bg-[var(--surface-default)]"
               }`}
             >
               <div className="min-w-0">

--- a/apps/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
@@ -100,7 +100,7 @@ export function AssistantTerminalPanel() {
           Loading terminal...
         </div>
       ) : !assistantId ? (
-        <div className="rounded-lg border border-[var(--border-default)] px-4 py-3 text-body-medium-lighter text-[var(--content-tertiary)]">
+        <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 text-body-medium-lighter text-[var(--content-tertiary)]">
           <div className="flex items-center gap-2 px-1 py-0.5">
             <Terminal className="h-4 w-4 shrink-0" />
             <span>

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -110,7 +110,7 @@ export function FeatureFlagsPanel() {
             placeholder="Search flags..."
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}
-            className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--surface-default)] py-2 pl-9 pr-3 text-body-medium-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
+            className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-default)] py-2 pl-9 pr-3 text-body-medium-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
           />
         </div>
 

--- a/apps/web/src/domains/settings/components/panels/sentry-testing-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/sentry-testing-panel.tsx
@@ -109,7 +109,7 @@ function SentryTestRow({
   onClick,
 }: SentryTestRowProps) {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-lg border border-[var(--border-default)] px-4 py-3">
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-[var(--border-base)] px-4 py-3">
       <div className="flex min-w-0 items-center gap-3">
         <div className="shrink-0">{icon}</div>
         <div className="min-w-0">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19,7 +19,10 @@ body {
 
 @keyframes fadeInUp {
   0% { transform: translateY(16px); opacity: 0; }
-  100% { transform: translateY(0); opacity: 1; }
+  /* End at `none` (not translateY(0)) so the filled-forwards transform does
+     not create a containing block — otherwise position:fixed descendants like
+     the Dropdown menu anchor to this element instead of the viewport. */
+  100% { transform: none; opacity: 1; }
 }
 
 @keyframes typing-dot-pulse {

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -129,6 +129,10 @@ export const router = createBrowserRouter(
                   path: "onboarding/hosting",
                   lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
                 },
+                {
+                  path: "onboarding/api-key",
+                  lazy: { Component: () => import("@/domains/onboarding/pages/api-key-screen").then((m) => m.ApiKeyScreen) },
+                },
               ],
             },
             {

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -129,7 +129,7 @@ const WWW_DOMAIN = "vellum.ai";
 export function legalUrl(
   path: (typeof routes.docs.legal)[keyof typeof routes.docs.legal],
 ): string {
-  return `https://${WWW_DOMAIN}${path}`;
+  return docsUrl(path);
 }
 
 /** Full external URL for a docs page hosted on the marketing site. */

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -111,6 +111,7 @@ export const routes = {
   },
 
   docs: {
+    hostingOptions: r("/docs/hosting-options"),
     legal: {
       privacyPolicy: r("/docs/privacy-policy"),
       termsOfUse: r("/docs/vellum-terms-of-use"),
@@ -127,6 +128,11 @@ const WWW_DOMAIN = "vellum.ai";
 export function legalUrl(
   path: (typeof routes.docs.legal)[keyof typeof routes.docs.legal],
 ): string {
+  return `https://${WWW_DOMAIN}${path}`;
+}
+
+/** Full external URL for a docs page hosted on the marketing site. */
+export function docsUrl(path: string): string {
   return `https://${WWW_DOMAIN}${path}`;
 }
 

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -60,6 +60,7 @@ export const routes = {
   onboarding: {
     welcome: r("/assistant/onboarding/welcome"),
     hosting: r("/assistant/onboarding/hosting"),
+    apiKey: r("/assistant/onboarding/api-key"),
     privacy: r("/assistant/onboarding/privacy"),
     prechat: r("/assistant/onboarding/prechat"),
     hatching: r("/assistant/onboarding/hatching"),


### PR DESCRIPTION
## Summary

Brings the Vite (`apps/web`) onboarding closer to the legacy macOS flow and fixes several UI issues on the hosting, privacy, and (new) API-key steps.

### Hosting step
- Add **Back** button and **"Need help choosing?"** docs link (parity with macOS).
- Equal-height option cards via `grid auto-rows-fr`; full-width Back/Continue buttons matching the card width.
- Fix too-dark card border (the undefined `--border-default` token fell back to `currentColor`) → `--border-element`.

### Privacy step
- Consent checkboxes now use the dark primary fill instead of the green positive fill (matches mock).
- Always shown for **every** hosting option (previously Local/Docker skipped it).

### New API-key step ("Connect a Model Provider")
- Ported from macOS: provider dropdown + per-provider key placeholder, secure key input, **"Don't have it? Get an API key here"** docs link, Continue (disabled until a required key is entered) + Back.
- Shown for **Local/Docker only** (Vellum Cloud is managed → skipped), mirroring the macOS logic.
- Trimmed provider catalog ported into `apps/web` (placeholders, docs URLs, `requiresKey`).
- Key collected in sessionStorage (consume-once) and applied post-hatch via `writeSecret` + `createConnection` on the generated daemon client (no cross-domain import of settings).
- Flow: **Hosting → (API key, Local/Docker) → Privacy → Hatching**; `?hosting` param threaded through privacy so the local hatch still fires; `decideHatchGate` no longer bypasses consent for local mode.

### Cross-cutting fixes
- Replace the undefined `--border-default` token with `--border-base` across settings/contacts components (same `currentColor` fallback bug).
- `fadeInUp` keyframe ends at `transform: none` (was `translateY(0)`) to avoid creating a containing block.
- `OnboardingLayout` mounts a `PortalContainerProvider` so the Dropdown menu portals out of the centered/animated column and anchors to the viewport (fixes the menu rendering far to the side).

## Verification
- `tsc --noEmit`: no errors in changed files (pre-existing design-library `bottom-sheet` errors only).
- `eslint`: clean across all changed files.
- Cross-domain import audit: passes.
- `bun test src/domains/onboarding`: 17 pass (incl. new `provider-key.test.ts` covering the consume-once contract).

## Notes / follow-ups
- Provider-key application is best-effort: failures are logged to Sentry and onboarding proceeds (user can fix in Settings), matching macOS fire-and-forget behavior. Worth a manual end-to-end check (`vel up` → Local → enter an Anthropic key → confirm the assistant uses it).
- `openai-compatible` collects only a key (no base URL), same limitation as the macOS step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)