### PR TITLE
feat(web): carry base_url and models through onboarding pending provider key

### DIFF
--- a/apps/web/src/domains/onboarding/provider-key.test.ts
+++ b/apps/web/src/domains/onboarding/provider-key.test.ts
@@ -42,4 +42,27 @@ describe("pending provider key", () => {
     setPendingProviderKey({ provider: "ollama", key: "" });
     expect(consumePendingProviderKey()).toEqual({ provider: "ollama", key: "" });
   });
+
+  test("round-trips openai-compatible baseUrl + models", () => {
+    setPendingProviderKey({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a", "model-b"],
+    });
+    expect(peekPendingProviderKey()).toEqual({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a", "model-b"],
+    });
+  });
+
+  test("providers without custom fields round-trip without baseUrl/models", () => {
+    setPendingProviderKey({ provider: "anthropic", key: "sk-ant-test" });
+    const peeked = peekPendingProviderKey();
+    expect(peeked).toEqual({ provider: "anthropic", key: "sk-ant-test" });
+    expect(peeked?.baseUrl).toBeUndefined();
+    expect(peeked?.models).toBeUndefined();
+  });
 });

--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -12,6 +12,10 @@ export interface PendingProviderKey {
   provider: OnboardingProviderId;
   /** Empty for keyless providers (e.g. Ollama). */
   key: string;
+  /** Custom endpoint base URL; set only for openai-compatible. */
+  baseUrl?: string;
+  /** Model identifiers exposed by the endpoint; set only for openai-compatible. */
+  models?: string[];
 }
 
 export function setPendingProviderKey(value: PendingProviderKey | null): void {
@@ -84,6 +88,8 @@ async function createProviderConnection(
   assistantId: string,
   provider: OnboardingProviderId,
   hasKey: boolean,
+  baseUrl?: string,
+  models?: string[],
 ): Promise<void> {
   const auth = hasKey
     ? { type: "api_key", credential: `credential/${provider}/api_key` }
@@ -91,7 +97,15 @@ async function createProviderConnection(
   const result = await client.post({
     url: "/v1/assistants/{assistant_id}/inference/provider-connections",
     path: { assistant_id: assistantId },
-    body: { name: provider, provider, auth },
+    body: {
+      name: provider,
+      provider,
+      auth,
+      ...(baseUrl ? { base_url: baseUrl } : {}),
+      ...(models && models.length > 0
+        ? { models: models.map((id) => ({ id })) }
+        : {}),
+    },
     headers: { "Content-Type": "application/json" },
   });
   if (!result.response?.ok) {
@@ -117,5 +131,11 @@ export async function applyPendingProviderKey(
   if (hasKey) {
     await writeApiKeySecret(assistantId, pending.provider, trimmed);
   }
-  await createProviderConnection(assistantId, pending.provider, hasKey);
+  await createProviderConnection(
+    assistantId,
+    pending.provider,
+    hasKey,
+    pending.baseUrl?.trim() || undefined,
+    pending.models,
+  );
 }


### PR DESCRIPTION
## Summary
- Extend PendingProviderKey with optional baseUrl + models (openai-compatible only).
- Forward base_url and models[{id}] in the onboarding provider-connection create POST when present; non-custom providers send an identical payload.

Part of plan: openai-compatible-onboarding.md (PR 2 of 3)