### PR TITLE
feat(web): hot-reload the open app preview on daemon app_preview_update events

### DIFF
--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -28,6 +28,12 @@ export interface AppViewerContainerProps {
   compileStatus?: "building" | "ok" | "error";
   /** Compile diagnostics surfaced in the build-error badge. */
   buildErrors?: string[];
+  /**
+   * Generation counter bumped by the daemon on every successful recompile.
+   * Folded into the iframe key so a bumped generation force-remounts the
+   * preview even when `html` is byte-identical to the prior render.
+   */
+  reloadGeneration?: number;
 }
 
 /**
@@ -109,6 +115,7 @@ export function AppViewerContainer({
   route,
   compileStatus,
   buildErrors,
+  reloadGeneration,
 }: AppViewerContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -122,8 +129,8 @@ export function AppViewerContainer({
     for (let i = 0; i < html.length; i++) {
       hash = ((hash << 5) - hash + html.charCodeAt(i)) | 0;
     }
-    return `app-${appId}-${hash}`;
-  }, [html, appId]);
+    return `app-${appId}-${reloadGeneration ?? 0}-${hash}`;
+  }, [html, appId, reloadGeneration]);
 
   useSandboxFetchProxy(iframeRef, {
     frameId: appId,

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
@@ -19,6 +20,78 @@ export interface AppViewerContainerProps {
   isDeploying?: boolean;
   /** Deep-link route passed to the app as `window.vellum.route`. */
   route?: string;
+  /**
+   * Live-build status from the daemon. Only `"error"` renders UI (a small
+   * non-blocking badge over the last-good preview); `"building"`/`"ok"`/
+   * undefined render nothing — the live iframe swap is the success feedback.
+   */
+  compileStatus?: "building" | "ok" | "error";
+  /** Compile diagnostics surfaced in the build-error badge. */
+  buildErrors?: string[];
+}
+
+/**
+ * Non-blocking badge shown over the last-good preview when a recompile fails.
+ * The iframe stays fully visible behind it (keep-last-good); the badge can be
+ * dismissed and expanded to reveal the raw `buildErrors`.
+ */
+export function BuildErrorBadge({ buildErrors }: { buildErrors?: string[] }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  if (dismissed) return null;
+  const errors = buildErrors ?? [];
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-2"
+      role="status"
+      aria-label="App build error"
+    >
+      <div
+        className="pointer-events-auto max-w-full rounded-lg border px-3 py-2 shadow-sm"
+        style={{
+          background: "var(--surface-overlay)",
+          borderColor: "var(--border-base)",
+        }}
+      >
+        <div className="flex items-center gap-2 text-label-small-default">
+          <AlertTriangle
+            className="h-4 w-4 shrink-0 text-danger-500"
+            aria-hidden
+          />
+          <span style={{ color: "var(--content-default)" }}>
+            Build error — showing last working version
+          </span>
+          {errors.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="underline underline-offset-2"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              {expanded ? "Hide details" : "Details"}
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Dismiss build error"
+            onClick={() => setDismissed(true)}
+            className="ml-1 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+        {expanded && errors.length > 0 && (
+          <pre
+            className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words text-label-small-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {errors.join("\n")}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function AppViewerContainer({
@@ -34,6 +107,8 @@ export function AppViewerContainer({
   onDeploy,
   isDeploying,
   route,
+  compileStatus,
+  buildErrors,
 }: AppViewerContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -69,6 +144,9 @@ export function AppViewerContainer({
       />
 
       <div className="relative min-h-0 flex-1">
+        {compileStatus === "error" && (
+          <BuildErrorBadge buildErrors={buildErrors} />
+        )}
         <iframe
           ref={iframeRef}
           key={iframeKey}

--- a/apps/web/src/components/build-error-badge.test.tsx
+++ b/apps/web/src/components/build-error-badge.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BuildErrorBadge } from "@/components/app-viewer-container";
+
+describe("BuildErrorBadge", () => {
+  test("renders the last-working-version message", () => {
+    const html = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["TS2322: type error"]} />,
+    );
+    expect(html).toContain("Build error");
+    expect(html).toContain("showing last working version");
+  });
+
+  test("is overlaid and non-blocking so it never hides the iframe", () => {
+    // The container is absolutely positioned and pointer-events-none, so the
+    // last-good preview iframe behind it stays fully visible and interactive.
+    const html = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["boom"]} />,
+    );
+    expect(html).toContain("absolute");
+    expect(html).toContain("pointer-events-none");
+  });
+
+  test("offers a details affordance when buildErrors are present", () => {
+    const withErrors = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["boom"]} />,
+    );
+    expect(withErrors).toContain("Details");
+
+    const withoutErrors = renderToStaticMarkup(<BuildErrorBadge />);
+    expect(withoutErrors).not.toContain("Details");
+  });
+});

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1380,6 +1380,8 @@ export function ChatRouteContent({
             isSharing={isSharing}
             onDeploy={deployToVercel ? handleDeployApp : undefined}
             isDeploying={isDeploying}
+            compileStatus={openedAppState.compileStatus}
+            buildErrors={openedAppState.buildErrors}
             isEditing
           />
         }
@@ -1409,6 +1411,8 @@ export function ChatRouteContent({
         isSharing={isSharing}
         onDeploy={deployToVercel ? handleDeployApp : undefined}
         isDeploying={isDeploying}
+        compileStatus={openedAppState.compileStatus}
+        buildErrors={openedAppState.buildErrors}
       />
     );
   }

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1382,6 +1382,7 @@ export function ChatRouteContent({
             isDeploying={isDeploying}
             compileStatus={openedAppState.compileStatus}
             buildErrors={openedAppState.buildErrors}
+            reloadGeneration={openedAppState.reloadGeneration}
             isEditing
           />
         }
@@ -1413,6 +1414,7 @@ export function ChatRouteContent({
         isDeploying={isDeploying}
         compileStatus={openedAppState.compileStatus}
         buildErrors={openedAppState.buildErrors}
+        reloadGeneration={openedAppState.reloadGeneration}
       />
     );
   }

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.test.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Verifies the mobile open-app overlay forwards live-build state
+ * (`compileStatus`/`buildErrors`) to `AppViewerContainer`, so the mobile path
+ * surfaces the same non-blocking build-error badge as desktop.
+ *
+ * `AppViewerContainer` pulls in a heavy subtree (sandbox proxy, matchMedia via
+ * `useIsMobile`) that doesn't server-render, so we stub it and assert on the
+ * props the overlay hands down.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { AppViewerContainerProps } from "@/components/app-viewer-container";
+
+const captured: { props?: AppViewerContainerProps } = {};
+const lastProps = (): AppViewerContainerProps | undefined => captured.props;
+mock.module("@/components/app-viewer-container", () => ({
+  AppViewerContainer: (props: AppViewerContainerProps) => {
+    captured.props = props;
+    return null;
+  },
+}));
+
+// Imported AFTER the mock so the component picks up the stub.
+import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
+import type { OpenedAppState } from "@/stores/viewer-store";
+
+const baseAppState: OpenedAppState = {
+  appId: "app-1",
+  name: "My App",
+  html: "<html></html>",
+};
+
+const noopProps = {
+  isAppMinimized: false,
+  assistantId: "assistant-1",
+  onToggleMinimized: () => {},
+  onClose: () => {},
+  onShare: () => {},
+  isSharing: false,
+  isDeploying: false,
+};
+
+describe("MobileAppOverlay", () => {
+  test("forwards compileStatus and buildErrors to AppViewerContainer", () => {
+    captured.props = undefined;
+    renderToStaticMarkup(
+      <MobileAppOverlay
+        {...noopProps}
+        openedAppState={{
+          ...baseAppState,
+          compileStatus: "error",
+          buildErrors: ["TS2322: type error"],
+        }}
+      />,
+    );
+    expect(lastProps()?.compileStatus).toBe("error");
+    expect(lastProps()?.buildErrors).toEqual(["TS2322: type error"]);
+  });
+
+  test("forwards undefined build state when none is present", () => {
+    captured.props = undefined;
+    renderToStaticMarkup(
+      <MobileAppOverlay {...noopProps} openedAppState={baseAppState} />,
+    );
+    expect(lastProps()?.compileStatus).toBeUndefined();
+    expect(lastProps()?.buildErrors).toBeUndefined();
+  });
+});

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -77,6 +77,7 @@ export function MobileAppOverlay({
         route={route}
         compileStatus={openedAppState.compileStatus}
         buildErrors={openedAppState.buildErrors}
+        reloadGeneration={openedAppState.reloadGeneration}
       />
     </div>
   );

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -75,6 +75,8 @@ export function MobileAppOverlay({
         isDeploying={isDeploying}
         isEditing={isAppMinimized}
         route={route}
+        compileStatus={openedAppState.compileStatus}
+        buildErrors={openedAppState.buildErrors}
       />
     </div>
   );

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -1,0 +1,36 @@
+/**
+ * Bus consumer for `app_preview_update` SSE events.
+ *
+ * Live-refreshes the open app preview as the daemon recompiles a multifile
+ * app's source. Each successful recompile (`ok`) carries fresh html and a
+ * bumped `reloadGeneration`, which swaps the preview iframe; `building` and
+ * `error` events update status only and keep the last-good preview visible.
+ *
+ * References:
+ * - EVENT_BUS.md — bus subscription contract
+ * - stores/viewer-store.ts — app viewer state (`updateOpenedAppPreview`)
+ */
+
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Subscribes to `app_preview_update` SSE events via the event bus and forwards
+ * the live-build update to the viewer store.
+ *
+ * Like {@link useDocumentEditorSync}, this takes no `assistantId` — the viewer
+ * store is global and app ids are globally unique. The store action no-ops
+ * unless the event targets the currently active app.
+ */
+export function useAppPreviewSync(): void {
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
+    if (event.type !== "app_preview_update") return;
+    useViewerStore.getState().updateOpenedAppPreview(event.appId, {
+      html: event.html,
+      compileStatus: event.compileStatus,
+      buildErrors: event.buildErrors,
+      reloadGeneration: event.reloadGeneration,
+    });
+  });
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -10,6 +10,7 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
+import { useAppPreviewSync } from "@/hooks/use-app-preview-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
@@ -80,6 +81,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   useDocumentEditorSync();
+  useAppPreviewSync();
 
   useEventBusInit({ assistantId, isAssistantActive });
   // Inbound deep-link navigation + window activation. Mounted here

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -181,6 +181,78 @@ describe("updateOpenedAppPreview", () => {
     });
     expect(getState().openedAppState).toBeNull();
   });
+
+  it("persists reloadGeneration on an ok event", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v2</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    expect(getState().openedAppState?.reloadGeneration).toBe(5);
+  });
+
+  it("updates state on an ok event with identical html but a higher reloadGeneration", () => {
+    openSampleApp();
+    // First ok at generation 1.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 1,
+    });
+    const first = getState().openedAppState;
+    expect(first?.reloadGeneration).toBe(1);
+
+    // A successful recompile to byte-identical html, but a bumped generation:
+    // the backend bumps the generation so clients force-swap the iframe, so
+    // this must NOT be skipped by the no-op guard.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    const second = getState().openedAppState;
+    expect(second?.html).toBe(SAMPLE_APP.html);
+    expect(second?.reloadGeneration).toBe(2);
+    // The state object is a fresh reference so subscribers re-render.
+    expect(second).not.toBe(first);
+  });
+
+  it("no-ops on a truly-identical ok event (same html, generation, and status)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    const before = getState().openedAppState;
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    // Same reference: no set() fired, so no re-render / iframe churn.
+    expect(getState().openedAppState).toBe(before);
+  });
+
+  it("does not advance reloadGeneration on building/error (keep-last-good)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 4,
+    });
+    // A failed recompile carries the daemon's unchanged generation; the stored
+    // generation must stay at the last-good value so the iframe is not swapped.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 4,
+    });
+    expect(getState().openedAppState?.reloadGeneration).toBe(4);
+    expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
+  });
 });
 
 describe("handleAppLoadFailed", () => {

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -81,6 +81,108 @@ describe("setLoadedApp", () => {
   });
 });
 
+describe("updateOpenedAppPreview", () => {
+  function openSampleApp() {
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: SAMPLE_APP.appId,
+      openedAppState: { ...SAMPLE_APP },
+    });
+  }
+
+  it("swaps html and sets status on an ok event for the active app", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v2</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe("<h1>v2</h1>");
+    expect(app?.compileStatus).toBe("ok");
+    expect(app?.buildErrors).toBeUndefined();
+  });
+
+  it("keeps last-good html on a building event (status only)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "building",
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe(SAMPLE_APP.html);
+    expect(app?.compileStatus).toBe("building");
+  });
+
+  it("keeps last-good html on an error event and records buildErrors", () => {
+    openSampleApp();
+    // A fresh ok first, then a failed recompile.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["TS2322: type error"],
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe("<h1>good</h1>");
+    expect(app?.compileStatus).toBe("error");
+    expect(app?.buildErrors).toEqual(["TS2322: type error"]);
+  });
+
+  it("tracks building -> ok -> error, swapping html only on ok", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "building",
+      reloadGeneration: 1,
+    });
+    expect(getState().openedAppState?.html).toBe(SAMPLE_APP.html);
+
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>fresh</h1>");
+
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>fresh</h1>");
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+  });
+
+  it("ignores events for a non-active app", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview("other-app", {
+      html: "<h1>nope</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 9,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe(SAMPLE_APP.html);
+    expect(app?.compileStatus).toBeUndefined();
+  });
+
+  it("no-ops when no app is open", () => {
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>nope</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 1,
+    });
+    expect(getState().openedAppState).toBeNull();
+  });
+});
+
 describe("handleAppLoadFailed", () => {
   it("resets to chat view and clears app state", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1", openedAppState: SAMPLE_APP });

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -112,6 +112,14 @@ export interface OpenedAppState {
   dirName?: string;
   name: string;
   html: string;
+  /**
+   * Live-build status from the daemon's `app_preview_update` stream.
+   * Undefined for apps that haven't received a live-build event (e.g. just
+   * opened). `error` surfaces a non-blocking badge over the last-good html.
+   */
+  compileStatus?: "building" | "ok" | "error";
+  /** Compile diagnostics from the last `error` event; surfaced in the badge. */
+  buildErrors?: string[];
 }
 
 export interface OpenedDocumentState {
@@ -163,6 +171,15 @@ export interface ViewerActions {
   openApp: (appId: string) => void;
   loadApp: (assistantId: string, appId: string) => Promise<void>;
   setLoadedApp: (app: OpenedAppState) => void;
+  updateOpenedAppPreview: (
+    appId: string,
+    update: {
+      html?: string;
+      compileStatus: "building" | "ok" | "error";
+      buildErrors?: string[];
+      reloadGeneration: number;
+    },
+  ) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   toggleAppMinimized: () => void;
@@ -277,6 +294,36 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   setLoadedApp: (app) => {
     set({ openedAppState: app });
+  },
+
+  /**
+   * Apply a daemon `app_preview_update` live-build event to the open app.
+   *
+   * No-ops unless the event targets the currently active app and that app is
+   * already loaded — stale events for a since-closed/switched app are dropped.
+   *
+   * Keep-last-good: only an `ok` event carries fresh html and swaps the
+   * preview (the iframe remounts on html change). `building`/`error` update
+   * the status/errors but leave `html` untouched so the last working preview
+   * stays visible.
+   */
+  updateOpenedAppPreview: (appId, { html, compileStatus, buildErrors }) => {
+    const prev = get().openedAppState;
+    if (!prev || get().activeAppId !== appId || prev.appId !== appId) return;
+    const nextHtml =
+      compileStatus === "ok" && html !== undefined ? html : prev.html;
+    // Skip the update (and the re-render / iframe churn it triggers) when
+    // nothing observable changed — e.g. a repeated `building` heartbeat.
+    if (
+      prev.html === nextHtml &&
+      prev.compileStatus === compileStatus &&
+      prev.buildErrors === buildErrors
+    ) {
+      return;
+    }
+    set({
+      openedAppState: { ...prev, html: nextHtml, compileStatus, buildErrors },
+    });
   },
 
   handleAppLoadFailed: () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -120,6 +120,13 @@ export interface OpenedAppState {
   compileStatus?: "building" | "ok" | "error";
   /** Compile diagnostics from the last `error` event; surfaced in the badge. */
   buildErrors?: string[];
+  /**
+   * Generation counter bumped by the daemon on every SUCCESSFUL recompile
+   * (`compileStatus: "ok"`). Folded into the iframe key so a successful
+   * rebuild force-swaps the preview even when the resolved html is
+   * byte-identical to the currently open one.
+   */
+  reloadGeneration?: number;
 }
 
 export interface OpenedDocumentState {
@@ -303,26 +310,47 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
    * already loaded — stale events for a since-closed/switched app are dropped.
    *
    * Keep-last-good: only an `ok` event carries fresh html and swaps the
-   * preview (the iframe remounts on html change). `building`/`error` update
-   * the status/errors but leave `html` untouched so the last working preview
-   * stays visible.
+   * preview. `building`/`error` update the status/errors but leave `html`
+   * AND `reloadGeneration` untouched so the last working preview stays
+   * visible and the iframe is not remounted on a transient failure.
+   *
+   * The daemon bumps `reloadGeneration` on every successful recompile so
+   * clients force-swap the iframe (it's folded into the iframe key). A
+   * successful rebuild whose resolved html is byte-identical therefore still
+   * remounts the preview — so the no-op guard below only skips when the html,
+   * generation, AND status are all unchanged.
    */
-  updateOpenedAppPreview: (appId, { html, compileStatus, buildErrors }) => {
+  updateOpenedAppPreview: (
+    appId,
+    { html, compileStatus, buildErrors, reloadGeneration },
+  ) => {
     const prev = get().openedAppState;
     if (!prev || get().activeAppId !== appId || prev.appId !== appId) return;
-    const nextHtml =
-      compileStatus === "ok" && html !== undefined ? html : prev.html;
+    const isOk = compileStatus === "ok";
+    const nextHtml = isOk && html !== undefined ? html : prev.html;
+    // Only an `ok` event advances the stored generation; building/error keep
+    // the last-good generation so a transient failure never remounts.
+    const nextGeneration = isOk ? reloadGeneration : prev.reloadGeneration;
     // Skip the update (and the re-render / iframe churn it triggers) when
-    // nothing observable changed — e.g. a repeated `building` heartbeat.
+    // nothing observable changed — e.g. a repeated `building` heartbeat, or a
+    // successful recompile that resolved to byte-identical html AND did not
+    // bump the generation.
     if (
       prev.html === nextHtml &&
+      prev.reloadGeneration === nextGeneration &&
       prev.compileStatus === compileStatus &&
       prev.buildErrors === buildErrors
     ) {
       return;
     }
     set({
-      openedAppState: { ...prev, html: nextHtml, compileStatus, buildErrors },
+      openedAppState: {
+        ...prev,
+        html: nextHtml,
+        compileStatus,
+        buildErrors,
+        reloadGeneration: nextGeneration,
+      },
     });
   },
 


### PR DESCRIPTION
## Summary
- Add a global app-preview sync hook that applies daemon app_preview_update events to the open app (mirrors useDocumentEditorSync)
- viewer-store updateOpenedAppPreview keeps last-good html on building/error and live-swaps the iframe on ok
- Minimal non-blocking build-error badge over the last-good preview (no building overlay by design)

Part of plan: app-live-preview.md (PR 3 of 4)