### PR TITLE
fix(assistant): allow loopback openai-compatible base_url on self-hosted daemons

### DIFF
--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -392,6 +392,21 @@ describe("base_url SSRF on self-hosted vs platform", () => {
     ).rejects.toThrow(/cloud metadata or link-local/);
   });
 
+  test("self-hosted: rejects trailing-dot FQDN metadata.google.internal.", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-metadata-fqdn",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-metadata-fqdn" },
+          base_url: "http://metadata.google.internal./computeMetadata/v1/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
+
   test("self-hosted: rejects 169.254.169.254 link-local metadata IP", async () => {
     mockIsPlatform = false;
     await expect(

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -422,6 +422,67 @@ describe("base_url SSRF on self-hosted vs platform", () => {
     ).rejects.toThrow(/cloud metadata or link-local/);
   });
 
+  test("self-hosted: rejects AWS IPv6 metadata endpoint (fd00:ec2::254)", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-aws-ipv6-metadata",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-aws-ipv6" },
+          base_url: "http://[fd00:ec2::254]/latest/meta-data/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
+
+  test("self-hosted: rejects AWS IPv6 metadata endpoint in uncompressed form", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-aws-ipv6-metadata-uncompressed",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-aws-ipv6-uncompressed" },
+          base_url: "http://[fd00:ec2:0:0:0:0:0:254]/latest/meta-data/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
+
+  test("self-hosted: allows a legitimate non-metadata ULA", async () => {
+    mockIsPlatform = false;
+    const result = await handleCreate({
+      body: {
+        name: "self-hosted-ula-allowed",
+        provider: "openai-compatible",
+        auth: { type: "api_key", credential: "cred-ula" },
+        base_url: "http://[fd12:3456:789a::1]:1234/v1",
+        models: [{ id: "local-model" }],
+      },
+    });
+    expect((result as { baseUrl: string }).baseUrl).toBe(
+      "http://[fd12:3456:789a::1]:1234/v1",
+    );
+  });
+
+  test("self-hosted: rejects IPv6 link-local (fe80::1)", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-ipv6-link-local",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ipv6-link-local" },
+          base_url: "http://[fe80::1]:1234/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
+
   test("self-hosted: provider gate still rejects base_url on non-openai-compatible", async () => {
     mockIsPlatform = false;
     await expect(

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -6,7 +6,7 @@
  * with mocked DB, config, and DNS resolution.
  */
 import { Database } from "bun:sqlite";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
@@ -49,6 +49,14 @@ mock.module("../../../config/loader.js", () => ({
 // Mock DNS resolution: all hostnames resolve to a public IP by default.
 // Tests that need private-IP resolution override this per-test.
 let mockResolvedAddresses: string[] = ["93.184.216.34"];
+
+// Toggleable hosting mode: self-hosted (false) by default. Self-hosted daemons
+// allow loopback/private base_url for openai-compatible; platform-hosted do not.
+let mockIsPlatform = false;
+
+mock.module("../../../config/env-registry.js", () => ({
+  getIsPlatform: () => mockIsPlatform,
+}));
 
 // Import the real url-safety module for use inside the mock.
 const {
@@ -197,6 +205,12 @@ describe("base_url provider-type gate (create)", () => {
 // ---------------------------------------------------------------------------
 
 describe("base_url SSRF protection (create)", () => {
+  // Platform-hosted enforces the strict SSRF policy: private/local targets are
+  // always rejected. (Self-hosted relaxation is covered by its own block.)
+  beforeEach(() => {
+    mockIsPlatform = true;
+  });
+
   test("rejects private IP (192.168.x.x)", async () => {
     await expect(
       handleCreate({
@@ -311,6 +325,69 @@ describe("base_url SSRF protection (create)", () => {
     expect((result as { baseUrl: string }).baseUrl).toBe(
       "https://api.example.com/v1",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Self-hosted vs platform: loopback/private base_url for openai-compatible
+// ---------------------------------------------------------------------------
+
+describe("base_url SSRF on self-hosted vs platform", () => {
+  beforeEach(() => {
+    // Self-hosted is the default; public DNS keeps non-literal hosts safe.
+    mockIsPlatform = false;
+    mockResolvedAddresses = ["93.184.216.34"];
+  });
+
+  const localUrls = [
+    "http://localhost:1234/v1",
+    "http://127.0.0.1:1234/v1",
+    "http://192.168.1.10:1234/v1",
+  ];
+
+  for (const [i, url] of localUrls.entries()) {
+    test(`self-hosted: accepts loopback/private base_url ${url}`, async () => {
+      mockIsPlatform = false;
+      const result = await handleCreate({
+        body: {
+          name: `self-hosted-local-${i}`,
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-local" },
+          base_url: url,
+          models: [{ id: "local-model" }],
+        },
+      });
+      expect((result as { baseUrl: string }).baseUrl).toBe(url);
+    });
+
+    test(`platform-hosted: rejects loopback/private base_url ${url}`, async () => {
+      mockIsPlatform = true;
+      await expect(
+        handleCreate({
+          body: {
+            name: `platform-local-${i}`,
+            provider: "openai-compatible",
+            auth: { type: "api_key", credential: "cred-local" },
+            base_url: url,
+            models: [{ id: "local-model" }],
+          },
+        }),
+      ).rejects.toThrow(/private or local network/);
+    });
+  }
+
+  test("self-hosted: provider gate still rejects base_url on non-openai-compatible", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-gate-anthropic",
+          provider: "anthropic",
+          auth: { type: "api_key", credential: "cred-gate" },
+          base_url: "http://localhost:1234/v1",
+        },
+      }),
+    ).rejects.toThrow(/base_url is only valid for openai-compatible/);
   });
 });
 

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -61,6 +61,7 @@ mock.module("../../../config/env-registry.js", () => ({
 // Import the real url-safety module for use inside the mock.
 const {
   isPrivateOrLocalHost: realIsPrivateOrLocalHost,
+  isCloudMetadataOrLinkLocalHost: realIsCloudMetadataOrLinkLocalHost,
   isPrivateIPv4,
   isPrivateIPv6,
   isIPv4,
@@ -78,6 +79,7 @@ const {
 
 mock.module("../../../tools/network/url-safety.js", () => ({
   isPrivateOrLocalHost: realIsPrivateOrLocalHost,
+  isCloudMetadataOrLinkLocalHost: realIsCloudMetadataOrLinkLocalHost,
   isPrivateIPv4,
   isPrivateIPv6,
   isIPv4,
@@ -112,9 +114,8 @@ mock.module("../../../tools/network/url-safety.js", () => ({
   },
 }));
 
-const { ROUTES } = await import(
-  "../../../runtime/routes/inference-provider-connection-routes.js"
-);
+const { ROUTES } =
+  await import("../../../runtime/routes/inference-provider-connection-routes.js");
 
 const handleCreate = ROUTES.find(
   (r) => r.operationId === "inference_provider_connections_create",
@@ -292,7 +293,7 @@ describe("base_url SSRF protection (create)", () => {
           models: [{ id: "m" }],
         },
       }),
-    ).rejects.toThrow(/private or local network/);
+    ).rejects.toThrow(/cloud metadata or link-local/);
   });
 
   test("rejects hostname that resolves to a private IP", async () => {
@@ -375,6 +376,36 @@ describe("base_url SSRF on self-hosted vs platform", () => {
       ).rejects.toThrow(/private or local network/);
     });
   }
+
+  test("self-hosted: rejects metadata.google.internal even though private is allowed", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-metadata",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-metadata" },
+          base_url: "http://metadata.google.internal/computeMetadata/v1/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
+
+  test("self-hosted: rejects 169.254.169.254 link-local metadata IP", async () => {
+    mockIsPlatform = false;
+    await expect(
+      handleCreate({
+        body: {
+          name: "self-hosted-link-local",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-link-local" },
+          base_url: "http://169.254.169.254/latest/meta-data/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/cloud metadata or link-local/);
+  });
 
   test("self-hosted: provider gate still rejects base_url on non-openai-compatible", async () => {
     mockIsPlatform = false;

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -11,6 +11,7 @@
 import { z } from "zod";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getIsPlatform } from "../../config/env-registry.js";
 import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
@@ -75,8 +76,11 @@ function rejectDisabledOpenAICompatibleProvider(provider: string): void {
  * with a `base_url` pointing to their own server, which would redirect all
  * LLM calls (and the API key) to the attacker.
  *
- * Even for `openai-compatible`, the `base_url` must not point to private
- * networks or cloud metadata endpoints (SSRF protection).
+ * For `openai-compatible`, the `base_url` may point to loopback/private
+ * networks only on self-hosted daemons (`getIsPlatform()` is false) — this is
+ * required for local endpoints such as LM Studio, Ollama, and vLLM.
+ * Platform-hosted daemons keep the strict SSRF policy to prevent pivoting to
+ * internal or cloud-metadata services.
  */
 async function parseCustomProviderFields(
   body: Record<string, unknown>,
@@ -120,9 +124,12 @@ async function parseCustomProviderFields(
         );
       }
 
-      // SSRF protection: reject private IPs, localhost, cloud metadata endpoints.
+      // SSRF protection: reject private IPs, localhost, cloud metadata
+      // endpoints. Self-hosted daemons allow private/loopback targets so local
+      // endpoints (LM Studio, Ollama, vLLM) can be reached.
       const hostname = parsed.hostname;
-      if (isPrivateOrLocalHost(hostname)) {
+      const allowPrivate = !getIsPlatform();
+      if (!allowPrivate && isPrivateOrLocalHost(hostname)) {
         throw new BadRequestError(
           `Invalid base_url: must not point to a private or local network address.`,
         );
@@ -132,7 +139,7 @@ async function parseCustomProviderFields(
       const resolved = await resolveRequestAddress(
         hostname,
         resolveHostAddresses,
-        /* allowPrivateNetwork */ false,
+        allowPrivate,
       );
       if (resolved.blockedAddress) {
         throw new BadRequestError(

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -32,6 +32,7 @@ import {
   updateConnection,
 } from "../../providers/inference/connections.js";
 import {
+  isCloudMetadataOrLinkLocalHost,
   isPrivateOrLocalHost,
   resolveHostAddresses,
   resolveRequestAddress,
@@ -76,11 +77,13 @@ function rejectDisabledOpenAICompatibleProvider(provider: string): void {
  * with a `base_url` pointing to their own server, which would redirect all
  * LLM calls (and the API key) to the attacker.
  *
- * For `openai-compatible`, the `base_url` may point to loopback/private
+ * For `openai-compatible`, the `base_url` may point to loopback/private-LAN
  * networks only on self-hosted daemons (`getIsPlatform()` is false) — this is
  * required for local endpoints such as LM Studio, Ollama, and vLLM.
- * Platform-hosted daemons keep the strict SSRF policy to prevent pivoting to
- * internal or cloud-metadata services.
+ * Platform-hosted daemons keep the strict SSRF policy. Cloud-metadata and
+ * link-local endpoints (`metadata.google.internal`, 169.254.0.0/16, fe80::/10)
+ * are always blocked in every mode, including when the host or its resolved
+ * addresses point there, to prevent pivoting to cloud-metadata services.
  */
 async function parseCustomProviderFields(
   body: Record<string, unknown>,
@@ -124,11 +127,17 @@ async function parseCustomProviderFields(
         );
       }
 
-      // SSRF protection: reject private IPs, localhost, cloud metadata
-      // endpoints. Self-hosted daemons allow private/loopback targets so local
-      // endpoints (LM Studio, Ollama, vLLM) can be reached.
+      // SSRF protection. Cloud-metadata and link-local targets are always
+      // blocked. Private/loopback targets are blocked on platform-hosted
+      // daemons; self-hosted daemons allow them so local endpoints (LM Studio,
+      // Ollama, vLLM) can be reached.
       const hostname = parsed.hostname;
       const allowPrivate = !getIsPlatform();
+      if (isCloudMetadataOrLinkLocalHost(hostname)) {
+        throw new BadRequestError(
+          `Invalid base_url: must not point to a cloud metadata or link-local address.`,
+        );
+      }
       if (!allowPrivate && isPrivateOrLocalHost(hostname)) {
         throw new BadRequestError(
           `Invalid base_url: must not point to a private or local network address.`,
@@ -144,6 +153,17 @@ async function parseCustomProviderFields(
       if (resolved.blockedAddress) {
         throw new BadRequestError(
           `Invalid base_url: hostname resolves to a private network address.`,
+        );
+      }
+
+      // DNS-rebind guard: block when a hostname resolves to a cloud-metadata or
+      // link-local address even though private targets are otherwise allowed.
+      if (
+        allowPrivate &&
+        resolved.addresses.some(isCloudMetadataOrLinkLocalHost)
+      ) {
+        throw new BadRequestError(
+          `Invalid base_url: hostname resolves to a cloud metadata or link-local address.`,
         );
       }
 
@@ -241,7 +261,10 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const customFields = await parseCustomProviderFields(body, providerResult.data);
+  const customFields = await parseCustomProviderFields(
+    body,
+    providerResult.data,
+  );
 
   const result = createConnection(getDb(), {
     name,

--- a/assistant/src/tools/network/url-safety.ts
+++ b/assistant/src/tools/network/url-safety.ts
@@ -184,7 +184,9 @@ export function isPrivateOrLocalHost(hostname: string): boolean {
  * includes the 169.254.169.254 metadata IP used by AWS/GCP/Azure.
  */
 export function isCloudMetadataOrLinkLocalHost(hostname: string): boolean {
-  const host = unwrapBracketedHostname(hostname).toLowerCase();
+  const host = unwrapBracketedHostname(hostname)
+    .toLowerCase()
+    .replace(/\.$/, "");
   if (host === "metadata.google.internal") return true;
 
   const checkIPv4 = (ip: string): boolean => {

--- a/assistant/src/tools/network/url-safety.ts
+++ b/assistant/src/tools/network/url-safety.ts
@@ -114,6 +114,26 @@ export function extractEmbeddedIPv4FromIPv6(hostname: string): string | null {
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
 }
 
+function expandIPv6(host: string): string | null {
+  const normalized = host.split("%")[0];
+  if (normalized.includes(".")) return null; // embedded IPv4 handled by caller
+  const parts = normalized.split("::");
+  if (parts.length > 2) return null;
+  const head = parts[0] ? parts[0].split(":") : [];
+  const tail = parts.length === 2 && parts[1] ? parts[1].split(":") : [];
+  let groups: string[];
+  if (parts.length === 2) {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 1) return null;
+    groups = [...head, ...new Array(missing).fill("0"), ...tail];
+  } else {
+    groups = head;
+  }
+  if (groups.length !== 8) return null;
+  if (!groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) return null;
+  return groups.map((g) => g.padStart(4, "0")).join(":");
+}
+
 export function isIPv6(hostname: string): boolean {
   if (extractEmbeddedIPv4FromIPv6(hostname)) return true;
 
@@ -181,7 +201,10 @@ export function isPrivateOrLocalHost(hostname: string): boolean {
  * private/loopback networks are otherwise allowed (self-hosted daemons reaching
  * local model servers). Covers the well-known cloud metadata hostname plus
  * IPv4 (169.254.0.0/16) and IPv6 (fe80::/10) link-local ranges — the latter
- * includes the 169.254.169.254 metadata IP used by AWS/GCP/Azure.
+ * includes the 169.254.169.254 metadata IP used by AWS/GCP/Azure. It also
+ * covers the AWS EC2 Nitro IPv6 instance metadata endpoint (fd00:ec2::254) in
+ * any textual representation; general ULA (other fc00::/7 addresses) is not
+ * blocked here and remains allowed on self-hosted.
  */
 export function isCloudMetadataOrLinkLocalHost(hostname: string): boolean {
   const host = unwrapBracketedHostname(hostname)
@@ -196,17 +219,18 @@ export function isCloudMetadataOrLinkLocalHost(hostname: string): boolean {
 
   if (isIPv4(host)) return checkIPv4(host);
   if (isIPv6(host)) {
-    const normalized = host.split("%")[0];
-    if (
-      normalized.startsWith("fe8") ||
-      normalized.startsWith("fe9") ||
-      normalized.startsWith("fea") ||
-      normalized.startsWith("feb")
-    ) {
-      return true;
-    }
+    // Embedded IPv4 (e.g. ::ffff:169.254.169.254) → check the IPv4 part.
     const embedded = extractEmbeddedIPv4FromIPv6(host);
     if (embedded) return checkIPv4(embedded);
+
+    const expanded = expandIPv6(host);
+    if (expanded) {
+      const firstGroup = Number.parseInt(expanded.slice(0, 4), 16);
+      // IPv6 link-local fe80::/10 (fe80–febf).
+      if (firstGroup >= 0xfe80 && firstGroup <= 0xfebf) return true;
+      // AWS EC2 Nitro IPv6 instance metadata endpoint.
+      if (expanded === "fd00:0ec2:0000:0000:0000:0000:0000:0254") return true;
+    }
   }
   return false;
 }

--- a/assistant/src/tools/network/url-safety.ts
+++ b/assistant/src/tools/network/url-safety.ts
@@ -176,6 +176,39 @@ export function isPrivateOrLocalHost(hostname: string): boolean {
   return false;
 }
 
+/**
+ * Cloud-metadata and link-local hosts that must never be reachable, even when
+ * private/loopback networks are otherwise allowed (self-hosted daemons reaching
+ * local model servers). Covers the well-known cloud metadata hostname plus
+ * IPv4 (169.254.0.0/16) and IPv6 (fe80::/10) link-local ranges — the latter
+ * includes the 169.254.169.254 metadata IP used by AWS/GCP/Azure.
+ */
+export function isCloudMetadataOrLinkLocalHost(hostname: string): boolean {
+  const host = unwrapBracketedHostname(hostname).toLowerCase();
+  if (host === "metadata.google.internal") return true;
+
+  const checkIPv4 = (ip: string): boolean => {
+    const [a, b] = ip.split(".").map((part) => Number(part));
+    return a === 169 && b === 254;
+  };
+
+  if (isIPv4(host)) return checkIPv4(host);
+  if (isIPv6(host)) {
+    const normalized = host.split("%")[0];
+    if (
+      normalized.startsWith("fe8") ||
+      normalized.startsWith("fe9") ||
+      normalized.startsWith("fea") ||
+      normalized.startsWith("feb")
+    ) {
+      return true;
+    }
+    const embedded = extractEmbeddedIPv4FromIPv6(host);
+    if (embedded) return checkIPv4(embedded);
+  }
+  return false;
+}
+
 export async function resolveHostAddresses(
   hostname: string,
 ): Promise<string[]> {


### PR DESCRIPTION
## Summary
- Relax the inference-provider-connection SSRF guard so openai-compatible base_url may point to loopback/private addresses when the daemon is self-hosted (getIsPlatform() is false); platform-hosted stays strict.
- Enables local endpoints (LM Studio, Ollama, vLLM) during onboarding.

Part of plan: openai-compatible-onboarding.md (PR 1 of 3)