### PR TITLE
feat(web): auto-open the side-by-side app panel when an app build begins

### DIFF
--- a/apps/web/src/hooks/use-app-preview-sync.test.tsx
+++ b/apps/web/src/hooks/use-app-preview-sync.test.tsx
@@ -122,6 +122,29 @@ describe("useAppPreviewSync auto-open", () => {
     expect(useViewerStore.getState().mainView).toBe("app-editing");
   });
 
+  test("a terminal ok does not yank the user back after they navigate away mid-build", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // Build starts → panel opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    // User navigates away to a document — a path that does NOT mark the app
+    // as dismissed.
+    useViewerStore.setState({ mainView: "document", activeAppId: null });
+    // The terminal `ok` for the same build arrives — it must NOT reopen the
+    // split-view.
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    expect(useViewerStore.getState().mainView).toBe("document");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("a terminal error does not auto-open a not-yet-open app", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // A terminal status with no prior build-start for this app: must not open.
+    emitPreview("app-1", "error", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
   test("does not auto-open when the assistant is not active", () => {
     renderHook(() =>
       useAppPreviewSync({ ...DESKTOP_ACTIVE, isAssistantActive: false }),

--- a/apps/web/src/hooks/use-app-preview-sync.test.tsx
+++ b/apps/web/src/hooks/use-app-preview-sync.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+import { __resetForTesting, publish } from "@/lib/event-bus";
+
+// `revealAppForBuild` → `loadApp`'s fetch hits `appsByIdOpenPost`. Mock the
+// daemon SDK so the call resolves in-process (the synchronous view
+// transition under test lands first) and no unhandled rejection escapes.
+// Bun's `mock.module` leaks across files — run this file on its own.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  appsByIdOpenPost: () =>
+    Promise.resolve({
+      data: { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" },
+    }),
+  documentsByIdGet: () => Promise.resolve({ data: null }),
+}));
+
+const { useAppPreviewSync } = await import("@/hooks/use-app-preview-sync");
+const { useViewerStore } = await import("@/stores/viewer-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+
+function emitPreview(
+  appId: string,
+  compileStatus: "building" | "ok" | "error",
+  opts: { conversationId?: string; reloadGeneration?: number; html?: string } = {},
+): void {
+  publish("sse.event", {
+    id: "evt-1",
+    conversationId: opts.conversationId,
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: "app_preview_update",
+      appId,
+      html: opts.html ?? "<h1>App</h1>",
+      compileStatus,
+      reloadGeneration: opts.reloadGeneration ?? 0,
+    },
+  } as unknown as AssistantEventEnvelope);
+}
+
+type Params = Parameters<typeof useAppPreviewSync>[0];
+const DESKTOP_ACTIVE: Params = {
+  assistantId: "asst-1",
+  isAssistantActive: true,
+  isMobile: false,
+};
+
+beforeEach(() => {
+  __resetForTesting();
+  useViewerStore.getState().reset();
+  useConversationStore.getState().reset();
+  useConversationStore.getState().setActiveConversationId("conv-1");
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useAppPreviewSync auto-open", () => {
+  test("a first building event for a non-open app opens the app-editing split", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("app-editing");
+    expect(viewer.activeAppId).toBe("app-1");
+    // The edit-chat target is set so the desktop branch renders.
+    expect(useConversationStore.getState().editingConversationId).toBe("conv-1");
+  });
+
+  test("falls back to the active conversation when the envelope omits one", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building");
+    expect(useConversationStore.getState().editingConversationId).toBe("conv-1");
+  });
+
+  test("does not disrupt an app that is already open", () => {
+    useViewerStore.setState({
+      mainView: "app-editing",
+      activeAppId: "app-1",
+      openedAppState: {
+        appId: "app-1",
+        dirName: "my-app",
+        name: "My App",
+        html: "<h1>App</h1>",
+      },
+    });
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("app-editing");
+    expect(viewer.activeAppId).toBe("app-1");
+  });
+
+  test("does not re-open an app dismissed during the same build", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // Build starts → panel opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    // User closes the panel mid-build.
+    useViewerStore.getState().closeApp();
+    expect(useViewerStore.getState().dismissedBuildAppId).toBe("app-1");
+    // Subsequent events for the SAME build do not pop it back open.
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 2 });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("a fresh build sequence re-opens after a dismissal", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    // User closes mid/after build.
+    useViewerStore.getState().closeApp();
+    expect(useViewerStore.getState().dismissedBuildAppId).toBe("app-1");
+    // A NEW build sequence begins (building after a terminal ok) → the
+    // hook clears the dismissal and the panel re-opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().dismissedBuildAppId).toBeNull();
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+  });
+
+  test("does not auto-open when the assistant is not active", () => {
+    renderHook(() =>
+      useAppPreviewSync({ ...DESKTOP_ACTIVE, isAssistantActive: false }),
+    );
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("does not auto-open when there is no active assistant", () => {
+    renderHook(() => useAppPreviewSync({ ...DESKTOP_ACTIVE, assistantId: null }));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
+  test("does not force the split on mobile", () => {
+    renderHook(() => useAppPreviewSync({ ...DESKTOP_ACTIVE, isMobile: true }));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -79,19 +79,23 @@ export function useAppPreviewSync({
     });
 
     // (2) Auto-open the split-view for a build that just started.
+    //
+    // A fresh build sequence: the first `building` event we've seen for this
+    // app, or a `building` event that follows a terminal status. This is the
+    // ONLY signal that may auto-open the panel — terminal `ok`/`error` events
+    // must never reveal it. Otherwise, if the user navigates away to a
+    // document/tool-detail/other view mid-build, the terminal event for the
+    // same build would yank them back into `app-editing`.
     const prevStatus = lastStatusByApp.current.get(event.appId);
     lastStatusByApp.current.set(event.appId, event.compileStatus);
-    // A fresh build sequence: the first event we've seen for this app, or a
-    // `building` event that follows a terminal status. Use this as the
-    // "build started" signal AND to reset a prior user dismissal so the
-    // next build re-opens the panel.
+    if (event.compileStatus !== "building") return;
     const isFreshBuildStart =
       prevStatus === undefined ||
-      (event.compileStatus === "building" &&
-        (prevStatus === "ok" || prevStatus === "error"));
-    if (isFreshBuildStart) {
-      viewer.clearBuildDismissal(event.appId);
-    }
+      prevStatus === "ok" ||
+      prevStatus === "error";
+    if (!isFreshBuildStart) return;
+    // Reset a prior user dismissal so this fresh build re-opens the panel.
+    viewer.clearBuildDismissal(event.appId);
 
     // Mobile keeps the existing overlay path — don't force the split.
     // Gate on the active assistant so a background/transitioning assistant

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -1,36 +1,121 @@
 /**
  * Bus consumer for `app_preview_update` SSE events.
  *
- * Live-refreshes the open app preview as the daemon recompiles a multifile
- * app's source. Each successful recompile (`ok`) carries fresh html and a
- * bumped `reloadGeneration`, which swaps the preview iframe; `building` and
- * `error` events update status only and keep the last-good preview visible.
+ * Two responsibilities, both driven off the daemon's live-build stream:
+ *
+ * 1. **Hot-reload the open preview** — forward every event to
+ *    `updateOpenedAppPreview`, which swaps the iframe on a successful
+ *    recompile and surfaces a build-error badge otherwise (PR 3). That
+ *    action no-ops unless the event targets the currently active app.
+ * 2. **Auto-open the split-view** — when a build begins for an app that
+ *    is NOT currently open, pop open the desktop chat-left / preview-right
+ *    panel (`revealAppForBuild`) so the user watches it build side-by-side
+ *    (Lovable-style). Desktop-only; gated on the active assistant.
+ *
+ * Assistant/conversation gating: the bus-owned SSE connection is
+ * assistant-scoped (`sseService.attach(assistantId)` is re-attached when
+ * the active assistant changes), so every `sse.event` already belongs to
+ * the currently-active assistant — there is no `assistantId` on the
+ * `app_preview_update` payload to filter on. We additionally gate on the
+ * caller-supplied active `assistantId` + `isAssistantActive` (the same
+ * pattern as `useConversationSync`) so a background/transitioning
+ * assistant never yanks a panel open, and so we have the id `loadApp`
+ * needs. The envelope's `conversationId` becomes the edit-chat target so
+ * the desktop `app-editing` branch (which requires `editingConversationId`)
+ * actually renders for the conversation the user is viewing.
  *
  * References:
  * - EVENT_BUS.md — bus subscription contract
- * - stores/viewer-store.ts — app viewer state (`updateOpenedAppPreview`)
+ * - hooks/use-conversation-sync.ts — the active-assistant gating pattern
+ * - stores/viewer-store.ts — app viewer state + `revealAppForBuild`
  */
+
+import { useRef } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
+interface UseAppPreviewSyncParams {
+  /** Active assistant id (owner of the bus SSE connection). */
+  assistantId: string | null;
+  /** Whether that assistant is in the `active` lifecycle phase. */
+  isAssistantActive: boolean;
+  /**
+   * Mobile viewport. On mobile the desktop split-view doesn't exist, so we
+   * never force it open — the existing `MobileAppOverlay` path is unchanged.
+   */
+  isMobile: boolean;
+}
+
 /**
- * Subscribes to `app_preview_update` SSE events via the event bus and forwards
- * the live-build update to the viewer store.
- *
- * Like {@link useDocumentEditorSync}, this takes no `assistantId` — the viewer
- * store is global and app ids are globally unique. The store action no-ops
- * unless the event targets the currently active app.
+ * Subscribes to `app_preview_update` SSE events via the event bus,
+ * forwards the live-build update to the open preview, and auto-opens the
+ * side-by-side panel when a build begins for a not-yet-open app.
  */
-export function useAppPreviewSync(): void {
+export function useAppPreviewSync({
+  assistantId,
+  isAssistantActive,
+  isMobile,
+}: UseAppPreviewSyncParams): void {
+  // Last seen compile status per app, so we can detect when a *fresh*
+  // build sequence begins (first event, or a `building` that follows a
+  // terminal `ok`/`error`). A ref — this is per-event bookkeeping, not
+  // render-visible state.
+  const lastStatusByApp = useRef(new Map<string, "building" | "ok" | "error">());
+
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "app_preview_update") return;
-    useViewerStore.getState().updateOpenedAppPreview(event.appId, {
+
+    const viewer = useViewerStore.getState();
+
+    // (1) Hot-reload the open preview (no-ops unless this is the active app).
+    viewer.updateOpenedAppPreview(event.appId, {
       html: event.html,
       compileStatus: event.compileStatus,
       buildErrors: event.buildErrors,
       reloadGeneration: event.reloadGeneration,
     });
+
+    // (2) Auto-open the split-view for a build that just started.
+    const prevStatus = lastStatusByApp.current.get(event.appId);
+    lastStatusByApp.current.set(event.appId, event.compileStatus);
+    // A fresh build sequence: the first event we've seen for this app, or a
+    // `building` event that follows a terminal status. Use this as the
+    // "build started" signal AND to reset a prior user dismissal so the
+    // next build re-opens the panel.
+    const isFreshBuildStart =
+      prevStatus === undefined ||
+      (event.compileStatus === "building" &&
+        (prevStatus === "ok" || prevStatus === "error"));
+    if (isFreshBuildStart) {
+      viewer.clearBuildDismissal(event.appId);
+    }
+
+    // Mobile keeps the existing overlay path — don't force the split.
+    // Gate on the active assistant so a background/transitioning assistant
+    // never yanks a panel open.
+    if (isMobile || !assistantId || !isAssistantActive) return;
+    // Bail early when `revealAppForBuild` would no-op anyway — the user is
+    // already viewing this app, or dismissed it for the current build — so
+    // we don't disturb their edit-chat target. Mirrors the store guards.
+    // Re-read state here: `clearBuildDismissal` above may have just cleared
+    // the flag, and the `viewer` snapshot taken earlier would be stale.
+    const current = useViewerStore.getState();
+    const alreadyViewing =
+      current.activeAppId === event.appId &&
+      (current.mainView === "app" || current.mainView === "app-editing");
+    if (alreadyViewing || current.dismissedBuildAppId === event.appId) return;
+    // Set the edit-chat target to the conversation driving this build so
+    // the desktop `app-editing` branch renders. Fall back to the active
+    // conversation when the envelope omits it.
+    const conversationId =
+      envelope.conversationId ??
+      useConversationStore.getState().activeConversationId;
+    if (conversationId) {
+      useConversationStore.getState().setEditingConversationId(conversationId);
+    }
+    current.revealAppForBuild(assistantId, event.appId);
   });
 }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -81,7 +81,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   useDocumentEditorSync();
-  useAppPreviewSync();
+  useAppPreviewSync({ assistantId, isAssistantActive, isMobile });
 
   useEventBusInit({ assistantId, isAssistantActive });
   // Inbound deep-link navigation + window activation. Mounted here

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -1,4 +1,18 @@
-import { beforeEach, describe, it, expect } from "bun:test";
+import { beforeEach, describe, it, expect, mock } from "bun:test";
+
+// `revealAppForBuild`/`loadApp` fire `appsByIdOpenPost` to fetch the first
+// frame. Mock the daemon SDK so the network call resolves in-process —
+// the synchronous view transition (the part under test) lands before the
+// resolved fetch settles, and the mock prevents an unhandled rejection.
+// Bun's `mock.module` leaks across files, so run this file on its own
+// (`bun test src/stores/viewer-store.test.ts`) per apps/web testing notes.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  appsByIdOpenPost: () =>
+    Promise.resolve({
+      data: { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" },
+    }),
+  documentsByIdGet: () => Promise.resolve({ data: null }),
+}));
 
 import {
   isAppNotFoundError,
@@ -275,6 +289,85 @@ describe("closeApp", () => {
     expect(state.activeAppId).toBeNull();
     expect(state.openedAppState).toBeNull();
     expect(state.isAppMinimized).toBe(false);
+  });
+});
+
+describe("closeApp build dismissal", () => {
+  it("records the closed app as dismissed for the current build", () => {
+    useViewerStore.setState({ mainView: "app-editing", activeAppId: "app-1" });
+    getState().closeApp();
+    expect(getState().dismissedBuildAppId).toBe("app-1");
+  });
+
+  it("re-opening an app clears its stale dismissal (openApp/loadApp)", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().openApp("app-1");
+    expect(getState().dismissedBuildAppId).toBeNull();
+  });
+});
+
+describe("clearBuildDismissal", () => {
+  it("clears the flag when the appId matches", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().clearBuildDismissal("app-1");
+    expect(getState().dismissedBuildAppId).toBeNull();
+  });
+
+  it("is a no-op when the appId does not match", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().clearBuildDismissal("app-2");
+    expect(getState().dismissedBuildAppId).toBe("app-1");
+  });
+});
+
+describe("revealAppForBuild", () => {
+  it("opens the app-editing split-view and sets activeAppId for a not-open app", () => {
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    expect(state.mainView).toBe("app-editing");
+    expect(state.activeAppId).toBe("app-1");
+    expect(state.isAppMinimized).toBe(false);
+  });
+
+  it("does not disrupt an app the user is already viewing (app view)", () => {
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: "app-1",
+      openedAppState: SAMPLE_APP,
+    });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    // Stays in the full-width app view — not yanked into the split.
+    expect(state.mainView).toBe("app");
+    expect(state.openedAppState).toBe(SAMPLE_APP);
+  });
+
+  it("does not disrupt an app the user is already editing (app-editing view)", () => {
+    useViewerStore.setState({
+      mainView: "app-editing",
+      activeAppId: "app-1",
+      openedAppState: SAMPLE_APP,
+    });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    expect(getState().mainView).toBe("app-editing");
+    expect(getState().openedAppState).toBe(SAMPLE_APP);
+  });
+
+  it("does not re-open an app the user dismissed during the current build", () => {
+    useViewerStore.setState({ mainView: "chat", dismissedBuildAppId: "app-1" });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeAppId).toBeNull();
+  });
+
+  it("opens despite a dismissal recorded for a DIFFERENT app", () => {
+    useViewerStore.setState({ mainView: "chat", dismissedBuildAppId: "app-2" });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    expect(getState().mainView).toBe("app-editing");
+    expect(getState().activeAppId).toBe("app-1");
+    // The other app's dismissal is untouched.
+    expect(getState().dismissedBuildAppId).toBe("app-2");
   });
 });
 

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -82,6 +82,42 @@ export function isAppNotFoundError(err: unknown): boolean {
   return typeof message === "string" && message.startsWith("App not found");
 }
 
+/**
+ * Fetch an app's html and store it as `openedAppState`, WITHOUT touching
+ * `mainView` — the caller owns the view transition (`loadApp` → `"app"`,
+ * `revealAppForBuild` → `"app-editing"`). Bails out if the active app
+ * changed while the request was in flight. Shared so both callers get the
+ * same 404-tolerance + cache-priming behavior.
+ */
+async function fetchAndSetApp(
+  set: (partial: Partial<ViewerState>) => void,
+  get: () => ViewerStore,
+  assistantId: string,
+  appId: string,
+): Promise<void> {
+  try {
+    const { data: result } = await appsByIdOpenPost({
+      path: { assistant_id: assistantId, id: appId },
+      throwOnError: true,
+    });
+    if (get().activeAppId !== appId) return;
+    const app = { appId: result.appId, dirName: result.dirName, name: result.name, html: result.html };
+    set({ openedAppState: app });
+    primeAppHtmlCache(assistantId, result.appId, result.html);
+  } catch (err) {
+    if (get().activeAppId !== appId) return;
+    // 404s here are an expected condition (app was deleted on the
+    // server but the client still has a reference). Skip the Sentry
+    // capture for those — the daemon already returns a structured
+    // `{ code: "NOT_FOUND", message }` body — and let the UI fall
+    // back to chat as below. Unexpected failures still report.
+    if (!isAppNotFoundError(err)) {
+      captureError(err, { context: "openApp" });
+    }
+    set({ mainView: "chat", activeAppId: null, openedAppState: null });
+  }
+}
+
 function resolveViewBefore(
   state: ViewerState,
   field: "viewBeforeDocument" | "viewBeforeSubagentDetail" | "viewBeforeToolDetail",
@@ -157,6 +193,14 @@ export interface ViewerState {
   mainView: MainView;
   activeAppId: string | null;
   openedAppState: OpenedAppState | null;
+  /**
+   * App id the user explicitly dismissed (closed/exited) during the
+   * current build, so the auto-open (`revealAppForBuild`) does not fight
+   * the user by popping the panel back open for that same build. Reset
+   * to `null` when a fresh build sequence begins for a different app, or
+   * when the user reopens an app. Transient UI state, not persisted.
+   */
+  dismissedBuildAppId: string | null;
   activeDocumentSurfaceId: string | null;
   openedDocumentState: OpenedDocumentState | null;
   isAppMinimized: boolean;
@@ -177,6 +221,13 @@ export interface ViewerActions {
   // --- App viewer ---
   openApp: (appId: string) => void;
   loadApp: (assistantId: string, appId: string) => Promise<void>;
+  /**
+   * Auto-open the chat-left / preview-right split-view for an app whose
+   * build just started (driven by the first `app_preview_update` event).
+   * Sets `mainView: "app-editing"` + `activeAppId` and loads the first
+   * frame; live `app_preview_update`s then hot-swap the preview (PR 3).
+   */
+  revealAppForBuild: (assistantId: string, appId: string) => void;
   setLoadedApp: (app: OpenedAppState) => void;
   updateOpenedAppPreview: (
     appId: string,
@@ -189,6 +240,13 @@ export interface ViewerActions {
   ) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
+  /**
+   * Clear the build-dismissal flag for `appId` (no-op if it doesn't
+   * match), letting `revealAppForBuild` auto-open the panel again on the
+   * NEXT build. Called by the app-preview hook when a fresh build
+   * sequence begins for an app the user previously dismissed.
+   */
+  clearBuildDismissal: (appId: string) => void;
   toggleAppMinimized: () => void;
   handleAppUnpinned: (appId: string) => boolean;
   enterAppEditing: () => void;
@@ -227,6 +285,7 @@ const INITIAL_STATE: ViewerState = {
   mainView: "chat",
   activeAppId: null,
   openedAppState: null,
+  dismissedBuildAppId: null,
   activeDocumentSurfaceId: null,
   openedDocumentState: null,
   isAppMinimized: false,
@@ -266,6 +325,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeAppId: appId,
       openedAppState: null,
       isAppMinimized: false,
+      // Re-opening an app clears any stale dismissal for it so a later
+      // build's auto-open isn't suppressed by an old close.
+      dismissedBuildAppId: null,
     });
   },
 
@@ -275,28 +337,39 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeAppId: appId,
       openedAppState: null,
       isAppMinimized: false,
+      dismissedBuildAppId: null,
     });
-    try {
-      const { data: result } = await appsByIdOpenPost({
-        path: { assistant_id: assistantId, id: appId },
-        throwOnError: true,
-      });
-      if (get().activeAppId !== appId) return;
-      const app = { appId: result.appId, dirName: result.dirName, name: result.name, html: result.html };
-      set({ openedAppState: app });
-      primeAppHtmlCache(assistantId, result.appId, result.html);
-    } catch (err) {
-      if (get().activeAppId !== appId) return;
-      // 404s here are an expected condition (app was deleted on the
-      // server but the client still has a reference). Skip the Sentry
-      // capture for those — the daemon already returns a structured
-      // `{ code: "NOT_FOUND", message }` body — and let the UI fall
-      // back to chat as below. Unexpected failures still report.
-      if (!isAppNotFoundError(err)) {
-        captureError(err, { context: "openApp" });
-      }
-      set({ mainView: "chat", activeAppId: null, openedAppState: null });
+    await fetchAndSetApp(set, get, assistantId, appId);
+  },
+
+  revealAppForBuild: (assistantId, appId) => {
+    const state = get();
+    // Already looking at this app — never yank the view (or re-fetch)
+    // out from under the user mid-build. `app-editing` and the
+    // full-width `app` view both count as "viewing this app".
+    if (
+      state.activeAppId === appId &&
+      (state.mainView === "app" || state.mainView === "app-editing")
+    ) {
+      return;
     }
+    // The user explicitly closed the panel for this app during the
+    // current build — respect that and don't pop it back open. The
+    // hook clears this flag (`clearBuildDismissal`) when a fresh build
+    // sequence begins, so the next build re-opens.
+    if (state.dismissedBuildAppId === appId) return;
+    set({
+      mainView: "app-editing",
+      activeAppId: appId,
+      openedAppState: null,
+      isAppMinimized: false,
+    });
+    // Load the first frame; subsequent `app_preview_update`s hot-swap
+    // the preview (PR 3) via `updateOpenedAppPreview`. `fetchAndSetApp`
+    // keeps `mainView` untouched (unlike `loadApp`), so the split-view
+    // we just entered survives the async load. Fire-and-forget — the
+    // helper bails on its own if the active app changed meanwhile.
+    void fetchAndSetApp(set, get, assistantId, appId);
   },
 
   setLoadedApp: (app) => {
@@ -363,12 +436,23 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   },
 
   closeApp: () => {
+    // Remember which app the user just dismissed so the build auto-open
+    // (`revealAppForBuild`) doesn't immediately re-open the panel for the
+    // same in-flight build. Cleared by `clearBuildDismissal` when a fresh
+    // build sequence starts, or by re-opening the app (`openApp`/`loadApp`).
+    const dismissedBuildAppId = get().activeAppId ?? get().dismissedBuildAppId;
     set({
       mainView: "chat",
       activeAppId: null,
       openedAppState: null,
       isAppMinimized: false,
+      dismissedBuildAppId,
     });
+  },
+
+  clearBuildDismissal: (appId) => {
+    if (get().dismissedBuildAppId !== appId) return;
+    set({ dismissedBuildAppId: null });
   },
 
   toggleAppMinimized: () => {


### PR DESCRIPTION
## Summary
- Add viewer-store revealAppForBuild and auto-open the app-editing split-view on the first app_preview_update for the active assistant
- Gate on the currently-viewed assistant/conversation; respect a user-dismissal guard for the current build; desktop-only (mobile unaffected)
- Preview then hot-reloads live via PR 3

Part of plan: app-live-preview.md (PR 4 of 4)