### PR TITLE
fix(web): send live clientTimezone with each chat message for temporal grounding

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -22,6 +22,7 @@ import {
 import { persistPreChatOnboardingProfile } from "@/domains/onboarding/prechat-profile";
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 120_000;
@@ -504,6 +505,15 @@ export async function postChatMessage(
     sourceChannel: "vellum",
     interface: "vellum",
   };
+  // Read the effective timezone LIVE at send time (not from cached state) so
+  // every message carries the user's current zone, keeping the assistant's
+  // per-turn time awareness fresh as the OS/browser timezone changes. The
+  // daemon route consumes this field in its turn-timezone cascade (see
+  // `assistant/src/runtime/routes/conversation-routes.ts`, where the request
+  // schema accepts `clientTimezone: z.string().optional()` and forwards it
+  // into `resolveTurnTimezoneContext`).
+  const clientTimezone = getEffectiveTimezone();
+  if (clientTimezone) body.clientTimezone = clientTimezone;
   const conversationField = pickConversationIdWireField();
   if (conversationId !== null || conversationField !== "conversationId") {
     body[conversationField] = conversationId;

--- a/apps/web/src/domains/chat/api/post-chat-message.test.ts
+++ b/apps/web/src/domains/chat/api/post-chat-message.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Mock the effective-timezone resolver so we can control the zone
+// `postChatMessage` reads at send time without touching localStorage/Intl.
+let mockEffectiveTimezone = "America/New_York";
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => mockEffectiveTimezone,
+}));
+
 import { postChatMessage } from "@/domains/chat/api/messages";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -445,5 +452,87 @@ describe("postChatMessage server-minted conversation flow", () => {
     const body = getMessageBody();
     expect(body.conversationKey).toBe("conv-existing");
     expect(body).not.toHaveProperty("conversationId");
+  });
+});
+
+describe("postChatMessage clientTimezone payload", () => {
+  // Every message carries the live effective timezone so the assistant's
+  // per-turn time awareness stays current as the OS/browser zone changes.
+  // The daemon route (`conversation-routes.ts`) consumes `clientTimezone`
+  // in its turn-timezone cascade — no backend change is needed here.
+  let originalFetch: typeof fetch;
+  let originalDocument: unknown;
+  let capturedRequests: Array<{ url: string; body: string }> = [];
+
+  beforeEach(() => {
+    mockEffectiveTimezone = "America/New_York";
+    originalFetch = globalThis.fetch;
+    capturedRequests = [];
+    useAssistantIdentityStore.getState().clearIdentity();
+    originalDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { document?: unknown }).document = { cookie: "csrftoken=test" };
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      let bodyText: string | undefined;
+      if (input instanceof Request) {
+        bodyText = await input.clone().text();
+      } else if (typeof init?.body === "string") {
+        bodyText = init.body;
+      }
+      capturedRequests.push({ url, body: bodyText ?? "" });
+      return new Response(
+        JSON.stringify({
+          accepted: true,
+          messageId: "msg-1",
+          conversationId: "conv-resp-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDocument === undefined) {
+      delete (globalThis as { document?: unknown }).document;
+    } else {
+      (globalThis as { document?: unknown }).document = originalDocument;
+    }
+    useAssistantIdentityStore.getState().clearIdentity();
+  });
+
+  function getMessageBody(): Record<string, unknown> {
+    const requests = capturedRequests.filter((r) => r.url.includes("/messages/"));
+    expect(requests).toHaveLength(1);
+    return JSON.parse(requests[0]!.body) as Record<string, unknown>;
+  }
+
+  test("includes the live effective timezone on the wire", async () => {
+    mockEffectiveTimezone = "Europe/Berlin";
+
+    await postChatMessage("asst-1", "K", "hello");
+
+    const body = getMessageBody();
+    expect(body.clientTimezone).toBe("Europe/Berlin");
+  });
+
+  test("reflects a changed zone on the next message (read live at send time)", async () => {
+    await postChatMessage("asst-1", "K", "first");
+    expect(getMessageBody().clientTimezone).toBe("America/New_York");
+
+    capturedRequests = [];
+    mockEffectiveTimezone = "Asia/Tokyo";
+
+    await postChatMessage("asst-1", "K", "second");
+    expect(getMessageBody().clientTimezone).toBe("Asia/Tokyo");
+  });
+
+  test("omits clientTimezone when the resolver returns an empty string", async () => {
+    mockEffectiveTimezone = "";
+
+    await postChatMessage("asst-1", "K", "hello");
+
+    const body = getMessageBody();
+    expect(body).not.toHaveProperty("clientTimezone");
   });
 });


### PR DESCRIPTION
## Summary
- postChatMessage now reads getEffectiveTimezone() at send time and sets body.clientTimezone
- Daemon route already accepts/forwards clientTimezone; no backend change

Part of plan: fix-timezone-auto-update.md (PR 5 of 6)