### PR TITLE
Graceful handling for upstream web_search tool failures (ATL-727)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Environment and data layout                 | [Environment and Data Layout](#environment-and-data-layout) (this file)                            |
 | Multi-local instance isolation              | [Multi-Local Instance Isolation](#multi-local-instance-isolation) (this file)                      |
 | Docker volume architecture                  | [Docker Volume Architecture](#docker-volume-architecture) (this file)                              |
+| Web search failure normalization            | [Web Search Failure Normalization](#web-search-failure-normalization) (this file)                  |
 | Service communication matrix                | [`docs/service-communication-matrix.md`](docs/service-communication-matrix.md)                     |
 
 ## Cross-Cutting Invariants
@@ -633,6 +634,20 @@ Runtime enforcement is layered. `disk-pressure-policy.ts` classifies turns befor
 Tool access is also narrowed during cleanup mode. The runtime marks cleanup turns in the tool context, `tool-approval-handler.ts` rejects non-cleanup-safe tools, and terminal background modes for `bash` and `host_bash` are rejected. When a new lock is created, already registered background terminal tools are cancelled with the disk-pressure reason.
 
 The macOS app owns the local client contract through `DiskPressureStatusStore`. On app activation and SSE changes, it fetches or applies the latest status. If acknowledgement is required, the main window and pop-out thread windows show a blocking safe-storage banner; the guardian must acknowledge or dismiss before continuing. After acknowledgement, chat surfaces keep a persistent cleanup status banner explaining that background processes and trusted-contact messages remain blocked until storage is freed. Acknowledgement request failures are shown in the banner so the modal does not fail silently.
+
+## Web Search Failure Normalization
+
+<!-- ATL-727: centralized web_search backend-failure normalization. -->
+
+Every `web_search` failure path funnels through a single classification layer so the same recoverable, user-facing copy reaches all clients while raw provider detail stays in telemetry only. The classifier lives in `assistant/src/tools/network/web-search-error.ts` (`classifyWebSearchFailure`), a pure leaf module with no daemon/agent/client imports.
+
+- **Single user-facing message.** Genuine backend failures (provider `unavailable` / `internal_error` / `overloaded_error`, post-retry `429`, app-side 5xx, thrown network/timeout/DNS-on-search errors) map to one constant, `WEB_SEARCH_BACKEND_FAILURE_MESSAGE`. It propagates to every client via `WebSearchMetadata.errorMessage` and is written identically by the native Anthropic `server_tool_complete` handler in `assistant/src/daemon/conversation-agent-loop-handlers.ts` and by the app-side `backendFailureResult` helper in `assistant/src/tools/network/web-search.ts`. The copy reads as guidance (retry / continue without search / paste details) and never blames the user, claims the whole internet is down, or embeds raw provider data.
+- **Raw detail logged, not shown.** The originating status code / error code / provider body is preserved only in the structured `web_search_backend_failure` warning (`logWebSearchBackendFailure`, field `rawDetail`, truncated, query text never logged — only `queryLength`). This telemetry is gated on `classification.isBackendFailure`, so recoverable non-backend categories (`query_too_long`, `max_uses_exceeded`, config/auth, `invalid_input`) keep their own specific copy and never count as provider outages.
+- **Per-turn dedup.** A burst of backend failures in one turn surfaces at most one full friendly notice; the native handler tracks this via `webSearchBackendFailureNotified` keyed by request id (the first failure sets `fallbackShown: true`, later ones get a terse line). Every failure is still logged.
+- **Honest, recoverable continuation.** A backend failure is a normal `tool_result` (`isError: true`, empty results), not a thrown provider error — the agent loop continues, and the search is never silently marked successful. A successful empty search (zero results) stays a success: no `errorMessage`, no telemetry.
+- **No conflation with `web_fetch`.** The normalization layer keys exclusively on `web_search` (native server-tool web_search and the app-side search tool). It never inspects `WebFetchMetadata`, so a `web_fetch` DNS failure (e.g. an unresolved host) keeps its own `webFetch.errorMessage` and is never rewritten to the search backend copy.
+
+End-to-end coverage lives in `assistant/src/__tests__/web-search-backend-failure.test.ts`.
 
 ## Maintenance Rule
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -18,8 +18,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildWebSearchErrorStep,
   computeToolCallCardData,
   hasWebTool,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
 } from "@/domains/chat/hooks/use-tool-call-card-data";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type {
@@ -497,6 +499,177 @@ describe("computeToolCallCardData — mixed web + non-web groups", () => {
     // currentStepTitle reflects the latest call (the bash tool).
     expect(data.currentStepTitle).toBe("Working (bash)");
     expect(data.currentStepInfo).toBe("ls");
+  });
+});
+
+describe("computeToolCallCardData — web_search backend-failure copy", () => {
+  // Mirror of WEB_SEARCH_BACKEND_FAILURE_MESSAGE in
+  // assistant/src/tools/network/web-search-error.ts (and the module-local
+  // constant in use-tool-call-card-data.ts). apps/web cannot import from
+  // assistant/, so the canonical string is duplicated here verbatim.
+  const CANONICAL_BACKEND_FAILURE_MESSAGE =
+    "Search is having trouble right now. You can try again in a moment, continue without web search, or paste the relevant details here and I'll use those.";
+
+  test("renders the canonical backend-failure message verbatim when the daemon provides it", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      // Verbatim — not overridden, not truncated to "Search failed.".
+      errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+    });
+    expect(data.currentStepInfo).toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("the local default string matches the canonical assistant constant", () => {
+    expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).toBe(
+      CANONICAL_BACKEND_FAILURE_MESSAGE,
+    );
+  });
+
+  test("buildWebSearchErrorStep falls back to the friendly default when errorMessage is undefined", () => {
+    // The error step renders verbatim copy from the daemon when present, but
+    // must degrade to the canonical friendly message if the backend ever
+    // omits it (regression for the buildWebSearchErrorStep default).
+    const step = buildWebSearchErrorStep({
+      query: "tigers",
+      provider: "anthropic-native",
+      resultCount: 0,
+      durationMs: 800,
+      results: [],
+      // errorMessage intentionally omitted.
+    });
+    expect(step).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      errorMessage: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    });
+  });
+
+  test("web_fetch DNS/host errors never render as a web_search backend failure", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_fetch", status: "error" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webFetch: {
+          url: "https://grimgoods.io/products",
+          finalUrl: "https://grimgoods.io/products",
+          status: 0,
+          byteCount: 0,
+          charCount: 0,
+          truncated: false,
+          domain: "grimgoods.io",
+          redirectCount: 0,
+          durationMs: 120,
+          errorMessage:
+            'Error: Unable to resolve host "grimgoods.io" while fetching the page',
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    // No web_search_error step is produced from a web_fetch failure.
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    // The friendly web_search backend copy is never surfaced for a fetch error.
+    expect(data.currentStepInfo).not.toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("a failed web_search with empty results and NO errorMessage renders the friendly default via the UI path", () => {
+    // Daemon omits webSearch.errorMessage but the tool call itself is terminal
+    // with status "error" (mapped from the tool_result isError flag). This is
+    // the production UI path Codex flagged — buildWebSearchErrorStep's friendly
+    // default must be reachable, not only via the direct unit test.
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "error" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          // errorMessage intentionally omitted.
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(data.steps[0]).toEqual({
+      kind: "web_search_error",
+      title: "Web search failed",
+      durationLabel: "<1s",
+      errorMessage: CANONICAL_BACKEND_FAILURE_MESSAGE,
+    });
+    expect(data.currentStepTitle).toBe("Web search failed");
+    expect(data.currentStepInfo).toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("a successful no_results web_search (status completed, no errorMessage) stays a normal step", () => {
+    // ATL-727 core invariant: an empty-but-successful search must NOT render as
+    // a failure. status "completed" + no errorMessage => normal web_search step.
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 800,
+          results: [],
+          // errorMessage intentionally omitted; this is a real no_results hit.
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    expect(data.steps[0]!.kind).toBe("web_search");
+    expect(data.currentStepInfo).not.toBe(CANONICAL_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("a successful web_search with results produces no error step", () => {
+    const toolCalls = [
+      makeToolCall({ id: "tc-1", toolName: "web_search", status: "completed" }),
+    ];
+    const liveWebActivity: Record<string, ToolActivityMetadata> = {
+      "tc-1": {
+        webSearch: {
+          query: "tigers",
+          provider: "anthropic-native",
+          resultCount: 2,
+          durationMs: 1500,
+          results: [makeResult(1), makeResult(2)],
+        },
+      },
+    };
+    const data = computeToolCallCardData(toolCalls, liveWebActivity, null);
+    expect(
+      data.steps.some((step) => step.kind === "web_search_error"),
+    ).toBe(false);
+    expect(data.steps[0]!.kind).toBe("web_search");
   });
 });
 

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -29,6 +29,15 @@ import { useTurnStore } from "@/domains/chat/turn-store";
 /** Max favicon chips to render inside a single `web_search` step row. */
 const MAX_VISIBLE_RESULTS = 5;
 
+/**
+ * Friendly fallback copy for a `web_search` backend failure when the daemon
+ * omits `webSearch.errorMessage`. apps/web CANNOT import from `assistant/`, so
+ * this is a local mirror — keep in sync with WEB_SEARCH_BACKEND_FAILURE_MESSAGE
+ * in assistant/src/tools/network/web-search-error.ts.
+ */
+export const WEB_SEARCH_BACKEND_FAILURE_MESSAGE =
+  "Search is having trouble right now. You can try again in a moment, continue without web search, or paste the relevant details here and I'll use those.";
+
 /** Tool names whose presence triggers the web-search step path. */
 export const WEB_TOOL_NAMES = new Set(["web_search", "web_fetch"]);
 
@@ -229,14 +238,14 @@ function buildWebSearchStepFromResultText(
   };
 }
 
-function buildWebSearchErrorStep(
+export function buildWebSearchErrorStep(
   metadata: NonNullable<ToolActivityMetadata["webSearch"]>,
 ): ToolCallCardStep {
   return {
     kind: "web_search_error",
     title: "Web search failed",
     durationLabel: formatMs(metadata.durationMs),
-    errorMessage: metadata.errorMessage ?? "Search failed.",
+    errorMessage: metadata.errorMessage ?? WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
   };
 }
 
@@ -259,6 +268,31 @@ function resolveMetadata(
 
 function isTerminalStatus(tc: ChatMessageToolCall): boolean {
   return tc.status === "completed" || tc.status === "error";
+}
+
+/**
+ * Classify a `web_search` whose metadata carried zero results as a *failure*
+ * (vs. a successful `no_results` search).
+ *
+ * The backend is the single centralization point and sets
+ * `webSearch.errorMessage` on every genuine failure (see
+ * `errorResult` in assistant/src/tools/network/web-search.ts), so a present
+ * `errorMessage` is the primary signal. As defensive depth for the case where
+ * the daemon ever omits that message on a failed search, we also treat the
+ * tool call's own terminal `status === "error"` (mapped from the tool_result
+ * `isError` flag in `applyToolResult`) as a failure signal.
+ *
+ * Crucially, a successful empty/`no_results` search lands as
+ * `status === "completed"` with no `errorMessage`, so it is NOT classified as
+ * a failure — ATL-727's core invariant (empty-but-successful must not render
+ * as a failure) is preserved.
+ */
+function isFailedEmptyWebSearch(
+  ws: NonNullable<ToolActivityMetadata["webSearch"]>,
+  tc: ChatMessageToolCall,
+): boolean {
+  if (ws.results.length > 0) return false;
+  return Boolean(ws.errorMessage) || tc.status === "error";
 }
 
 /**
@@ -334,8 +368,7 @@ function deriveCurrentStepTitle(
       const terminal = isTerminalStatus(tc);
       if (
         metadata?.webSearch &&
-        metadata.webSearch.errorMessage &&
-        metadata.webSearch.results.length === 0
+        isFailedEmptyWebSearch(metadata.webSearch, tc)
       ) {
         return "Web search failed";
       }
@@ -372,8 +405,8 @@ function deriveCurrentStepInfo(
 
     if (metadata?.webSearch) {
       const ws = metadata.webSearch;
-      if (ws.errorMessage && ws.results.length === 0) {
-        return ws.errorMessage;
+      if (isFailedEmptyWebSearch(ws, tc)) {
+        return ws.errorMessage ?? WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
       }
       if (ws.results.length > 0) {
         return ws.results[ws.results.length - 1]!.title;
@@ -516,7 +549,7 @@ export function computeToolCallCardData(
     const terminal = isTerminalStatus(tc);
     if (metadata?.webSearch) {
       const ws = metadata.webSearch;
-      if (ws.errorMessage && ws.results.length === 0) {
+      if (isFailedEmptyWebSearch(ws, tc)) {
         steps.push(buildWebSearchErrorStep(ws));
       } else {
         steps.push(buildWebSearchStep(ws, terminal));

--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -272,6 +272,13 @@ function executeWebSearch(input: Record<string, unknown>) {
   return webSearchTool.execute(input, {} as never);
 }
 
+function executeWebSearchWithSignal(
+  input: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  return webSearchTool.execute(input, { signal } as never);
+}
+
 // ---------------------------------------------------------------------------
 // OpenAI Responses API provider tests
 // ---------------------------------------------------------------------------
@@ -787,5 +794,26 @@ describe("Cross-Provider Web Search — app-side backend failure normalization",
     expect(result.content).not.toContain("do-not-leak-429");
     expect(meta?.errorMessage).not.toContain("quota burned");
     expect(meta?.errorMessage).not.toContain("do-not-leak-429");
+  });
+
+  test("caller abort re-throws instead of producing a backend failure (no telemetry)", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    // A caller-aborted request surfaces an AbortError from fetch.
+    globalThis.fetch = (async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }) as unknown as typeof fetch;
+
+    // The cancellation must re-throw so the executor's abort handling takes
+    // over — NOT resolve to the friendly backend-failure result.
+    await expect(
+      executeWebSearchWithSignal({ query: "cancel me" }, controller.signal),
+    ).rejects.toThrow();
+
+    // No spurious backend-failure telemetry for a user/external cancellation.
+    expect(backendFailureLog()).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   ContentBlock,
@@ -220,6 +220,57 @@ import {
   OpenAIChatCompletionsProvider,
   OpenAIResponsesProvider,
 } from "../providers/openai/client.js";
+
+// ---------------------------------------------------------------------------
+// App-side web_search provider adapters (Brave/Perplexity/Tavily)
+//
+// Exercise the real `web-search.ts` execute path with a mocked config, provider
+// key, and global fetch. The logger is mocked to capture structured warnings so
+// we can assert the `web_search_backend_failure` telemetry (ATL-727).
+// ---------------------------------------------------------------------------
+
+let mockWebSearchProvider: string = "brave";
+let mockProviderKey: string | undefined = "test-key";
+const capturedWarnLogs: Record<string, unknown>[] = [];
+
+const realConfigLoader = await import("../config/loader.js");
+mock.module("../config/loader.js", () => ({
+  ...realConfigLoader,
+  getConfig: () => ({
+    services: { "web-search": { provider: mockWebSearchProvider } },
+  }),
+}));
+
+const realSecureKeys = await import("../security/secure-keys.js");
+mock.module("../security/secure-keys.js", () => ({
+  ...realSecureKeys,
+  getProviderKeyAsync: async () => mockProviderKey,
+}));
+
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (prop === "warn") {
+          return (obj: Record<string, unknown>) => {
+            capturedWarnLogs.push(obj);
+          };
+        }
+        return () => {};
+      },
+    }),
+}));
+
+const { webSearchTool } = await import("../tools/network/web-search.js");
+const { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } = await import(
+  "../tools/network/web-search-error.js"
+);
+
+function executeWebSearch(input: Record<string, unknown>) {
+  return webSearchTool.execute(input, {} as never);
+}
 
 // ---------------------------------------------------------------------------
 // OpenAI Responses API provider tests
@@ -602,5 +653,139 @@ describe("Cross-Provider Web Search — Gemini", () => {
       (p) => p.functionCall !== undefined,
     );
     expect(functionCallParts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// App-side provider backend-failure normalization (ATL-727)
+// ---------------------------------------------------------------------------
+
+describe("Cross-Provider Web Search — app-side backend failure normalization", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockWebSearchProvider = "brave";
+    mockProviderKey = "test-key";
+    capturedWarnLogs.length = 0;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function backendFailureLog() {
+    return capturedWarnLogs.find(
+      (entry) => entry.event === "web_search_backend_failure",
+    );
+  }
+
+  test("503 from provider yields friendly recoverable copy in content + errorMessage, logs raw 503, no body leak", async () => {
+    const rawBody = '{"error":"upstream exploded","trace":"do-not-leak"}';
+    globalThis.fetch = (async () =>
+      new Response(rawBody, { status: 503 })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "needle in a haystack" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.results).toEqual([]);
+    expect(meta?.resultCount).toBe(0);
+
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.provider).toBe("brave");
+    expect(logEntry!.errorCategory).toBe("backend_unavailable");
+    expect(logEntry!.fallbackShown).toBe(true);
+    expect(logEntry!.queryLength).toBe("needle in a haystack".length);
+    expect(String(logEntry!.rawDetail)).toContain("503");
+    // Provider diagnostic body is preserved in internal telemetry rawDetail.
+    expect(String(logEntry!.rawDetail)).toContain("upstream exploded");
+    expect(String(logEntry!.rawDetail)).toContain("do-not-leak");
+
+    // Raw provider body must never reach user-facing fields.
+    expect(result.content).not.toContain("upstream exploded");
+    expect(result.content).not.toContain("do-not-leak");
+    expect(meta?.errorMessage).not.toContain("upstream exploded");
+    expect(meta?.errorMessage).not.toContain("do-not-leak");
+  });
+
+  test("thrown network error yields the same friendly backend result", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "offline" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.errorCategory).toBe("backend_unavailable");
+    expect(result.content).not.toContain("fetch failed");
+  });
+
+  test("401 invalid-key preserves the specific message, not the backend copy", async () => {
+    globalThis.fetch = (async () =>
+      new Response("Unauthorized", { status: 401 })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "bad key" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Invalid or expired Brave Search API key");
+    expect(result.content).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(backendFailureLog()).toBeUndefined();
+  });
+
+  test("HTTP 200 with zero results stays a success (unchanged)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ web: { results: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "no hits" });
+
+    expect(result.isError).toBe(false);
+    expect(result.activityMetadata?.webSearch?.errorMessage).toBeUndefined();
+    expect(result.content).toContain("No results found");
+    expect(backendFailureLog()).toBeUndefined();
+  });
+
+  test("post-retry 429 yields the friendly recoverable copy and preserves body in rawDetail", async () => {
+    const rawBody = '{"error":"quota burned","retryHint":"do-not-leak-429"}';
+    globalThis.fetch = (async () =>
+      new Response(rawBody, {
+        status: 429,
+        headers: { "retry-after": "0" },
+      })) as unknown as typeof fetch;
+
+    const result = await executeWebSearch({ query: "rate limited" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    const logEntry = backendFailureLog();
+    expect(logEntry).toBeDefined();
+    expect(logEntry!.errorCategory).toBe("rate_limited");
+    expect(String(logEntry!.rawDetail)).toContain("429");
+    // Provider diagnostic body is preserved in internal telemetry rawDetail.
+    expect(String(logEntry!.rawDetail)).toContain("quota burned");
+    expect(String(logEntry!.rawDetail)).toContain("do-not-leak-429");
+
+    // Raw provider body must never reach user-facing fields.
+    expect(result.content).not.toContain("quota burned");
+    expect(result.content).not.toContain("do-not-leak-429");
+    expect(meta?.errorMessage).not.toContain("quota burned");
+    expect(meta?.errorMessage).not.toContain("do-not-leak-429");
   });
 });

--- a/assistant/src/__tests__/helpers/native-web-search-harness.ts
+++ b/assistant/src/__tests__/helpers/native-web-search-harness.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared test harness for driving the daemon's native `server_tool_complete`
+ * web_search handler in isolation (ATL-727).
+ *
+ * Both `native-web-search.test.ts` and `web-search-backend-failure.test.ts`
+ * exercise the same handler the same way: build a set of mocked
+ * `EventHandlerDeps` (capturing emitted `ServerMessage`s and `rlog.warn`
+ * records), then drive a `server_tool_start` → `server_tool_complete` pair.
+ * This module is the single source of truth for that harness so the two suites
+ * cannot drift apart.
+ *
+ * Note: each consuming test file must still install its own
+ * `mock.module(...)` stubs for the daemon collaborators the handler imports at
+ * load time (config loader, conversation-crud, llm-request-log-store), because
+ * Bun's `mock.module()` is scoped to the file that registers it.
+ */
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../../daemon/conversation-agent-loop-handlers.js";
+import { dispatchAgentEvent } from "../../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+
+/** A `tool_result` `ServerMessage` emitted by the handler. */
+export type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+/** A captured `rlog.warn(obj, msg)` call. */
+export interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+export interface HandlerHarness {
+  deps: EventHandlerDeps;
+  /** Every `ServerMessage` the handler emitted via `onEvent`. */
+  events: ServerMessage[];
+  /** Every `rlog.warn(obj, msg)` call the handler made. */
+  warnings: LogRecord[];
+}
+
+/** Build mocked handler deps that capture emitted events and warn logs. */
+export function createHandlerDeps(reqId = "req-web-search"): HandlerHarness {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+/** The `server_tool_complete` payload shape a test supplies. */
+export interface WebSearchCompleteEvent {
+  isError: boolean;
+  errorCode?: string;
+  errorMessage?: string;
+  content?: unknown[];
+}
+
+/** Drive one native (Anthropic) web_search start → complete pair. */
+export async function completeNativeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: WebSearchCompleteEvent,
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+/** All `tool_result` events emitted so far, in order. */
+export function toolResults(events: ServerMessage[]): ToolResultEvent[] {
+  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
+}
+
+/** The most recent `tool_result` event, if any. */
+export function lastToolResult(
+  events: ServerMessage[],
+): ToolResultEvent | undefined {
+  const results = toolResults(events);
+  return results[results.length - 1];
+}
+
+/** The captured `web_search_backend_failure` telemetry warn records. */
+export function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
+  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
+}

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -71,9 +71,53 @@ mock.module("@anthropic-ai/sdk", () => ({
   },
 }));
 
+// Mock daemon collaborators the handler module imports at load time so the
+// handler-level tests below can drive `server_tool_complete` in isolation.
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
 // Import after mocking
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  type EventHandlerDeps,
+  type EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
 import { AnthropicProvider } from "../providers/anthropic/client.js";
 import { isNativeWebSearchCapableProvider } from "../providers/registry.js";
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -497,5 +541,210 @@ describe("Native Web Search — Streaming Events", () => {
       (e) => e.type === "tool_use_preview_start",
     );
     expect(toolUseEvents).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Native server_tool_complete backend-failure handling (ATL-727)
+// ---------------------------------------------------------------------------
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+function createHandlerDeps(reqId = "req-web-search"): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+  warnings: LogRecord[];
+} {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+async function completeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: {
+    isError: boolean;
+    errorCode?: string;
+    errorMessage?: string;
+    content?: unknown[];
+  },
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
+  const results = events.filter(
+    (e): e is ToolResultEvent => e.type === "tool_result",
+  );
+  return results[results.length - 1];
+}
+
+describe("Native Web Search — Backend Failure Handling", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("backend failure surfaces friendly copy with isError true and empty results", async () => {
+    const { deps, events } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_backend", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(result?.isError).toBe(true);
+    expect(result?.activityMetadata?.webSearch?.resultCount).toBe(0);
+    expect(result?.activityMetadata?.webSearch?.results).toEqual([]);
+  });
+
+  test("raw error_code is logged under web_search_backend_failure but absent from user copy", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_log", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const failureLog = warnings.find(
+      (w) => w.obj.event === "web_search_backend_failure",
+    );
+    expect(failureLog).toBeDefined();
+    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
+    expect(failureLog?.obj.fallbackShown).toBe(true);
+
+    const errorMessage = lastToolResult(events)?.activityMetadata?.webSearch
+      ?.errorMessage;
+    expect(errorMessage).not.toContain("unavailable");
+  });
+
+  test("dedups repeat backend failures within one turn to a single friendly notice", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+
+    await completeWebSearch(state, deps, "tu_dup_1", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+    await completeWebSearch(state, deps, "tu_dup_2", {
+      isError: true,
+      errorCode: "overloaded_error",
+    });
+
+    const results = events.filter(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    // The second backend failure in the same turn is terse, not the full notice.
+    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+
+    const failureLogs = warnings.filter(
+      (w) => w.obj.event === "web_search_backend_failure",
+    );
+    // Both failures are logged, but only the first reports fallbackShown.
+    expect(failureLogs).toHaveLength(2);
+    expect(failureLogs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(
+      1,
+    );
+  });
+
+  test("successful search leaves errorMessage undefined and populates results", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_ok", {
+      isError: false,
+      content: [
+        {
+          type: "web_search_result",
+          title: "Weather",
+          url: "https://example.com/weather",
+        },
+      ],
+    });
+
+    const meta = lastToolResult(events)?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBeUndefined();
+    expect(meta?.resultCount).toBe(1);
+    expect(meta?.results[0]?.title).toBe("Weather");
+    expect(lastToolResult(events)?.isError).toBe(false);
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
+  });
+
+  test("query_too_long yields a distinct non-backend message", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+    await completeWebSearch(state, deps, "tu_long", {
+      isError: true,
+      errorCode: "query_too_long",
+    });
+
+    const errorMessage = lastToolResult(events)?.activityMetadata?.webSearch
+      ?.errorMessage;
+    expect(errorMessage).toBeDefined();
+    expect(errorMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    // Recoverable non-backend errors must NOT emit backend-failure telemetry.
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -666,6 +666,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
       (w) => w.obj.event === "web_search_backend_failure",
     );
     expect(failureLog).toBeDefined();
+    expect(failureLog?.obj.provider).toBe("anthropic-native");
     expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
     expect(failureLog?.obj.fallbackShown).toBe(true);
 

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -110,14 +110,17 @@ mock.module("../memory/llm-request-log-store.js", () => ({
 // Import after mocking
 import {
   createEventHandlerState,
-  dispatchAgentEvent,
-  type EventHandlerDeps,
   type EventHandlerState,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import { AnthropicProvider } from "../providers/anthropic/client.js";
 import { isNativeWebSearchCapableProvider } from "../providers/registry.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
+import {
+  completeNativeWebSearch,
+  createHandlerDeps,
+  lastToolResult,
+  toolResults,
+} from "./helpers/native-web-search-harness.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -548,90 +551,6 @@ describe("Native Web Search — Streaming Events", () => {
 // Tests — Native server_tool_complete backend-failure handling (ATL-727)
 // ---------------------------------------------------------------------------
 
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
-
-interface LogRecord {
-  obj: Record<string, unknown>;
-  msg?: string;
-}
-
-function createHandlerDeps(reqId = "req-web-search"): {
-  deps: EventHandlerDeps;
-  events: ServerMessage[];
-  warnings: LogRecord[];
-} {
-  const events: ServerMessage[] = [];
-  const warnings: LogRecord[] = [];
-  const rlog = {
-    warn: (obj: Record<string, unknown>, msg?: string) =>
-      warnings.push({ obj, msg }),
-    info: () => {},
-    error: () => {},
-    debug: () => {},
-    trace: () => {},
-    fatal: () => {},
-  };
-  const deps = {
-    ctx: {
-      conversationId: "conv-web-search",
-      provider: { name: "anthropic" },
-      traceEmitter: { emit: () => {} },
-      streamThinking: false,
-      emitActivityState: () => {},
-      markWorkspaceTopLevelDirty: () => {},
-      currentTurnSurfaces: [],
-    } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
-    reqId,
-    isFirstMessage: false,
-    shouldGenerateTitle: false,
-    rlog: rlog as unknown as EventHandlerDeps["rlog"],
-    turnChannelContext: {
-      userMessageChannel: "vellum",
-      assistantMessageChannel: "vellum",
-    } as EventHandlerDeps["turnChannelContext"],
-    turnInterfaceContext: {
-      userMessageInterface: "macos",
-      assistantMessageInterface: "macos",
-    } as EventHandlerDeps["turnInterfaceContext"],
-  } as EventHandlerDeps;
-  return { deps, events, warnings };
-}
-
-async function completeWebSearch(
-  state: EventHandlerState,
-  deps: EventHandlerDeps,
-  toolUseId: string,
-  event: {
-    isError: boolean;
-    errorCode?: string;
-    errorMessage?: string;
-    content?: unknown[];
-  },
-): Promise<void> {
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_start",
-    name: "web_search",
-    toolUseId,
-    input: { query: "what is the weather" },
-  });
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_complete",
-    toolUseId,
-    isError: event.isError,
-    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
-    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
-    content: event.content ?? [],
-  });
-}
-
-function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
-  const results = events.filter(
-    (e): e is ToolResultEvent => e.type === "tool_result",
-  );
-  return results[results.length - 1];
-}
-
 describe("Native Web Search — Backend Failure Handling", () => {
   let state: EventHandlerState;
 
@@ -641,7 +560,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("backend failure surfaces friendly copy with isError true and empty results", async () => {
     const { deps, events } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_backend", {
+    await completeNativeWebSearch(state, deps, "tu_backend", {
       isError: true,
       errorCode: "unavailable",
     });
@@ -657,7 +576,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("raw error_code is logged under web_search_backend_failure but absent from user copy", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_log", {
+    await completeNativeWebSearch(state, deps, "tu_log", {
       isError: true,
       errorCode: "unavailable",
     });
@@ -678,18 +597,16 @@ describe("Native Web Search — Backend Failure Handling", () => {
   test("dedups repeat backend failures within one turn to a single friendly notice", async () => {
     const { deps, events, warnings } = createHandlerDeps();
 
-    await completeWebSearch(state, deps, "tu_dup_1", {
+    await completeNativeWebSearch(state, deps, "tu_dup_1", {
       isError: true,
       errorCode: "unavailable",
     });
-    await completeWebSearch(state, deps, "tu_dup_2", {
+    await completeNativeWebSearch(state, deps, "tu_dup_2", {
       isError: true,
       errorCode: "overloaded_error",
     });
 
-    const results = events.filter(
-      (e): e is ToolResultEvent => e.type === "tool_result",
-    );
+    const results = toolResults(events);
     expect(results).toHaveLength(2);
     expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
       WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
@@ -711,7 +628,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("successful search leaves errorMessage undefined and populates results", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_ok", {
+    await completeNativeWebSearch(state, deps, "tu_ok", {
       isError: false,
       content: [
         {
@@ -734,7 +651,7 @@ describe("Native Web Search — Backend Failure Handling", () => {
 
   test("query_too_long yields a distinct non-backend message", async () => {
     const { deps, events, warnings } = createHandlerDeps();
-    await completeWebSearch(state, deps, "tu_long", {
+    await completeNativeWebSearch(state, deps, "tu_long", {
       isError: true,
       errorCode: "query_too_long",
     });
@@ -744,6 +661,30 @@ describe("Native Web Search — Backend Failure Handling", () => {
     expect(errorMessage).toBeDefined();
     expect(errorMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     // Recoverable non-backend errors must NOT emit backend-failure telemetry.
+    expect(
+      warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
+    ).toHaveLength(0);
+  });
+
+  test("message-less native failure (no error_code) surfaces friendly copy, not the terse 'Search failed' placeholder, and emits no backend telemetry", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-unknown");
+    // `isError:true` with no error_code/message classifies as `unknown`
+    // (isBackendFailure:false, empty userMessage). It must still get the
+    // friendly copy rather than the bare "Search failed".
+    await completeNativeWebSearch(state, deps, "tu_unknown", {
+      isError: true,
+    });
+
+    const result = lastToolResult(events);
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.errorMessage).not.toBe("Search failed");
+    expect(result?.isError).toBe(true);
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+
+    // An unclassifiable failure borrows the friendly copy but must NOT be
+    // logged as a backend outage.
     expect(
       warnings.filter((w) => w.obj.event === "web_search_backend_failure"),
     ).toHaveLength(0);

--- a/assistant/src/__tests__/web-search-backend-failure.test.ts
+++ b/assistant/src/__tests__/web-search-backend-failure.test.ts
@@ -12,18 +12,17 @@
 //   - `tools/network/web-search.ts` — the app-side `backendFailureResult`
 //     helper routes 5xx/network/429 to the same copy.
 //
-// This file locks the cross-cutting acceptance criteria in one place by
-// driving the real handler + the real classifier end to end:
-//   - friendly copy surfaced to the client,
-//   - raw provider detail logged-not-shown,
-//   - per-turn dedup,
+// The single-layer native-handler invariants (friendly copy + isError + empty
+// results, raw-detail-logged-not-shown, per-turn dedup, successful-empty
+// search) are owned by `native-web-search.test.ts`. This file locks the
+// cross-cutting acceptance criteria that file does not cover:
 //   - honest continuation (the failure is a recoverable tool_result, not a
 //     thrown provider error; the search is never marked successful),
-//   - web_fetch DNS failures are NOT conflated with the search backend copy,
-//   - a successful empty search stays successful (no telemetry, no errorMessage).
+//   - web_fetch DNS failures are NOT conflated with the search backend copy.
 //
-// The native path reuses the handler harness from PR 2's
-// `native-web-search.test.ts`; the web_fetch invariant is exercised through
+// It genuinely reuses the shared handler harness in
+// `helpers/native-web-search-harness.ts` (the same harness driven by
+// `native-web-search.test.ts`); the web_fetch invariant is exercised through
 // the same `handleToolResult` path an app-executed fetch tool drives.
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -33,6 +32,7 @@ import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.
 // ---------------------------------------------------------------------------
 // Mock the daemon collaborators the handler module imports at load time so the
 // handler can be driven in isolation (mirrors native-web-search.test.ts).
+// `mock.module()` is file-scoped, so the shared harness cannot install these.
 // ---------------------------------------------------------------------------
 
 mock.module("../config/loader.js", () => ({
@@ -73,171 +73,21 @@ mock.module("../memory/llm-request-log-store.js", () => ({
 import {
   createEventHandlerState,
   dispatchAgentEvent,
-  type EventHandlerDeps,
   type EventHandlerState,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
-
-// ---------------------------------------------------------------------------
-// Handler harness
-// ---------------------------------------------------------------------------
-
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
-
-interface LogRecord {
-  obj: Record<string, unknown>;
-  msg?: string;
-}
-
-function createHandlerDeps(reqId = "req-web-search"): {
-  deps: EventHandlerDeps;
-  events: ServerMessage[];
-  warnings: LogRecord[];
-} {
-  const events: ServerMessage[] = [];
-  const warnings: LogRecord[] = [];
-  const rlog = {
-    warn: (obj: Record<string, unknown>, msg?: string) =>
-      warnings.push({ obj, msg }),
-    info: () => {},
-    error: () => {},
-    debug: () => {},
-    trace: () => {},
-    fatal: () => {},
-  };
-  const deps = {
-    ctx: {
-      conversationId: "conv-web-search",
-      provider: { name: "anthropic" },
-      traceEmitter: { emit: () => {} },
-      streamThinking: false,
-      emitActivityState: () => {},
-      markWorkspaceTopLevelDirty: () => {},
-      currentTurnSurfaces: [],
-    } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
-    reqId,
-    isFirstMessage: false,
-    shouldGenerateTitle: false,
-    rlog: rlog as unknown as EventHandlerDeps["rlog"],
-    turnChannelContext: {
-      userMessageChannel: "vellum",
-      assistantMessageChannel: "vellum",
-    } as EventHandlerDeps["turnChannelContext"],
-    turnInterfaceContext: {
-      userMessageInterface: "macos",
-      assistantMessageInterface: "macos",
-    } as EventHandlerDeps["turnInterfaceContext"],
-  } as EventHandlerDeps;
-  return { deps, events, warnings };
-}
-
-/** Drive one native (Anthropic) web_search start → complete pair. */
-async function completeNativeWebSearch(
-  state: EventHandlerState,
-  deps: EventHandlerDeps,
-  toolUseId: string,
-  event: {
-    isError: boolean;
-    errorCode?: string;
-    errorMessage?: string;
-    content?: unknown[];
-  },
-): Promise<void> {
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_start",
-    name: "web_search",
-    toolUseId,
-    input: { query: "what is the weather" },
-  });
-  await dispatchAgentEvent(state, deps, {
-    type: "server_tool_complete",
-    toolUseId,
-    isError: event.isError,
-    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
-    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
-    content: event.content ?? [],
-  });
-}
-
-function toolResults(events: ServerMessage[]): ToolResultEvent[] {
-  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
-}
-
-function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
-  const results = toolResults(events);
-  return results[results.length - 1];
-}
-
-function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
-  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
-}
+import {
+  backendFailureLogs,
+  completeNativeWebSearch,
+  createHandlerDeps,
+  lastToolResult,
+} from "./helpers/native-web-search-harness.js";
 
 describe("web_search backend-failure end-to-end (ATL-727)", () => {
   let state: EventHandlerState;
 
   beforeEach(() => {
     state = createEventHandlerState();
-  });
-
-  test("native backend failure surfaces friendly copy, empty results, and logs raw detail not shown to the user", async () => {
-    const { deps, events, warnings } = createHandlerDeps();
-
-    await completeNativeWebSearch(state, deps, "tu_native", {
-      isError: true,
-      errorCode: "unavailable",
-    });
-
-    const result = lastToolResult(events);
-    expect(result).toBeDefined();
-    expect(result?.isError).toBe(true);
-
-    const meta = result?.activityMetadata?.webSearch;
-    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
-    expect(meta?.provider).toBe("anthropic-native");
-    expect(meta?.resultCount).toBe(0);
-    expect(meta?.results).toEqual([]);
-
-    // Raw provider detail is captured in telemetry only.
-    const failureLog = backendFailureLogs(warnings)[0];
-    expect(failureLog).toBeDefined();
-    expect(failureLog?.obj.errorCategory).toBe("backend_unavailable");
-    expect(failureLog?.obj.fallbackShown).toBe(true);
-    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
-
-    // ...and never leaks into the user-facing copy.
-    expect(meta?.errorMessage).not.toContain("unavailable");
-    expect(result?.result).not.toContain("unavailable");
-  });
-
-  test("dedups two native backend failures in one turn to a single full notice", async () => {
-    const { deps, events, warnings } = createHandlerDeps("req-dedup-turn");
-
-    await completeNativeWebSearch(state, deps, "tu_dup_1", {
-      isError: true,
-      errorCode: "unavailable",
-    });
-    await completeNativeWebSearch(state, deps, "tu_dup_2", {
-      isError: true,
-      errorCode: "overloaded_error",
-    });
-
-    const results = toolResults(events);
-    expect(results).toHaveLength(2);
-
-    // First failure gets the full friendly notice; the second is terse.
-    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
-      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
-    );
-    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
-      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
-    );
-
-    // Both failures are still logged; exactly one reports fallbackShown.
-    const logs = backendFailureLogs(warnings);
-    expect(logs).toHaveLength(2);
-    expect(logs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(1);
   });
 
   test("backend failure stays an honest, recoverable tool result (not a thrown provider error, never marked successful)", async () => {
@@ -311,26 +161,6 @@ describe("web_search backend-failure end-to-end (ATL-727)", () => {
     // No webSearch metadata is fabricated for a fetch failure.
     expect(result?.activityMetadata?.webSearch).toBeUndefined();
     // And the web_search backend-failure telemetry never fires for a fetch.
-    expect(backendFailureLogs(warnings)).toHaveLength(0);
-  });
-
-  test("successful empty native search stays successful with no telemetry and no errorMessage", async () => {
-    const { deps, events, warnings } = createHandlerDeps("req-no-results");
-
-    await completeNativeWebSearch(state, deps, "tu_empty", {
-      isError: false,
-      content: [],
-    });
-
-    const result = lastToolResult(events);
-    expect(result?.isError).toBe(false);
-
-    const meta = result?.activityMetadata?.webSearch;
-    expect(meta?.resultCount).toBe(0);
-    expect(meta?.results).toEqual([]);
-    expect(meta?.errorMessage).toBeUndefined();
-
-    // No-results is a success, not a backend failure: no telemetry fires.
     expect(backendFailureLogs(warnings)).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/web-search-backend-failure.test.ts
+++ b/assistant/src/__tests__/web-search-backend-failure.test.ts
@@ -1,0 +1,336 @@
+// End-to-end integration coverage for the centralized web_search
+// backend-failure normalization layer (ATL-727).
+//
+// PRs 1-4 built the layer in three places:
+//   - `tools/network/web-search-error.ts` — `classifyWebSearchFailure` +
+//     `WEB_SEARCH_BACKEND_FAILURE_MESSAGE` + the structured
+//     `web_search_backend_failure` log helper.
+//   - `daemon/conversation-agent-loop-handlers.ts` — the native
+//     `server_tool_complete` handler maps Anthropic backend failures to the
+//     friendly copy, dedups per turn (`webSearchBackendFailureNotified`), and
+//     gates telemetry on `classification.isBackendFailure`.
+//   - `tools/network/web-search.ts` — the app-side `backendFailureResult`
+//     helper routes 5xx/network/429 to the same copy.
+//
+// This file locks the cross-cutting acceptance criteria in one place by
+// driving the real handler + the real classifier end to end:
+//   - friendly copy surfaced to the client,
+//   - raw provider detail logged-not-shown,
+//   - per-turn dedup,
+//   - honest continuation (the failure is a recoverable tool_result, not a
+//     thrown provider error; the search is never marked successful),
+//   - web_fetch DNS failures are NOT conflated with the search backend copy,
+//   - a successful empty search stays successful (no telemetry, no errorMessage).
+//
+// The native path reuses the handler harness from PR 2's
+// `native-web-search.test.ts`; the web_fetch invariant is exercised through
+// the same `handleToolResult` path an app-executed fetch tool drives.
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
+
+// ---------------------------------------------------------------------------
+// Mock the daemon collaborators the handler module imports at load time so the
+// handler can be driven in isolation (mirrors native-web-search.test.ts).
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// Import after mocking.
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  type EventHandlerDeps,
+  type EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../tools/network/web-search-error.js";
+
+// ---------------------------------------------------------------------------
+// Handler harness
+// ---------------------------------------------------------------------------
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+interface LogRecord {
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+function createHandlerDeps(reqId = "req-web-search"): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+  warnings: LogRecord[];
+} {
+  const events: ServerMessage[] = [];
+  const warnings: LogRecord[] = [];
+  const rlog = {
+    warn: (obj: Record<string, unknown>, msg?: string) =>
+      warnings.push({ obj, msg }),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+  const deps = {
+    ctx: {
+      conversationId: "conv-web-search",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId,
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: rlog as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events, warnings };
+}
+
+/** Drive one native (Anthropic) web_search start → complete pair. */
+async function completeNativeWebSearch(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  toolUseId: string,
+  event: {
+    isError: boolean;
+    errorCode?: string;
+    errorMessage?: string;
+    content?: unknown[];
+  },
+): Promise<void> {
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_start",
+    name: "web_search",
+    toolUseId,
+    input: { query: "what is the weather" },
+  });
+  await dispatchAgentEvent(state, deps, {
+    type: "server_tool_complete",
+    toolUseId,
+    isError: event.isError,
+    ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+    ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+    content: event.content ?? [],
+  });
+}
+
+function toolResults(events: ServerMessage[]): ToolResultEvent[] {
+  return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
+}
+
+function lastToolResult(events: ServerMessage[]): ToolResultEvent | undefined {
+  const results = toolResults(events);
+  return results[results.length - 1];
+}
+
+function backendFailureLogs(warnings: LogRecord[]): LogRecord[] {
+  return warnings.filter((w) => w.obj.event === "web_search_backend_failure");
+}
+
+describe("web_search backend-failure end-to-end (ATL-727)", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("native backend failure surfaces friendly copy, empty results, and logs raw detail not shown to the user", async () => {
+    const { deps, events, warnings } = createHandlerDeps();
+
+    await completeNativeWebSearch(state, deps, "tu_native", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+
+    const result = lastToolResult(events);
+    expect(result).toBeDefined();
+    expect(result?.isError).toBe(true);
+
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(meta?.provider).toBe("anthropic-native");
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+
+    // Raw provider detail is captured in telemetry only.
+    const failureLog = backendFailureLogs(warnings)[0];
+    expect(failureLog).toBeDefined();
+    expect(failureLog?.obj.errorCategory).toBe("backend_unavailable");
+    expect(failureLog?.obj.fallbackShown).toBe(true);
+    expect(String(failureLog?.obj.rawDetail)).toContain("unavailable");
+
+    // ...and never leaks into the user-facing copy.
+    expect(meta?.errorMessage).not.toContain("unavailable");
+    expect(result?.result).not.toContain("unavailable");
+  });
+
+  test("dedups two native backend failures in one turn to a single full notice", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-dedup-turn");
+
+    await completeNativeWebSearch(state, deps, "tu_dup_1", {
+      isError: true,
+      errorCode: "unavailable",
+    });
+    await completeNativeWebSearch(state, deps, "tu_dup_2", {
+      isError: true,
+      errorCode: "overloaded_error",
+    });
+
+    const results = toolResults(events);
+    expect(results).toHaveLength(2);
+
+    // First failure gets the full friendly notice; the second is terse.
+    expect(results[0]?.activityMetadata?.webSearch?.errorMessage).toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    expect(results[1]?.activityMetadata?.webSearch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+
+    // Both failures are still logged; exactly one reports fallbackShown.
+    const logs = backendFailureLogs(warnings);
+    expect(logs).toHaveLength(2);
+    expect(logs.filter((w) => w.obj.fallbackShown === true)).toHaveLength(1);
+  });
+
+  test("backend failure stays an honest, recoverable tool result (not a thrown provider error, never marked successful)", async () => {
+    const { deps, events } = createHandlerDeps("req-honesty");
+
+    // A recoverable backend failure flows as a tool_result, so dispatch must
+    // resolve without throwing.
+    await expect(
+      completeNativeWebSearch(state, deps, "tu_honesty", {
+        isError: true,
+        errorCode: "unavailable",
+      }),
+    ).resolves.toBeUndefined();
+
+    const result = lastToolResult(events);
+    // The search is never silently upgraded to a success.
+    expect(result?.isError).toBe(true);
+    expect(result?.activityMetadata?.webSearch?.resultCount).toBe(0);
+    expect(result?.activityMetadata?.webSearch?.results).toEqual([]);
+  });
+
+  test("web_fetch DNS failure is NOT conflated with the web_search backend copy", async () => {
+    // The normalization layer keys exclusively on web_search (the native
+    // `server_tool_complete` handler and `web-search.ts`). It never inspects
+    // `webFetch` metadata. handleToolResult forwards an app-executed tool's
+    // `activityMetadata` verbatim, so a web_fetch DNS failure must reach the
+    // client with its own copy and acquire NO `webSearch` metadata. Drive that
+    // path directly with a DNS-failure fetch result for grimgoods.io.
+    const { deps, events, warnings } = createHandlerDeps("req-web-fetch");
+
+    const dnsError =
+      'Error: Unable to resolve host "grimgoods.io" (DNS lookup failed)';
+    const fetchMetadata: ToolActivityMetadata = {
+      webFetch: {
+        url: "https://grimgoods.io",
+        finalUrl: "https://grimgoods.io",
+        status: 0,
+        byteCount: 0,
+        charCount: 0,
+        truncated: false,
+        domain: "grimgoods.io",
+        redirectCount: 0,
+        durationMs: 12,
+        errorMessage: dnsError,
+      },
+    };
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_fetch",
+      name: "web_fetch",
+      input: { url: "https://grimgoods.io" },
+    });
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_result",
+      toolUseId: "tu_fetch",
+      content: dnsError,
+      isError: true,
+      activityMetadata: fetchMetadata,
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.isError).toBe(true);
+
+    // The DNS error keeps its own webFetch copy untouched...
+    expect(result?.activityMetadata?.webFetch?.errorMessage).toBe(dnsError);
+    // ...and is never rewritten to the search backend copy.
+    expect(result?.activityMetadata?.webFetch?.errorMessage).not.toBe(
+      WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    );
+    // No webSearch metadata is fabricated for a fetch failure.
+    expect(result?.activityMetadata?.webSearch).toBeUndefined();
+    // And the web_search backend-failure telemetry never fires for a fetch.
+    expect(backendFailureLogs(warnings)).toHaveLength(0);
+  });
+
+  test("successful empty native search stays successful with no telemetry and no errorMessage", async () => {
+    const { deps, events, warnings } = createHandlerDeps("req-no-results");
+
+    await completeNativeWebSearch(state, deps, "tu_empty", {
+      isError: false,
+      content: [],
+    });
+
+    const result = lastToolResult(events);
+    expect(result?.isError).toBe(false);
+
+    const meta = result?.activityMetadata?.webSearch;
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+    expect(meta?.errorMessage).toBeUndefined();
+
+    // No-results is a success, not a backend failure: no telemetry fires.
+    expect(backendFailureLogs(warnings)).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -270,7 +270,7 @@ describe("native server_tool_complete metadata", () => {
     expect(durB).toBeGreaterThanOrEqual(durA);
   });
 
-  test("forwards provider error codes instead of generic 'Search failed'", async () => {
+  test("maps recoverable error codes to friendly copy, not the raw code", async () => {
     const { deps, events } = createCollectorDeps();
     const toolUseId = "tu_err_code";
 
@@ -292,9 +292,11 @@ describe("native server_tool_complete metadata", () => {
     const toolResultEvent = events.find(
       (e): e is ToolResultEvent => e.type === "tool_result",
     );
-    expect(toolResultEvent?.activityMetadata?.webSearch?.errorMessage).toBe(
-      "max_uses_exceeded",
-    );
+    const errorMessage =
+      toolResultEvent?.activityMetadata?.webSearch?.errorMessage;
+    // The raw provider code is never user-visible.
+    expect(errorMessage).not.toBe("max_uses_exceeded");
+    expect(errorMessage).toContain("web-search limit");
   });
 
   test("does NOT emit activityMetadata for non-Anthropic providers", async () => {

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -51,6 +51,7 @@ mock.module("../../memory/llm-request-log-store.js", () => ({
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../../tools/network/web-search-error.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -352,7 +353,7 @@ describe("native server_tool_complete metadata", () => {
       (e): e is ToolResultEvent => e.type === "tool_result",
     );
     const meta = toolResultEvent?.activityMetadata?.webSearch;
-    expect(meta?.errorMessage).toBe("Search failed");
+    expect(meta?.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     expect(meta?.resultCount).toBe(0);
     expect(meta?.results).toEqual([]);
     expect(toolResultEvent?.isError).toBe(true);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -56,6 +56,11 @@ import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
 import {
+  classifyWebSearchFailure,
+  logWebSearchBackendFailure,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+} from "../tools/network/web-search-error.js";
+import {
   buildPricingUsage,
   resolveStructuredPricing,
 } from "../usage/pricing.js";
@@ -246,6 +251,8 @@ export interface EventHandlerState {
   readonly serverToolStartedAt: Map<string, number>;
   /** Original input from server_tool_start, keyed by tool_use_id, so the complete handler can read the query. */
   readonly serverToolInputs: Map<string, Record<string, unknown>>;
+  /** Request ids for which a user-facing web_search backend-failure notice was already surfaced this turn (dedup noisy repeats). Keyed by request id; each turn has a fresh request id, so this grows at most one entry per turn. */
+  readonly webSearchBackendFailureNotified: Set<string>;
   /** Active debounce timer for partial persistence; `undefined` when idle. */
   pendingPartialFlushTimer: ReturnType<typeof setTimeout> | undefined;
   /** In-flight partial flush write awaited at finalize to avoid overwrite races. */
@@ -311,6 +318,7 @@ export function createEventHandlerState(): EventHandlerState {
     turnStartedAt: Date.now(),
     serverToolStartedAt: new Map(),
     serverToolInputs: new Map(),
+    webSearchBackendFailureNotified: new Set(),
     pendingPartialFlushTimer: undefined,
     pendingPartialFlushPromise: undefined,
     currentMessageContent: [],
@@ -1828,9 +1836,52 @@ export async function dispatchAgentEvent(
         // for them would mis-label the provider and ship empty results.
         const isAnthropicNative = deps.ctx.provider.name === "anthropic";
 
-        const errorMessage = event.isError
-          ? (event.errorMessage ?? event.errorCode ?? "Search failed")
-          : undefined;
+        // Classify provider failures through the shared normalizer so the same
+        // friendly copy propagates to every client via WebSearchMetadata, while
+        // the raw provider detail stays in telemetry only (ATL-727).
+        const classification = classifyWebSearchFailure({
+          errorCode: event.errorCode,
+          error: event.errorMessage,
+          isError: event.isError,
+          hasResults: results.length > 0,
+        });
+
+        let errorMessage: string | undefined;
+        let fallbackShown = false;
+        if (event.isError) {
+          // Dedup the user-facing friendly notice per turn (request id) so a
+          // burst of backend failures surfaces at most one full notice. The raw
+          // provider error is preserved on every failure via telemetry below.
+          const alreadyNotified = state.webSearchBackendFailureNotified.has(
+            deps.reqId,
+          );
+          if (classification.isBackendFailure) {
+            if (alreadyNotified) {
+              errorMessage = "Search is still having trouble.";
+            } else {
+              state.webSearchBackendFailureNotified.add(deps.reqId);
+              errorMessage = WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
+              fallbackShown = true;
+            }
+
+            // Backend-failure telemetry (provider outages / rate limits) must
+            // fire only for genuine backend classifications so it does not
+            // count recoverable input/quota errors as provider failures.
+            logWebSearchBackendFailure(deps.rlog, {
+              provider: "anthropic-native",
+              requestId: deps.reqId,
+              errorCategory: classification.category,
+              rawDetail: classification.rawDetail,
+              fallbackShown,
+              queryLength: query.length,
+            });
+          } else {
+            // Recoverable, non-backend categories (query_too_long,
+            // max_uses_exceeded, unknown) are not deduped against the backend
+            // notice; fall back to a concise message when there is no copy.
+            errorMessage = classification.userMessage || "Search failed";
+          }
+        }
 
         const metadata: WebSearchMetadata | undefined = isAnthropicNative
           ? {

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1849,13 +1849,21 @@ export async function dispatchAgentEvent(
         let errorMessage: string | undefined;
         let fallbackShown = false;
         if (event.isError) {
-          // Dedup the user-facing friendly notice per turn (request id) so a
-          // burst of backend failures surfaces at most one full notice. The raw
-          // provider error is preserved on every failure via telemetry below.
-          const alreadyNotified = state.webSearchBackendFailureNotified.has(
-            deps.reqId,
-          );
-          if (classification.isBackendFailure) {
+          // A genuine backend failure OR an unclassifiable, message-less native
+          // failure (e.g. `isError:true` with no `error_code`) both surface the
+          // friendly backend copy: a terse "Search failed" placeholder is the
+          // confusing copy this normalization exists to eliminate (ATL-727).
+          // Recoverable categories that carry a real user message
+          // (query_too_long, max_uses_exceeded) keep their own copy.
+          const useBackendCopy =
+            classification.isBackendFailure || !classification.userMessage;
+          if (useBackendCopy) {
+            // Dedup the user-facing friendly notice per turn (request id) so a
+            // burst of failures surfaces at most one full notice. The raw
+            // provider error is preserved on every failure via telemetry below.
+            const alreadyNotified = state.webSearchBackendFailureNotified.has(
+              deps.reqId,
+            );
             if (alreadyNotified) {
               errorMessage = "Search is still having trouble.";
             } else {
@@ -1866,22 +1874,25 @@ export async function dispatchAgentEvent(
 
             // Backend-failure telemetry (provider outages / rate limits) must
             // fire only for genuine backend classifications so it does not
-            // count recoverable input/quota errors as provider failures.
-            logWebSearchBackendFailure(deps.rlog, {
-              provider: isAnthropicNative
-                ? "anthropic-native"
-                : deps.ctx.provider.name,
-              requestId: deps.reqId,
-              errorCategory: classification.category,
-              rawDetail: classification.rawDetail,
-              fallbackShown,
-              queryLength: query.length,
-            });
+            // count recoverable input/quota errors — or a message-less unknown
+            // failure that merely borrows the friendly copy — as provider
+            // outages.
+            if (classification.isBackendFailure) {
+              logWebSearchBackendFailure(deps.rlog, {
+                provider: isAnthropicNative
+                  ? "anthropic-native"
+                  : deps.ctx.provider.name,
+                requestId: deps.reqId,
+                errorCategory: classification.category,
+                rawDetail: classification.rawDetail,
+                fallbackShown,
+                queryLength: query.length,
+              });
+            }
           } else {
-            // Recoverable, non-backend categories (query_too_long,
-            // max_uses_exceeded, unknown) are not deduped against the backend
-            // notice; fall back to a concise message when there is no copy.
-            errorMessage = classification.userMessage || "Search failed";
+            // Recoverable, non-backend categories with their own user-facing
+            // copy (query_too_long, max_uses_exceeded) keep that message.
+            errorMessage = classification.userMessage;
           }
         }
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1868,7 +1868,9 @@ export async function dispatchAgentEvent(
             // fire only for genuine backend classifications so it does not
             // count recoverable input/quota errors as provider failures.
             logWebSearchBackendFailure(deps.rlog, {
-              provider: "anthropic-native",
+              provider: isAnthropicNative
+                ? "anthropic-native"
+                : deps.ctx.provider.name,
               requestId: deps.reqId,
               errorCategory: classification.category,
               rawDetail: classification.rawDetail,

--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../web-search-error.js";
+
 // Mutable mock state - set per test
 let mockWebSearchProvider: string | undefined = "perplexity";
 let mockBraveSecureKey: string | undefined;
@@ -32,7 +34,9 @@ mock.module("../../../security/secure-keys.js", () => ({
   },
 }));
 
+const realLogger = await import("../../../util/logger.js");
 mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -169,7 +173,9 @@ describe("web_search activity metadata", () => {
     expect(meta.provider).toBe("perplexity");
     expect(meta.resultCount).toBe(0);
     expect(meta.results).toEqual([]);
-    expect(meta.errorMessage).toContain("rate limit exceeded");
+    // Post-retry rate limits now surface the centralized friendly recoverable
+    // copy (ATL-727) rather than provider-specific rate-limit wording.
+    expect(meta.errorMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
   });
 
   // ---- Tavily -------------------------------------------------------------

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../web-search-error.js";
+
 // Mutable mock state - set per test
 let mockWebSearchProvider: string | undefined = "perplexity";
 let mockWebSearchMode: string | undefined = "your-own";
@@ -42,7 +44,9 @@ mock.module("../../../security/secure-keys.js", () => ({
   },
 }));
 
+const realLogger = await import("../../../util/logger.js");
 mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -201,7 +205,8 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("rate limit exceeded");
+    // Post-retry rate limits surface the friendly recoverable copy (ATL-727).
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     // 1 initial + 3 retries = 4 calls
     expect(callCount).toBe(4);
   });
@@ -214,7 +219,9 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("status 500");
+    // 5xx is a backend failure -> friendly recoverable copy, no raw status.
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.content).not.toContain("500");
   });
 
   // ---- Brave provider -----------------------------------------------------
@@ -673,7 +680,8 @@ describe("web_search tool", () => {
 
     const result = await execute({ query: "test" });
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("rate limit exceeded");
+    // Post-retry rate limits surface the friendly recoverable copy (ATL-727).
+    expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     expect(callCount).toBe(4);
   });
 

--- a/assistant/src/tools/network/web-search-error.test.ts
+++ b/assistant/src/tools/network/web-search-error.test.ts
@@ -75,6 +75,35 @@ describe("classifyWebSearchFailure", () => {
     expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
   });
 
+  test("tagged abort with a transport-shaped cause is not a backend failure", () => {
+    // A user cancellation wrapped as a ProviderError that ALSO carries a
+    // transport-shaped `cause` (ECONNRESET). The tagged abort guard must win
+    // over transport-retryability so this is not mislabeled a backend outage.
+    const err = Object.assign(new Error("Request was aborted"), {
+      name: "ProviderError",
+      cause: { code: "ECONNRESET" },
+      abortReason: createAbortReason("user_cancel", "cancelGeneration"),
+    });
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.category).not.toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("explicit statusCode wins over a misleading error-body keyword", () => {
+    // The provider response body contains "aborted" (a keyword the error-body
+    // heuristic would sniff as a non-failure), but the authoritative HTTP 503
+    // must classify this as a backend failure.
+    const result = classifyWebSearchFailure({
+      isError: true,
+      statusCode: 503,
+      error: new Error("the upstream request was aborted unexpectedly"),
+    });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(true);
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
   test("ECONNRESET network error is a backend failure", () => {
     const err = Object.assign(new Error("socket hang up"), {
       code: "ECONNRESET",
@@ -197,7 +226,6 @@ describe("logWebSearchBackendFailure", () => {
     logWebSearchBackendFailure(fakeLogger, {
       provider: "anthropic",
       requestId: "req-1",
-      correlationId: "corr-1",
       errorCategory: "backend_unavailable",
       rawDetail: "errorCode=unavailable",
       fallbackShown: true,

--- a/assistant/src/tools/network/web-search-error.test.ts
+++ b/assistant/src/tools/network/web-search-error.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+
+import { createAbortReason } from "../../util/abort-reasons.js";
+import {
+  classifyWebSearchFailure,
+  logWebSearchBackendFailure,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+} from "./web-search-error.js";
+
+describe("classifyWebSearchFailure", () => {
+  test("Anthropic 'unavailable' code is a backend failure with friendly copy", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      errorCode: "unavailable",
+    });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(true);
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.rawDetail).toContain("unavailable");
+  });
+
+  test.each(["internal_error", "overloaded_error"])(
+    "Anthropic '%s' code is a backend failure",
+    (errorCode) => {
+      const result = classifyWebSearchFailure({ isError: true, errorCode });
+      expect(result.category).toBe("backend_unavailable");
+      expect(result.isBackendFailure).toBe(true);
+    },
+  );
+
+  test("HTTP 503 is a backend failure", () => {
+    const result = classifyWebSearchFailure({ isError: true, statusCode: 503 });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("thrown TypeError('fetch failed') is a backend failure", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      error: new TypeError("fetch failed"),
+    });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(true);
+  });
+
+  test("AbortError-shaped timeout is a backend failure", () => {
+    const err = new Error("The operation was aborted due to timeout");
+    err.name = "AbortError";
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.category).toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(true);
+  });
+
+  test("user-initiated abort is not a backend failure", () => {
+    const err = new Error("The operation was aborted");
+    err.name = "AbortError";
+    Object.assign(err, {
+      reason: createAbortReason("user_cancel", "cancelGeneration"),
+    });
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("wrapped ProviderError carrying abortReason is not a backend failure", () => {
+    // A provider wrapper erases the AbortError name and re-words the message,
+    // but carries the tagged reason on `abortReason` (ProviderError shape).
+    const err = Object.assign(new Error("Request was aborted"), {
+      name: "ProviderError",
+      abortReason: createAbortReason("user_cancel", "cancelGeneration"),
+    });
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.category).not.toBe("backend_unavailable");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("ECONNRESET network error is a backend failure", () => {
+    const err = Object.assign(new Error("socket hang up"), {
+      code: "ECONNRESET",
+    });
+    const result = classifyWebSearchFailure({ isError: true, error: err });
+    expect(result.category).toBe("backend_unavailable");
+  });
+
+  test("Anthropic 'too_many_requests' code is rate-limited with backend copy", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      errorCode: "too_many_requests",
+    });
+    expect(result.category).toBe("rate_limited");
+    expect(result.isBackendFailure).toBe(true);
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("HTTP 429 is rate-limited with backend copy", () => {
+    const result = classifyWebSearchFailure({ isError: true, statusCode: 429 });
+    expect(result.category).toBe("rate_limited");
+    expect(result.userMessage).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("'query_too_long' has a distinct, non-backend message", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      errorCode: "query_too_long",
+    });
+    expect(result.category).toBe("query_too_long");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.userMessage.length).toBeGreaterThan(0);
+  });
+
+  test("'max_uses_exceeded' has a distinct, non-backend message", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      errorCode: "max_uses_exceeded",
+    });
+    expect(result.category).toBe("max_uses_exceeded");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+    expect(result.userMessage.length).toBeGreaterThan(0);
+  });
+
+  test("'invalid_input' is unknown and not a backend failure", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      errorCode: "invalid_input",
+    });
+    expect(result.category).toBe("unknown");
+    expect(result.isBackendFailure).toBe(false);
+  });
+
+  test("HTTP 401 is a config failure, not the backend copy", () => {
+    const result = classifyWebSearchFailure({ isError: true, statusCode: 401 });
+    expect(result.category).toBe("config");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("HTTP 403 is a config failure", () => {
+    const result = classifyWebSearchFailure({ isError: true, statusCode: 403 });
+    expect(result.category).toBe("config");
+    expect(result.isBackendFailure).toBe(false);
+  });
+
+  test("successful-but-empty result is no_results, not a failure", () => {
+    const result = classifyWebSearchFailure({
+      isError: false,
+      hasResults: false,
+    });
+    expect(result.category).toBe("no_results");
+    expect(result.isBackendFailure).toBe(false);
+    expect(result.userMessage).not.toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
+  });
+
+  test("rawDetail is truncated to 500 chars", () => {
+    const result = classifyWebSearchFailure({
+      isError: true,
+      error: new Error("x".repeat(1000)),
+    });
+    expect(result.rawDetail.length).toBeLessThanOrEqual(500 + 40);
+    expect(result.rawDetail).toContain("truncated");
+  });
+});
+
+describe("WEB_SEARCH_BACKEND_FAILURE_MESSAGE copy safety", () => {
+  test("offers retry / continue-without / paste", () => {
+    expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).toContain("try again");
+    expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).toContain("continue without");
+    expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).toContain("paste");
+  });
+
+  test("contains no raw provider details, JSON, or exception names", () => {
+    for (const banned of [
+      "{",
+      "error_code",
+      "Anthropic",
+      "web_search_tool_result_error",
+      "TypeError",
+      "stack",
+    ]) {
+      expect(WEB_SEARCH_BACKEND_FAILURE_MESSAGE).not.toContain(banned);
+    }
+  });
+});
+
+describe("logWebSearchBackendFailure", () => {
+  test("captures the event and rawDetail without raw query text", () => {
+    const calls: unknown[][] = [];
+    const fakeLogger = {
+      warn: (...args: unknown[]) => {
+        calls.push(args);
+      },
+    } as unknown as Parameters<typeof logWebSearchBackendFailure>[0];
+
+    const secretQuery = "super secret user query text";
+    logWebSearchBackendFailure(fakeLogger, {
+      provider: "anthropic",
+      requestId: "req-1",
+      correlationId: "corr-1",
+      errorCategory: "backend_unavailable",
+      rawDetail: "errorCode=unavailable",
+      fallbackShown: true,
+      queryLength: secretQuery.length,
+    });
+
+    expect(calls).toHaveLength(1);
+    const [payload, msg] = calls[0] as [Record<string, unknown>, string];
+    expect(payload.event).toBe("web_search_backend_failure");
+    expect(payload.tool).toBe("web_search");
+    expect(payload.provider).toBe("anthropic");
+    expect(payload.rawDetail).toBe("errorCode=unavailable");
+    expect(payload.queryLength).toBe(secretQuery.length);
+    expect(msg).toBe("web_search backend failure");
+
+    // The raw query text must never appear anywhere in the logged payload.
+    const serialized = JSON.stringify(calls);
+    expect(serialized).not.toContain(secretQuery);
+  });
+});

--- a/assistant/src/tools/network/web-search-error.ts
+++ b/assistant/src/tools/network/web-search-error.ts
@@ -129,6 +129,23 @@ function categoryFromStatusCode(
 function categoryFromError(error: unknown): WebSearchFailureCategory | undefined {
   if (error == null) return undefined;
 
+  // A user-initiated abort (Stop/Esc, preemption, dispose) is not a failure.
+  // The tagged `AbortReason` may surface directly (`AbortSignal.throwIfAborted`
+  // throws `signal.reason` verbatim), via `error.reason`, or — when a provider
+  // wrapper erases the `AbortError` name — on `ProviderError.abortReason`. Check
+  // all three FIRST, before the transport-retryability and abort/timeout
+  // substring heuristics, so a tagged cancellation that ALSO carries a
+  // transport-shaped `cause` (e.g. ECONNRESET) short-circuits to "not a
+  // failure" instead of being mislabeled a backend outage. A bare
+  // AbortError/timeout with no tagged reason still falls through below.
+  if (
+    isAbortReason(error) ||
+    isAbortReason((error as { reason?: unknown }).reason) ||
+    isAbortReason((error as { abortReason?: unknown }).abortReason)
+  ) {
+    return undefined;
+  }
+
   // Retryable transport failures (ECONNRESET/ECONNREFUSED/ETIMEDOUT, socket
   // hang-ups, including one level of `cause` chain) are backend failures.
   if (isRetryableNetworkError(error)) return "backend_unavailable";
@@ -138,20 +155,6 @@ function categoryFromError(error: unknown): WebSearchFailureCategory | undefined
     : "";
   const haystack = `${name} ${(error as { message?: unknown }).message ?? ""}`
     .toLowerCase();
-
-  // A user-initiated abort (Stop/Esc, preemption, dispose) is not a failure.
-  // The tagged `AbortReason` may surface directly (`AbortSignal.throwIfAborted`
-  // throws `signal.reason` verbatim), via `error.reason`, or — when a provider
-  // wrapper erases the `AbortError` name — on `ProviderError.abortReason`. Check
-  // all three before the abort/timeout substring heuristic so a wrapped abort
-  // like "Request was aborted" short-circuits the backend-failure path.
-  if (
-    isAbortReason(error) ||
-    isAbortReason((error as { reason?: unknown }).reason) ||
-    isAbortReason((error as { abortReason?: unknown }).abortReason)
-  ) {
-    return undefined;
-  }
 
   // web_search-only: treat aborts/timeouts/DNS/fetch failures (the cases
   // `isRetryableNetworkError` doesn't cover) as backend failures.
@@ -205,14 +208,20 @@ export function classifyWebSearchFailure(
     };
   }
 
+  // Resolution order: Anthropic `errorCode` → explicit HTTP `statusCode` →
+  // error-body/network heuristics. An explicit status code is authoritative
+  // over substring-sniffing the provider's response body (which can contain
+  // misleading keywords like "timeout"/"abort"). Tagged user-aborts carry no
+  // status code, so they still flow through `categoryFromError` and
+  // short-circuit to a non-failure.
   const category =
     (input.errorCode != null
       ? categoryFromErrorCode(input.errorCode)
       : undefined) ??
-    categoryFromError(input.error) ??
     (typeof input.statusCode === "number"
       ? categoryFromStatusCode(input.statusCode)
       : undefined) ??
+    categoryFromError(input.error) ??
     "unknown";
 
   return {
@@ -226,7 +235,6 @@ export function classifyWebSearchFailure(
 export interface WebSearchBackendFailureMeta {
   provider: string;
   requestId?: string;
-  correlationId?: string;
   errorCategory: WebSearchFailureCategory;
   rawDetail: string;
   fallbackShown: boolean;
@@ -249,7 +257,6 @@ export function logWebSearchBackendFailure(
       tool: "web_search",
       provider: meta.provider,
       requestId: meta.requestId,
-      correlationId: meta.correlationId,
       errorCategory: meta.errorCategory,
       rawDetail: meta.rawDetail,
       fallbackShown: meta.fallbackShown,

--- a/assistant/src/tools/network/web-search-error.ts
+++ b/assistant/src/tools/network/web-search-error.ts
@@ -1,0 +1,260 @@
+// Single source of truth for classifying `web_search` provider/backend
+// failures and the user-facing copy we surface for them (ATL-727).
+//
+// This is a pure leaf module: it has NO imports from `daemon/`, `agent/`,
+// `apps/`, or any client/UI package. It may only import the logger and pino
+// types (for the telemetry helper). Every web_search code path — native
+// Anthropic handler, app-side providers, and the web client default — funnels
+// failures through `classifyWebSearchFailure` so the same friendly message
+// propagates to every client via `WebSearchMetadata.errorMessage`.
+
+import type { Logger } from "pino";
+
+import { isAbortReason } from "../../util/abort-reasons.js";
+import { truncateForLog } from "../../util/logger.js";
+import { isRetryableNetworkError } from "../../util/retry.js";
+
+/**
+ * Canonical user-facing copy for a recoverable web_search backend failure.
+ * This is what propagates to every client via `WebSearchMetadata.errorMessage`.
+ *
+ * It names the search tool as the thing struggling, offers retry /
+ * continue-without-search / paste-details, does not blame the user, does not
+ * imply we can fix the provider, does not claim the whole internet or all
+ * tools are down, and contains no raw provider details, JSON, stack traces,
+ * or exception names.
+ */
+export const WEB_SEARCH_BACKEND_FAILURE_MESSAGE =
+  "Search is having trouble right now. You can try again in a moment, continue without web search, or paste the relevant details here and I'll use those.";
+
+const QUERY_TOO_LONG_MESSAGE =
+  "That search query was too long. Try a shorter query.";
+
+const MAX_USES_EXCEEDED_MESSAGE =
+  "I've hit the web-search limit for this turn. I can continue without more searches, or you can paste the details and I'll use those.";
+
+const CONFIG_MESSAGE = "Web search isn't configured.";
+
+export type WebSearchFailureCategory =
+  | "backend_unavailable"
+  | "rate_limited"
+  | "query_too_long"
+  | "max_uses_exceeded"
+  | "config"
+  | "no_results"
+  | "unknown";
+
+export interface WebSearchFailureClassification {
+  category: WebSearchFailureCategory;
+  isBackendFailure: boolean;
+  userMessage: string;
+  rawDetail: string;
+}
+
+export interface WebSearchFailureInput {
+  /** Anthropic `web_search_tool_result_error` code, when present. */
+  errorCode?: string;
+  /** Thrown error or rejected value from a fetch/provider call. */
+  error?: unknown;
+  /** HTTP status code from a provider response, when present. */
+  statusCode?: number;
+  /** Whether the tool result was flagged as an error. */
+  isError?: boolean;
+  /** Whether a successful call returned any results. */
+  hasResults?: boolean;
+}
+
+/** Categories we consider a transient backend failure worth the friendly copy. */
+function isBackendFailureCategory(category: WebSearchFailureCategory): boolean {
+  return category === "backend_unavailable" || category === "rate_limited";
+}
+
+function userMessageFor(category: WebSearchFailureCategory): string {
+  switch (category) {
+    case "backend_unavailable":
+    case "rate_limited":
+      return WEB_SEARCH_BACKEND_FAILURE_MESSAGE;
+    case "query_too_long":
+      return QUERY_TOO_LONG_MESSAGE;
+    case "max_uses_exceeded":
+      return MAX_USES_EXCEEDED_MESSAGE;
+    case "config":
+      return CONFIG_MESSAGE;
+    case "no_results":
+    case "unknown":
+      // Neutral passthrough: callers keep their existing behavior.
+      return "";
+  }
+}
+
+/** Map an Anthropic `web_search_tool_result_error` code to a category. */
+function categoryFromErrorCode(
+  errorCode: string,
+): WebSearchFailureCategory | undefined {
+  switch (errorCode) {
+    case "unavailable":
+    case "internal_error":
+    case "overloaded_error":
+      return "backend_unavailable";
+    case "too_many_requests":
+      return "rate_limited";
+    case "query_too_long":
+      return "query_too_long";
+    case "max_uses_exceeded":
+      return "max_uses_exceeded";
+    case "invalid_input":
+      // Recoverable, but not a backend failure — let callers handle it.
+      return "unknown";
+    default:
+      return undefined;
+  }
+}
+
+/** Map an HTTP status code to a category. */
+function categoryFromStatusCode(
+  statusCode: number,
+): WebSearchFailureCategory | undefined {
+  if (statusCode === 429) return "rate_limited";
+  if (statusCode === 401 || statusCode === 403) return "config";
+  if (statusCode >= 500) return "backend_unavailable";
+  return undefined;
+}
+
+/**
+ * Classify a thrown error / rejected value. This module is web_search-only, so
+ * network-layer failures (fetch failed, connection reset/refused, DNS, and
+ * timeouts without an explicit user-abort reason) are treated as backend
+ * failures.
+ */
+function categoryFromError(error: unknown): WebSearchFailureCategory | undefined {
+  if (error == null) return undefined;
+
+  // Retryable transport failures (ECONNRESET/ECONNREFUSED/ETIMEDOUT, socket
+  // hang-ups, including one level of `cause` chain) are backend failures.
+  if (isRetryableNetworkError(error)) return "backend_unavailable";
+
+  const name = typeof (error as { name?: unknown }).name === "string"
+    ? (error as { name: string }).name
+    : "";
+  const haystack = `${name} ${(error as { message?: unknown }).message ?? ""}`
+    .toLowerCase();
+
+  // A user-initiated abort (Stop/Esc, preemption, dispose) is not a failure.
+  // The tagged `AbortReason` may surface directly (`AbortSignal.throwIfAborted`
+  // throws `signal.reason` verbatim), via `error.reason`, or — when a provider
+  // wrapper erases the `AbortError` name — on `ProviderError.abortReason`. Check
+  // all three before the abort/timeout substring heuristic so a wrapped abort
+  // like "Request was aborted" short-circuits the backend-failure path.
+  if (
+    isAbortReason(error) ||
+    isAbortReason((error as { reason?: unknown }).reason) ||
+    isAbortReason((error as { abortReason?: unknown }).abortReason)
+  ) {
+    return undefined;
+  }
+
+  // web_search-only: treat aborts/timeouts/DNS/fetch failures (the cases
+  // `isRetryableNetworkError` doesn't cover) as backend failures.
+  if (
+    name === "AbortError" ||
+    haystack.includes("abort") ||
+    haystack.includes("timeout") ||
+    haystack.includes("timed out") ||
+    haystack.includes("fetch failed") ||
+    haystack.includes("failed to fetch") ||
+    haystack.includes("enotfound")
+  ) {
+    return "backend_unavailable";
+  }
+  return undefined;
+}
+
+/** Build the internal-only raw detail string (never embedded in userMessage). */
+function buildRawDetail(input: WebSearchFailureInput): string {
+  const parts: string[] = [];
+  if (input.errorCode) parts.push(`errorCode=${input.errorCode}`);
+  if (typeof input.statusCode === "number") {
+    parts.push(`statusCode=${input.statusCode}`);
+  }
+  if (input.error != null) {
+    const err = input.error as { message?: unknown };
+    const msg =
+      typeof err.message === "string" ? err.message : String(input.error);
+    if (msg) parts.push(msg);
+  }
+  return truncateForLog(parts.join(" "), 500);
+}
+
+/**
+ * Classify a web_search failure into a stable category, a user-facing message,
+ * and an internal-only raw detail. Never treats an empty-but-successful result
+ * as a failure.
+ */
+export function classifyWebSearchFailure(
+  input: WebSearchFailureInput,
+): WebSearchFailureClassification {
+  const rawDetail = buildRawDetail(input);
+
+  // Success-passthrough: nothing went wrong, there were just no results.
+  if (!input.isError && input.error == null) {
+    return {
+      category: "no_results",
+      isBackendFailure: false,
+      userMessage: userMessageFor("no_results"),
+      rawDetail,
+    };
+  }
+
+  const category =
+    (input.errorCode != null
+      ? categoryFromErrorCode(input.errorCode)
+      : undefined) ??
+    categoryFromError(input.error) ??
+    (typeof input.statusCode === "number"
+      ? categoryFromStatusCode(input.statusCode)
+      : undefined) ??
+    "unknown";
+
+  return {
+    category,
+    isBackendFailure: isBackendFailureCategory(category),
+    userMessage: userMessageFor(category),
+    rawDetail,
+  };
+}
+
+export interface WebSearchBackendFailureMeta {
+  provider: string;
+  requestId?: string;
+  correlationId?: string;
+  errorCategory: WebSearchFailureCategory;
+  rawDetail: string;
+  fallbackShown: boolean;
+  queryLength?: number;
+}
+
+/**
+ * Emit a structured warning for a web_search backend failure (ATL-727).
+ *
+ * Do NOT log raw query text — only `queryLength`. `rawDetail` is internal-only
+ * provider/HTTP context and must never be surfaced to users.
+ */
+export function logWebSearchBackendFailure(
+  log: Logger,
+  meta: WebSearchBackendFailureMeta,
+): void {
+  log.warn(
+    {
+      event: "web_search_backend_failure",
+      tool: "web_search",
+      provider: meta.provider,
+      requestId: meta.requestId,
+      correlationId: meta.correlationId,
+      errorCategory: meta.errorCategory,
+      rawDetail: meta.rawDetail,
+      fallbackShown: meta.fallbackShown,
+      queryLength: meta.queryLength,
+    },
+    "web_search backend failure",
+  );
+}

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -6,6 +6,7 @@ import type {
 import { RiskLevel } from "../../permissions/types.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { wrapUntrustedContent } from "../../security/untrusted-content.js";
+import { isAbortReason } from "../../util/abort-reasons.js";
 import { faviconUrlForDomain } from "../../util/favicon.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -387,19 +388,6 @@ function errorResult(
 }
 
 /**
- * Build a {@link ToolExecutionResult} for a genuine backend/transport failure
- * (5xx, post-retry rate-limit, thrown network/timeout error). Routes the raw
- * detail through {@link classifyWebSearchFailure}: when it is a backend failure
- * we surface the friendly recoverable copy (the bare sentence so the model
- * reads it as guidance — retry / continue-without-search / paste-details —
- * rather than fabricating) in both the model-facing `content` and the client
- * `errorMessage`, and log the raw detail via telemetry. Non-backend categories
- * (e.g. an unexpected 4xx) fall back to {@link errorResult} with `fallback`.
- *
- * Raw provider JSON / status text must never reach `content` or `errorMessage`;
- * only `rawDetail` (internal-only) captures it for the log.
- */
-/**
  * Wrap an already-read provider response body so {@link backendFailureResult}
  * forwards it into the classifier's internal-only `rawDetail` (telemetry). The
  * classifier reads `error.message`; `buildRawDetail` truncates to ≤500 chars.
@@ -422,6 +410,19 @@ function safeStringifyBody(body: unknown): string {
   }
 }
 
+/**
+ * Build a {@link ToolExecutionResult} for a genuine backend/transport failure
+ * (5xx, post-retry rate-limit, thrown network/timeout error). Routes the raw
+ * detail through {@link classifyWebSearchFailure}: when it is a backend failure
+ * we surface the friendly recoverable copy (the bare sentence so the model
+ * reads it as guidance — retry / continue-without-search / paste-details —
+ * rather than fabricating) in both the model-facing `content` and the client
+ * `errorMessage`, and log the raw detail via telemetry. Non-backend categories
+ * (e.g. an unexpected 4xx) fall back to {@link errorResult} with `fallback`.
+ *
+ * Raw provider JSON / status text must never reach `content` or `errorMessage`;
+ * only `rawDetail` (internal-only) captures it for the log.
+ */
 function backendFailureResult(
   query: string,
   provider: WebSearchProvider,
@@ -468,13 +469,24 @@ function backendFailureResult(
  * Route a thrown fetch error (network/timeout) through {@link backendFailureResult}
  * as a `backend_unavailable` candidate, falling back to a `Web search failed: …`
  * error for non-backend throws (e.g. a JSON parse error).
+ *
+ * If the caller aborted the request (`signal.aborted` — the user hit Stop/Esc,
+ * or an external caller cancelled), the thrown error is re-thrown so the
+ * executor's existing cancellation handling takes over. A user-cancel must NOT
+ * surface the friendly backend copy or emit `web_search_backend_failure`
+ * telemetry. Internal fetch timeouts (where the caller's signal is not aborted)
+ * still route to the friendly backend result.
  */
 function networkFailureResult(
   query: string,
   provider: WebSearchProvider,
   startedAt: number,
   err: unknown,
+  signal?: AbortSignal,
 ): ToolExecutionResult {
+  if (signal?.aborted || isAbortReason((err as { reason?: unknown })?.reason)) {
+    throw err;
+  }
   return backendFailureResult(
     query,
     provider,
@@ -510,7 +522,7 @@ async function executeBraveSearch(
         signal,
       });
     } catch (err) {
-      return networkFailureResult(query, "brave", startedAt, err);
+      return networkFailureResult(query, "brave", startedAt, err, signal);
     }
 
     if (response.ok) {
@@ -693,7 +705,7 @@ async function executePerplexitySearch(
         signal,
       });
     } catch (err) {
-      return networkFailureResult(query, "perplexity", startedAt, err);
+      return networkFailureResult(query, "perplexity", startedAt, err, signal);
     }
 
     if (response.ok) {
@@ -791,7 +803,7 @@ async function executeTavilySearch(
         signal,
       });
     } catch (err) {
-      return networkFailureResult(query, "tavily", startedAt, err);
+      return networkFailureResult(query, "tavily", startedAt, err, signal);
     }
 
     if (response.ok) {
@@ -992,7 +1004,13 @@ export const webSearchTool = {
         });
       } catch (err) {
         log.error({ err }, "Managed web search failed");
-        return networkFailureResult(query, "brave", startedAt, err);
+        return networkFailureResult(
+          query,
+          "brave",
+          startedAt,
+          err,
+          context.signal,
+        );
       }
     }
 
@@ -1039,7 +1057,13 @@ export const webSearchTool = {
       });
     } catch (err) {
       log.error({ err }, "Web search failed");
-      return networkFailureResult(query, provider, startedAt, err);
+      return networkFailureResult(
+        query,
+        provider,
+        startedAt,
+        err,
+        context.signal,
+      );
     }
   },
 } satisfies ToolDefinition;

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -22,6 +22,11 @@ import type {
 } from "../types.js";
 import { extractDomain } from "./domain-normalize.js";
 import type { ManagedSearchProxyResult } from "./managed-search-proxy.js";
+import {
+  classifyWebSearchFailure,
+  logWebSearchBackendFailure,
+  WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+} from "./web-search-error.js";
 
 const log = getLogger("web-search");
 
@@ -381,6 +386,104 @@ function errorResult(
   };
 }
 
+/**
+ * Build a {@link ToolExecutionResult} for a genuine backend/transport failure
+ * (5xx, post-retry rate-limit, thrown network/timeout error). Routes the raw
+ * detail through {@link classifyWebSearchFailure}: when it is a backend failure
+ * we surface the friendly recoverable copy (the bare sentence so the model
+ * reads it as guidance — retry / continue-without-search / paste-details —
+ * rather than fabricating) in both the model-facing `content` and the client
+ * `errorMessage`, and log the raw detail via telemetry. Non-backend categories
+ * (e.g. an unexpected 4xx) fall back to {@link errorResult} with `fallback`.
+ *
+ * Raw provider JSON / status text must never reach `content` or `errorMessage`;
+ * only `rawDetail` (internal-only) captures it for the log.
+ */
+/**
+ * Wrap an already-read provider response body so {@link backendFailureResult}
+ * forwards it into the classifier's internal-only `rawDetail` (telemetry). The
+ * classifier reads `error.message`; `buildRawDetail` truncates to ≤500 chars.
+ * Returns `undefined` for an empty body so we don't pad `rawDetail` with noise.
+ * The body must NEVER reach user-facing `content`/`errorMessage`.
+ */
+function rawBodyDetail(body: unknown): { message: string } | undefined {
+  if (body == null) return undefined;
+  const text =
+    typeof body === "string" ? body : safeStringifyBody(body);
+  const trimmed = text.trim();
+  return trimmed ? { message: trimmed } : undefined;
+}
+
+function safeStringifyBody(body: unknown): string {
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
+}
+
+function backendFailureResult(
+  query: string,
+  provider: WebSearchProvider,
+  startedAt: number,
+  raw: { error?: unknown; statusCode?: number; errorCode?: string },
+  fallback: string,
+): ToolExecutionResult {
+  const classification = classifyWebSearchFailure({
+    isError: true,
+    error: raw.error,
+    statusCode: raw.statusCode,
+    errorCode: raw.errorCode,
+  });
+
+  if (!classification.isBackendFailure) {
+    return errorResult(query, provider, startedAt, fallback);
+  }
+
+  logWebSearchBackendFailure(log, {
+    provider,
+    errorCategory: classification.category,
+    rawDetail: classification.rawDetail,
+    fallbackShown: true,
+    queryLength: query.length,
+  });
+
+  return {
+    content: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+    isError: true,
+    activityMetadata: {
+      webSearch: {
+        query,
+        provider,
+        resultCount: 0,
+        durationMs: Date.now() - startedAt,
+        results: [],
+        errorMessage: WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
+      },
+    },
+  };
+}
+
+/**
+ * Route a thrown fetch error (network/timeout) through {@link backendFailureResult}
+ * as a `backend_unavailable` candidate, falling back to a `Web search failed: …`
+ * error for non-backend throws (e.g. a JSON parse error).
+ */
+function networkFailureResult(
+  query: string,
+  provider: WebSearchProvider,
+  startedAt: number,
+  err: unknown,
+): ToolExecutionResult {
+  return backendFailureResult(
+    query,
+    provider,
+    startedAt,
+    { error: err },
+    `Web search failed: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
 async function executeBraveSearch(
   query: string,
   count: number,
@@ -396,21 +499,26 @@ async function executeBraveSearch(
   const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/json",
-        "Accept-Encoding": "gzip",
-        "X-Subscription-Token": apiKey,
-      },
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "Accept-Encoding": "gzip",
+          "X-Subscription-Token": apiKey,
+        },
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "brave", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as BraveSearchResponse;
       return successfulBraveResult(data, query, startedAt);
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -436,20 +544,22 @@ async function executeBraveSearch(
     }
 
     log.warn({ status: response.status }, "Brave Search API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "brave",
       startedAt,
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Brave Search rate limit exceeded after retries. Try again shortly."
         : `Brave Search API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "brave",
     startedAt,
+    { statusCode: 429 },
     "Brave Search rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -478,6 +588,23 @@ async function executeManagedBraveSearch(
   );
 
   if (!proxyResult.ok) {
+    // Keep billing/auth/unavailable mapping as specific copy; route genuine
+    // platform 5xx (transport-level failures) to the friendly backend helper.
+    if (
+      proxyResult.kind === "platform-error" &&
+      proxyResult.status >= 500
+    ) {
+      return backendFailureResult(
+        query,
+        "brave",
+        startedAt,
+        {
+          statusCode: proxyResult.status,
+          error: rawBodyDetail(proxyResult.body),
+        },
+        managedSearchProxyErrorMessage(proxyResult),
+      );
+    }
     return errorResult(
       query,
       "brave",
@@ -503,12 +630,18 @@ async function executeManagedBraveSearch(
     );
   }
 
-  if (proxyResult.status === 429) {
-    return errorResult(
+  if (proxyResult.status === 429 || proxyResult.status >= 500) {
+    return backendFailureResult(
       query,
       "brave",
       startedAt,
-      "Managed Brave Search rate limit exceeded. Try again shortly.",
+      {
+        statusCode: proxyResult.status,
+        error: rawBodyDetail(proxyResult.body),
+      },
+      proxyResult.status === 429
+        ? "Managed Brave Search rate limit exceeded. Try again shortly."
+        : `Managed Brave Search provider returned status ${proxyResult.status}`,
     );
   }
 
@@ -545,18 +678,23 @@ async function executePerplexitySearch(
 ): Promise<ToolExecutionResult> {
   const startedAt = Date.now();
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(PERPLEXITY_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: "sonar",
-        messages: [{ role: "user", content: query }],
-      }),
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(PERPLEXITY_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "sonar",
+          messages: [{ role: "user", content: query }],
+        }),
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "perplexity", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as PerplexityResponse;
@@ -574,7 +712,7 @@ async function executePerplexitySearch(
       };
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -600,20 +738,22 @@ async function executePerplexitySearch(
     }
 
     log.warn({ status: response.status }, "Perplexity API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "perplexity",
       startedAt,
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Perplexity rate limit exceeded after retries. Try again shortly."
         : `Perplexity API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "perplexity",
     startedAt,
+    { statusCode: 429 },
     "Perplexity rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -638,16 +778,21 @@ async function executeTavilySearch(
   const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
-    const response = await fetch(TAVILY_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-        "X-Client-Source": "vellum-assistant",
-      },
-      body: JSON.stringify(body),
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(TAVILY_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "X-Client-Source": "vellum-assistant",
+        },
+        body: JSON.stringify(body),
+        signal,
+      });
+    } catch (err) {
+      return networkFailureResult(query, "tavily", startedAt, err);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as TavilySearchResponse;
@@ -665,7 +810,7 @@ async function executeTavilySearch(
       };
     }
 
-    await response.text();
+    const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
       return errorResult(
@@ -691,20 +836,22 @@ async function executeTavilySearch(
     }
 
     log.warn({ status: response.status }, "Tavily Search API error");
-    return errorResult(
+    return backendFailureResult(
       query,
       "tavily",
       startedAt,
+      { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
         ? "Tavily Search rate limit exceeded after retries. Try again shortly."
         : `Tavily Search API returned status ${response.status}`,
     );
   }
 
-  return errorResult(
+  return backendFailureResult(
     query,
     "tavily",
     startedAt,
+    { statusCode: 429 },
     "Tavily Search rate limit exceeded after retries. Try again shortly.",
   );
 }
@@ -844,14 +991,8 @@ export const webSearchTool = {
           signal: context.signal,
         });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
         log.error({ err }, "Managed web search failed");
-        return errorResult(
-          query,
-          "brave",
-          startedAt,
-          `Managed web search failed: ${msg}`,
-        );
+        return networkFailureResult(query, "brave", startedAt, err);
       }
     }
 
@@ -897,14 +1038,8 @@ export const webSearchTool = {
         signal: context.signal,
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, "Web search failed");
-      return errorResult(
-        query,
-        provider,
-        startedAt,
-        `Web search failed: ${msg}`,
-      );
+      return networkFailureResult(query, provider, startedAt, err);
     }
   },
 } satisfies ToolDefinition;


### PR DESCRIPTION
## Summary
Adds a narrow, centralized error-normalization layer for `web_search`: backend/server-side failures (Anthropic `web_search_tool_result_error`, app-side provider 5xx/network/timeout/post-retry-429) map to one friendly, actionable user message that propagates to all clients via `WebSearchMetadata.errorMessage`. Raw provider detail is preserved only in `web_search_backend_failure` structured telemetry, repeat notices are de-duplicated per turn, the model keeps continuing honestly (search stays `isError:true`, never marked successful), and `web_fetch` DNS handling plus the empty-but-successful "no results" case are left untouched.

## Self-review result
PASS — 3 review rounds. Round 1 fixed 5 gaps (abort-guard precedence, statusCode-authoritative classification, dropped unused `correlationId`, app-side caller-abort short-circuit, provider label). Round 2 fixed 2 gaps (message-less native failures now surface the friendly copy instead of a terse "Search failed"; deduplicated the daemon-handler test harness). Round 3 returned clean across all four passes.

## PRs merged into feature branch
- #32971: feat(web-search): add centralized web_search failure normalizer and telemetry helper (PR 1)
- #32970: test(web): guard web_search backend copy rendering and prevent web_fetch DNS conflation (PR 4)
- #32974: feat(web-search): map native web_search backend failures to friendly copy with per-turn dedup (PR 2)
- #32975: feat(web-search): normalize app-side provider backend failures to friendly recoverable copy (PR 3)
- #32978: test(web-search): end-to-end backend-failure coverage + document the normalized error flow (PR 5)

### Fix PRs (self-review remediation)
- #32983: abort-guard precedence + statusCode-authoritative classification + drop unused correlationId
- #32984: derive web_search_backend_failure provider label from the actual provider
- #32985: treat caller-aborted app-side searches as cancellations, not backend failures; relocate orphaned doc-comment
- #32987: never surface terse "Search failed" on native failures; share web_search test harness

Part of plan: web-search-failure.md