### PR TITLE
fix(web): drop stale app build events + canonical type reuse + badge reset

### DIFF
--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,8 +1,9 @@
 import { AlertTriangle, X } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
+import type { AppCompileStatus } from "@/stores/viewer-store";
 import { injectBridge } from "@/utils/sandbox-bridge";
 
 export interface AppViewerContainerProps {
@@ -25,7 +26,7 @@ export interface AppViewerContainerProps {
    * non-blocking badge over the last-good preview); `"building"`/`"ok"`/
    * undefined render nothing — the live iframe swap is the success feedback.
    */
-  compileStatus?: "building" | "ok" | "error";
+  compileStatus?: AppCompileStatus;
   /** Compile diagnostics surfaced in the build-error badge. */
   buildErrors?: string[];
   /**
@@ -44,8 +45,16 @@ export interface AppViewerContainerProps {
 export function BuildErrorBadge({ buildErrors }: { buildErrors?: string[] }) {
   const [dismissed, setDismissed] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  if (dismissed) return null;
   const errors = buildErrors ?? [];
+  // The component stays mounted across successive `error` events (compileStatus
+  // remains "error"), so a prior dismissal would otherwise hide every later,
+  // DISTINCT build failure. Reset the dismissal when the error identity changes
+  // so a new failure re-shows the badge.
+  const errorKey = errors.join("\n");
+  useEffect(() => {
+    setDismissed(false);
+  }, [errorKey]);
+  if (dismissed) return null;
   return (
     <div
       className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-2"

--- a/apps/web/src/components/build-error-badge.test.tsx
+++ b/apps/web/src/components/build-error-badge.test.tsx
@@ -1,7 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
 import { BuildErrorBadge } from "@/components/app-viewer-container";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("BuildErrorBadge", () => {
   test("renders the last-working-version message", () => {
@@ -30,5 +36,29 @@ describe("BuildErrorBadge", () => {
 
     const withoutErrors = renderToStaticMarkup(<BuildErrorBadge />);
     expect(withoutErrors).not.toContain("Details");
+  });
+
+  test("re-shows after dismissal when a new, distinct error arrives", () => {
+    // The component is NOT remounted between successive `error` events, so a
+    // prior dismissal must not hide a later DISTINCT failure.
+    const { rerender } = render(<BuildErrorBadge buildErrors={["boom"]} />);
+    expect(screen.queryByLabelText("App build error")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Dismiss build error"));
+    expect(screen.queryByLabelText("App build error")).toBeNull();
+
+    // A new, distinct build error for the still-mounted badge re-shows it.
+    rerender(<BuildErrorBadge buildErrors={["different error"]} />);
+    expect(screen.queryByLabelText("App build error")).not.toBeNull();
+  });
+
+  test("stays dismissed while the same error persists (no flicker)", () => {
+    // A repeated identical `error` event must not undo the user's dismissal.
+    const { rerender } = render(<BuildErrorBadge buildErrors={["boom"]} />);
+    fireEvent.click(screen.getByLabelText("Dismiss build error"));
+    expect(screen.queryByLabelText("App build error")).toBeNull();
+
+    rerender(<BuildErrorBadge buildErrors={["boom"]} />);
+    expect(screen.queryByLabelText("App build error")).toBeNull();
   });
 });

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -34,7 +34,7 @@ import { useRef } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { useViewerStore, type AppCompileStatus } from "@/stores/viewer-store";
 
 interface UseAppPreviewSyncParams {
   /** Active assistant id (owner of the bus SSE connection). */
@@ -62,7 +62,7 @@ export function useAppPreviewSync({
   // build sequence begins (first event, or a `building` that follows a
   // terminal `ok`/`error`). A ref — this is per-event bookkeeping, not
   // render-visible state.
-  const lastStatusByApp = useRef(new Map<string, "building" | "ok" | "error">());
+  const lastStatusByApp = useRef(new Map<string, AppCompileStatus>());
 
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -267,6 +267,98 @@ describe("updateOpenedAppPreview", () => {
     expect(getState().openedAppState?.reloadGeneration).toBe(4);
     expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
   });
+
+  it("drops a stale error from an older overlapping build (generation behind stored ok)", () => {
+    openSampleApp();
+    // Newer build lands ok at generation 5.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    const after = getState().openedAppState;
+    // A SLOW older build (generation 3) fails AFTER the newer ok already
+    // landed — it must NOT regress the preview into an error state.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>stale</h1>",
+      compileStatus: "error",
+      buildErrors: ["stale boom"],
+      reloadGeneration: 3,
+    });
+    // Same reference: the stale event was dropped, no set() fired.
+    expect(getState().openedAppState).toBe(after);
+    expect(getState().openedAppState?.compileStatus).toBe("ok");
+    expect(getState().openedAppState?.html).toBe("<h1>new-good</h1>");
+  });
+
+  it("drops a stale building event from an older overlapping build", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    const after = getState().openedAppState;
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "building",
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState).toBe(after);
+    expect(getState().openedAppState?.compileStatus).toBe("ok");
+  });
+
+  it("applies a building/error event whose generation equals the stored generation", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    // The terminal event of THIS build carries the same (unchanged) generation
+    // — equal is not stale, so it still applies (keep-last-good).
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 5,
+    });
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+    expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
+  });
+
+  it("applies an ok event even when its generation is below the stored generation", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v5</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    // `ok` is never dropped by the stale guard — it carries fresh html. (In
+    // practice the daemon's generation is monotonic, but the guard only
+    // targets building/error.)
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v3</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>v3</h1>");
+    expect(getState().openedAppState?.reloadGeneration).toBe(3);
+  });
+
+  it("does not drop an error when no generation has been stored yet (missing is not stale)", () => {
+    openSampleApp();
+    // No prior ok — stored generation is undefined. An error event must still
+    // surface (matches the prior behavior for first-event error).
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 0,
+    });
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+    expect(getState().openedAppState?.buildErrors).toEqual(["boom"]);
+  });
 });
 
 describe("handleAppLoadFailed", () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -20,12 +20,31 @@
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
 
+import type { AppPreviewUpdateEvent } from "@vellumai/assistant-api";
 import { captureError } from "@/lib/sentry/capture-error";
 import { create } from "zustand";
 
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { createSelectors } from "@/utils/create-selectors";
+
+/**
+ * Live-build compile status, derived from the canonical `app_preview_update`
+ * wire contract (`@vellumai/assistant-api`) rather than re-spelling the
+ * literal union. Shared with `app-viewer-container.tsx` and
+ * `use-app-preview-sync.ts` so all web sites stay in lockstep with the daemon.
+ */
+export type AppCompileStatus = AppPreviewUpdateEvent["compileStatus"];
+
+/**
+ * The fields an `app_preview_update` event contributes to the open preview,
+ * picked from the canonical event so the update-param shape can't drift from
+ * the wire contract.
+ */
+export type AppPreviewUpdate = Pick<
+  AppPreviewUpdateEvent,
+  "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
+>;
 
 /** Views that overlay the main content and track a "back" destination. */
 type OverlayView = "document" | "subagent-detail" | "tool-detail";
@@ -153,7 +172,7 @@ export interface OpenedAppState {
    * Undefined for apps that haven't received a live-build event (e.g. just
    * opened). `error` surfaces a non-blocking badge over the last-good html.
    */
-  compileStatus?: "building" | "ok" | "error";
+  compileStatus?: AppCompileStatus;
   /** Compile diagnostics from the last `error` event; surfaced in the badge. */
   buildErrors?: string[];
   /**
@@ -229,15 +248,7 @@ export interface ViewerActions {
    */
   revealAppForBuild: (assistantId: string, appId: string) => void;
   setLoadedApp: (app: OpenedAppState) => void;
-  updateOpenedAppPreview: (
-    appId: string,
-    update: {
-      html?: string;
-      compileStatus: "building" | "ok" | "error";
-      buildErrors?: string[];
-      reloadGeneration: number;
-    },
-  ) => void;
+  updateOpenedAppPreview: (appId: string, update: AppPreviewUpdate) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   /**
@@ -387,6 +398,15 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
    * AND `reloadGeneration` untouched so the last working preview stays
    * visible and the iframe is not remounted on a transient failure.
    *
+   * Drop-stale: builds can overlap, so a SLOW older build may emit its
+   * terminal `building`/`error` event AFTER a newer build already landed an
+   * `ok`. Applying that stale status would regress the preview (paint an
+   * `error`/`building` over the latest good frame). We therefore ignore a
+   * `building`/`error` event whose `reloadGeneration` is strictly BELOW the
+   * stored generation. `ok` events still apply (they carry the freshest html
+   * and the newest generation). Missing/0 generations are treated as
+   * not-stale-blocking, preserving the pre-existing behavior.
+   *
    * The daemon bumps `reloadGeneration` on every successful recompile so
    * clients force-swap the iframe (it's folded into the iframe key). A
    * successful rebuild whose resolved html is byte-identical therefore still
@@ -400,6 +420,16 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     const prev = get().openedAppState;
     if (!prev || get().activeAppId !== appId || prev.appId !== appId) return;
     const isOk = compileStatus === "ok";
+    // Drop a stale terminal event from an older overlapping build: its
+    // generation is behind the last-good `ok` we already applied. `ok`
+    // events are never dropped here — they carry the newest generation.
+    if (
+      !isOk &&
+      prev.reloadGeneration !== undefined &&
+      reloadGeneration < prev.reloadGeneration
+    ) {
+      return;
+    }
     const nextHtml = isOk && html !== undefined ? html : prev.html;
     // Only an `ok` event advances the stored generation; building/error keep
     // the last-good generation so a transient failure never remounts.


### PR DESCRIPTION
## Summary
Fixes three gaps from plan review for app-live-preview.md.

**Gap 1:** updateOpenedAppPreview ignored event generation, so a stale older-build error could regress the preview; now drops building/error events behind the stored reloadGeneration.
**Gap 2:** compileStatus union re-declared across ~4 web sites; now derived from the canonical AppPreviewUpdateEvent.
**Gap 3:** BuildErrorBadge dismissal persisted across distinct errors; now resets on a new failure.