### PR TITLE
fix(web): stop assistant avatar eyes freezing squished after streaming

### DIFF
--- a/apps/web/src/components/avatar/animated-avatar.test.tsx
+++ b/apps/web/src/components/avatar/animated-avatar.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the "stuck blink" bug: a blink is a
+ * `setIsBlinking(true)` → 150ms → `false` pair, and if `isStreaming` flips
+ * true mid-blink the effect cleanup cancels the pending "un-blink" timeout.
+ * Without the streaming guard the eyes freeze squished (scaleY 0.1) until the
+ * component remounts (page refresh / conversation switch).
+ *
+ * bun:test has no fake-timer API, so we capture the callback the blink effect
+ * registers via setTimeout and invoke it from `act()` — same approach as
+ * website-carousel.test.tsx.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act } from "react";
+import { cleanup, render } from "@testing-library/react";
+
+// Force animations on (don't let prefers-reduced-motion short-circuit blinks).
+mock.module("motion/react", () => ({
+  useReducedMotion: () => false,
+}));
+
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+const TRAITS = { bodyShape: "sprout", eyeStyle: "grumpy", color: "green" };
+
+/** The eyes live in the second <g> of the avatar SVG (body is the first). */
+function eyeTransform(container: HTMLElement): string {
+  const groups = container.querySelectorAll("svg > g");
+  return (groups[1] as SVGGElement).style.transform;
+}
+
+let timeoutCallbacks: Array<() => void>;
+let realSetTimeout: typeof globalThis.setTimeout;
+
+beforeEach(() => {
+  timeoutCallbacks = [];
+  realSetTimeout = globalThis.setTimeout;
+  // Capture scheduled callbacks instead of running them on a real clock.
+  globalThis.setTimeout = ((fn: () => void) => {
+    timeoutCallbacks.push(fn);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof globalThis.setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = realSetTimeout;
+  cleanup();
+});
+
+describe("AnimatedAvatar blink", () => {
+  test("a blink interrupted by streaming does not leave the eyes squished", () => {
+    const { container, rerender } = render(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isStreaming={false}
+      />,
+    );
+
+    // Eyes open by default.
+    expect(eyeTransform(container)).toBe("scaleY(1)");
+
+    // Fire the scheduled blink → setIsBlinking(true): eyes squish.
+    act(() => {
+      timeoutCallbacks[0]?.();
+    });
+    expect(eyeTransform(container)).toBe("scaleY(0.1)");
+
+    // Streaming begins mid-blink. Before the fix this froze the eyes squished
+    // until a remount; now the eyes return to open.
+    rerender(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isStreaming
+      />,
+    );
+    expect(eyeTransform(container)).toBe("scaleY(1)");
+  });
+});

--- a/apps/web/src/components/avatar/animated-avatar.test.tsx
+++ b/apps/web/src/components/avatar/animated-avatar.test.tsx
@@ -14,16 +14,10 @@ import {
   beforeEach,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import { act } from "react";
 import { cleanup, render } from "@testing-library/react";
-
-// Force animations on (don't let prefers-reduced-motion short-circuit blinks).
-mock.module("motion/react", () => ({
-  useReducedMotion: () => false,
-}));
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";

--- a/apps/web/src/components/avatar/animated-avatar.tsx
+++ b/apps/web/src/components/avatar/animated-avatar.tsx
@@ -158,7 +158,17 @@ export function AnimatedAvatar({
   const morphTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    if (reduce || isStreaming) return;
+    // Force eyes open whenever blinking is disabled (reduced-motion or
+    // streaming). A blink is a `setIsBlinking(true)` → 150ms → `false` pair;
+    // if `isStreaming` flips true mid-blink, this effect's cleanup cancels the
+    // pending "un-blink" timeout, so without this reset `isBlinking` freezes
+    // at `true` and the eyes stay squished (scaleY 0.1) until the component
+    // remounts (page refresh / conversation switch). Mirrors the twitch
+    // guard (`effectiveTwitchAngle = isStreaming ? 0 : twitchAngle`).
+    if (reduce || isStreaming) {
+      setIsBlinking(false);
+      return;
+    }
     let cancelled = false;
 
     function scheduleBlink() {
@@ -196,7 +206,14 @@ export function AnimatedAvatar({
   }, [reduce, isStreaming]);
 
   useEffect(() => {
-    if (reduce || isStreaming) return;
+    // Reset the body angle when twitching is disabled so a twitch interrupted
+    // mid-flight by streaming can't freeze the body rotated. (The render also
+    // guards this via `effectiveTwitchAngle`, but resetting the state keeps it
+    // correct after streaming ends without waiting for the next twitch cycle.)
+    if (reduce || isStreaming) {
+      setTwitchAngle(0);
+      return;
+    }
     let cancelled = false;
 
     function scheduleTwitch() {
@@ -252,6 +269,9 @@ export function AnimatedAvatar({
       : "avatar-breathe-kf 4s ease-in-out infinite";
 
   const effectiveTwitchAngle = isStreaming ? 0 : twitchAngle;
+  // Never squish the eyes while streaming — guards the one frame between
+  // `isStreaming` flipping true and the blink effect resetting `isBlinking`.
+  const effectiveBlinking = isBlinking && !isStreaming;
   const currentBodyPath = morphPaths[morphIndex] ?? bodyShape.svgPath;
 
   return (
@@ -287,7 +307,7 @@ export function AnimatedAvatar({
 
       <g
         style={{
-          transform: isBlinking ? "scaleY(0.1)" : "scaleY(1)",
+          transform: effectiveBlinking ? "scaleY(0.1)" : "scaleY(1)",
           transformOrigin: `${eyeCenterOutputX}px ${eyeCenterOutputY}px`,
           transition: "transform 0.15s ease-in-out",
         }}

--- a/apps/web/src/components/avatar/chat-avatar.tsx
+++ b/apps/web/src/components/avatar/chat-avatar.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from "motion/react";
-import { useCallback, useMemo, useState, type CSSProperties } from "react";
+import { memo, useCallback, useMemo, useState, type CSSProperties } from "react";
 
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 import {
@@ -104,7 +104,7 @@ function ProgressOverlay({
  *     sweep across the whole avatar (no corner badge). Default behavior (flag
  *     off) leaves the old transcript "thinking…" dots in charge.
  */
-export function ChatAvatar({
+function ChatAvatarComponent({
   components,
   traits,
   customImageUrl,
@@ -221,3 +221,14 @@ export function ChatAvatar({
     </motion.div>
   );
 }
+
+/**
+ * Memoized so the avatar subtree only re-renders when its own props change
+ * (components/traits/image, size, the streaming/processing flags) rather than
+ * on every parent transcript re-render. `Transcript` is a `forwardRef` (not
+ * memoized) and re-renders frequently during streaming, while the avatar runs
+ * per-frame animation work — so skipping unrelated re-renders matters. All
+ * props are primitives or stable references (avatar data is React-Query-cached
+ * with `staleTime: Infinity`), so the default shallow comparison is correct.
+ */
+export const ChatAvatar = memo(ChatAvatarComponent);

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1168,6 +1168,34 @@ export function ChatRouteContent({
       </div>
     ) : undefined;
 
+  // Stable callback so the latest-turn avatar slot isn't rebuilt on every
+  // transcript render. Paired with `memo(ChatAvatar)`, the avatar re-renders
+  // only when its inputs actually change (avatar data, or the streaming /
+  // processing flags) rather than on each parent render.
+  const renderAvatar = useMemo(
+    () =>
+      avatarComponents || avatarImageUrl
+        ? () => (
+            <ChatAvatar
+              components={avatarComponents}
+              traits={avatarTraits}
+              customImageUrl={avatarImageUrl}
+              size={56}
+              interactive
+              isStreaming={isAssistantStreaming}
+              isProcessing={activeConversationIsProcessing}
+            />
+          )
+        : undefined,
+    [
+      avatarComponents,
+      avatarImageUrl,
+      avatarTraits,
+      isAssistantStreaming,
+      activeConversationIsProcessing,
+    ],
+  );
+
   const chatTranscriptProps: TranscriptProps = {
     items: transcriptItems,
     conversationId: activeConversationId,
@@ -1241,20 +1269,7 @@ export function ChatRouteContent({
           onCancel={handleContactPromptCancel}
         />
       ) : null,
-    renderAvatar:
-      avatarComponents || avatarImageUrl
-        ? () => (
-            <ChatAvatar
-              components={avatarComponents}
-              traits={avatarTraits}
-              customImageUrl={avatarImageUrl}
-              size={56}
-              interactive
-              isStreaming={isAssistantStreaming}
-              isProcessing={activeConversationIsProcessing}
-            />
-          )
-        : undefined,
+    renderAvatar,
     onPullRefresh: handlePullRefresh,
     pullRefreshEnabled: chatPullToRefreshEnabled && touchSupported,
     scrollCoordinatorState: {


### PR DESCRIPTION
Two related avatar fixes: a correctness bug (frozen eyes) and a small perf cleanup in the same component family.

---

## 1. Stuck-blink bug (correctness)

### Problem
The assistant avatar's grumpy eyes rendered as a thin flattened line instead of the proper expression, only correcting on a page refresh or conversation switch.

### Root cause
A blink is a `setIsBlinking(true)` → 150ms → `setIsBlinking(false)` pair. The blink `useEffect` bailed out during streaming with a bare early `return` that did not reset state:

```tsx
useEffect(() => {
  if (reduce || isStreaming) return;   // no setIsBlinking(false)
  ...
}, [reduce, isStreaming]);
```

If `isStreaming` flips `true` mid-blink, the effect cleanup cancels the pending "un-blink" timeout, so `isBlinking` freezes at `true` and the eyes stay at `scaleY(0.1)` until a remount. The render read `isBlinking` directly with no streaming guard, unlike twitch (`effectiveTwitchAngle = isStreaming ? 0 : twitchAngle`). `isAssistantStreaming` toggles repeatedly across a multi-step turn, so a long turn makes the freeze likely. Avatar trait data was never involved — it stays correct in the React Query cache (which is why a conversation switch reusing that cache renders fine once remounted).

### Fix
- Reset `isBlinking` / `twitchAngle` when their effect is disabled (reduced-motion or streaming) so an interrupted animation can't freeze its state.
- Gate the eye squish on `!isStreaming` (`effectiveBlinking`), mirroring the twitch guard, so the eyes can't squish even for the single frame before the effect runs.

### Verification
- Regression test (`animated-avatar.test.tsx`) fires a blink, flips `isStreaming`, asserts eyes return to `scaleY(1)`. **Confirmed it fails on the pre-fix code and passes after.**

---

## 2. Avatar re-render churn (perf)

### Problem
`Transcript` is a `forwardRef` (not memoized) and re-renders frequently during streaming. The avatar slot was an inline arrow rebuilt every render and `ChatAvatar` was unmemoized, so the avatar subtree re-rendered (running per-frame animation work) on every parent render even when nothing about the avatar changed.

### Fix
- Wrap `ChatAvatar` in `React.memo` — its props are primitives or stable refs (avatar data is React-Query-cached with `staleTime: Infinity`), so the default shallow comparison is correct.
- Hoist `renderAvatar` into a `useMemo` keyed on the avatar inputs and the streaming/processing flags.

No behavior change; the avatar now re-renders only when its inputs change.

---

## Tests
- `bun test src/components/avatar/` → 8 pass (incl. the new regression test).
- `bun test src/domains/chat/transcript/` → 151 pass.
- Typecheck: no new errors in the changed files (the pre-existing `workspace-tree.tsx` duplicate-React-types error is unrelated and present on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)