### PR TITLE
feat(web): add useEffectiveTimezone hook that re-reads on focus and device-setting change

### DIFF
--- a/apps/web/src/utils/use-effective-timezone.test.tsx
+++ b/apps/web/src/utils/use-effective-timezone.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let currentZone = "America/New_York";
+let renderCount = 0;
+
+// The hook re-reads `getEffectiveTimezone` on focus/visibility/override changes,
+// so drive it from a mutable mock we can flip between renders.
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => currentZone,
+}));
+
+// Capture the watcher callback and its cleanup so we can fire the callback
+// directly and assert the cleanup runs on unmount.
+let watchCallback: (() => void) | null = null;
+const unwatch = mock(() => {});
+mock.module("@/utils/device-settings", () => ({
+  watchDeviceSetting: (_name: string, cb: () => void) => {
+    watchCallback = cb;
+    return unwatch;
+  },
+}));
+
+const { useEffectiveTimezone } = await import("@/utils/use-effective-timezone");
+
+function renderTracked() {
+  renderCount = 0;
+  return renderHook(() => {
+    renderCount += 1;
+    return useEffectiveTimezone();
+  });
+}
+
+beforeEach(() => {
+  currentZone = "America/New_York";
+  watchCallback = null;
+  unwatch.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("useEffectiveTimezone", () => {
+  test("initial value equals getEffectiveTimezone()", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(result.current).toBe("America/New_York");
+  });
+
+  test("updates on window focus when the zone changes", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(result.current).toBe("America/New_York");
+
+    currentZone = "Europe/Paris";
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(result.current).toBe("Europe/Paris");
+  });
+
+  test("updates on visibilitychange to visible", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+
+    currentZone = "Asia/Tokyo";
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+    act(() => {
+      window.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe("Asia/Tokyo");
+  });
+
+  test("ignores visibilitychange when not visible", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+
+    currentZone = "Asia/Tokyo";
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    act(() => {
+      window.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe("America/New_York");
+  });
+
+  test("updates when the device:timezone watcher fires", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(watchCallback).not.toBeNull();
+
+    currentZone = "Europe/London";
+    act(() => {
+      watchCallback?.();
+    });
+
+    expect(result.current).toBe("Europe/London");
+  });
+
+  test("calls the watcher cleanup on unmount", () => {
+    const { unmount } = renderHook(() => useEffectiveTimezone());
+    expect(unwatch).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unwatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not re-render when the recomputed value is unchanged", () => {
+    const { result } = renderTracked();
+    const initialRenders = renderCount;
+    expect(result.current).toBe("America/New_York");
+
+    // Zone unchanged — refresh should be a no-op, no extra render.
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(renderCount).toBe(initialRenders);
+    expect(result.current).toBe("America/New_York");
+  });
+});

--- a/apps/web/src/utils/use-effective-timezone.ts
+++ b/apps/web/src/utils/use-effective-timezone.ts
@@ -1,0 +1,47 @@
+/**
+ * Reactive hook for the current effective timezone.
+ *
+ * The browser emits no native event when the OS timezone changes, so there is
+ * nothing to subscribe to for a live zone switch. Instead we re-read the
+ * effective zone on window focus and on `visibilitychange` to visible — the
+ * moments a user is most likely to return after changing their system clock or
+ * crossing a timezone — plus on `device:timezone` setting changes (manual
+ * override) via the device-setting watcher.
+ *
+ * The functional `setTz` update returns the previous reference when the
+ * recomputed zone is unchanged, so React skips the re-render in the common
+ * no-op case.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { watchDeviceSetting } from "@/utils/device-settings";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+
+/** Returns the live effective timezone, updating on focus/visibility/override changes. */
+export function useEffectiveTimezone(): string {
+  const [tz, setTz] = useState(getEffectiveTimezone);
+
+  const refresh = useCallback(() => {
+    setTz((prev) => {
+      const next = getEffectiveTimezone();
+      return next === prev ? prev : next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    window.addEventListener("focus", refresh);
+    window.addEventListener("visibilitychange", onVisibilityChange);
+    const unwatch = watchDeviceSetting("timezone", refresh);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      window.removeEventListener("visibilitychange", onVisibilityChange);
+      unwatch();
+    };
+  }, [refresh]);
+
+  return tz;
+}


### PR DESCRIPTION
## Summary
- Add useEffectiveTimezone() hook returning the live effective zone
- Re-reads on window focus, visibilitychange→visible, and device:timezone changes

Part of plan: fix-timezone-auto-update.md (PR 2 of 6)