### PR TITLE
feat(daemon): emit app live-build status with keep-last-good preview on compile failure

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -1,9 +1,4 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useRef,
-} from "react";
+import { type Dispatch, type SetStateAction, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/stores/conversation-store";
@@ -232,7 +227,8 @@ export function useStreamEventHandler(
         confirmationToolCallMap: store.confirmationToolCallMap,
         setAssetsRefreshKey,
         dismissedSurfaceIds: store.dismissedSurfaceIds,
-        contextWindowUsageByConversation: store.contextWindowUsageByConversation,
+        contextWindowUsageByConversation:
+          store.contextWindowUsageByConversation,
         setContextWindowUsage: store.setContextWindowUsage,
         scheduleConversationListRefetch,
         queryClient,
@@ -380,6 +376,7 @@ export function useStreamEventHandler(
         case "document_comment_reopened":
         case "document_comment_deleted":
         case "interaction_resolved":
+        case "app_preview_update":
           break;
         case "unknown":
           break;

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -1,4 +1,7 @@
-import { type DisplayMessage, isSurfaceInteractive } from "@/domains/chat/types/types";
+import {
+  type DisplayMessage,
+  isSurfaceInteractive,
+} from "@/domains/chat/types/types";
 import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { AssistantEvent } from "@/types/event-types";
@@ -29,6 +32,11 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "disk_pressure_status_changed",
   "home_feed_updated",
   "relationship_state_updated",
+  // Live app-build preview broadcast — app-scoped (`appId`), carries no
+  // `conversationId`, so the conversation-id gate would otherwise drop it.
+  // The chat handler is a no-op for it today; the app-preview store wiring
+  // lives outside this domain.
+  "app_preview_update",
   // Workspace-scoped prompt — the `contacts/prompt` IPC route fires it
   // from settings or skill flows that have no conversation binding, so
   // the wire payload has no `conversationId` and the conversation gate

--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the live-build orchestration that emits `app_preview_update`
+ * events on multifile app source changes, keeping the last-good preview on a
+ * transient compile failure.
+ *
+ * Exercises `runAppLiveBuild` directly via dependency injection so it does not
+ * stand up the full daemon server.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { CompileResult } from "../bundler/app-compiler.js";
+import {
+  __resetAppReloadGenerations,
+  type AppLiveBuildDeps,
+  runAppLiveBuild,
+} from "../daemon/app-live-build.js";
+import type { AppPreviewUpdate } from "../daemon/message-types/apps.js";
+import type { AppDefinition } from "../memory/app-store.js";
+
+const APP_ID = "app-live-1";
+const LAST_GOOD_HTML = "<html>last-good</html>";
+const FRESH_HTML = "<html>fresh</html>";
+
+const fakeApp = { id: APP_ID } as unknown as AppDefinition;
+
+interface Harness {
+  deps: AppLiveBuildDeps;
+  settledCount: () => number;
+}
+
+function makeHarness(opts: { compile: () => Promise<CompileResult> }): Harness {
+  let settled = 0;
+  const deps: AppLiveBuildDeps = {
+    compileApp: opts.compile,
+    resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
+    broadcast: () => {},
+    refreshSurfaces: () => {},
+    onSettled: () => {
+      settled++;
+    },
+  };
+  return { deps, settledCount: () => settled };
+}
+
+function ok(): CompileResult {
+  return { ok: true, errors: [], warnings: [], durationMs: 1 };
+}
+
+function fail(messages: string[]): CompileResult {
+  return {
+    ok: false,
+    errors: messages.map((text) => ({ text })),
+    warnings: [],
+    durationMs: 1,
+  };
+}
+
+describe("runAppLiveBuild", () => {
+  beforeEach(() => {
+    __resetAppReloadGenerations();
+  });
+
+  test("clean compile broadcasts building then ok with a bumped reloadGeneration", async () => {
+    let distFresh = false;
+    const compile = async () => {
+      distFresh = true;
+      return ok();
+    };
+    const broadcasts: AppPreviewUpdate[] = [];
+    const refreshCalls: Array<
+      Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
+    > = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: compile,
+      resolveEffectiveAppHtml: () => (distFresh ? FRESH_HTML : LAST_GOOD_HTML),
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual(["building", "ok"]);
+
+    const building = broadcasts[0];
+    expect(building.html).toBe(LAST_GOOD_HTML);
+    expect(building.reloadGeneration).toBe(0);
+
+    const okMsg = broadcasts[1];
+    expect(okMsg.html).toBe(FRESH_HTML);
+    expect(okMsg.reloadGeneration).toBe(1); // bumped
+    expect(okMsg.buildErrors).toBeUndefined();
+
+    expect(refreshCalls).toHaveLength(1);
+    expect(refreshCalls[0].compileStatus).toBe("ok");
+    expect(refreshCalls[0].reloadGeneration).toBe(1);
+  });
+
+  test("failed compile keeps last-good html and an unchanged reloadGeneration", async () => {
+    // First do a clean build to advance the generation to 1.
+    {
+      const compile = async () => ok();
+      const broadcasts: AppPreviewUpdate[] = [];
+      const deps: AppLiveBuildDeps = {
+        compileApp: compile,
+        resolveEffectiveAppHtml: () => FRESH_HTML,
+        broadcast: (msg) => broadcasts.push(msg),
+        refreshSurfaces: () => {},
+        onSettled: () => {},
+      };
+      await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+      expect(broadcasts[1].reloadGeneration).toBe(1);
+    }
+
+    // Now a failing compile. `resolveEffectiveAppHtml` would return the
+    // placeholder after `rm -rf dist/`, but the orchestrator must have
+    // captured the last-good html BEFORE compiling.
+    const broadcasts: AppPreviewUpdate[] = [];
+    const refreshCalls: Array<
+      Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
+    > = [];
+    let compiled = false;
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => {
+        compiled = true; // simulate `rm -rf dist/` wiping dist
+        return fail(["Could not resolve 'foo'", "Unexpected token"]);
+      },
+      // After dist is wiped, html resolution degrades to a placeholder.
+      resolveEffectiveAppHtml: () =>
+        compiled ? "<p>App compilation failed.</p>" : LAST_GOOD_HTML,
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual([
+      "building",
+      "error",
+    ]);
+
+    const errMsg = broadcasts[1];
+    expect(errMsg.compileStatus).toBe("error");
+    // Last-good html, NOT the post-rm placeholder.
+    expect(errMsg.html).toBe(LAST_GOOD_HTML);
+    expect(errMsg.buildErrors).toEqual([
+      "Could not resolve 'foo'",
+      "Unexpected token",
+    ]);
+    // reloadGeneration unchanged (still 1 from the prior clean build).
+    expect(errMsg.reloadGeneration).toBe(1);
+
+    expect(refreshCalls).toHaveLength(1);
+    expect(refreshCalls[0].compileStatus).toBe("error");
+    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    expect(refreshCalls[0].buildErrors).toEqual([
+      "Could not resolve 'foo'",
+      "Unexpected token",
+    ]);
+  });
+
+  test("thrown compile is treated as a failure that keeps last-good preview", async () => {
+    const broadcasts: AppPreviewUpdate[] = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => {
+        throw new Error("boom");
+      },
+      resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: () => {},
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual([
+      "building",
+      "error",
+    ]);
+    expect(broadcasts[1].html).toBe(LAST_GOOD_HTML);
+    expect(broadcasts[1].reloadGeneration).toBe(0);
+  });
+
+  test("settle/onSettled fires on every outcome", async () => {
+    const h = makeHarness({ compile: async () => ok() });
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", h.deps);
+    expect(h.settledCount()).toBe(1);
+
+    const h2 = makeHarness({ compile: async () => fail(["x"]) });
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", h2.deps);
+    expect(h2.settledCount()).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -9,13 +9,13 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import type { AppPreviewUpdateEvent } from "../api/events/app-preview-update.js";
 import type { CompileResult } from "../bundler/app-compiler.js";
 import {
   __resetAppReloadGenerations,
   type AppLiveBuildDeps,
   runAppLiveBuild,
 } from "../daemon/app-live-build.js";
-import type { AppPreviewUpdate } from "../daemon/message-types/apps.js";
 import type { AppDefinition } from "../memory/app-store.js";
 
 const APP_ID = "app-live-1";
@@ -67,7 +67,7 @@ describe("runAppLiveBuild", () => {
       distFresh = true;
       return ok();
     };
-    const broadcasts: AppPreviewUpdate[] = [];
+    const broadcasts: AppPreviewUpdateEvent[] = [];
     const refreshCalls: Array<
       Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
     > = [];
@@ -101,7 +101,7 @@ describe("runAppLiveBuild", () => {
     // First do a clean build to advance the generation to 1.
     {
       const compile = async () => ok();
-      const broadcasts: AppPreviewUpdate[] = [];
+      const broadcasts: AppPreviewUpdateEvent[] = [];
       const deps: AppLiveBuildDeps = {
         compileApp: compile,
         resolveEffectiveAppHtml: () => FRESH_HTML,
@@ -116,7 +116,7 @@ describe("runAppLiveBuild", () => {
     // Now a failing compile. `resolveEffectiveAppHtml` would return the
     // placeholder after `rm -rf dist/`, but the orchestrator must have
     // captured the last-good html BEFORE compiling.
-    const broadcasts: AppPreviewUpdate[] = [];
+    const broadcasts: AppPreviewUpdateEvent[] = [];
     const refreshCalls: Array<
       Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
     > = [];
@@ -162,7 +162,7 @@ describe("runAppLiveBuild", () => {
   });
 
   test("thrown compile is treated as a failure that keeps last-good preview", async () => {
-    const broadcasts: AppPreviewUpdate[] = [];
+    const broadcasts: AppPreviewUpdateEvent[] = [];
     const deps: AppLiveBuildDeps = {
       compileApp: async () => {
         throw new Error("boom");
@@ -181,6 +181,63 @@ describe("runAppLiveBuild", () => {
     ]);
     expect(broadcasts[1].html).toBe(LAST_GOOD_HTML);
     expect(broadcasts[1].reloadGeneration).toBe(0);
+  });
+
+  test("two overlapping successful compiles yield distinct increasing generations", async () => {
+    // Both invocations capture the same starting generation BEFORE awaiting
+    // their (serialized) compile. The generation must be read-and-bumped AFTER
+    // each compile succeeds so the second successful build does not reuse the
+    // first's reloadGeneration — otherwise clients drop the latest output.
+    const okBroadcasts: AppPreviewUpdateEvent[] = [];
+    const okRefreshGenerations: number[] = [];
+
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    let firstStarted!: () => void;
+    const firstStartedGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    let compileCount = 0;
+    const deps: AppLiveBuildDeps = {
+      // First compile blocks until both invocations are in-flight, so they both
+      // captured the same starting generation before either bumps it.
+      compileApp: async () => {
+        compileCount += 1;
+        if (compileCount === 1) {
+          firstStarted();
+          await firstGate;
+        }
+        return ok();
+      },
+      resolveEffectiveAppHtml: () => FRESH_HTML,
+      broadcast: (msg) => {
+        if (msg.compileStatus === "ok") okBroadcasts.push(msg);
+      },
+      refreshSurfaces: (_id, o) => {
+        if (o.reloadGeneration !== undefined)
+          okRefreshGenerations.push(o.reloadGeneration);
+      },
+      onSettled: () => {},
+    };
+
+    const first = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    await firstStartedGate;
+    // Second invocation starts (and snapshots the same generation) while the
+    // first is still awaiting its compile.
+    const second = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    const generations = okBroadcasts
+      .map((b) => b.reloadGeneration)
+      .sort((a, b) => a - b);
+    expect(generations).toEqual([1, 2]);
+    // Broadcast generations match the ones written to surfaces.
+    expect([...okRefreshGenerations].sort((a, b) => a - b)).toEqual([1, 2]);
   });
 
   test("settle/onSettled fires on every outcome", async () => {

--- a/assistant/src/api/events/app-preview-update.ts
+++ b/assistant/src/api/events/app-preview-update.ts
@@ -1,0 +1,33 @@
+/**
+ * `app_preview_update` SSE event.
+ *
+ * Live-build status broadcast for a multifile app's preview, emitted on every
+ * source-file recompile so clients (web) can hot-swap the preview iframe while
+ * the assistant is still writing, while keeping the last-good preview on a
+ * transient compile error.
+ *
+ * - `building`: a recompile started; `html` is the current (last-good)
+ *   resolved html so the client can show a building overlay without blanking.
+ * - `ok`: recompile succeeded; `html` is the fresh resolved html and
+ *   `reloadGeneration` is bumped so the client swaps the iframe.
+ * - `error`: recompile failed; `html` is the previous good html, `buildErrors`
+ *   carries the compile diagnostics, and `reloadGeneration` is unchanged so the
+ *   iframe is NOT swapped.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AppPreviewUpdateEventSchema = z.object({
+  type: z.literal("app_preview_update"),
+  appId: z.string(),
+  html: z.string(),
+  compileStatus: z.enum(["building", "ok", "error"]),
+  buildErrors: z.array(z.string()).optional(),
+  reloadGeneration: z.number(),
+});
+
+export type AppPreviewUpdateEvent = z.infer<typeof AppPreviewUpdateEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { AppPreviewUpdateEventSchema } from "./events/app-preview-update.js";
 import { AssistantActivityStateEventSchema } from "./events/assistant-activity-state.js";
 import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js";
 import { AssistantTurnStartEventSchema } from "./events/assistant-turn-start.js";
@@ -50,6 +51,10 @@ import { UserMessageEchoEventSchema } from "./events/user-message-echo.js";
 
 export { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "./constants/call-sites.js";
 export { DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC } from "./constants/tool-execution.js";
+export {
+  type AppPreviewUpdateEvent,
+  AppPreviewUpdateEventSchema,
+} from "./events/app-preview-update.js";
 export {
   type AssistantActivityAnchor,
   AssistantActivityAnchorSchema,
@@ -394,6 +399,7 @@ export {
  * migration recipe.
  */
 export const AssistantEventSchema = z.discriminatedUnion("type", [
+  AppPreviewUpdateEventSchema,
   AssistantActivityStateEventSchema,
   AssistantTextDeltaEventSchema,
   AssistantTurnStartEventSchema,

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -1,0 +1,133 @@
+/**
+ * Live-build orchestration for multifile app source changes.
+ *
+ * On every detected source-file change the daemon recompiles the app and
+ * refreshes connected surfaces. This module owns the `app_preview_update`
+ * broadcast contract that lets web hot-swap the preview iframe while the
+ * assistant is still writing, while keeping the last-good preview on a
+ * transient compile error.
+ *
+ * The orchestration is dependency-injected so it can be unit-tested without
+ * standing up the full daemon server.
+ */
+
+import type { CompileResult } from "../bundler/app-compiler.js";
+import type { AppDefinition } from "../memory/app-store.js";
+import type { AppPreviewUpdate } from "./message-types/apps.js";
+
+export interface AppLiveBuildDeps {
+  /** Compile the multifile app at `appDir`. Begins with `rm -rf dist/`. */
+  compileApp: (appDir: string) => Promise<CompileResult>;
+  /** Resolve the effective (inlined) preview html for the app's current dist. */
+  resolveEffectiveAppHtml: (app: AppDefinition) => string;
+  /** Broadcast an app_preview_update event to all connected clients. */
+  broadcast: (msg: AppPreviewUpdate) => void;
+  /**
+   * Refresh in-memory/persisted surfaces for the app. Returns the applied
+   * reload generation so this orchestrator can keep one source of truth shared
+   * with the broadcast event. When `reloadGeneration` is supplied the caller is
+   * expected to use it verbatim.
+   */
+  refreshSurfaces: (
+    appId: string,
+    opts: {
+      fileChange: true;
+      compileStatus: "ok" | "error";
+      buildErrors?: string[];
+      reloadGeneration?: number;
+    },
+  ) => void;
+  /** Notify the app-list / publish pipeline (existing side effects). */
+  onSettled: () => void;
+}
+
+/**
+ * Per-app reload generation counter — the single source of truth for the
+ * `reloadGeneration` field shared by the broadcast event and the refreshed
+ * surfaces. Bumped only on a successful recompile.
+ */
+const appReloadGenerations = new Map<string, number>();
+
+/** Test-only reset of the generation counters. */
+export function __resetAppReloadGenerations(): void {
+  appReloadGenerations.clear();
+}
+
+/**
+ * Recompile a multifile app on source change and broadcast its live-build
+ * status, keeping the last-good preview on compile failure.
+ */
+export async function runAppLiveBuild(
+  appId: string,
+  app: AppDefinition,
+  appDir: string,
+  deps: AppLiveBuildDeps,
+): Promise<void> {
+  const currentGeneration = appReloadGenerations.get(appId) ?? 0;
+
+  // Capture the last-good resolved html BEFORE compiling: compileApp begins
+  // with `rm -rf dist/`, so on a failed compile the dist (and thus the
+  // resolvable html) would otherwise be wiped.
+  const lastGoodHtml = deps.resolveEffectiveAppHtml(app);
+
+  // Settle a terminal outcome: refresh surfaces, broadcast the preview update,
+  // and run the existing app-list/publish side effects.
+  const emit = (
+    update: Pick<
+      AppPreviewUpdate,
+      "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
+    >,
+  ) => {
+    if (update.compileStatus !== "building") {
+      deps.refreshSurfaces(appId, {
+        fileChange: true,
+        compileStatus: update.compileStatus,
+        buildErrors: update.buildErrors,
+        reloadGeneration: update.reloadGeneration,
+      });
+    }
+    deps.broadcast({ type: "app_preview_update", appId, ...update });
+    if (update.compileStatus !== "building") deps.onSettled();
+  };
+
+  // Show a building overlay immediately without blanking the preview.
+  emit({
+    html: lastGoodHtml,
+    compileStatus: "building",
+    reloadGeneration: currentGeneration,
+  });
+
+  let result: CompileResult;
+  try {
+    result = await deps.compileApp(appDir);
+  } catch {
+    // Treat a thrown compile as a failed compile: keep the last-good preview.
+    emit({
+      html: lastGoodHtml,
+      compileStatus: "error",
+      buildErrors: ["Recompile failed"],
+      reloadGeneration: currentGeneration,
+    });
+    return;
+  }
+
+  if (result.ok) {
+    const nextGeneration = currentGeneration + 1;
+    appReloadGenerations.set(appId, nextGeneration);
+    emit({
+      html: deps.resolveEffectiveAppHtml(app),
+      compileStatus: "ok",
+      reloadGeneration: nextGeneration,
+    });
+    return;
+  }
+
+  // Failed compile: do NOT push broken/placeholder html and do NOT bump the
+  // reload generation. Re-broadcast the captured last-good html plus errors.
+  emit({
+    html: lastGoodHtml,
+    compileStatus: "error",
+    buildErrors: result.errors.map((e) => e.text),
+    reloadGeneration: currentGeneration,
+  });
+}

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -11,9 +11,9 @@
  * standing up the full daemon server.
  */
 
+import type { AppPreviewUpdateEvent } from "../api/events/app-preview-update.js";
 import type { CompileResult } from "../bundler/app-compiler.js";
 import type { AppDefinition } from "../memory/app-store.js";
-import type { AppPreviewUpdate } from "./message-types/apps.js";
 
 export interface AppLiveBuildDeps {
   /** Compile the multifile app at `appDir`. Begins with `rm -rf dist/`. */
@@ -21,7 +21,7 @@ export interface AppLiveBuildDeps {
   /** Resolve the effective (inlined) preview html for the app's current dist. */
   resolveEffectiveAppHtml: (app: AppDefinition) => string;
   /** Broadcast an app_preview_update event to all connected clients. */
-  broadcast: (msg: AppPreviewUpdate) => void;
+  broadcast: (msg: AppPreviewUpdateEvent) => void;
   /**
    * Refresh in-memory/persisted surfaces for the app. Returns the applied
    * reload generation so this orchestrator can keep one source of truth shared
@@ -63,7 +63,11 @@ export async function runAppLiveBuild(
   appDir: string,
   deps: AppLiveBuildDeps,
 ): Promise<void> {
-  const currentGeneration = appReloadGenerations.get(appId) ?? 0;
+  // Snapshot the current generation for the non-bumping `building`/`error`
+  // outcomes. The successful `ok` outcome instead reads-and-bumps the counter
+  // AFTER the (serialized) compile resolves, so two overlapping builds that
+  // both succeed produce two distinct, monotonically increasing generations.
+  const generationAtStart = appReloadGenerations.get(appId) ?? 0;
 
   // Capture the last-good resolved html BEFORE compiling: compileApp begins
   // with `rm -rf dist/`, so on a failed compile the dist (and thus the
@@ -74,7 +78,7 @@ export async function runAppLiveBuild(
   // and run the existing app-list/publish side effects.
   const emit = (
     update: Pick<
-      AppPreviewUpdate,
+      AppPreviewUpdateEvent,
       "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
     >,
   ) => {
@@ -94,7 +98,7 @@ export async function runAppLiveBuild(
   emit({
     html: lastGoodHtml,
     compileStatus: "building",
-    reloadGeneration: currentGeneration,
+    reloadGeneration: generationAtStart,
   });
 
   let result: CompileResult;
@@ -106,13 +110,17 @@ export async function runAppLiveBuild(
       html: lastGoodHtml,
       compileStatus: "error",
       buildErrors: ["Recompile failed"],
-      reloadGeneration: currentGeneration,
+      reloadGeneration: generationAtStart,
     });
     return;
   }
 
   if (result.ok) {
-    const nextGeneration = currentGeneration + 1;
+    // Read-and-bump AFTER the compile resolves so overlapping successful
+    // builds each get a distinct, monotonically increasing generation. (Both
+    // the read and the write happen synchronously here with no intervening
+    // await, so they are atomic against other invocations.)
+    const nextGeneration = (appReloadGenerations.get(appId) ?? 0) + 1;
     appReloadGenerations.set(appId, nextGeneration);
     emit({
       html: deps.resolveEffectiveAppHtml(app),
@@ -128,6 +136,6 @@ export async function runAppLiveBuild(
     html: lastGoodHtml,
     compileStatus: "error",
     buildErrors: result.errors.map((e) => e.text),
-    reloadGeneration: currentGeneration,
+    reloadGeneration: generationAtStart,
   });
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1798,16 +1798,37 @@ export async function handleSurfaceAction(
 
 /**
  * After an app_refresh, refresh any active surface that displays the updated app.
+ *
+ * Returns whether any surface was refreshed plus the `reloadGeneration` that was
+ * applied, so live-build callers (the source-change recompile path) can emit a
+ * broadcast event whose generation counter agrees with the surface state.
+ *
+ * Additive live-build opts (do not affect the existing macOS path):
+ * - `compileStatus: "error"` keeps the last-good html and does NOT bump
+ *   `reloadGeneration` (the preview iframe is not swapped on a transient error).
+ * - `reloadGeneration` overrides the per-surface bump with an explicit value so
+ *   the server can keep one source of truth shared with the broadcast event.
  */
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
   appId: string,
-  opts?: { fileChange?: boolean; status?: string },
-): boolean {
+  opts?: {
+    fileChange?: boolean;
+    status?: string;
+    compileStatus?: "building" | "ok" | "error";
+    buildErrors?: string[];
+    reloadGeneration?: number;
+  },
+): { refreshed: boolean; reloadGeneration: number } {
   const app = getApp(appId);
-  if (!app) return false;
+  if (!app) return { refreshed: false, reloadGeneration: 0 };
+
+  // On a failed recompile, keep the last-good preview: do not swap html and do
+  // not bump the reload counter.
+  const isError = opts?.compileStatus === "error";
 
   let refreshed = false;
+  let appliedGeneration = opts?.reloadGeneration ?? 0;
   for (const [surfaceId, stored] of ctx.surfaceState.entries()) {
     if (stored.surfaceType !== "dynamic_page") continue;
     const data = stored.data as DynamicPageSurfaceData;
@@ -1816,14 +1837,23 @@ export function refreshSurfacesForApp(
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
+    // Compute the next reload generation. An explicit override (live-build
+    // path) wins so web and macOS agree; otherwise keep the existing
+    // per-surface bump on file change. A failed compile never bumps.
+    const nextGeneration = isError
+      ? (data.reloadGeneration ?? 0)
+      : (opts?.reloadGeneration ?? (data.reloadGeneration ?? 0) + 1);
+    appliedGeneration = nextGeneration;
+
     // Update in-memory surface state so the next refinement gets fresh HTML.
     // For multifile apps, resolve the compiled dist/index.html with inlined
     // assets rather than the empty root index.html (app.htmlDefinition).
+    // On a failed compile, retain the existing html (last-good preview).
     const updatedData: DynamicPageSurfaceData = {
       ...data,
-      html: resolveEffectiveAppHtml(app),
-      ...(opts?.fileChange
-        ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 }
+      ...(isError ? {} : { html: resolveEffectiveAppHtml(app) }),
+      ...(opts?.fileChange && !isError
+        ? { reloadGeneration: nextGeneration }
         : {}),
       ...(opts?.status !== undefined ? { status: opts.status } : {}),
     };
@@ -1851,7 +1881,7 @@ export function refreshSurfacesForApp(
       "Auto-refreshed surface after app_refresh",
     );
   }
-  return refreshed;
+  return { refreshed, reloadGeneration: appliedGeneration };
 }
 
 export function buildCompletionSummary(

--- a/assistant/src/daemon/message-types/apps.ts
+++ b/assistant/src/daemon/message-types/apps.ts
@@ -333,6 +333,29 @@ export interface AppFilesChanged {
   appId: string;
 }
 
+/**
+ * Live-build status broadcast for a multifile app's preview, emitted on every
+ * source-file recompile so clients (web) can hot-swap the preview iframe while
+ * the assistant is still writing, while keeping the last-good preview on a
+ * transient compile error.
+ *
+ * - `building`: a recompile started; `html` is the current (last-good)
+ *   resolved html so the client can show a building overlay without blanking.
+ * - `ok`: recompile succeeded; `html` is the fresh resolved html and
+ *   `reloadGeneration` is bumped so the client swaps the iframe.
+ * - `error`: recompile failed; `html` is the previous good html, `buildErrors`
+ *   carries the compile diagnostics, and `reloadGeneration` is unchanged so the
+ *   iframe is NOT swapped.
+ */
+export interface AppPreviewUpdate {
+  type: "app_preview_update";
+  appId: string;
+  html: string;
+  compileStatus: "building" | "ok" | "error";
+  buildErrors?: string[];
+  reloadGeneration: number;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _AppsClientMessages =
@@ -381,4 +404,5 @@ export type _AppsServerMessages =
   | AppPreviewResponse
   | PublishPageResponse
   | UnpublishPageResponse
-  | AppFilesChanged;
+  | AppFilesChanged
+  | AppPreviewUpdate;

--- a/assistant/src/daemon/message-types/apps.ts
+++ b/assistant/src/daemon/message-types/apps.ts
@@ -1,5 +1,6 @@
 // App management, gallery, publishing, and sharing types.
 
+import type { AppPreviewUpdateEvent } from "../../api/events/app-preview-update.js";
 import type { GalleryManifest } from "../../gallery/gallery-manifest.js";
 
 // === Client → Server ===
@@ -333,28 +334,9 @@ export interface AppFilesChanged {
   appId: string;
 }
 
-/**
- * Live-build status broadcast for a multifile app's preview, emitted on every
- * source-file recompile so clients (web) can hot-swap the preview iframe while
- * the assistant is still writing, while keeping the last-good preview on a
- * transient compile error.
- *
- * - `building`: a recompile started; `html` is the current (last-good)
- *   resolved html so the client can show a building overlay without blanking.
- * - `ok`: recompile succeeded; `html` is the fresh resolved html and
- *   `reloadGeneration` is bumped so the client swaps the iframe.
- * - `error`: recompile failed; `html` is the previous good html, `buildErrors`
- *   carries the compile diagnostics, and `reloadGeneration` is unchanged so the
- *   iframe is NOT swapped.
- */
-export interface AppPreviewUpdate {
-  type: "app_preview_update";
-  appId: string;
-  html: string;
-  compileStatus: "building" | "ok" | "error";
-  buildErrors?: string[];
-  reloadGeneration: number;
-}
+// `app_preview_update` (the live-build preview broadcast) is now canonical:
+// its wire contract lives in `../../api/events/app-preview-update.js`. Daemon
+// emitters/consumers import `AppPreviewUpdateEvent` directly from there.
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
@@ -405,4 +387,4 @@ export type _AppsServerMessages =
   | PublishPageResponse
   | UnpublishPageResponse
   | AppFilesChanged
-  | AppPreviewUpdate;
+  | AppPreviewUpdateEvent;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -9,7 +9,12 @@ import type { CesClient } from "../credential-execution/client.js";
 import type { CesProcessManager } from "../credential-execution/process-manager.js";
 import { AssistantIpcServer } from "../ipc/assistant-server.js";
 import { SkillIpcServer } from "../ipc/skill-server.js";
-import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
+import {
+  getApp,
+  getAppDirPath,
+  isMultifileApp,
+  resolveEffectiveAppHtml,
+} from "../memory/app-store.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -26,6 +31,7 @@ import { updatePublishedAppDeployment } from "../services/published-app-updater.
 import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { runAppLiveBuild } from "./app-live-build.js";
 import {
   AppSourceWatcher,
   setEnsureAppSourceWatcher,
@@ -236,10 +242,9 @@ export class DaemonServer {
     const app = getApp(appId);
     if (!app) return;
 
-    const doRefresh = () => {
-      for (const conversation of allConversations()) {
-        refreshSurfacesForApp(conversation, appId, { fileChange: true });
-      }
+    // Notify the app-list / publish pipeline (fires regardless of compile
+    // outcome, matching the prior behavior).
+    const settle = () => {
       broadcastMessage({ type: "app_files_changed", appId });
       publishAppsChanged();
       void updatePublishedAppDeployment(appId);
@@ -247,24 +252,34 @@ export class DaemonServer {
 
     if (isMultifileApp(app)) {
       const appDir = getAppDirPath(appId);
-      void compileApp(appDir)
-        .then((result) => {
-          if (!result.ok) {
+      void runAppLiveBuild(appId, app, appDir, {
+        compileApp,
+        resolveEffectiveAppHtml,
+        broadcast: (msg) => broadcastMessage(msg),
+        refreshSurfaces: (id, opts) => {
+          if (opts.compileStatus === "error") {
             log.warn(
-              { appId, errors: result.errors },
-              "Recompile failed on app source change",
+              { appId: id, errors: opts.buildErrors },
+              "Recompile failed on app source change — keeping last-good preview",
             );
           }
-          doRefresh();
-        })
-        .catch((err) => {
-          log.warn({ appId, err }, "Recompile threw on app source change");
-          doRefresh();
-        });
+          for (const conversation of allConversations()) {
+            refreshSurfacesForApp(conversation, id, opts);
+          }
+        },
+        onSettled: settle,
+      }).catch((err) => {
+        log.warn({ appId, err }, "Live build threw on app source change");
+        settle();
+      });
       return;
     }
 
-    doRefresh();
+    // Single-file apps: no recompile, just refresh surfaces and settle.
+    for (const conversation of allConversations()) {
+      refreshSurfacesForApp(conversation, appId, { fileChange: true });
+    }
+    settle();
   }
 
   // ── Server lifecycle ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `app_preview_update` broadcast event (building/ok/error + buildErrors + reloadGeneration)
- On compile failure during live recompile, keep the last-good preview and surface a build-error status instead of pushing broken output
- Thread additive compileStatus/buildErrors through refreshSurfacesForApp without changing the existing macOS reloadGeneration path

Part of plan: app-live-preview.md (PR 1 of 4)