### PR TITLE
feat(gateway): accept velay-attested managed live-voice auth

### DIFF
--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -1,6 +1,14 @@
 import { readFileSync } from "node:fs";
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
@@ -238,6 +246,125 @@ describe("createLiveVoiceWebsocketHandler", () => {
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(500);
+  });
+});
+
+describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () => {
+  const TEST_TOKEN = mintEdgeToken();
+  const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
+  const originalIsPlatform = process.env.IS_PLATFORM;
+
+  function setPlatform(on: boolean) {
+    if (on) {
+      process.env.IS_PLATFORM = "true";
+    } else {
+      delete process.env.IS_PLATFORM;
+    }
+  }
+
+  function makeVelayReq(
+    headers: Record<string, string> = {
+      "x-velay-user-id": VELAY_USER_ID,
+      "x-velay-org-id": VELAY_ORG_ID,
+      "x-velay-actor": "user",
+    },
+  ) {
+    return new Request("http://localhost:7830/v1/live-voice", {
+      headers: { upgrade: "websocket", ...headers },
+    });
+  }
+
+  afterEach(() => {
+    if (originalIsPlatform === undefined) {
+      delete process.env.IS_PLATFORM;
+    } else {
+      process.env.IS_PLATFORM = originalIsPlatform;
+    }
+  });
+
+  test("managed mode + valid X-Velay-* headers authorizes the upgrade", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(makeVelayReq(), server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("managed mode without velay headers and without actor JWT is rejected", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/live-voice", {
+      headers: { upgrade: "websocket" },
+    });
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("managed mode with X-Velay-Actor other than 'user' is rejected", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(
+      makeVelayReq({
+        "x-velay-user-id": VELAY_USER_ID,
+        "x-velay-org-id": VELAY_ORG_ID,
+        "x-velay-actor": "service",
+      }),
+      server,
+    );
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("managed mode missing org id falls through and is rejected", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(
+      makeVelayReq({
+        "x-velay-user-id": VELAY_USER_ID,
+        "x-velay-actor": "user",
+      }),
+      server,
+    );
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("local mode does NOT trust client-supplied X-Velay-* headers", () => {
+    setPlatform(false);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(makeVelayReq(), server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("managed mode still accepts a valid actor edge JWT (no velay headers)", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -13,6 +13,59 @@ const log = getLogger("live-voice-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
+// ---------------------------------------------------------------------------
+// Velay-attested managed auth headers
+// ---------------------------------------------------------------------------
+//
+// In managed/cloud deployments the only ingress is the velay tunnel. On a
+// validated `/v1/live-voice` upgrade, velay authenticates the browser's
+// wsToken against the platform, STRIPS any client-supplied copies of these
+// headers, and INJECTS trusted ones before forwarding the upgrade through the
+// tunnel to the gateway. A browser on a managed assistant cannot mint the
+// local actor edge JWT the self-hosted path requires, so the gateway trusts
+// this velay attestation INSTEAD — but only in managed mode, where velay is
+// the sole ingress. In self-hosted mode there is no velay to strip/inject
+// these headers, so they are never trusted (a client could spoof them).
+const VELAY_USER_ID_HEADER = "x-velay-user-id";
+const VELAY_ORG_ID_HEADER = "x-velay-org-id";
+const VELAY_ACTOR_HEADER = "x-velay-actor";
+
+/**
+ * True when the gateway runs in managed/cloud mode (vembda + velay ingress).
+ * Mirrors the `IS_PLATFORM` check used by the gateway's HTTP edge auth
+ * (`src/http/middleware/auth.ts`) and feature-flag resolver.
+ */
+function isPlatformManaged(): boolean {
+  const v = process.env.IS_PLATFORM?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
+/** Velay-attested managed caller context, extracted from injected headers. */
+type VelayAttestedContext = {
+  userId: string;
+  orgId: string;
+};
+
+/**
+ * Extract a velay-attested managed caller context from the upgrade request.
+ *
+ * Returns null when the request does not carry a complete, well-formed velay
+ * attestation (`X-Velay-User-Id` + `X-Velay-Org-Id` both present, with
+ * `X-Velay-Actor: user`). Callers MUST only trust the result in managed mode.
+ */
+function extractVelayAttestedContext(
+  req: Request,
+): VelayAttestedContext | null {
+  const userId = req.headers.get(VELAY_USER_ID_HEADER)?.trim();
+  const orgId = req.headers.get(VELAY_ORG_ID_HEADER)?.trim();
+  const actor = req.headers.get(VELAY_ACTOR_HEADER)?.trim().toLowerCase();
+
+  if (!userId || !orgId || actor !== "user") {
+    return null;
+  }
+  return { userId, orgId };
+}
+
 export type LiveVoiceSocketData = {
   wsType: "live-voice";
   config: GatewayConfig;
@@ -59,6 +112,23 @@ function checkLiveVoiceAuth(
 ): Response | null {
   if (!config.runtimeProxyRequireAuth) {
     return null;
+  }
+
+  // Managed/cloud path: velay (the sole ingress) validates the browser wsToken
+  // and injects trusted X-Velay-* headers. We trust them ONLY in managed mode —
+  // a self-hosted gateway has no velay to strip client-supplied copies, so it
+  // must never honor these headers and instead requires the actor edge JWT.
+  if (isPlatformManaged()) {
+    const velayContext = extractVelayAttestedContext(req);
+    if (velayContext) {
+      log.info(
+        { userId: velayContext.userId, orgId: velayContext.orgId },
+        "Live voice WS: authenticated via velay-attested managed context",
+      );
+      return null;
+    }
+    // No (or incomplete) velay attestation — fall through to the actor-JWT
+    // path below so a managed deployment still accepts a valid actor edge JWT.
   }
 
   const authHeader = req.headers.get("authorization");


### PR DESCRIPTION
## Summary
- Gateway live-voice upgrade now accepts velay-injected X-Velay-User-Id/Org-Id (managed mode only) in addition to the local actor edge JWT; mints the svc_gateway token; self-hosted does not trust client X-Velay-*; ensures /v1/live-voice is in the velay allowed-paths.

Part of plan: web-live-voice-backend.md (PR B4)