### PR TITLE
feat(memory-v3): classify-union enriches recently-edited pages, not just unassigned

### DIFF
--- a/assistant/src/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/memory/v3/__tests__/maintain-job.test.ts
@@ -9,7 +9,12 @@ import type { MemoryJob } from "../../jobs-store.js";
 import { readPage, writePage } from "../../v2/page-store.js";
 import type { ConceptPage } from "../../v2/types.js";
 import type { AssignPageResult, AssignPagesOptions } from "../assign.js";
-import { maintainJob, type MaintainJobDeps } from "../maintain-job.js";
+import {
+  type ClassifyCandidate,
+  computeClassifyTargets,
+  maintainJob,
+  type MaintainJobDeps,
+} from "../maintain-job.js";
 import type { LeafNode, LeafPath, LeafTree, Slug } from "../types.js";
 
 const FLAG_SHADOW = "memory-v3-shadow";
@@ -66,9 +71,9 @@ describe("maintainJob", () => {
 
   function deps(overrides: Partial<MaintainJobDeps> = {}): {
     deps: MaintainJobDeps;
-    calls: { assign: number; invalidate: number };
+    calls: { assign: number; invalidate: number; commit: number };
   } {
-    const calls = { assign: 0, invalidate: 0 };
+    const calls = { assign: 0, invalidate: 0, commit: 0 };
     const base: MaintainJobDeps = {
       workspaceDir,
       loadTree: async () => makeTree(["domain/topic-a", "domain/topic-b"]),
@@ -77,6 +82,10 @@ describe("maintainJob", () => {
       ): Promise<AssignPageResult[]> => {
         calls.assign += 1;
         return [];
+      },
+      selectClassifyTargets: async () => [],
+      commitClassifyHighWater: () => {
+        calls.commit += 1;
       },
       invalidateLanes: () => {
         calls.invalidate += 1;
@@ -181,5 +190,99 @@ describe("maintainJob", () => {
     expect(outcome.failures).toContain("load_tree");
     expect(calls.assign).toBe(0);
     expect(calls.invalidate).toBe(1);
+  });
+
+  test("classifies the selected delta targets (passes them to assignPages)", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    let seenSlugs: Slug[] | undefined;
+    const { deps: d } = deps({
+      selectClassifyTargets: async () => ["p-new", "p-edited"],
+      assignPages: async (opts: AssignPagesOptions) => {
+        seenSlugs = opts.slugs;
+        return [];
+      },
+    });
+    await maintainJob(JOB, CONFIG, d);
+    expect(seenSlugs).toEqual(["p-new", "p-edited"]);
+  });
+
+  test("advances the high-water mark after a successful classify pass", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps();
+    await maintainJob(JOB, CONFIG, d);
+    expect(calls.commit).toBe(1);
+  });
+
+  test("does not advance the high-water mark when classify throws", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      assignPages: async () => {
+        throw new Error("assign boom");
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+    expect(outcome.failures).toContain("assign");
+    expect(calls.commit).toBe(0);
+  });
+});
+
+describe("computeClassifyTargets", () => {
+  const page = (
+    slug: string,
+    modifiedAt: number,
+    leaves: string[] = [],
+  ): ClassifyCandidate => ({ slug, modifiedAt, leaves });
+
+  test("first run (null high-water) classifies only unassigned pages", () => {
+    const targets = computeClassifyTargets(
+      [page("unassigned", 100, []), page("assigned-recent", 200, ["domain/a"])],
+      null,
+    );
+    expect(targets).toEqual(["unassigned"]);
+  });
+
+  test("re-classifies an already-assigned page edited since the high-water", () => {
+    const targets = computeClassifyTargets(
+      [page("assigned-edited", 300, ["domain/a"])],
+      200,
+    );
+    expect(targets).toEqual(["assigned-edited"]);
+  });
+
+  test("skips an assigned page untouched since the high-water (no self-trigger / drift)", () => {
+    const targets = computeClassifyTargets(
+      [page("assigned-stale", 150, ["domain/a"])],
+      200,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  test("still classifies unassigned pages regardless of mtime", () => {
+    const targets = computeClassifyTargets(
+      [page("unassigned-old", 10, [])],
+      200,
+    );
+    expect(targets).toEqual(["unassigned-old"]);
+  });
+
+  test("excludes synthetic skill/CLI rows (modifiedAt 0) despite empty leaves", () => {
+    const targets = computeClassifyTargets(
+      [page("skills/meet-join", 0, []), page("real", 300, [])],
+      200,
+    );
+    expect(targets).toEqual(["real"]);
+  });
+
+  test("targets = unassigned ∪ recently-edited, excluding assigned-and-stale", () => {
+    const targets = computeClassifyTargets(
+      [
+        page("unassigned-old", 10, []),
+        page("assigned-stale", 150, ["domain/a"]),
+        page("assigned-fresh", 300, ["domain/a"]),
+        page("skills/x", 0, []),
+      ],
+      200,
+    );
+    expect(targets).toEqual(["unassigned-old", "assigned-fresh"]);
   });
 });

--- a/assistant/src/memory/v3/maintain-job.ts
+++ b/assistant/src/memory/v3/maintain-job.ts
@@ -4,9 +4,12 @@
  * A flag-gated, best-effort self-maintenance pass over the v3 topic tree and
  * its page→leaf assignments. It runs three independent stages, in order:
  *
- *   1. **Classify-union** — `assignPages` over every page whose `leaves:`
- *      frontmatter is empty or missing, UNIONing freshly classified leaves into
- *      each page (never dropping existing picks).
+ *   1. **Classify-union** — `assignPages` over the delta: every page that is
+ *      still unassigned (empty `leaves:`) plus every page edited since the last
+ *      successful pass (the high-water mark below), UNIONing freshly classified
+ *      leaves into each page (never dropping existing picks). Re-touching
+ *      already-assigned-but-recently-edited pages lets the classifier enrich the
+ *      assistant's own in-consolidation labels with any leaves it missed.
  *   2. **Prune** — drop any frontmatter `leaves:` entry that points at a leaf
  *      path no longer present in the tree (dangling references left behind when
  *      a leaf is renamed or removed). Read + rewrite only the affected pages.
@@ -26,6 +29,7 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { getMemoryCheckpoint, setMemoryCheckpoint } from "../checkpoints.js";
 import type { MemoryJob } from "../jobs-store.js";
 import { getPageIndex } from "../v2/page-index.js";
 import { listPages, readPage, writePage } from "../v2/page-store.js";
@@ -37,6 +41,18 @@ import type { LeafPath, LeafTree, Slug } from "./types.js";
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
 const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
+/**
+ * Durable checkpoint holding the epoch-ms high-water mark of the last successful
+ * classify-union pass. Pages whose mtime is past this mark are re-classified
+ * (enrichment); the mark is advanced only after a pass completes, captured after
+ * its writes so the pass's own frontmatter rewrites do not re-trigger it.
+ * Distinct from `memory_v3_maintain_last_run` (the enqueue-cadence checkpoint in
+ * `jobs-worker.ts`), which advances on every backstop enqueue rather than on an
+ * actual maintenance run.
+ */
+const MAINTAIN_ENRICH_HIGH_WATER_KEY =
+  "memory_v3_maintain:enriched_through_ms" as const;
+
 const log = getLogger("memory-v3-maintain");
 
 /** Injectable collaborators; defaults wire the real implementations. */
@@ -45,6 +61,16 @@ export interface MaintainJobDeps {
   loadTree: () => Promise<LeafTree>;
   /** Classify-union pass over pages. */
   assignPages: typeof realAssignPages;
+  /**
+   * The slugs to classify this pass: unassigned pages plus pages edited since
+   * the last successful pass. See {@link computeClassifyTargets}.
+   */
+  selectClassifyTargets: () => Promise<Slug[]>;
+  /**
+   * Persist the enrichment high-water mark after a successful classify pass. The
+   * value is captured after the pass's writes (see the key docstring).
+   */
+  commitClassifyHighWater: (highWaterMs: number) => void;
   /** Drop the memoized v3 lanes so the next turn rebuilds tree + needle. */
   invalidateLanes: () => void;
   /** Workspace root; pages live under `<workspaceDir>/memory/concepts/`. */
@@ -81,11 +107,73 @@ async function loadTreeFromWorkspace(workspaceDir: string): Promise<LeafTree> {
   return realLoadLeafTree(resolveDataDir(), pageLeaves);
 }
 
+/** Page-index projection the classify-target selector reads. */
+export interface ClassifyCandidate {
+  slug: Slug;
+  /** File mtime in epoch ms; 0 for synthetic skill/CLI rows (excluded). */
+  modifiedAt: number;
+  /** Leaf assignments from frontmatter; `[]` when unassigned. */
+  leaves: LeafPath[];
+}
+
+/**
+ * Pick the pages the classify-union stage should run this pass:
+ *
+ *  - **Unassigned** pages (empty `leaves:`) — always classified so a page is
+ *    never left permanently unrouted (the pre-enrichment behavior).
+ *  - **Recently edited** pages (mtime past `prevHighWaterMs`) — even when
+ *    already assigned, so the classifier can enrich the assistant's own
+ *    in-consolidation labels with leaves it missed. `assignPages` UNIONs, so a
+ *    page's existing picks are never dropped — only added to.
+ *
+ * Synthetic skill/CLI rows (`modifiedAt === 0`) are excluded: they are
+ * capability entries, not topic-tree pages. On the first run (`prevHighWaterMs`
+ * null) the recency arm is disabled, so a fresh or freshly-backfilled install
+ * does a single unassigned-only pass instead of re-classifying the whole corpus.
+ */
+export function computeClassifyTargets(
+  pages: ReadonlyArray<ClassifyCandidate>,
+  prevHighWaterMs: number | null,
+): Slug[] {
+  const targets: Slug[] = [];
+  for (const page of pages) {
+    if (page.modifiedAt <= 0) continue; // synthetic capability row
+    const unassigned = page.leaves.length === 0;
+    const recentlyEdited =
+      prevHighWaterMs !== null && page.modifiedAt > prevHighWaterMs;
+    if (unassigned || recentlyEdited) targets.push(page.slug);
+  }
+  return targets;
+}
+
+/** Read the persisted high-water mark, treating missing/garbage as first-run. */
+function readClassifyHighWater(): number | null {
+  const raw = getMemoryCheckpoint(MAINTAIN_ENRICH_HIGH_WATER_KEY);
+  if (raw === null) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** Default target selector: page index → {@link computeClassifyTargets}. */
+async function selectClassifyTargetsFromWorkspace(
+  workspaceDir: string,
+): Promise<Slug[]> {
+  const index = await getPageIndex(workspaceDir);
+  return computeClassifyTargets(index.entries, readClassifyHighWater());
+}
+
+function commitClassifyHighWater(highWaterMs: number): void {
+  setMemoryCheckpoint(MAINTAIN_ENRICH_HIGH_WATER_KEY, String(highWaterMs));
+}
+
 function defaultDeps(): MaintainJobDeps {
   const workspaceDir = getWorkspaceDir();
   return {
     loadTree: () => loadTreeFromWorkspace(workspaceDir),
     assignPages: realAssignPages,
+    selectClassifyTargets: () =>
+      selectClassifyTargetsFromWorkspace(workspaceDir),
+    commitClassifyHighWater,
     invalidateLanes: realInvalidateLanes,
     workspaceDir,
   };
@@ -162,15 +250,21 @@ export async function maintainJob(
   }
 
   if (tree) {
-    // Stage 1: classify-union over unassigned pages.
+    // Stage 1: classify-union over the delta (unassigned ∪ recently-edited).
     try {
+      const targets = await deps.selectClassifyTargets();
       const results = await deps.assignPages({
         tree,
         workspaceDir: deps.workspaceDir,
+        slugs: targets,
       });
       outcome.assigned = results.filter(
         (r) => !r.failed && r.after.length > r.before.length,
       ).length;
+      // Advance the high-water mark only on success, captured AFTER the writes
+      // above so pages this pass just rewrote (mtime now bumped) sit at-or-below
+      // the mark and do not re-trigger themselves next pass.
+      deps.commitClassifyHighWater(Date.now());
     } catch (err) {
       outcome.failures.push("assign");
       log.warn(


### PR DESCRIPTION
## Summary
- The `memory_v3_maintain` classify-union stage now runs over a **delta** — pages still unassigned (empty `leaves:`) **plus** pages edited since the last successful pass — instead of unassigned-only. Already-labeled pages the assistant touched during consolidation get re-classified so the union can enrich them with leaves it missed. `assignPages` UNIONs, so the assistant's own picks are never dropped — only added to.
- A durable high-water checkpoint (`memory_v3_maintain:enriched_through_ms`) bounds the work to the consolidation delta. It is advanced only after a successful pass and captured *after* the pass's writes, so the frontmatter rewrites the pass itself makes don't re-trigger classification next pass (the self-trigger trap).
- First-run guard: with no checkpoint the recency arm is disabled, so a fresh or freshly-backfilled install does a single unassigned-only pass instead of re-classifying the whole corpus. Synthetic skill/CLI rows (mtime `0`) are excluded — they are capability entries, not topic-tree pages.

## Why
The maintain job's union design is "the assistant labels pages from the inside during consolidation; the classifier catches what it missed." But the prior pass only ran on *unassigned* pages, so a page the assistant labeled with one obvious leaf — yet under-labeled — was never enriched afterward. Re-touching recently-edited pages closes that gap, while the high-water and first-run guards keep the cost at "the handful of pages that changed," not the full corpus.

The delta logic is extracted into a pure, exported `computeClassifyTargets(pages, prevHighWaterMs)` so the union/recency/synthetic-exclusion rules are unit-tested directly without DB or page-index infrastructure.

## Production safety
Flag-gated and inert by default: `maintainJob` no-ops unless `memory-v3-shadow` or `memory-v3-live` is enabled, so with both off (the production default) this changes nothing. No new HTTP routes, no schema/migration, no openapi change.

## Verification
- `bunx tsc --noEmit`: clean (0 errors).
- `bun test src/memory/v3/__tests__/maintain-job.test.ts`: **16 pass / 0 fail** — 6 new pure-function cases for the delta logic (first-run, recency enrichment, stale-skip / self-trigger guard, synthetic exclusion, union composition) + 3 wiring cases (targets passed through, high-water committed on success, not committed on failure) + the existing 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)