### PR TITLE
[codex] Gate onboarding telemetry on analytics opt-in

### DIFF
--- a/apps/web/src/domains/onboarding/funnel-events.test.ts
+++ b/apps/web/src/domains/onboarding/funnel-events.test.ts
@@ -11,12 +11,14 @@ import {
   readOnboardingFunnelVariant,
   resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
 const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
   sessionStorage.clear();
   localStorage.clear();
+  useOnboardingStore.setState({ shareAnalytics: true });
   __resetOnboardingFunnelEventsForTests();
 });
 
@@ -101,6 +103,7 @@ describe("onboarding funnel events", () => {
   });
 
   test("emits fire-and-forget telemetry payloads with the same session id", () => {
+    localStorage.setItem("device:share_analytics", "true");
     const fetchMock = mock(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response("{}", { status: 200 }),
@@ -140,5 +143,33 @@ describe("onboarding funnel events", () => {
       funnel_version: ONBOARDING_FUNNEL_VERSION,
       ab_variant: "pared_down",
     });
+  });
+
+  test("does not emit telemetry until analytics sharing is explicitly opted in", () => {
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
+      userId: "user-123",
+      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+    });
+
+    localStorage.setItem("device:share_analytics", "false");
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
+      userId: "user-123",
+      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+    });
+
+    localStorage.setItem("device:share_analytics", "true");
+    useOnboardingStore.setState({ shareAnalytics: false });
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
+      userId: "user-123",
+      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/onboarding/prefs.ts
+++ b/apps/web/src/domains/onboarding/prefs.ts
@@ -20,7 +20,7 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/utils/local-settings";
-import { getDeviceSetting } from "@/utils/device-settings";
+import { getDeviceBool, getDeviceSetting } from "@/utils/device-settings";
 import {
   KEY_TOS_ACCEPTED,
   KEY_AI_DATA_CONSENT,
@@ -136,9 +136,20 @@ export function readAiDataConsent(): boolean {
   return useOnboardingStore.getState().aiDataConsent;
 }
 
-/** SSR-safe, non-hook read of the anonymous product analytics preference. */
+/**
+ * SSR-safe, non-hook read for telemetry emitters.
+ *
+ * Unlike the onboarding UI, this treats an absent preference as no consent:
+ * direct analytics uploads should only run after the privacy screen or
+ * settings page has persisted an explicit opt-in. The in-memory store must
+ * also agree so a failed opt-out write cannot leave an older stored opt-in
+ * authorizing a new event.
+ */
 export function readShareAnalytics(): boolean {
-  return useOnboardingStore.getState().shareAnalytics;
+  return (
+    useOnboardingStore.getState().shareAnalytics &&
+    getDeviceBool("shareAnalytics", false)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Require an explicit Share Analytics opt-in before direct web onboarding funnel uploads run.
- Keep the direct emitter guarded by both current in-memory preference state and the stored device preference so stale stored opt-ins cannot override a current opt-out.
- Add regression coverage for unset analytics preference, explicit opt-out, and stale stored opt-in/current opt-out cases.

## Why

Onboarding progress events feed telemetry dashboards and should only be emitted when the user has opted into sharing analytics data. The backend telemetry recorder/reporter already respects `collectUsageData`; this tightens the direct web funnel emitter path as well.

## Validation

- `cd apps/web && bun test src/domains/onboarding/funnel-events.test.ts`
- `cd apps/web && bun run lint`
- `cd assistant && bun test src/telemetry/usage-telemetry-reporter.test.ts`

Known pre-existing validation issue:

- `cd apps/web && bunx tsc --noEmit` currently fails on unrelated `conversation-starter` and command-palette typing errors in `apps/web/src/domains/chat/...` on fresh `origin/main`. The staged-file lint and focused onboarding test pass.