### PR TITLE
fix(web): make billing usage queries follow the live timezone

### DIFF
--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -5,7 +5,9 @@ import {
   type DropdownOption,
 } from "@vellum/design-library/components/dropdown";
 
-import { toLocalDateString } from "@/components/charts/format-date-label";
+import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export interface DateRange {
   readonly from: string;
@@ -25,14 +27,24 @@ const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = [
   { value: "90", label: "Last 90 days" },
 ];
 
-function computeRange(days: number): DateRange {
-  const today = new Date();
-  const from = new Date(today);
-  from.setDate(today.getDate() - (days - 1));
-  return {
-    from: toLocalDateString(from),
-    to: toLocalDateString(today),
-  };
+/**
+ * Compute a "last N days" range whose calendar bounds are expressed in the
+ * given IANA timezone, so they stay aligned with the `tz` sent to the backend.
+ *
+ * "Today" is the calendar date in `tz`; the lower bound is that date minus
+ * `days - 1`. Day arithmetic runs on a UTC date anchored at noon to avoid DST
+ * edge slips when subtracting whole days.
+ */
+export function computeRangeInTimezone(
+  days: number,
+  tz: string = getEffectiveTimezone(),
+): DateRange {
+  const to = toTimezoneDateString(new Date(), tz);
+  const [y, m, d] = to.split("-").map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - (days - 1));
+  const from = toTimezoneDateString(anchor, "UTC");
+  return { from, to };
 }
 
 function daysBetween(from: string, to: string): number {
@@ -43,6 +55,8 @@ function daysBetween(from: string, to: string): number {
 }
 
 export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
+  const tz = useEffectiveTimezone();
+
   const selectedPreset = useMemo<PresetDays>(() => {
     const days = daysBetween(value.from, value.to);
     if (days === 7) return "7";
@@ -51,7 +65,7 @@ export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   }, [value.from, value.to]);
 
   const handleChange = (preset: PresetDays) => {
-    onChange(computeRange(Number(preset)));
+    onChange(computeRangeInTimezone(Number(preset), tz));
   };
 
   return (

--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -15,3 +15,16 @@ export function toLocalDateString(d: Date): string {
   const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
 }
+
+/**
+ * Format a `Date` as a "YYYY-MM-DD" string representing the calendar date in
+ * the given IANA timezone. `en-CA` yields ISO-like `YYYY-MM-DD` output.
+ */
+export function toTimezoneDateString(d: Date, tz: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -3,8 +3,16 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
+  getDefaultDateRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function daysApart(from: string, to: string): number {
+  const ms = Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`);
+  return Math.round(ms / 86_400_000) + 1;
+}
 
 function makeState(): UsageChartState {
   return {
@@ -30,6 +38,29 @@ describe("buildBillingUsageTotalsQuery", () => {
     expect(query.tz).toBe("America/New_York");
     expect(query.from).toBe("2026-01-01");
     expect(query.to).toBe("2026-01-31");
+  });
+});
+
+describe("getDefaultDateRange", () => {
+  test("computes a 30-day range as YYYY-MM-DD bounds in the given tz", () => {
+    const { from, to } = getDefaultDateRange("America/New_York");
+    expect(from).toMatch(DATE_RE);
+    expect(to).toMatch(DATE_RE);
+    expect(daysApart(from, to)).toBe(30);
+  });
+
+  test("uses the supplied tz so dates can differ from another zone at a boundary", () => {
+    // Across a wide UTC offset gap, the calendar 'today' can differ. We assert
+    // each zone yields a self-consistent, well-formed 30-day range; at the
+    // right instant Kiritimati (UTC+14) and Niue (UTC-11) sit on different
+    // calendar days, so the computed bounds are independent per zone.
+    const east = getDefaultDateRange("Pacific/Kiritimati");
+    const west = getDefaultDateRange("Pacific/Niue");
+    for (const r of [east, west]) {
+      expect(r.from).toMatch(DATE_RE);
+      expect(r.to).toMatch(DATE_RE);
+      expect(daysApart(r.from, r.to)).toBe(30);
+    }
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  buildBillingUsageSeriesQuery,
+  buildBillingUsageTotalsQuery,
+  type UsageChartState,
+} from "./use-billing-usage-data";
+
+function makeState(): UsageChartState {
+  return {
+    dateRange: { from: "2026-01-01", to: "2026-01-31" },
+    setDateRange: () => {},
+    drilldown: null,
+    setDrilldown: () => {},
+  };
+}
+
+describe("buildBillingUsageSeriesQuery", () => {
+  test("uses the explicit tz argument", () => {
+    const query = buildBillingUsageSeriesQuery(makeState(), "America/New_York");
+    expect(query.tz).toBe("America/New_York");
+    expect(query.from).toBe("2026-01-01");
+    expect(query.to).toBe("2026-01-31");
+  });
+});
+
+describe("buildBillingUsageTotalsQuery", () => {
+  test("uses the explicit tz argument", () => {
+    const query = buildBillingUsageTotalsQuery(makeState(), "America/New_York");
+    expect(query.tz).toBe("America/New_York");
+    expect(query.from).toBe("2026-01-01");
+    expect(query.to).toBe("2026-01-31");
+  });
+});
+
+describe("default tz resolution", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("defaults to getEffectiveTimezone() for both builders", async () => {
+    mock.module("@/utils/effective-timezone", () => ({
+      getEffectiveTimezone: () => "Europe/Berlin",
+    }));
+
+    // Re-import after mocking so the builders pick up the mocked default.
+    const { buildBillingUsageSeriesQuery: buildSeries, buildBillingUsageTotalsQuery: buildTotals } =
+      await import("./use-billing-usage-data");
+
+    expect(buildSeries(makeState()).tz).toBe("Europe/Berlin");
+    expect(buildTotals(makeState()).tz).toBe("Europe/Berlin");
+  });
+});

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 
-import type { DateRange } from "@/components/charts/date-range-select";
-import { toLocalDateString } from "@/components/charts/format-date-label";
+import {
+  type DateRange,
+  computeRangeInTimezone,
+} from "@/components/charts/date-range-select";
 import {
   organizationsBillingUsageSeriesRetrieveOptions,
   organizationsBillingUsageTotalsRetrieveOptions,
@@ -18,14 +20,12 @@ import {
 } from "@/utils/llm-dimension";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
-export function getDefaultDateRange(): DateRange {
-  const today = new Date();
-  const from = new Date(today);
-  from.setDate(from.getDate() - 29);
-  return {
-    from: toLocalDateString(from),
-    to: toLocalDateString(today),
-  };
+/**
+ * Default "Last 30 days" range, with calendar bounds computed in the effective
+ * timezone so they stay aligned with the `tz` sent to the billing backend.
+ */
+export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRange {
+  return computeRangeInTimezone(30, tz);
 }
 
 export type UsageChartState = {

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -10,12 +10,13 @@ import type {
   OrganizationsBillingUsageSeriesRetrieveData,
   OrganizationsBillingUsageTotalsRetrieveData,
 } from "@/generated/api/types.gen";
-import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import {
   DEFAULT_LLM_USAGE_DIMENSION,
   type LlmUsageDimension,
   toBillingGroupBy,
 } from "@/utils/llm-dimension";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function getDefaultDateRange(): DateRange {
   const today = new Date();
@@ -57,7 +58,7 @@ export function getBillingUsageGroupBy(
 
 export function buildBillingUsageSeriesQuery(
   state: UsageChartState,
-  tz: string = getBrowserTimezone(),
+  tz: string = getEffectiveTimezone(),
 ): NonNullable<OrganizationsBillingUsageSeriesRetrieveData["query"]> {
   return {
     from: state.dateRange.from,
@@ -74,7 +75,7 @@ export function buildBillingUsageSeriesQuery(
 
 export function buildBillingUsageTotalsQuery(
   state: UsageChartState,
-  tz: string = getBrowserTimezone(),
+  tz: string = getEffectiveTimezone(),
 ): NonNullable<OrganizationsBillingUsageTotalsRetrieveData["query"]> {
   return {
     from: state.dateRange.from,
@@ -87,15 +88,17 @@ export function buildBillingUsageTotalsQuery(
 }
 
 export function useBillingUsageData(state: UsageChartState) {
+  const tz = useEffectiveTimezone();
+
   const seriesQuery = useQuery(
     organizationsBillingUsageSeriesRetrieveOptions({
-      query: buildBillingUsageSeriesQuery(state),
+      query: buildBillingUsageSeriesQuery(state, tz),
     }),
   );
 
   const totalsQuery = useQuery(
     organizationsBillingUsageTotalsRetrieveOptions({
-      query: buildBillingUsageTotalsQuery(state),
+      query: buildBillingUsageTotalsQuery(state, tz),
     }),
   );
 


### PR DESCRIPTION
## Summary
- useBillingUsageData now passes reactive useEffectiveTimezone() into both builders
- Builder tz defaults switched from getBrowserTimezone() to getEffectiveTimezone()

Part of plan: fix-timezone-auto-update.md (PR 4 of 6)