### PR TITLE
fix(web-search): never surface terse 'Search failed' on native failures; share web_search test harness (ATL-727)

### DIFF
--- a/assistant/src/__tests__/helpers/native-web-search-harness.ts
+++ b/assistant/src/__tests__/helpers/native-web-search-harness.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared test harness for driving the daemon's native `server_tool_complete`
+ * web_search handler in isolation (ATL-727).
+ *
+ * Both `native-web-search.test.ts` and `web-search-backend-failure.test.ts`
+ * exercise the same handler the same way: build a set of mocked
+ * `EventHandlerDeps` (capturing emitted `ServerMessage`s and `rlog.warn`
+ * records), then drive a `server_tool_start` → `server_tool_complete` pair.
+ * This module is the single source of truth for that harness so the two suites
+ * cannot drift apart.
+ *
+ * Note: each consuming test file must still install its own
+ * `mock.module(...)` stubs for the daemon collaborators the handler imports at
+ * load time (config loader, conversation-crud, llm-request-log-store), because
+ * Bun's `mock.module()` is scoped to the file that registers it.
+ */
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../../daemon/conversation-agent-loop-handlers.js";
+import { dispatchAgentEvent } from "../../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+
+/** A `tool_result` `ServerMessage` emitted by the handler. */
+export type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+/** A captured `rlog.warn(obj, msg)` call. */
+export interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+export interface HandlerHarness {
+  deps: EventHandlerDeps;
+  /** Every `ServerMessage` the handler emitted via `onEvent`. */
+  events: ServerMessage[];
+  /** Every `rlog.warn(obj, msg)` call the handler made. */
+  warnings: LogRecord[];
+}
+
+/** Build mocked handler deps that capture emitted events and warn logs. */
+export function createHandlerDeps(reqId = "req-web-search"): HandlerHarness {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+/** The `server_tool_complete` payload shape a test supplies. */
+export interface WebSearchCompleteEvent {
+  isError: boolean;
+  errorCode?: string;
+  errorMessage?: string;
+  content?: unknown[];
+}
+
+/** Drive one native (Anthropic) web_search start → complete pair. */
+export async function completeNativeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: WebSearchCompleteEvent,
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+/** All `tool_result` events emitted so far, in order. */
+export function toolResults(events: ServerMessage[]): ToolResultEvent[] {
+  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
+}
+
+/** The most recent `tool_result` event, if any. */
+export function lastToolResult(
+  events: ServerMessage[],
+): ToolResultEvent | undefined {
+  const results = toolResults(events);
+  return results[results.length - 1];
+}
+
+/** The captured `web_search_backend_failure` telemetry warn records. */
+export function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
+  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
+}

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -110,14 +110,17 @@ mock.module("../memory/llm-request-log-store.js", () => ({
 // Import after mocking
 import {
   createEventHandlerState,
-  dispatchAgentEvent,
-  type EventHandlerDeps,
   type EventHandlerState,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import { AnthropicProvider } from "../providers/anthropic/client.js";
 import { isNativeWebSearchCapableProvider } from "../providers/registry.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
+import {
+  completeNativeWebSearch,
+  createHandlerDeps,
+  lastToolResult,
+  toolResults,
+} from "./helpers/native-web-search-harness.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -548,90 +551,6 @@ describe("Native Web Search — Streaming Events", () => {
 // Tests — Native server_tool_complete backend-failure handling (ATL-727)
 // ---------------------------------------------------------------------------
 
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
-
-interface LogRecord {
-  obj: Record<string, unknown>;
-  msg?: string;
-}
-
-function createHandlerDeps(reqId = "req-web-search"): {
-  deps: EventHandlerDeps;
-  events: ServerMessage[];
-  warnings: LogRecord[];
-} {
-  const events: ServerMessage[] = [];
-  const warnings: LogRecord[] = [];
-  const rlog = {
-    warn: (obj: Record<string, unknown>, msg?: string) =>
-      warnings.push({ obj, msg }),
-    info: () => {},
-    error: () => {},
-    debug: () => {},
-    trace: () => {},
-    fatal: () => {},
-  };
-  const deps = {
-    ctx: {
-      conversationId: "conv-web-search",
-      provider: { name: "anthropic" },
-      traceEmitter: { emit: () => {} },
-      streamThinking: false,
-      emitActivityState: () => {},
-      markWorkspaceTopLevelDirty: () => {},
-      currentTurnSurfaces: [],
-    } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
-    reqId,
-    isFirstMessage: false,
-    shouldGenerateTitle: false,
-    rlog: rlog as unknown as EventHandlerDeps["rlog"],
-    turnChannelContext: {
-      userMessageChannel: "vellum",
-      assistantMessageChannel: "vellum",
-    } as EventHandlerDeps["turnChannelContext"],
-    turnInterfaceContext: {
-      userMessageInterface: "macos",
-      assistantMessageInterface: "macos",
-    } as EventHandlerDeps["turnInterfaceContext"],
-  } as EventHandlerDeps;
-  return { deps, events, warnings };
-}
-
-async function completeWebSearch(
-  state: EventHandlerState,
-  deps: EventHandlerDeps,
-  toolUseId: string,
-  event: {
-    isError: boolean;
-    errorCode?: string;
-    errorMessage?: string;
-    content?: unknown[];
-  },
-): Promise<void> {
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_start",
-    name: "web_search",
-    toolUseId,
-    input: { query: "what is the weather" },
-  });
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_complete",
-    toolUseId,
-    isError: event.isError,
-    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
-    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
-    content: event.content ?? [],
-  });
-}
-
-function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
-  const results = events.filter(
-    (e): e is ToolResultEvent => e.type === "tool_result",
-  );
-  return results[results.length - 1];
-}
-
 describe("Native Web Search — Backend Failure Handling", () => {
   let state: EventHandlerState;
 
@@ -641,7 +560,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("backend failure surfaces friendly copy with isError true and empty results", async () => {
     const { deps, events } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_backend", {
+    await completeNativeWebSearch(state, deps, "tu_backend", {
       isError: true,
       errorCode: "unavailable",
     });
@@ -657,7 +576,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("raw error_code is logged under web_search_backend_failure but absent from user copy", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_log", {
+    await completeNativeWebSearch(state, deps, "tu_log", {
       isError: true,
       errorCode: "unavailable",
     });
@@ -678,18 +597,16 @@ describe("Native Web Search — Backend Failure Handling", () => {
   test("dedups repeat backend failures within one turn to a single friendly notice", async () => {
     const { deps, events, warnings } = createHandlerDeps();
 
-    await completeWebSearch(state, deps, "tu_dup_1", {
+    await completeNativeWebSearch(state, deps, "tu_dup_1", {
       isError: true,
       errorCode: "unavailable",
     });
-    await completeWebSearch(state, deps, "tu_dup_2", {
+    await completeNativeWebSearch(state, deps, "tu_dup_2", {
       isError: true,
       errorCode: "overloaded_error",
     });
 
-    const results = events.filter(
-      (e): e is ToolResultEvent => e.type === "tool_result",
-    );
+    const results = toolResults(events);
     expect(results).toHaveLength(2);
     expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
       WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
@@ -711,7 +628,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("successful search leaves errorMessage undefined and populates results", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_ok", {
+    await completeNativeWebSearch(state, deps, "tu_ok", {
       isError: false,
       content: [
         {
@@ -734,7 +651,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("query_too_long yields a distinct non-backend message", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_long", {
+    await completeNativeWebSearch(state, deps, "tu_long", {
       isError: true,
       errorCode: "query_too_long",
     });
@@ -744,6 +661,30 @@ describe("Native Web Search — Backend Failure Handling", () => {
     expect(errorMessage).toBeDefined();
     expect(errorMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     // Recoverable non-backend errors must NOT emit backend-failure telemetry.
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
+  });
+
+  test("message-less native failure (no error_code) surfaces friendly copy, not the terse 'Search failed' placeholder, and emits no backend telemetry", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-unknown");
+    // `isError:true` with no error_code/message classifies as `unknown`
+    // (isBackendFailure:false, empty userMessage). It must still get the
+    // friendly copy rather than the bare "Search failed".
+    await completeNativeWebSearch(state, deps, "tu_unknown", {
+      isError: true,
+    });
+
+    const result = lastToolResult(events);
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.errorMessage).not.toBe("Search failed");
+    expect(result?.isError).toBe(true);
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+
+    // An unclassifiable failure borrows the friendly copy but must NOT be
+    // logged as a backend outage.
     expect(
       warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
     ).toHaveLength(0);

--- a/assistant/src/__tests__/web-search-backend-failure.test.ts
+++ b/assistant/src/__tests__/web-search-backend-failure.test.ts
@@ -12,18 +12,17 @@
 //   - `tools/network/web-search.ts` — the app-side `backendFailureResult`
 //     helper routes 5xx/network/429 to the same copy.
 //
-// This file locks the cross-cutting acceptance criteria in one place by
-// driving the real handler + the real classifier end to end:
-//   - friendly copy surfaced to the client,
-//   - raw provider detail logged-not-shown,
-//   - per-turn dedup,
+// The single-layer native-handler invariants (friendly copy + isError + empty
+// results, raw-detail-logged-not-shown, per-turn dedup, successful-empty
+// search) are owned by `native-web-search.test.ts`. This file locks the
+// cross-cutting acceptance criteria that file does not cover:
 //   - honest continuation (the failure is a recoverable tool_result, not a
 //     thrown provider error; the search is never marked successful),
-//   - web_fetch DNS failures are NOT conflated with the search backend copy,
-//   - a successful empty search stays successful (no telemetry, no errorMessage).
+//   - web_fetch DNS failures are NOT conflated with the search backend copy.
 //
-// The native path reuses the handler harness from PR 2's
-// `native-web-search.test.ts`; the web_fetch invariant is exercised through
+// It genuinely reuses the shared handler harness in
+// `helpers/native-web-search-harness.ts` (the same harness driven by
+// `native-web-search.test.ts`); the web_fetch invariant is exercised through
 // the same `handleToolResult` path an app-executed fetch tool drives.
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -33,6 +32,7 @@ import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.
 // ---------------------------------------------------------------------------
 // Mock the daemon collaborators the handler module imports at load time so the
 // handler can be driven in isolation (mirrors native-web-search.test.ts).
+// `mock.module()` is file-scoped, so the shared harness cannot install these.
 // ---------------------------------------------------------------------------
 
 mock.module("../config/loader.js", () => ({
@@ -73,171 +73,21 @@ mock.module("../memory/llm-request-log-store.js", () => ({
 import {
   createEventHandlerState,
   dispatchAgentEvent,
-  type EventHandlerDeps,
   type EventHandlerState,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
-
-// ---------------------------------------------------------------------------
-// Handler harness
-// ---------------------------------------------------------------------------
-
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
-
-interface LogRecord {
-  obj: Record<string, unknown>;
-  msg?: string;
-}
-
-function createHandlerDeps(reqId = "req-web-search"): {
-  deps: EventHandlerDeps;
-  events: ServerMessage[];
-  warnings: LogRecord[];
-} {
-  const events: ServerMessage[] = [];
-  const warnings: LogRecord[] = [];
-  const rlog = {
-    warn: (obj: Record<string, unknown>, msg?: string) =>
-      warnings.push({ obj, msg }),
-    info: () => {},
-    error: () => {},
-    debug: () => {},
-    trace: () => {},
-    fatal: () => {},
-  };
-  const deps = {
-    ctx: {
-      conversationId: "conv-web-search",
-      provider: { name: "anthropic" },
-      traceEmitter: { emit: () => {} },
-      streamThinking: false,
-      emitActivityState: () => {},
-      markWorkspaceTopLevelDirty: () => {},
-      currentTurnSurfaces: [],
-    } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
-    reqId,
-    isFirstMessage: false,
-    shouldGenerateTitle: false,
-    rlog: rlog as unknown as EventHandlerDeps["rlog"],
-    turnChannelContext: {
-      userMessageChannel: "vellum",
-      assistantMessageChannel: "vellum",
-    } as EventHandlerDeps["turnChannelContext"],
-    turnInterfaceContext: {
-      userMessageInterface: "macos",
-      assistantMessageInterface: "macos",
-    } as EventHandlerDeps["turnInterfaceContext"],
-  } as EventHandlerDeps;
-  return { deps, events, warnings };
-}
-
-/** Drive one native (Anthropic) web_search start → complete pair. */
-async function completeNativeWebSearch(
-  state: EventHandlerState,
-  deps: EventHandlerDeps,
-  toolUseId: string,
-  event: {
-    isError: boolean;
-    errorCode?: string;
-    errorMessage?: string;
-    content?: unknown[];
-  },
-): Promise<void> {
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_start",
-    name: "web_search",
-    toolUseId,
-    input: { query: "what is the weather" },
-  });
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_complete",
-    toolUseId,
-    isError: event.isError,
-    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
-    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
-    content: event.content ?? [],
-  });
-}
-
-function toolResults(events: ServerMessage[]): ToolResultEvent[] {
-  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
-}
-
-function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
-  const results = toolResults(events);
-  return results[results.length - 1];
-}
-
-function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
-  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
-}
+import {
+  backendFailureLogs,
+  completeNativeWebSearch,
+  createHandlerDeps,
+  lastToolResult,
+} from "./helpers/native-web-search-harness.js";
 
 describe("web_search backend-failure end-to-end (ATL-727)", () => {
   let state: EventHandlerState;
 
   beforeEach(() => {
     state = createEventHandlerState();
-  });
-
-  test("native backend failure surfaces friendly copy, empty results, and logs raw detail not shown to the user", async () => {
-    const { deps, events, warnings } = createHandlerDeps();
-
-    await completeNativeWebSearch(state, deps, "tu_native", {
-      isError: true,
-      errorCode: "unavailable",
-    });
-
-    const result = lastToolResult(events);
-    expect(result).toBeDefined();
-    expect(result?.isError).toBe(true);
-
-    const meta = result?.activityMetadata?.webSearch;
-    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
-    expect(meta?.provider).toBe("anthropic-native");
-    expect(meta?.resultCount).toBe(0);
-    expect(meta?.results).toEqual([]);
-
-    // Raw provider detail is captured in telemetry only.
-    const failureLog = backendFailureLogs(warnings)[0];
-    expect(failureLog).toBeDefined();
-    expect(failureLog?.obj.errorCategory).toBe("backend_unavailable");
-    expect(failureLog?.obj.fallbackShown).toBe(true);
-    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
-
-    // ...and never leaks into the user-facing copy.
-    expect(meta?.errorMessage).not.toContain("unavailable");
-    expect(result?.result).not.toContain("unavailable");
-  });
-
-  test("dedups two native backend failures in one turn to a single full notice", async () => {
-    const { deps, events, warnings } = createHandlerDeps("req-dedup-turn");
-
-    await completeNativeWebSearch(state, deps, "tu_dup_1", {
-      isError: true,
-      errorCode: "unavailable",
-    });
-    await completeNativeWebSearch(state, deps, "tu_dup_2", {
-      isError: true,
-      errorCode: "overloaded_error",
-    });
-
-    const results = toolResults(events);
-    expect(results).toHaveLength(2);
-
-    // First failure gets the full friendly notice; the second is terse.
-    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
-      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
-    );
-    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
-      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
-    );
-
-    // Both failures are still logged; exactly one reports fallbackShown.
-    const logs = backendFailureLogs(warnings);
-    expect(logs).toHaveLength(2);
-    expect(logs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(1);
   });
 
   test("backend failure stays an honest, recoverable tool result (not a thrown provider error, never marked successful)", async () => {
@@ -311,26 +161,6 @@ describe("web_search backend-failure end-to-end (ATL-727)", () => {
     // No webSearch metadata is fabricated for a fetch failure.
     expect(result?.activityMetadata?.webSearch).toBeUndefined();
     // And the web_search backend-failure telemetry never fires for a fetch.
-    expect(backendFailureLogs(warnings)).toHaveLength(0);
-  });
-
-  test("successful empty native search stays successful with no telemetry and no errorMessage", async () => {
-    const { deps, events, warnings } = createHandlerDeps("req-no-results");
-
-    await completeNativeWebSearch(state, deps, "tu_empty", {
-      isError: false,
-      content: [],
-    });
-
-    const result = lastToolResult(events);
-    expect(result?.isError).toBe(false);
-
-    const meta = result?.activityMetadata?.webSearch;
-    expect(meta?.resultCount).toBe(0);
-    expect(meta?.results).toEqual([]);
-    expect(meta?.errorMessage).toBeUndefined();
-
-    // No-results is a success, not a backend failure: no telemetry fires.
     expect(backendFailureLogs(warnings)).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -51,6 +51,7 @@ mock.module("../../memory/llm-request-log-store.js", () => ({
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../../tools/network/web-search-error.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -352,7 +353,7 @@ describe("native server_tool_complete metadata", () => {
       (e): e is ToolResultEvent => e.type === "tool_result",
     );
     const meta = toolResultEvent?.activityMetadata?.webSearch;
-    expect(meta?.errorMessage).toBe("Search failed");
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     expect(meta?.resultCount).toBe(0);
     expect(meta?.results).toEqual([]);
     expect(toolResultEvent?.isError).toBe(true);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1849,13 +1849,21 @@ export async function dispatchAgentEvent(
         let errorMessage: string | undefined;
         let fallbackShown = false;
         if (event.isError) {
-          // Dedup the user-facing friendly notice per turn (request id) so a
-          // burst of backend failures surfaces at most one full notice. The raw
-          // provider error is preserved on every failure via telemetry below.
-          const alreadyNotified = state.webSearchBackendFailureNotified.has(
-            deps.reqId,
-          );
-          if (classification.isBackendFailure) {
+          // A genuine backend failure OR an unclassifiable, message-less native
+          // failure (e.g. `isError:true` with no `error_code`) both surface the
+          // friendly backend copy: a terse "Search failed" placeholder is the
+          // confusing copy this normalization exists to eliminate (ATL-727).
+          // Recoverable categories that carry a real user message
+          // (query_too_long, max_uses_exceeded) keep their own copy.
+          const useBackendCopy =
+            classification.isBackendFailure || !classification.userMessage;
+          if (useBackendCopy) {
+            // Dedup the user-facing friendly notice per turn (request id) so a
+            // burst of failures surfaces at most one full notice. The raw
+            // provider error is preserved on every failure via telemetry below.
+            const alreadyNotified = state.webSearchBackendFailureNotified.has(
+              deps.reqId,
+            );
             if (alreadyNotified) {
               errorMessage = "Search is still having trouble.";
             } else {
@@ -1866,22 +1874,25 @@ export async function dispatchAgentEvent(
 
             // Backend-failure telemetry (provider outages / rate limits) must
             // fire only for genuine backend classifications so it does not
-            // count recoverable input/quota errors as provider failures.
-            logWebSearchBackendFailure(deps.rlog, {
-              provider: isAnthropicNative
-                ? "anthropic-native"
-                : deps.ctx.provider.name,
-              requestId: deps.reqId,
-              errorCategory: classification.category,
-              rawDetail: classification.rawDetail,
-              fallbackShown,
-              queryLength: query.length,
-            });
+            // count recoverable input/quota errors — or a message-less unknown
+            // failure that merely borrows the friendly copy — as provider
+            // outages.
+            if (classification.isBackendFailure) {
+              logWebSearchBackendFailure(deps.rlog, {
+                provider: isAnthropicNative
+                  ? "anthropic-native"
+                  : deps.ctx.provider.name,
+                requestId: deps.reqId,
+                errorCategory: classification.category,
+                rawDetail: classification.rawDetail,
+                fallbackShown,
+                queryLength: query.length,
+              });
+            }
           } else {
-            // Recoverable, non-backend categories (query_too_long,
-            // max_uses_exceeded, unknown) are not deduped against the backend
-            // notice; fall back to a concise message when there is no copy.
-            errorMessage = classification.userMessage || "Search failed";
+            // Recoverable, non-backend categories with their own user-facing
+            // copy (query_too_long, max_uses_exceeded) keep that message.
+            errorMessage = classification.userMessage;
           }
         }
 


### PR DESCRIPTION
## Summary
Round-2 plan-review fixes (web-search-failure.md):
- Native web_search failures with no error_code now surface WEB_SEARCH_BACKEND_FAILURE_MESSAGE (deduped) instead of the terse 'Search failed' placeholder; telemetry stays gated on genuine backend classifications; isError/empty-results unchanged
- Extracted the duplicated daemon-handler test harness into assistant/src/__tests__/helpers and removed overlapping cases across native-web-search and web-search-backend-failure tests