### PR TITLE
fix(web): make usage charts follow the live timezone

### DIFF
--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -8,7 +8,7 @@ import { Dropdown } from "@vellum/design-library";
 import { storePendingInitialMessage } from "@/utils/initial-message-launch";
 import { routes } from "@/utils/routes";
 import { formatCost, formatTokens } from "@/domains/logs/format";
-import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import {
   buildCallSiteMetadataMap,
   fetchUsageCallSiteCatalog,
@@ -92,7 +92,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   );
   const rangeWindow = useMemo(() => resolveRangeWindow(range), [range]);
   const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
-  const [timezone] = useState(getBrowserTimezone);
+  const timezone = useEffectiveTimezone();
 
   const startCostConversation = (message: string) => {
     storePendingInitialMessage(message);

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -90,9 +90,13 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   const [groupBy, setGroupBy] = useState<UsageGroupBy>(
     DEFAULT_USAGE_GROUP_BY,
   );
-  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range]);
-  const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
   const timezone = useEffectiveTimezone();
+  // Depend on `timezone` so bounded ranges (e.g. "Today", "Last 7 days")
+  // recompute their browser-local from/to boundaries when the live zone
+  // changes (OS or `device:timezone` update), keeping them aligned with the
+  // `tz` sent to the backend instead of using stale boundaries.
+  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range, timezone]);
+  const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
 
   const startCostConversation = (message: string) => {
     storePendingInitialMessage(message);


### PR DESCRIPTION
## Summary
- Replace cached useState(getBrowserTimezone) with reactive useEffectiveTimezone()
- Usage queries re-key and refetch when the zone changes

Part of plan: fix-timezone-auto-update.md (PR 3 of 6)