### PR TITLE
feat(assistant): expose incognito fields in conversation CRUD

### DIFF
--- a/assistant/src/memory/__tests__/conversation-crud-incognito.test.ts
+++ b/assistant/src/memory/__tests__/conversation-crud-incognito.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createConversation,
+  getConversation,
+} from "../conversation-crud.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+}
+
+describe("createConversation incognito fields", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("persists explicit incognito and factorInMemories opts", () => {
+    const { id } = createConversation({
+      incognito: true,
+      factorInMemories: false,
+    });
+
+    const row = getConversation(id);
+    expect(row).not.toBeNull();
+    expect(row?.incognito).toBe(1);
+    expect(row?.factorInMemories).toBe(0);
+  });
+
+  test("defaults incognito off and factorInMemories on", () => {
+    const { id } = createConversation({ title: "Default" });
+
+    const row = getConversation(id);
+    expect(row).not.toBeNull();
+    expect(row?.incognito).toBe(0);
+    expect(row?.factorInMemories).toBe(1);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -231,6 +231,8 @@ export interface ConversationRow {
   inferenceProfileSessionId: string | null;
   inferenceProfileExpiresAt: number | null;
   lastNotifiedInferenceProfile: string | null;
+  incognito: number;
+  factorInMemories: number;
 }
 
 export const parseConversation = createRowMapper<
@@ -265,6 +267,8 @@ export const parseConversation = createRowMapper<
   inferenceProfileSessionId: "inferenceProfileSessionId",
   inferenceProfileExpiresAt: "inferenceProfileExpiresAt",
   lastNotifiedInferenceProfile: "lastNotifiedInferenceProfile",
+  incognito: "incognito",
+  factorInMemories: "factorInMemories",
 });
 
 /** Allowed values for the `role` column on `messages`. */
@@ -501,6 +505,8 @@ export function createConversation(
         scheduleJobId?: string;
         groupId?: string;
         forkParentConversationId?: string;
+        incognito?: boolean;
+        factorInMemories?: boolean;
       },
 ) {
   const db = getDb();
@@ -540,6 +546,8 @@ export function createConversation(
     memoryScopeId,
     scheduleJobId: opts.scheduleJobId ?? null,
     forkParentConversationId: opts.forkParentConversationId ?? null,
+    incognito: opts.incognito ? 1 : 0,
+    factorInMemories: opts.factorInMemories === false ? 0 : 1,
   };
 
   // Retry on SQLITE_BUSY and SQLITE_IOERR — transient disk I/O errors or WAL


### PR DESCRIPTION
## Summary
- Add `incognito` + `factorInMemories` to ConversationRow, parseConversation mapper, and createConversation opts/insert

Part of plan: incognito-conversations.md (PR 5 of 16)