### PR TITLE
feat(web): add getEffectiveTimezone resolver (device override → live browser zone)

### DIFF
--- a/apps/web/src/utils/effective-timezone.test.ts
+++ b/apps/web/src/utils/effective-timezone.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for `getEffectiveTimezone`.
+ *
+ * Mocks the two collaborators (`getDeviceSetting`, `getBrowserTimezone`)
+ * rather than touching real `localStorage`/`Intl`, so the resolver's
+ * override-vs-auto branching is pinned in isolation.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getDeviceSettingMock = mock((_name: string, fallback: string) => fallback);
+mock.module("@/utils/device-settings", () => ({
+  getDeviceSetting: getDeviceSettingMock,
+}));
+
+const getBrowserTimezoneMock = mock(() => "America/Los_Angeles");
+mock.module("@/utils/browser-timezone", () => ({
+  getBrowserTimezone: getBrowserTimezoneMock,
+}));
+
+import { getEffectiveTimezone } from "./effective-timezone";
+
+beforeEach(() => {
+  getDeviceSettingMock.mockReset();
+  getBrowserTimezoneMock.mockReset();
+  getDeviceSettingMock.mockImplementation((_name, fallback) => fallback);
+  getBrowserTimezoneMock.mockImplementation(() => "America/Los_Angeles");
+});
+
+describe("getEffectiveTimezone", () => {
+  test("returns the device override when device:timezone is set", () => {
+    getDeviceSettingMock.mockImplementation(() => "America/New_York");
+
+    expect(getEffectiveTimezone()).toBe("America/New_York");
+    expect(getBrowserTimezoneMock).not.toHaveBeenCalled();
+  });
+
+  test("trims surrounding whitespace from a real override", () => {
+    getDeviceSettingMock.mockImplementation(() => "  Europe/London  ");
+
+    expect(getEffectiveTimezone()).toBe("Europe/London");
+  });
+
+  test("falls back to the live browser zone when the override is empty", () => {
+    expect(getEffectiveTimezone()).toBe("America/Los_Angeles");
+    expect(getBrowserTimezoneMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("treats a whitespace-only override as empty and falls back", () => {
+    getDeviceSettingMock.mockImplementation(() => "   ");
+
+    expect(getEffectiveTimezone()).toBe("America/Los_Angeles");
+    expect(getBrowserTimezoneMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/utils/effective-timezone.ts
+++ b/apps/web/src/utils/effective-timezone.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for "what timezone should the client use right now?".
+ *
+ * Two modes, keyed off the `device:timezone` setting:
+ *
+ * - **Manual override** (`device:timezone` is a non-empty IANA zone): the user
+ *   deliberately picked a zone. It always wins and is intentionally NOT
+ *   auto-updated when the OS timezone changes — a manual choice stays put.
+ * - **Auto** (`device:timezone` is empty/absent): follow the live browser zone.
+ *   `getBrowserTimezone()` re-reads `Intl` on every call, so switching OS
+ *   timezones is reflected the next time this resolver runs.
+ *
+ * Callers should use this instead of `getBrowserTimezone()` directly so the
+ * override-vs-auto semantics are applied consistently across the web client.
+ */
+
+import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getDeviceSetting } from "@/utils/device-settings";
+
+/**
+ * Resolve the effective timezone: a trimmed `device:timezone` override when
+ * present, otherwise the live browser zone.
+ */
+export function getEffectiveTimezone(): string {
+  const override = getDeviceSetting("timezone", "").trim();
+  if (override) return override;
+  return getBrowserTimezone();
+}


### PR DESCRIPTION
## Summary
- Add getEffectiveTimezone() — trimmed device:timezone override wins, else live browser zone
- Shared single source of truth for timezone reads across the web client

Part of plan: fix-timezone-auto-update.md (PR 1 of 6)