### PR TITLE
feat(assistant): add incognito + factor_in_memories columns to conversations

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -73,6 +73,7 @@ import {
   migrateConversationInferenceProfileSession,
   migrateConversationLastNotifiedProfile,
   migrateConversationsArchivedAt,
+  migrateConversationsIncognitoFlags,
   migrateConversationsLastMessageAt,
   migrateConversationsThreadTypeIndex,
   migrateCreateConversationGraphMemoryState,
@@ -474,6 +475,7 @@ export function initializeDb(): void {
     migrateAddMemoryV3Selections,
     migrateScheduleScriptTimeout,
     migrateMessagesRoleCreatedAtIndex,
+    migrateConversationsIncognitoFlags,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/271-conversations-incognito-flags.ts
+++ b/assistant/src/memory/migrations/271-conversations-incognito-flags.ts
@@ -1,0 +1,39 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Adds the incognito conversation flags to `conversations`:
+ *
+ * - `incognito` (default 0) — when set, the conversation never produces
+ *   memories.
+ * - `factor_in_memories` (default 1) — controls whether existing memories are
+ *   recalled into the conversation.
+ *
+ * An index on `incognito` supports filtering incognito conversations out of
+ * memory-producing queries.
+ *
+ * Idempotent — the `ADD COLUMN` statements are wrapped in try/catch (mirroring
+ * the surrounding additive-column migrations, e.g.
+ * 253-conversation-last-notified-profile and 221-conversations-archived-at),
+ * and `CREATE INDEX IF NOT EXISTS` is a no-op once the index exists.
+ */
+export function migrateConversationsIncognitoFlags(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN incognito INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+  try {
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN factor_in_memories INTEGER NOT NULL DEFAULT 1`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_conversations_incognito ON conversations(incognito)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -257,6 +257,7 @@ export { migrateLlmUsageEventsAddAssistantVersion } from "./267-llm-usage-events
 export { migrateAddMemoryV3Selections } from "./268-add-memory-v3-selections.js";
 export { migrateScheduleScriptTimeout } from "./269-schedule-script-timeout.js";
 export { migrateMessagesRoleCreatedAtIndex } from "./270-messages-role-created-at-index.js";
+export { migrateConversationsIncognitoFlags } from "./271-conversations-incognito-flags.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -45,6 +45,8 @@ export const conversations = sqliteTable(
     inferenceProfileSessionId: text("inference_profile_session_id"),
     inferenceProfileExpiresAt: integer("inference_profile_expires_at"),
     lastNotifiedInferenceProfile: text("last_notified_inference_profile"),
+    incognito: integer("incognito").notNull().default(0),
+    factorInMemories: integer("factor_in_memories").notNull().default(1),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),
@@ -54,6 +56,7 @@ export const conversations = sqliteTable(
     index("idx_conversations_fork_parent_conversation_id").on(
       table.forkParentConversationId,
     ),
+    index("idx_conversations_incognito").on(table.incognito),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Add `incognito` and `factor_in_memories` columns to the conversations table + index
- Idempotent migration 271 wired into db-init migration steps

Part of plan: incognito-conversations.md (PR 1 of 16)