### PR TITLE
fix(daemon): don't persist a none avatar manifest (preserve legacy sidecar-write compatibility)

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -169,7 +169,7 @@ describe("avatar-store", () => {
   });
 
   describe("clearAvatar", () => {
-    test("removes all artifacts and writes a none manifest", () => {
+    test("removes all artifacts AND the manifest (none == absence)", () => {
       writeFileSync(path(IMAGE_FILENAME), Buffer.from("png"));
       writeFileSync(path(TRAITS_FILENAME), JSON.stringify(VALID_TRAITS));
       writeFileSync(path(ASCII_FILENAME), "ascii art");
@@ -179,23 +179,15 @@ describe("avatar-store", () => {
       expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
       expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
       expect(existsSync(path(ASCII_FILENAME))).toBe(false);
-      expect(readManifestFile()).toEqual({
-        kind: "none",
-        traits: null,
-        source: null,
-        image: null,
-      });
+      // "No avatar" is represented by the absence of avatar.json, so a later
+      // legacy sidecar write isn't shadowed by a stale `none` manifest.
+      expect(readManifestFile()).toBeNull();
     });
 
     test("is idempotent when nothing exists", () => {
       clearAvatar();
       clearAvatar();
-      expect(readManifestFile()).toEqual({
-        kind: "none",
-        traits: null,
-        source: null,
-        image: null,
-      });
+      expect(readManifestFile()).toBeNull();
     });
   });
 });

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { getLogger } from "../util/logger.js";
 import {
   AVATAR_IMAGE_FILENAME,
+  AVATAR_MANIFEST_FILENAME,
   getAvatarDir,
   getAvatarImagePath,
 } from "../util/platform.js";
@@ -90,8 +91,14 @@ export function setImage(pngBuffer: Buffer, source: AvatarSource): void {
 }
 
 /**
- * Clears the avatar entirely: removes the PNG and character sidecars, then
- * records a `none` manifest. Idempotent — safe to call when nothing exists.
+ * Clears the avatar entirely: removes the PNG, character sidecars, and the
+ * manifest itself. Idempotent — safe to call when nothing exists.
+ *
+ * "No avatar" is represented by the ABSENCE of a manifest, not a persisted
+ * `kind:"none"`. Deleting avatar.json (rather than writing `none`) keeps an
+ * emptied workspace manifest-less, so a later legacy sidecar write is still
+ * picked up by the read-time self-heal instead of being shadowed by a stale
+ * `none` manifest.
  */
 export function clearAvatar(): void {
   const avatarDir = getAvatarDir();
@@ -100,8 +107,7 @@ export function clearAvatar(): void {
   rmSync(join(avatarDir, AVATAR_IMAGE_FILENAME), { force: true });
   rmSync(join(avatarDir, TRAITS_FILENAME), { force: true });
   rmSync(join(avatarDir, ASCII_FILENAME), { force: true });
-
-  writeManifest({ kind: "none", traits: null, source: null, image: null });
+  rmSync(join(avatarDir, AVATAR_MANIFEST_FILENAME), { force: true });
 
   log.info("Cleared avatar — removed all artifacts");
 }

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -140,7 +140,7 @@ describe("GET /avatar/state", () => {
     }
   });
 
-  test("self-heals and persists kind:none (no throw, no 404) for an empty workspace", async () => {
+  test("returns kind:none WITHOUT persisting a manifest for an empty workspace (no throw, no 404)", async () => {
     let result: AvatarState | undefined;
     expect(() => {
       result = getStateHandler()({}) as AvatarState;
@@ -152,10 +152,9 @@ describe("GET /avatar/state", () => {
       image: null,
     });
 
-    const persisted = JSON.parse(
-      readFileSync(join(avatarDir, MANIFEST_FILENAME), "utf-8"),
-    ) as AvatarState;
-    expect(persisted).toEqual(result!);
+    // `none` is deliberately NOT persisted — the workspace stays manifest-less
+    // so a later legacy sidecar write is still picked up by the next self-heal.
+    expect(existsSync(join(avatarDir, MANIFEST_FILENAME))).toBe(false);
   });
 });
 
@@ -377,12 +376,10 @@ describe("avatar write/remove handlers", () => {
       expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
       expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
       expect(existsSync(path(ASCII_FILENAME))).toBe(false);
-      expect(readManifestFile()).toEqual({
-        kind: "none",
-        traits: null,
-        source: null,
-        image: null,
-      });
+      // none == absence: the manifest is deleted, not written as kind:none.
+      expect(readManifestFile()).toBeNull();
+      // A subsequent read still derives kind:none for the empty workspace.
+      expect((getStateHandler()({}) as AvatarState).kind).toBe("none");
     });
 
     test("reports hadAvatar:true for a character-only workspace (traits, no PNG)", async () => {
@@ -407,10 +404,12 @@ describe("avatar write/remove handlers", () => {
       expect(result.ok).toBe(true);
       expect(result.hadAvatar).toBe(true);
       expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
-      expect(readManifestFile()!.kind).toBe("none");
+      // none == absence: the manifest is deleted, and a read derives none.
+      expect(readManifestFile()).toBeNull();
+      expect((getStateHandler()({}) as AvatarState).kind).toBe("none");
     });
 
-    test("reports hadAvatar:false and still writes kind:none when nothing exists", async () => {
+    test("reports hadAvatar:false and leaves no manifest when nothing exists", async () => {
       const handler = getHandler("avatar_remove");
       const result = (await handler({ body: {} })) as {
         ok: boolean;
@@ -418,7 +417,7 @@ describe("avatar write/remove handlers", () => {
       };
       expect(result.ok).toBe(true);
       expect(result.hadAvatar).toBe(false);
-      expect(readManifestFile()!.kind).toBe("none");
+      expect(readManifestFile()).toBeNull();
     });
   });
 });

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -54,8 +54,10 @@ function handleGetCharacterComponents() {
  * The migration (092) seeds `avatar.json` for every workspace, so the manifest
  * is normally present. If it is somehow missing (e.g. a workspace that predates
  * the manifest and skipped the migration), we derive state from the legacy
- * sidecar files *once* and persist it via `writeManifest` so subsequent reads
- * hit the manifest directly — no per-request legacy inference.
+ * sidecar files. A *real* avatar (character/image) is persisted once so
+ * subsequent reads hit the manifest directly; an empty (`none`) result is NOT
+ * persisted, so an avatar-less workspace stays manifest-less and a later legacy
+ * sidecar write is still picked up by the next self-heal (backward compat).
  */
 function readManifestSelfHealing(): AvatarState {
   const manifest = readManifest();
@@ -63,13 +65,17 @@ function readManifestSelfHealing(): AvatarState {
     return manifest;
   }
   const derived = deriveStateFromLegacyFiles();
+  // Only persist a real avatar. Persisting `none` would shadow a later legacy
+  // sidecar write behind a stale manifest (see migration 094 + clearAvatar).
   // Persist is best-effort: on a read-only / permission-restricted workspace the
   // write can throw. Swallow it so a GET still returns the derived state instead
   // of turning into a 500 — the next read simply self-heals again.
-  try {
-    writeManifest(derived);
-  } catch (err) {
-    log.warn({ err }, "Failed to persist self-healed avatar manifest");
+  if (derived.kind !== "none") {
+    try {
+      writeManifest(derived);
+    } catch (err) {
+      log.warn({ err }, "Failed to persist self-healed avatar manifest");
+    }
   }
   return derived;
 }

--- a/assistant/src/workspace/migrations/094-seed-avatar-manifest.ts
+++ b/assistant/src/workspace/migrations/094-seed-avatar-manifest.ts
@@ -132,9 +132,16 @@ export const seedAvatarManifestMigration: WorkspaceMigration = {
     // Idempotent: if a manifest already exists, leave it untouched.
     if (existsSync(manifestPath)) return;
 
-    // For a brand-new workspace (no legacy files) this naturally derives
-    // { kind: "none" }, so we don't need to branch on ctx.isNewWorkspace.
     const state = deriveStateFromLegacyFiles(avatarDir);
+
+    // Only seed a manifest for a *real* avatar (character/image). An avatar-less
+    // workspace derives { kind: "none" }; we deliberately do NOT write that, so
+    // the workspace stays manifest-less and the read-time self-heal can still
+    // pick up a later legacy sidecar write (older clients / automation that set
+    // an avatar via the generic workspace-file API) instead of being shadowed by
+    // a stale `none` manifest. "No avatar" == absence of avatar.json everywhere.
+    if (state.kind === "none") return;
+
     writeManifest(state, avatarDir);
   },
   down(workspaceDir: string): void {

--- a/assistant/src/workspace/migrations/__tests__/094-seed-avatar-manifest.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/094-seed-avatar-manifest.test.ts
@@ -87,14 +87,12 @@ describe("094-seed-avatar-manifest", () => {
     expect(manifest.image).toBeNull();
   });
 
-  test("neither present → none", () => {
+  test("neither present → no manifest written (none == absence of avatar.json)", () => {
     seedAvatarManifestMigration.run(workspaceDir);
 
-    const manifest = readManifest();
-    expect(manifest.kind).toBe("none");
-    expect(manifest.traits).toBeNull();
-    expect(manifest.image).toBeNull();
-    expect(manifest.source).toBeNull();
+    // An avatar-less workspace must stay manifest-less so a later legacy sidecar
+    // write is still picked up by the read-time self-heal.
+    expect(existsSync(manifestPath)).toBe(false);
   });
 
   test("re-run is a no-op (does not overwrite an existing manifest)", () => {


### PR DESCRIPTION
## Summary
Addresses post-merge Codex review feedback on #32564 (already merged to main): once avatar.json exists — even a migration-seeded kind:none — a later avatar set via the legacy workspace/write sidecar API (stale web tabs, older macOS clients, automation) is ignored, because the read path only derives from legacy files when the manifest is *missing*. /avatar/state and /avatar/get then serve stale none.

Fix: represent 'no avatar' as the absence of avatar.json everywhere, so an avatar-less workspace stays manifest-less and the read-time self-heal keeps picking up legacy sidecar writes until a real avatar (character/image) or a manifest-aware mutation locks it in.

- Migration 094: skip seeding a manifest when the derived state is none.
- readManifestSelfHealing (avatar-routes.ts): on manifest-miss, only persist a derived character/image; never persist none.
- clearAvatar (avatar-store.ts): delete avatar.json instead of writing kind:none.
- Tests updated to assert none == absent manifest (reads still return kind:none).

Deliberately NOT adding per-read sidecar-mtime detection — reintroduces the rejected mtime heuristic; all first-party writers are already manifest-aware.

Addresses review threads on #32564.