### PR TITLE
feat(web): send incognito + factorInMemories in postChatMessage body

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -486,6 +486,8 @@ export async function postChatMessage(
   content: string,
   attachmentIds: string[] = [],
   onboarding?: PreChatOnboardingContext,
+  incognito?: boolean,
+  factorInMemories?: boolean,
 ): Promise<PostMessageResult> {
   // Wire-field selection picks exactly one of `conversationId` (0.8.6+
   // strict internal-id lookup) or `conversationKey` (legacy
@@ -507,6 +509,12 @@ export async function postChatMessage(
     sourceChannel: "vellum",
     interface: "vellum",
   };
+  // Incognito context is only attached when the caller flags the send as
+  // incognito; non-incognito sends stay byte-for-byte unchanged on the wire.
+  if (incognito) {
+    body.incognito = true;
+    body.factorInMemories = factorInMemories ?? false;
+  }
   const conversationField = pickConversationIdWireField();
   if (conversationId !== null || conversationField !== "conversationId") {
     body[conversationField] = conversationId;

--- a/apps/web/src/domains/chat/api/post-chat-message.test.ts
+++ b/apps/web/src/domains/chat/api/post-chat-message.test.ts
@@ -188,6 +188,89 @@ describe("postChatMessage onboarding payload", () => {
   });
 });
 
+describe("postChatMessage incognito payload", () => {
+  // Incognito context (`incognito` + `factorInMemories`) is threaded into
+  // the request body only when the caller flags the send as incognito.
+  // Normal sends must stay byte-for-byte unchanged on the wire.
+  let originalFetch: typeof fetch;
+  let originalDocument: unknown;
+  let capturedRequests: Array<{ url: string; body: string }> = [];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedRequests = [];
+    useAssistantIdentityStore.getState().clearIdentity();
+    originalDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { document?: unknown }).document = { cookie: "csrftoken=test" };
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      let bodyText: string | undefined;
+      if (input instanceof Request) {
+        bodyText = await input.clone().text();
+      } else if (typeof init?.body === "string") {
+        bodyText = init.body;
+      }
+      capturedRequests.push({ url, body: bodyText ?? "" });
+      return new Response(
+        JSON.stringify({
+          accepted: true,
+          messageId: "msg-1",
+          conversationId: "conv-resp-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDocument === undefined) {
+      delete (globalThis as { document?: unknown }).document;
+    } else {
+      (globalThis as { document?: unknown }).document = originalDocument;
+    }
+    useAssistantIdentityStore.getState().clearIdentity();
+  });
+
+  function getMessageBody(): Record<string, unknown> {
+    const requests = capturedRequests.filter((r) => r.url.includes("/messages/"));
+    expect(requests).toHaveLength(1);
+    return JSON.parse(requests[0]!.body) as Record<string, unknown>;
+  }
+
+  test("omits incognito fields on a normal (non-incognito) send", async () => {
+    await postChatMessage("asst-1", "K", "hello");
+
+    const body = getMessageBody();
+    expect(body).not.toHaveProperty("incognito");
+    expect(body).not.toHaveProperty("factorInMemories");
+  });
+
+  test("includes incognito with factorInMemories: false", async () => {
+    await postChatMessage("asst-1", "K", "hello", [], undefined, true, false);
+
+    const body = getMessageBody();
+    expect(body.incognito).toBe(true);
+    expect(body.factorInMemories).toBe(false);
+  });
+
+  test("includes factorInMemories: true when requested", async () => {
+    await postChatMessage("asst-1", "K", "hello", [], undefined, true, true);
+
+    const body = getMessageBody();
+    expect(body.incognito).toBe(true);
+    expect(body.factorInMemories).toBe(true);
+  });
+
+  test("defaults factorInMemories to false when incognito is set without the flag", async () => {
+    await postChatMessage("asst-1", "K", "hello", [], undefined, true);
+
+    const body = getMessageBody();
+    expect(body.incognito).toBe(true);
+    expect(body.factorInMemories).toBe(false);
+  });
+});
+
 describe("postChatMessage wire-field bilingual cutover", () => {
   // Verifies the assistant-version gate picks exactly ONE wire field
   // on `POST /v1/messages`:


### PR DESCRIPTION
## Summary
- Add optional `incognito` + `factorInMemories` params to postChatMessage; only included in the body for incognito sends
- Unit tests cover normal vs incognito branches

Part of plan: incognito-conversations.md (PR 4 of 16)