### PR TITLE
feat(web): show OAuth callback URL in "Your Own" integration tab

### DIFF
--- a/apps/web/src/domains/settings/api/oauth-providers.ts
+++ b/apps/web/src/domains/settings/api/oauth-providers.ts
@@ -31,3 +31,28 @@ export async function fetchOAuthProviders(
   const data: OAuthProviderCatalogResponse = await res.json();
   return data.providers ?? [];
 }
+
+/** Subset of the full provider detail response that the web UI consumes. */
+export interface OAuthProviderDetail {
+  oauth_callback_url: string | null;
+}
+
+interface OAuthProviderDetailResponse {
+  provider: Record<string, unknown>;
+  oauth_callback_url: string | null;
+}
+
+export async function fetchOAuthProviderDetail(
+  assistantId: string,
+  providerKey: string,
+): Promise<OAuthProviderDetail> {
+  const res = await fetch(
+    `/v1/assistants/${assistantId}/oauth/providers/${encodeURIComponent(providerKey)}`,
+    { headers: buildVellumHeaders() },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch OAuth provider detail (HTTP ${res.status})`);
+  }
+  const data: OAuthProviderDetailResponse = await res.json();
+  return { oauth_callback_url: data.oauth_callback_url ?? null };
+}

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Check,
+  Copy,
   ExternalLink,
   Loader2,
   Plus,
@@ -38,6 +40,7 @@ import {
   type OAuthAppConnection,
 } from "@/domains/settings/api/oauth-apps";
 
+import { fetchOAuthProviderDetail } from "@/domains/settings/api/oauth-providers";
 import { IntegrationIcon } from "@/domains/settings/components/integration-icon";
 import {
   type OAuthCompletePayload,
@@ -893,6 +896,8 @@ function YourOwnTab({
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [creatingApp, setCreatingApp] = useState(false);
+  const [oauthCallbackUrl, setOauthCallbackUrl] = useState<string | null>(null);
+  const [callbackUrlCopied, setCallbackUrlCopied] = useState(false);
   const [deletingAppId, setDeletingAppId] = useState<string | null>(null);
   const [connectingAppId, setConnectingAppId] = useState<string | null>(null);
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
@@ -934,6 +939,17 @@ function YourOwnTab({
   useEffect(() => {
     void loadApps();
   }, [loadApps]);
+
+  useEffect(() => {
+    let active = true;
+    void fetchOAuthProviderDetail(assistantId, providerKey).then(
+      (detail) => {
+        if (active) setOauthCallbackUrl(detail.oauth_callback_url);
+      },
+      () => {},
+    );
+    return () => { active = false; };
+  }, [assistantId, providerKey]);
 
   const shouldShowForm = apps.length === 0 || isShowingAddAppForm;
 
@@ -1062,6 +1078,48 @@ function YourOwnTab({
               sent to Vellum.
             </p>
           </div>
+          {oauthCallbackUrl ? (
+            <div className="space-y-1">
+              <p className="text-body-small-default text-[var(--content-secondary)]">
+                Redirect URL
+              </p>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="text"
+                  value={oauthCallbackUrl}
+                  readOnly
+                  fullWidth
+                />
+                <Button
+                  type="button"
+                  variant="outlined"
+                  size="compact"
+                  onClick={() => {
+                    void navigator.clipboard
+                      .writeText(oauthCallbackUrl)
+                      .then(() => {
+                        setCallbackUrlCopied(true);
+                        toast.success("Copied to clipboard!");
+                        setTimeout(() => setCallbackUrlCopied(false), 2000);
+                      });
+                  }}
+                  aria-label={
+                    callbackUrlCopied ? "Copied" : "Copy redirect URL"
+                  }
+                  iconOnly={
+                    callbackUrlCopied ? (
+                      <Check aria-hidden />
+                    ) : (
+                      <Copy aria-hidden />
+                    )
+                  }
+                />
+              </div>
+              <p className="text-body-small-default text-[var(--content-tertiary)]">
+                Add this URL to your OAuth app&apos;s redirect settings.
+              </p>
+            </div>
+          ) : null}
           <Input
             label="Client ID"
             type="text"

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -7,6 +7,7 @@
  */
 
 import { loadConfig } from "../../config/loader.js";
+import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
   deleteConnection,
@@ -85,13 +86,24 @@ function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
     );
   }
 
-  if (!isProviderVisible(row, loadConfig())) {
+  const config = loadConfig();
+  if (!isProviderVisible(row, config)) {
     throw new NotFoundError(
       `No OAuth provider registered for "${providerKey}"`,
     );
   }
 
-  return { provider: serializeProviderFull(row) };
+  let oauthCallbackUrl: string | null = null;
+  try {
+    oauthCallbackUrl = getOAuthCallbackUrl(config);
+  } catch {
+    // Ingress not configured or disabled — callback URL unavailable
+  }
+
+  return {
+    provider: serializeProviderFull(row),
+    oauth_callback_url: oauthCallbackUrl,
+  };
 }
 
 function handleRegisterProvider({ body = {} }: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -7,6 +7,7 @@
  */
 
 import { loadConfig } from "../../config/loader.js";
+import { resolvePlatformCallbackRegistrationContext } from "../../inbound/platform-callback-registration.js";
 import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
@@ -77,7 +78,7 @@ function handleListProviders({ queryParams = {} }: RouteHandlerArgs) {
   return { providers: serialized };
 }
 
-function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
+async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   const { providerKey } = pathParams;
   const row = getProvider(providerKey);
   if (!row) {
@@ -97,7 +98,16 @@ function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   try {
     oauthCallbackUrl = getOAuthCallbackUrl(config);
   } catch {
-    // Ingress not configured or disabled — callback URL unavailable
+    // Self-hosted ingress not configured — fall back to platform URL
+    try {
+      const ctx = await resolvePlatformCallbackRegistrationContext();
+      if (ctx.enabled) {
+        const base = ctx.platformBaseUrl.replace(/\/+$/, "");
+        oauthCallbackUrl = `${base}/v1/gateway/callbacks/${ctx.assistantId}/webhooks/oauth/callback/`;
+      }
+    } catch {
+      // Platform context unavailable
+    }
   }
 
   return {

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -7,7 +7,6 @@
  */
 
 import { loadConfig } from "../../config/loader.js";
-import { resolveCallbackUrl } from "../../inbound/platform-callback-registration.js";
 import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
@@ -78,7 +77,7 @@ function handleListProviders({ queryParams = {} }: RouteHandlerArgs) {
   return { providers: serialized };
 }
 
-async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
+function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   const { providerKey } = pathParams;
   const row = getProvider(providerKey);
   if (!row) {
@@ -96,13 +95,9 @@ async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
 
   let oauthCallbackUrl: string | null = null;
   try {
-    oauthCallbackUrl = await resolveCallbackUrl(
-      () => getOAuthCallbackUrl(config),
-      "webhooks/oauth/callback",
-      "oauth",
-    );
+    oauthCallbackUrl = getOAuthCallbackUrl(config);
   } catch {
-    // Ingress not configured and platform callbacks unavailable
+    // Ingress not configured or disabled — callback URL unavailable
   }
 
   return {

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -7,7 +7,6 @@
  */
 
 import { loadConfig } from "../../config/loader.js";
-import { resolvePlatformCallbackRegistrationContext } from "../../inbound/platform-callback-registration.js";
 import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
@@ -78,7 +77,7 @@ function handleListProviders({ queryParams = {} }: RouteHandlerArgs) {
   return { providers: serialized };
 }
 
-async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
+function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   const { providerKey } = pathParams;
   const row = getProvider(providerKey);
   if (!row) {
@@ -98,16 +97,7 @@ async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   try {
     oauthCallbackUrl = getOAuthCallbackUrl(config);
   } catch {
-    // Self-hosted ingress not configured — fall back to platform URL
-    try {
-      const ctx = await resolvePlatformCallbackRegistrationContext();
-      if (ctx.enabled) {
-        const base = ctx.platformBaseUrl.replace(/\/+$/, "");
-        oauthCallbackUrl = `${base}/v1/gateway/callbacks/${ctx.assistantId}/webhooks/oauth/callback/`;
-      }
-    } catch {
-      // Platform context unavailable
-    }
+    // Ingress not configured or disabled — callback URL unavailable
   }
 
   return {

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -7,8 +7,8 @@
  */
 
 import { loadConfig } from "../../config/loader.js";
-import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import { resolveCallbackUrl } from "../../inbound/platform-callback-registration.js";
+import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
   deleteConnection,

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -8,6 +8,7 @@
 
 import { loadConfig } from "../../config/loader.js";
 import { getOAuthCallbackUrl } from "../../inbound/public-ingress-urls.js";
+import { resolveCallbackUrl } from "../../inbound/platform-callback-registration.js";
 import {
   deleteApp,
   deleteConnection,
@@ -77,7 +78,7 @@ function handleListProviders({ queryParams = {} }: RouteHandlerArgs) {
   return { providers: serialized };
 }
 
-function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
+async function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
   const { providerKey } = pathParams;
   const row = getProvider(providerKey);
   if (!row) {
@@ -95,9 +96,13 @@ function handleGetProvider({ pathParams = {} }: RouteHandlerArgs) {
 
   let oauthCallbackUrl: string | null = null;
   try {
-    oauthCallbackUrl = getOAuthCallbackUrl(config);
+    oauthCallbackUrl = await resolveCallbackUrl(
+      () => getOAuthCallbackUrl(config),
+      "webhooks/oauth/callback",
+      "oauth",
+    );
   } catch {
-    // Ingress not configured or disabled — callback URL unavailable
+    // Ingress not configured and platform callbacks unavailable
   }
 
   return {


### PR DESCRIPTION
## Summary

- Adds `oauth_callback_url` to the provider detail endpoint response (`GET /v1/oauth/providers/:providerKey`), computed from the gateway's public ingress URL (gracefully returns `null` when ingress isn't configured)
- Adds `fetchOAuthProviderDetail()` frontend API function to fetch the provider detail
- Displays the callback URL as a read-only "Redirect URL" field with a copy-to-clipboard button in the "Your Own" tab of the integration detail modal, above the Client ID / Client Secret inputs

## Original prompt

The user noticed that when configuring a "Your Own" OAuth app through the web Integrations UI, there's no indication of what callback/redirect URL to use. The CLI and assistant skill flows surface this information, but the web UI only asks for Client ID and Client Secret. The plan was to have the modal fetch the provider detail endpoint to get the gateway callback URL (`${publicBaseUrl}/webhooks/oauth/callback`) and display it as a copyable field in the form, keeping the list response slim.

## Test plan

- [ ] Start the dev server → Settings → Integrations → pick any provider → "Your Own" tab
- [ ] Verify the redirect URL appears as a read-only field with a copy button above the credential inputs
- [ ] Click the copy button and verify it copies the URL and shows a "Copied!" toast
- [ ] Verify the URL is absent when public ingress is not configured


🤖 Generated with [Claude Code](https://claude.com/claude-code)