### PR TITLE
fix(web): recompute billing preset bounds when the effective timezone changes (Codex P2)

### DIFF
--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -19,13 +19,18 @@ interface DateRangeSelectProps {
   readonly onChange: (range: DateRange) => void;
 }
 
-type PresetDays = "7" | "30" | "90";
+/**
+ * Single source of truth for the relative presets this control exposes. Other
+ * modules (e.g. billing reconciliation) iterate this to recompute whichever
+ * preset is active when the effective timezone changes.
+ */
+export const PRESET_DAYS = [7, 30, 90] as const;
 
-const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = [
-  { value: "7", label: "Last 7 days" },
-  { value: "30", label: "Last 30 days" },
-  { value: "90", label: "Last 90 days" },
-];
+type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
+
+const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = PRESET_DAYS.map(
+  (days) => ({ value: `${days}`, label: `Last ${days} days` }),
+);
 
 /**
  * Compute a "last N days" range whose calendar bounds are expressed in the

--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -24,7 +24,7 @@ import { BillingUsageChart, type ChartMetric } from "@/domains/settings/componen
 import {
   type BillingUsageSourceFilter,
   getDefaultDateRange,
-  reconcileDefaultRange,
+  reconcilePresetRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
@@ -61,21 +61,16 @@ export function BillingUsagePanel() {
   const [dateRange, setDateRange] = useState<DateRange>(() =>
     getDefaultDateRange(tz),
   );
-  // Tracks the default that matches the active tz, so a tz change can re-derive
-  // the default range without clobbering a range the user customized.
-  const prevDefaultRef = useRef<DateRange>(dateRange);
+  // Tracks the tz the active range was computed in, so a tz change can recompute
+  // whichever relative preset is active without clobbering an untracked range.
+  // Initialized to the current tz so the first effect run is a no-op.
+  const prevTzRef = useRef<string>(tz);
 
   useEffect(() => {
-    const nextDefault = getDefaultDateRange(tz);
-    setDateRange((current) => {
-      const reconciled = reconcileDefaultRange(
-        current,
-        prevDefaultRef.current,
-        nextDefault,
-      );
-      prevDefaultRef.current = nextDefault;
-      return reconciled;
-    });
+    const prevTz = prevTzRef.current;
+    prevTzRef.current = tz;
+    if (prevTz === tz) return;
+    setDateRange((current) => reconcilePresetRange(current, prevTz, tz));
   }, [tz]);
 
   const [drilldown, setDrilldown] = useState<{

--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -24,8 +24,10 @@ import { BillingUsageChart, type ChartMetric } from "@/domains/settings/componen
 import {
   type BillingUsageSourceFilter,
   getDefaultDateRange,
+  reconcileDefaultRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 const METRIC_ITEMS: SegmentControlItem<ChartMetric>[] = [
   { value: "spend", label: "Spend ($)" },
@@ -55,7 +57,27 @@ function formatEventCount(count: number | undefined): string {
 }
 
 export function BillingUsagePanel() {
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const tz = useEffectiveTimezone();
+  const [dateRange, setDateRange] = useState<DateRange>(() =>
+    getDefaultDateRange(tz),
+  );
+  // Tracks the default that matches the active tz, so a tz change can re-derive
+  // the default range without clobbering a range the user customized.
+  const prevDefaultRef = useRef<DateRange>(dateRange);
+
+  useEffect(() => {
+    const nextDefault = getDefaultDateRange(tz);
+    setDateRange((current) => {
+      const reconciled = reconcileDefaultRange(
+        current,
+        prevDefaultRef.current,
+        nextDefault,
+      );
+      prevDefaultRef.current = nextDefault;
+      return reconciled;
+    });
+  }, [tz]);
+
   const [drilldown, setDrilldown] = useState<{
     usageSource: BillingUsageSourceFilter;
     llmDimension?: LlmUsageDimension;

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+import { computeRangeInTimezone } from "@/components/charts/date-range-select";
+
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
   getDefaultDateRange,
-  reconcileDefaultRange,
+  reconcilePresetRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
 
@@ -65,30 +67,33 @@ describe("getDefaultDateRange", () => {
   });
 });
 
-describe("reconcileDefaultRange", () => {
-  const prevDefault = { from: "2026-01-01", to: "2026-01-30" };
-  const nextDefault = { from: "2026-01-02", to: "2026-01-31" };
+describe("reconcilePresetRange", () => {
+  // Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) sit a full calendar
+  // day apart at most instants, so a preset's bounds differ between the zones.
+  const EAST = "Pacific/Kiritimati";
+  const WEST = "Pacific/Niue";
 
-  test("adopts the new default when still on the previous default", () => {
-    const result = reconcileDefaultRange(
-      { ...prevDefault },
-      prevDefault,
-      nextDefault,
-    );
-    expect(result).toBe(nextDefault);
-  });
+  for (const days of [7, 30, 90]) {
+    test(`recomputes the active ${days}-day preset across a tz change`, () => {
+      const current = computeRangeInTimezone(days, EAST);
+      const result = reconcilePresetRange(current, EAST, WEST);
+      expect(result).toEqual(computeRangeInTimezone(days, WEST));
+    });
+  }
 
-  test("preserves a customized range across a tz-driven default change", () => {
-    const custom = { from: "2025-12-01", to: "2025-12-15" };
-    const result = reconcileDefaultRange(custom, prevDefault, nextDefault);
+  test("leaves a range that matches no preset unchanged", () => {
+    // 45 days apart matches none of the 7/30/90 presets.
+    const custom = { from: "2025-12-01", to: "2026-01-14" };
+    const result = reconcilePresetRange(custom, EAST, WEST);
     expect(result).toBe(custom);
   });
 
-  test("returns the current reference when the default is unchanged", () => {
-    const current = { from: "2026-01-01", to: "2026-01-30" };
-    const result = reconcileDefaultRange(current, prevDefault, prevDefault);
-    expect(result).toBe(prevDefault);
-    expect(result).toEqual(current);
+  test("returns the same reference when the matched preset is unchanged", () => {
+    // Same tz on both sides: the preset's bounds are identical, so the helper
+    // must bail out referentially rather than allocate a new range.
+    const current = computeRangeInTimezone(7, EAST);
+    const result = reconcilePresetRange(current, EAST, EAST);
+    expect(result).toBe(current);
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -4,6 +4,7 @@ import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
   getDefaultDateRange,
+  reconcileDefaultRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
 
@@ -61,6 +62,33 @@ describe("getDefaultDateRange", () => {
       expect(r.to).toMatch(DATE_RE);
       expect(daysApart(r.from, r.to)).toBe(30);
     }
+  });
+});
+
+describe("reconcileDefaultRange", () => {
+  const prevDefault = { from: "2026-01-01", to: "2026-01-30" };
+  const nextDefault = { from: "2026-01-02", to: "2026-01-31" };
+
+  test("adopts the new default when still on the previous default", () => {
+    const result = reconcileDefaultRange(
+      { ...prevDefault },
+      prevDefault,
+      nextDefault,
+    );
+    expect(result).toBe(nextDefault);
+  });
+
+  test("preserves a customized range across a tz-driven default change", () => {
+    const custom = { from: "2025-12-01", to: "2025-12-15" };
+    const result = reconcileDefaultRange(custom, prevDefault, nextDefault);
+    expect(result).toBe(custom);
+  });
+
+  test("returns the current reference when the default is unchanged", () => {
+    const current = { from: "2026-01-01", to: "2026-01-30" };
+    const result = reconcileDefaultRange(current, prevDefault, prevDefault);
+    expect(result).toBe(prevDefault);
+    expect(result).toEqual(current);
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type DateRange,
+  PRESET_DAYS,
   computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
@@ -29,22 +30,32 @@ export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRa
 }
 
 /**
- * Reconcile the active date range against a timezone-driven default change.
+ * Reconcile the active date range against a timezone change.
  *
- * When the effective timezone shifts, the default "last 30 days" bounds move by
- * a calendar day. We adopt the new default ONLY if the user was still sitting on
- * the previous default (i.e. hadn't customized the range); an explicit user
- * selection is left untouched. Returns the same `current` reference when nothing
- * should change so callers can rely on referential bail-outs.
+ * The billing control exposes only relative presets (7/30/90 days), so when the
+ * effective timezone shifts we recompute whichever preset the user is currently
+ * on for the new timezone. We detect that preset by matching `current` against
+ * each preset's bounds computed for the PREVIOUS timezone; on a match we return
+ * the same preset recomputed for the NEW timezone. A range matching no preset is
+ * left untouched, defensively leaving any untracked/custom range alone, and the
+ * same `current` reference is returned whenever the bounds don't change so
+ * callers can rely on referential bail-outs.
  */
-export function reconcileDefaultRange(
+export function reconcilePresetRange(
   current: DateRange,
-  prevDefault: DateRange,
-  nextDefault: DateRange,
+  prevTz: string,
+  nextTz: string,
 ): DateRange {
-  const wasOnDefault =
-    current.from === prevDefault.from && current.to === prevDefault.to;
-  return wasOnDefault ? nextDefault : current;
+  for (const days of PRESET_DAYS) {
+    const prev = computeRangeInTimezone(days, prevTz);
+    if (current.from === prev.from && current.to === prev.to) {
+      const next = computeRangeInTimezone(days, nextTz);
+      return next.from === current.from && next.to === current.to
+        ? current
+        : next;
+    }
+  }
+  return current;
 }
 
 export type UsageChartState = {

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -28,6 +28,25 @@ export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRa
   return computeRangeInTimezone(30, tz);
 }
 
+/**
+ * Reconcile the active date range against a timezone-driven default change.
+ *
+ * When the effective timezone shifts, the default "last 30 days" bounds move by
+ * a calendar day. We adopt the new default ONLY if the user was still sitting on
+ * the previous default (i.e. hadn't customized the range); an explicit user
+ * selection is left untouched. Returns the same `current` reference when nothing
+ * should change so callers can rely on referential bail-outs.
+ */
+export function reconcileDefaultRange(
+  current: DateRange,
+  prevDefault: DateRange,
+  nextDefault: DateRange,
+): DateRange {
+  const wasOnDefault =
+    current.from === prevDefault.from && current.to === prevDefault.to;
+  return wasOnDefault ? nextDefault : current;
+}
+
 export type UsageChartState = {
   dateRange: DateRange;
   setDateRange: (range: DateRange) => void;


### PR DESCRIPTION
## Summary
- BillingUsagePanel now recomputes the default/preset date range when the effective timezone changes
- Only when the user is still on the default preset; explicit custom ranges are preserved
- Addresses Codex P2 follow-up on PR #33038

Part of plan: fix-timezone-auto-update.md (follow-up to PR 4)