### PR TITLE
feat(web-search): map native web_search backend failures to friendly copy with per-turn dedup (ATL-727)

### DIFF
--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -732,7 +732,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
   });
 
   test("query_too_long yields a distinct non-backend message", async () => {
-    const { deps, events } = createHandlerDeps();
+    const { deps, events, warnings } = createHandlerDeps();
     await completeWebSearch(state, deps, "tu_long", {
       isError: true,
       errorCode: "query_too_long",
@@ -742,5 +742,9 @@ describe("Native Web Search — Backend Failure Handling", () => {
       ?.errorMessage;
     expect(errorMessage).toBeDefined();
     expect(errorMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    // Recoverable non-backend errors must NOT emit backend-failure telemetry.
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -108,7 +108,6 @@ mock.module("../memory/llm-request-log-store.js", () => ({
 }));
 
 // Import after mocking
-import { AnthropicProvider } from "../providers/anthropic/client.js";
 import {
   createEventHandlerState,
   dispatchAgentEvent,
@@ -116,6 +115,7 @@ import {
   type EventHandlerState,
 } from "../daemon/conversation-agent-loop-handlers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import { AnthropicProvider } from "../providers/anthropic/client.js";
 import { isNativeWebSearchCapableProvider } from "../providers/registry.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
 

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -71,9 +71,53 @@ mock.module("@anthropic-ai/sdk", () => ({
   },
 }));
 
+// Mock daemon collaborators the handler module imports at load time so the
+// handler-level tests below can drive `server_tool_complete` in isolation.
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
 // Import after mocking
 import { AnthropicProvider } from "../providers/anthropic/client.js";
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  type EventHandlerDeps,
+  type EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
 import { isNativeWebSearchCapableProvider } from "../providers/registry.js";
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -497,5 +541,206 @@ describe("Native Web Search — Streaming Events", () => {
       (e) => e.type === "tool_use_preview_start",
     );
     expect(toolUseEvents).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Native server_tool_complete backend-failure handling (ATL-727)
+// ---------------------------------------------------------------------------
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+function createHandlerDeps(reqId = "req-web-search"): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+  warnings: LogRecord[];
+} {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+async function completeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: {
+    isError: boolean;
+    errorCode?: string;
+    errorMessage?: string;
+    content?: unknown[];
+  },
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
+  const results = events.filter(
+    (e): e is ToolResultEvent => e.type === "tool_result",
+  );
+  return results[results.length - 1];
+}
+
+describe("Native Web Search — Backend Failure Handling", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("backend failure surfaces friendly copy with isError true and empty results", async () => {
+    const { deps, events } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_backend", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(result?.isError).toBe(true);
+    expect(result?.activityMetadata?.webSearch?.resultCount).toBe(0);
+    expect(result?.activityMetadata?.webSearch?.results).toEqual([]);
+  });
+
+  test("raw error_code is logged under web_search_backend_failure but absent from user copy", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_log", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const failureLog = warnings.find(
+      (w) => w.obj.event === "web_search_backend_failure",
+    );
+    expect(failureLog).toBeDefined();
+    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
+    expect(failureLog?.obj.fallbackShown).toBe(true);
+
+    const errorMessage = lastToolResult(events)?.activityMetadata?.webSearch
+      ?.errorMessage;
+    expect(errorMessage).not.toContain("unavailable");
+  });
+
+  test("dedups repeat backend failures within one turn to a single friendly notice", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+
+    await completeWebSearch(state, deps, "tu_dup_1", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+    await completeWebSearch(state, deps, "tu_dup_2", {
+      isError: true,
+      errorCode: "overloaded_error",
+    });
+
+    const results = events.filter(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    // The second backend failure in the same turn is terse, not the full notice.
+    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+
+    const failureLogs = warnings.filter(
+      (w) => w.obj.event === "web_search_backend_failure",
+    );
+    // Both failures are logged, but only the first reports fallbackShown.
+    expect(failureLogs).toHaveLength(2);
+    expect(failureLogs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(
+      1,
+    );
+  });
+
+  test("successful search leaves errorMessage undefined and populates results", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_ok", {
+      isError: false,
+      content: [
+        {
+          type: "web_search_result",
+          title: "Weather",
+          url: "https://example.com/weather",
+        },
+      ],
+    });
+
+    const meta = lastToolResult(events)?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBeUndefined();
+    expect(meta?.resultCount).toBe(1);
+    expect(meta?.results[0]?.title).toBe("Weather");
+    expect(lastToolResult(events)?.isError).toBe(false);
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
+  });
+
+  test("query_too_long yields a distinct non-backend message", async () => {
+    const { deps, events } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_long", {
+      isError: true,
+      errorCode: "query_too_long",
+    });
+
+    const errorMessage = lastToolResult(events)?.activityMetadata?.webSearch
+      ?.errorMessage;
+    expect(errorMessage).toBeDefined();
+    expect(errorMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
   });
 });

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -270,7 +270,7 @@ describe("native server_tool_complete metadata", () => {
     expect(durB).toBeGreaterThanOrEqual(durA);
   });
 
-  test("forwards provider error codes instead of generic 'Search failed'", async () => {
+  test("maps recoverable error codes to friendly copy, not the raw code", async () => {
     const { deps, events } = createCollectorDeps();
     const toolUseId = "tu_err_code";
 
@@ -292,9 +292,11 @@ describe("native server_tool_complete metadata", () => {
     const toolResultEvent = events.find(
       (e): e is ToolResultEvent => e.type === "tool_result",
     );
-    expect(toolResultEvent?.activityMetadata?.webSearch?.errorMessage).toBe(
-      "max_uses_exceeded",
-    );
+    const errorMessage =
+      toolResultEvent?.activityMetadata?.webSearch?.errorMessage;
+    // The raw provider code is never user-visible.
+    expect(errorMessage).not.toBe("max_uses_exceeded");
+    expect(errorMessage).toContain("web-search limit");
   });
 
   test("does NOT emit activityMetadata for non-Anthropic providers", async () => {

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1863,21 +1863,24 @@ export async function dispatchAgentEvent(
               errorMessage = WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
               fallbackShown = true;
             }
+
+            // Backend-failure telemetry (provider outages / rate limits) must
+            // fire only for genuine backend classifications so it does not
+            // count recoverable input/quota errors as provider failures.
+            logWebSearchBackendFailure(deps.rlog, {
+              provider: "anthropic-native",
+              requestId: deps.reqId,
+              errorCategory: classification.category,
+              rawDetail: classification.rawDetail,
+              fallbackShown,
+              queryLength: query.length,
+            });
           } else {
             // Recoverable, non-backend categories (query_too_long,
             // max_uses_exceeded, unknown) are not deduped against the backend
             // notice; fall back to a concise message when there is no copy.
             errorMessage = classification.userMessage || "Search failed";
           }
-
-          logWebSearchBackendFailure(deps.rlog, {
-            provider: "anthropic-native",
-            requestId: deps.reqId,
-            errorCategory: classification.category,
-            rawDetail: classification.rawDetail,
-            fallbackShown,
-            queryLength: query.length,
-          });
         }
 
         const metadata: WebSearchMetadata | undefined = isAnthropicNative

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -56,6 +56,11 @@ import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
 import {
+  classifyWebSearchFailure,
+  logWebSearchBackendFailure,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+} from "../tools/network/web-search-error.js";
+import {
   buildPricingUsage,
   resolveStructuredPricing,
 } from "../usage/pricing.js";
@@ -246,6 +251,8 @@ export interface EventHandlerState {
   readonly serverToolStartedAt: Map<string, number>;
   /** Original input from server_tool_start, keyed by tool_use_id, so the complete handler can read the query. */
   readonly serverToolInputs: Map<string, Record<string, unknown>>;
+  /** Request ids for which a user-facing web_search backend-failure notice was already surfaced this turn (dedup noisy repeats). Keyed by request id; each turn has a fresh request id, so this grows at most one entry per turn. */
+  readonly webSearchBackendFailureNotified: Set<string>;
   /** Active debounce timer for partial persistence; `undefined` when idle. */
   pendingPartialFlushTimer: ReturnType<typeof setTimeout> | undefined;
   /** In-flight partial flush write awaited at finalize to avoid overwrite races. */
@@ -311,6 +318,7 @@ export function createEventHandlerState(): EventHandlerState {
     turnStartedAt: Date.now(),
     serverToolStartedAt: new Map(),
     serverToolInputs: new Map(),
+    webSearchBackendFailureNotified: new Set(),
     pendingPartialFlushTimer: undefined,
     pendingPartialFlushPromise: undefined,
     currentMessageContent: [],
@@ -1828,9 +1836,49 @@ export async function dispatchAgentEvent(
         // for them would mis-label the provider and ship empty results.
         const isAnthropicNative = deps.ctx.provider.name === "anthropic";
 
-        const errorMessage = event.isError
-          ? (event.errorMessage ?? event.errorCode ?? "Search failed")
-          : undefined;
+        // Classify provider failures through the shared normalizer so the same
+        // friendly copy propagates to every client via WebSearchMetadata, while
+        // the raw provider detail stays in telemetry only (ATL-727).
+        const classification = classifyWebSearchFailure({
+          errorCode: event.errorCode,
+          error: event.errorMessage,
+          isError: event.isError,
+          hasResults: results.length > 0,
+        });
+
+        let errorMessage: string | undefined;
+        let fallbackShown = false;
+        if (event.isError) {
+          // Dedup the user-facing friendly notice per turn (request id) so a
+          // burst of backend failures surfaces at most one full notice. The raw
+          // provider error is preserved on every failure via telemetry below.
+          const alreadyNotified = state.webSearchBackendFailureNotified.has(
+            deps.reqId,
+          );
+          if (classification.isBackendFailure) {
+            if (alreadyNotified) {
+              errorMessage = "Search is still having trouble.";
+            } else {
+              state.webSearchBackendFailureNotified.add(deps.reqId);
+              errorMessage = WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
+              fallbackShown = true;
+            }
+          } else {
+            // Recoverable, non-backend categories (query_too_long,
+            // max_uses_exceeded, unknown) are not deduped against the backend
+            // notice; fall back to a concise message when there is no copy.
+            errorMessage = classification.userMessage || "Search failed";
+          }
+
+          logWebSearchBackendFailure(deps.rlog, {
+            provider: "anthropic-native",
+            requestId: deps.reqId,
+            errorCategory: classification.category,
+            rawDetail: classification.rawDetail,
+            fallbackShown,
+            queryLength: query.length,
+          });
+        }
 
         const metadata: WebSearchMetadata | undefined = isAnthropicNative
           ? {


### PR DESCRIPTION
## Summary
- Classify native Anthropic web_search backend failures and surface one friendly per-turn notice via WebSearchMetadata.errorMessage
- Preserve raw error_code in web_search_backend_failure telemetry; isError stays true so the model sees the failure honestly

Part of plan: web-search-failure.md (PR 2 of 5)