### PR TITLE
ci(release): migrate to install-shared-packages composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2759,13 +2759,10 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: assistant
 
-      - name: Install nested package dependencies
-        run: |
-          for dir in packages/*/ skills/*/; do
-            [ -f "${dir}/package.json" ] || continue
-            echo "Installing dependencies in ${dir}"
-            (cd "${dir}" && bun install --frozen-lockfile 2>/dev/null || bun install)
-          done
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/service-contracts packages/ces-client packages/gateway-client skills/meet-join gateway
 
       - name: Lint
         run: bun run lint
@@ -2808,10 +2805,10 @@ jobs:
         with:
           bun-version: '1.3.11'
 
-      - name: Install workspace package dependencies
-        run: |
-          cd packages/environments && bun install --frozen-lockfile
-          cd ../local-mode && bun install --frozen-lockfile
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -2835,6 +2832,11 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
+
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/service-contracts packages/ces-client packages/assistant-client
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -2867,11 +2869,10 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: credential-executor
 
-      - name: Install linked package dependencies
-        run: |
-          for pkg in $(jq -r '.bundledDependencies[]' credential-executor/package.json | sed 's|@vellumai/||'); do
-            cd packages/$pkg && bun install --frozen-lockfile && cd ../..;
-          done
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/service-contracts
 
       - name: Typecheck
         run: bun run typecheck


### PR DESCRIPTION
## Summary
- Replaced four different ad-hoc install patterns in `release.yml` (inline `cd` chains, `for dir in packages/*/` glob loop, `jq` bundledDependencies loop) with the reusable `install-shared-packages` composite action from #32976
- Added the missing shared-package install step to `ci-gateway` (latent bug — currently not triggered because gateway doesn't follow transitive `file:` imports in CI, but would break if it did)
- The composite action's transitive-dep guard now protects the release workflow too

## Original prompt
After fixing a release CI typecheck failure (#32977) with an inline workaround, we discovered that #32976 had already introduced a proper composite action (`install-shared-packages`) with a transitive-dep guard for the PR and main CI workflows. The release workflow was the only one still using ad-hoc install patterns — this PR migrates it for consistency and to get the guard's protection.