### PR TITLE
feat(web): sync detected timezone to daemon config.ui.detectedTimezone

### DIFF
--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -19,6 +19,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { publish } from "@/lib/event-bus";
 
 // Mutable zone returned by the mocked hook; tests flip it then re-render.
 interface PatchArgs {
@@ -31,8 +32,14 @@ let currentTz = "America/New_York";
 const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
 const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
 
+// Both the reactive hook and the imperative resume/focus reader resolve
+// to the same mutable `currentTz`.
 mock.module("@/utils/use-effective-timezone", () => ({
   useEffectiveTimezone: () => currentTz,
+}));
+
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => currentTz,
 }));
 
 mock.module("@/generated/api/client.gen", () => ({
@@ -146,5 +153,48 @@ describe("TimezoneSync", () => {
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
     expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("retries on app.resume with the same zone after a failed initial sync", async () => {
+    // Initial sync rejects (e.g. resumed while offline). The guard ref
+    // stays unsynced because we only record the key on success.
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("offline");
+    });
+    renderSync();
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // Resume with the SAME zone — a retry must fire even though tz is
+    // unchanged (the offline-then-resume case).
+    publish("app.resume", { signal: "visibility" });
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("retries on window focus with the same zone after a failed initial sync", async () => {
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("offline");
+    });
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // No zone flip: the prior success recorded the key, so both triggers
+    // are no-ops (no redundant PATCH).
+    publish("app.resume", { signal: "visibility" });
+    window.dispatchEvent(new Event("focus"));
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for the headless `TimezoneSync` component.
+ *
+ * Strategy: mock the generated API client's `patch` and the effective-
+ * timezone hook, drive the active assistant id through the real
+ * selection store, and assert the PATCH fires only for genuinely new
+ * `{ ui: { detectedTimezone } }` values.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+
+// Mutable zone returned by the mocked hook; tests flip it then re-render.
+interface PatchArgs {
+  url: string;
+  path: { assistant_id: string };
+  body: { ui: Record<string, unknown> };
+}
+
+let currentTz = "America/New_York";
+const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
+const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
+
+mock.module("@/utils/use-effective-timezone", () => ({
+  useEffectiveTimezone: () => currentTz,
+}));
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: { patch: patchMock },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { TimezoneSync } = await import("@/components/timezone-sync");
+
+function renderSync() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<TimezoneSync />, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  currentTz = "America/New_York";
+  patchMock.mockClear();
+  captureErrorMock.mockClear();
+  patchMock.mockImplementation(async () => ({ data: {} }));
+  useAssistantSelectionStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantSelectionStore.setState({ activeAssistantId: null });
+});
+
+function lastBody() {
+  return patchMock.mock.calls.at(-1)?.[0]?.body;
+}
+
+describe("TimezoneSync", () => {
+  test("PATCHes detectedTimezone once on mount with a resolvable assistant id", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    const call = patchMock.mock.calls[0]![0];
+    expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
+    expect(call.path).toEqual({ assistant_id: "asst-1" });
+    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("never writes userTimezone", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()?.ui).not.toHaveProperty("userTimezone");
+  });
+
+  test("a zone change triggers exactly one additional PATCH with the new zone", async () => {
+    const { rerender } = renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    currentTz = "Europe/London";
+    rerender(<TimezoneSync />);
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+  });
+
+  test("no additional PATCH when the zone is unchanged across re-renders", async () => {
+    const { rerender } = renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    rerender(<TimezoneSync />);
+    rerender(<TimezoneSync />);
+
+    // Give any stray effect a chance to fire, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("no PATCH when the effective zone is empty", async () => {
+    currentTz = "";
+    renderSync();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  test("no PATCH when no assistant id is available", async () => {
+    useAssistantSelectionStore.setState({ activeAssistantId: null });
+    renderSync();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  test("captures errors silently and allows a later retry of the failed zone", async () => {
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    const { rerender } = renderSync();
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+    expect(captureErrorMock.mock.calls[0]![1]).toEqual({
+      context: "timezone-sync-detected",
+    });
+
+    // The onError handler reset the guard for the failed zone, so the
+    // next time that same zone comes back around (after a focus that
+    // flips it away and back) it re-syncs instead of being suppressed.
+    currentTz = "Europe/London";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+
+    currentTz = "America/New_York";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+});

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -16,22 +16,33 @@
  * `useAssistantSelectionStore`, which the lifecycle populates once a
  * logged-in assistant resolves; until then the id is null and we skip.
  *
+ * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
+ * failed sync (e.g. resumed-after-offline) leaves the key "unsynced"
+ * and is retried on the next `app.resume` bus signal or window focus —
+ * even when the effective zone string is unchanged. A successful prior
+ * sync makes those triggers a no-op, preserving the no-redundant-PATCH
+ * guarantee.
+ *
  * Renders `null` and is silent on error — a failed background sync must
  * never surface a toast.
  */
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
 
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { client } from "@/generated/api/client.gen";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { captureError } from "@/lib/sentry/capture-error";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function TimezoneSync(): null {
+  // Reactive zone drives the effect below; resume/focus handlers re-read
+  // the *current* zone via `getEffectiveTimezone()` to avoid stale closures.
   const tz = useEffectiveTimezone();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
 
-  const { mutate: patchDetectedTimezone } = useMutation({
+  const { mutateAsync: patchDetectedTimezone } = useMutation({
     mutationFn: async (vars: { assistantId: string; tz: string }) => {
       const { data } = await client.patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
@@ -43,29 +54,49 @@ export function TimezoneSync(): null {
     },
   });
 
-  // `${assistantId}:${tz}` we last kicked off a sync for, to avoid
-  // redundant PATCHes and render loops when neither has changed. Keyed
-  // on the assistant too so switching assistants re-syncs even when the
-  // zone is identical.
+  // `${assistantId}:${tz}` of the last *successful* sync, to avoid
+  // redundant PATCHes when nothing has changed. Keyed on the assistant
+  // too so switching assistants re-syncs even when the zone is identical.
+  // Only advanced on success, so a failed sync stays "unsynced" and is
+  // retried on the next resume/focus.
   const lastSyncedRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    if (!tz || !assistantId) return;
-    const key = `${assistantId}:${tz}`;
+  // Hold the live assistant id so resume/focus handlers (which capture
+  // `trySync` once) always target the current assistant.
+  const assistantIdRef = useRef(assistantId);
+  assistantIdRef.current = assistantId;
+
+  const trySync = useCallback(() => {
+    const currentAssistantId = assistantIdRef.current;
+    const currentTz = getEffectiveTimezone();
+    if (!currentAssistantId || !currentTz) return;
+
+    const key = `${currentAssistantId}:${currentTz}`;
     if (lastSyncedRef.current === key) return;
-    lastSyncedRef.current = key;
-    // Fire-and-forget: background sync, silent on error.
-    patchDetectedTimezone(
-      { assistantId, tz },
-      {
-        onError: (error) => {
-          // Allow a retry of this zone on the next focus/change.
-          if (lastSyncedRef.current === key) lastSyncedRef.current = null;
-          captureError(error, { context: "timezone-sync-detected" });
-        },
-      },
-    );
-  }, [tz, assistantId, patchDetectedTimezone]);
+
+    // Fire-and-forget: background sync, silent on error. Only record the
+    // key on success so a transient failure is retried on next trigger.
+    patchDetectedTimezone({ assistantId: currentAssistantId, tz: currentTz })
+      .then(() => {
+        lastSyncedRef.current = key;
+      })
+      .catch((error) => {
+        captureError(error, { context: "timezone-sync-detected" });
+      });
+  }, [patchDetectedTimezone]);
+
+  // Reactive path: zone or assistant change.
+  useEffect(() => {
+    trySync();
+  }, [tz, assistantId, trySync]);
+
+  // Resume/focus path: retry a previously failed sync even when the zone
+  // string is unchanged. A successful prior sync makes this a no-op.
+  useBusSubscription("app.resume", trySync);
+  useEffect(() => {
+    window.addEventListener("focus", trySync);
+    return () => window.removeEventListener("focus", trySync);
+  }, [trySync]);
 
   return null;
 }

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,0 +1,71 @@
+/**
+ * Headless background sync of the live effective timezone into the
+ * assistant daemon config at `config.ui.detectedTimezone`.
+ *
+ * `useEffectiveTimezone()` re-reads the zone on window focus,
+ * visibility, and device-setting override changes, so this component
+ * keeps the daemon's *detected* zone fresh for background grounding
+ * (memory retrospective, scheduling) that has no per-turn
+ * `clientTimezone`. Per the backend resolver cascade this only ever
+ * writes `detectedTimezone` — `config.ui.userTimezone` is owned by the
+ * settings UI and a manual override still wins.
+ *
+ * Mounted once in `RootLayout` (behind `authMiddleware`), so it lives
+ * for the whole authenticated session and never renders on public
+ * `/account` routes. The active assistant id comes from
+ * `useAssistantSelectionStore`, which the lifecycle populates once a
+ * logged-in assistant resolves; until then the id is null and we skip.
+ *
+ * Renders `null` and is silent on error — a failed background sync must
+ * never surface a toast.
+ */
+import { useEffect, useRef } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { client } from "@/generated/api/client.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+
+export function TimezoneSync(): null {
+  const tz = useEffectiveTimezone();
+  const assistantId = useAssistantSelectionStore.use.activeAssistantId();
+
+  const { mutate: patchDetectedTimezone } = useMutation({
+    mutationFn: async (vars: { assistantId: string; tz: string }) => {
+      const { data } = await client.patch<Record<string, unknown>, unknown, true>({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: vars.assistantId },
+        body: { ui: { detectedTimezone: vars.tz } },
+        throwOnError: true,
+      });
+      return data;
+    },
+  });
+
+  // `${assistantId}:${tz}` we last kicked off a sync for, to avoid
+  // redundant PATCHes and render loops when neither has changed. Keyed
+  // on the assistant too so switching assistants re-syncs even when the
+  // zone is identical.
+  const lastSyncedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!tz || !assistantId) return;
+    const key = `${assistantId}:${tz}`;
+    if (lastSyncedRef.current === key) return;
+    lastSyncedRef.current = key;
+    // Fire-and-forget: background sync, silent on error.
+    patchDetectedTimezone(
+      { assistantId, tz },
+      {
+        onError: (error) => {
+          // Allow a retry of this zone on the next focus/change.
+          if (lastSyncedRef.current === key) lastSyncedRef.current = null;
+          captureError(error, { context: "timezone-sync-detected" });
+        },
+      },
+    );
+  }, [tz, assistantId, patchDetectedTimezone]);
+
+  return null;
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -18,6 +18,7 @@ import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-sync";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { TimezoneSync } from "@/components/timezone-sync";
 
 /**
  * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
@@ -134,6 +135,10 @@ export function RootLayout() {
 
       {/* Portal target for mobile overlays that use `position: fixed`. */}
       <div id="viewport-overlays" />
+
+      {/* Headless: keeps daemon config.ui.detectedTimezone fresh on
+          focus/zone change. No-ops until an assistant id resolves. */}
+      <TimezoneSync />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add headless TimezoneSync component that PATCHes ui.detectedTimezone when the live zone changes
- Guarded against redundant PATCHes; never writes userTimezone; silent on error
- Mounted in the authenticated app shell

Part of plan: fix-timezone-auto-update.md (PR 6 of 6)