### PR TITLE
[codex] Fix pending initial chat prompts

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -78,6 +78,7 @@ import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-pale
 import { useMessageReconciliation } from "@/domains/chat/hooks/use-message-reconciliation";
 import { useStreamEventHandler } from "@/domains/chat/hooks/use-stream-event-handler";
 import { useSendMessage } from "@/domains/chat/hooks/use-send-message";
+import { useInitialMessageLaunch } from "@/domains/chat/hooks/use-initial-message-launch";
 import { useInteractionActions } from "@/domains/chat/hooks/use-interaction-actions";
 import { useEventStream } from "@/domains/chat/hooks/use-event-stream";
 import { hydrateLastSeenSeqFromStorage } from "@/lib/streaming/last-seen-seq";
@@ -702,6 +703,15 @@ export function ChatPage() {
     useInteractionStore.getState().dismissQuestion();
     await baseHandleStopGenerating();
   }, [baseHandleStopGenerating]);
+
+  useInitialMessageLaunch({
+    assistantId,
+    activeConversationId,
+    reachabilityPhase: reachability.state.phase,
+    pendingInitialMessageRef,
+    startNewConversation,
+    sendMessage,
+  });
 
   // Auto-send a message when navigated to with ?prompt= (e.g. Submit Feedback)
   const promptConsumedRef = useRef<string | null>(null);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -704,6 +704,10 @@ export function ChatPage() {
     await baseHandleStopGenerating();
   }, [baseHandleStopGenerating]);
 
+  const probeInitialMessageReachability = useCallback(() => {
+    reachability.probe({ mode: "background" });
+  }, [reachability.probe]);
+
   useInitialMessageLaunch({
     assistantId,
     activeConversationId,
@@ -711,6 +715,7 @@ export function ChatPage() {
     pendingInitialMessageRef,
     startNewConversation,
     sendMessage,
+    probeReachability: probeInitialMessageReachability,
   });
 
   // Auto-send a message when navigated to with ?prompt= (e.g. Submit Feedback)

--- a/apps/web/src/domains/chat/hooks/use-initial-message-launch.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-initial-message-launch.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+
+import type { ReachabilityPhase } from "@/assistant/use-assistant-reachability";
+import { useInitialMessageLaunch } from "@/domains/chat/hooks/use-initial-message-launch";
+import { INITIAL_MESSAGE_SESSION_KEY } from "@/utils/initial-message-launch";
+
+type PendingInitialMessage = {
+  conversationId: string;
+  content: string;
+};
+
+const PROMPT =
+  "Please load the llm-cost-optimizer skill. Analyze my recent LLM usage.";
+
+describe("useInitialMessageLaunch", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    sessionStorage.clear();
+  });
+
+  function renderLaunchHook({
+    assistantId = "asst-1",
+    activeConversationId = null,
+    reachabilityPhase = "ready",
+    pendingInitialMessageRef = {
+      current: null,
+    } as MutableRefObject<PendingInitialMessage | null>,
+    startNewConversation = mock(() => {}),
+    sendMessage = mock(async () => {}),
+  }: {
+    assistantId?: string | null;
+    activeConversationId?: string | null;
+    reachabilityPhase?: ReachabilityPhase;
+    pendingInitialMessageRef?: MutableRefObject<PendingInitialMessage | null>;
+    startNewConversation?: (opts?: {
+      silent?: boolean;
+      initialMessage?: string;
+    }) => void;
+    sendMessage?: (content: string) => Promise<void>;
+  } = {}) {
+    return renderHook(
+      (props: {
+        assistantId: string | null;
+        activeConversationId: string | null;
+        reachabilityPhase: ReachabilityPhase;
+      }) =>
+        useInitialMessageLaunch({
+          assistantId: props.assistantId,
+          activeConversationId: props.activeConversationId,
+          reachabilityPhase: props.reachabilityPhase,
+          pendingInitialMessageRef,
+          startNewConversation,
+          sendMessage,
+        }),
+      {
+        initialProps: {
+          assistantId,
+          activeConversationId,
+          reachabilityPhase,
+        },
+      },
+    );
+  }
+
+  test("consumes a stored prompt, starts a draft, and sends once when reachable", async () => {
+    sessionStorage.setItem(INITIAL_MESSAGE_SESSION_KEY, PROMPT);
+    const pendingInitialMessageRef: MutableRefObject<PendingInitialMessage | null> =
+      { current: null };
+    const startNewConversation = mock(
+      (opts?: { silent?: boolean; initialMessage?: string }) => {
+        pendingInitialMessageRef.current = {
+          conversationId: "draft-1",
+          content: opts?.initialMessage ?? "",
+        };
+      },
+    );
+    const sendMessage = mock(async () => {});
+
+    const { rerender } = renderLaunchHook({
+      activeConversationId: null,
+      pendingInitialMessageRef,
+      startNewConversation,
+      sendMessage,
+    });
+
+    await waitFor(() =>
+      expect(startNewConversation).toHaveBeenCalledWith({
+        initialMessage: PROMPT,
+      }),
+    );
+    expect(sessionStorage.getItem(INITIAL_MESSAGE_SESSION_KEY)).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    rerender({
+      assistantId: "asst-1",
+      activeConversationId: "draft-1",
+      reachabilityPhase: "ready",
+    });
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(PROMPT));
+    expect(pendingInitialMessageRef.current).toBeNull();
+
+    rerender({
+      assistantId: "asst-1",
+      activeConversationId: "draft-1",
+      reachabilityPhase: "ready",
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not consume the stored prompt before an assistant is selected", async () => {
+    sessionStorage.setItem(INITIAL_MESSAGE_SESSION_KEY, PROMPT);
+    const startNewConversation = mock(() => {});
+
+    const { rerender } = renderLaunchHook({
+      assistantId: null,
+      startNewConversation,
+    });
+
+    await Promise.resolve();
+    expect(startNewConversation).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(INITIAL_MESSAGE_SESSION_KEY)).toBe(PROMPT);
+
+    rerender({
+      assistantId: "asst-1",
+      activeConversationId: null,
+      reachabilityPhase: "ready",
+    });
+
+    await waitFor(() => expect(startNewConversation).toHaveBeenCalled());
+    expect(sessionStorage.getItem(INITIAL_MESSAGE_SESSION_KEY)).toBeNull();
+  });
+
+  test("waits for reachability before sending a staged initial message", async () => {
+    const pendingInitialMessageRef: MutableRefObject<PendingInitialMessage | null> =
+      {
+        current: {
+          conversationId: "draft-1",
+          content: PROMPT,
+        },
+      };
+    const sendMessage = mock(async () => {});
+
+    const { rerender } = renderLaunchHook({
+      activeConversationId: "draft-1",
+      reachabilityPhase: "connecting",
+      pendingInitialMessageRef,
+      sendMessage,
+    });
+
+    await Promise.resolve();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(pendingInitialMessageRef.current?.content).toBe(PROMPT);
+
+    rerender({
+      assistantId: "asst-1",
+      activeConversationId: "draft-1",
+      reachabilityPhase: "ready",
+    });
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(PROMPT));
+    expect(pendingInitialMessageRef.current).toBeNull();
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-initial-message-launch.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-initial-message-launch.test.tsx
@@ -33,6 +33,7 @@ describe("useInitialMessageLaunch", () => {
     } as MutableRefObject<PendingInitialMessage | null>,
     startNewConversation = mock(() => {}),
     sendMessage = mock(async () => {}),
+    probeReachability = mock(() => {}),
   }: {
     assistantId?: string | null;
     activeConversationId?: string | null;
@@ -43,6 +44,7 @@ describe("useInitialMessageLaunch", () => {
       initialMessage?: string;
     }) => void;
     sendMessage?: (content: string) => Promise<void>;
+    probeReachability?: () => void;
   } = {}) {
     return renderHook(
       (props: {
@@ -57,6 +59,7 @@ describe("useInitialMessageLaunch", () => {
           pendingInitialMessageRef,
           startNewConversation,
           sendMessage,
+          probeReachability,
         }),
       {
         initialProps: {
@@ -166,5 +169,77 @@ describe("useInitialMessageLaunch", () => {
 
     await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(PROMPT));
     expect(pendingInitialMessageRef.current).toBeNull();
+  });
+
+  test("probes reachability when a staged initial message is waiting from idle", async () => {
+    const pendingInitialMessageRef: MutableRefObject<PendingInitialMessage | null> =
+      {
+        current: {
+          conversationId: "draft-1",
+          content: PROMPT,
+        },
+      };
+    const probeReachability = mock(() => {});
+    const sendMessage = mock(async () => {});
+
+    renderLaunchHook({
+      activeConversationId: "draft-1",
+      reachabilityPhase: "idle",
+      pendingInitialMessageRef,
+      sendMessage,
+      probeReachability,
+    });
+
+    await waitFor(() => expect(probeReachability).toHaveBeenCalledTimes(1));
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(pendingInitialMessageRef.current?.content).toBe(PROMPT);
+  });
+
+  test("carries a stored prompt across the index-to-conversation remount", async () => {
+    sessionStorage.setItem(INITIAL_MESSAGE_SESSION_KEY, PROMPT);
+    const firstMountPendingRef: MutableRefObject<PendingInitialMessage | null> =
+      { current: null };
+    const startNewConversation = mock(
+      (opts?: { silent?: boolean; initialMessage?: string }) => {
+        firstMountPendingRef.current = {
+          conversationId: "draft-1",
+          content: opts?.initialMessage ?? "",
+        };
+      },
+    );
+
+    const firstMount = renderLaunchHook({
+      activeConversationId: null,
+      pendingInitialMessageRef: firstMountPendingRef,
+      startNewConversation,
+    });
+
+    await waitFor(() => expect(startNewConversation).toHaveBeenCalled());
+    firstMount.unmount();
+
+    const secondMountPendingRef: MutableRefObject<PendingInitialMessage | null> =
+      { current: null };
+    const probeReachability = mock(() => {});
+    const sendMessage = mock(async () => {});
+
+    const { rerender } = renderLaunchHook({
+      activeConversationId: "draft-1",
+      reachabilityPhase: "idle",
+      pendingInitialMessageRef: secondMountPendingRef,
+      probeReachability,
+      sendMessage,
+    });
+
+    await waitFor(() => expect(probeReachability).toHaveBeenCalledTimes(1));
+    expect(secondMountPendingRef.current?.content).toBe(PROMPT);
+
+    rerender({
+      assistantId: "asst-1",
+      activeConversationId: "draft-1",
+      reachabilityPhase: "ready",
+    });
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(PROMPT));
+    expect(secondMountPendingRef.current).toBeNull();
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-initial-message-launch.ts
+++ b/apps/web/src/domains/chat/hooks/use-initial-message-launch.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+
+import type { ReachabilityPhase } from "@/assistant/use-assistant-reachability";
+import { consumePendingInitialMessage } from "@/utils/initial-message-launch";
+
+type PendingInitialMessage = {
+  conversationId: string;
+  content: string;
+};
+
+interface UseInitialMessageLaunchParams {
+  assistantId: string | null;
+  activeConversationId: string | null;
+  reachabilityPhase: ReachabilityPhase;
+  pendingInitialMessageRef: MutableRefObject<PendingInitialMessage | null>;
+  startNewConversation: (opts?: {
+    silent?: boolean;
+    initialMessage?: string;
+  }) => void;
+  sendMessage: (content: string) => Promise<void>;
+}
+
+export function useInitialMessageLaunch({
+  assistantId,
+  activeConversationId,
+  reachabilityPhase,
+  pendingInitialMessageRef,
+  startNewConversation,
+  sendMessage,
+}: UseInitialMessageLaunchParams) {
+  const consumedStoredMessageRef = useRef(false);
+
+  useEffect(() => {
+    if (consumedStoredMessageRef.current || !assistantId) return;
+
+    const message = consumePendingInitialMessage();
+    if (!message) return;
+
+    consumedStoredMessageRef.current = true;
+    startNewConversation({ initialMessage: message });
+  }, [assistantId, startNewConversation]);
+
+  useEffect(() => {
+    if (!assistantId || !activeConversationId || reachabilityPhase !== "ready") {
+      return;
+    }
+
+    const pending = pendingInitialMessageRef.current;
+    if (!pending || pending.conversationId !== activeConversationId) return;
+
+    pendingInitialMessageRef.current = null;
+    void sendMessage(pending.content);
+  }, [
+    activeConversationId,
+    assistantId,
+    pendingInitialMessageRef,
+    reachabilityPhase,
+    sendMessage,
+  ]);
+}

--- a/apps/web/src/domains/chat/hooks/use-initial-message-launch.ts
+++ b/apps/web/src/domains/chat/hooks/use-initial-message-launch.ts
@@ -8,6 +8,8 @@ type PendingInitialMessage = {
   content: string;
 };
 
+let routedInitialMessage: PendingInitialMessage | null = null;
+
 interface UseInitialMessageLaunchParams {
   assistantId: string | null;
   activeConversationId: string | null;
@@ -18,6 +20,7 @@ interface UseInitialMessageLaunchParams {
     initialMessage?: string;
   }) => void;
   sendMessage: (content: string) => Promise<void>;
+  probeReachability: () => void;
 }
 
 export function useInitialMessageLaunch({
@@ -27,6 +30,7 @@ export function useInitialMessageLaunch({
   pendingInitialMessageRef,
   startNewConversation,
   sendMessage,
+  probeReachability,
 }: UseInitialMessageLaunchParams) {
   const consumedStoredMessageRef = useRef(false);
 
@@ -38,7 +42,37 @@ export function useInitialMessageLaunch({
 
     consumedStoredMessageRef.current = true;
     startNewConversation({ initialMessage: message });
-  }, [assistantId, startNewConversation]);
+
+    const pending = pendingInitialMessageRef.current;
+    if (pending?.content === message) {
+      routedInitialMessage = pending;
+    }
+  }, [assistantId, pendingInitialMessageRef, startNewConversation]);
+
+  useEffect(() => {
+    if (!assistantId || !activeConversationId || !routedInitialMessage) return;
+    if (routedInitialMessage.conversationId !== activeConversationId) return;
+
+    pendingInitialMessageRef.current = routedInitialMessage;
+    routedInitialMessage = null;
+  }, [activeConversationId, assistantId, pendingInitialMessageRef]);
+
+  useEffect(() => {
+    if (!assistantId || !activeConversationId || reachabilityPhase !== "idle") {
+      return;
+    }
+
+    const pending = pendingInitialMessageRef.current;
+    if (!pending || pending.conversationId !== activeConversationId) return;
+
+    probeReachability();
+  }, [
+    activeConversationId,
+    assistantId,
+    pendingInitialMessageRef,
+    probeReachability,
+    reachabilityPhase,
+  ]);
 
   useEffect(() => {
     if (!assistantId || !activeConversationId || reachabilityPhase !== "ready") {


### PR DESCRIPTION
## Summary

- Adds a chat-side launch hook that consumes pending initial-message handoffs from sessionStorage.
- Sends staged initial messages once the draft conversation is active and the assistant is reachable.
- Wires the hook into ChatPage so the usage cost-analysis button and other initialMessage callers actually submit their prompt.

## Root Cause

The usage page stored the cost-analysis prompt with storePendingInitialMessage() and navigated to /assistant, but ChatPage never consumed that storage key. Separately, startNewConversation({ initialMessage }) staged pendingInitialMessageRef without any send path.

## Validation

- bun test src/domains/chat/utils/initial-message-launch.test.ts src/domains/chat/hooks/use-initial-message-launch.test.tsx
- bun run lint src/domains/chat/hooks/use-initial-message-launch.ts src/domains/chat/hooks/use-initial-message-launch.test.tsx src/domains/chat/chat-page.tsx
- bun run typecheck