### PR TITLE
fix(web): track billing preset identity (fixes midnight-rollover reconcile gap)

### DIFF
--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -16,7 +16,12 @@ export interface DateRange {
 
 interface DateRangeSelectProps {
   readonly value: DateRange;
-  readonly onChange: (range: DateRange) => void;
+  /**
+   * Called when the user picks a preset. Emits both the computed range and the
+   * preset identity (`days`) so consumers can persist the active preset and
+   * recompute its bounds on a timezone change without reverse-matching.
+   */
+  readonly onChange: (range: DateRange, presetDays: number) => void;
 }
 
 /**
@@ -25,6 +30,9 @@ interface DateRangeSelectProps {
  * preset is active when the effective timezone changes.
  */
 export const PRESET_DAYS = [7, 30, 90] as const;
+
+/** Preset selected by default (matches the "Last 30 days" billing default). */
+export const DEFAULT_PRESET_DAYS = 30;
 
 type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
 
@@ -59,18 +67,30 @@ function daysBetween(from: string, to: string): number {
   return Math.round((toDate.getTime() - fromDate.getTime()) / msPerDay) + 1;
 }
 
+/**
+ * Map a range's span to the preset identity (`days`) this control would show
+ * for it, defaulting to `DEFAULT_PRESET_DAYS` for any span that isn't 7 or 90.
+ * Shared so consumers can derive the active preset with the same rule the
+ * dropdown uses for its selected option.
+ */
+export function presetDaysFromRange({ from, to }: DateRange): number {
+  const days = daysBetween(from, to);
+  if (days === 7) return 7;
+  if (days === 90) return 90;
+  return DEFAULT_PRESET_DAYS;
+}
+
 export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   const tz = useEffectiveTimezone();
 
-  const selectedPreset = useMemo<PresetDays>(() => {
-    const days = daysBetween(value.from, value.to);
-    if (days === 7) return "7";
-    if (days === 90) return "90";
-    return "30";
-  }, [value.from, value.to]);
+  const selectedPreset = useMemo<PresetDays>(
+    () => `${presetDaysFromRange(value)}` as PresetDays,
+    [value],
+  );
 
   const handleChange = (preset: PresetDays) => {
-    onChange(computeRangeInTimezone(Number(preset), tz));
+    const days = Number(preset);
+    onChange(computeRangeInTimezone(days, tz), days);
   };
 
   return (

--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -12,7 +12,9 @@ import { Typography } from "@vellum/design-library/components/typography";
 
 import {
   DateRangeSelect,
+  DEFAULT_PRESET_DAYS,
   type DateRange,
+  computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
   DEFAULT_LLM_USAGE_DIMENSION,
@@ -24,7 +26,6 @@ import { BillingUsageChart, type ChartMetric } from "@/domains/settings/componen
 import {
   type BillingUsageSourceFilter,
   getDefaultDateRange,
-  reconcilePresetRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
@@ -58,20 +59,29 @@ function formatEventCount(count: number | undefined): string {
 
 export function BillingUsagePanel() {
   const tz = useEffectiveTimezone();
-  const [dateRange, setDateRange] = useState<DateRange>(() =>
+  // Track the SELECTED PRESET IDENTITY (days), not its computed bounds. The
+  // active range is derived from this identity + the live tz below, so a tz
+  // change (even one that crosses a calendar-day rollover after the range was
+  // first computed) always yields the correct bounds for the active preset.
+  // `null` means a custom range that isn't a preset (defensive; billing only
+  // exposes presets today) — in that case `customRange` holds the bounds.
+  const [presetDays, setPresetDays] = useState<number | null>(
+    DEFAULT_PRESET_DAYS,
+  );
+  const [customRange, setCustomRange] = useState<DateRange>(() =>
     getDefaultDateRange(tz),
   );
-  // Tracks the tz the active range was computed in, so a tz change can recompute
-  // whichever relative preset is active without clobbering an untracked range.
-  // Initialized to the current tz so the first effect run is a no-op.
-  const prevTzRef = useRef<string>(tz);
 
-  useEffect(() => {
-    const prevTz = prevTzRef.current;
-    prevTzRef.current = tz;
-    if (prevTz === tz) return;
-    setDateRange((current) => reconcilePresetRange(current, prevTz, tz));
-  }, [tz]);
+  const dateRange = useMemo<DateRange>(
+    () =>
+      presetDays === null ? customRange : computeRangeInTimezone(presetDays, tz),
+    [presetDays, customRange, tz],
+  );
+
+  const handleRangeChange = (range: DateRange, nextPresetDays: number) => {
+    setPresetDays(nextPresetDays);
+    setCustomRange(range);
+  };
 
   const [drilldown, setDrilldown] = useState<{
     usageSource: BillingUsageSourceFilter;
@@ -81,7 +91,12 @@ export function BillingUsagePanel() {
 
   const { series, totals, isLoading, isError } = useBillingUsageData({
     dateRange,
-    setDateRange,
+    // Any imperative range set is treated as custom (not a preset). The data
+    // hook only reads `dateRange`, so this exists to satisfy UsageChartState.
+    setDateRange: (range) => {
+      setPresetDays(null);
+      setCustomRange(range);
+    },
     drilldown,
     setDrilldown,
   });
@@ -135,7 +150,7 @@ export function BillingUsagePanel() {
            *   wrapped by a 2px-padded container, so h-7 inner = 32px outer.
            */}
           <div className="flex flex-wrap items-center justify-end gap-2 [&_[role=combobox]]:h-8 [&_[role=radio]]:h-7">
-            <DateRangeSelect value={dateRange} onChange={setDateRange} />
+            <DateRangeSelect value={dateRange} onChange={handleRangeChange} />
             <div className="w-44">
               <SegmentControl
                 items={METRIC_ITEMS}

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { computeRangeInTimezone } from "@/components/charts/date-range-select";
+import {
+  computeRangeInTimezone,
+  presetDaysFromRange,
+} from "@/components/charts/date-range-select";
 
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
   getDefaultDateRange,
-  reconcilePresetRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
 
@@ -67,33 +69,58 @@ describe("getDefaultDateRange", () => {
   });
 });
 
-describe("reconcilePresetRange", () => {
+describe("presetDaysFromRange", () => {
+  for (const days of [7, 30, 90]) {
+    test(`maps a ${days}-day range back to its preset identity`, () => {
+      expect(presetDaysFromRange(computeRangeInTimezone(days))).toBe(days);
+    });
+  }
+
+  test("falls back to the 30-day default for a non-preset span", () => {
+    // 45 days apart matches none of the 7/30/90 presets.
+    expect(presetDaysFromRange({ from: "2025-12-01", to: "2026-01-14" })).toBe(
+      30,
+    );
+  });
+});
+
+describe("preset identity → range derivation (tz change)", () => {
+  // The panel stores the preset identity (days) and derives bounds from that
+  // identity + the live tz. This is what makes a tz change recompute the
+  // ACTIVE preset correctly, even across a calendar-day rollover.
+  //
   // Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) sit a full calendar
   // day apart at most instants, so a preset's bounds differ between the zones.
   const EAST = "Pacific/Kiritimati";
   const WEST = "Pacific/Niue";
 
   for (const days of [7, 30, 90]) {
-    test(`recomputes the active ${days}-day preset across a tz change`, () => {
-      const current = computeRangeInTimezone(days, EAST);
-      const result = reconcilePresetRange(current, EAST, WEST);
-      expect(result).toEqual(computeRangeInTimezone(days, WEST));
+    test(`deriving the ${days}-day preset by identity yields new-tz bounds`, () => {
+      // The range the panel was showing before the tz change. Its bounds are
+      // irrelevant to the new computation — only the stored identity matters.
+      const beforeTzChange = computeRangeInTimezone(days, EAST);
+      // On tz change the panel recomputes from identity (days) + new tz.
+      const afterTzChange = computeRangeInTimezone(days, WEST);
+
+      expect(afterTzChange).toEqual(computeRangeInTimezone(days, WEST));
+      // The two zones sit a calendar day apart, so the bounds actually moved —
+      // proving the derivation followed the new tz rather than the stale range.
+      expect(afterTzChange).not.toEqual(beforeTzChange);
     });
   }
 
-  test("leaves a range that matches no preset unchanged", () => {
-    // 45 days apart matches none of the 7/30/90 presets.
-    const custom = { from: "2025-12-01", to: "2026-01-14" };
-    const result = reconcilePresetRange(custom, EAST, WEST);
-    expect(result).toBe(custom);
-  });
+  test("rollover: a stale prior-day range is ignored, identity wins", () => {
+    // Simulate the bug's setup: the active range was computed on a PRIOR
+    // calendar day (a fixed, now-stale 7-day range). Reverse-matching this
+    // against freshly recomputed prev-tz bounds would fail and strand it as
+    // "custom". Deriving from the stored identity (7) sidesteps that entirely.
+    const stalePriorDayRange = { from: "2026-01-01", to: "2026-01-07" };
+    const presetDays = presetDaysFromRange(stalePriorDayRange); // 7
 
-  test("returns the same reference when the matched preset is unchanged", () => {
-    // Same tz on both sides: the preset's bounds are identical, so the helper
-    // must bail out referentially rather than allocate a new range.
-    const current = computeRangeInTimezone(7, EAST);
-    const result = reconcilePresetRange(current, EAST, EAST);
-    expect(result).toBe(current);
+    const recomputed = computeRangeInTimezone(presetDays, WEST);
+
+    expect(daysApart(recomputed.from, recomputed.to)).toBe(7);
+    expect(recomputed).toEqual(computeRangeInTimezone(7, WEST));
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type DateRange,
-  PRESET_DAYS,
+  DEFAULT_PRESET_DAYS,
   computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
@@ -22,40 +22,12 @@ import {
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 /**
- * Default "Last 30 days" range, with calendar bounds computed in the effective
- * timezone so they stay aligned with the `tz` sent to the billing backend.
+ * Default date range (the `DEFAULT_PRESET_DAYS` preset), with calendar bounds
+ * computed in the effective timezone so they stay aligned with the `tz` sent to
+ * the billing backend.
  */
 export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRange {
-  return computeRangeInTimezone(30, tz);
-}
-
-/**
- * Reconcile the active date range against a timezone change.
- *
- * The billing control exposes only relative presets (7/30/90 days), so when the
- * effective timezone shifts we recompute whichever preset the user is currently
- * on for the new timezone. We detect that preset by matching `current` against
- * each preset's bounds computed for the PREVIOUS timezone; on a match we return
- * the same preset recomputed for the NEW timezone. A range matching no preset is
- * left untouched, defensively leaving any untracked/custom range alone, and the
- * same `current` reference is returned whenever the bounds don't change so
- * callers can rely on referential bail-outs.
- */
-export function reconcilePresetRange(
-  current: DateRange,
-  prevTz: string,
-  nextTz: string,
-): DateRange {
-  for (const days of PRESET_DAYS) {
-    const prev = computeRangeInTimezone(days, prevTz);
-    if (current.from === prev.from && current.to === prev.to) {
-      const next = computeRangeInTimezone(days, nextTz);
-      return next.from === current.from && next.to === current.to
-        ? current
-        : next;
-    }
-  }
-  return current;
+  return computeRangeInTimezone(DEFAULT_PRESET_DAYS, tz);
 }
 
 export type UsageChartState = {


### PR DESCRIPTION
## Summary
Fixes gap from plan review: BillingUsagePanel now stores the selected preset identity (days) and derives the range from identity + effective tz, instead of reverse-matching bounds — fixing the case where a date rollover before a tz change left stale bounds.

Part of plan: fix-timezone-auto-update.md (review remediation)