### PR TITLE
Skip local key reprovision for managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1713,12 +1713,24 @@ final class ConversationManager: ConversationRestorerDelegate {
 
     // MARK: - Managed Key Reprovisioning
 
+    nonisolated static func shouldReprovisionAssistantKeyViaLocalBootstrap(for assistant: LockfileAssistant) -> Bool {
+        !assistant.isManaged && (!assistant.isRemote || assistant.isDocker)
+    }
+
     private func reprovisionManagedKey() async {
         guard let assistantId = LockfileAssistant.loadActiveAssistantId(), !assistantId.isEmpty else {
             log.warning("Cannot reprovision — no connected assistant ID")
             return
         }
-        log.info("Managed API key invalid — attempting reprovision for \(assistantId, privacy: .public)")
+        guard let assistant = LockfileAssistant.loadByName(assistantId) else {
+            log.warning("Cannot reprovision assistant API key — active assistant \(assistantId, privacy: .public) is missing from the lockfile")
+            return
+        }
+        guard Self.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant) else {
+            log.warning("Skipping local assistant API key reprovision for \(assistantId, privacy: .public) because local bootstrap is only valid for local or Docker assistants")
+            return
+        }
+        log.info("Assistant API key invalid — attempting local reprovision for \(assistantId, privacy: .public)")
         let credentialStorage = FileCredentialStorage()
         let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
         do {
@@ -1727,9 +1739,9 @@ final class ConversationManager: ConversationRestorerDelegate {
                 clientPlatform: "macos",
                 assistantVersion: connectionManager.assistantVersion
             )
-            log.info("Managed API key reprovisioned successfully")
+            log.info("Assistant API key reprovisioned successfully")
         } catch {
-            log.error("Failed to reprovision managed API key: \(error.localizedDescription)")
+            log.error("Failed to reprovision assistant API key: \(error.localizedDescription)")
         }
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationManagerManagedKeyReprovisionTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerManagedKeyReprovisionTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class ConversationManagerManagedKeyReprovisionTests: XCTestCase {
+    func testManagedAssistantsDoNotUseLocalBootstrapForKeyReprovision() {
+        let assistant = makeAssistant(cloud: "vellum")
+
+        XCTAssertFalse(
+            ConversationManager.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant)
+        )
+    }
+
+    func testLegacyPlatformAssistantsDoNotUseLocalBootstrapForKeyReprovision() {
+        let assistant = makeAssistant(cloud: "platform")
+
+        XCTAssertFalse(
+            ConversationManager.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant)
+        )
+    }
+
+    func testGenericRemoteAssistantsDoNotUseLocalBootstrapForKeyReprovision() {
+        let assistant = makeAssistant(cloud: "aws")
+
+        XCTAssertFalse(
+            ConversationManager.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant)
+        )
+    }
+
+    func testLocalAssistantsUseLocalBootstrapForKeyReprovision() {
+        let assistant = makeAssistant(cloud: "local")
+
+        XCTAssertTrue(
+            ConversationManager.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant)
+        )
+    }
+
+    func testDockerAssistantsUseLocalBootstrapForKeyReprovision() {
+        let assistant = makeAssistant(cloud: "docker")
+
+        XCTAssertTrue(
+            ConversationManager.shouldReprovisionAssistantKeyViaLocalBootstrap(for: assistant)
+        )
+    }
+
+    private func makeAssistant(cloud: String) -> LockfileAssistant {
+        LockfileAssistant(
+            assistantId: "assistant-123",
+            runtimeUrl: "https://example.com",
+            bearerToken: nil,
+            cloud: cloud,
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil,
+            baseDataDir: nil,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- prevent the managed-key-invalid recovery path from calling LocalAssistantBootstrapService for platform-managed assistants
- keep local bootstrap reprovision available only for local and Docker assistants
- add regression coverage for managed, legacy platform, generic remote, local, and Docker assistant modes

## Context
Managed assistants already use their platform assistant UUID as the runtime assistant ID. Reusing LocalAssistantBootstrapService in the managed-key-invalid path sends that UUID to the self-hosted-local registration endpoint as runtime_assistant_id, which can create accidental Local: <managed-id> assistant rows and inject the wrong assistant API key identity back into the runtime.

This is the client-side hotfix. A platform-side guard should follow to reject self-hosted-local registration when runtime_assistant_id matches an existing non-local assistant.

## Testing
- swift test --package-path clients --filter ConversationManagerManagedKeyReprovisionTests
- pre-push hook: Swift build in clients/ passed
- pre-push hook: design token guard passed