### PR TITLE
fix(design-library): escape currency $ adjacent to en/em dashes (JARVIS-1006)

### DIFF
--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -166,6 +166,22 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("$100");
   });
 
+  test("currency ranges with en/em dashes are not mangled into math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Savings are closer to $12K–$17K, maybe $1M—$2M.",
+      }),
+    );
+
+    // The dash between the amounts must not let the first `$` open a math
+    // span that closes on the next `$` (the italic-math wonk).
+    expect(html).not.toContain("katex");
+    expect(html).toContain("$12K");
+    expect(html).toContain("$17K");
+    expect(html).toContain("$1M");
+    expect(html).toContain("$2M");
+  });
+
   test("legitimate inline math still renders via KaTeX", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -182,6 +182,19 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("$2M");
   });
 
+  test("suffixed amounts with a trailing + are not mangled into math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Whitestone is premium - $1M+ homes earning $500K+ a year.",
+      }),
+    );
+
+    // "$1M+" must not open a math span that closes on the next "$".
+    expect(html).not.toContain("katex");
+    expect(html).toContain("$1M+");
+    expect(html).toContain("$500K+");
+  });
+
   test("legitimate inline math still renders via KaTeX", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -286,9 +286,15 @@ function buildMarkdownComponents(
  * ending at a word/punctuation boundary. Intentionally narrow so real math is
  * preserved — `$E = mc^2$`, `$x^2$`, `$\frac12$` have no digit after `$`, and
  * `$2x + 1$` has the digit followed by a variable rather than a boundary.
+ *
+ * The boundary set includes the en-dash `–` and em-dash `—` (not just the
+ * plain hyphen `-`) because ranges like `$12K–$17K` are common; without them
+ * the opening `$` of the first amount stays unescaped and pairs with the next
+ * `$` into an italic math span. `–—` are literal members of the class; the
+ * plain `-` stays last so it is never read as a range operator.
  */
 const CURRENCY_AMOUNT =
-  /\$(\d[\d,]*(?:\.\d+)?(?:bn|tn|trn|[KMBT])?)(?=$|[\s).,;:!?%"'’\]}/-]|&)/gi;
+  /\$(\d[\d,]*(?:\.\d+)?(?:bn|tn|trn|[KMBT])?)(?=$|[\s).,;:!?%"'’\]}/–—-]|&)/gi;
 
 /**
  * remark-math treats `$…$` as inline LaTeX, so monetary text like

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -292,9 +292,14 @@ function buildMarkdownComponents(
  * the opening `$` of the first amount stays unescaped and pairs with the next
  * `$` into an italic math span. `–—` are literal members of the class; the
  * plain `-` stays last so it is never read as a range operator.
+ *
+ * A `+` is consumed only as part of a *suffixed* amount (`$1M+`, `$500K+` —
+ * the "or more" idiom) so those amounts terminate at a clean boundary. It is
+ * deliberately NOT a general boundary char: a bare `$1+1$` keeps `1` followed
+ * by `+` with no boundary, so real arithmetic math is preserved.
  */
 const CURRENCY_AMOUNT =
-  /\$(\d[\d,]*(?:\.\d+)?(?:bn|tn|trn|[KMBT])?)(?=$|[\s).,;:!?%"'’\]}/–—-]|&)/gi;
+  /\$(\d[\d,]*(?:\.\d+)?(?:(?:bn|tn|trn|[KMBT])\+?)?)(?=$|[\s).,;:!?%"'’\]}/–—-]|&)/gi;
 
 /**
  * remark-math treats `$…$` as inline LaTeX, so monetary text like


### PR DESCRIPTION
## Problem

A user reported "italicization wonk" while working through rent-vs-buy / mortgage calculations on the iPhone web client. Large runs of text rendered in slanted KaTeX math typography, and the console flooded with KaTeX `commentAtEnd` warnings.

## Root cause

The markdown renderer (`packages/design-library/src/components/markdown-message.tsx`) runs `remark-math` + `rehype-katex`, which treats `$…$` as inline LaTeX. Dollar amounts in prose (`$1,700 to $3,200`, `$12K–$17K`, `$1M+`) get paired into math spans and italicized. When a captured span contains a `%` (e.g. `38%`), KaTeX additionally emits the `commentAtEnd` strict-mode warning — same root cause, just a second symptom.

The existing `escapeCurrencyDollars()` mitigation (#32861, JARVIS-1006) escapes the `$` of currency amounts so they aren't parsed as math, but its `CURRENCY_AMOUNT` boundary set was incomplete:

1. **Dash ranges** — `$12K–$17K`: the en-dash `–` (U+2013) / em-dash `—` (U+2014) weren't boundary chars (only the plain hyphen `-` was), so the first amount's `$` stayed unescaped and opened a math span.
2. **"Or more" suffix** — `$1M+`, `$500K+`: `+` wasn't a boundary char, same failure.

## Fix

Two surgical extensions to the `CURRENCY_AMOUNT` boundary, both root-cause:

1. Add `–—` to the boundary character class (literals; the plain `-` stays last so it's never read as a range operator).
2. Consume a trailing `+` **only when it follows a scale suffix** (`(?:bn|tn|trn|[KMBT])\+?`), so `$1M+`/`$500K+` terminate cleanly while bare arithmetic `$1+1$` (digit-then-`+`, no boundary) keeps its math.

Real math is unaffected: escaping still requires `$` immediately followed by a digit and a currency-shaped token, so `$x^2$`, `$E=mc^2$`, `$2x+1$`, `$1+1$` all still render via KaTeX.

Once deployed, both the italic rendering and the KaTeX console warnings disappear, because currency text never reaches KaTeX.

## Note on the original screenshot

The reported screenshot predates *any* escaping (#32861 landed ~19h after the feedback was captured), so in it every `$amount` is italicized — including space-bounded ones already handled by #32861. This PR closes the remaining dash-range and `+`-suffix gaps that would still break even with #32861 deployed.

## Verification

- `bun test markdown-message.test.tsx` → 21 pass (new regression tests for en/em-dash ranges and `+`-suffixed amounts, plus preserved real-math tests).
- `bun run typecheck` → clean.
- Reproduced the bug and the fix against the live code for every dollar pattern in the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)