### PR TITLE
fix(daemon): reloadGeneration coherence (no macOS-reload collision) + drop dead return

### DIFF
--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -29,13 +29,31 @@ interface Harness {
   settledCount: () => number;
 }
 
+/**
+ * Default `refreshSurfaces` stub: models the real surface counter as the
+ * single source of truth. Tracks a per-app generation and, on a successful
+ * recompile, advances it to at least the supplied floor (`max(floor, gen + 1)`)
+ * and returns it. A failed compile does not bump and returns the current value.
+ */
+function makeSurfaceCounter() {
+  const generations = new Map<string, number>();
+  const refreshSurfaces: AppLiveBuildDeps["refreshSurfaces"] = (id, opts) => {
+    const current = generations.get(id) ?? 0;
+    if (opts.compileStatus === "error") return current;
+    const next = Math.max(opts.reloadGeneration ?? 0, current + 1);
+    generations.set(id, next);
+    return next;
+  };
+  return { refreshSurfaces, peek: (id: string) => generations.get(id) ?? 0 };
+}
+
 function makeHarness(opts: { compile: () => Promise<CompileResult> }): Harness {
   let settled = 0;
   const deps: AppLiveBuildDeps = {
     compileApp: opts.compile,
     resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
     broadcast: () => {},
-    refreshSurfaces: () => {},
+    refreshSurfaces: makeSurfaceCounter().refreshSurfaces,
     onSettled: () => {
       settled++;
     },
@@ -71,11 +89,15 @@ describe("runAppLiveBuild", () => {
     const refreshCalls: Array<
       Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
     > = [];
+    const surface = makeSurfaceCounter();
     const deps: AppLiveBuildDeps = {
       compileApp: compile,
       resolveEffectiveAppHtml: () => (distFresh ? FRESH_HTML : LAST_GOOD_HTML),
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      refreshSurfaces: (id, o) => {
+        refreshCalls.push(o);
+        return surface.refreshSurfaces(id, o);
+      },
       onSettled: () => {},
     };
 
@@ -92,12 +114,15 @@ describe("runAppLiveBuild", () => {
     expect(okMsg.reloadGeneration).toBe(1); // bumped
     expect(okMsg.buildErrors).toBeUndefined();
 
+    // Only the terminal `ok` outcome refreshes surfaces; the broadcast
+    // generation equals the one the surface applied.
     expect(refreshCalls).toHaveLength(1);
     expect(refreshCalls[0].compileStatus).toBe("ok");
-    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    expect(okMsg.reloadGeneration).toBe(surface.peek(APP_ID));
   });
 
   test("failed compile keeps last-good html and an unchanged reloadGeneration", async () => {
+    const surface = makeSurfaceCounter();
     // First do a clean build to advance the generation to 1.
     {
       const compile = async () => ok();
@@ -106,7 +131,7 @@ describe("runAppLiveBuild", () => {
         compileApp: compile,
         resolveEffectiveAppHtml: () => FRESH_HTML,
         broadcast: (msg) => broadcasts.push(msg),
-        refreshSurfaces: () => {},
+        refreshSurfaces: surface.refreshSurfaces,
         onSettled: () => {},
       };
       await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
@@ -130,7 +155,10 @@ describe("runAppLiveBuild", () => {
       resolveEffectiveAppHtml: () =>
         compiled ? "<p>App compilation failed.</p>" : LAST_GOOD_HTML,
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      refreshSurfaces: (id, o) => {
+        refreshCalls.push(o);
+        return surface.refreshSurfaces(id, o);
+      },
       onSettled: () => {},
     };
 
@@ -154,7 +182,9 @@ describe("runAppLiveBuild", () => {
 
     expect(refreshCalls).toHaveLength(1);
     expect(refreshCalls[0].compileStatus).toBe("error");
-    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    // The error path does not pass a generation floor; the surface owns its
+    // (unchanged) generation on a failed compile.
+    expect(refreshCalls[0].reloadGeneration).toBeUndefined();
     expect(refreshCalls[0].buildErrors).toEqual([
       "Could not resolve 'foo'",
       "Unexpected token",
@@ -169,7 +199,7 @@ describe("runAppLiveBuild", () => {
       },
       resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: () => {},
+      refreshSurfaces: makeSurfaceCounter().refreshSurfaces,
       onSettled: () => {},
     };
 
@@ -184,12 +214,14 @@ describe("runAppLiveBuild", () => {
   });
 
   test("two overlapping successful compiles yield distinct increasing generations", async () => {
-    // Both invocations capture the same starting generation BEFORE awaiting
-    // their (serialized) compile. The generation must be read-and-bumped AFTER
-    // each compile succeeds so the second successful build does not reuse the
-    // first's reloadGeneration — otherwise clients drop the latest output.
+    // Both invocations are in-flight at once. The generation is read-and-bumped
+    // (through the shared surface counter) AFTER each compile succeeds, so the
+    // second successful build cannot reuse the first's reloadGeneration —
+    // otherwise the macOS change-detection would drop the latest output.
     const okBroadcasts: AppPreviewUpdateEvent[] = [];
     const okRefreshGenerations: number[] = [];
+    // A single surface counter shared by both invocations, as in production.
+    const surface = makeSurfaceCounter();
 
     let releaseFirst!: () => void;
     const firstGate = new Promise<void>((resolve) => {
@@ -203,8 +235,8 @@ describe("runAppLiveBuild", () => {
 
     let compileCount = 0;
     const deps: AppLiveBuildDeps = {
-      // First compile blocks until both invocations are in-flight, so they both
-      // captured the same starting generation before either bumps it.
+      // First compile blocks until both invocations are in-flight, so they
+      // overlap before either advances the generation.
       compileApp: async () => {
         compileCount += 1;
         if (compileCount === 1) {
@@ -217,17 +249,17 @@ describe("runAppLiveBuild", () => {
       broadcast: (msg) => {
         if (msg.compileStatus === "ok") okBroadcasts.push(msg);
       },
-      refreshSurfaces: (_id, o) => {
-        if (o.reloadGeneration !== undefined)
-          okRefreshGenerations.push(o.reloadGeneration);
+      refreshSurfaces: (id, o) => {
+        const applied = surface.refreshSurfaces(id, o);
+        if (o.compileStatus === "ok") okRefreshGenerations.push(applied);
+        return applied;
       },
       onSettled: () => {},
     };
 
     const first = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
     await firstStartedGate;
-    // Second invocation starts (and snapshots the same generation) while the
-    // first is still awaiting its compile.
+    // Second invocation starts while the first is still awaiting its compile.
     const second = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
     releaseFirst();
     await Promise.all([first, second]);
@@ -238,6 +270,43 @@ describe("runAppLiveBuild", () => {
     expect(generations).toEqual([1, 2]);
     // Broadcast generations match the ones written to surfaces.
     expect([...okRefreshGenerations].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  test("first live-build after an app_create surface bump does not collide", async () => {
+    // Reproduces the Gap-1 collision: `app_create` bumped the surface to 1
+    // (via the non-live-build +1 path) while the live-build module counter is
+    // still 0. The first successful live-build must NOT reuse generation 1 —
+    // the macOS client uses change-detection (gen != lastGen), so reusing the
+    // value it already saw would suppress a legitimate reload.
+    const surface = makeSurfaceCounter();
+    // Simulate the app_create surface bump (no live-build floor → +1 to 1).
+    expect(
+      surface.refreshSurfaces(APP_ID, {
+        fileChange: true,
+        // Cast: app_create/app_refresh path has no compileStatus, modeled here
+        // as a non-error bump.
+        compileStatus: "ok",
+      } as Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]),
+    ).toBe(1);
+
+    const okBroadcasts: AppPreviewUpdateEvent[] = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => ok(),
+      resolveEffectiveAppHtml: () => FRESH_HTML,
+      broadcast: (msg) => {
+        if (msg.compileStatus === "ok") okBroadcasts.push(msg);
+      },
+      refreshSurfaces: surface.refreshSurfaces,
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(okBroadcasts).toHaveLength(1);
+    // Strictly greater than the 1 the surface (and client) already had.
+    expect(okBroadcasts[0].reloadGeneration).toBeGreaterThan(1);
+    // Broadcast equals the surface's current generation (single source).
+    expect(okBroadcasts[0].reloadGeneration).toBe(surface.peek(APP_ID));
   });
 
   test("settle/onSettled fires on every outcome", async () => {

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -23,10 +23,13 @@ export interface AppLiveBuildDeps {
   /** Broadcast an app_preview_update event to all connected clients. */
   broadcast: (msg: AppPreviewUpdateEvent) => void;
   /**
-   * Refresh in-memory/persisted surfaces for the app. Returns the applied
-   * reload generation so this orchestrator can keep one source of truth shared
-   * with the broadcast event. When `reloadGeneration` is supplied the caller is
-   * expected to use it verbatim.
+   * Refresh in-memory/persisted surfaces for the app. The per-surface
+   * `reloadGeneration` is the single source of truth for the macOS reload, so
+   * this returns the highest generation actually applied across surfaces.
+   * `reloadGeneration` is a monotonic floor: each surface advances to at least
+   * `floor` but never below `currentGeneration + 1`, so the broadcast can adopt
+   * the returned value and stay in agreement with — and strictly ahead of —
+   * what clients last saw.
    */
   refreshSurfaces: (
     appId: string,
@@ -36,15 +39,21 @@ export interface AppLiveBuildDeps {
       buildErrors?: string[];
       reloadGeneration?: number;
     },
-  ) => void;
+  ) => number;
   /** Notify the app-list / publish pipeline (existing side effects). */
   onSettled: () => void;
 }
 
 /**
- * Per-app reload generation counter — the single source of truth for the
- * `reloadGeneration` field shared by the broadcast event and the refreshed
- * surfaces. Bumped only on a successful recompile.
+ * Per-app reload generation counter for the `app_preview_update` broadcast.
+ *
+ * The per-surface counter (see `refreshSurfacesForApp`) is the authoritative
+ * source of truth for the macOS change-detection reload; this map mirrors the
+ * highest generation applied to any surface so overlapping live builds keep
+ * issuing strictly increasing broadcast generations even when no surface is
+ * currently mounted. It is reconciled from `refreshSurfaces`' return value on
+ * every successful recompile, so it can never collide with or regress below
+ * what a client last saw.
  */
 const appReloadGenerations = new Map<string, number>();
 
@@ -64,9 +73,8 @@ export async function runAppLiveBuild(
   deps: AppLiveBuildDeps,
 ): Promise<void> {
   // Snapshot the current generation for the non-bumping `building`/`error`
-  // outcomes. The successful `ok` outcome instead reads-and-bumps the counter
-  // AFTER the (serialized) compile resolves, so two overlapping builds that
-  // both succeed produce two distinct, monotonically increasing generations.
+  // outcomes (these never advance the counter, so they re-broadcast whatever
+  // generation a client already has).
   const generationAtStart = appReloadGenerations.get(appId) ?? 0;
 
   // Capture the last-good resolved html BEFORE compiling: compileApp begins
@@ -74,55 +82,70 @@ export async function runAppLiveBuild(
   // resolvable html) would otherwise be wiped.
   const lastGoodHtml = deps.resolveEffectiveAppHtml(app);
 
-  // Settle a terminal outcome: refresh surfaces, broadcast the preview update,
-  // and run the existing app-list/publish side effects.
-  const emit = (
+  // Broadcast the preview update and run the existing app-list/publish side
+  // effects. Surface refresh (the source of the reload generation) happens in
+  // the caller for the `ok` path, since its applied generation feeds the
+  // broadcast; the non-bumping `error` path refreshes here.
+  const broadcastUpdate = (
     update: Pick<
       AppPreviewUpdateEvent,
       "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
     >,
   ) => {
-    if (update.compileStatus !== "building") {
-      deps.refreshSurfaces(appId, {
-        fileChange: true,
-        compileStatus: update.compileStatus,
-        buildErrors: update.buildErrors,
-        reloadGeneration: update.reloadGeneration,
-      });
-    }
     deps.broadcast({ type: "app_preview_update", appId, ...update });
     if (update.compileStatus !== "building") deps.onSettled();
   };
 
-  // Show a building overlay immediately without blanking the preview.
-  emit({
+  // Show a building overlay immediately without blanking the preview. No
+  // surface refresh: a building status must not bump the reload generation.
+  broadcastUpdate({
     html: lastGoodHtml,
     compileStatus: "building",
     reloadGeneration: generationAtStart,
   });
+
+  const settleError = (buildErrors: string[]) => {
+    // Failed compile: do NOT push broken/placeholder html and do NOT bump the
+    // reload generation. Re-broadcast the captured last-good html plus errors.
+    deps.refreshSurfaces(appId, {
+      fileChange: true,
+      compileStatus: "error",
+      buildErrors,
+    });
+    broadcastUpdate({
+      html: lastGoodHtml,
+      compileStatus: "error",
+      buildErrors,
+      reloadGeneration: generationAtStart,
+    });
+  };
 
   let result: CompileResult;
   try {
     result = await deps.compileApp(appDir);
   } catch {
     // Treat a thrown compile as a failed compile: keep the last-good preview.
-    emit({
-      html: lastGoodHtml,
-      compileStatus: "error",
-      buildErrors: ["Recompile failed"],
-      reloadGeneration: generationAtStart,
-    });
+    settleError(["Recompile failed"]);
     return;
   }
 
   if (result.ok) {
-    // Read-and-bump AFTER the compile resolves so overlapping successful
-    // builds each get a distinct, monotonically increasing generation. (Both
-    // the read and the write happen synchronously here with no intervening
-    // await, so they are atomic against other invocations.)
-    const nextGeneration = (appReloadGenerations.get(appId) ?? 0) + 1;
+    // Let the surface refresh advance the authoritative per-surface counter and
+    // tell us the generation it applied. We pass the module counter + 1 as a
+    // monotonic floor and adopt the returned value (which is also >= every
+    // surface's prior generation + 1), so the broadcast can never collide with
+    // or regress below what a client last saw, even across overlapping builds.
+    // The read-and-write of the module counter is synchronous (no intervening
+    // await), so it is atomic against other in-flight invocations.
+    const floor = (appReloadGenerations.get(appId) ?? 0) + 1;
+    const appliedGeneration = deps.refreshSurfaces(appId, {
+      fileChange: true,
+      compileStatus: "ok",
+      reloadGeneration: floor,
+    });
+    const nextGeneration = Math.max(floor, appliedGeneration);
     appReloadGenerations.set(appId, nextGeneration);
-    emit({
+    broadcastUpdate({
       html: deps.resolveEffectiveAppHtml(app),
       compileStatus: "ok",
       reloadGeneration: nextGeneration,
@@ -130,12 +153,5 @@ export async function runAppLiveBuild(
     return;
   }
 
-  // Failed compile: do NOT push broken/placeholder html and do NOT bump the
-  // reload generation. Re-broadcast the captured last-good html plus errors.
-  emit({
-    html: lastGoodHtml,
-    compileStatus: "error",
-    buildErrors: result.errors.map((e) => e.text),
-    reloadGeneration: generationAtStart,
-  });
+  settleError(result.errors.map((e) => e.text));
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1799,15 +1799,20 @@ export async function handleSurfaceAction(
 /**
  * After an app_refresh, refresh any active surface that displays the updated app.
  *
- * Returns whether any surface was refreshed plus the `reloadGeneration` that was
- * applied, so live-build callers (the source-change recompile path) can emit a
- * broadcast event whose generation counter agrees with the surface state.
+ * The per-surface `reloadGeneration` is the single source of truth for the
+ * macOS change-detection reload. This function read-modify-writes it and
+ * returns the highest generation it applied so live-build callers (the
+ * source-change recompile path) can reconcile their per-app counter and emit a
+ * broadcast event whose `reloadGeneration` agrees with the surface state.
  *
  * Additive live-build opts (do not affect the existing macOS path):
  * - `compileStatus: "error"` keeps the last-good html and does NOT bump
  *   `reloadGeneration` (the preview iframe is not swapped on a transient error).
- * - `reloadGeneration` overrides the per-surface bump with an explicit value so
- *   the server can keep one source of truth shared with the broadcast event.
+ * - `reloadGeneration` is a monotonic floor from live-build's per-app counter:
+ *   each surface advances to `max(floor, currentGeneration + 1)`, so the value
+ *   is always strictly greater than what the client last saw (never a collision
+ *   that would suppress a reload) while still honoring the live-build counter
+ *   when it is already ahead.
  */
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
@@ -1837,13 +1842,15 @@ export function refreshSurfacesForApp(
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
-    // Compute the next reload generation. An explicit override (live-build
-    // path) wins so web and macOS agree; otherwise keep the existing
-    // per-surface bump on file change. A failed compile never bumps.
+    // Compute the next reload generation. A failed compile never bumps. On a
+    // bump, always go strictly above this surface's current generation so the
+    // macOS change-detection fires; an explicit floor from live-build's per-app
+    // counter raises it further so web and macOS stay in agreement.
+    const bumped = (data.reloadGeneration ?? 0) + 1;
     const nextGeneration = isError
       ? (data.reloadGeneration ?? 0)
-      : (opts?.reloadGeneration ?? (data.reloadGeneration ?? 0) + 1);
-    appliedGeneration = nextGeneration;
+      : Math.max(opts?.reloadGeneration ?? 0, bumped);
+    appliedGeneration = Math.max(appliedGeneration, nextGeneration);
 
     // Update in-memory surface state so the next refinement gets fresh HTML.
     // For multifile apps, resolve the compiled dist/index.html with inlined

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -266,9 +266,19 @@ export class DaemonServer {
               "Recompile failed on app source change — keeping last-good preview",
             );
           }
+          // Return the highest generation applied across all conversations'
+          // surfaces so the live-build orchestrator can keep its broadcast
+          // generation in agreement with — and ahead of — every surface.
+          let maxGeneration = opts.reloadGeneration ?? 0;
           for (const conversation of allConversations()) {
-            refreshSurfacesForApp(conversation, id, opts);
+            const { reloadGeneration } = refreshSurfacesForApp(
+              conversation,
+              id,
+              opts,
+            );
+            maxGeneration = Math.max(maxGeneration, reloadGeneration);
           }
+          return maxGeneration;
         },
         onSettled: settle,
       }).catch((err) => {


### PR DESCRIPTION
## Summary
Fixes two coupled gaps from plan review for app-live-preview.md.

**Gap 1:** live-build's module-level reloadGeneration could collide with the per-surface counter used by macOS (change-detection), suppressing a legitimate reload. Now monotonic relative to the surface counter.
**Gap 2:** refreshSurfacesForApp's widened { refreshed, reloadGeneration } return was unused with a misleading doc-comment; resolved coherently with Gap 1.