### PR TITLE
fix(web): correct timezone-sync cascade semantics + in-flight PATCH race

### DIFF
--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for the headless `TimezoneSync` component.
  *
- * Strategy: mock the generated API client's `patch` and the effective-
- * timezone hook, drive the active assistant id through the real
- * selection store, and assert the PATCH fires only for genuinely new
- * `{ ui: { detectedTimezone } }` values.
+ * Strategy: mock the generated API client's `patch`, the browser-zone and
+ * device-setting readers (separately), and the effective-timezone hook
+ * (the reactivity trigger), drive the active assistant id through the real
+ * selection store, and assert the PATCH writes both `detectedTimezone`
+ * (browser zone) and `userTimezone` (override or "") and never persists a
+ * stale zone when requests overlap.
  */
 import {
   afterEach,
@@ -21,25 +23,32 @@ import type { ReactNode } from "react";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { publish } from "@/lib/event-bus";
 
-// Mutable zone returned by the mocked hook; tests flip it then re-render.
 interface PatchArgs {
   url: string;
   path: { assistant_id: string };
   body: { ui: Record<string, unknown> };
 }
 
-let currentTz = "America/New_York";
+// Mutable separate readers; tests flip them then re-render. `browserTz`
+// is the live auto zone; `override` is the manual `device:timezone`.
+let browserTz = "America/New_York";
+let override = "";
 const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
 const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
 
-// Both the reactive hook and the imperative resume/focus reader resolve
-// to the same mutable `currentTz`.
+// The hook is just a reactivity trigger; it folds override over browser
+// zone (matching the real implementation) so a flip of either re-renders.
 mock.module("@/utils/use-effective-timezone", () => ({
-  useEffectiveTimezone: () => currentTz,
+  useEffectiveTimezone: () => (override.trim() ? override.trim() : browserTz),
 }));
 
-mock.module("@/utils/effective-timezone", () => ({
-  getEffectiveTimezone: () => currentTz,
+mock.module("@/utils/browser-timezone", () => ({
+  getBrowserTimezone: () => browserTz,
+}));
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceSetting: (_name: string, fallback: string) =>
+    override === "" ? fallback : override,
 }));
 
 mock.module("@/generated/api/client.gen", () => ({
@@ -63,7 +72,8 @@ function renderSync() {
 }
 
 beforeEach(() => {
-  currentTz = "America/New_York";
+  browserTz = "America/New_York";
+  override = "";
   patchMock.mockClear();
   captureErrorMock.mockClear();
   patchMock.mockImplementation(async () => ({ data: {} }));
@@ -80,46 +90,61 @@ function lastBody() {
 }
 
 describe("TimezoneSync", () => {
-  test("PATCHes detectedTimezone once on mount with a resolvable assistant id", async () => {
+  test("PATCHes both fields once on mount in auto mode (userTimezone cleared)", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
     const call = patchMock.mock.calls[0]![0];
     expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
     expect(call.path).toEqual({ assistant_id: "asst-1" });
-    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(call.body).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
-  test("never writes userTimezone", async () => {
+  test("manual override is written to userTimezone; detectedTimezone carries the live browser zone", async () => {
+    override = "Asia/Tokyo";
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()?.ui).not.toHaveProperty("userTimezone");
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
+    });
   });
 
-  test("a zone change triggers exactly one additional PATCH with the new zone", async () => {
+  test("trims the override before writing userTimezone", async () => {
+    override = "  Asia/Tokyo  ";
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
+    });
+  });
+
+  test("a browser-zone change triggers exactly one additional PATCH with the new zone", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    currentTz = "Europe/London";
+    browserTz = "Europe/London";
     rerender(<TimezoneSync />);
 
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "Europe/London", userTimezone: "" },
+    });
   });
 
-  test("no additional PATCH when the zone is unchanged across re-renders", async () => {
+  test("no additional PATCH when nothing changed across re-renders (redundant-key dedupe)", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
     rerender(<TimezoneSync />);
     rerender(<TimezoneSync />);
 
-    // Give any stray effect a chance to fire, then assert it didn't.
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("no PATCH when the effective zone is empty", async () => {
-    currentTz = "";
+  test("no PATCH when the browser zone is empty", async () => {
+    browserTz = "";
     renderSync();
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).not.toHaveBeenCalled();
@@ -139,25 +164,22 @@ describe("TimezoneSync", () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
     expect(captureErrorMock.mock.calls[0]![1]).toEqual({
-      context: "timezone-sync-detected",
+      context: "timezone-sync",
     });
 
-    // The onError handler reset the guard for the failed zone, so the
-    // next time that same zone comes back around (after a focus that
-    // flips it away and back) it re-syncs instead of being suppressed.
-    currentTz = "Europe/London";
+    browserTz = "Europe/London";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
 
-    currentTz = "America/New_York";
+    browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("retries on app.resume with the same zone after a failed initial sync", async () => {
-    // Initial sync rejects (e.g. resumed while offline). The guard ref
-    // stays unsynced because we only record the key on success.
     patchMock.mockImplementationOnce(async () => {
       throw new Error("offline");
     });
@@ -165,11 +187,11 @@ describe("TimezoneSync", () => {
     await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    // Resume with the SAME zone — a retry must fire even though tz is
-    // unchanged (the offline-then-resume case).
     publish("app.resume", { signal: "visibility" });
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("retries on window focus with the same zone after a failed initial sync", async () => {
@@ -182,19 +204,62 @@ describe("TimezoneSync", () => {
 
     window.dispatchEvent(new Event("focus"));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    // No zone flip: the prior success recorded the key, so both triggers
-    // are no-ops (no redundant PATCH).
     publish("app.resume", { signal: "visibility" });
     window.dispatchEvent(new Event("focus"));
 
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("last-writer-wins: a slow older PATCH cannot overwrite a newer zone", async () => {
+    // Two overlapping triggers; the FIRST (older zone) resolves AFTER the
+    // SECOND (newer zone). The final synced state must reflect the newer
+    // zone, and the stale older completion must not re-open it for resync.
+    const resolvers: Array<() => void> = [];
+    patchMock.mockImplementation(
+      () =>
+        new Promise<{ data: Record<string, unknown> }>((resolve) => {
+          resolvers.push(() => resolve({ data: {} }));
+        }),
+    );
+
+    const { rerender } = renderSync();
+    // First PATCH issued (mount) for America/New_York; still pending.
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // Zone flips before the first request settles → second PATCH issued.
+    browserTz = "Europe/London";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+
+    expect(resolvers).toHaveLength(2);
+    // Newer request resolves first, then the stale older one resolves last.
+    resolvers[1]!();
+    resolvers[0]!();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The newer zone is the synced state: re-rendering with Europe/London
+    // (the latest issued key) must NOT trigger a redundant PATCH...
+    rerender(<TimezoneSync />);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(2);
+
+    // ...and flipping back to the older zone DOES PATCH (so the stale
+    // completion never recorded America/New_York as the synced key).
+    browserTz = "America/New_York";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 });

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,30 +1,34 @@
 /**
- * Headless background sync of the live effective timezone into the
- * assistant daemon config at `config.ui.detectedTimezone`.
+ * Headless background sync of the client's timezone into the assistant
+ * daemon config, writing both cascade tiers separately:
  *
- * `useEffectiveTimezone()` re-reads the zone on window focus,
- * visibility, and device-setting override changes, so this component
- * keeps the daemon's *detected* zone fresh for background grounding
- * (memory retrospective, scheduling) that has no per-turn
- * `clientTimezone`. Per the backend resolver cascade this only ever
- * writes `detectedTimezone` — `config.ui.userTimezone` is owned by the
- * settings UI and a manual override still wins.
+ * - `ui.userTimezone`  ← the manual `device:timezone` override (trimmed),
+ *   or `""` to CLEAR it when in auto mode. A deliberate override must
+ *   live in this tier so it outranks another client's per-turn
+ *   `clientTimezone`; storing it in `detectedTimezone` (the weakest
+ *   relevant tier) would let a transient per-turn zone win.
+ * - `ui.detectedTimezone` ← the live auto browser zone, used for
+ *   background grounding (memory retrospective, scheduling) that has no
+ *   per-turn `clientTimezone`.
  *
- * Mounted once in `RootLayout` (behind `authMiddleware`), so it lives
- * for the whole authenticated session and never renders on public
- * `/account` routes. The active assistant id comes from
- * `useAssistantSelectionStore`, which the lifecycle populates once a
- * logged-in assistant resolves; until then the id is null and we skip.
+ * This is the single point that mirrors `device:timezone` into config;
+ * the settings picker only writes localStorage. `useEffectiveTimezone()`
+ * is used purely as a reactivity trigger (focus / app.resume / device
+ * watcher) so the sync re-runs when either the browser zone or the
+ * override changes.
  *
  * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
- * failed sync (e.g. resumed-after-offline) leaves the key "unsynced"
- * and is retried on the next `app.resume` bus signal or window focus —
- * even when the effective zone string is unchanged. A successful prior
- * sync makes those triggers a no-op, preserving the no-redundant-PATCH
- * guarantee.
+ * failed sync (e.g. resumed-after-offline) leaves the key "unsynced" and
+ * is retried on the next `app.resume` or focus — even when the values
+ * are unchanged. A successful prior sync makes those triggers a no-op.
  *
- * Renders `null` and is silent on error — a failed background sync must
- * never surface a toast.
+ * iOS fires `app.resume`+`focus` back-to-back, so PATCHes can overlap. A
+ * monotonic request token guarantees last-writer-wins: a slow older
+ * request's success is ignored once a newer request has been issued, so
+ * a stale zone can never be persisted.
+ *
+ * Mounted once in `RootLayout` (behind `authMiddleware`). Renders `null`
+ * and is silent on error — a failed background sync must never toast.
  */
 import { useCallback, useEffect, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
@@ -33,33 +37,47 @@ import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { client } from "@/generated/api/client.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { captureError } from "@/lib/sentry/capture-error";
-import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getDeviceSetting } from "@/utils/device-settings";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function TimezoneSync(): null {
-  // Reactive zone drives the effect below; resume/focus handlers re-read
-  // the *current* zone via `getEffectiveTimezone()` to avoid stale closures.
-  const tz = useEffectiveTimezone();
+  // Reactivity trigger only: this value changes whenever the browser zone
+  // or the override changes, re-running the effect below. The actual
+  // detected/override values are re-read imperatively inside `trySync`.
+  const effectiveTz = useEffectiveTimezone();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
 
-  const { mutateAsync: patchDetectedTimezone } = useMutation({
-    mutationFn: async (vars: { assistantId: string; tz: string }) => {
+  const { mutateAsync: patchTimezone } = useMutation({
+    mutationFn: async (vars: {
+      assistantId: string;
+      detectedTimezone: string;
+      userTimezone: string;
+    }) => {
       const { data } = await client.patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: vars.assistantId },
-        body: { ui: { detectedTimezone: vars.tz } },
+        body: {
+          ui: {
+            detectedTimezone: vars.detectedTimezone,
+            userTimezone: vars.userTimezone,
+          },
+        },
         throwOnError: true,
       });
       return data;
     },
   });
 
-  // `${assistantId}:${tz}` of the last *successful* sync, to avoid
-  // redundant PATCHes when nothing has changed. Keyed on the assistant
-  // too so switching assistants re-syncs even when the zone is identical.
-  // Only advanced on success, so a failed sync stays "unsynced" and is
-  // retried on the next resume/focus.
+  // Dedupe key of the last *successful* sync, covering both values plus
+  // the assistant (so switching assistants re-syncs even when unchanged).
+  // Only advanced on success, so a failed sync stays "unsynced".
   const lastSyncedRef = useRef<string | null>(null);
+
+  // Monotonic token: incremented per issued PATCH. A request only records
+  // its key if it is still the latest issued, so a slow older completion
+  // cannot overwrite a newer zone (last-writer-wins).
+  const requestSeqRef = useRef(0);
 
   // Hold the live assistant id so resume/focus handlers (which capture
   // `trySync` once) always target the current assistant.
@@ -68,30 +86,34 @@ export function TimezoneSync(): null {
 
   const trySync = useCallback(() => {
     const currentAssistantId = assistantIdRef.current;
-    const currentTz = getEffectiveTimezone();
-    if (!currentAssistantId || !currentTz) return;
+    const detectedTimezone = getBrowserTimezone();
+    const userTimezone = getDeviceSetting("timezone", "").trim();
+    if (!currentAssistantId || !detectedTimezone) return;
 
-    const key = `${currentAssistantId}:${currentTz}`;
+    const key = `${currentAssistantId}:${detectedTimezone}:${userTimezone}`;
     if (lastSyncedRef.current === key) return;
 
+    const seq = ++requestSeqRef.current;
     // Fire-and-forget: background sync, silent on error. Only record the
-    // key on success so a transient failure is retried on next trigger.
-    patchDetectedTimezone({ assistantId: currentAssistantId, tz: currentTz })
+    // key on success, and only if no newer request has since been issued.
+    patchTimezone({ assistantId: currentAssistantId, detectedTimezone, userTimezone })
       .then(() => {
-        lastSyncedRef.current = key;
+        if (seq === requestSeqRef.current) {
+          lastSyncedRef.current = key;
+        }
       })
       .catch((error) => {
-        captureError(error, { context: "timezone-sync-detected" });
+        captureError(error, { context: "timezone-sync" });
       });
-  }, [patchDetectedTimezone]);
+  }, [patchTimezone]);
 
-  // Reactive path: zone or assistant change.
+  // Reactive path: zone/override or assistant change.
   useEffect(() => {
     trySync();
-  }, [tz, assistantId, trySync]);
+  }, [effectiveTz, assistantId, trySync]);
 
-  // Resume/focus path: retry a previously failed sync even when the zone
-  // string is unchanged. A successful prior sync makes this a no-op.
+  // Resume/focus path: retry a previously failed sync even when the
+  // values are unchanged. A successful prior sync makes this a no-op.
   useBusSubscription("app.resume", trySync);
   useEffect(() => {
     window.addEventListener("focus", trySync);


### PR DESCRIPTION
## Summary
Fixes two plan-review gaps in TimezoneSync:
- Manual override now syncs to ui.userTimezone (sticky, top of cascade); auto browser zone to ui.detectedTimezone; userTimezone cleared ("") in auto mode.
- Adds a request token / in-flight guard so a slow older PATCH cannot overwrite a newer zone (last-writer-wins).

Part of plan: fix-timezone-auto-update.md (review remediation)