### PR TITLE
fix: correct setup-gcloud action SHA in upload-skill-assets workflow

### DIFF
--- a/.github/workflows/upload-skill-assets.yaml
+++ b/.github/workflows/upload-skill-assets.yaml
@@ -26,7 +26,7 @@ jobs:
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v2.1.4
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       - name: Upload skill icons to GCS
         env:


### PR DESCRIPTION
## Summary
- Fixes the `setup-gcloud` action SHA from a non-existent commit to the correct `v2.1.4` tag SHA (`77e7a55`), which was causing the workflow to fail with a startup error on every trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)