### PR TITLE
perf(daemon): reuse a warm esbuild context per app for fast hot-reload recompiles

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -27,6 +27,7 @@
         "croner": "10.0.1",
         "dotenv": "17.3.1",
         "drizzle-orm": "0.45.2",
+        "esbuild": "0.19.12",
         "jszip": "3.10.1",
         "marked": "18.0.0",
         "minimatch": "10.2.4",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -55,6 +55,7 @@
     "croner": "10.0.1",
     "dotenv": "17.3.1",
     "drizzle-orm": "0.45.2",
+    "esbuild": "0.19.12",
     "jszip": "3.10.1",
     "marked": "18.0.0",
     "minimatch": "10.2.4",

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-import { compileApp } from "../bundler/app-compiler.js";
+import {
+  __getAppCompilerContextStats,
+  __resetAppCompilerContextStats,
+  compileApp,
+  disposeAppCompilerContexts,
+} from "../bundler/app-compiler.js";
 import {
   ALLOWED_PACKAGES,
   getCacheDir,
@@ -24,6 +29,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await disposeAppCompilerContexts();
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -411,6 +417,51 @@ console.log("styled");`,
     const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
     expect(js).toContain("updated");
     expect(js).not.toContain("original");
+  });
+
+  test("second compile of the same app reuses the warm esbuild context", async () => {
+    const appDir = await scaffold("warm-context", {
+      "main.tsx": `console.log("v1");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    __resetAppCompilerContextStats();
+
+    const r1 = await compileApp(appDir);
+    expect(r1.ok).toBe(true);
+    // First compile creates a fresh context.
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+    expect(__getAppCompilerContextStats().rebuildCount).toBe(0);
+
+    // Edit and recompile: the context is reused (rebuild), not recreated.
+    await writeFile(join(appDir, "src", "main.tsx"), `console.log("v2");`);
+    const r2 = await compileApp(appDir);
+    expect(r2.ok).toBe(true);
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+    expect(__getAppCompilerContextStats().rebuildCount).toBe(1);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js).toContain("v2");
+    expect(js).not.toContain("v1");
+  });
+
+  test("compile error maps esbuild diagnostics to the result shape", async () => {
+    const appDir = await scaffold("warm-context-error", {
+      "main.tsx": `const x = <<<broken>>>;`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    const result = await compileApp(appDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(typeof result.errors[0].text).toBe("string");
+    expect(result.errors[0].text.length).toBeGreaterThan(0);
+    // esbuild diagnostics carry a structured location.
+    expect(result.errors[0].location?.file).toBeTruthy();
+    expect(typeof result.errors[0].location?.line).toBe("number");
+    expect(typeof result.errors[0].location?.column).toBe("number");
   });
 });
 

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -445,6 +445,47 @@ console.log("styled");`,
     expect(js).not.toContain("v1");
   });
 
+  test("recreates the warm context when nodePaths change (new allowed import resolves)", async () => {
+    // Start from a clean package cache so the first compile (no bare imports)
+    // runs with nodePaths that exclude the not-yet-existent cache node_modules.
+    const cacheNodeModules = join(getCacheDir(), "node_modules");
+    await rm(cacheNodeModules, { recursive: true, force: true });
+
+    const appDir = await scaffold("nodepaths-change", {
+      "main.tsx": `console.log("no imports yet");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    __resetAppCompilerContextStats();
+
+    // First compile: no third-party imports, so the cache node_modules dir is
+    // not created and is absent from nodePaths. Creates a fresh context.
+    const r1 = await compileApp(appDir);
+    expect(r1.ok).toBe(true);
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+
+    // Add an allowed import. resolveAppImports() installs lodash-es, which
+    // creates the cache node_modules dir and so extends nodePaths. The cached
+    // context's identity must change, forcing a dispose + recreate (not a
+    // plain rebuild against the stale resolver paths).
+    await writeFile(
+      join(appDir, "src", "main.tsx"),
+      `import { camelCase } from "lodash-es";\nconsole.log(camelCase("hello world"));`,
+    );
+    const r2 = await compileApp(appDir);
+
+    // The second resolve must succeed — the recreated context sees the newly
+    // installed package via the updated nodePaths.
+    expect(r2.ok).toBe(true);
+    expect(r2.errors).toHaveLength(0);
+
+    // Two distinct contexts were created (recreated, not reused).
+    expect(__getAppCompilerContextStats().createCount).toBe(2);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js).toContain("hello world");
+  }, 30_000);
+
   test("compile error maps esbuild diagnostics to the result shape", async () => {
     const appDir = await scaffold("warm-context-error", {
       "main.tsx": `const x = <<<broken>>>;`,

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -277,13 +277,15 @@ const compileSlots = new Map<string, CompileSlot>();
  *
  * The first compile for an appDir creates a context and caches it; subsequent
  * compiles call ctx.rebuild(), which reuses esbuild's hot module graph and is
- * typically sub-second. The cached entryPoints are recorded so the context can
- * be torn down and rebuilt if the set of entry points changes (e.g. a new
- * top-level source file is added).
+ * typically sub-second. A stable `key` fingerprinting the resolution-relevant
+ * build options (entry points + nodePaths) is recorded so the context can be
+ * torn down and rebuilt if any of them change — e.g. a new top-level source
+ * file is added, or the user adds an allowed third-party import whose newly
+ * installed package cache extends nodePaths.
  */
 interface CachedContext {
   ctx: esbuild.BuildContext;
-  entryPoints: string[];
+  key: string;
 }
 
 const appContexts = new Map<string, CachedContext>();
@@ -308,11 +310,19 @@ export function __resetAppCompilerContextStats(): void {
   contextStats.rebuildCount = 0;
 }
 
-/** True if the two entry-point lists are identical (order-insensitive). */
-function sameEntryPoints(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  const set = new Set(a);
-  return b.every((p) => set.has(p));
+/**
+ * Build a stable identity key for the resolution-relevant build options.
+ *
+ * Two contexts are interchangeable only if they share the same entry points
+ * AND the same module-resolution roots (nodePaths). Sorting makes the key
+ * order-insensitive so a reorder alone never forces a needless recreate, while
+ * any added/removed entry point or nodePath does.
+ */
+function contextKey(entryPoints: string[], nodePaths: string[]): string {
+  return JSON.stringify({
+    entryPoints: [...entryPoints].sort(),
+    nodePaths: [...nodePaths].sort(),
+  });
 }
 
 /**
@@ -324,7 +334,8 @@ let esbuildBinaryConfigured = false;
 
 /**
  * Get (or lazily create) the warm esbuild context for an appDir, recreating it
- * if the resolved entry points changed since it was cached.
+ * if any resolution-relevant build option (entry points or nodePaths) changed
+ * since it was cached.
  */
 async function getOrCreateContext(
   appDir: string,
@@ -332,13 +343,15 @@ async function getOrCreateContext(
   distDir: string,
   nodePaths: string[],
 ): Promise<esbuild.BuildContext> {
+  const key = contextKey(entryPoints, nodePaths);
   const cached = appContexts.get(appDir);
   if (cached) {
-    if (sameEntryPoints(cached.entryPoints, entryPoints)) {
+    if (cached.key === key) {
       contextStats.rebuildCount++;
       return cached.ctx;
     }
-    // Entry points changed — dispose the stale context and build a fresh one.
+    // A resolution input changed (entry points or nodePaths) — dispose the
+    // stale context and build a fresh one so esbuild picks up the new paths.
     appContexts.delete(appDir);
     await cached.ctx.dispose();
   }
@@ -365,7 +378,7 @@ async function getOrCreateContext(
     absWorkingDir: appDir,
   });
   contextStats.createCount++;
-  appContexts.set(appDir, { ctx, entryPoints });
+  appContexts.set(appDir, { ctx, key });
   return ctx;
 }
 

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -1,17 +1,22 @@
 /**
  * Compiler for multi-file TSX apps.
  *
- * Shells out to the esbuild CLI binary (JIT-downloaded on first use) to
- * compile src/main.tsx -> dist/main.js, then copies index.html with
- * script/style tag injection.
+ * Compiles src/main.tsx -> dist/main.js via esbuild's JS API using a warm,
+ * incremental build context cached per app directory, then copies index.html
+ * with script/style tag injection. Reusing the context lets esbuild keep its
+ * module graph hot, so recompiles on source edits are typically sub-second.
  *
- * This avoids importing esbuild's JS API (which caches its native binary
- * path at module load time and breaks inside bun --compile's /$bunfs/).
+ * esbuild resolves its native binary relative to its package at module load,
+ * which does not exist inside bun --compile's /$bunfs/. We point
+ * ESBUILD_BINARY_PATH at the on-disk binary produced by ensureCompilerTools()
+ * so the JS API works in both `bun run` and compiled-binary modes.
  */
 
 import { existsSync, rmSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+
+import * as esbuild from "esbuild";
 
 import { getLogger } from "../util/logger.js";
 import { ensureCompilerTools } from "./compiler-tools.js";
@@ -37,46 +42,19 @@ export interface CompileResult {
 }
 
 /**
- * Parse esbuild CLI stderr into structured diagnostics.
- * esbuild outputs errors like:
- *   ✘ [ERROR] Could not resolve "foo"
- *       src/main.tsx:3:7:
+ * Map an esbuild JS API Message into our structured CompileDiagnostic shape:
+ * the message text plus an optional { file, line, column } location.
  */
-function parseEsbuildStderr(stderr: string): {
-  errors: CompileDiagnostic[];
-  warnings: CompileDiagnostic[];
-} {
-  const errors: CompileDiagnostic[] = [];
-  const warnings: CompileDiagnostic[] = [];
-  const lines = stderr.split("\n");
-
-  for (let i = 0; i < lines.length; i++) {
-    const errorMatch = lines[i].match(/✘ \[ERROR\] (.+)/);
-    const warnMatch = lines[i].match(/▲ \[WARNING\] (.+)/);
-
-    if (errorMatch || warnMatch) {
-      const text = (errorMatch ?? warnMatch)![1];
-      const diag: CompileDiagnostic = { text };
-
-      // Next non-empty line may have location: "    file:line:col:"
-      const locLine = lines[i + 1]?.trim();
-      if (locLine) {
-        const locMatch = locLine.match(/^(.+):(\d+):(\d+):?$/);
-        if (locMatch) {
-          diag.location = {
-            file: locMatch[1],
-            line: parseInt(locMatch[2], 10),
-            column: parseInt(locMatch[3], 10),
-          };
-        }
-      }
-
-      if (errorMatch) errors.push(diag);
-      else warnings.push(diag);
-    }
+function toDiagnostic(message: esbuild.Message): CompileDiagnostic {
+  const diag: CompileDiagnostic = { text: message.text };
+  if (message.location) {
+    diag.location = {
+      file: message.location.file,
+      line: message.location.line,
+      column: message.location.column,
+    };
   }
-
-  return { errors, warnings };
+  return diag;
 }
 
 /**
@@ -295,6 +273,119 @@ interface CompileSlot {
 const compileSlots = new Map<string, CompileSlot>();
 
 /**
+ * Warm esbuild build contexts, one per app directory.
+ *
+ * The first compile for an appDir creates a context and caches it; subsequent
+ * compiles call ctx.rebuild(), which reuses esbuild's hot module graph and is
+ * typically sub-second. The cached entryPoints are recorded so the context can
+ * be torn down and rebuilt if the set of entry points changes (e.g. a new
+ * top-level source file is added).
+ */
+interface CachedContext {
+  ctx: esbuild.BuildContext;
+  entryPoints: string[];
+}
+
+const appContexts = new Map<string, CachedContext>();
+
+/**
+ * Test/diagnostics hook: counts how many times a fresh esbuild context was
+ * created (vs reused). A reused context increments rebuildCount instead.
+ */
+const contextStats = { createCount: 0, rebuildCount: 0 };
+
+/** Exposed for tests: read and reset the context create/rebuild counters. */
+export function __getAppCompilerContextStats(): {
+  createCount: number;
+  rebuildCount: number;
+} {
+  return { ...contextStats };
+}
+
+/** Exposed for tests: reset the context create/rebuild counters. */
+export function __resetAppCompilerContextStats(): void {
+  contextStats.createCount = 0;
+  contextStats.rebuildCount = 0;
+}
+
+/** True if the two entry-point lists are identical (order-insensitive). */
+function sameEntryPoints(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((p) => set.has(p));
+}
+
+/**
+ * Whether ESBUILD_BINARY_PATH has been pointed at the on-disk binary.
+ * esbuild resolves its binary lazily on the first build, so this must be set
+ * before any context is created — but only once, since esbuild caches it.
+ */
+let esbuildBinaryConfigured = false;
+
+/**
+ * Get (or lazily create) the warm esbuild context for an appDir, recreating it
+ * if the resolved entry points changed since it was cached.
+ */
+async function getOrCreateContext(
+  appDir: string,
+  entryPoints: string[],
+  distDir: string,
+  nodePaths: string[],
+): Promise<esbuild.BuildContext> {
+  const cached = appContexts.get(appDir);
+  if (cached) {
+    if (sameEntryPoints(cached.entryPoints, entryPoints)) {
+      contextStats.rebuildCount++;
+      return cached.ctx;
+    }
+    // Entry points changed — dispose the stale context and build a fresh one.
+    appContexts.delete(appDir);
+    await cached.ctx.dispose();
+  }
+
+  const ctx = await esbuild.context({
+    entryPoints,
+    bundle: true,
+    minify: true,
+    outdir: distDir,
+    format: "esm",
+    target: "es2022",
+    jsx: "automatic",
+    jsxImportSource: "preact",
+    alias: { react: "preact/compat", "react-dom": "preact/compat" },
+    loader: {
+      ".tsx": "tsx",
+      ".ts": "ts",
+      ".jsx": "jsx",
+      ".js": "js",
+      ".css": "css",
+    },
+    nodePaths,
+    logLevel: "silent",
+    absWorkingDir: appDir,
+  });
+  contextStats.createCount++;
+  appContexts.set(appDir, { ctx, entryPoints });
+  return ctx;
+}
+
+/**
+ * Dispose every cached esbuild context and stop their child esbuild services.
+ * Called on daemon shutdown so no esbuild subprocesses are left running.
+ */
+export async function disposeAppCompilerContexts(): Promise<void> {
+  const contexts = [...appContexts.values()];
+  appContexts.clear();
+  await Promise.all(
+    contexts.map(({ ctx }) =>
+      ctx.dispose().catch((err) => {
+        log.warn({ err }, "Failed to dispose esbuild context");
+      }),
+    ),
+  );
+}
+
+/**
  * Compile a TSX app from appDir/src/ into appDir/dist/.
  *
  * Expects appDir/src/main.tsx as the entry point and appDir/src/index.html
@@ -400,54 +491,45 @@ async function runCompile(appDir: string): Promise<CompileResult> {
   // Scan source files for bare imports and JIT-install allowed packages
   await resolveAppImports(srcDir);
 
-  // Build NODE_PATH: preact parent dir + shared package cache
+  // Point esbuild's JS API at the on-disk binary. esbuild otherwise resolves
+  // it relative to its package, which doesn't exist inside bun --compile's
+  // /$bunfs/. esbuild caches the path on first build, so set it only once.
+  if (!esbuildBinaryConfigured) {
+    process.env.ESBUILD_BINARY_PATH = tools.esbuildBin;
+    esbuildBinaryConfigured = true;
+  }
+
+  // Resolution roots for bare imports: preact parent dir + shared package cache
   const preactParent = dirname(tools.preactDir);
   const cacheNodeModules = join(getCacheDir(), "node_modules");
-  const nodePath = [preactParent, cacheNodeModules]
-    .filter((p) => existsSync(p))
-    .join(":");
+  const nodePaths = [preactParent, cacheNodeModules].filter((p) =>
+    existsSync(p),
+  );
 
-  // Shell out to esbuild CLI
-  const args = [
-    entryPoint,
-    "--bundle",
-    "--minify",
-    `--outdir=${distDir}`,
-    "--format=esm",
-    "--target=es2022",
-    "--jsx=automatic",
-    "--jsx-import-source=preact",
-    "--alias:react=preact/compat",
-    "--alias:react-dom=preact/compat",
-    "--loader:.tsx=tsx",
-    "--loader:.ts=ts",
-    "--loader:.jsx=jsx",
-    "--loader:.js=js",
-    "--loader:.css=css",
-    "--log-level=warning",
-  ];
-
-  const proc = Bun.spawn({
-    cmd: [tools.esbuildBin, ...args],
-    cwd: appDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: { ...process.env, NODE_PATH: nodePath },
-  });
-
-  await proc.exited;
-  const stderr = await new Response(proc.stderr).text();
-
-  if (proc.exitCode !== 0) {
+  // esbuild's rebuild() resolves with an empty errors array on success and
+  // rejects with a BuildFailure carrying errors/warnings on failure.
+  let result: esbuild.BuildResult;
+  try {
+    const ctx = await getOrCreateContext(
+      appDir,
+      [entryPoint],
+      distDir,
+      nodePaths,
+    );
+    result = await ctx.rebuild();
+  } catch (err) {
     const durationMs = Math.round(performance.now() - start);
-    const { errors, warnings } = parseEsbuildStderr(stderr);
-    // If parsing found nothing, use raw stderr as the error
-    if (errors.length === 0 && stderr.trim()) {
-      errors.push({ text: stderr.trim() });
+    const failure = err as Partial<esbuild.BuildFailure>;
+    const errors = (failure.errors ?? []).map(toDiagnostic);
+    const warnings = (failure.warnings ?? []).map(toDiagnostic);
+    if (errors.length === 0) {
+      errors.push({ text: err instanceof Error ? err.message : String(err) });
     }
     log.info({ durationMs, errorCount: errors.length }, "Build failed");
     return { ok: false, errors, warnings, durationMs };
   }
+
+  const warnings = result.warnings.map(toDiagnostic);
 
   // Copy index.html and inject script/style tags
   const htmlSrc = join(srcDir, "index.html");
@@ -479,5 +561,5 @@ async function runCompile(appDir: string): Promise<CompileResult> {
 
   const durationMs = Math.round(performance.now() - start);
   log.info({ durationMs }, "Build succeeded");
-  return { ok: true, errors: [], warnings: [], durationMs };
+  return { ok: true, errors: [], warnings, durationMs };
 }

--- a/assistant/src/bundler/compiler-tools.ts
+++ b/assistant/src/bundler/compiler-tools.ts
@@ -24,8 +24,12 @@ import { PromiseGuard } from "../util/promise-guard.js";
 
 const log = getLogger("compiler-tools");
 
-// Pinned versions matching assistant/bun.lock
-const ESBUILD_VERSION = "0.24.2";
+// Pinned versions matching assistant/bun.lock.
+// ESBUILD_VERSION must match the esbuild JS API package version (see
+// node_modules/esbuild/package.json): app-compiler.ts drives the JS API and
+// points ESBUILD_BINARY_PATH at this on-disk binary, and esbuild refuses to
+// run a binary whose version differs from the host package.
+const ESBUILD_VERSION = "0.19.12";
 const PREACT_VERSION = "10.28.4";
 
 const TOOLS_VERSION = `esbuild-${ESBUILD_VERSION}_preact-${PREACT_VERSION}`;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { disposeAcpSessionManager } from "../acp/index.js";
-import { compileApp } from "../bundler/app-compiler.js";
+import {
+  compileApp,
+  disposeAppCompilerContexts,
+} from "../bundler/app-compiler.js";
 import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
 import type { CesClient } from "../credential-execution/client.js";
@@ -335,6 +338,7 @@ export class DaemonServer {
     this.evictor.stop();
     this.configWatcher.stop();
     this.appSourceWatcher.stop();
+    void disposeAppCompilerContexts();
     this.pluginSourceWatcher.stop();
     this.cliIpc.stop();
     this.skillIpc.stop();


### PR DESCRIPTION
## Summary
- Replace cold per-call esbuild CLI subprocess with a cached incremental esbuild build context per app dir
- Preserve the existing compileApp result/diagnostic contract (no caller changes)
- Serialize per-app rebuilds and dispose contexts on shutdown

Part of plan: app-live-preview.md (PR 2 of 4)