### PR TITLE
test(web-search): end-to-end backend-failure coverage + document the normalized error flow (ATL-727)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Environment and data layout                 | [Environment and Data Layout](#environment-and-data-layout) (this file)                            |
 | Multi-local instance isolation              | [Multi-Local Instance Isolation](#multi-local-instance-isolation) (this file)                      |
 | Docker volume architecture                  | [Docker Volume Architecture](#docker-volume-architecture) (this file)                              |
+| Web search failure normalization            | [Web Search Failure Normalization](#web-search-failure-normalization) (this file)                  |
 | Service communication matrix                | [`docs/service-communication-matrix.md`](docs/service-communication-matrix.md)                     |
 
 ## Cross-Cutting Invariants
@@ -633,6 +634,20 @@ Runtime enforcement is layered. `disk-pressure-policy.ts` classifies turns befor
 Tool access is also narrowed during cleanup mode. The runtime marks cleanup turns in the tool context, `tool-approval-handler.ts` rejects non-cleanup-safe tools, and terminal background modes for `bash` and `host_bash` are rejected. When a new lock is created, already registered background terminal tools are cancelled with the disk-pressure reason.
 
 The macOS app owns the local client contract through `DiskPressureStatusStore`. On app activation and SSE changes, it fetches or applies the latest status. If acknowledgement is required, the main window and pop-out thread windows show a blocking safe-storage banner; the guardian must acknowledge or dismiss before continuing. After acknowledgement, chat surfaces keep a persistent cleanup status banner explaining that background processes and trusted-contact messages remain blocked until storage is freed. Acknowledgement request failures are shown in the banner so the modal does not fail silently.
+
+## Web Search Failure Normalization
+
+<!-- ATL-727: centralized web_search backend-failure normalization. -->
+
+Every `web_search` failure path funnels through a single classification layer so the same recoverable, user-facing copy reaches all clients while raw provider detail stays in telemetry only. The classifier lives in `assistant/src/tools/network/web-search-error.ts` (`classifyWebSearchFailure`), a pure leaf module with no daemon/agent/client imports.
+
+- **Single user-facing message.** Genuine backend failures (provider `unavailable` / `internal_error` / `overloaded_error`, post-retry `429`, app-side 5xx, thrown network/timeout/DNS-on-search errors) map to one constant, `WEB_SEARCH_BACKEND_FAILURE_MESSAGE`. It propagates to every client via `WebSearchMetadata.errorMessage` and is written identically by the native Anthropic `server_tool_complete` handler in `assistant/src/daemon/conversation-agent-loop-handlers.ts` and by the app-side `backendFailureResult` helper in `assistant/src/tools/network/web-search.ts`. The copy reads as guidance (retry / continue without search / paste details) and never blames the user, claims the whole internet is down, or embeds raw provider data.
+- **Raw detail logged, not shown.** The originating status code / error code / provider body is preserved only in the structured `web_search_backend_failure` warning (`logWebSearchBackendFailure`, field `rawDetail`, truncated, query text never logged — only `queryLength`). This telemetry is gated on `classification.isBackendFailure`, so recoverable non-backend categories (`query_too_long`, `max_uses_exceeded`, config/auth, `invalid_input`) keep their own specific copy and never count as provider outages.
+- **Per-turn dedup.** A burst of backend failures in one turn surfaces at most one full friendly notice; the native handler tracks this via `webSearchBackendFailureNotified` keyed by request id (the first failure sets `fallbackShown: true`, later ones get a terse line). Every failure is still logged.
+- **Honest, recoverable continuation.** A backend failure is a normal `tool_result` (`isError: true`, empty results), not a thrown provider error — the agent loop continues, and the search is never silently marked successful. A successful empty search (zero results) stays a success: no `errorMessage`, no telemetry.
+- **No conflation with `web_fetch`.** The normalization layer keys exclusively on `web_search` (native server-tool web_search and the app-side search tool). It never inspects `WebFetchMetadata`, so a `web_fetch` DNS failure (e.g. an unresolved host) keeps its own `webFetch.errorMessage` and is never rewritten to the search backend copy.
+
+End-to-end coverage lives in `assistant/src/__tests__/web-search-backend-failure.test.ts`.
 
 ## Maintenance Rule
 

--- a/assistant/src/__tests__/web-search-backend-failure.test.ts
+++ b/assistant/src/__tests__/web-search-backend-failure.test.ts
@@ -1,0 +1,336 @@
+// End-to-end integration coverage for the centralized web_search
+// backend-failure normalization layer (ATL-727).
+//
+// PRs 1-4 built the layer in three places:
+//   - `tools/network/web-search-error.ts` — `classifyWebSearchFailure` +
+//     `WEB_SEARCH_BACKEND_FAILURE_MESSAGE` + the structured
+//     `web_search_backend_failure` log helper.
+//   - `daemon/conversation-agent-loop-handlers.ts` — the native
+//     `server_tool_complete` handler maps Anthropic backend failures to the
+//     friendly copy, dedups per turn (`webSearchBackendFailureNotified`), and
+//     gates telemetry on `classification.isBackendFailure`.
+//   - `tools/network/web-search.ts` — the app-side `backendFailureResult`
+//     helper routes 5xx/network/429 to the same copy.
+//
+// This file locks the cross-cutting acceptance criteria in one place by
+// driving the real handler + the real classifier end to end:
+//   - friendly copy surfaced to the client,
+//   - raw provider detail logged-not-shown,
+//   - per-turn dedup,
+//   - honest continuation (the failure is a recoverable tool_result, not a
+//     thrown provider error; the search is never marked successful),
+//   - web_fetch DNS failures are NOT conflated with the search backend copy,
+//   - a successful empty search stays successful (no telemetry, no errorMessage).
+//
+// The native path reuses the handler harness from PR 2's
+// `native-web-search.test.ts`; the web_fetch invariant is exercised through
+// the same `handleToolResult` path an app-executed fetch tool drives.
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
+
+// ---------------------------------------------------------------------------
+// Mock the daemon collaborators the handler module imports at load time so the
+// handler can be driven in isolation (mirrors native-web-search.test.ts).
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// Import after mocking.
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  type EventHandlerDeps,
+  type EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
+
+// ---------------------------------------------------------------------------
+// Handler harness
+// ---------------------------------------------------------------------------
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+function createHandlerDeps(reqId = "req-web-search"): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+  warnings: LogRecord[];
+} {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+/** Drive one native (Anthropic) web_search start → complete pair. */
+async function completeNativeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: {
+    isError: boolean;
+    errorCode?: string;
+    errorMessage?: string;
+    content?: unknown[];
+  },
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+function toolResults(events: ServerMessage[]): ToolResultEvent[] {
+  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
+}
+
+function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
+  const results = toolResults(events);
+  return results[results.length - 1];
+}
+
+function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
+  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
+}
+
+describe("web_search backend-failure end-to-end (ATL-727)", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("native backend failure surfaces friendly copy, empty results, and logs raw detail not shown to the user", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+
+    await completeNativeWebSearch(state, deps, "tu_native", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const result = lastToolResult(events);
+    expect(result).toBeDefined();
+    expect(result?.isError).toBe(true);
+
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.provider).toBe("anthropic-native");
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+
+    // Raw provider detail is captured in telemetry only.
+    const failureLog = backendFailureLogs(warnings)[0];
+    expect(failureLog).toBeDefined();
+    expect(failureLog?.obj.errorCategory).toBe("backend_unavailable");
+    expect(failureLog?.obj.fallbackShown).toBe(true);
+    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
+
+    // ...and never leaks into the user-facing copy.
+    expect(meta?.errorMessage).not.toContain("unavailable");
+    expect(result?.result).not.toContain("unavailable");
+  });
+
+  test("dedups two native backend failures in one turn to a single full notice", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-dedup-turn");
+
+    await completeNativeWebSearch(state, deps, "tu_dup_1", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+    await completeNativeWebSearch(state, deps, "tu_dup_2", {
+      isError: true,
+      errorCode: "overloaded_error",
+    });
+
+    const results = toolResults(events);
+    expect(results).toHaveLength(2);
+
+    // First failure gets the full friendly notice; the second is terse.
+    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+
+    // Both failures are still logged; exactly one reports fallbackShown.
+    const logs = backendFailureLogs(warnings);
+    expect(logs).toHaveLength(2);
+    expect(logs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(1);
+  });
+
+  test("backend failure stays an honest, recoverable tool result (not a thrown provider error, never marked successful)", async () => {
+    const { deps, events } = createHandlerDeps("req-honesty");
+
+    // A recoverable backend failure flows as a tool_result, so dispatch must
+    // resolve without throwing.
+    await expect(
+      completeNativeWebSearch(state, deps, "tu_honesty", {
+        isError: true,
+        errorCode: "unavailable",
+      }),
+    ).resolves.toBeUndefined();
+
+    const result = lastToolResult(events);
+    // The search is never silently upgraded to a success.
+    expect(result?.isError).toBe(true);
+    expect(result?.activityMetadata?.webSearch?.resultCount).toBe(0);
+    expect(result?.activityMetadata?.webSearch?.results).toEqual([]);
+  });
+
+  test("web_fetch DNS failure is NOT conflated with the web_search backend copy", async () => {
+    // The normalization layer keys exclusively on web_search (the native
+    // `server_tool_complete` handler and `web-search.ts`). It never inspects
+    // `webFetch` metadata. handleToolResult forwards an app-executed tool's
+    // `activityMetadata` verbatim, so a web_fetch DNS failure must reach the
+    // client with its own copy and acquire NO `webSearch` metadata. Drive that
+    // path directly with a DNS-failure fetch result for grimgoods.io.
+    const { deps, events, warnings } = createHandlerDeps("req-web-fetch");
+
+    const dnsError =
+      'Error: Unable to resolve host "grimgoods.io" (DNS lookup failed)';
+    const fetchMetadata: ToolActivityMetadata = {
+      webFetch: {
+        url: "https://grimgoods.io",
+        finalUrl: "https://grimgoods.io",
+        status: 0,
+        byteCount: 0,
+        charCount: 0,
+        truncated: false,
+        domain: "grimgoods.io",
+        redirectCount: 0,
+        durationMs: 12,
+        errorMessage: dnsError,
+      },
+    };
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_fetch",
+      name: "web_fetch",
+      input: { url: "https://grimgoods.io" },
+    });
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_result",
+      toolUseId: "tu_fetch",
+      content: dnsError,
+      isError: true,
+      activityMetadata: fetchMetadata,
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.isError).toBe(true);
+
+    // The DNS error keeps its own webFetch copy untouched...
+    expect(result?.activityMetadata?.webFetch?.errorMessage).toBe(dnsError);
+    // ...and is never rewritten to the search backend copy.
+    expect(result?.activityMetadata?.webFetch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    // No webSearch metadata is fabricated for a fetch failure.
+    expect(result?.activityMetadata?.webSearch).toBeUndefined();
+    // And the web_search backend-failure telemetry never fires for a fetch.
+    expect(backendFailureLogs(warnings)).toHaveLength(0);
+  });
+
+  test("successful empty native search stays successful with no telemetry and no errorMessage", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-no-results");
+
+    await completeNativeWebSearch(state, deps, "tu_empty", {
+      isError: false,
+      content: [],
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.isError).toBe(false);
+
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+    expect(meta?.errorMessage).toBeUndefined();
+
+    // No-results is a success, not a backend failure: no telemetry fires.
+    expect(backendFailureLogs(warnings)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add an integration test locking the end-to-end web_search backend-failure flow: friendly copy surfaced, raw detail logged-not-shown, per-turn dedup, honest continuation, web_fetch DNS unaffected, no-results unaffected
- Document the centralized normalization layer in ARCHITECTURE.md (ATL-727)

Part of plan: web-search-failure.md (PR 5 of 5)