### PR TITLE
feat(web-search): normalize app-side provider backend failures to friendly recoverable copy (ATL-727)

### DIFF
--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -701,6 +701,9 @@ describe("Cross-Provider Web Search — app-side backend failure normalization",
     expect(logEntry!.fallbackShown).toBe(true);
     expect(logEntry!.queryLength).toBe("needle in a haystack".length);
     expect(String(logEntry!.rawDetail)).toContain("503");
+    // Provider diagnostic body is preserved in internal telemetry rawDetail.
+    expect(String(logEntry!.rawDetail)).toContain("upstream exploded");
+    expect(String(logEntry!.rawDetail)).toContain("do-not-leak");
 
     // Raw provider body must never reach user-facing fields.
     expect(result.content).not.toContain("upstream exploded");
@@ -757,9 +760,10 @@ describe("Cross-Provider Web Search — app-side backend failure normalization",
     expect(backendFailureLog()).toBeUndefined();
   });
 
-  test("post-retry 429 yields the friendly recoverable copy", async () => {
+  test("post-retry 429 yields the friendly recoverable copy and preserves body in rawDetail", async () => {
+    const rawBody = '{"error":"quota burned","retryHint":"do-not-leak-429"}';
     globalThis.fetch = (async () =>
-      new Response("Too Many Requests", {
+      new Response(rawBody, {
         status: 429,
         headers: { "retry-after": "0" },
       })) as unknown as typeof fetch;
@@ -768,11 +772,20 @@ describe("Cross-Provider Web Search — app-side backend failure normalization",
 
     expect(result.isError).toBe(true);
     expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
-    expect(result.activityMetadata?.webSearch?.errorMessage).toBe(
-      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
-    );
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     const logEntry = backendFailureLog();
     expect(logEntry).toBeDefined();
     expect(logEntry!.errorCategory).toBe("rate_limited");
+    expect(String(logEntry!.rawDetail)).toContain("429");
+    // Provider diagnostic body is preserved in internal telemetry rawDetail.
+    expect(String(logEntry!.rawDetail)).toContain("quota burned");
+    expect(String(logEntry!.rawDetail)).toContain("do-not-leak-429");
+
+    // Raw provider body must never reach user-facing fields.
+    expect(result.content).not.toContain("quota burned");
+    expect(result.content).not.toContain("do-not-leak-429");
+    expect(meta?.errorMessage).not.toContain("quota burned");
+    expect(meta?.errorMessage).not.toContain("do-not-leak-429");
   });
 });

--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   ContentBlock,
@@ -220,6 +220,57 @@ import {
   OpenAIChatCompletionsProvider,
   OpenAIResponsesProvider,
 } from "../providers/openai/client.js";
+
+// ---------------------------------------------------------------------------
+// App-side web_search provider adapters (Brave/Perplexity/Tavily)
+//
+// Exercise the real `web-search.ts` execute path with a mocked config, provider
+// key, and global fetch. The logger is mocked to capture structured warnings so
+// we can assert the `web_search_backend_failure` telemetry (ATL-727).
+// ---------------------------------------------------------------------------
+
+let mockWebSearchProvider: string = "brave";
+let mockProviderKey: string | undefined = "test-key";
+const capturedWarnLogs: Record<string, unknown>[] = [];
+
+const realConfigLoader = await import("../config/loader.js");
+mock.module("../config/loader.js", () => ({
+  ...realConfigLoader,
+  getConfig: () => ({
+    services: { "web-search": { provider: mockWebSearchProvider } },
+  }),
+}));
+
+const realSecureKeys = await import("../security/secure-keys.js");
+mock.module("../security/secure-keys.js", () => ({
+  ...realSecureKeys,
+  getProviderKeyAsync: async () => mockProviderKey,
+}));
+
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (prop === "warn") {
+          return (obj: Record<string, unknown>) => {
+            capturedWarnLogs.push(obj);
+          };
+        }
+        return () => {};
+      },
+    }),
+}));
+
+const { webSearchTool } = await import("../tools/network/web-search.js");
+const { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } = await import(
+  "../tools/network/web-search-error.js"
+);
+
+function executeWebSearch(input: Record<string, unknown>) {
+  return webSearchTool.execute(input, {} as never);
+}
 
 // ---------------------------------------------------------------------------
 // OpenAI Responses API provider tests
@@ -602,5 +653,126 @@ describe("Cross-Provider Web Search — Gemini", () => {
       (p) => p.functionCall !== undefined,
     );
     expect(functionCallParts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// App-side provider backend-failure normalization (ATL-727)
+// ---------------------------------------------------------------------------
+
+describe("Cross-Provider Web Search — app-side backend failure normalization", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockWebSearchProvider = "brave";
+    mockProviderKey = "test-key";
+    capturedWarnLogs.length = 0;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function backendFailureLog() {
+    return capturedWarnLogs.find(
+      (entry) => entry.event === "web_search_backend_failure",
+    );
+  }
+
+  test("503 from provider yields friendly recoverable copy in content + errorMessage, logs raw 503, no body leak", async () => {
+    const rawBody = '{"error":"upstream exploded","trace":"do-not-leak"}';
+    globalThis.fetch = (async () =>
+      new Response(rawBody, { status: 503 })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "needle in a haystack" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.results).toEqual([]);
+    expect(meta?.resultCount).toBe(0);
+
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.provider).toBe("brave");
+    expect(logEntry!.errorCategory).toBe("backend_unavailable");
+    expect(logEntry!.fallbackShown).toBe(true);
+    expect(logEntry!.queryLength).toBe("needle in a haystack".length);
+    expect(String(logEntry!.rawDetail)).toContain("503");
+
+    // Raw provider body must never reach user-facing fields.
+    expect(result.content).not.toContain("upstream exploded");
+    expect(result.content).not.toContain("do-not-leak");
+    expect(meta?.errorMessage).not.toContain("upstream exploded");
+    expect(meta?.errorMessage).not.toContain("do-not-leak");
+  });
+
+  test("thrown network error yields the same friendly backend result", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "offline" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.errorCategory).toBe("backend_unavailable");
+    expect(result.content).not.toContain("fetch failed");
+  });
+
+  test("401 invalid-key preserves the specific message, not the backend copy", async () => {
+    globalThis.fetch = (async () =>
+      new Response("Unauthorized", { status: 401 })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "bad key" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Invalid or expired Brave Search API key");
+    expect(result.content).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(backendFailureLog()).toBeUndefined();
+  });
+
+  test("HTTP 200 with zero results stays a success (unchanged)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ web: { results: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "no hits" });
+
+    expect(result.isError).toBe(false);
+    expect(result.activityMetadata?.webSearch?.errorMessage).toBeUndefined();
+    expect(result.content).toContain("No results found");
+    expect(backendFailureLog()).toBeUndefined();
+  });
+
+  test("post-retry 429 yields the friendly recoverable copy", async () => {
+    globalThis.fetch = (async () =>
+      new Response("Too Many Requests", {
+        status: 429,
+        headers: { "retry-after": "0" },
+      })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "rate limited" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.errorCategory).toBe("rate_limited");
   });
 });

--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../web-search-error.js";
+
 // Mutable mock state - set per test
 let mockWebSearchProvider: string | undefined = "perplexity";
 let mockBraveSecureKey: string | undefined;
@@ -32,7 +34,9 @@ mock.module("../../../security/secure-keys.js", () => ({
   },
 }));
 
+const realLogger = await import("../../../util/logger.js");
 mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -169,7 +173,9 @@ describe("web_search activity metadata", () => {
     expect(meta.provider).toBe("perplexity");
     expect(meta.resultCount).toBe(0);
     expect(meta.results).toEqual([]);
-    expect(meta.errorMessage).toContain("rate limit exceeded");
+    // Post-retry rate limits now surface the centralized friendly recoverable
+    // copy (ATL-727) rather than provider-specific rate-limit wording.
+    expect(meta.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
   });
 
   // ---- Tavily -------------------------------------------------------------

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../web-search-error.js";
+
 // Mutable mock state - set per test
 let mockWebSearchProvider: string | undefined = "perplexity";
 let mockWebSearchMode: string | undefined = "your-own";
@@ -42,7 +44,9 @@ mock.module("../../../security/secure-keys.js", () => ({
   },
 }));
 
+const realLogger = await import("../../../util/logger.js");
 mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -201,7 +205,8 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("rate limit exceeded");
+    // Post-retry rate limits surface the friendly recoverable copy (ATL-727).
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     // 1 initial + 3 retries = 4 calls
     expect(callCount).toBe(4);
   });
@@ -214,7 +219,9 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("status 500");
+    // 5xx is a backend failure -> friendly recoverable copy, no raw status.
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.content).not.toContain("500");
   });
 
   // ---- Brave provider -----------------------------------------------------
@@ -673,7 +680,8 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("rate limit exceeded");
+    // Post-retry rate limits surface the friendly recoverable copy (ATL-727).
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     expect(callCount).toBe(4);
   });
 

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -22,6 +22,11 @@ import type {
 } from "../types.js";
 import { extractDomain } from "./domain-normalize.js";
 import type { ManagedSearchProxyResult } from "./managed-search-proxy.js";
+import {
+  classifyWebSearchFailure,
+  logWebSearchBackendFailure,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+} from "./web-search-error.js";
 
 const log = getLogger("web-search");
 
@@ -381,6 +386,81 @@ function errorResult(
   };
 }
 
+/**
+ * Build a {@link ToolExecutionResult} for a genuine backend/transport failure
+ * (5xx, post-retry rate-limit, thrown network/timeout error). Routes the raw
+ * detail through {@link classifyWebSearchFailure}: when it is a backend failure
+ * we surface the friendly recoverable copy (the bare sentence so the model
+ * reads it as guidance — retry / continue-without-search / paste-details —
+ * rather than fabricating) in both the model-facing `content` and the client
+ * `errorMessage`, and log the raw detail via telemetry. Non-backend categories
+ * (e.g. an unexpected 4xx) fall back to {@link errorResult} with `fallback`.
+ *
+ * Raw provider JSON / status text must never reach `content` or `errorMessage`;
+ * only `rawDetail` (internal-only) captures it for the log.
+ */
+function backendFailureResult(
+  query: string,
+  provider: WebSearchProvider,
+  startedAt: number,
+  raw: { error?: unknown; statusCode?: number; errorCode?: string },
+  fallback: string,
+): ToolExecutionResult {
+  const classification = classifyWebSearchFailure({
+    isError: true,
+    error: raw.error,
+    statusCode: raw.statusCode,
+    errorCode: raw.errorCode,
+  });
+
+  if (!classification.isBackendFailure) {
+    return errorResult(query, provider, startedAt, fallback);
+  }
+
+  logWebSearchBackendFailure(log, {
+    provider,
+    errorCategory: classification.category,
+    rawDetail: classification.rawDetail,
+    fallbackShown: true,
+    queryLength: query.length,
+  });
+
+  return {
+    content: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    isError: true,
+    activityMetadata: {
+      webSearch: {
+        query,
+        provider,
+        resultCount: 0,
+        durationMs: Date.now() - startedAt,
+        results: [],
+        errorMessage: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+      },
+    },
+  };
+}
+
+/**
+ * Route a thrown fetch error (network/timeout) through {@link backendFailureResult}
+ * as a `backend_unavailable` candidate, falling back to a `Web search failed: …`
+ * error for non-backend throws (e.g. a JSON parse error).
+ */
+function networkFailureResult(
+  query: string,
+  provider: WebSearchProvider,
+  startedAt: number,
+  err: unknown,
+): ToolExecutionResult {
+  return backendFailureResult(
+    query,
+    provider,
+    startedAt,
+    { error: err },
+    `Web search failed: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
 async function executeBraveSearch(
   query: string,
   count: number,
@@ -396,14 +476,19 @@ async function executeBraveSearch(
   const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/json",
-        "Accept-Encoding": "gzip",
-        "X-Subscription-Token": apiKey,
-      },
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "Accept-Encoding": "gzip",
+          "X-Subscription-Token": apiKey,
+        },
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "brave", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as BraveSearchResponse;
@@ -436,20 +521,22 @@ async function executeBraveSearch(
     }
 
     log.warn({ status: response.status }, "Brave Search API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "brave",
       startedAt,
+      { statusCode: response.status },
       response.status === 429
         ? "Brave Search rate limit exceeded after retries. Try again shortly."
         : `Brave Search API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "brave",
     startedAt,
+    { statusCode: 429 },
     "Brave Search rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -478,6 +565,20 @@ async function executeManagedBraveSearch(
   );
 
   if (!proxyResult.ok) {
+    // Keep billing/auth/unavailable mapping as specific copy; route genuine
+    // platform 5xx (transport-level failures) to the friendly backend helper.
+    if (
+      proxyResult.kind === "platform-error" &&
+      proxyResult.status >= 500
+    ) {
+      return backendFailureResult(
+        query,
+        "brave",
+        startedAt,
+        { statusCode: proxyResult.status },
+        managedSearchProxyErrorMessage(proxyResult),
+      );
+    }
     return errorResult(
       query,
       "brave",
@@ -503,12 +604,15 @@ async function executeManagedBraveSearch(
     );
   }
 
-  if (proxyResult.status === 429) {
-    return errorResult(
+  if (proxyResult.status === 429 || proxyResult.status >= 500) {
+    return backendFailureResult(
       query,
       "brave",
       startedAt,
-      "Managed Brave Search rate limit exceeded. Try again shortly.",
+      { statusCode: proxyResult.status },
+      proxyResult.status === 429
+        ? "Managed Brave Search rate limit exceeded. Try again shortly."
+        : `Managed Brave Search provider returned status ${proxyResult.status}`,
     );
   }
 
@@ -545,18 +649,23 @@ async function executePerplexitySearch(
 ): Promise<ToolExecutionResult> {
   const startedAt = Date.now();
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(PERPLEXITY_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: "sonar",
-        messages: [{ role: "user", content: query }],
-      }),
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(PERPLEXITY_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "sonar",
+          messages: [{ role: "user", content: query }],
+        }),
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "perplexity", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as PerplexityResponse;
@@ -600,20 +709,22 @@ async function executePerplexitySearch(
     }
 
     log.warn({ status: response.status }, "Perplexity API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "perplexity",
       startedAt,
+      { statusCode: response.status },
       response.status === 429
         ? "Perplexity rate limit exceeded after retries. Try again shortly."
         : `Perplexity API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "perplexity",
     startedAt,
+    { statusCode: 429 },
     "Perplexity rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -638,16 +749,21 @@ async function executeTavilySearch(
   const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(TAVILY_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-        "X-Client-Source": "vellum-assistant",
-      },
-      body: JSON.stringify(body),
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(TAVILY_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "X-Client-Source": "vellum-assistant",
+        },
+        body: JSON.stringify(body),
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "tavily", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as TavilySearchResponse;
@@ -691,20 +807,22 @@ async function executeTavilySearch(
     }
 
     log.warn({ status: response.status }, "Tavily Search API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "tavily",
       startedAt,
+      { statusCode: response.status },
       response.status === 429
         ? "Tavily Search rate limit exceeded after retries. Try again shortly."
         : `Tavily Search API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "tavily",
     startedAt,
+    { statusCode: 429 },
     "Tavily Search rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -844,14 +962,8 @@ export const webSearchTool = {
           signal: context.signal,
         });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
         log.error({ err }, "Managed web search failed");
-        return errorResult(
-          query,
-          "brave",
-          startedAt,
-          `Managed web search failed: ${msg}`,
-        );
+        return networkFailureResult(query, "brave", startedAt, err);
       }
     }
 
@@ -897,14 +1009,8 @@ export const webSearchTool = {
         signal: context.signal,
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, "Web search failed");
-      return errorResult(
-        query,
-        provider,
-        startedAt,
-        `Web search failed: ${msg}`,
-      );
+      return networkFailureResult(query, provider, startedAt, err);
     }
   },
 } satisfies ToolDefinition;

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -399,6 +399,29 @@ function errorResult(
  * Raw provider JSON / status text must never reach `content` or `errorMessage`;
  * only `rawDetail` (internal-only) captures it for the log.
  */
+/**
+ * Wrap an already-read provider response body so {@link backendFailureResult}
+ * forwards it into the classifier's internal-only `rawDetail` (telemetry). The
+ * classifier reads `error.message`; `buildRawDetail` truncates to ≤500 chars.
+ * Returns `undefined` for an empty body so we don't pad `rawDetail` with noise.
+ * The body must NEVER reach user-facing `content`/`errorMessage`.
+ */
+function rawBodyDetail(body: unknown): { message: string } | undefined {
+  if (body == null) return undefined;
+  const text =
+    typeof body === "string" ? body : safeStringifyBody(body);
+  const trimmed = text.trim();
+  return trimmed ? { message: trimmed } : undefined;
+}
+
+function safeStringifyBody(body: unknown): string {
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
+}
+
 function backendFailureResult(
   query: string,
   provider: WebSearchProvider,
@@ -495,7 +518,7 @@ async function executeBraveSearch(
       return successfulBraveResult(data, query, startedAt);
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -525,7 +548,7 @@ async function executeBraveSearch(
       query,
       "brave",
       startedAt,
-      { statusCode: response.status },
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Brave Search rate limit exceeded after retries. Try again shortly."
         : `Brave Search API returned status ${response.status}`,
@@ -575,7 +598,10 @@ async function executeManagedBraveSearch(
         query,
         "brave",
         startedAt,
-        { statusCode: proxyResult.status },
+        {
+          statusCode: proxyResult.status,
+          error: rawBodyDetail(proxyResult.body),
+        },
         managedSearchProxyErrorMessage(proxyResult),
       );
     }
@@ -609,7 +635,10 @@ async function executeManagedBraveSearch(
       query,
       "brave",
       startedAt,
-      { statusCode: proxyResult.status },
+      {
+        statusCode: proxyResult.status,
+        error: rawBodyDetail(proxyResult.body),
+      },
       proxyResult.status === 429
         ? "Managed Brave Search rate limit exceeded. Try again shortly."
         : `Managed Brave Search provider returned status ${proxyResult.status}`,
@@ -683,7 +712,7 @@ async function executePerplexitySearch(
       };
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -713,7 +742,7 @@ async function executePerplexitySearch(
       query,
       "perplexity",
       startedAt,
-      { statusCode: response.status },
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Perplexity rate limit exceeded after retries. Try again shortly."
         : `Perplexity API returned status ${response.status}`,
@@ -781,7 +810,7 @@ async function executeTavilySearch(
       };
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -811,7 +840,7 @@ async function executeTavilySearch(
       query,
       "tavily",
       startedAt,
-      { statusCode: response.status },
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Tavily Search rate limit exceeded after retries. Try again shortly."
         : `Tavily Search API returned status ${response.status}`,


### PR DESCRIPTION
## Summary
- Route app-side provider 5xx/network/timeout/post-retry-429 failures through the centralized normalizer to a friendly recoverable message in both model-facing content and client errorMessage
- Preserve raw detail in web_search_backend_failure telemetry; keep invalid-key/config/empty-results paths unchanged

Part of plan: web-search-failure.md (PR 3 of 5)