### PR TITLE
fix(ci): install workspace package deps before CLI typecheck

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2808,6 +2808,11 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install workspace package dependencies
+        run: |
+          cd packages/environments && bun install --frozen-lockfile
+          cd ../local-mode && bun install --frozen-lockfile
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
         working-directory: cli


### PR DESCRIPTION
## Summary
- The `ci-cli` release job only ran `bun install` in `cli/`, but the CLI's `file:` dependency `@vellumai/local-mode` imports `@vellumai/environments` — and TypeScript resolves that import from the real file path (`packages/local-mode/`), not through the CLI's `node_modules`
- Added an install step for `packages/environments` and `packages/local-mode` so their `node_modules` exist when TypeScript walks the directory tree

## Original prompt
Fix the CI failure on the release/v0.8.7 branch where the `ci-cli` typecheck step fails with `Cannot find module '@vellumai/environments'`. The recently extracted `@vellumai/environments` and `@vellumai/local-mode` workspace packages need their own `node_modules` installed for TypeScript module resolution to work when following symlinked `file:` dependencies.