### PR TITLE
feat(web): add flag-gated New incognito chat entry points

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -281,6 +281,19 @@ export function ChatLayout() {
     requestComposerFocus();
   }, [navigate]);
 
+  const handleStartNewIncognitoConversation = useCallback(() => {
+    haptic.light();
+    useViewerStore.getState().setMainView("chat");
+    const draftConversationId = createDraftConversationId();
+    useConversationStore.getState().setActiveConversationId(draftConversationId);
+    useConversationStore.getState().setConversationSettings(draftConversationId, {
+      incognito: true,
+      factorInMemories: false,
+    });
+    void navigate(routes.conversation(draftConversationId));
+    requestComposerFocus();
+  }, [navigate]);
+
   const handleOpenHome = useCallback(() => {
     navigate(routes.home);
   }, [navigate]);
@@ -616,6 +629,7 @@ export function ChatLayout() {
         attentionConversationIds={attentionConversationIds}
         onSelectConversation={handleSelectConversation}
         onStartNewConversation={handleStartNewConversation}
+        onStartNewIncognitoConversation={handleStartNewIncognitoConversation}
         isIntelligenceActive={isIdentityActive}
         onOpenIntelligence={handleOpenIdentity}
         isLibraryActive={isLibraryActive}
@@ -656,6 +670,7 @@ export function ChatLayout() {
       attentionConversationIds,
       handleSelectConversation,
       handleStartNewConversation,
+      handleStartNewIncognitoConversation,
       handleTogglePinConversation,
       handleRenameConversation,
       handleArchiveConversation,

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clock,
+  EyeOff,
   Hash,
   Layers,
   LayoutGrid,
@@ -16,6 +17,7 @@ import {
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import {
   ConversationActionsMenu,
@@ -62,6 +64,8 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onOpenApp?: (appId: string) => void;
   activeAppId?: string;
   onStartNewConversation?: () => void;
+  /** Flag-gated incognito new-conversation entry. Omitted when the flag is off. */
+  onStartNewIncognitoConversation?: () => void;
   footerAction?: ReactNode;
   onClose?: () => void;
 
@@ -140,6 +144,7 @@ export function AssistantSideMenu({
   onOpenApp,
   activeAppId,
   onStartNewConversation,
+  onStartNewIncognitoConversation,
   footerAction,
   onPinConversation,
   onRenameConversation,
@@ -171,6 +176,7 @@ export function AssistantSideMenu({
   });
 
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
+  const incognitoEnabled = useAssistantFeatureFlagStore.use.incognitoConversations();
 
   // --- Render helpers (action wiring, context menu, pin toggle) ---
 
@@ -320,15 +326,28 @@ export function AssistantSideMenu({
   // --- Header actions ---
 
   const headerActions = onStartNewConversation ? (
-    <Button
-      variant="ghost"
-      size="compact"
-      iconOnly={<SquarePen />}
-      aria-label="New conversation"
-      tooltip="New conversation"
-      tooltipSide="right"
-      onClick={() => { onStartNewConversation(); onClose?.(); }}
-    />
+    <>
+      {incognitoEnabled && onStartNewIncognitoConversation ? (
+        <Button
+          variant="ghost"
+          size="compact"
+          iconOnly={<EyeOff />}
+          aria-label="New incognito conversation"
+          tooltip="New incognito conversation"
+          tooltipSide="right"
+          onClick={() => { onStartNewIncognitoConversation(); onClose?.(); }}
+        />
+      ) : null}
+      <Button
+        variant="ghost"
+        size="compact"
+        iconOnly={<SquarePen />}
+        aria-label="New conversation"
+        tooltip="New conversation"
+        tooltipSide="right"
+        onClick={() => { onStartNewConversation(); onClose?.(); }}
+      />
+    </>
   ) : null;
 
   // --- Flat conversation list renderer ---

--- a/apps/web/src/domains/home/home-greeting-header.tsx
+++ b/apps/web/src/domains/home/home-greeting-header.tsx
@@ -1,4 +1,4 @@
-import { SquarePen } from "lucide-react";
+import { EyeOff, SquarePen } from "lucide-react";
 
 import { Button, Typography } from "@vellum/design-library";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
@@ -12,6 +12,8 @@ interface HomeGreetingHeaderProps {
   greeting?: string;
   isMobile?: boolean;
   onStartNewChat: () => void;
+  /** Flag-gated incognito new-chat entry. Omitted when the flag is off. */
+  onStartNewIncognitoChat?: () => void;
 }
 
 // Mirrors `computeGreeting` in assistant/src/runtime/routes/home-feed-routes.ts
@@ -32,6 +34,7 @@ export function HomeGreetingHeader({
   greeting,
   isMobile,
   onStartNewChat,
+  onStartNewIncognitoChat,
 }: HomeGreetingHeaderProps) {
   return (
     <div className="flex items-center justify-between gap-[var(--app-spacing-md)]">
@@ -47,24 +50,36 @@ export function HomeGreetingHeader({
         </Typography>
       </div>
 
-      {isMobile ? (
-        <Button
-          variant="primary"
-          iconOnly={<SquarePen />}
-          onClick={onStartNewChat}
-          aria-label="New Chat"
-          tooltip="New Chat"
-          className="!rounded-full"
-        />
-      ) : (
-        <Button
-          variant="primary"
-          leftIcon={<SquarePen />}
-          onClick={onStartNewChat}
-        >
-          New Chat
-        </Button>
-      )}
+      <div className="flex shrink-0 items-center gap-[var(--app-spacing-sm)]">
+        {onStartNewIncognitoChat ? (
+          <Button
+            variant="ghost"
+            iconOnly={<EyeOff />}
+            onClick={onStartNewIncognitoChat}
+            aria-label="New incognito chat"
+            tooltip="New incognito chat"
+            className={isMobile ? "!rounded-full" : undefined}
+          />
+        ) : null}
+        {isMobile ? (
+          <Button
+            variant="primary"
+            iconOnly={<SquarePen />}
+            onClick={onStartNewChat}
+            aria-label="New Chat"
+            tooltip="New Chat"
+            className="!rounded-full"
+          />
+        ) : (
+          <Button
+            variant="primary"
+            leftIcon={<SquarePen />}
+            onClick={onStartNewChat}
+          >
+            New Chat
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -48,6 +48,8 @@ export interface HomePageProps {
   assistantId: string;
   validConversationIds: Set<string>;
   onStartNewChat: () => void;
+  /** Flag-gated incognito new-chat entry. Omitted when the flag is off. */
+  onStartNewIncognitoChat?: () => void;
   onOpenConversation: (conversationId: string) => void;
   onSuggestionSelected: (prompt: string) => void;
 }
@@ -56,6 +58,7 @@ export function HomePage({
   assistantId,
   validConversationIds,
   onStartNewChat,
+  onStartNewIncognitoChat,
   onOpenConversation,
   onSuggestionSelected,
 }: HomePageProps) {
@@ -138,6 +141,7 @@ export function HomePage({
         greeting={feedQuery.data?.contextBanner?.greeting}
         isMobile={isMobile}
         onStartNewChat={onStartNewChat}
+        onStartNewIncognitoChat={onStartNewIncognitoChat}
       />
       {feedQuery.isError ? (
         <div

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/hooks/conversation-queries";
 import { mergeConversationLists } from "@/utils/conversation-cache";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { HomePage } from "@/domains/home/home-page";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -23,6 +24,7 @@ export function HomePageRoute() {
   const assistantId = useActiveAssistantId();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
   const isMobile = useIsMobile();
+  const incognitoEnabled = useAssistantFeatureFlagStore.use.incognitoConversations();
   const { conversations: foregroundConversations } =
     useConversationListQuery(assistantId);
   // Recap/feed items can reference background and scheduled jobs, so the home
@@ -71,6 +73,25 @@ export function HomePageRoute() {
         navigate(routes.conversation(draftConversationId));
         requestComposerFocus();
       }}
+      onStartNewIncognitoChat={
+        incognitoEnabled
+          ? () => {
+              useViewerStore.getState().setMainView("chat");
+              const draftConversationId = createDraftConversationId();
+              useConversationStore
+                .getState()
+                .setActiveConversationId(draftConversationId);
+              useConversationStore
+                .getState()
+                .setConversationSettings(draftConversationId, {
+                  incognito: true,
+                  factorInMemories: false,
+                });
+              navigate(routes.conversation(draftConversationId));
+              requestComposerFocus();
+            }
+          : undefined
+      }
       onOpenConversation={(conversationId) =>
         navigate(routes.conversation(conversationId))
       }

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -459,7 +459,7 @@
     },
     {
       "id": "incognito-conversations",
-      "scope": "client",
+      "scope": "both",
       "key": "incognito-conversations",
       "label": "Incognito Conversations",
       "description": "Expose incognito conversations in the UI: a New incognito chat entry point, a header badge, and a control to choose whether existing memories are factored in. Incognito conversations never produce memories.",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -459,7 +459,7 @@
     },
     {
       "id": "incognito-conversations",
-      "scope": "client",
+      "scope": "both",
       "key": "incognito-conversations",
       "label": "Incognito Conversations",
       "description": "Expose incognito conversations in the UI: a New incognito chat entry point, a header badge, and a control to choose whether existing memories are factored in. Incognito conversations never produce memories.",


### PR DESCRIPTION
## Summary
- Add a flag-gated New incognito chat entry point on the home page and sidebar that opens a draft with incognito settings (factor-in-memories off by default)

Part of plan: incognito-conversations.md (PR 12 of 16)