### PR TITLE
Improve onboarding bootstrap and first-turn loading

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -406,6 +406,7 @@ export function ActiveChatView() {
   const autoGreetPending = useAutoGreetGate(
     activeConversationId,
     peekPendingPreChatContext()?.initialMessage != null,
+    onboardingConversationId,
   );
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
@@ -512,7 +513,9 @@ export function ActiveChatView() {
   if (autoGreetPending) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-[var(--text-secondary)]">Connecting…</p>
+        <p className="text-[var(--text-secondary)]">
+          Starting your first conversation…
+        </p>
       </div>
     );
   }

--- a/apps/web/src/domains/chat/hooks/use-auto-greet-gate.ts
+++ b/apps/web/src/domains/chat/hooks/use-auto-greet-gate.ts
@@ -8,13 +8,13 @@
  * 1. **Pre-chat sessionStorage detector** — if a pending pre-chat context
  *    exists on mount (e.g. after a page reload mid-flow), re-arm the gate
  *    so the auto-send hook can fire without the user seeing the raw chat UI.
- * 2. **Messages-arrived clear** — once the first message appears, the gate
+ * 2. **Assistant-output clear** — once assistant output appears, the gate
  *    drops immediately.
  * 3. **Safety timer** — a 10-second backstop prevents the user from being
  *    stranded on the overlay if auto-send or greeting fails.
  * 4. **Conversation-switch clear** — switching away from the hatched
- *    conversation dismisses the gate (auto-greet is system-wide, not
- *    per-conversation).
+ *    conversation dismisses the gate, except for the onboarding draft→real
+ *    conversation handoff while assistant output is still pending.
  */
 
 import { useEffect, useRef } from "react";
@@ -22,14 +22,20 @@ import { useEffect, useRef } from "react";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  hasAssistantMessage,
+  shouldClearFirstMessageGateOnConversationChange,
+} from "@/domains/chat/utils/chat";
 
 export function useAutoGreetGate(
   activeConversationId: string | null,
   hasPendingPreChatMessage: boolean,
+  onboardingDraftConversationId: string | null,
 ): boolean {
   const autoGreetPending =
     useAssistantLifecycleStore.use.expectingFirstMessage();
   const messages = useChatSessionStore.use.messages();
+  const firstAssistantMessageArrived = hasAssistantMessage(messages);
 
   // 1. Pre-chat sessionStorage detector — re-arm gate on reload.
   useEffect(() => {
@@ -38,11 +44,13 @@ export function useAutoGreetGate(
     }
   }, [hasPendingPreChatMessage]);
 
-  // 2. Clear gate once the first message appears.
+  // 2. Clear gate once assistant output appears.
   useEffect(() => {
     if (!autoGreetPending) return;
-    if (messages.length > 0) lifecycleService.clearExpectingFirstMessage();
-  }, [autoGreetPending, messages.length]);
+    if (firstAssistantMessageArrived) {
+      lifecycleService.clearExpectingFirstMessage();
+    }
+  }, [autoGreetPending, firstAssistantMessageArrived]);
 
   // 3. Safety timer — 10s backstop.
   useEffect(() => {
@@ -55,18 +63,30 @@ export function useAutoGreetGate(
   }, [autoGreetPending]);
 
   // 4. Conversation-switch clear — dismiss gate when the user navigates
-  // to a different conversation after first mount. Draft → real ID
-  // handoff also trips this, but by then the messages-arrived effect
-  // has already dismissed the gate, so the second dismiss is a no-op.
+  // to a different conversation after first mount, but preserve it across
+  // onboarding draft → real conversation handoff until assistant output exists.
   const lastSeenConvIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (activeConversationId == null) return;
     const previous = lastSeenConvIdRef.current;
     lastSeenConvIdRef.current = activeConversationId;
-    if (previous != null && previous !== activeConversationId) {
+    if (
+      shouldClearFirstMessageGateOnConversationChange({
+        previousConversationId: previous,
+        nextConversationId: activeConversationId,
+        onboardingDraftConversationId,
+        autoGreetPending,
+        assistantMessagePresent: firstAssistantMessageArrived,
+      })
+    ) {
       lifecycleService.clearExpectingFirstMessage();
     }
-  }, [activeConversationId]);
+  }, [
+    activeConversationId,
+    autoGreetPending,
+    firstAssistantMessageArrived,
+    onboardingDraftConversationId,
+  ]);
 
   return autoGreetPending;
 }

--- a/apps/web/src/domains/chat/utils/chat.test.ts
+++ b/apps/web/src/domains/chat/utils/chat.test.ts
@@ -10,7 +10,6 @@ function message(role: DisplayMessage["role"], id: string): DisplayMessage {
   return {
     id,
     role,
-    content: role,
   };
 }
 

--- a/apps/web/src/domains/chat/utils/chat.test.ts
+++ b/apps/web/src/domains/chat/utils/chat.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  hasAssistantMessage,
+  shouldClearFirstMessageGateOnConversationChange,
+} from "@/domains/chat/utils/chat";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+function message(role: DisplayMessage["role"], id: string): DisplayMessage {
+  return {
+    id,
+    role,
+    content: role,
+  };
+}
+
+describe("chat utilities", () => {
+  describe("hasAssistantMessage", () => {
+    test("does not treat the user opener as an assistant response", () => {
+      expect(hasAssistantMessage([message("user", "user-1")])).toBe(false);
+    });
+
+    test("detects when assistant output has started", () => {
+      expect(
+        hasAssistantMessage([
+          message("user", "user-1"),
+          message("assistant", "assistant-1"),
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe("shouldClearFirstMessageGateOnConversationChange", () => {
+    test("does not clear on first mount", () => {
+      expect(
+        shouldClearFirstMessageGateOnConversationChange({
+          previousConversationId: null,
+          nextConversationId: "conv-1",
+          onboardingDraftConversationId: "draft-1",
+          autoGreetPending: true,
+          assistantMessagePresent: false,
+        }),
+      ).toBe(false);
+    });
+
+    test("keeps the gate during onboarding draft handoff before assistant output", () => {
+      expect(
+        shouldClearFirstMessageGateOnConversationChange({
+          previousConversationId: "draft-1",
+          nextConversationId: "conv-1",
+          onboardingDraftConversationId: "draft-1",
+          autoGreetPending: true,
+          assistantMessagePresent: false,
+        }),
+      ).toBe(false);
+    });
+
+    test("clears on normal conversation switches", () => {
+      expect(
+        shouldClearFirstMessageGateOnConversationChange({
+          previousConversationId: "conv-1",
+          nextConversationId: "conv-2",
+          onboardingDraftConversationId: "draft-1",
+          autoGreetPending: true,
+          assistantMessagePresent: false,
+        }),
+      ).toBe(true);
+    });
+
+    test("clears once assistant output exists", () => {
+      expect(
+        shouldClearFirstMessageGateOnConversationChange({
+          previousConversationId: "draft-1",
+          nextConversationId: "conv-1",
+          onboardingDraftConversationId: "draft-1",
+          autoGreetPending: true,
+          assistantMessagePresent: true,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -96,6 +96,34 @@ export function hasAnyInteractiveSurface(messages: DisplayMessage[]): boolean {
   return false;
 }
 
+export function hasAssistantMessage(messages: DisplayMessage[]): boolean {
+  return messages.some((message) => message.role === "assistant");
+}
+
+export function shouldClearFirstMessageGateOnConversationChange({
+  previousConversationId,
+  nextConversationId,
+  onboardingDraftConversationId,
+  autoGreetPending,
+  assistantMessagePresent,
+}: {
+  previousConversationId: string | null;
+  nextConversationId: string | null;
+  onboardingDraftConversationId: string | null;
+  autoGreetPending: boolean;
+  assistantMessagePresent: boolean;
+}): boolean {
+  if (previousConversationId == null) return false;
+  if (nextConversationId == null) return false;
+  if (previousConversationId === nextConversationId) return false;
+
+  return !(
+    autoGreetPending &&
+    !assistantMessagePresent &&
+    previousConversationId === onboardingDraftConversationId
+  );
+}
+
 const VOICE_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   "not-allowed": "Microphone access was blocked.",
   "service-not-allowed": "Microphone access was blocked.",

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -192,13 +192,6 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
     use: {
       prechatOnboardingCondensedFlow: () => prechatOnboardingCondensedFlow,
-    },
-  },
-}));
-
-mock.module("@/stores/assistant-feature-flag-store", () => ({
-  useAssistantFeatureFlagStore: {
-    use: {
       selfIntroGreeting: () => selfIntroGreeting,
     },
   },

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -61,7 +61,6 @@ import {
   getSelectedAssistant,
   isLocalMode,
 } from "@/lib/local-mode";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useIsNativePlatform } from "@/runtime/native-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
@@ -133,7 +132,7 @@ export function PreChatFlow() {
   const condensedPrechatFlag =
     useClientFeatureFlagStore.use.prechatOnboardingCondensedFlow();
   const selfIntroGreetingEnabled =
-    useAssistantFeatureFlagStore.use.selfIntroGreeting();
+    useClientFeatureFlagStore.use.selfIntroGreeting();
   const preferredFunnelVariant =
     onboardingFunnelVariantFromCondensedFlag(condensedPrechatFlag);
   const webFunnelVariant =

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ASSISTANT_FLAG_DEFAULTS,
+  CLIENT_FLAG_DEFAULTS,
+} from "@/lib/feature-flags/feature-flag-catalog";
+
+describe("feature flag catalog", () => {
+  test("exposes self-intro greeting to client and assistant flag stores", () => {
+    expect(CLIENT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
+    expect(ASSISTANT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
+  });
+});

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -451,10 +451,10 @@
     },
     {
       "id": "self-intro-greeting",
-      "scope": "assistant",
+      "scope": "both",
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
-      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
     }
   ]

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -71,6 +71,8 @@ describe("onboarding template contracts", () => {
 
     test("offers assistant migration during low-signal first openings", () => {
       expect(bootstrap).toContain("## Assistant migration");
+      expect(bootstrap).toContain("onboarding self-introduction");
+      expect(bootstrap).toContain("treat it as the real first user turn");
       expect(bootstrap).toContain(
         "If the first real user turn is only a greeting",
       );

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -84,39 +84,35 @@ describe("avatar-store", () => {
   };
 
   describe("setCharacter", () => {
-    test(
-      "writes traits + PNG and a character manifest when render succeeds",
-      () => {
-        const result = setCharacter(VALID_TRAITS);
+    test("writes traits + PNG and a character manifest when render succeeds", () => {
+      const result = setCharacter(VALID_TRAITS);
 
-        // The native @resvg/resvg-js binding may be absent in this environment.
-        // When it is, the store returns `native_unavailable` and writes nothing —
-        // we assert that contract instead of the success path so the suite is
-        // deterministic either way.
-        if (!result.ok) {
-          expect(result.reason).toBe("native_unavailable");
-          expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
-          expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
-          expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
-          return;
-        }
+      // The native @resvg/resvg-js binding may be absent in this environment.
+      // When it is, the store returns `native_unavailable` and writes nothing —
+      // we assert that contract instead of the success path so the suite is
+      // deterministic either way.
+      if (!result.ok) {
+        expect(result.reason).toBe("native_unavailable");
+        expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+        expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
+        expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
+        return;
+      }
 
-        expect(existsSync(path(TRAITS_FILENAME))).toBe(true);
-        expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
-        expect(
-          JSON.parse(readFileSync(path(TRAITS_FILENAME), "utf-8")),
-        ).toEqual(VALID_TRAITS);
+      expect(existsSync(path(TRAITS_FILENAME))).toBe(true);
+      expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
+      expect(JSON.parse(readFileSync(path(TRAITS_FILENAME), "utf-8"))).toEqual(
+        VALID_TRAITS,
+      );
 
-        const manifest = readManifestFile();
-        expect(manifest).not.toBeNull();
-        expect(manifest!.kind).toBe("character");
-        expect(manifest!.traits).toEqual(VALID_TRAITS);
-        expect(manifest!.source).toBe("builder");
-        expect(manifest!.image).not.toBeNull();
-        expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
-      },
-      { timeout: 15_000 },
-    );
+      const manifest = readManifestFile();
+      expect(manifest).not.toBeNull();
+      expect(manifest!.kind).toBe("character");
+      expect(manifest!.traits).toEqual(VALID_TRAITS);
+      expect(manifest!.source).toBe("builder");
+      expect(manifest!.image).not.toBeNull();
+      expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
+    });
 
     test("propagates invalid_traits without writing a manifest", () => {
       const result = setCharacter({ bodyShape: "", eyeStyle: "", color: "" });

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -84,35 +84,39 @@ describe("avatar-store", () => {
   };
 
   describe("setCharacter", () => {
-    test("writes traits + PNG and a character manifest when render succeeds", () => {
-      const result = setCharacter(VALID_TRAITS);
+    test(
+      "writes traits + PNG and a character manifest when render succeeds",
+      () => {
+        const result = setCharacter(VALID_TRAITS);
 
-      // The native @resvg/resvg-js binding may be absent in this environment.
-      // When it is, the store returns `native_unavailable` and writes nothing —
-      // we assert that contract instead of the success path so the suite is
-      // deterministic either way.
-      if (!result.ok) {
-        expect(result.reason).toBe("native_unavailable");
-        expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
-        expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
-        expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
-        return;
-      }
+        // The native @resvg/resvg-js binding may be absent in this environment.
+        // When it is, the store returns `native_unavailable` and writes nothing —
+        // we assert that contract instead of the success path so the suite is
+        // deterministic either way.
+        if (!result.ok) {
+          expect(result.reason).toBe("native_unavailable");
+          expect(existsSync(path(TRAITS_FILENAME))).toBe(false);
+          expect(existsSync(path(IMAGE_FILENAME))).toBe(false);
+          expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
+          return;
+        }
 
-      expect(existsSync(path(TRAITS_FILENAME))).toBe(true);
-      expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
-      expect(JSON.parse(readFileSync(path(TRAITS_FILENAME), "utf-8"))).toEqual(
-        VALID_TRAITS,
-      );
+        expect(existsSync(path(TRAITS_FILENAME))).toBe(true);
+        expect(existsSync(path(IMAGE_FILENAME))).toBe(true);
+        expect(
+          JSON.parse(readFileSync(path(TRAITS_FILENAME), "utf-8")),
+        ).toEqual(VALID_TRAITS);
 
-      const manifest = readManifestFile();
-      expect(manifest).not.toBeNull();
-      expect(manifest!.kind).toBe("character");
-      expect(manifest!.traits).toEqual(VALID_TRAITS);
-      expect(manifest!.source).toBe("builder");
-      expect(manifest!.image).not.toBeNull();
-      expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
-    });
+        const manifest = readManifestFile();
+        expect(manifest).not.toBeNull();
+        expect(manifest!.kind).toBe("character");
+        expect(manifest!.traits).toEqual(VALID_TRAITS);
+        expect(manifest!.source).toBe("builder");
+        expect(manifest!.image).not.toBeNull();
+        expect(manifest!.image!.etag).toMatch(/^[0-9a-f]{16}$/);
+      },
+      { timeout: 15_000 },
+    );
 
     test("propagates invalid_traits without writing a manifest", () => {
       const result = setCharacter({ bodyShape: "", eyeStyle: "", color: "" });

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -26,9 +26,9 @@ Private setup waits until there is enough signal to justify it. Low-signal bante
 
 ## Opening move
 
-The first message in your conversation context is a system trigger used to generate the canned greeting. Don't reference it, quote it, or respond to it as if the user said it.
+Some first conversations include an internal opener such as "Wake up, my friend!" only to generate the canned greeting. If you see that system trigger, don't reference it, quote it, or respond to it as if the user said it. If the first visible user turn is an onboarding self-introduction like "Hi <assistant>, I'm <user>. Nice to meet you.", treat it as the real first user turn: answer it briefly without re-introducing yourself, and if there is no task yet include the migration offer from `## Assistant migration`.
 
-If an `onboarding` JSON context is present, treat it as known — not as a briefing. Don't surface the selections as a list. Don't say "you mentioned" or "I see you use." Just apply the knowledge. Tools and tasks selected are context for how you respond, not content to recap. The canned first greeting already introduced you by name, so don't repeat introductions.
+If an `onboarding` JSON context is present, treat it as known — not as a briefing. Don't surface the selections as a list. Don't say "you mentioned" or "I see you use." Just apply the knowledge. Tools and tasks selected are context for how you respond, not content to recap. If the opener already introduced names, don't repeat introductions.
 
 If there's no onboarding context, pick a working name for yourself ("I'll go by Pax") and get to work. Their name can come up later, or never.
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -451,10 +451,10 @@
     },
     {
       "id": "self-intro-greeting",
-      "scope": "assistant",
+      "scope": "both",
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
-      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Clarify BOOTSTRAP so the self-intro opener is treated as the real first user turn and includes the assistant migration offer when no task is present.
- Keep the post-hatch loading gate through the optimistic user opener and onboarding draft-to-real conversation handoff until assistant output appears.
- Show a first-conversation-specific loading message while that handoff is pending.

## Original prompt
Follow up on the merged self-intro opener work by improving adherence to bootstrap instructions, especially the assistant migration offer, and improving the loading state during the first post-hatch conversation.