### PR TITLE
feat(memory-v3): always-on synthetic capabilities leaf (skills + CLI) for v2 parity

### DIFF
--- a/assistant/src/memory/v3/__tests__/capabilities.test.ts
+++ b/assistant/src/memory/v3/__tests__/capabilities.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CAPABILITIES_LEAF_PATH,
+  type CapabilityResolvers,
+  injectCapabilitiesLeaf,
+  isCapabilitySlug,
+  renderCapabilityContent,
+} from "../capabilities.js";
+import { buildNeedleIndex } from "../needle.js";
+import type { LeafPath, LeafTree, Slug } from "../types.js";
+
+function emptyTree(): LeafTree {
+  return { leaves: new Map(), byPage: new Map<Slug, LeafPath[]>() };
+}
+
+describe("isCapabilitySlug", () => {
+  test("true for skill and CLI-command slugs, false otherwise", () => {
+    expect(isCapabilitySlug("skills/meet-join")).toBe(true);
+    expect(isCapabilitySlug("cli-commands/schedules")).toBe(true);
+    expect(isCapabilitySlug("relationship/vows")).toBe(false);
+    expect(isCapabilitySlug("some-page")).toBe(false);
+  });
+});
+
+describe("injectCapabilitiesLeaf", () => {
+  test("registers an always-on leaf with the synthetic slugs as members", () => {
+    const tree = emptyTree();
+    const core = new Set<LeafPath>();
+    injectCapabilitiesLeaf(tree, core, ["skills/foo", "cli-commands/bar"]);
+
+    const leaf = tree.leaves.get(CAPABILITIES_LEAF_PATH);
+    expect(leaf?.frontmatter.in_core).toBe(true);
+    expect(leaf?.members).toEqual(["skills/foo", "cli-commands/bar"]);
+    expect(core.has(CAPABILITIES_LEAF_PATH)).toBe(true);
+  });
+
+  test("unions the leaf into each member's byPage entry without dropping existing leaves", () => {
+    const tree = emptyTree();
+    tree.byPage.set("skills/foo", ["other/leaf"]);
+    injectCapabilitiesLeaf(tree, new Set<LeafPath>(), [
+      "skills/foo",
+      "cli-commands/bar",
+    ]);
+
+    expect(tree.byPage.get("skills/foo")).toEqual([
+      "other/leaf",
+      CAPABILITIES_LEAF_PATH,
+    ]);
+    expect(tree.byPage.get("cli-commands/bar")).toEqual([
+      CAPABILITIES_LEAF_PATH,
+    ]);
+  });
+
+  test("is idempotent — re-injecting does not duplicate the byPage entry", () => {
+    const tree = emptyTree();
+    const core = new Set<LeafPath>();
+    injectCapabilitiesLeaf(tree, core, ["skills/foo"]);
+    injectCapabilitiesLeaf(tree, core, ["skills/foo"]);
+    expect(tree.byPage.get("skills/foo")).toEqual([CAPABILITIES_LEAF_PATH]);
+  });
+
+  test("stays always-on even with no installed skills/commands", () => {
+    const tree = emptyTree();
+    const core = new Set<LeafPath>();
+    injectCapabilitiesLeaf(tree, core, []);
+    expect(tree.leaves.get(CAPABILITIES_LEAF_PATH)?.members).toEqual([]);
+    expect(core.has(CAPABILITIES_LEAF_PATH)).toBe(true);
+  });
+});
+
+describe("renderCapabilityContent", () => {
+  const resolvers: CapabilityResolvers = {
+    skill: (slug) =>
+      slug === "skills/foo" ? { id: "foo", content: "foo capability" } : null,
+    cli: (slug) =>
+      slug === "cli-commands/bar"
+        ? { id: "bar", content: "bar capability" }
+        : null,
+  };
+
+  test("renders a skill slug with a Skill header", () => {
+    expect(renderCapabilityContent("skills/foo", resolvers)).toBe(
+      "# Skill: foo\nfoo capability",
+    );
+  });
+
+  test("renders a CLI-command slug with a CLI header", () => {
+    expect(renderCapabilityContent("cli-commands/bar", resolvers)).toBe(
+      "# CLI command: bar\nbar capability",
+    );
+  });
+
+  test("degrades to '' for a capability slug the cache cannot resolve", () => {
+    expect(renderCapabilityContent("skills/missing", resolvers)).toBe("");
+  });
+
+  test("returns null for a non-capability slug so the caller reads the on-disk page", () => {
+    expect(renderCapabilityContent("relationship/vows", resolvers)).toBeNull();
+  });
+});
+
+describe("needle indexes injected capability members", () => {
+  test("a skill slug is lexically retrievable by its title and summary", async () => {
+    const tree = emptyTree();
+    injectCapabilitiesLeaf(tree, new Set<LeafPath>(), ["skills/meet-join"]);
+
+    const needle = await buildNeedleIndex(
+      tree,
+      async () => "Join and transcribe a video meeting",
+    );
+
+    // By slug-derived title token.
+    expect(needle.query("meet", 5)).toContain("skills/meet-join");
+    // By summary token.
+    expect(needle.query("transcribe", 5)).toContain("skills/meet-join");
+  });
+});

--- a/assistant/src/memory/v3/capabilities.ts
+++ b/assistant/src/memory/v3/capabilities.ts
@@ -1,0 +1,124 @@
+/**
+ * Memory v3 — synthetic "capabilities" leaf (skills + `assistant` CLI commands).
+ *
+ * v2 surfaces the assistant's invokable capabilities — installed/catalog skills
+ * and top-level CLI subcommands — by seeding them as synthetic concept-collection
+ * rows (`skills/<id>`, `cli-commands/<name>`) into the unified router pool, then
+ * rendering the router-selected ones under `### Skills You Can Use` / `### CLI
+ * Commands You Can Use`. They are NOT always-injected — they are router-selected
+ * per turn, same as concept pages.
+ *
+ * v3 reproduces that behavior with one always-on leaf:
+ *  - The leaf is synthesized in code (not a `leaves/*.md` data file) and injected
+ *    ONLY into the live lane tree (see `shadow-plugin.ts`). Because the classifier
+ *    builds its own tree without this injection, concept pages are never routed
+ *    INTO the capabilities leaf.
+ *  - Its members are the synthetic skill/CLI slugs, so the BM25 needle indexes
+ *    them for free (the needle corpus is `tree.byPage`).
+ *  - It is added to the always-on core set, so L1 always opens it and the per-leaf
+ *    L2 selects the relevant subset each turn — the semantic equivalent of v2's
+ *    "always in the pool, selected per turn".
+ *
+ * Page summaries for synthetic slugs already resolve through the existing
+ * `pageSummary` lane (the v2 page index appends skill/CLI rows with a summary),
+ * so only full-content rendering for the live `<memory>` block needs a synthetic
+ * fallback — see {@link renderCapabilityContent}.
+ */
+
+import {
+  getCliCommandCapability,
+  isCliCommandSlug,
+} from "../v2/cli-command-store.js";
+import { getSkillCapability, isSkillSlug } from "../v2/skill-store.js";
+import type { LeafNode, LeafPath, LeafTree, Slug } from "./types.js";
+
+/** Path of the always-on synthetic leaf that owns skill + CLI capability rows. */
+export const CAPABILITIES_LEAF_PATH: LeafPath = "capabilities";
+
+/** L1/needle label for the capabilities leaf. */
+export const CAPABILITIES_LEAF_DESCRIPTION =
+  "Tools the assistant can invoke: installed and available skills, and the " +
+  "top-level `assistant` CLI subcommands — what the assistant can DO and how " +
+  "to reach for each capability.";
+
+/** True iff the slug is a synthetic skill or CLI-command capability row. */
+export function isCapabilitySlug(slug: Slug): boolean {
+  return isSkillSlug(slug) || isCliCommandSlug(slug);
+}
+
+/**
+ * Inject the synthetic capabilities leaf into a live lane tree: register the leaf
+ * node with `syntheticSlugs` as members, add the leaf to each member's `byPage`
+ * entry (UNION — never drops existing leaves), and mark the leaf always-on by
+ * adding its path to `core`. Mutates `tree` and `core` in place. Idempotent.
+ *
+ * Must run BEFORE the needle is built so the synthetic members land in the needle
+ * corpus (`tree.byPage`).
+ */
+export function injectCapabilitiesLeaf(
+  tree: LeafTree,
+  core: Set<LeafPath>,
+  syntheticSlugs: Slug[],
+): void {
+  const node: LeafNode = {
+    path: CAPABILITIES_LEAF_PATH,
+    frontmatter: { path: CAPABILITIES_LEAF_PATH, in_core: true },
+    description: CAPABILITIES_LEAF_DESCRIPTION,
+    members: [...syntheticSlugs],
+    domain: CAPABILITIES_LEAF_PATH,
+  };
+  tree.leaves.set(CAPABILITIES_LEAF_PATH, node);
+
+  for (const slug of syntheticSlugs) {
+    const existing = tree.byPage.get(slug) ?? [];
+    if (!existing.includes(CAPABILITIES_LEAF_PATH)) {
+      tree.byPage.set(slug, [...existing, CAPABILITIES_LEAF_PATH]);
+    }
+  }
+
+  // Always-on: L1 always opens it, L2 selects the relevant subset per turn.
+  core.add(CAPABILITIES_LEAF_PATH);
+}
+
+interface CapabilityEntry {
+  id: string;
+  content: string;
+}
+
+export interface CapabilityResolvers {
+  skill: (idOrSlug: string) => CapabilityEntry | null;
+  cli: (idOrSlug: string) => CapabilityEntry | null;
+}
+
+const defaultResolvers: CapabilityResolvers = {
+  skill: getSkillCapability,
+  cli: getCliCommandCapability,
+};
+
+/**
+ * Render a synthetic skill/CLI slug's full capability content for the live
+ * `<memory>` block, mirroring {@link renderV3PageContent}'s `# header\n<content>`
+ * shape. Returns:
+ *  - the rendered block when the slug is a capability slug and resolves;
+ *  - `""` when it is a capability slug but the cache has no entry (degrade to a
+ *    blank section rather than throwing or falling through to an on-disk read
+ *    that would also miss);
+ *  - `null` when the slug is NOT a capability slug, so the caller falls through
+ *    to its normal on-disk page rendering.
+ *
+ * `resolvers` is injectable for tests; production uses the v2 store caches.
+ */
+export function renderCapabilityContent(
+  slug: Slug,
+  resolvers: CapabilityResolvers = defaultResolvers,
+): string | null {
+  if (isSkillSlug(slug)) {
+    const entry = resolvers.skill(slug);
+    return entry ? `# Skill: ${entry.id}\n${entry.content}` : "";
+  }
+  if (isCliCommandSlug(slug)) {
+    const entry = resolvers.cli(slug);
+    return entry ? `# CLI command: ${entry.id}\n${entry.content}` : "";
+  }
+  return null;
+}

--- a/assistant/src/memory/v3/page-content.ts
+++ b/assistant/src/memory/v3/page-content.ts
@@ -1,5 +1,6 @@
 import { getWorkspaceDir } from "../../util/platform.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
+import { renderCapabilityContent } from "./capabilities.js";
 import type { Slug } from "./types.js";
 
 /**
@@ -9,11 +10,18 @@ import type { Slug } from "./types.js";
  * failure) degrades to "" — `renderMemoryBlock` still emits a line for the
  * slug, and a blank section is preferable to throwing into the turn.
  *
+ * Synthetic capability slugs (skills, `assistant` CLI commands) have no on-disk
+ * page; they resolve through {@link renderCapabilityContent} instead of
+ * `readPage`. A non-null result (including "") means the slug was a capability
+ * slug and was handled here.
+ *
  * Shared by the live injector (`shadow-plugin.ts`) and the inspector
  * selection-log store (`selection-log-store.ts`) so the inspector's rendered
  * block is byte-identical to what live injection produces.
  */
 export async function renderV3PageContent(slug: Slug): Promise<string> {
+  const capability = renderCapabilityContent(slug);
+  if (capability !== null) return capability;
   try {
     const page = await readPage(getWorkspaceDir(), slug);
     if (!page) return "";

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -44,6 +44,7 @@ import {
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { getPageIndex } from "../v2/page-index.js";
+import { injectCapabilitiesLeaf, isCapabilitySlug } from "./capabilities.js";
 import { loadCore } from "./core.js";
 import type { NeedleIndex } from "./needle.js";
 import { buildNeedleIndex } from "./needle.js";
@@ -130,6 +131,17 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   }
   const tree = await loadLeafTree(dataDir, pageLeaves);
   const core = await loadCore(dataDir);
+
+  // Always-on synthetic capabilities leaf: skill + CLI-command rows the page
+  // index already carries (with summaries). Injecting them as leaf members puts
+  // them in the needle corpus (`tree.byPage`) and, via `core`, makes L1 always
+  // open the leaf so L2 selects the relevant subset each turn — matching v2's
+  // "always in the pool, router-selected" capability surfacing. Done before
+  // `buildNeedleIndex` so the synthetic members are indexed.
+  const capabilitySlugs = pageIndex.entries
+    .map((entry) => entry.slug)
+    .filter(isCapabilitySlug);
+  injectCapabilitiesLeaf(tree, core, capabilitySlugs);
 
   const needle = await buildNeedleIndex(tree, pageSummary);
   const workingSet = new WorkingSet(


### PR DESCRIPTION
## Summary
- Adds an always-on synthetic **capabilities leaf** to the v3 live lane so the assistant's invokable capabilities — installed/catalog skills (`skills/<id>`) and top-level `assistant` CLI subcommands (`cli-commands/<name>`) — are surfaced the way v2 surfaces them: members of an always-open leaf, with per-leaf L2 selecting the relevant subset each turn. (v2 router-selects them from its unified pool; an always-on leaf + L2 is the topic-tree equivalent — always considered, selected per turn, not always-injected.)
- Because the leaf's members land in `tree.byPage`, the BM25 needle indexes them **for free** — a lexical query ("schedule", "transcribe") can surface the matching skill/CLI slug. No separate needle wiring.
- The leaf is synthesized in code and injected ONLY into the live lane tree (`initLanes`), so the maintenance classifier — which builds its own tree — never routes concept pages into it.
- `renderV3PageContent` gains a synthetic fallback (`renderCapabilityContent`) so a selected skill/CLI slug renders its capability content into the `<memory>` block instead of `""` (synthetic rows have no on-disk page). Page *summaries* already resolve through the existing page-index lane, so only full-content rendering needed the fallback.

## Why
A v3 cutover would otherwise silently drop the assistant's capability awareness (v2's `### Skills You Can Use` / CLI discovery) — a backwards-compat regression. This restores parity. **Flag-gated**: the leaf is only injected in the v3 lane path (`memory-v3-shadow` / `memory-v3-live`), so with both flags off (production default) nothing changes.

Reuses the existing v2 stores (`isSkillSlug` / `getSkillCapability`, `isCliCommandSlug` / `getCliCommandCapability`) — no new content machinery or sync path. Membership is derived from whatever the page index currently carries, so skill/CLI installs and uninstalls are picked up on the next lane rebuild.

## Cost
One extra always-on per-leaf L2 call per turn over a stable catalog (cache-warm per-leaf prefix). The L1 leaf index grows by one stable line.

## Verification
- `bunx tsc --noEmit`: clean (0 errors).
- New `capabilities.test.ts`: **10/0** — leaf membership / byPage union / always-on / idempotency, content rendering (skill, CLI, missing-cache degrade-to-`""`, non-capability passthrough-to-`null`), and a needle-indexing proof that an injected skill slug is lexically retrievable.
- Regression (single-file, CI parity): shadow-plugin **12/0**, orchestrate **9/0**, render-injection **4/0**, selection-log-store **6/0**, live-integration **4/0**.

## Follow-up (noted, not blocking)
v2 groups capabilities under single `### Skills You Can Use` / `### CLI Commands You Can Use` headings; this renders each selected capability as its own `# Skill: <id>` / `# CLI command: <id>` section. Functionally equivalent (the model sees each capability's content); exact section-grouping parity is a render-detail follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)