### PR TITLE
fix(web): use app.resume bus signal for timezone visibility refresh (addresses Codex review)

### DIFF
--- a/apps/web/src/utils/use-effective-timezone.test.tsx
+++ b/apps/web/src/utils/use-effective-timezone.test.tsx
@@ -21,6 +21,21 @@ mock.module("@/utils/device-settings", () => ({
   },
 }));
 
+// The hook subscribes to the cross-domain bus `app.resume` signal via
+// `useBusSubscription`, which calls `subscribe` from `@/lib/event-bus`.
+// Capture the registered event + handler so we can invoke it directly, and
+// expose an unsubscribe mock so we can assert teardown on unmount.
+let busEvent: string | null = null;
+let busHandler: (() => void) | null = null;
+const busUnsubscribe = mock(() => {});
+mock.module("@/lib/event-bus", () => ({
+  subscribe: (event: string, handler: () => void) => {
+    busEvent = event;
+    busHandler = handler;
+    return busUnsubscribe;
+  },
+}));
+
 const { useEffectiveTimezone } = await import("@/utils/use-effective-timezone");
 
 function renderTracked() {
@@ -34,7 +49,10 @@ function renderTracked() {
 beforeEach(() => {
   currentZone = "America/New_York";
   watchCallback = null;
+  busEvent = null;
+  busHandler = null;
   unwatch.mockClear();
+  busUnsubscribe.mockClear();
   localStorage.clear();
 });
 
@@ -61,34 +79,21 @@ describe("useEffectiveTimezone", () => {
     expect(result.current).toBe("Europe/Paris");
   });
 
-  test("updates on visibilitychange to visible", () => {
+  test("subscribes to the bus `app.resume` signal", () => {
+    renderHook(() => useEffectiveTimezone());
+    expect(busEvent).toBe("app.resume");
+    expect(busHandler).not.toBeNull();
+  });
+
+  test("updates when the bus `app.resume` signal fires", () => {
     const { result } = renderHook(() => useEffectiveTimezone());
 
     currentZone = "Asia/Tokyo";
-    Object.defineProperty(document, "visibilityState", {
-      value: "visible",
-      configurable: true,
-    });
     act(() => {
-      window.dispatchEvent(new Event("visibilitychange"));
+      busHandler?.();
     });
 
     expect(result.current).toBe("Asia/Tokyo");
-  });
-
-  test("ignores visibilitychange when not visible", () => {
-    const { result } = renderHook(() => useEffectiveTimezone());
-
-    currentZone = "Asia/Tokyo";
-    Object.defineProperty(document, "visibilityState", {
-      value: "hidden",
-      configurable: true,
-    });
-    act(() => {
-      window.dispatchEvent(new Event("visibilitychange"));
-    });
-
-    expect(result.current).toBe("America/New_York");
   });
 
   test("updates when the device:timezone watcher fires", () => {
@@ -103,13 +108,15 @@ describe("useEffectiveTimezone", () => {
     expect(result.current).toBe("Europe/London");
   });
 
-  test("calls the watcher cleanup on unmount", () => {
+  test("calls the watcher and bus cleanups on unmount", () => {
     const { unmount } = renderHook(() => useEffectiveTimezone());
     expect(unwatch).not.toHaveBeenCalled();
+    expect(busUnsubscribe).not.toHaveBeenCalled();
 
     unmount();
 
     expect(unwatch).toHaveBeenCalledTimes(1);
+    expect(busUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
   test("does not re-render when the recomputed value is unchanged", () => {

--- a/apps/web/src/utils/use-effective-timezone.ts
+++ b/apps/web/src/utils/use-effective-timezone.ts
@@ -3,10 +3,15 @@
  *
  * The browser emits no native event when the OS timezone changes, so there is
  * nothing to subscribe to for a live zone switch. Instead we re-read the
- * effective zone on window focus and on `visibilitychange` to visible — the
- * moments a user is most likely to return after changing their system clock or
- * crossing a timezone — plus on `device:timezone` setting changes (manual
- * override) via the device-setting watcher.
+ * effective zone on window focus and on the cross-domain bus `app.resume`
+ * signal — the moments a user is most likely to return after changing their
+ * system clock or crossing a timezone — plus on `device:timezone` setting
+ * changes (manual override) via the device-setting watcher.
+ *
+ * Visibility is intentionally not listened to directly here: the EVENT_BUS
+ * convention reserves `document` visibility listeners to
+ * `runtime/event-sources/dom-visibility.ts`, which publishes `app.resume`
+ * (fanning in page visibility, Capacitor app-state, and network-online).
  *
  * The functional `setTz` update returns the previous reference when the
  * recomputed zone is unchanged, so React skips the re-render in the common
@@ -15,10 +20,11 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { watchDeviceSetting } from "@/utils/device-settings";
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
 
-/** Returns the live effective timezone, updating on focus/visibility/override changes. */
+/** Returns the live effective timezone, updating on focus/resume/override changes. */
 export function useEffectiveTimezone(): string {
   const [tz, setTz] = useState(getEffectiveTimezone);
 
@@ -29,16 +35,13 @@ export function useEffectiveTimezone(): string {
     });
   }, []);
 
+  useBusSubscription("app.resume", refresh);
+
   useEffect(() => {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") refresh();
-    };
     window.addEventListener("focus", refresh);
-    window.addEventListener("visibilitychange", onVisibilityChange);
     const unwatch = watchDeviceSetting("timezone", refresh);
     return () => {
       window.removeEventListener("focus", refresh);
-      window.removeEventListener("visibilitychange", onVisibilityChange);
       unwatch();
     };
   }, [refresh]);


### PR DESCRIPTION
## Summary
- Replace raw window visibilitychange listener with the centralized app.resume event-bus subscription
- Matches EVENT_BUS convention (visibility listeners reserved to dom-visibility.ts); keeps focus + device:timezone triggers
- Addresses Codex P2 review feedback on PR #33029

Part of plan: fix-timezone-auto-update.md (follow-up to PR 2)