### PR TITLE
fix(web-search): harden web_search failure classifier (abort precedence, statusCode authority) (ATL-727)

### DIFF
--- a/assistant/src/tools/network/web-search-error.test.ts
+++ b/assistant/src/tools/network/web-search-error.test.ts
@@ -75,6 +75,35 @@ describe("classifyWebSearchFailure", () => {
     expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
   });
 
+  test("tagged abort with a transport-shaped cause is not a backend failure", () => {
+    // A user cancellation wrapped as a ProviderError that ALSO carries a
+    // transport-shaped `cause` (ECONNRESET). The tagged abort guard must win
+    // over transport-retryability so this is not mislabeled a backend outage.
+    const err = Object.assign(new Error("Request was aborted"), {
+      name: "ProviderError",
+      cause: { code: "ECONNRESET" },
+      abortReason: createAbortReason("user_cancel", "cancelGeneration"),
+    });
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.category).not.toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("explicit statusCode wins over a misleading error-body keyword", () => {
+    // The provider response body contains "aborted" (a keyword the error-body
+    // heuristic would sniff as a non-failure), but the authoritative HTTP 503
+    // must classify this as a backend failure.
+    const result = classifyWebSearchFailure({
+      isError: true,
+      statusCode: 503,
+      error: new Error("the upstream request was aborted unexpectedly"),
+    });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(true);
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
   test("ECONNRESET network error is a backend failure", () => {
     const err = Object.assign(new Error("socket hang up"), {
       code: "ECONNRESET",
@@ -197,7 +226,6 @@ describe("logWebSearchBackendFailure", () => {
     logWebSearchBackendFailure(fakeLogger, {
       provider: "anthropic",
       requestId: "req-1",
-      correlationId: "corr-1",
       errorCategory: "backend_unavailable",
       rawDetail: "errorCode=unavailable",
       fallbackShown: true,

--- a/assistant/src/tools/network/web-search-error.ts
+++ b/assistant/src/tools/network/web-search-error.ts
@@ -129,6 +129,23 @@ function categoryFromStatusCode(
 function categoryFromError(error: unknown): WebSearchFailureCategory | undefined {
   if (error == null) return undefined;
 
+  // A user-initiated abort (Stop/Esc, preemption, dispose) is not a failure.
+  // The tagged `AbortReason` may surface directly (`AbortSignal.throwIfAborted`
+  // throws `signal.reason` verbatim), via `error.reason`, or — when a provider
+  // wrapper erases the `AbortError` name — on `ProviderError.abortReason`. Check
+  // all three FIRST, before the transport-retryability and abort/timeout
+  // substring heuristics, so a tagged cancellation that ALSO carries a
+  // transport-shaped `cause` (e.g. ECONNRESET) short-circuits to "not a
+  // failure" instead of being mislabeled a backend outage. A bare
+  // AbortError/timeout with no tagged reason still falls through below.
+  if (
+    isAbortReason(error) ||
+    isAbortReason((error as { reason?: unknown }).reason) ||
+    isAbortReason((error as { abortReason?: unknown }).abortReason)
+  ) {
+    return undefined;
+  }
+
   // Retryable transport failures (ECONNRESET/ECONNREFUSED/ETIMEDOUT, socket
   // hang-ups, including one level of `cause` chain) are backend failures.
   if (isRetryableNetworkError(error)) return "backend_unavailable";
@@ -138,20 +155,6 @@ function categoryFromError(error: unknown): WebSearchFailureCategory | undefined
     : "";
   const haystack = `${name} ${(error as { message?: unknown }).message ?? ""}`
     .toLowerCase();
-
-  // A user-initiated abort (Stop/Esc, preemption, dispose) is not a failure.
-  // The tagged `AbortReason` may surface directly (`AbortSignal.throwIfAborted`
-  // throws `signal.reason` verbatim), via `error.reason`, or — when a provider
-  // wrapper erases the `AbortError` name — on `ProviderError.abortReason`. Check
-  // all three before the abort/timeout substring heuristic so a wrapped abort
-  // like "Request was aborted" short-circuits the backend-failure path.
-  if (
-    isAbortReason(error) ||
-    isAbortReason((error as { reason?: unknown }).reason) ||
-    isAbortReason((error as { abortReason?: unknown }).abortReason)
-  ) {
-    return undefined;
-  }
 
   // web_search-only: treat aborts/timeouts/DNS/fetch failures (the cases
   // `isRetryableNetworkError` doesn't cover) as backend failures.
@@ -205,14 +208,20 @@ export function classifyWebSearchFailure(
     };
   }
 
+  // Resolution order: Anthropic `errorCode` → explicit HTTP `statusCode` →
+  // error-body/network heuristics. An explicit status code is authoritative
+  // over substring-sniffing the provider's response body (which can contain
+  // misleading keywords like "timeout"/"abort"). Tagged user-aborts carry no
+  // status code, so they still flow through `categoryFromError` and
+  // short-circuit to a non-failure.
   const category =
     (input.errorCode != null
       ? categoryFromErrorCode(input.errorCode)
       : undefined) ??
-    categoryFromError(input.error) ??
     (typeof input.statusCode === "number"
       ? categoryFromStatusCode(input.statusCode)
       : undefined) ??
+    categoryFromError(input.error) ??
     "unknown";
 
   return {
@@ -226,7 +235,6 @@ export function classifyWebSearchFailure(
 export interface WebSearchBackendFailureMeta {
   provider: string;
   requestId?: string;
-  correlationId?: string;
   errorCategory: WebSearchFailureCategory;
   rawDetail: string;
   fallbackShown: boolean;
@@ -249,7 +257,6 @@ export function logWebSearchBackendFailure(
       tool: "web_search",
       provider: meta.provider,
       requestId: meta.requestId,
-      correlationId: meta.correlationId,
       errorCategory: meta.errorCategory,
       rawDetail: meta.rawDetail,
       fallbackShown: meta.fallbackShown,


### PR DESCRIPTION
## Summary
Fixes gaps from plan review (web-search-failure.md):
- Tagged user-abort guard now runs before transport-retryability in categoryFromError so wrapped cancellations are not mislabeled backend failures
- Explicit HTTP statusCode is authoritative over error-body keyword sniffing in classifyWebSearchFailure
- Removed unused correlationId telemetry field