### PR TITLE
fix(web-search): correct provider label in shared server_tool_complete telemetry (ATL-727)

### DIFF
--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -666,6 +666,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
       (w) => w.obj.event === "web_search_backend_failure",
     );
     expect(failureLog).toBeDefined();
+    expect(failureLog?.obj.provider).toBe("anthropic-native");
     expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
     expect(failureLog?.obj.fallbackShown).toBe(true);
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1868,7 +1868,9 @@ export async function dispatchAgentEvent(
             // fire only for genuine backend classifications so it does not
             // count recoverable input/quota errors as provider failures.
             logWebSearchBackendFailure(deps.rlog, {
-              provider: "anthropic-native",
+              provider: isAnthropicNative
+                ? "anthropic-native"
+                : deps.ctx.provider.name,
               requestId: deps.reqId,
               errorCategory: classification.category,
               rawDetail: classification.rawDetail,


### PR DESCRIPTION
## Summary
Fixes a gap from plan review (web-search-failure.md): the shared server_tool_complete handler hardcoded provider: anthropic-native in web_search_backend_failure telemetry even though the channel is shared with other providers. Now derived from the actual provider (isAnthropicNative).