### PR TITLE
fix(notifications): suppress passive notification conversations unconditionally

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -870,7 +870,7 @@ describe("pairDeliveryWithConversation", () => {
     expect(addMessageMock).toHaveBeenCalledTimes(1);
   });
 
-  test("passive vellum signal still honors explicit reuse_existing action", async () => {
+  test("passive vellum signal suppresses even when decision engine says reuse_existing", async () => {
     mockExistingConversations["conv-explicit-passive"] = {
       id: "conv-explicit-passive",
       source: "notification",
@@ -890,10 +890,11 @@ describe("pairDeliveryWithConversation", () => {
       { conversationAction },
     );
 
-    expect(result.conversationId).toBe("conv-explicit-passive");
+    expect(result.conversationId).toBeNull();
+    expect(result.messageId).toBeNull();
     expect(result.createdNewConversation).toBe(false);
     expect(createConversationMock).not.toHaveBeenCalled();
-    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).not.toHaveBeenCalled();
   });
 
   // ── conversationMetadata.conversationType override ─────────────────

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -120,9 +120,13 @@ export async function pairDeliveryWithConversation(
     // Passive vellum notifications surface via the home feed alone and link
     // back to the originating conversation via `signal.sourceContextId`.
     // Materializing a fresh per-notification conversation just to host the
-    // seed message leaves a graveyard entry in the sidebar; skip it unless
-    // the producer opted in via `requiresConversation` or the decision engine
-    // requested explicit reuse of a target conversation.
+    // seed message leaves a graveyard entry in the sidebar; skip it
+    // unconditionally when the producer did not opt in via
+    // `requiresConversation`. The decision engine's `reuse_existing` hint is
+    // also ignored here: even a successful reuse would append a seed message
+    // to a conversation that the user didn't ask for, and a failed reuse
+    // (stale target / source mismatch) falls through to `createConversation`
+    // — producing exactly the graveyard entry we want to avoid.
     //
     // Gated on `home-page`: the home feed is the surface that hosts passive
     // notifications, so when the flag is off there is nowhere for them to
@@ -131,7 +135,6 @@ export async function pairDeliveryWithConversation(
     if (
       strategy === "start_new_conversation" &&
       !signal.requiresConversation &&
-      conversationAction?.action !== "reuse_existing" &&
       isHomePageEnabled()
     ) {
       return {


### PR DESCRIPTION
## Summary
- Passive vellum notifications (e.g. `schedule.notify`) were still creating sidebar conversations despite Sidd's May 28 suppression fix
- Root cause: the suppression guard in `conversation-pairing.ts` had a carve-out for `reuse_existing` — when the decision engine LLM returned that action for a passive signal, the guard was bypassed. If the reuse target was stale or had a source mismatch, it fell through to `createConversation()`, producing a graveyard conversation
- Fix: remove the `conversationAction?.action !== "reuse_existing"` condition so passive notifications are suppressed regardless of LLM suggestion

## Test plan
- [x] Updated existing test to assert suppression when `reuse_existing` is suggested for a passive signal
- [x] All 35 conversation-pairing tests pass
- [x] All notification broadcaster + home-feed tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)