### PR TITLE
[codex] Restore preference credit rows

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -1,7 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
 import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
+  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -13,6 +15,7 @@ import { useNavigate } from "react-router";
 
 import {
   BottomSheet,
+  Button,
   PanelItem,
   Popover,
   SideMenu,
@@ -20,11 +23,16 @@ import {
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { useAuthStore } from "@/stores/auth-store";
-import { usePlatformGate } from "@/hooks/use-platform-gate";
+import {
+  useActiveAssistantIsPlatformHosted,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
 import { adminUrl, routes } from "@/utils/routes";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 
 // Modal only opens when the user clicks "Share Feedback" — defer loading
 // until then to keep the modal's form deps (markdown editor, etc.) out of
@@ -32,6 +40,11 @@ import { ThemeToggle } from "@/components/theme-toggle";
 const ShareFeedbackModal = lazy(() =>
   import("@/components/share-feedback-modal").then((m) => ({
     default: m.ShareFeedbackModal,
+  })),
+);
+const EarnCreditsModal = lazy(() =>
+  import("@/components/earn-credits-modal").then((m) => ({
+    default: m.EarnCreditsModal,
   })),
 );
 
@@ -50,6 +63,7 @@ export function PreferencesMenu({
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+  const [isEarnCreditsOpen, setIsEarnCreditsOpen] = useState(false);
 
   if (!isLoggedIn) {
     return null;
@@ -70,6 +84,7 @@ export function PreferencesMenu({
     <PreferencesMenuContent
       onClose={closeMenu}
       onShareFeedback={() => setIsFeedbackOpen(true)}
+      onEarnCredits={() => setIsEarnCreditsOpen(true)}
     />
   );
 
@@ -110,6 +125,15 @@ export function PreferencesMenu({
           />
         </LazyBoundary>
       ) : null}
+
+      {isEarnCreditsOpen ? (
+        <LazyBoundary>
+          <EarnCreditsModal
+            open={isEarnCreditsOpen}
+            onClose={() => setIsEarnCreditsOpen(false)}
+          />
+        </LazyBoundary>
+      ) : null}
     </>
   );
 }
@@ -117,22 +141,72 @@ export function PreferencesMenu({
 interface PreferencesMenuContentProps {
   onClose: () => void;
   onShareFeedback: () => void;
+  onEarnCredits: () => void;
 }
 
 function PreferencesMenuContent({
   onClose,
   onShareFeedback,
+  onEarnCredits,
 }: PreferencesMenuContentProps) {
   const navigate = useNavigate();
   const logout = useAuthStore.use.logout();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
+  const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
+  const isOrgReady = useIsOrgReady();
+  const showBillingRows =
+    billingPlatformGate === "full" && isPlatformHosted && isOrgReady;
+  const { data: billingSummary } = useQuery({
+    ...organizationsBillingSummaryRetrieveOptions(),
+    enabled: showBillingRows,
+  });
+  const effectiveBalance = billingSummary?.effective_balance ?? null;
 
   return (
     <>
       <ThemeToggle className="px-2 pt-0" />
 
       <MenuDivider />
+
+      {showBillingRows ? (
+        <>
+          {effectiveBalance !== null ? (
+            <>
+              <div className="flex items-center justify-between gap-3 py-2 pl-[8px]">
+                <span
+                  className="text-body-medium-lighter"
+                  style={{ color: "var(--content-default)" }}
+                >
+                  {formatWholeCredits(effectiveBalance)} credits
+                </span>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  onClick={() => {
+                    onClose();
+                    navigate(routes.settings.billing);
+                  }}
+                >
+                  Add credits
+                </Button>
+              </div>
+              <MenuDivider />
+            </>
+          ) : null}
+
+          <PanelItem
+            icon={Gift}
+            label="Earn credits"
+            onSelect={() => {
+              onClose();
+              onEarnCredits();
+            }}
+          />
+          <MenuDivider />
+        </>
+      ) : null}
 
       <PanelItem
         icon={SettingsIcon}
@@ -185,6 +259,17 @@ function PreferencesMenuContent({
       />
     </>
   );
+}
+
+function formatWholeCredits(value: string): string {
+  const num = parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return value;
+  }
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 function MenuDivider() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -53,6 +53,15 @@ extension MainWindowView {
                             AppDelegate.shared?.handlePlatformLoginSucceeded()
                         })
                     }
+                },
+                onOpenBilling: {
+                    sidebar.showPreferencesDrawer = false
+                    settingsStore.pendingSettingsTab = .billing
+                    windowState.selection = .panel(.settings)
+                },
+                onEarnCredits: {
+                    sidebar.showPreferencesDrawer = false
+                    showEarnCreditsModal = true
                 }
             )
             .frame(width: drawerWidth)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -86,6 +86,7 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     @State var showConversationSwitcher = false
+    @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
     /// Selected conversation currently being activated from a user navigation
     /// action. While non-nil, the chat surface renders a switch-loading
@@ -622,6 +623,10 @@ struct MainWindowView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .overlay { preferencesDismissLayer }
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
+            .sheet(isPresented: $showEarnCreditsModal) {
+                EarnCreditsModal()
+                    .preferredColorScheme(themePreference == "light" ? .light : (themePreference == "dark" || themePreference == "velvet") ? .dark : systemIsDark ? .dark : .light)
+            }
             .overlay { conversationSwitcherDismissLayer }
             .overlay(alignment: .topLeading) { conversationSwitcherDrawerLayer }
             .ignoresSafeArea(edges: .top)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -8,6 +8,22 @@ struct DrawerMenuView: View {
     let onShareFeedback: () -> Void
     let onLogOut: () -> Void
     let onSignIn: () -> Void
+    let onOpenBilling: () -> Void
+    let onEarnCredits: () -> Void
+
+    @State private var effectiveBalance: String?
+    @State private var isLowBalance = false
+    @State private var isZeroBalance = false
+    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
+
+    private var isBillingVisible: Bool {
+        return authManager.isAuthenticated &&
+        connectedOrgId != nil
+    }
+
+    private var isReferralVisible: Bool {
+        isBillingVisible
+    }
 
     var body: some View {
         VMenu {
@@ -17,6 +33,42 @@ struct DrawerMenuView: View {
 
             VMenuCustomRow {
                 tightDividerLine
+            }
+
+            if let balance = effectiveBalance {
+                VMenuCustomRow {
+                    HStack {
+                        Text("\(balance) credits")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(
+                                isZeroBalance ? VColor.systemNegativeStrong :
+                                isLowBalance ? VColor.systemMidStrong :
+                                VColor.contentDefault
+                            )
+                        Spacer()
+                        if isBillingVisible {
+                            Button("Add credits") { onOpenBilling() }
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.primaryBase)
+                                .buttonStyle(.plain)
+                        }
+                    }
+                    .frame(minHeight: VSize.rowMinHeight)
+                }
+
+                VMenuCustomRow {
+                    tightDividerLine
+                }
+
+                if isReferralVisible {
+                    VMenuItem(icon: VIcon.gift.rawValue, label: String(localized: "Earn credits")) {
+                        onEarnCredits()
+                    }
+
+                    VMenuCustomRow {
+                        tightDividerLine
+                    }
+                }
             }
 
             VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
@@ -30,6 +82,9 @@ struct DrawerMenuView: View {
                 VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
             }
         }
+        .task(id: connectedOrgId) {
+            await loadBalance()
+        }
     }
 
     /// 1pt divider line without VMenuDivider's 4pt vertical padding,
@@ -38,5 +93,28 @@ struct DrawerMenuView: View {
         Rectangle()
             .fill(VColor.borderOverlay)
             .frame(height: 1)
+    }
+
+    private func loadBalance() async {
+        guard authManager.isAuthenticated, connectedOrgId != nil else {
+            effectiveBalance = nil
+            isLowBalance = false
+            isZeroBalance = false
+            return
+        }
+        do {
+            var summary = try await BillingService.shared.getBillingSummary()
+            if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
+                summary = bootstrapped
+            }
+            let balanceString = summary.effective_balance
+            effectiveBalance = balanceString
+            if let value = Double(balanceString) {
+                isZeroBalance = value <= 0
+                isLowBalance = value < 1.0
+            }
+        } catch {
+            // Silently ignore errors; the drawer should remain usable without billing data.
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -97,11 +97,10 @@ struct DrawerMenuView: View {
 
     private func loadBalance() async {
         guard authManager.isAuthenticated, connectedOrgId != nil else {
-            effectiveBalance = nil
-            isLowBalance = false
-            isZeroBalance = false
+            clearBalance()
             return
         }
+        clearBalance()
         do {
             var summary = try await BillingService.shared.getBillingSummary()
             if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
@@ -116,5 +115,11 @@ struct DrawerMenuView: View {
         } catch {
             // Silently ignore errors; the drawer should remain usable without billing data.
         }
+    }
+
+    private func clearBalance() {
+        effectiveBalance = nil
+        isLowBalance = false
+        isZeroBalance = false
     }
 }


### PR DESCRIPTION
## Summary

Restores the preference popover/drawer credit UI that was removed in PR #31229 while we work on a better usage presentation.

- Adds the web Preferences credit balance row with its Add credits action.
- Restores the web Earn credits row and lazy referral modal.
- Restores the macOS preferences drawer balance row, billing navigation, and Earn credits sheet.
- Gates the web billing query to platform-hosted assistants with an active organization to avoid self-hosted/org-readiness race requests.

## Validation

- `cd apps/web && bun test src/domains/chat/components/preferences-menu.test.tsx`
- `cd apps/web && bunx tsc --noEmit`
- `cd apps/web && bun run lint`
- `cd clients/macos && ./build.sh lint`
- `git diff --check`
- Pre-push hook: Swift build and design token guard passed