### PR TITLE
fix(web): match sidebar group spacing to Figma mock (4px rhythm)

### DIFF
--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -456,7 +456,7 @@ export function AssistantSideMenu({
         <SideMenu.Separator />
       </SideMenu.Header>
 
-      <SideMenu.Body className="pt-3 max-md:pt-4">
+      <SideMenu.Body className="gap-1 pt-3 max-md:pt-4">
         {collapsed && variant === "rail" ? (
           <div className="flex flex-col items-center gap-1">
             {headerActions}
@@ -529,6 +529,7 @@ export function AssistantSideMenu({
 
             <SideMenu.Section
               title="Conversations"
+              className="gap-1"
               actions={variant === "overlay" ? undefined : headerActions}
             >
               {renderFlatList(
@@ -541,6 +542,7 @@ export function AssistantSideMenu({
 
               <CollapsibleNavSection.Root
                 type="multiple"
+                className="gap-1"
                 value={sidebar.effectiveOpenCategories}
                 onValueChange={sidebar.onOpenCategoriesChange}
               >
@@ -594,6 +596,7 @@ export function AssistantSideMenu({
                   <SideMenu.Section title="Your Groups">
                     <CollapsibleNavSection.Root
                       type="multiple"
+                      className="gap-1"
                       value={sidebar.effectiveOpenCustomGroups}
                       onValueChange={sidebar.onOpenCustomGroupsChange}
                     >


### PR DESCRIPTION
## Summary
Tightens the vertical spacing between conversation group sections in the web/iOS chat sidebar to a uniform 4px to match the Figma mock (node 4500:119658). CSS-only; scoped to `apps/web/src/domains/chat/components/assistant-side-menu.tsx` via call-site `gap-1` overrides (tailwind-merge collapses the design-library `gap-3`/`gap-2` defaults). No design-library defaults changed; no behavior changes.

## Self-review result
Skipped (`--skip-review`). Implementation validated by the impl agent: typecheck, lint, and `assistant-side-menu.test.tsx` (12/12) all pass.

## PRs merged into feature branch
- #33020: fix(web): match sidebar group spacing to Figma mock (4px rhythm)

Part of plan: sidebar-group-spacing.md