### PR TITLE
test(web): guard web_search backend copy rendering and prevent web_fetch DNS conflation

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -18,8 +18,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildWebSearchErrorStep,
   computeToolCallCardData,
   hasWebTool,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
 } from "@/domains/chat/hooks/use-tool-call-card-data";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type {
@@ -497,6 +499,120 @@ describe("computeToolCallCardData — mixed web + non-web groups", () => {
     // currentStepTitle reflects the latest call (the bash tool).
     expect(data.currentStepTitle).toBe("Working (bash)");
     expect(data.currentStepInfo).toBe("ls");
+  });
+});
+
+describe("computeToolCallCardData — web_search backend-failure copy", () => {
+  // Mirror of WEB_SEARCH_BACKEND_FAILURE_MESSAGE in
+  // assistant/src/tools/network/web-search-error.ts (and the module-local
+  // constant in use-tool-call-card-data.ts). apps/web cannot import from
+  // assistant/, so the canonical string is duplicated here verbatim.
+  const CANONICAL_BACKEND_FAILURE_MESSAGE =
+    "Search is having trouble right now. You can try again in a moment, continue without web search, or paste the relevant details here and I'll use those.";
+
+  test("renders the canonical backend-failure message verbatim when the daemon provides it", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      // Verbatim — not overridden, not truncated to "Search failed.".
+      errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+    });
+    expect(data.currentStepInfo).toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("the local default string matches the canonical assistant constant", () => {
+    expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).toBe(
+      CANONICAL_BACKEND_FAILURE_MESSAGE,
+    );
+  });
+
+  test("buildWebSearchErrorStep falls back to the friendly default when errorMessage is undefined", () => {
+    // The error step renders verbatim copy from the daemon when present, but
+    // must degrade to the canonical friendly message if the backend ever
+    // omits it (regression for the buildWebSearchErrorStep default).
+    const step = buildWebSearchErrorStep({
+      query: "tigers",
+      provider: "anthropic-native",
+      resultCount: 0,
+      durationMs: 800,
+      results: [],
+      // errorMessage intentionally omitted.
+    });
+    expect(step).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      errorMessage: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    });
+  });
+
+  test("web_fetch DNS/host errors never render as a web_search backend failure", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_fetch", status: "error" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webFetch: {
+          url: "https://grimgoods.io/products",
+          finalUrl: "https://grimgoods.io/products",
+          status: 0,
+          byteCount: 0,
+          charCount: 0,
+          truncated: false,
+          domain: "grimgoods.io",
+          redirectCount: 0,
+          durationMs: 120,
+          errorMessage:
+            'Error: Unable to resolve host "grimgoods.io" while fetching the page',
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    // No web_search_error step is produced from a web_fetch failure.
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    // The friendly web_search backend copy is never surfaced for a fetch error.
+    expect(data.currentStepInfo).not.toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("a successful web_search with results produces no error step", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 2,
+          durationMs: 1500,
+          results: [makeResult(1), makeResult(2)],
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    expect(data.steps[0]!.kind).toBe("web_search");
   });
 });
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -593,6 +593,63 @@ describe("computeToolCallCardData — web_search backend-failure copy", () => {
     expect(data.currentStepInfo).not.toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
   });
 
+  test("a failed web_search with empty results and NO errorMessage renders the friendly default via the UI path", () => {
+    // Daemon omits webSearch.errorMessage but the tool call itself is terminal
+    // with status "error" (mapped from the tool_result isError flag). This is
+    // the production UI path Codex flagged — buildWebSearchErrorStep's friendly
+    // default must be reachable, not only via the direct unit test.
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "error" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          // errorMessage intentionally omitted.
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+    });
+    expect(data.currentStepTitle).toBe("Web search failed");
+    expect(data.currentStepInfo).toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("a successful no_results web_search (status completed, no errorMessage) stays a normal step", () => {
+    // ATL-727 core invariant: an empty-but-successful search must NOT render as
+    // a failure. status "completed" + no errorMessage => normal web_search step.
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          // errorMessage intentionally omitted; this is a real no_results hit.
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    expect(data.steps[0]!.kind).toBe("web_search");
+    expect(data.currentStepInfo).not.toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
   test("a successful web_search with results produces no error step", () => {
     const toolCalls = [
       makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -271,6 +271,31 @@ function isTerminalStatus(tc: ChatMessageToolCall): boolean {
 }
 
 /**
+ * Classify a `web_search` whose metadata carried zero results as a *failure*
+ * (vs. a successful `no_results` search).
+ *
+ * The backend is the single centralization point and sets
+ * `webSearch.errorMessage` on every genuine failure (see
+ * `errorResult` in assistant/src/tools/network/web-search.ts), so a present
+ * `errorMessage` is the primary signal. As defensive depth for the case where
+ * the daemon ever omits that message on a failed search, we also treat the
+ * tool call's own terminal `status === "error"` (mapped from the tool_result
+ * `isError` flag in `applyToolResult`) as a failure signal.
+ *
+ * Crucially, a successful empty/`no_results` search lands as
+ * `status === "completed"` with no `errorMessage`, so it is NOT classified as
+ * a failure — ATL-727's core invariant (empty-but-successful must not render
+ * as a failure) is preserved.
+ */
+function isFailedEmptyWebSearch(
+  ws: NonNullable<ToolActivityMetadata["webSearch"]>,
+  tc: ChatMessageToolCall,
+): boolean {
+  if (ws.results.length > 0) return false;
+  return Boolean(ws.errorMessage) || tc.status === "error";
+}
+
+/**
  * Map a tool call's `confirmationDecision` + `status` to the unified card's
  * narrowed step-status enum. `"denied"` precedence beats both `"error"` and
  * `"completed"` so the denied chrome stays visible after the daemon
@@ -343,8 +368,7 @@ function deriveCurrentStepTitle(
       const terminal = isTerminalStatus(tc);
       if (
         metadata?.webSearch &&
-        metadata.webSearch.errorMessage &&
-        metadata.webSearch.results.length === 0
+        isFailedEmptyWebSearch(metadata.webSearch, tc)
       ) {
         return "Web search failed";
       }
@@ -381,8 +405,8 @@ function deriveCurrentStepInfo(
 
     if (metadata?.webSearch) {
       const ws = metadata.webSearch;
-      if (ws.errorMessage && ws.results.length === 0) {
-        return ws.errorMessage;
+      if (isFailedEmptyWebSearch(ws, tc)) {
+        return ws.errorMessage ?? WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
       }
       if (ws.results.length > 0) {
         return ws.results[ws.results.length - 1]!.title;
@@ -525,7 +549,7 @@ export function computeToolCallCardData(
     const terminal = isTerminalStatus(tc);
     if (metadata?.webSearch) {
       const ws = metadata.webSearch;
-      if (ws.errorMessage && ws.results.length === 0) {
+      if (isFailedEmptyWebSearch(ws, tc)) {
         steps.push(buildWebSearchErrorStep(ws));
       } else {
         steps.push(buildWebSearchStep(ws, terminal));

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -29,6 +29,15 @@ import { useTurnStore } from "@/domains/chat/turn-store";
 /** Max favicon chips to render inside a single `web_search` step row. */
 const MAX_VISIBLE_RESULTS = 5;
 
+/**
+ * Friendly fallback copy for a `web_search` backend failure when the daemon
+ * omits `webSearch.errorMessage`. apps/web CANNOT import from `assistant/`, so
+ * this is a local mirror — keep in sync with WEB_SEARCH_BACKEND_FAILURE_MESSAGE
+ * in assistant/src/tools/network/web-search-error.ts.
+ */
+export const WEB_SEARCH_BACKEND_FAILURE_MESSAGE =
+  "Search is having trouble right now. You can try again in a moment, continue without web search, or paste the relevant details here and I'll use those.";
+
 /** Tool names whose presence triggers the web-search step path. */
 export const WEB_TOOL_NAMES = new Set(["web_search", "web_fetch"]);
 
@@ -229,14 +238,14 @@ function buildWebSearchStepFromResultText(
   };
 }
 
-function buildWebSearchErrorStep(
+export function buildWebSearchErrorStep(
   metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
 ): ToolCallCardStep {
   return {
     kind: "web_search_error",
     title: "Web search failed",
     durationLabel: formatMs(metadata.durationMs),
-    errorMessage: metadata.errorMessage ?? "Search failed.",
+    errorMessage: metadata.errorMessage ?? WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
   };
 }
 


### PR DESCRIPTION
## Summary
- Default web_search error step copy to the canonical friendly message (kept in sync with the assistant constant)
- Lock with tests that web_fetch DNS/host errors never render as a web_search backend failure

Part of plan: web-search-failure.md (PR 4 of 5)