### PR TITLE
fix: remove setup-gcloud from upload-skill-assets workflow

### DIFF
--- a/.github/workflows/upload-skill-assets.yaml
+++ b/.github/workflows/upload-skill-assets.yaml
@@ -25,9 +25,6 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
-
       - name: Upload skill icons to GCS
         env:
           BUCKET: ${{ vars.GCS_SKILL_ASSETS_BUCKET }}


### PR DESCRIPTION
## Summary
- Removes `google-github-actions/setup-gcloud` which is not in the org's actions allowlist — `gcloud` is pre-installed on Ubuntu runners (same pattern as `deploy-web-spa.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)