### PR TITLE
fix(web): make usage-tab range window genuinely timezone-aware

### DIFF
--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -7,16 +7,6 @@ export function formatDateLabel(dateStr: string): string {
 }
 
 /**
- * Format a `Date` as a "YYYY-MM-DD" string using local time.
- */
-export function toLocalDateString(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-/**
  * Format a `Date` as a "YYYY-MM-DD" string representing the calendar date in
  * the given IANA timezone. `en-CA` yields ISO-like `YYYY-MM-DD` output.
  */
@@ -27,4 +17,45 @@ export function toTimezoneDateString(d: Date, tz: string): string {
     month: "2-digit",
     day: "2-digit",
   }).format(d);
+}
+
+/**
+ * Epoch ms for the start of the calendar day `dateStr` ("YYYY-MM-DD") as it
+ * occurs in the given IANA timezone — i.e. zone-local midnight. DST-safe:
+ * derives the zone's UTC offset at that instant and subtracts it, so the
+ * returned epoch maps back to 00:00 wall-clock in `tz`.
+ */
+export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  // Provisional UTC midnight, then correct by the zone offset observed there.
+  const utcMidnight = Date.UTC(y, m - 1, d);
+  const offsetMs = utcMidnight - zonedWallClockEpoch(new Date(utcMidnight), tz);
+  return utcMidnight + offsetMs;
+}
+
+/**
+ * Interpret the wall-clock time that `instant` shows in `tz` as if it were UTC,
+ * returning that as epoch ms. Used to recover a zone's UTC offset.
+ */
+function zonedWallClockEpoch(instant: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(instant);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+  return Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
 }

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -92,10 +92,14 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   );
   const timezone = useEffectiveTimezone();
   // Depend on `timezone` so bounded ranges (e.g. "Today", "Last 7 days")
-  // recompute their browser-local from/to boundaries when the live zone
-  // changes (OS or `device:timezone` update), keeping them aligned with the
-  // `tz` sent to the backend instead of using stale boundaries.
-  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range, timezone]);
+  // recompute their from/to boundaries in the effective zone when it changes
+  // (OS or `device:timezone` update). `resolveRangeWindow` derives the calendar
+  // day boundaries in `timezone`, keeping them aligned with the `tz` sent to
+  // the backend rather than browser-local boundaries.
+  const rangeWindow = useMemo(
+    () => resolveRangeWindow(range, timezone),
+    [range, timezone],
+  );
   const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
 
   const startCostConversation = (message: string) => {

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import { resolveRangeWindow } from "@/domains/logs/usage-tab-state";
+
+const UTC = "UTC";
+
+describe("resolveRangeWindow", () => {
+  test("'all' returns from=0 and to=now regardless of tz", () => {
+    const now = Date.UTC(2026, 5, 2, 12, 0, 0);
+    expect(resolveRangeWindow("all", "America/New_York", now)).toEqual({
+      from: 0,
+      to: now,
+    });
+  });
+
+  test("'to' is the current instant; 'today' from is zone-local midnight", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const { from, to } = resolveRangeWindow("today", UTC, now);
+    expect(to).toBe(now);
+    // UTC midnight of 2026-06-02
+    expect(from).toBe(Date.UTC(2026, 5, 2, 0, 0, 0));
+  });
+
+  test("'7d' from is six zone-local days before today (UTC)", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const { from } = resolveRangeWindow("7d", UTC, now);
+    expect(from).toBe(Date.UTC(2026, 4, 27, 0, 0, 0));
+  });
+
+  test("day boundaries are computed in the supplied tz", () => {
+    // An instant where the calendar day differs across far-apart zones.
+    // 2026-06-02T01:00:00Z: UTC+14 (Kiritimati) is already 2026-06-02 15:00,
+    // while UTC-11 (Niue) is still 2026-06-01 14:00.
+    const now = Date.UTC(2026, 5, 2, 1, 0, 0);
+
+    const east = resolveRangeWindow("today", "Pacific/Kiritimati", now);
+    const west = resolveRangeWindow("today", "Pacific/Niue", now);
+
+    // Different calendar "today" => different from-boundaries.
+    expect(east.from).not.toBe(west.from);
+
+    // Sanity-check the actual calendar dates the boundaries land on.
+    expect(toTimezoneDateString(new Date(east.from), "Pacific/Kiritimati")).toBe(
+      "2026-06-02",
+    );
+    expect(toTimezoneDateString(new Date(west.from), "Pacific/Niue")).toBe(
+      "2026-06-01",
+    );
+  });
+
+  test("from epoch maps back to zone-local midnight (DST-safe)", () => {
+    // US DST is in effect in June; verify the from-boundary is local midnight.
+    const now = Date.UTC(2026, 5, 2, 18, 0, 0);
+    const tz = "America/New_York";
+    const { from } = resolveRangeWindow("7d", tz, now);
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(from));
+    const hour = parts.find((p) => p.type === "hour")?.value;
+    const minute = parts.find((p) => p.type === "minute")?.value;
+    expect(`${hour}:${minute}`).toBe("00:00");
+  });
+});

--- a/apps/web/src/domains/logs/usage-tab-state.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.ts
@@ -1,3 +1,7 @@
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
 import { LLM_USAGE_DIMENSION_LABELS } from "@/utils/llm-dimension";
 import { UsageRequestError } from "./usage-api";
 import type {
@@ -119,8 +123,15 @@ const RANGE_START_DAY_OFFSETS: Record<Exclude<UsageTimeRange, "all">, number> =
     "90d": 89,
   };
 
+/**
+ * Resolve the `{ from, to }` epoch-ms window for a usage range, with calendar
+ * day boundaries computed in the effective `tz` so they stay aligned with the
+ * `tz` sent to the backend (which buckets by that zone). `to` is the current
+ * instant; `from` is zone-local midnight of the range's first calendar day.
+ */
 export function resolveRangeWindow(
   range: UsageTimeRange,
+  tz: string,
   now: Date | number = Date.now(),
 ): {
   from: number;
@@ -130,13 +141,15 @@ export function resolveRangeWindow(
   if (range === "all") {
     return { from: 0, to };
   }
-  const localNow = new Date(to);
   const dayOffset = RANGE_START_DAY_OFFSETS[range];
-  const from = new Date(
-    localNow.getFullYear(),
-    localNow.getMonth(),
-    localNow.getDate() - dayOffset,
-  ).getTime();
+  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
+  // anchor to avoid DST slips before resolving zone-local midnight.
+  const todayInTz = toTimezoneDateString(new Date(to), tz);
+  const [y, m, d] = todayInTz.split("-").map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - dayOffset);
+  const fromDate = toTimezoneDateString(anchor, "UTC");
+  const from = timezoneDayStartEpoch(fromDate, tz);
   return { from, to };
 }
 


### PR DESCRIPTION
## Summary
Fixes gap from plan review: resolveRangeWindow now computes day boundaries in the effective timezone (matching the tz sent to the backend), instead of browser-local with a misleading 'timezone-aware' comment. Removes dead toLocalDateString.

Part of plan: fix-timezone-auto-update.md (review remediation)