### PR TITLE
App Builder — Live Hot-Reload Preview While Building (Web Spike)

### DIFF
--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,8 +1,9 @@
 import { AlertTriangle, X } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
+import type { AppCompileStatus } from "@/stores/viewer-store";
 import { injectBridge } from "@/utils/sandbox-bridge";
 
 export interface AppViewerContainerProps {
@@ -25,7 +26,7 @@ export interface AppViewerContainerProps {
    * non-blocking badge over the last-good preview); `"building"`/`"ok"`/
    * undefined render nothing — the live iframe swap is the success feedback.
    */
-  compileStatus?: "building" | "ok" | "error";
+  compileStatus?: AppCompileStatus;
   /** Compile diagnostics surfaced in the build-error badge. */
   buildErrors?: string[];
   /**
@@ -44,8 +45,16 @@ export interface AppViewerContainerProps {
 export function BuildErrorBadge({ buildErrors }: { buildErrors?: string[] }) {
   const [dismissed, setDismissed] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  if (dismissed) return null;
   const errors = buildErrors ?? [];
+  // The component stays mounted across successive `error` events (compileStatus
+  // remains "error"), so a prior dismissal would otherwise hide every later,
+  // DISTINCT build failure. Reset the dismissal when the error identity changes
+  // so a new failure re-shows the badge.
+  const errorKey = errors.join("\n");
+  useEffect(() => {
+    setDismissed(false);
+  }, [errorKey]);
+  if (dismissed) return null;
   return (
     <div
       className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-2"

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
@@ -19,6 +20,84 @@ export interface AppViewerContainerProps {
   isDeploying?: boolean;
   /** Deep-link route passed to the app as `window.vellum.route`. */
   route?: string;
+  /**
+   * Live-build status from the daemon. Only `"error"` renders UI (a small
+   * non-blocking badge over the last-good preview); `"building"`/`"ok"`/
+   * undefined render nothing — the live iframe swap is the success feedback.
+   */
+  compileStatus?: "building" | "ok" | "error";
+  /** Compile diagnostics surfaced in the build-error badge. */
+  buildErrors?: string[];
+  /**
+   * Generation counter bumped by the daemon on every successful recompile.
+   * Folded into the iframe key so a bumped generation force-remounts the
+   * preview even when `html` is byte-identical to the prior render.
+   */
+  reloadGeneration?: number;
+}
+
+/**
+ * Non-blocking badge shown over the last-good preview when a recompile fails.
+ * The iframe stays fully visible behind it (keep-last-good); the badge can be
+ * dismissed and expanded to reveal the raw `buildErrors`.
+ */
+export function BuildErrorBadge({ buildErrors }: { buildErrors?: string[] }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  if (dismissed) return null;
+  const errors = buildErrors ?? [];
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-2"
+      role="status"
+      aria-label="App build error"
+    >
+      <div
+        className="pointer-events-auto max-w-full rounded-lg border px-3 py-2 shadow-sm"
+        style={{
+          background: "var(--surface-overlay)",
+          borderColor: "var(--border-base)",
+        }}
+      >
+        <div className="flex items-center gap-2 text-label-small-default">
+          <AlertTriangle
+            className="h-4 w-4 shrink-0 text-danger-500"
+            aria-hidden
+          />
+          <span style={{ color: "var(--content-default)" }}>
+            Build error — showing last working version
+          </span>
+          {errors.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="underline underline-offset-2"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              {expanded ? "Hide details" : "Details"}
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Dismiss build error"
+            onClick={() => setDismissed(true)}
+            className="ml-1 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+        {expanded && errors.length > 0 && (
+          <pre
+            className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words text-label-small-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {errors.join("\n")}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function AppViewerContainer({
@@ -34,6 +113,9 @@ export function AppViewerContainer({
   onDeploy,
   isDeploying,
   route,
+  compileStatus,
+  buildErrors,
+  reloadGeneration,
 }: AppViewerContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -47,8 +129,8 @@ export function AppViewerContainer({
     for (let i = 0; i < html.length; i++) {
       hash = ((hash << 5) - hash + html.charCodeAt(i)) | 0;
     }
-    return `app-${appId}-${hash}`;
-  }, [html, appId]);
+    return `app-${appId}-${reloadGeneration ?? 0}-${hash}`;
+  }, [html, appId, reloadGeneration]);
 
   useSandboxFetchProxy(iframeRef, {
     frameId: appId,
@@ -69,6 +151,9 @@ export function AppViewerContainer({
       />
 
       <div className="relative min-h-0 flex-1">
+        {compileStatus === "error" && (
+          <BuildErrorBadge buildErrors={buildErrors} />
+        )}
         <iframe
           ref={iframeRef}
           key={iframeKey}

--- a/apps/web/src/components/build-error-badge.test.tsx
+++ b/apps/web/src/components/build-error-badge.test.tsx
@@ -1,7 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
 import { BuildErrorBadge } from "@/components/app-viewer-container";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("BuildErrorBadge", () => {
   test("renders the last-working-version message", () => {
@@ -30,5 +36,29 @@ describe("BuildErrorBadge", () => {
 
     const withoutErrors = renderToStaticMarkup(<BuildErrorBadge />);
     expect(withoutErrors).not.toContain("Details");
+  });
+
+  test("re-shows after dismissal when a new, distinct error arrives", () => {
+    // The component is NOT remounted between successive `error` events, so a
+    // prior dismissal must not hide a later DISTINCT failure.
+    const { rerender } = render(<BuildErrorBadge buildErrors={["boom"]} />);
+    expect(screen.queryByLabelText("App build error")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Dismiss build error"));
+    expect(screen.queryByLabelText("App build error")).toBeNull();
+
+    // A new, distinct build error for the still-mounted badge re-shows it.
+    rerender(<BuildErrorBadge buildErrors={["different error"]} />);
+    expect(screen.queryByLabelText("App build error")).not.toBeNull();
+  });
+
+  test("stays dismissed while the same error persists (no flicker)", () => {
+    // A repeated identical `error` event must not undo the user's dismissal.
+    const { rerender } = render(<BuildErrorBadge buildErrors={["boom"]} />);
+    fireEvent.click(screen.getByLabelText("Dismiss build error"));
+    expect(screen.queryByLabelText("App build error")).toBeNull();
+
+    rerender(<BuildErrorBadge buildErrors={["boom"]} />);
+    expect(screen.queryByLabelText("App build error")).toBeNull();
   });
 });

--- a/apps/web/src/components/build-error-badge.test.tsx
+++ b/apps/web/src/components/build-error-badge.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BuildErrorBadge } from "@/components/app-viewer-container";
+
+describe("BuildErrorBadge", () => {
+  test("renders the last-working-version message", () => {
+    const html = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["TS2322: type error"]} />,
+    );
+    expect(html).toContain("Build error");
+    expect(html).toContain("showing last working version");
+  });
+
+  test("is overlaid and non-blocking so it never hides the iframe", () => {
+    // The container is absolutely positioned and pointer-events-none, so the
+    // last-good preview iframe behind it stays fully visible and interactive.
+    const html = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["boom"]} />,
+    );
+    expect(html).toContain("absolute");
+    expect(html).toContain("pointer-events-none");
+  });
+
+  test("offers a details affordance when buildErrors are present", () => {
+    const withErrors = renderToStaticMarkup(
+      <BuildErrorBadge buildErrors={["boom"]} />,
+    );
+    expect(withErrors).toContain("Details");
+
+    const withoutErrors = renderToStaticMarkup(<BuildErrorBadge />);
+    expect(withoutErrors).not.toContain("Details");
+  });
+});

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1380,6 +1380,9 @@ export function ChatRouteContent({
             isSharing={isSharing}
             onDeploy={deployToVercel ? handleDeployApp : undefined}
             isDeploying={isDeploying}
+            compileStatus={openedAppState.compileStatus}
+            buildErrors={openedAppState.buildErrors}
+            reloadGeneration={openedAppState.reloadGeneration}
             isEditing
           />
         }
@@ -1409,6 +1412,9 @@ export function ChatRouteContent({
         isSharing={isSharing}
         onDeploy={deployToVercel ? handleDeployApp : undefined}
         isDeploying={isDeploying}
+        compileStatus={openedAppState.compileStatus}
+        buildErrors={openedAppState.buildErrors}
+        reloadGeneration={openedAppState.reloadGeneration}
       />
     );
   }

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.test.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Verifies the mobile open-app overlay forwards live-build state
+ * (`compileStatus`/`buildErrors`) to `AppViewerContainer`, so the mobile path
+ * surfaces the same non-blocking build-error badge as desktop.
+ *
+ * `AppViewerContainer` pulls in a heavy subtree (sandbox proxy, matchMedia via
+ * `useIsMobile`) that doesn't server-render, so we stub it and assert on the
+ * props the overlay hands down.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { AppViewerContainerProps } from "@/components/app-viewer-container";
+
+const captured: { props?: AppViewerContainerProps } = {};
+const lastProps = (): AppViewerContainerProps | undefined => captured.props;
+mock.module("@/components/app-viewer-container", () => ({
+  AppViewerContainer: (props: AppViewerContainerProps) => {
+    captured.props = props;
+    return null;
+  },
+}));
+
+// Imported AFTER the mock so the component picks up the stub.
+import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
+import type { OpenedAppState } from "@/stores/viewer-store";
+
+const baseAppState: OpenedAppState = {
+  appId: "app-1",
+  name: "My App",
+  html: "<html></html>",
+};
+
+const noopProps = {
+  isAppMinimized: false,
+  assistantId: "assistant-1",
+  onToggleMinimized: () => {},
+  onClose: () => {},
+  onShare: () => {},
+  isSharing: false,
+  isDeploying: false,
+};
+
+describe("MobileAppOverlay", () => {
+  test("forwards compileStatus and buildErrors to AppViewerContainer", () => {
+    captured.props = undefined;
+    renderToStaticMarkup(
+      <MobileAppOverlay
+        {...noopProps}
+        openedAppState={{
+          ...baseAppState,
+          compileStatus: "error",
+          buildErrors: ["TS2322: type error"],
+        }}
+      />,
+    );
+    expect(lastProps()?.compileStatus).toBe("error");
+    expect(lastProps()?.buildErrors).toEqual(["TS2322: type error"]);
+  });
+
+  test("forwards undefined build state when none is present", () => {
+    captured.props = undefined;
+    renderToStaticMarkup(
+      <MobileAppOverlay {...noopProps} openedAppState={baseAppState} />,
+    );
+    expect(lastProps()?.compileStatus).toBeUndefined();
+    expect(lastProps()?.buildErrors).toBeUndefined();
+  });
+});

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -75,6 +75,9 @@ export function MobileAppOverlay({
         isDeploying={isDeploying}
         isEditing={isAppMinimized}
         route={route}
+        compileStatus={openedAppState.compileStatus}
+        buildErrors={openedAppState.buildErrors}
+        reloadGeneration={openedAppState.reloadGeneration}
       />
     </div>
   );

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -1,9 +1,4 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useRef,
-} from "react";
+import { type Dispatch, type SetStateAction, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/stores/conversation-store";
@@ -232,7 +227,8 @@ export function useStreamEventHandler(
         confirmationToolCallMap: store.confirmationToolCallMap,
         setAssetsRefreshKey,
         dismissedSurfaceIds: store.dismissedSurfaceIds,
-        contextWindowUsageByConversation: store.contextWindowUsageByConversation,
+        contextWindowUsageByConversation:
+          store.contextWindowUsageByConversation,
         setContextWindowUsage: store.setContextWindowUsage,
         scheduleConversationListRefetch,
         queryClient,
@@ -380,6 +376,7 @@ export function useStreamEventHandler(
         case "document_comment_reopened":
         case "document_comment_deleted":
         case "interaction_resolved":
+        case "app_preview_update":
           break;
         case "unknown":
           break;

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -1,4 +1,7 @@
-import { type DisplayMessage, isSurfaceInteractive } from "@/domains/chat/types/types";
+import {
+  type DisplayMessage,
+  isSurfaceInteractive,
+} from "@/domains/chat/types/types";
 import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { AssistantEvent } from "@/types/event-types";
@@ -29,6 +32,11 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "disk_pressure_status_changed",
   "home_feed_updated",
   "relationship_state_updated",
+  // Live app-build preview broadcast — app-scoped (`appId`), carries no
+  // `conversationId`, so the conversation-id gate would otherwise drop it.
+  // The chat handler is a no-op for it today; the app-preview store wiring
+  // lives outside this domain.
+  "app_preview_update",
   // Workspace-scoped prompt — the `contacts/prompt` IPC route fires it
   // from settings or skill flows that have no conversation binding, so
   // the wire payload has no `conversationId` and the conversation gate

--- a/apps/web/src/hooks/use-app-preview-sync.test.tsx
+++ b/apps/web/src/hooks/use-app-preview-sync.test.tsx
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+import { __resetForTesting, publish } from "@/lib/event-bus";
+
+// `revealAppForBuild` → `loadApp`'s fetch hits `appsByIdOpenPost`. Mock the
+// daemon SDK so the call resolves in-process (the synchronous view
+// transition under test lands first) and no unhandled rejection escapes.
+// Bun's `mock.module` leaks across files — run this file on its own.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  appsByIdOpenPost: () =>
+    Promise.resolve({
+      data: { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" },
+    }),
+  documentsByIdGet: () => Promise.resolve({ data: null }),
+}));
+
+const { useAppPreviewSync } = await import("@/hooks/use-app-preview-sync");
+const { useViewerStore } = await import("@/stores/viewer-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+
+function emitPreview(
+  appId: string,
+  compileStatus: "building" | "ok" | "error",
+  opts: { conversationId?: string; reloadGeneration?: number; html?: string } = {},
+): void {
+  publish("sse.event", {
+    id: "evt-1",
+    conversationId: opts.conversationId,
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: "app_preview_update",
+      appId,
+      html: opts.html ?? "<h1>App</h1>",
+      compileStatus,
+      reloadGeneration: opts.reloadGeneration ?? 0,
+    },
+  } as unknown as AssistantEventEnvelope);
+}
+
+type Params = Parameters<typeof useAppPreviewSync>[0];
+const DESKTOP_ACTIVE: Params = {
+  assistantId: "asst-1",
+  isAssistantActive: true,
+  isMobile: false,
+};
+
+beforeEach(() => {
+  __resetForTesting();
+  useViewerStore.getState().reset();
+  useConversationStore.getState().reset();
+  useConversationStore.getState().setActiveConversationId("conv-1");
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useAppPreviewSync auto-open", () => {
+  test("a first building event for a non-open app opens the app-editing split", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("app-editing");
+    expect(viewer.activeAppId).toBe("app-1");
+    // The edit-chat target is set so the desktop branch renders.
+    expect(useConversationStore.getState().editingConversationId).toBe("conv-1");
+  });
+
+  test("falls back to the active conversation when the envelope omits one", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building");
+    expect(useConversationStore.getState().editingConversationId).toBe("conv-1");
+  });
+
+  test("does not disrupt an app that is already open", () => {
+    useViewerStore.setState({
+      mainView: "app-editing",
+      activeAppId: "app-1",
+      openedAppState: {
+        appId: "app-1",
+        dirName: "my-app",
+        name: "My App",
+        html: "<h1>App</h1>",
+      },
+    });
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("app-editing");
+    expect(viewer.activeAppId).toBe("app-1");
+  });
+
+  test("does not re-open an app dismissed during the same build", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // Build starts → panel opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    // User closes the panel mid-build.
+    useViewerStore.getState().closeApp();
+    expect(useViewerStore.getState().dismissedBuildAppId).toBe("app-1");
+    // Subsequent events for the SAME build do not pop it back open.
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 2 });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("a fresh build sequence re-opens after a dismissal", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    // User closes mid/after build.
+    useViewerStore.getState().closeApp();
+    expect(useViewerStore.getState().dismissedBuildAppId).toBe("app-1");
+    // A NEW build sequence begins (building after a terminal ok) → the
+    // hook clears the dismissal and the panel re-opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().dismissedBuildAppId).toBeNull();
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+  });
+
+  test("a terminal ok does not yank the user back after they navigate away mid-build", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // Build starts → panel opens.
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    // User navigates away to a document — a path that does NOT mark the app
+    // as dismissed.
+    useViewerStore.setState({ mainView: "document", activeAppId: null });
+    // The terminal `ok` for the same build arrives — it must NOT reopen the
+    // split-view.
+    emitPreview("app-1", "ok", { conversationId: "conv-1", reloadGeneration: 1 });
+    expect(useViewerStore.getState().mainView).toBe("document");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("a terminal error does not auto-open a not-yet-open app", () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // A terminal status with no prior build-start for this app: must not open.
+    emitPreview("app-1", "error", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("does not auto-open when the assistant is not active", () => {
+    renderHook(() =>
+      useAppPreviewSync({ ...DESKTOP_ACTIVE, isAssistantActive: false }),
+    );
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("does not auto-open when there is no active assistant", () => {
+    renderHook(() => useAppPreviewSync({ ...DESKTOP_ACTIVE, assistantId: null }));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
+  test("does not force the split on mobile", () => {
+    renderHook(() => useAppPreviewSync({ ...DESKTOP_ACTIVE, isMobile: true }));
+    emitPreview("app-1", "building", { conversationId: "conv-1" });
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-app-preview-sync.test.tsx
+++ b/apps/web/src/hooks/use-app-preview-sync.test.tsx
@@ -8,13 +8,28 @@ import { __resetForTesting, publish } from "@/lib/event-bus";
 // daemon SDK so the call resolves in-process (the synchronous view
 // transition under test lands first) and no unhandled rejection escapes.
 // Bun's `mock.module` leaks across files — run this file on its own.
+//
+// The fetch races the in-progress (dist-deleted) compile, so it resolves the
+// "App compilation failed" placeholder rather than the last-good html — model
+// that here so the seed-preservation test is realistic.
+const FETCH_PLACEHOLDER_HTML = "<p>App compilation failed.</p>";
 mock.module("@/generated/daemon/sdk.gen", () => ({
   appsByIdOpenPost: () =>
     Promise.resolve({
-      data: { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" },
+      data: {
+        appId: "app-1",
+        dirName: "my-app",
+        name: "My App",
+        html: FETCH_PLACEHOLDER_HTML,
+      },
     }),
   documentsByIdGet: () => Promise.resolve({ data: null }),
 }));
+
+/** Flush pending microtasks so the fire-and-forget fetch settles. */
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve();
+}
 
 const { useAppPreviewSync } = await import("@/hooks/use-app-preview-sync");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -165,5 +180,57 @@ describe("useAppPreviewSync auto-open", () => {
     emitPreview("app-1", "building", { conversationId: "conv-1" });
     expect(useViewerStore.getState().mainView).toBe("chat");
     expect(useViewerStore.getState().activeAppId).toBeNull();
+  });
+
+  test("seeds the opened preview with the build event's last-good html", async () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    // Build-start for a closed app, carrying the last working html. The panel
+    // opens seeded with that html immediately.
+    emitPreview("app-1", "building", {
+      conversationId: "conv-1",
+      html: "<h1>Last good</h1>",
+    });
+    expect(useViewerStore.getState().openedAppState?.html).toBe(
+      "<h1>Last good</h1>",
+    );
+    // The racing fetch resolves the failure placeholder, but the seeded
+    // last-good html must survive (preserveSeededHtml).
+    await flushMicrotasks();
+    expect(useViewerStore.getState().openedAppState?.html).toBe(
+      "<h1>Last good</h1>",
+    );
+  });
+
+  test("a subsequent error keeps the seeded html, not a placeholder", async () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", {
+      conversationId: "conv-1",
+      html: "<h1>Last good</h1>",
+    });
+    await flushMicrotasks();
+    // The build then fails. Keep-last-good must preserve the seeded html
+    // rather than reverting to the fetch's placeholder.
+    emitPreview("app-1", "error", { conversationId: "conv-1" });
+    const viewer = useViewerStore.getState();
+    expect(viewer.openedAppState?.html).toBe("<h1>Last good</h1>");
+    expect(viewer.openedAppState?.compileStatus).toBe("error");
+  });
+
+  test("a subsequent ok swaps in the fresh html", async () => {
+    renderHook(() => useAppPreviewSync(DESKTOP_ACTIVE));
+    emitPreview("app-1", "building", {
+      conversationId: "conv-1",
+      html: "<h1>Last good</h1>",
+    });
+    await flushMicrotasks();
+    // A successful recompile carries the rebuilt html and a bumped generation.
+    emitPreview("app-1", "ok", {
+      conversationId: "conv-1",
+      html: "<h1>Fresh</h1>",
+      reloadGeneration: 1,
+    });
+    const viewer = useViewerStore.getState();
+    expect(viewer.openedAppState?.html).toBe("<h1>Fresh</h1>");
+    expect(viewer.openedAppState?.reloadGeneration).toBe(1);
   });
 });

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -34,7 +34,7 @@ import { useRef } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { useViewerStore, type AppCompileStatus } from "@/stores/viewer-store";
 
 interface UseAppPreviewSyncParams {
   /** Active assistant id (owner of the bus SSE connection). */
@@ -62,7 +62,7 @@ export function useAppPreviewSync({
   // build sequence begins (first event, or a `building` that follows a
   // terminal `ok`/`error`). A ref — this is per-event bookkeeping, not
   // render-visible state.
-  const lastStatusByApp = useRef(new Map<string, "building" | "ok" | "error">());
+  const lastStatusByApp = useRef(new Map<string, AppCompileStatus>());
 
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -1,36 +1,125 @@
 /**
  * Bus consumer for `app_preview_update` SSE events.
  *
- * Live-refreshes the open app preview as the daemon recompiles a multifile
- * app's source. Each successful recompile (`ok`) carries fresh html and a
- * bumped `reloadGeneration`, which swaps the preview iframe; `building` and
- * `error` events update status only and keep the last-good preview visible.
+ * Two responsibilities, both driven off the daemon's live-build stream:
+ *
+ * 1. **Hot-reload the open preview** — forward every event to
+ *    `updateOpenedAppPreview`, which swaps the iframe on a successful
+ *    recompile and surfaces a build-error badge otherwise (PR 3). That
+ *    action no-ops unless the event targets the currently active app.
+ * 2. **Auto-open the split-view** — when a build begins for an app that
+ *    is NOT currently open, pop open the desktop chat-left / preview-right
+ *    panel (`revealAppForBuild`) so the user watches it build side-by-side
+ *    (Lovable-style). Desktop-only; gated on the active assistant.
+ *
+ * Assistant/conversation gating: the bus-owned SSE connection is
+ * assistant-scoped (`sseService.attach(assistantId)` is re-attached when
+ * the active assistant changes), so every `sse.event` already belongs to
+ * the currently-active assistant — there is no `assistantId` on the
+ * `app_preview_update` payload to filter on. We additionally gate on the
+ * caller-supplied active `assistantId` + `isAssistantActive` (the same
+ * pattern as `useConversationSync`) so a background/transitioning
+ * assistant never yanks a panel open, and so we have the id `loadApp`
+ * needs. The envelope's `conversationId` becomes the edit-chat target so
+ * the desktop `app-editing` branch (which requires `editingConversationId`)
+ * actually renders for the conversation the user is viewing.
  *
  * References:
  * - EVENT_BUS.md — bus subscription contract
- * - stores/viewer-store.ts — app viewer state (`updateOpenedAppPreview`)
+ * - hooks/use-conversation-sync.ts — the active-assistant gating pattern
+ * - stores/viewer-store.ts — app viewer state + `revealAppForBuild`
  */
+
+import { useRef } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
+interface UseAppPreviewSyncParams {
+  /** Active assistant id (owner of the bus SSE connection). */
+  assistantId: string | null;
+  /** Whether that assistant is in the `active` lifecycle phase. */
+  isAssistantActive: boolean;
+  /**
+   * Mobile viewport. On mobile the desktop split-view doesn't exist, so we
+   * never force it open — the existing `MobileAppOverlay` path is unchanged.
+   */
+  isMobile: boolean;
+}
+
 /**
- * Subscribes to `app_preview_update` SSE events via the event bus and forwards
- * the live-build update to the viewer store.
- *
- * Like {@link useDocumentEditorSync}, this takes no `assistantId` — the viewer
- * store is global and app ids are globally unique. The store action no-ops
- * unless the event targets the currently active app.
+ * Subscribes to `app_preview_update` SSE events via the event bus,
+ * forwards the live-build update to the open preview, and auto-opens the
+ * side-by-side panel when a build begins for a not-yet-open app.
  */
-export function useAppPreviewSync(): void {
+export function useAppPreviewSync({
+  assistantId,
+  isAssistantActive,
+  isMobile,
+}: UseAppPreviewSyncParams): void {
+  // Last seen compile status per app, so we can detect when a *fresh*
+  // build sequence begins (first event, or a `building` that follows a
+  // terminal `ok`/`error`). A ref — this is per-event bookkeeping, not
+  // render-visible state.
+  const lastStatusByApp = useRef(new Map<string, "building" | "ok" | "error">());
+
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "app_preview_update") return;
-    useViewerStore.getState().updateOpenedAppPreview(event.appId, {
+
+    const viewer = useViewerStore.getState();
+
+    // (1) Hot-reload the open preview (no-ops unless this is the active app).
+    viewer.updateOpenedAppPreview(event.appId, {
       html: event.html,
       compileStatus: event.compileStatus,
       buildErrors: event.buildErrors,
       reloadGeneration: event.reloadGeneration,
     });
+
+    // (2) Auto-open the split-view for a build that just started.
+    //
+    // A fresh build sequence: the first `building` event we've seen for this
+    // app, or a `building` event that follows a terminal status. This is the
+    // ONLY signal that may auto-open the panel — terminal `ok`/`error` events
+    // must never reveal it. Otherwise, if the user navigates away to a
+    // document/tool-detail/other view mid-build, the terminal event for the
+    // same build would yank them back into `app-editing`.
+    const prevStatus = lastStatusByApp.current.get(event.appId);
+    lastStatusByApp.current.set(event.appId, event.compileStatus);
+    if (event.compileStatus !== "building") return;
+    const isFreshBuildStart =
+      prevStatus === undefined ||
+      prevStatus === "ok" ||
+      prevStatus === "error";
+    if (!isFreshBuildStart) return;
+    // Reset a prior user dismissal so this fresh build re-opens the panel.
+    viewer.clearBuildDismissal(event.appId);
+
+    // Mobile keeps the existing overlay path — don't force the split.
+    // Gate on the active assistant so a background/transitioning assistant
+    // never yanks a panel open.
+    if (isMobile || !assistantId || !isAssistantActive) return;
+    // Bail early when `revealAppForBuild` would no-op anyway — the user is
+    // already viewing this app, or dismissed it for the current build — so
+    // we don't disturb their edit-chat target. Mirrors the store guards.
+    // Re-read state here: `clearBuildDismissal` above may have just cleared
+    // the flag, and the `viewer` snapshot taken earlier would be stale.
+    const current = useViewerStore.getState();
+    const alreadyViewing =
+      current.activeAppId === event.appId &&
+      (current.mainView === "app" || current.mainView === "app-editing");
+    if (alreadyViewing || current.dismissedBuildAppId === event.appId) return;
+    // Set the edit-chat target to the conversation driving this build so
+    // the desktop `app-editing` branch renders. Fall back to the active
+    // conversation when the envelope omits it.
+    const conversationId =
+      envelope.conversationId ??
+      useConversationStore.getState().activeConversationId;
+    if (conversationId) {
+      useConversationStore.getState().setEditingConversationId(conversationId);
+    }
+    current.revealAppForBuild(assistantId, event.appId);
   });
 }

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -1,0 +1,36 @@
+/**
+ * Bus consumer for `app_preview_update` SSE events.
+ *
+ * Live-refreshes the open app preview as the daemon recompiles a multifile
+ * app's source. Each successful recompile (`ok`) carries fresh html and a
+ * bumped `reloadGeneration`, which swaps the preview iframe; `building` and
+ * `error` events update status only and keep the last-good preview visible.
+ *
+ * References:
+ * - EVENT_BUS.md — bus subscription contract
+ * - stores/viewer-store.ts — app viewer state (`updateOpenedAppPreview`)
+ */
+
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Subscribes to `app_preview_update` SSE events via the event bus and forwards
+ * the live-build update to the viewer store.
+ *
+ * Like {@link useDocumentEditorSync}, this takes no `assistantId` — the viewer
+ * store is global and app ids are globally unique. The store action no-ops
+ * unless the event targets the currently active app.
+ */
+export function useAppPreviewSync(): void {
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
+    if (event.type !== "app_preview_update") return;
+    useViewerStore.getState().updateOpenedAppPreview(event.appId, {
+      html: event.html,
+      compileStatus: event.compileStatus,
+      buildErrors: event.buildErrors,
+      reloadGeneration: event.reloadGeneration,
+    });
+  });
+}

--- a/apps/web/src/hooks/use-app-preview-sync.ts
+++ b/apps/web/src/hooks/use-app-preview-sync.ts
@@ -70,13 +70,17 @@ export function useAppPreviewSync({
 
     const viewer = useViewerStore.getState();
 
-    // (1) Hot-reload the open preview (no-ops unless this is the active app).
-    viewer.updateOpenedAppPreview(event.appId, {
+    // The live-build fields this event contributes, used both to hot-reload
+    // the open preview and to seed an auto-opened one.
+    const preview = {
       html: event.html,
       compileStatus: event.compileStatus,
       buildErrors: event.buildErrors,
       reloadGeneration: event.reloadGeneration,
-    });
+    };
+
+    // (1) Hot-reload the open preview (no-ops unless this is the active app).
+    viewer.updateOpenedAppPreview(event.appId, preview);
 
     // (2) Auto-open the split-view for a build that just started.
     //
@@ -120,6 +124,10 @@ export function useAppPreviewSync({
     if (conversationId) {
       useConversationStore.getState().setEditingConversationId(conversationId);
     }
-    current.revealAppForBuild(assistantId, event.appId);
+    // Seed the opened state with the build event's last-good html so the
+    // newly opened preview shows the last working version immediately. The
+    // store's fetch races the in-progress compile (which deletes `dist/`) and
+    // can otherwise resolve the "App compilation failed" placeholder.
+    current.revealAppForBuild(assistantId, event.appId, preview);
   });
 }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -81,7 +81,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   useDocumentEditorSync();
-  useAppPreviewSync();
+  useAppPreviewSync({ assistantId, isAssistantActive, isMobile });
 
   useEventBusInit({ assistantId, isAssistantActive });
   // Inbound deep-link navigation + window activation. Mounted here

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -10,6 +10,7 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
+import { useAppPreviewSync } from "@/hooks/use-app-preview-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
@@ -80,6 +81,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   useDocumentEditorSync();
+  useAppPreviewSync();
 
   useEventBusInit({ assistantId, isAssistantActive });
   // Inbound deep-link navigation + window activation. Mounted here

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -1,4 +1,18 @@
-import { beforeEach, describe, it, expect } from "bun:test";
+import { beforeEach, describe, it, expect, mock } from "bun:test";
+
+// `revealAppForBuild`/`loadApp` fire `appsByIdOpenPost` to fetch the first
+// frame. Mock the daemon SDK so the network call resolves in-process —
+// the synchronous view transition (the part under test) lands before the
+// resolved fetch settles, and the mock prevents an unhandled rejection.
+// Bun's `mock.module` leaks across files, so run this file on its own
+// (`bun test src/stores/viewer-store.test.ts`) per apps/web testing notes.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  appsByIdOpenPost: () =>
+    Promise.resolve({
+      data: { appId: "app-1", dirName: "my-app", name: "My App", html: "<h1>App</h1>" },
+    }),
+  documentsByIdGet: () => Promise.resolve({ data: null }),
+}));
 
 import {
   isAppNotFoundError,
@@ -275,6 +289,85 @@ describe("closeApp", () => {
     expect(state.activeAppId).toBeNull();
     expect(state.openedAppState).toBeNull();
     expect(state.isAppMinimized).toBe(false);
+  });
+});
+
+describe("closeApp build dismissal", () => {
+  it("records the closed app as dismissed for the current build", () => {
+    useViewerStore.setState({ mainView: "app-editing", activeAppId: "app-1" });
+    getState().closeApp();
+    expect(getState().dismissedBuildAppId).toBe("app-1");
+  });
+
+  it("re-opening an app clears its stale dismissal (openApp/loadApp)", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().openApp("app-1");
+    expect(getState().dismissedBuildAppId).toBeNull();
+  });
+});
+
+describe("clearBuildDismissal", () => {
+  it("clears the flag when the appId matches", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().clearBuildDismissal("app-1");
+    expect(getState().dismissedBuildAppId).toBeNull();
+  });
+
+  it("is a no-op when the appId does not match", () => {
+    useViewerStore.setState({ dismissedBuildAppId: "app-1" });
+    getState().clearBuildDismissal("app-2");
+    expect(getState().dismissedBuildAppId).toBe("app-1");
+  });
+});
+
+describe("revealAppForBuild", () => {
+  it("opens the app-editing split-view and sets activeAppId for a not-open app", () => {
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    expect(state.mainView).toBe("app-editing");
+    expect(state.activeAppId).toBe("app-1");
+    expect(state.isAppMinimized).toBe(false);
+  });
+
+  it("does not disrupt an app the user is already viewing (app view)", () => {
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: "app-1",
+      openedAppState: SAMPLE_APP,
+    });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    // Stays in the full-width app view — not yanked into the split.
+    expect(state.mainView).toBe("app");
+    expect(state.openedAppState).toBe(SAMPLE_APP);
+  });
+
+  it("does not disrupt an app the user is already editing (app-editing view)", () => {
+    useViewerStore.setState({
+      mainView: "app-editing",
+      activeAppId: "app-1",
+      openedAppState: SAMPLE_APP,
+    });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    expect(getState().mainView).toBe("app-editing");
+    expect(getState().openedAppState).toBe(SAMPLE_APP);
+  });
+
+  it("does not re-open an app the user dismissed during the current build", () => {
+    useViewerStore.setState({ mainView: "chat", dismissedBuildAppId: "app-1" });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeAppId).toBeNull();
+  });
+
+  it("opens despite a dismissal recorded for a DIFFERENT app", () => {
+    useViewerStore.setState({ mainView: "chat", dismissedBuildAppId: "app-2" });
+    getState().revealAppForBuild("assistant-1", "app-1");
+    expect(getState().mainView).toBe("app-editing");
+    expect(getState().activeAppId).toBe("app-1");
+    // The other app's dismissal is untouched.
+    expect(getState().dismissedBuildAppId).toBe("app-2");
   });
 });
 

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -461,6 +461,44 @@ describe("revealAppForBuild", () => {
     // The other app's dismissal is untouched.
     expect(getState().dismissedBuildAppId).toBe("app-2");
   });
+
+  it("seeds openedAppState with the build event's last-good html", () => {
+    getState().revealAppForBuild("assistant-1", "app-1", {
+      html: "<h1>Last good</h1>",
+      compileStatus: "building",
+      reloadGeneration: 3,
+    });
+    const state = getState();
+    expect(state.mainView).toBe("app-editing");
+    // Seeded synchronously, before the (racing) fetch settles.
+    expect(state.openedAppState?.html).toBe("<h1>Last good</h1>");
+    expect(state.openedAppState?.compileStatus).toBe("building");
+    expect(state.openedAppState?.reloadGeneration).toBe(3);
+  });
+
+  it("keeps the seeded html after the racing fetch settles", async () => {
+    getState().revealAppForBuild("assistant-1", "app-1", {
+      html: "<h1>Last good</h1>",
+      compileStatus: "building",
+      reloadGeneration: 3,
+    });
+    // Let the fire-and-forget fetch resolve. The mock returns the
+    // post-rm placeholder html; the seeded last-good html must win, while
+    // the fetched metadata (name/dirName) is adopted.
+    await Promise.resolve();
+    await Promise.resolve();
+    const state = getState();
+    expect(state.openedAppState?.html).toBe("<h1>Last good</h1>");
+    expect(state.openedAppState?.name).toBe("My App");
+    expect(state.openedAppState?.dirName).toBe("my-app");
+  });
+
+  it("adopts the fetched html when no seed is provided", async () => {
+    getState().revealAppForBuild("assistant-1", "app-1");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getState().openedAppState?.html).toBe("<h1>App</h1>");
+  });
 });
 
 describe("toggleAppMinimized", () => {

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -81,6 +81,180 @@ describe("setLoadedApp", () => {
   });
 });
 
+describe("updateOpenedAppPreview", () => {
+  function openSampleApp() {
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: SAMPLE_APP.appId,
+      openedAppState: { ...SAMPLE_APP },
+    });
+  }
+
+  it("swaps html and sets status on an ok event for the active app", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v2</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe("<h1>v2</h1>");
+    expect(app?.compileStatus).toBe("ok");
+    expect(app?.buildErrors).toBeUndefined();
+  });
+
+  it("keeps last-good html on a building event (status only)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "building",
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe(SAMPLE_APP.html);
+    expect(app?.compileStatus).toBe("building");
+  });
+
+  it("keeps last-good html on an error event and records buildErrors", () => {
+    openSampleApp();
+    // A fresh ok first, then a failed recompile.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["TS2322: type error"],
+      reloadGeneration: 2,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe("<h1>good</h1>");
+    expect(app?.compileStatus).toBe("error");
+    expect(app?.buildErrors).toEqual(["TS2322: type error"]);
+  });
+
+  it("tracks building -> ok -> error, swapping html only on ok", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "building",
+      reloadGeneration: 1,
+    });
+    expect(getState().openedAppState?.html).toBe(SAMPLE_APP.html);
+
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>fresh</h1>");
+
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>fresh</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>fresh</h1>");
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+  });
+
+  it("ignores events for a non-active app", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview("other-app", {
+      html: "<h1>nope</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 9,
+    });
+    const app = getState().openedAppState;
+    expect(app?.html).toBe(SAMPLE_APP.html);
+    expect(app?.compileStatus).toBeUndefined();
+  });
+
+  it("no-ops when no app is open", () => {
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>nope</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 1,
+    });
+    expect(getState().openedAppState).toBeNull();
+  });
+
+  it("persists reloadGeneration on an ok event", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v2</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    expect(getState().openedAppState?.reloadGeneration).toBe(5);
+  });
+
+  it("updates state on an ok event with identical html but a higher reloadGeneration", () => {
+    openSampleApp();
+    // First ok at generation 1.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 1,
+    });
+    const first = getState().openedAppState;
+    expect(first?.reloadGeneration).toBe(1);
+
+    // A successful recompile to byte-identical html, but a bumped generation:
+    // the backend bumps the generation so clients force-swap the iframe, so
+    // this must NOT be skipped by the no-op guard.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 2,
+    });
+    const second = getState().openedAppState;
+    expect(second?.html).toBe(SAMPLE_APP.html);
+    expect(second?.reloadGeneration).toBe(2);
+    // The state object is a fresh reference so subscribers re-render.
+    expect(second).not.toBe(first);
+  });
+
+  it("no-ops on a truly-identical ok event (same html, generation, and status)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    const before = getState().openedAppState;
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    // Same reference: no set() fired, so no re-render / iframe churn.
+    expect(getState().openedAppState).toBe(before);
+  });
+
+  it("does not advance reloadGeneration on building/error (keep-last-good)", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 4,
+    });
+    // A failed recompile carries the daemon's unchanged generation; the stored
+    // generation must stay at the last-good value so the iframe is not swapped.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 4,
+    });
+    expect(getState().openedAppState?.reloadGeneration).toBe(4);
+    expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
+  });
+});
+
 describe("handleAppLoadFailed", () => {
   it("resets to chat view and clears app state", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1", openedAppState: SAMPLE_APP });

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -267,6 +267,98 @@ describe("updateOpenedAppPreview", () => {
     expect(getState().openedAppState?.reloadGeneration).toBe(4);
     expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
   });
+
+  it("drops a stale error from an older overlapping build (generation behind stored ok)", () => {
+    openSampleApp();
+    // Newer build lands ok at generation 5.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    const after = getState().openedAppState;
+    // A SLOW older build (generation 3) fails AFTER the newer ok already
+    // landed — it must NOT regress the preview into an error state.
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>stale</h1>",
+      compileStatus: "error",
+      buildErrors: ["stale boom"],
+      reloadGeneration: 3,
+    });
+    // Same reference: the stale event was dropped, no set() fired.
+    expect(getState().openedAppState).toBe(after);
+    expect(getState().openedAppState?.compileStatus).toBe("ok");
+    expect(getState().openedAppState?.html).toBe("<h1>new-good</h1>");
+  });
+
+  it("drops a stale building event from an older overlapping build", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    const after = getState().openedAppState;
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>new-good</h1>",
+      compileStatus: "building",
+      reloadGeneration: 2,
+    });
+    expect(getState().openedAppState).toBe(after);
+    expect(getState().openedAppState?.compileStatus).toBe("ok");
+  });
+
+  it("applies a building/error event whose generation equals the stored generation", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    // The terminal event of THIS build carries the same (unchanged) generation
+    // — equal is not stale, so it still applies (keep-last-good).
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>good</h1>",
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 5,
+    });
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+    expect(getState().openedAppState?.html).toBe("<h1>good</h1>");
+  });
+
+  it("applies an ok event even when its generation is below the stored generation", () => {
+    openSampleApp();
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v5</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 5,
+    });
+    // `ok` is never dropped by the stale guard — it carries fresh html. (In
+    // practice the daemon's generation is monotonic, but the guard only
+    // targets building/error.)
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: "<h1>v3</h1>",
+      compileStatus: "ok",
+      reloadGeneration: 3,
+    });
+    expect(getState().openedAppState?.html).toBe("<h1>v3</h1>");
+    expect(getState().openedAppState?.reloadGeneration).toBe(3);
+  });
+
+  it("does not drop an error when no generation has been stored yet (missing is not stale)", () => {
+    openSampleApp();
+    // No prior ok — stored generation is undefined. An error event must still
+    // surface (matches the prior behavior for first-event error).
+    getState().updateOpenedAppPreview(SAMPLE_APP.appId, {
+      html: SAMPLE_APP.html,
+      compileStatus: "error",
+      buildErrors: ["boom"],
+      reloadGeneration: 0,
+    });
+    expect(getState().openedAppState?.compileStatus).toBe("error");
+    expect(getState().openedAppState?.buildErrors).toEqual(["boom"]);
+  });
 });
 
 describe("handleAppLoadFailed", () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -82,6 +82,42 @@ export function isAppNotFoundError(err: unknown): boolean {
   return typeof message === "string" && message.startsWith("App not found");
 }
 
+/**
+ * Fetch an app's html and store it as `openedAppState`, WITHOUT touching
+ * `mainView` — the caller owns the view transition (`loadApp` → `"app"`,
+ * `revealAppForBuild` → `"app-editing"`). Bails out if the active app
+ * changed while the request was in flight. Shared so both callers get the
+ * same 404-tolerance + cache-priming behavior.
+ */
+async function fetchAndSetApp(
+  set: (partial: Partial<ViewerState>) => void,
+  get: () => ViewerStore,
+  assistantId: string,
+  appId: string,
+): Promise<void> {
+  try {
+    const { data: result } = await appsByIdOpenPost({
+      path: { assistant_id: assistantId, id: appId },
+      throwOnError: true,
+    });
+    if (get().activeAppId !== appId) return;
+    const app = { appId: result.appId, dirName: result.dirName, name: result.name, html: result.html };
+    set({ openedAppState: app });
+    primeAppHtmlCache(assistantId, result.appId, result.html);
+  } catch (err) {
+    if (get().activeAppId !== appId) return;
+    // 404s here are an expected condition (app was deleted on the
+    // server but the client still has a reference). Skip the Sentry
+    // capture for those — the daemon already returns a structured
+    // `{ code: "NOT_FOUND", message }` body — and let the UI fall
+    // back to chat as below. Unexpected failures still report.
+    if (!isAppNotFoundError(err)) {
+      captureError(err, { context: "openApp" });
+    }
+    set({ mainView: "chat", activeAppId: null, openedAppState: null });
+  }
+}
+
 function resolveViewBefore(
   state: ViewerState,
   field: "viewBeforeDocument" | "viewBeforeSubagentDetail" | "viewBeforeToolDetail",
@@ -157,6 +193,14 @@ export interface ViewerState {
   mainView: MainView;
   activeAppId: string | null;
   openedAppState: OpenedAppState | null;
+  /**
+   * App id the user explicitly dismissed (closed/exited) during the
+   * current build, so the auto-open (`revealAppForBuild`) does not fight
+   * the user by popping the panel back open for that same build. Reset
+   * to `null` when a fresh build sequence begins for a different app, or
+   * when the user reopens an app. Transient UI state, not persisted.
+   */
+  dismissedBuildAppId: string | null;
   activeDocumentSurfaceId: string | null;
   openedDocumentState: OpenedDocumentState | null;
   isAppMinimized: boolean;
@@ -177,6 +221,13 @@ export interface ViewerActions {
   // --- App viewer ---
   openApp: (appId: string) => void;
   loadApp: (assistantId: string, appId: string) => Promise<void>;
+  /**
+   * Auto-open the chat-left / preview-right split-view for an app whose
+   * build just started (driven by the first `app_preview_update` event).
+   * Sets `mainView: "app-editing"` + `activeAppId` and loads the first
+   * frame; live `app_preview_update`s then hot-swap the preview (PR 3).
+   */
+  revealAppForBuild: (assistantId: string, appId: string) => void;
   setLoadedApp: (app: OpenedAppState) => void;
   updateOpenedAppPreview: (
     appId: string,
@@ -189,6 +240,13 @@ export interface ViewerActions {
   ) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
+  /**
+   * Clear the build-dismissal flag for `appId` (no-op if it doesn't
+   * match), letting `revealAppForBuild` auto-open the panel again on the
+   * NEXT build. Called by the app-preview hook when a fresh build
+   * sequence begins for an app the user previously dismissed.
+   */
+  clearBuildDismissal: (appId: string) => void;
   toggleAppMinimized: () => void;
   handleAppUnpinned: (appId: string) => boolean;
   enterAppEditing: () => void;
@@ -227,6 +285,7 @@ const INITIAL_STATE: ViewerState = {
   mainView: "chat",
   activeAppId: null,
   openedAppState: null,
+  dismissedBuildAppId: null,
   activeDocumentSurfaceId: null,
   openedDocumentState: null,
   isAppMinimized: false,
@@ -266,6 +325,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeAppId: appId,
       openedAppState: null,
       isAppMinimized: false,
+      // Re-opening an app clears any stale dismissal for it so a later
+      // build's auto-open isn't suppressed by an old close.
+      dismissedBuildAppId: null,
     });
   },
 
@@ -275,28 +337,39 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeAppId: appId,
       openedAppState: null,
       isAppMinimized: false,
+      dismissedBuildAppId: null,
     });
-    try {
-      const { data: result } = await appsByIdOpenPost({
-        path: { assistant_id: assistantId, id: appId },
-        throwOnError: true,
-      });
-      if (get().activeAppId !== appId) return;
-      const app = { appId: result.appId, dirName: result.dirName, name: result.name, html: result.html };
-      set({ openedAppState: app });
-      primeAppHtmlCache(assistantId, result.appId, result.html);
-    } catch (err) {
-      if (get().activeAppId !== appId) return;
-      // 404s here are an expected condition (app was deleted on the
-      // server but the client still has a reference). Skip the Sentry
-      // capture for those — the daemon already returns a structured
-      // `{ code: "NOT_FOUND", message }` body — and let the UI fall
-      // back to chat as below. Unexpected failures still report.
-      if (!isAppNotFoundError(err)) {
-        captureError(err, { context: "openApp" });
-      }
-      set({ mainView: "chat", activeAppId: null, openedAppState: null });
+    await fetchAndSetApp(set, get, assistantId, appId);
+  },
+
+  revealAppForBuild: (assistantId, appId) => {
+    const state = get();
+    // Already looking at this app — never yank the view (or re-fetch)
+    // out from under the user mid-build. `app-editing` and the
+    // full-width `app` view both count as "viewing this app".
+    if (
+      state.activeAppId === appId &&
+      (state.mainView === "app" || state.mainView === "app-editing")
+    ) {
+      return;
     }
+    // The user explicitly closed the panel for this app during the
+    // current build — respect that and don't pop it back open. The
+    // hook clears this flag (`clearBuildDismissal`) when a fresh build
+    // sequence begins, so the next build re-opens.
+    if (state.dismissedBuildAppId === appId) return;
+    set({
+      mainView: "app-editing",
+      activeAppId: appId,
+      openedAppState: null,
+      isAppMinimized: false,
+    });
+    // Load the first frame; subsequent `app_preview_update`s hot-swap
+    // the preview (PR 3) via `updateOpenedAppPreview`. `fetchAndSetApp`
+    // keeps `mainView` untouched (unlike `loadApp`), so the split-view
+    // we just entered survives the async load. Fire-and-forget — the
+    // helper bails on its own if the active app changed meanwhile.
+    void fetchAndSetApp(set, get, assistantId, appId);
   },
 
   setLoadedApp: (app) => {
@@ -363,12 +436,23 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   },
 
   closeApp: () => {
+    // Remember which app the user just dismissed so the build auto-open
+    // (`revealAppForBuild`) doesn't immediately re-open the panel for the
+    // same in-flight build. Cleared by `clearBuildDismissal` when a fresh
+    // build sequence starts, or by re-opening the app (`openApp`/`loadApp`).
+    const dismissedBuildAppId = get().activeAppId ?? get().dismissedBuildAppId;
     set({
       mainView: "chat",
       activeAppId: null,
       openedAppState: null,
       isAppMinimized: false,
+      dismissedBuildAppId,
     });
+  },
+
+  clearBuildDismissal: (appId) => {
+    if (get().dismissedBuildAppId !== appId) return;
+    set({ dismissedBuildAppId: null });
   },
 
   toggleAppMinimized: () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -112,6 +112,21 @@ export interface OpenedAppState {
   dirName?: string;
   name: string;
   html: string;
+  /**
+   * Live-build status from the daemon's `app_preview_update` stream.
+   * Undefined for apps that haven't received a live-build event (e.g. just
+   * opened). `error` surfaces a non-blocking badge over the last-good html.
+   */
+  compileStatus?: "building" | "ok" | "error";
+  /** Compile diagnostics from the last `error` event; surfaced in the badge. */
+  buildErrors?: string[];
+  /**
+   * Generation counter bumped by the daemon on every SUCCESSFUL recompile
+   * (`compileStatus: "ok"`). Folded into the iframe key so a successful
+   * rebuild force-swaps the preview even when the resolved html is
+   * byte-identical to the currently open one.
+   */
+  reloadGeneration?: number;
 }
 
 export interface OpenedDocumentState {
@@ -163,6 +178,15 @@ export interface ViewerActions {
   openApp: (appId: string) => void;
   loadApp: (assistantId: string, appId: string) => Promise<void>;
   setLoadedApp: (app: OpenedAppState) => void;
+  updateOpenedAppPreview: (
+    appId: string,
+    update: {
+      html?: string;
+      compileStatus: "building" | "ok" | "error";
+      buildErrors?: string[];
+      reloadGeneration: number;
+    },
+  ) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   toggleAppMinimized: () => void;
@@ -277,6 +301,57 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   setLoadedApp: (app) => {
     set({ openedAppState: app });
+  },
+
+  /**
+   * Apply a daemon `app_preview_update` live-build event to the open app.
+   *
+   * No-ops unless the event targets the currently active app and that app is
+   * already loaded — stale events for a since-closed/switched app are dropped.
+   *
+   * Keep-last-good: only an `ok` event carries fresh html and swaps the
+   * preview. `building`/`error` update the status/errors but leave `html`
+   * AND `reloadGeneration` untouched so the last working preview stays
+   * visible and the iframe is not remounted on a transient failure.
+   *
+   * The daemon bumps `reloadGeneration` on every successful recompile so
+   * clients force-swap the iframe (it's folded into the iframe key). A
+   * successful rebuild whose resolved html is byte-identical therefore still
+   * remounts the preview — so the no-op guard below only skips when the html,
+   * generation, AND status are all unchanged.
+   */
+  updateOpenedAppPreview: (
+    appId,
+    { html, compileStatus, buildErrors, reloadGeneration },
+  ) => {
+    const prev = get().openedAppState;
+    if (!prev || get().activeAppId !== appId || prev.appId !== appId) return;
+    const isOk = compileStatus === "ok";
+    const nextHtml = isOk && html !== undefined ? html : prev.html;
+    // Only an `ok` event advances the stored generation; building/error keep
+    // the last-good generation so a transient failure never remounts.
+    const nextGeneration = isOk ? reloadGeneration : prev.reloadGeneration;
+    // Skip the update (and the re-render / iframe churn it triggers) when
+    // nothing observable changed — e.g. a repeated `building` heartbeat, or a
+    // successful recompile that resolved to byte-identical html AND did not
+    // bump the generation.
+    if (
+      prev.html === nextHtml &&
+      prev.reloadGeneration === nextGeneration &&
+      prev.compileStatus === compileStatus &&
+      prev.buildErrors === buildErrors
+    ) {
+      return;
+    }
+    set({
+      openedAppState: {
+        ...prev,
+        html: nextHtml,
+        compileStatus,
+        buildErrors,
+        reloadGeneration: nextGeneration,
+      },
+    });
   },
 
   handleAppLoadFailed: () => {

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -20,12 +20,31 @@
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
 
+import type { AppPreviewUpdateEvent } from "@vellumai/assistant-api";
 import { captureError } from "@/lib/sentry/capture-error";
 import { create } from "zustand";
 
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { createSelectors } from "@/utils/create-selectors";
+
+/**
+ * Live-build compile status, derived from the canonical `app_preview_update`
+ * wire contract (`@vellumai/assistant-api`) rather than re-spelling the
+ * literal union. Shared with `app-viewer-container.tsx` and
+ * `use-app-preview-sync.ts` so all web sites stay in lockstep with the daemon.
+ */
+export type AppCompileStatus = AppPreviewUpdateEvent["compileStatus"];
+
+/**
+ * The fields an `app_preview_update` event contributes to the open preview,
+ * picked from the canonical event so the update-param shape can't drift from
+ * the wire contract.
+ */
+export type AppPreviewUpdate = Pick<
+  AppPreviewUpdateEvent,
+  "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
+>;
 
 /** Views that overlay the main content and track a "back" destination. */
 type OverlayView = "document" | "subagent-detail" | "tool-detail";
@@ -153,7 +172,7 @@ export interface OpenedAppState {
    * Undefined for apps that haven't received a live-build event (e.g. just
    * opened). `error` surfaces a non-blocking badge over the last-good html.
    */
-  compileStatus?: "building" | "ok" | "error";
+  compileStatus?: AppCompileStatus;
   /** Compile diagnostics from the last `error` event; surfaced in the badge. */
   buildErrors?: string[];
   /**
@@ -229,15 +248,7 @@ export interface ViewerActions {
    */
   revealAppForBuild: (assistantId: string, appId: string) => void;
   setLoadedApp: (app: OpenedAppState) => void;
-  updateOpenedAppPreview: (
-    appId: string,
-    update: {
-      html?: string;
-      compileStatus: "building" | "ok" | "error";
-      buildErrors?: string[];
-      reloadGeneration: number;
-    },
-  ) => void;
+  updateOpenedAppPreview: (appId: string, update: AppPreviewUpdate) => void;
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   /**
@@ -387,6 +398,15 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
    * AND `reloadGeneration` untouched so the last working preview stays
    * visible and the iframe is not remounted on a transient failure.
    *
+   * Drop-stale: builds can overlap, so a SLOW older build may emit its
+   * terminal `building`/`error` event AFTER a newer build already landed an
+   * `ok`. Applying that stale status would regress the preview (paint an
+   * `error`/`building` over the latest good frame). We therefore ignore a
+   * `building`/`error` event whose `reloadGeneration` is strictly BELOW the
+   * stored generation. `ok` events still apply (they carry the freshest html
+   * and the newest generation). Missing/0 generations are treated as
+   * not-stale-blocking, preserving the pre-existing behavior.
+   *
    * The daemon bumps `reloadGeneration` on every successful recompile so
    * clients force-swap the iframe (it's folded into the iframe key). A
    * successful rebuild whose resolved html is byte-identical therefore still
@@ -400,6 +420,16 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     const prev = get().openedAppState;
     if (!prev || get().activeAppId !== appId || prev.appId !== appId) return;
     const isOk = compileStatus === "ok";
+    // Drop a stale terminal event from an older overlapping build: its
+    // generation is behind the last-good `ok` we already applied. `ok`
+    // events are never dropped here — they carry the newest generation.
+    if (
+      !isOk &&
+      prev.reloadGeneration !== undefined &&
+      reloadGeneration < prev.reloadGeneration
+    ) {
+      return;
+    }
     const nextHtml = isOk && html !== undefined ? html : prev.html;
     // Only an `ok` event advances the stored generation; building/error keep
     // the last-good generation so a transient failure never remounts.

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -46,6 +46,13 @@ export type AppPreviewUpdate = Pick<
   "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
 >;
 
+/**
+ * Last-good preview snapshot from a `building` build-start event, used to seed
+ * an auto-opened preview (`revealAppForBuild`) so it shows the last working
+ * html instead of a placeholder while the in-progress compile is mid-flight.
+ */
+export type RevealAppSeed = AppPreviewUpdate;
+
 /** Views that overlay the main content and track a "back" destination. */
 type OverlayView = "document" | "subagent-detail" | "tool-detail";
 
@@ -107,12 +114,21 @@ export function isAppNotFoundError(err: unknown): boolean {
  * `revealAppForBuild` → `"app-editing"`). Bails out if the active app
  * changed while the request was in flight. Shared so both callers get the
  * same 404-tolerance + cache-priming behavior.
+ *
+ * When auto-opening mid-build (`revealAppForBuild`), `fetchAndSetApp` can race
+ * the in-progress compile, which begins by deleting `dist/`. A racing fetch
+ * then resolves the "App compilation failed" placeholder rather than the last
+ * working html. The caller passes `preserveSeededHtml: true` in that case (it
+ * already seeded `openedAppState.html` from the build event's last-good html),
+ * so the fetch adopts only the freshly fetched metadata (name/dirName) and
+ * KEEPS the seeded html — a subsequent `ok` event swaps in the rebuilt html.
  */
 async function fetchAndSetApp(
   set: (partial: Partial<ViewerState>) => void,
   get: () => ViewerStore,
   assistantId: string,
   appId: string,
+  preserveSeededHtml = false,
 ): Promise<void> {
   try {
     const { data: result } = await appsByIdOpenPost({
@@ -120,9 +136,21 @@ async function fetchAndSetApp(
       throwOnError: true,
     });
     if (get().activeAppId !== appId) return;
-    const app = { appId: result.appId, dirName: result.dirName, name: result.name, html: result.html };
+    // Keep the build-event's last-good html when the fetch raced the
+    // dist-deleting compile; otherwise adopt the fetched html.
+    const seeded = preserveSeededHtml ? get().openedAppState : null;
+    const html = seeded && seeded.appId === appId ? seeded.html : result.html;
+    const app = {
+      appId: result.appId,
+      dirName: result.dirName,
+      name: result.name,
+      html,
+      compileStatus: seeded?.compileStatus,
+      buildErrors: seeded?.buildErrors,
+      reloadGeneration: seeded?.reloadGeneration,
+    };
     set({ openedAppState: app });
-    primeAppHtmlCache(assistantId, result.appId, result.html);
+    primeAppHtmlCache(assistantId, result.appId, html);
   } catch (err) {
     if (get().activeAppId !== appId) return;
     // 404s here are an expected condition (app was deleted on the
@@ -245,8 +273,16 @@ export interface ViewerActions {
    * build just started (driven by the first `app_preview_update` event).
    * Sets `mainView: "app-editing"` + `activeAppId` and loads the first
    * frame; live `app_preview_update`s then hot-swap the preview (PR 3).
+   *
+   * `seed` carries the build event's last-good html so the newly opened
+   * preview shows the last working version immediately, rather than the
+   * placeholder a racing (dist-deleted) fetch would otherwise resolve.
    */
-  revealAppForBuild: (assistantId: string, appId: string) => void;
+  revealAppForBuild: (
+    assistantId: string,
+    appId: string,
+    seed?: RevealAppSeed,
+  ) => void;
   setLoadedApp: (app: OpenedAppState) => void;
   updateOpenedAppPreview: (appId: string, update: AppPreviewUpdate) => void;
   handleAppLoadFailed: () => void;
@@ -353,7 +389,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     await fetchAndSetApp(set, get, assistantId, appId);
   },
 
-  revealAppForBuild: (assistantId, appId) => {
+  revealAppForBuild: (assistantId, appId, seed) => {
     const state = get();
     // Already looking at this app — never yank the view (or re-fetch)
     // out from under the user mid-build. `app-editing` and the
@@ -369,10 +405,27 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     // hook clears this flag (`clearBuildDismissal`) when a fresh build
     // sequence begins, so the next build re-opens.
     if (state.dismissedBuildAppId === appId) return;
+    // Seed the opened state from the build event's last-good html when we
+    // have it. The fetch below races the in-progress compile (which deletes
+    // `dist/`) and can resolve the "App compilation failed" placeholder; the
+    // seed ensures the newly opened preview shows the last working version,
+    // and `preserveSeededHtml` keeps it from being clobbered by that fetch.
+    // A subsequent `ok` event swaps in the rebuilt html as usual. Apps with
+    // no last-good (brand-new first build) carry no seed html and degrade to
+    // whatever the fetch resolves.
     set({
       mainView: "app-editing",
       activeAppId: appId,
-      openedAppState: null,
+      openedAppState: seed
+        ? {
+            appId,
+            name: "",
+            html: seed.html,
+            compileStatus: seed.compileStatus,
+            buildErrors: seed.buildErrors,
+            reloadGeneration: seed.reloadGeneration,
+          }
+        : null,
       isAppMinimized: false,
     });
     // Load the first frame; subsequent `app_preview_update`s hot-swap
@@ -380,7 +433,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     // keeps `mainView` untouched (unlike `loadApp`), so the split-view
     // we just entered survives the async load. Fire-and-forget — the
     // helper bails on its own if the active app changed meanwhile.
-    void fetchAndSetApp(set, get, assistantId, appId);
+    void fetchAndSetApp(set, get, assistantId, appId, seed !== undefined);
   },
 
   setLoadedApp: (app) => {

--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -27,6 +27,7 @@
         "croner": "10.0.1",
         "dotenv": "17.3.1",
         "drizzle-orm": "0.45.2",
+        "esbuild": "0.19.12",
         "jszip": "3.10.1",
         "marked": "18.0.0",
         "minimatch": "10.2.4",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -55,6 +55,7 @@
     "croner": "10.0.1",
     "dotenv": "17.3.1",
     "drizzle-orm": "0.45.2",
+    "esbuild": "0.19.12",
     "jszip": "3.10.1",
     "marked": "18.0.0",
     "minimatch": "10.2.4",

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-import { compileApp } from "../bundler/app-compiler.js";
+import {
+  __getAppCompilerContextStats,
+  __resetAppCompilerContextStats,
+  compileApp,
+  disposeAppCompilerContexts,
+} from "../bundler/app-compiler.js";
 import {
   ALLOWED_PACKAGES,
   getCacheDir,
@@ -24,6 +29,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await disposeAppCompilerContexts();
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -411,6 +417,92 @@ console.log("styled");`,
     const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
     expect(js).toContain("updated");
     expect(js).not.toContain("original");
+  });
+
+  test("second compile of the same app reuses the warm esbuild context", async () => {
+    const appDir = await scaffold("warm-context", {
+      "main.tsx": `console.log("v1");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    __resetAppCompilerContextStats();
+
+    const r1 = await compileApp(appDir);
+    expect(r1.ok).toBe(true);
+    // First compile creates a fresh context.
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+    expect(__getAppCompilerContextStats().rebuildCount).toBe(0);
+
+    // Edit and recompile: the context is reused (rebuild), not recreated.
+    await writeFile(join(appDir, "src", "main.tsx"), `console.log("v2");`);
+    const r2 = await compileApp(appDir);
+    expect(r2.ok).toBe(true);
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+    expect(__getAppCompilerContextStats().rebuildCount).toBe(1);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js).toContain("v2");
+    expect(js).not.toContain("v1");
+  });
+
+  test("recreates the warm context when nodePaths change (new allowed import resolves)", async () => {
+    // Start from a clean package cache so the first compile (no bare imports)
+    // runs with nodePaths that exclude the not-yet-existent cache node_modules.
+    const cacheNodeModules = join(getCacheDir(), "node_modules");
+    await rm(cacheNodeModules, { recursive: true, force: true });
+
+    const appDir = await scaffold("nodepaths-change", {
+      "main.tsx": `console.log("no imports yet");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    __resetAppCompilerContextStats();
+
+    // First compile: no third-party imports, so the cache node_modules dir is
+    // not created and is absent from nodePaths. Creates a fresh context.
+    const r1 = await compileApp(appDir);
+    expect(r1.ok).toBe(true);
+    expect(__getAppCompilerContextStats().createCount).toBe(1);
+
+    // Add an allowed import. resolveAppImports() installs lodash-es, which
+    // creates the cache node_modules dir and so extends nodePaths. The cached
+    // context's identity must change, forcing a dispose + recreate (not a
+    // plain rebuild against the stale resolver paths).
+    await writeFile(
+      join(appDir, "src", "main.tsx"),
+      `import { camelCase } from "lodash-es";\nconsole.log(camelCase("hello world"));`,
+    );
+    const r2 = await compileApp(appDir);
+
+    // The second resolve must succeed — the recreated context sees the newly
+    // installed package via the updated nodePaths.
+    expect(r2.ok).toBe(true);
+    expect(r2.errors).toHaveLength(0);
+
+    // Two distinct contexts were created (recreated, not reused).
+    expect(__getAppCompilerContextStats().createCount).toBe(2);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js).toContain("hello world");
+  }, 30_000);
+
+  test("compile error maps esbuild diagnostics to the result shape", async () => {
+    const appDir = await scaffold("warm-context-error", {
+      "main.tsx": `const x = <<<broken>>>;`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    const result = await compileApp(appDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(typeof result.errors[0].text).toBe("string");
+    expect(result.errors[0].text.length).toBeGreaterThan(0);
+    // esbuild diagnostics carry a structured location.
+    expect(result.errors[0].location?.file).toBeTruthy();
+    expect(typeof result.errors[0].location?.line).toBe("number");
+    expect(typeof result.errors[0].location?.column).toBe("number");
   });
 });
 

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -548,6 +548,31 @@ render(<App />, document.body);`,
       expect(typeof result.errors[0].text).toBe("string");
       expect(result.errors[0].text.length).toBeGreaterThan(0);
     });
+
+    test("CLI fallback parses the location frame across the blank line", async () => {
+      __setEsbuildLoaderOverride(async () => null);
+
+      // A "Could not resolve" import error: esbuild prints a summary line, a
+      // blank line, then the "file:line:column:" frame. The import sits on
+      // line 2 so we can assert the parsed line number.
+      const appDir = await scaffold("cli-fallback-location", {
+        "main.tsx": `console.log("start");
+import { thing } from "./does-not-exist";
+console.log(thing);`,
+        "index.html": MINIMAL_HTML,
+      });
+
+      const result = await compileApp(appDir);
+      expect(result.ok).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+
+      // The CLI path must populate location with the same { file, line,
+      // column } shape as the JS-API path — not drop it on the blank line.
+      const loc = result.errors[0].location;
+      expect(loc?.file).toContain("main.tsx");
+      expect(loc?.line).toBe(2);
+      expect(typeof loc?.column).toBe("number");
+    });
   });
 });
 

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   __getAppCompilerContextStats,
   __resetAppCompilerContextStats,
+  __setEsbuildLoaderOverride,
   compileApp,
   disposeAppCompilerContexts,
 } from "../bundler/app-compiler.js";
@@ -503,6 +504,50 @@ console.log("styled");`,
     expect(result.errors[0].location?.file).toBeTruthy();
     expect(typeof result.errors[0].location?.line).toBe("number");
     expect(typeof result.errors[0].location?.column).toBe("number");
+  });
+
+  // -------------------------------------------------------------------------
+  // Native-CLI fallback path (compiled macOS binary, where the esbuild JS API
+  // can't resolve). Forced by injecting a loader that reports it unavailable.
+  // -------------------------------------------------------------------------
+  describe("native-CLI fallback (JS API unavailable)", () => {
+    afterAll(() => __setEsbuildLoaderOverride(null));
+
+    test("falls back to the CLI binary and produces the same success shape", async () => {
+      // null = JS API cannot be resolved → compileBundle uses compileWithCli.
+      __setEsbuildLoaderOverride(async () => null);
+
+      const appDir = await scaffold("cli-fallback-ok", {
+        "main.tsx": `import { render } from "preact";
+const App = () => <div>cli-fallback</div>;
+render(<App />, document.body);`,
+        "index.html": MINIMAL_HTML,
+      });
+
+      const result = await compileApp(appDir);
+      expect(result.ok).toBe(true);
+      expect(result.errors).toHaveLength(0);
+
+      const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+      expect(js).toContain("cli-fallback");
+      const html = await readFile(join(appDir, "dist", "index.html"), "utf-8");
+      expect(html).toContain('src="main.js"');
+    });
+
+    test("CLI fallback returns parsed diagnostics on a compile error", async () => {
+      __setEsbuildLoaderOverride(async () => null);
+
+      const appDir = await scaffold("cli-fallback-error", {
+        "main.tsx": `const x = <<<broken>>>;`,
+        "index.html": MINIMAL_HTML,
+      });
+
+      const result = await compileApp(appDir);
+      expect(result.ok).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(typeof result.errors[0].text).toBe("string");
+      expect(result.errors[0].text.length).toBeGreaterThan(0);
+    });
   });
 });
 

--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -29,13 +29,31 @@ interface Harness {
   settledCount: () => number;
 }
 
+/**
+ * Default `refreshSurfaces` stub: models the real surface counter as the
+ * single source of truth. Tracks a per-app generation and, on a successful
+ * recompile, advances it to at least the supplied floor (`max(floor, gen + 1)`)
+ * and returns it. A failed compile does not bump and returns the current value.
+ */
+function makeSurfaceCounter() {
+  const generations = new Map<string, number>();
+  const refreshSurfaces: AppLiveBuildDeps["refreshSurfaces"] = (id, opts) => {
+    const current = generations.get(id) ?? 0;
+    if (opts.compileStatus === "error") return current;
+    const next = Math.max(opts.reloadGeneration ?? 0, current + 1);
+    generations.set(id, next);
+    return next;
+  };
+  return { refreshSurfaces, peek: (id: string) => generations.get(id) ?? 0 };
+}
+
 function makeHarness(opts: { compile: () => Promise<CompileResult> }): Harness {
   let settled = 0;
   const deps: AppLiveBuildDeps = {
     compileApp: opts.compile,
     resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
     broadcast: () => {},
-    refreshSurfaces: () => {},
+    refreshSurfaces: makeSurfaceCounter().refreshSurfaces,
     onSettled: () => {
       settled++;
     },
@@ -71,11 +89,15 @@ describe("runAppLiveBuild", () => {
     const refreshCalls: Array<
       Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
     > = [];
+    const surface = makeSurfaceCounter();
     const deps: AppLiveBuildDeps = {
       compileApp: compile,
       resolveEffectiveAppHtml: () => (distFresh ? FRESH_HTML : LAST_GOOD_HTML),
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      refreshSurfaces: (id, o) => {
+        refreshCalls.push(o);
+        return surface.refreshSurfaces(id, o);
+      },
       onSettled: () => {},
     };
 
@@ -92,12 +114,15 @@ describe("runAppLiveBuild", () => {
     expect(okMsg.reloadGeneration).toBe(1); // bumped
     expect(okMsg.buildErrors).toBeUndefined();
 
+    // Only the terminal `ok` outcome refreshes surfaces; the broadcast
+    // generation equals the one the surface applied.
     expect(refreshCalls).toHaveLength(1);
     expect(refreshCalls[0].compileStatus).toBe("ok");
-    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    expect(okMsg.reloadGeneration).toBe(surface.peek(APP_ID));
   });
 
   test("failed compile keeps last-good html and an unchanged reloadGeneration", async () => {
+    const surface = makeSurfaceCounter();
     // First do a clean build to advance the generation to 1.
     {
       const compile = async () => ok();
@@ -106,7 +131,7 @@ describe("runAppLiveBuild", () => {
         compileApp: compile,
         resolveEffectiveAppHtml: () => FRESH_HTML,
         broadcast: (msg) => broadcasts.push(msg),
-        refreshSurfaces: () => {},
+        refreshSurfaces: surface.refreshSurfaces,
         onSettled: () => {},
       };
       await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
@@ -130,7 +155,10 @@ describe("runAppLiveBuild", () => {
       resolveEffectiveAppHtml: () =>
         compiled ? "<p>App compilation failed.</p>" : LAST_GOOD_HTML,
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      refreshSurfaces: (id, o) => {
+        refreshCalls.push(o);
+        return surface.refreshSurfaces(id, o);
+      },
       onSettled: () => {},
     };
 
@@ -154,7 +182,9 @@ describe("runAppLiveBuild", () => {
 
     expect(refreshCalls).toHaveLength(1);
     expect(refreshCalls[0].compileStatus).toBe("error");
-    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    // The error path does not pass a generation floor; the surface owns its
+    // (unchanged) generation on a failed compile.
+    expect(refreshCalls[0].reloadGeneration).toBeUndefined();
     expect(refreshCalls[0].buildErrors).toEqual([
       "Could not resolve 'foo'",
       "Unexpected token",
@@ -169,7 +199,7 @@ describe("runAppLiveBuild", () => {
       },
       resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
       broadcast: (msg) => broadcasts.push(msg),
-      refreshSurfaces: () => {},
+      refreshSurfaces: makeSurfaceCounter().refreshSurfaces,
       onSettled: () => {},
     };
 
@@ -184,12 +214,14 @@ describe("runAppLiveBuild", () => {
   });
 
   test("two overlapping successful compiles yield distinct increasing generations", async () => {
-    // Both invocations capture the same starting generation BEFORE awaiting
-    // their (serialized) compile. The generation must be read-and-bumped AFTER
-    // each compile succeeds so the second successful build does not reuse the
-    // first's reloadGeneration — otherwise clients drop the latest output.
+    // Both invocations are in-flight at once. The generation is read-and-bumped
+    // (through the shared surface counter) AFTER each compile succeeds, so the
+    // second successful build cannot reuse the first's reloadGeneration —
+    // otherwise the macOS change-detection would drop the latest output.
     const okBroadcasts: AppPreviewUpdateEvent[] = [];
     const okRefreshGenerations: number[] = [];
+    // A single surface counter shared by both invocations, as in production.
+    const surface = makeSurfaceCounter();
 
     let releaseFirst!: () => void;
     const firstGate = new Promise<void>((resolve) => {
@@ -203,8 +235,8 @@ describe("runAppLiveBuild", () => {
 
     let compileCount = 0;
     const deps: AppLiveBuildDeps = {
-      // First compile blocks until both invocations are in-flight, so they both
-      // captured the same starting generation before either bumps it.
+      // First compile blocks until both invocations are in-flight, so they
+      // overlap before either advances the generation.
       compileApp: async () => {
         compileCount += 1;
         if (compileCount === 1) {
@@ -217,17 +249,17 @@ describe("runAppLiveBuild", () => {
       broadcast: (msg) => {
         if (msg.compileStatus === "ok") okBroadcasts.push(msg);
       },
-      refreshSurfaces: (_id, o) => {
-        if (o.reloadGeneration !== undefined)
-          okRefreshGenerations.push(o.reloadGeneration);
+      refreshSurfaces: (id, o) => {
+        const applied = surface.refreshSurfaces(id, o);
+        if (o.compileStatus === "ok") okRefreshGenerations.push(applied);
+        return applied;
       },
       onSettled: () => {},
     };
 
     const first = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
     await firstStartedGate;
-    // Second invocation starts (and snapshots the same generation) while the
-    // first is still awaiting its compile.
+    // Second invocation starts while the first is still awaiting its compile.
     const second = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
     releaseFirst();
     await Promise.all([first, second]);
@@ -238,6 +270,43 @@ describe("runAppLiveBuild", () => {
     expect(generations).toEqual([1, 2]);
     // Broadcast generations match the ones written to surfaces.
     expect([...okRefreshGenerations].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  test("first live-build after an app_create surface bump does not collide", async () => {
+    // Reproduces the Gap-1 collision: `app_create` bumped the surface to 1
+    // (via the non-live-build +1 path) while the live-build module counter is
+    // still 0. The first successful live-build must NOT reuse generation 1 —
+    // the macOS client uses change-detection (gen != lastGen), so reusing the
+    // value it already saw would suppress a legitimate reload.
+    const surface = makeSurfaceCounter();
+    // Simulate the app_create surface bump (no live-build floor → +1 to 1).
+    expect(
+      surface.refreshSurfaces(APP_ID, {
+        fileChange: true,
+        // Cast: app_create/app_refresh path has no compileStatus, modeled here
+        // as a non-error bump.
+        compileStatus: "ok",
+      } as Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]),
+    ).toBe(1);
+
+    const okBroadcasts: AppPreviewUpdateEvent[] = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => ok(),
+      resolveEffectiveAppHtml: () => FRESH_HTML,
+      broadcast: (msg) => {
+        if (msg.compileStatus === "ok") okBroadcasts.push(msg);
+      },
+      refreshSurfaces: surface.refreshSurfaces,
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(okBroadcasts).toHaveLength(1);
+    // Strictly greater than the 1 the surface (and client) already had.
+    expect(okBroadcasts[0].reloadGeneration).toBeGreaterThan(1);
+    // Broadcast equals the surface's current generation (single source).
+    expect(okBroadcasts[0].reloadGeneration).toBe(surface.peek(APP_ID));
   });
 
   test("settle/onSettled fires on every outcome", async () => {

--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -272,6 +272,70 @@ describe("runAppLiveBuild", () => {
     expect([...okRefreshGenerations].sort((a, b) => a - b)).toEqual([1, 2]);
   });
 
+  test("queued failing build after an interleaved success reports the CURRENT generation", async () => {
+    // Regression: build A and queued build B overlap. A succeeds and bumps the
+    // generation; B then fails. B's error event must carry the current
+    // (post-A) generation, NOT the pre-A snapshot it was invoked with —
+    // otherwise its generation falls below the last applied `ok` and the web
+    // store's stale-event guard silently drops the compile error.
+    const surface = makeSurfaceCounter();
+    const okBroadcasts: AppPreviewUpdateEvent[] = [];
+    const errorBroadcasts: AppPreviewUpdateEvent[] = [];
+
+    let aStarted!: () => void;
+    const aStartedGate = new Promise<void>((resolve) => {
+      aStarted = resolve;
+    });
+    // B's compile blocks until A has fully settled (bumped the generation),
+    // modeling a queued rebuild that fails AFTER the prior build succeeded.
+    let releaseB!: () => void;
+    const bGate = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+
+    let compileCount = 0;
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => {
+        compileCount += 1;
+        if (compileCount === 1) {
+          aStarted();
+          return ok(); // A succeeds first and bumps the generation.
+        }
+        await bGate; // B fails only after A has settled.
+        return fail(["B broke"]);
+      },
+      resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
+      broadcast: (msg) => {
+        if (msg.compileStatus === "ok") okBroadcasts.push(msg);
+        if (msg.compileStatus === "error") errorBroadcasts.push(msg);
+      },
+      refreshSurfaces: surface.refreshSurfaces,
+      onSettled: () => {},
+    };
+
+    const a = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    await aStartedGate;
+    // B is invoked while A is in-flight, so it snapshots the pre-bump
+    // generation (0) at invocation time.
+    const b = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    await a; // A completes and bumps the generation to 1.
+    releaseB(); // Now let B fail.
+    await b;
+
+    // A bumped to generation 1.
+    expect(okBroadcasts).toHaveLength(1);
+    expect(okBroadcasts[0].reloadGeneration).toBe(1);
+
+    // B's error reports the CURRENT generation (1, post-A), not the pre-A 0,
+    // so the web stale-guard (drops non-ok below last `ok`) does NOT drop it.
+    expect(errorBroadcasts).toHaveLength(1);
+    expect(errorBroadcasts[0].reloadGeneration).toBe(1);
+    expect(errorBroadcasts[0].html).toBe(LAST_GOOD_HTML);
+    expect(errorBroadcasts[0].buildErrors).toEqual(["B broke"]);
+    // The error still does NOT bump the counter past A's generation.
+    expect(surface.peek(APP_ID)).toBe(1);
+  });
+
   test("first live-build after an app_create surface bump does not collide", async () => {
     // Reproduces the Gap-1 collision: `app_create` bumped the surface to 1
     // (via the non-live-build +1 path) while the live-build module counter is

--- a/assistant/src/__tests__/app-live-build.test.ts
+++ b/assistant/src/__tests__/app-live-build.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the live-build orchestration that emits `app_preview_update`
+ * events on multifile app source changes, keeping the last-good preview on a
+ * transient compile failure.
+ *
+ * Exercises `runAppLiveBuild` directly via dependency injection so it does not
+ * stand up the full daemon server.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { AppPreviewUpdateEvent } from "../api/events/app-preview-update.js";
+import type { CompileResult } from "../bundler/app-compiler.js";
+import {
+  __resetAppReloadGenerations,
+  type AppLiveBuildDeps,
+  runAppLiveBuild,
+} from "../daemon/app-live-build.js";
+import type { AppDefinition } from "../memory/app-store.js";
+
+const APP_ID = "app-live-1";
+const LAST_GOOD_HTML = "<html>last-good</html>";
+const FRESH_HTML = "<html>fresh</html>";
+
+const fakeApp = { id: APP_ID } as unknown as AppDefinition;
+
+interface Harness {
+  deps: AppLiveBuildDeps;
+  settledCount: () => number;
+}
+
+function makeHarness(opts: { compile: () => Promise<CompileResult> }): Harness {
+  let settled = 0;
+  const deps: AppLiveBuildDeps = {
+    compileApp: opts.compile,
+    resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
+    broadcast: () => {},
+    refreshSurfaces: () => {},
+    onSettled: () => {
+      settled++;
+    },
+  };
+  return { deps, settledCount: () => settled };
+}
+
+function ok(): CompileResult {
+  return { ok: true, errors: [], warnings: [], durationMs: 1 };
+}
+
+function fail(messages: string[]): CompileResult {
+  return {
+    ok: false,
+    errors: messages.map((text) => ({ text })),
+    warnings: [],
+    durationMs: 1,
+  };
+}
+
+describe("runAppLiveBuild", () => {
+  beforeEach(() => {
+    __resetAppReloadGenerations();
+  });
+
+  test("clean compile broadcasts building then ok with a bumped reloadGeneration", async () => {
+    let distFresh = false;
+    const compile = async () => {
+      distFresh = true;
+      return ok();
+    };
+    const broadcasts: AppPreviewUpdateEvent[] = [];
+    const refreshCalls: Array<
+      Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
+    > = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: compile,
+      resolveEffectiveAppHtml: () => (distFresh ? FRESH_HTML : LAST_GOOD_HTML),
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual(["building", "ok"]);
+
+    const building = broadcasts[0];
+    expect(building.html).toBe(LAST_GOOD_HTML);
+    expect(building.reloadGeneration).toBe(0);
+
+    const okMsg = broadcasts[1];
+    expect(okMsg.html).toBe(FRESH_HTML);
+    expect(okMsg.reloadGeneration).toBe(1); // bumped
+    expect(okMsg.buildErrors).toBeUndefined();
+
+    expect(refreshCalls).toHaveLength(1);
+    expect(refreshCalls[0].compileStatus).toBe("ok");
+    expect(refreshCalls[0].reloadGeneration).toBe(1);
+  });
+
+  test("failed compile keeps last-good html and an unchanged reloadGeneration", async () => {
+    // First do a clean build to advance the generation to 1.
+    {
+      const compile = async () => ok();
+      const broadcasts: AppPreviewUpdateEvent[] = [];
+      const deps: AppLiveBuildDeps = {
+        compileApp: compile,
+        resolveEffectiveAppHtml: () => FRESH_HTML,
+        broadcast: (msg) => broadcasts.push(msg),
+        refreshSurfaces: () => {},
+        onSettled: () => {},
+      };
+      await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+      expect(broadcasts[1].reloadGeneration).toBe(1);
+    }
+
+    // Now a failing compile. `resolveEffectiveAppHtml` would return the
+    // placeholder after `rm -rf dist/`, but the orchestrator must have
+    // captured the last-good html BEFORE compiling.
+    const broadcasts: AppPreviewUpdateEvent[] = [];
+    const refreshCalls: Array<
+      Parameters<AppLiveBuildDeps["refreshSurfaces"]>[1]
+    > = [];
+    let compiled = false;
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => {
+        compiled = true; // simulate `rm -rf dist/` wiping dist
+        return fail(["Could not resolve 'foo'", "Unexpected token"]);
+      },
+      // After dist is wiped, html resolution degrades to a placeholder.
+      resolveEffectiveAppHtml: () =>
+        compiled ? "<p>App compilation failed.</p>" : LAST_GOOD_HTML,
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: (_id, o) => refreshCalls.push(o),
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual([
+      "building",
+      "error",
+    ]);
+
+    const errMsg = broadcasts[1];
+    expect(errMsg.compileStatus).toBe("error");
+    // Last-good html, NOT the post-rm placeholder.
+    expect(errMsg.html).toBe(LAST_GOOD_HTML);
+    expect(errMsg.buildErrors).toEqual([
+      "Could not resolve 'foo'",
+      "Unexpected token",
+    ]);
+    // reloadGeneration unchanged (still 1 from the prior clean build).
+    expect(errMsg.reloadGeneration).toBe(1);
+
+    expect(refreshCalls).toHaveLength(1);
+    expect(refreshCalls[0].compileStatus).toBe("error");
+    expect(refreshCalls[0].reloadGeneration).toBe(1);
+    expect(refreshCalls[0].buildErrors).toEqual([
+      "Could not resolve 'foo'",
+      "Unexpected token",
+    ]);
+  });
+
+  test("thrown compile is treated as a failure that keeps last-good preview", async () => {
+    const broadcasts: AppPreviewUpdateEvent[] = [];
+    const deps: AppLiveBuildDeps = {
+      compileApp: async () => {
+        throw new Error("boom");
+      },
+      resolveEffectiveAppHtml: () => LAST_GOOD_HTML,
+      broadcast: (msg) => broadcasts.push(msg),
+      refreshSurfaces: () => {},
+      onSettled: () => {},
+    };
+
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+
+    expect(broadcasts.map((b) => b.compileStatus)).toEqual([
+      "building",
+      "error",
+    ]);
+    expect(broadcasts[1].html).toBe(LAST_GOOD_HTML);
+    expect(broadcasts[1].reloadGeneration).toBe(0);
+  });
+
+  test("two overlapping successful compiles yield distinct increasing generations", async () => {
+    // Both invocations capture the same starting generation BEFORE awaiting
+    // their (serialized) compile. The generation must be read-and-bumped AFTER
+    // each compile succeeds so the second successful build does not reuse the
+    // first's reloadGeneration — otherwise clients drop the latest output.
+    const okBroadcasts: AppPreviewUpdateEvent[] = [];
+    const okRefreshGenerations: number[] = [];
+
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    let firstStarted!: () => void;
+    const firstStartedGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    let compileCount = 0;
+    const deps: AppLiveBuildDeps = {
+      // First compile blocks until both invocations are in-flight, so they both
+      // captured the same starting generation before either bumps it.
+      compileApp: async () => {
+        compileCount += 1;
+        if (compileCount === 1) {
+          firstStarted();
+          await firstGate;
+        }
+        return ok();
+      },
+      resolveEffectiveAppHtml: () => FRESH_HTML,
+      broadcast: (msg) => {
+        if (msg.compileStatus === "ok") okBroadcasts.push(msg);
+      },
+      refreshSurfaces: (_id, o) => {
+        if (o.reloadGeneration !== undefined)
+          okRefreshGenerations.push(o.reloadGeneration);
+      },
+      onSettled: () => {},
+    };
+
+    const first = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    await firstStartedGate;
+    // Second invocation starts (and snapshots the same generation) while the
+    // first is still awaiting its compile.
+    const second = runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", deps);
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    const generations = okBroadcasts
+      .map((b) => b.reloadGeneration)
+      .sort((a, b) => a - b);
+    expect(generations).toEqual([1, 2]);
+    // Broadcast generations match the ones written to surfaces.
+    expect([...okRefreshGenerations].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  test("settle/onSettled fires on every outcome", async () => {
+    const h = makeHarness({ compile: async () => ok() });
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", h.deps);
+    expect(h.settledCount()).toBe(1);
+
+    const h2 = makeHarness({ compile: async () => fail(["x"]) });
+    await runAppLiveBuild(APP_ID, fakeApp, "/tmp/app", h2.deps);
+    expect(h2.settledCount()).toBe(1);
+  });
+});

--- a/assistant/src/api/events/app-preview-update.ts
+++ b/assistant/src/api/events/app-preview-update.ts
@@ -1,0 +1,33 @@
+/**
+ * `app_preview_update` SSE event.
+ *
+ * Live-build status broadcast for a multifile app's preview, emitted on every
+ * source-file recompile so clients (web) can hot-swap the preview iframe while
+ * the assistant is still writing, while keeping the last-good preview on a
+ * transient compile error.
+ *
+ * - `building`: a recompile started; `html` is the current (last-good)
+ *   resolved html so the client can show a building overlay without blanking.
+ * - `ok`: recompile succeeded; `html` is the fresh resolved html and
+ *   `reloadGeneration` is bumped so the client swaps the iframe.
+ * - `error`: recompile failed; `html` is the previous good html, `buildErrors`
+ *   carries the compile diagnostics, and `reloadGeneration` is unchanged so the
+ *   iframe is NOT swapped.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AppPreviewUpdateEventSchema = z.object({
+  type: z.literal("app_preview_update"),
+  appId: z.string(),
+  html: z.string(),
+  compileStatus: z.enum(["building", "ok", "error"]),
+  buildErrors: z.array(z.string()).optional(),
+  reloadGeneration: z.number(),
+});
+
+export type AppPreviewUpdateEvent = z.infer<typeof AppPreviewUpdateEventSchema>;

--- a/assistant/src/api/events/app-preview-update.ts
+++ b/assistant/src/api/events/app-preview-update.ts
@@ -7,7 +7,8 @@
  * transient compile error.
  *
  * - `building`: a recompile started; `html` is the current (last-good)
- *   resolved html so the client can show a building overlay without blanking.
+ *   resolved html so the client can keep showing the last-good preview while a
+ *   rebuild is in flight.
  * - `ok`: recompile succeeded; `html` is the fresh resolved html and
  *   `reloadGeneration` is bumped so the client swaps the iframe.
  * - `error`: recompile failed; `html` is the previous good html, `buildErrors`

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { AppPreviewUpdateEventSchema } from "./events/app-preview-update.js";
 import { AssistantActivityStateEventSchema } from "./events/assistant-activity-state.js";
 import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js";
 import { AssistantTurnStartEventSchema } from "./events/assistant-turn-start.js";
@@ -50,6 +51,10 @@ import { UserMessageEchoEventSchema } from "./events/user-message-echo.js";
 
 export { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "./constants/call-sites.js";
 export { DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC } from "./constants/tool-execution.js";
+export {
+  type AppPreviewUpdateEvent,
+  AppPreviewUpdateEventSchema,
+} from "./events/app-preview-update.js";
 export {
   type AssistantActivityAnchor,
   AssistantActivityAnchorSchema,
@@ -394,6 +399,7 @@ export {
  * migration recipe.
  */
 export const AssistantEventSchema = z.discriminatedUnion("type", [
+  AppPreviewUpdateEventSchema,
   AssistantActivityStateEventSchema,
   AssistantTextDeltaEventSchema,
   AssistantTurnStartEventSchema,

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -74,9 +74,12 @@ function toDiagnostic(message: esbuild.Message): CompileDiagnostic {
 /**
  * Parse esbuild CLI stderr into structured diagnostics matching the JS API's
  * CompileDiagnostic shape. Used by the native-CLI fallback path. esbuild
- * outputs errors like:
+ * prints a BLANK LINE between the summary line and the location frame:
  *   ✘ [ERROR] Could not resolve "foo"
+ *
  *       src/main.tsx:3:7:
+ * so the frame is not at lines[i + 1] — we scan forward past blank lines to
+ * find it, bounded so a diagnostic with no frame can't absorb a later one's.
  */
 function parseEsbuildStderr(stderr: string): {
   errors: CompileDiagnostic[];
@@ -94,18 +97,12 @@ function parseEsbuildStderr(stderr: string): {
       const text = (errorMatch ?? warnMatch)![1];
       const diag: CompileDiagnostic = { text };
 
-      // Next non-empty line may have location: "    file:line:col:"
-      const locLine = lines[i + 1]?.trim();
-      if (locLine) {
-        const locMatch = locLine.match(/^(.+):(\d+):(\d+):?$/);
-        if (locMatch) {
-          diag.location = {
-            file: locMatch[1],
-            line: parseInt(locMatch[2], 10),
-            column: parseInt(locMatch[3], 10),
-          };
-        }
-      }
+      // The location frame ("    file:line:col:") follows the summary after a
+      // blank line. Scan forward past blanks within a small window, stopping
+      // at the next diagnostic summary so a frame-less diagnostic doesn't
+      // absorb a later one's frame.
+      const location = findLocationFrame(lines, i + 1);
+      if (location) diag.location = location;
 
       if (errorMatch) errors.push(diag);
       else warnings.push(diag);
@@ -113,6 +110,36 @@ function parseEsbuildStderr(stderr: string): {
   }
 
   return { errors, warnings };
+}
+
+/** How many lines past a summary to search for its location frame. */
+const LOCATION_FRAME_WINDOW = 3;
+
+/**
+ * Scan forward from `start` for the first `file:line:column:` location frame,
+ * skipping blank lines. Stops (returning undefined) at the next diagnostic
+ * summary or after LOCATION_FRAME_WINDOW lines, so a diagnostic with no frame
+ * never claims a later diagnostic's location.
+ */
+function findLocationFrame(
+  lines: string[],
+  start: number,
+): CompileDiagnostic["location"] | undefined {
+  const end = Math.min(lines.length, start + LOCATION_FRAME_WINDOW);
+  for (let j = start; j < end; j++) {
+    const line = lines[j].trim();
+    if (!line) continue; // blank line between summary and frame
+    if (/[✘▲]/.test(lines[j])) break; // next diagnostic begins
+    const locMatch = line.match(/^(.+):(\d+):(\d+):?$/);
+    if (locMatch) {
+      return {
+        file: locMatch[1],
+        line: parseInt(locMatch[2], 10),
+        column: parseInt(locMatch[3], 10),
+      };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -6,17 +6,22 @@
  * with script/style tag injection. Reusing the context lets esbuild keep its
  * module graph hot, so recompiles on source edits are typically sub-second.
  *
- * esbuild resolves its native binary relative to its package at module load,
- * which does not exist inside bun --compile's /$bunfs/. We point
- * ESBUILD_BINARY_PATH at the on-disk binary produced by ensureCompilerTools()
- * so the JS API works in both `bun run` and compiled-binary modes.
+ * esbuild reads ESBUILD_BINARY_PATH at module init and otherwise resolves its
+ * native binary relative to its package — a path that does not exist inside
+ * bun --compile's /$bunfs/. To work in both `bun run` and compiled-binary
+ * modes, the esbuild JS API is imported lazily via loadEsbuild(): only after
+ * ensureCompilerTools() has produced the on-disk binary and we have set
+ * ESBUILD_BINARY_PATH to it, so esbuild snapshots the correct path. The module
+ * is also marked external in the macOS compiled-binary build (see
+ * clients/macos/build.sh) so its JS + platform native packages are resolved
+ * from disk rather than bundled into /$bunfs/.
  */
 
 import { existsSync, rmSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
-import * as esbuild from "esbuild";
+import type * as esbuild from "esbuild";
 
 import { getLogger } from "../util/logger.js";
 import { ensureCompilerTools } from "./compiler-tools.js";
@@ -326,11 +331,31 @@ function contextKey(entryPoints: string[], nodePaths: string[]): string {
 }
 
 /**
- * Whether ESBUILD_BINARY_PATH has been pointed at the on-disk binary.
- * esbuild resolves its binary lazily on the first build, so this must be set
- * before any context is created — but only once, since esbuild caches it.
+ * Lazily-imported esbuild JS API module, cached after the first load.
+ *
+ * esbuild reads ESBUILD_BINARY_PATH at module-init to resolve its native
+ * binary, so the import must happen only AFTER ensureCompilerTools() has
+ * produced the on-disk binary and ESBUILD_BINARY_PATH points at it (see
+ * loadEsbuild). Statically importing esbuild would snapshot an empty path
+ * inside bun --compile's /$bunfs/, where the package-relative binary is
+ * absent.
  */
-let esbuildBinaryConfigured = false;
+let esbuildModule: typeof esbuild | undefined;
+
+/**
+ * Point ESBUILD_BINARY_PATH at the on-disk binary, then lazily import (and
+ * cache) the esbuild JS API. esbuild snapshots the binary path at module init,
+ * so the env var must be set before the first import — which is why the import
+ * is deferred to here rather than top-level. `esbuildBin` must be the resolved
+ * binary path from ensureCompilerTools().
+ */
+async function loadEsbuild(esbuildBin: string): Promise<typeof esbuild> {
+  if (!esbuildModule) {
+    process.env.ESBUILD_BINARY_PATH = esbuildBin;
+    esbuildModule = await import("esbuild");
+  }
+  return esbuildModule;
+}
 
 /**
  * Get (or lazily create) the warm esbuild context for an appDir, recreating it
@@ -338,6 +363,7 @@ let esbuildBinaryConfigured = false;
  * since it was cached.
  */
 async function getOrCreateContext(
+  esbuildApi: typeof esbuild,
   appDir: string,
   entryPoints: string[],
   distDir: string,
@@ -356,7 +382,7 @@ async function getOrCreateContext(
     await cached.ctx.dispose();
   }
 
-  const ctx = await esbuild.context({
+  const ctx = await esbuildApi.context({
     entryPoints,
     bundle: true,
     minify: true,
@@ -504,14 +530,6 @@ async function runCompile(appDir: string): Promise<CompileResult> {
   // Scan source files for bare imports and JIT-install allowed packages
   await resolveAppImports(srcDir);
 
-  // Point esbuild's JS API at the on-disk binary. esbuild otherwise resolves
-  // it relative to its package, which doesn't exist inside bun --compile's
-  // /$bunfs/. esbuild caches the path on first build, so set it only once.
-  if (!esbuildBinaryConfigured) {
-    process.env.ESBUILD_BINARY_PATH = tools.esbuildBin;
-    esbuildBinaryConfigured = true;
-  }
-
   // Resolution roots for bare imports: preact parent dir + shared package cache
   const preactParent = dirname(tools.preactDir);
   const cacheNodeModules = join(getCacheDir(), "node_modules");
@@ -523,7 +541,9 @@ async function runCompile(appDir: string): Promise<CompileResult> {
   // rejects with a BuildFailure carrying errors/warnings on failure.
   let result: esbuild.BuildResult;
   try {
+    const esbuildApi = await loadEsbuild(tools.esbuildBin);
     const ctx = await getOrCreateContext(
+      esbuildApi,
       appDir,
       [entryPoint],
       distDir,

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -1,20 +1,29 @@
 /**
  * Compiler for multi-file TSX apps.
  *
- * Compiles src/main.tsx -> dist/main.js via esbuild's JS API using a warm,
- * incremental build context cached per app directory, then copies index.html
- * with script/style tag injection. Reusing the context lets esbuild keep its
- * module graph hot, so recompiles on source edits are typically sub-second.
+ * Compiles src/main.tsx -> dist/main.js, then copies index.html with
+ * script/style tag injection. Two compile paths exist, selected once per
+ * process via a one-time probe (see loadEsbuild + compileBundle):
+ *
+ * 1. Warm JS-API fast path (cloud/Docker, `bun run`). esbuild's JS API drives
+ *    a warm, incremental build context cached per app directory; reusing the
+ *    context keeps esbuild's module graph hot, so recompiles on source edits
+ *    are typically sub-second. This is the spike's target and the default.
+ *
+ * 2. Native-CLI fallback (compiled macOS `.app`). The esbuild JS package may
+ *    not be resolvable inside bun --compile's /$bunfs/ — the .app's
+ *    node_modules is stripped and only the platform-native @esbuild/* binary is
+ *    staged on disk by ensureCompilerTools(). When `import("esbuild")` cannot
+ *    resolve, we transparently fall back to spawning the on-disk esbuild native
+ *    binary (tools.esbuildBin) and parse its stderr into the same
+ *    CompileResult/CompileDiagnostic shape. This path has no warm context but
+ *    is proven to work in the compiled binary.
  *
  * esbuild reads ESBUILD_BINARY_PATH at module init and otherwise resolves its
- * native binary relative to its package — a path that does not exist inside
- * bun --compile's /$bunfs/. To work in both `bun run` and compiled-binary
- * modes, the esbuild JS API is imported lazily via loadEsbuild(): only after
- * ensureCompilerTools() has produced the on-disk binary and we have set
- * ESBUILD_BINARY_PATH to it, so esbuild snapshots the correct path. The module
- * is also marked external in the macOS compiled-binary build (see
- * clients/macos/build.sh) so its JS + platform native packages are resolved
- * from disk rather than bundled into /$bunfs/.
+ * native binary relative to its package, so the JS API is imported lazily via
+ * loadEsbuild() — only after ensureCompilerTools() has produced the on-disk
+ * binary and we have set ESBUILD_BINARY_PATH to it, so esbuild snapshots the
+ * correct path.
  */
 
 import { existsSync, rmSync } from "node:fs";
@@ -60,6 +69,50 @@ function toDiagnostic(message: esbuild.Message): CompileDiagnostic {
     };
   }
   return diag;
+}
+
+/**
+ * Parse esbuild CLI stderr into structured diagnostics matching the JS API's
+ * CompileDiagnostic shape. Used by the native-CLI fallback path. esbuild
+ * outputs errors like:
+ *   ✘ [ERROR] Could not resolve "foo"
+ *       src/main.tsx:3:7:
+ */
+function parseEsbuildStderr(stderr: string): {
+  errors: CompileDiagnostic[];
+  warnings: CompileDiagnostic[];
+} {
+  const errors: CompileDiagnostic[] = [];
+  const warnings: CompileDiagnostic[] = [];
+  const lines = stderr.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const errorMatch = lines[i].match(/✘ \[ERROR\] (.+)/);
+    const warnMatch = lines[i].match(/▲ \[WARNING\] (.+)/);
+
+    if (errorMatch || warnMatch) {
+      const text = (errorMatch ?? warnMatch)![1];
+      const diag: CompileDiagnostic = { text };
+
+      // Next non-empty line may have location: "    file:line:col:"
+      const locLine = lines[i + 1]?.trim();
+      if (locLine) {
+        const locMatch = locLine.match(/^(.+):(\d+):(\d+):?$/);
+        if (locMatch) {
+          diag.location = {
+            file: locMatch[1],
+            line: parseInt(locMatch[2], 10),
+            column: parseInt(locMatch[3], 10),
+          };
+        }
+      }
+
+      if (errorMatch) errors.push(diag);
+      else warnings.push(diag);
+    }
+  }
+
+  return { errors, warnings };
 }
 
 /**
@@ -343,16 +396,59 @@ function contextKey(entryPoints: string[], nodePaths: string[]): string {
 let esbuildModule: typeof esbuild | undefined;
 
 /**
+ * Whether the esbuild JS API has been probed and found unavailable this
+ * process (true in the compiled macOS binary, where the esbuild JS package is
+ * not on disk). Once unavailable, every compile uses the native-CLI fallback
+ * and we never re-probe the import.
+ */
+let esbuildApiUnavailable = false;
+
+/**
+ * Test-only hook: replace the esbuild JS-API loader. Returning null simulates
+ * the compiled-binary environment where `import("esbuild")` cannot resolve,
+ * forcing the native-CLI fallback. `undefined` (the default) uses the real
+ * dynamic import.
+ */
+let esbuildLoaderOverride:
+  | ((esbuildBin: string) => Promise<typeof esbuild | null>)
+  | undefined;
+
+/** Exposed for tests: force the esbuild JS-API loader (or reset with null). */
+export function __setEsbuildLoaderOverride(
+  loader: ((esbuildBin: string) => Promise<typeof esbuild | null>) | null,
+): void {
+  esbuildLoaderOverride = loader ?? undefined;
+  esbuildModule = undefined;
+  esbuildApiUnavailable = false;
+}
+
+/**
  * Point ESBUILD_BINARY_PATH at the on-disk binary, then lazily import (and
  * cache) the esbuild JS API. esbuild snapshots the binary path at module init,
  * so the env var must be set before the first import — which is why the import
  * is deferred to here rather than top-level. `esbuildBin` must be the resolved
  * binary path from ensureCompilerTools().
+ *
+ * Returns null (not throwing) when the JS package cannot be resolved — e.g. in
+ * the compiled macOS binary, whose stripped node_modules lack esbuild/lib/main.
+ * The caller then falls back to spawning the native CLI binary. A genuine
+ * compile failure surfaces later via ctx.rebuild() rejecting, NOT here.
  */
-async function loadEsbuild(esbuildBin: string): Promise<typeof esbuild> {
+async function loadEsbuild(esbuildBin: string): Promise<typeof esbuild | null> {
+  if (esbuildApiUnavailable) return null;
+  if (esbuildModule) return esbuildModule;
+
+  process.env.ESBUILD_BINARY_PATH = esbuildBin;
+  try {
+    esbuildModule = esbuildLoaderOverride
+      ? ((await esbuildLoaderOverride(esbuildBin)) ?? undefined)
+      : await import("esbuild");
+  } catch (err) {
+    log.info({ err }, "esbuild JS API unavailable; using native CLI fallback");
+  }
   if (!esbuildModule) {
-    process.env.ESBUILD_BINARY_PATH = esbuildBin;
-    esbuildModule = await import("esbuild");
+    esbuildApiUnavailable = true;
+    return null;
   }
   return esbuildModule;
 }
@@ -422,6 +518,131 @@ export async function disposeAppCompilerContexts(): Promise<void> {
       }),
     ),
   );
+}
+
+/** Diagnostics produced by a bundle step; non-empty errors = build failed. */
+interface BundleDiagnostics {
+  errors: CompileDiagnostic[];
+  warnings: CompileDiagnostic[];
+}
+
+/**
+ * Run the bundle step, preferring the warm esbuild JS-API context and falling
+ * back to spawning the native CLI binary when the JS API can't be resolved
+ * (compiled macOS binary). The fallback decision is cached per process via
+ * loadEsbuild, so the import is probed at most once.
+ */
+async function compileBundle(
+  esbuildBin: string,
+  appDir: string,
+  entryPoint: string,
+  distDir: string,
+  nodePaths: string[],
+): Promise<BundleDiagnostics> {
+  const esbuildApi = await loadEsbuild(esbuildBin);
+  if (esbuildApi) {
+    return compileWithEsbuildApi(
+      esbuildApi,
+      appDir,
+      entryPoint,
+      distDir,
+      nodePaths,
+    );
+  }
+  return compileWithCli(esbuildBin, appDir, entryPoint, distDir, nodePaths);
+}
+
+/**
+ * Fast path: bundle via the warm, incremental esbuild JS-API context.
+ *
+ * ctx.rebuild() resolves with an empty errors array on success and rejects
+ * with a BuildFailure carrying errors/warnings on failure. A rejection here is
+ * a genuine compile error (NOT a missing JS API — that is handled earlier by
+ * loadEsbuild returning null), so it must not trigger the CLI fallback.
+ */
+async function compileWithEsbuildApi(
+  esbuildApi: typeof esbuild,
+  appDir: string,
+  entryPoint: string,
+  distDir: string,
+  nodePaths: string[],
+): Promise<BundleDiagnostics> {
+  try {
+    const ctx = await getOrCreateContext(
+      esbuildApi,
+      appDir,
+      [entryPoint],
+      distDir,
+      nodePaths,
+    );
+    const result = await ctx.rebuild();
+    return { errors: [], warnings: result.warnings.map(toDiagnostic) };
+  } catch (err) {
+    const failure = err as Partial<esbuild.BuildFailure>;
+    const errors = (failure.errors ?? []).map(toDiagnostic);
+    const warnings = (failure.warnings ?? []).map(toDiagnostic);
+    if (errors.length === 0) {
+      errors.push({ text: err instanceof Error ? err.message : String(err) });
+    }
+    return { errors, warnings };
+  }
+}
+
+/**
+ * Fallback path: bundle by spawning the on-disk esbuild native binary.
+ *
+ * Used in the compiled macOS binary, where the esbuild JS package is absent
+ * from /$bunfs/. Has no warm context, but produces output and diagnostics
+ * identical to the JS-API path (stderr parsed via parseEsbuildStderr).
+ */
+async function compileWithCli(
+  esbuildBin: string,
+  appDir: string,
+  entryPoint: string,
+  distDir: string,
+  nodePaths: string[],
+): Promise<BundleDiagnostics> {
+  const args = [
+    entryPoint,
+    "--bundle",
+    "--minify",
+    `--outdir=${distDir}`,
+    "--format=esm",
+    "--target=es2022",
+    "--jsx=automatic",
+    "--jsx-import-source=preact",
+    "--alias:react=preact/compat",
+    "--alias:react-dom=preact/compat",
+    "--loader:.tsx=tsx",
+    "--loader:.ts=ts",
+    "--loader:.jsx=jsx",
+    "--loader:.js=js",
+    "--loader:.css=css",
+    "--log-level=warning",
+  ];
+
+  const proc = Bun.spawn({
+    cmd: [esbuildBin, ...args],
+    cwd: appDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NODE_PATH: nodePaths.join(":") },
+  });
+
+  await proc.exited;
+  const stderr = await new Response(proc.stderr).text();
+
+  if (proc.exitCode === 0) {
+    // Success: esbuild only emits warnings (if any) to stderr at this level.
+    return { errors: [], warnings: parseEsbuildStderr(stderr).warnings };
+  }
+
+  const { errors, warnings } = parseEsbuildStderr(stderr);
+  // If parsing found nothing structured, surface the raw stderr.
+  if (errors.length === 0 && stderr.trim()) {
+    errors.push({ text: stderr.trim() });
+  }
+  return { errors, warnings };
 }
 
 /**
@@ -537,32 +758,21 @@ async function runCompile(appDir: string): Promise<CompileResult> {
     existsSync(p),
   );
 
-  // esbuild's rebuild() resolves with an empty errors array on success and
-  // rejects with a BuildFailure carrying errors/warnings on failure.
-  let result: esbuild.BuildResult;
-  try {
-    const esbuildApi = await loadEsbuild(tools.esbuildBin);
-    const ctx = await getOrCreateContext(
-      esbuildApi,
-      appDir,
-      [entryPoint],
-      distDir,
-      nodePaths,
-    );
-    result = await ctx.rebuild();
-  } catch (err) {
+  // Run the actual bundle via the warm JS API (cloud) or the native CLI
+  // fallback (compiled binary). Both return the same diagnostic shape; a
+  // non-empty errors array means the build failed.
+  const { errors, warnings } = await compileBundle(
+    tools.esbuildBin,
+    appDir,
+    entryPoint,
+    distDir,
+    nodePaths,
+  );
+  if (errors.length > 0) {
     const durationMs = Math.round(performance.now() - start);
-    const failure = err as Partial<esbuild.BuildFailure>;
-    const errors = (failure.errors ?? []).map(toDiagnostic);
-    const warnings = (failure.warnings ?? []).map(toDiagnostic);
-    if (errors.length === 0) {
-      errors.push({ text: err instanceof Error ? err.message : String(err) });
-    }
     log.info({ durationMs, errorCount: errors.length }, "Build failed");
     return { ok: false, errors, warnings, durationMs };
   }
-
-  const warnings = result.warnings.map(toDiagnostic);
 
   // Copy index.html and inject script/style tags
   const htmlSrc = join(srcDir, "index.html");

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -1,17 +1,22 @@
 /**
  * Compiler for multi-file TSX apps.
  *
- * Shells out to the esbuild CLI binary (JIT-downloaded on first use) to
- * compile src/main.tsx -> dist/main.js, then copies index.html with
- * script/style tag injection.
+ * Compiles src/main.tsx -> dist/main.js via esbuild's JS API using a warm,
+ * incremental build context cached per app directory, then copies index.html
+ * with script/style tag injection. Reusing the context lets esbuild keep its
+ * module graph hot, so recompiles on source edits are typically sub-second.
  *
- * This avoids importing esbuild's JS API (which caches its native binary
- * path at module load time and breaks inside bun --compile's /$bunfs/).
+ * esbuild resolves its native binary relative to its package at module load,
+ * which does not exist inside bun --compile's /$bunfs/. We point
+ * ESBUILD_BINARY_PATH at the on-disk binary produced by ensureCompilerTools()
+ * so the JS API works in both `bun run` and compiled-binary modes.
  */
 
 import { existsSync, rmSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+
+import * as esbuild from "esbuild";
 
 import { getLogger } from "../util/logger.js";
 import { ensureCompilerTools } from "./compiler-tools.js";
@@ -37,46 +42,19 @@ export interface CompileResult {
 }
 
 /**
- * Parse esbuild CLI stderr into structured diagnostics.
- * esbuild outputs errors like:
- *   ✘ [ERROR] Could not resolve "foo"
- *       src/main.tsx:3:7:
+ * Map an esbuild JS API Message into our structured CompileDiagnostic shape:
+ * the message text plus an optional { file, line, column } location.
  */
-function parseEsbuildStderr(stderr: string): {
-  errors: CompileDiagnostic[];
-  warnings: CompileDiagnostic[];
-} {
-  const errors: CompileDiagnostic[] = [];
-  const warnings: CompileDiagnostic[] = [];
-  const lines = stderr.split("\n");
-
-  for (let i = 0; i < lines.length; i++) {
-    const errorMatch = lines[i].match(/✘ \[ERROR\] (.+)/);
-    const warnMatch = lines[i].match(/▲ \[WARNING\] (.+)/);
-
-    if (errorMatch || warnMatch) {
-      const text = (errorMatch ?? warnMatch)![1];
-      const diag: CompileDiagnostic = { text };
-
-      // Next non-empty line may have location: "    file:line:col:"
-      const locLine = lines[i + 1]?.trim();
-      if (locLine) {
-        const locMatch = locLine.match(/^(.+):(\d+):(\d+):?$/);
-        if (locMatch) {
-          diag.location = {
-            file: locMatch[1],
-            line: parseInt(locMatch[2], 10),
-            column: parseInt(locMatch[3], 10),
-          };
-        }
-      }
-
-      if (errorMatch) errors.push(diag);
-      else warnings.push(diag);
-    }
+function toDiagnostic(message: esbuild.Message): CompileDiagnostic {
+  const diag: CompileDiagnostic = { text: message.text };
+  if (message.location) {
+    diag.location = {
+      file: message.location.file,
+      line: message.location.line,
+      column: message.location.column,
+    };
   }
-
-  return { errors, warnings };
+  return diag;
 }
 
 /**
@@ -295,6 +273,132 @@ interface CompileSlot {
 const compileSlots = new Map<string, CompileSlot>();
 
 /**
+ * Warm esbuild build contexts, one per app directory.
+ *
+ * The first compile for an appDir creates a context and caches it; subsequent
+ * compiles call ctx.rebuild(), which reuses esbuild's hot module graph and is
+ * typically sub-second. A stable `key` fingerprinting the resolution-relevant
+ * build options (entry points + nodePaths) is recorded so the context can be
+ * torn down and rebuilt if any of them change — e.g. a new top-level source
+ * file is added, or the user adds an allowed third-party import whose newly
+ * installed package cache extends nodePaths.
+ */
+interface CachedContext {
+  ctx: esbuild.BuildContext;
+  key: string;
+}
+
+const appContexts = new Map<string, CachedContext>();
+
+/**
+ * Test/diagnostics hook: counts how many times a fresh esbuild context was
+ * created (vs reused). A reused context increments rebuildCount instead.
+ */
+const contextStats = { createCount: 0, rebuildCount: 0 };
+
+/** Exposed for tests: read and reset the context create/rebuild counters. */
+export function __getAppCompilerContextStats(): {
+  createCount: number;
+  rebuildCount: number;
+} {
+  return { ...contextStats };
+}
+
+/** Exposed for tests: reset the context create/rebuild counters. */
+export function __resetAppCompilerContextStats(): void {
+  contextStats.createCount = 0;
+  contextStats.rebuildCount = 0;
+}
+
+/**
+ * Build a stable identity key for the resolution-relevant build options.
+ *
+ * Two contexts are interchangeable only if they share the same entry points
+ * AND the same module-resolution roots (nodePaths). Sorting makes the key
+ * order-insensitive so a reorder alone never forces a needless recreate, while
+ * any added/removed entry point or nodePath does.
+ */
+function contextKey(entryPoints: string[], nodePaths: string[]): string {
+  return JSON.stringify({
+    entryPoints: [...entryPoints].sort(),
+    nodePaths: [...nodePaths].sort(),
+  });
+}
+
+/**
+ * Whether ESBUILD_BINARY_PATH has been pointed at the on-disk binary.
+ * esbuild resolves its binary lazily on the first build, so this must be set
+ * before any context is created — but only once, since esbuild caches it.
+ */
+let esbuildBinaryConfigured = false;
+
+/**
+ * Get (or lazily create) the warm esbuild context for an appDir, recreating it
+ * if any resolution-relevant build option (entry points or nodePaths) changed
+ * since it was cached.
+ */
+async function getOrCreateContext(
+  appDir: string,
+  entryPoints: string[],
+  distDir: string,
+  nodePaths: string[],
+): Promise<esbuild.BuildContext> {
+  const key = contextKey(entryPoints, nodePaths);
+  const cached = appContexts.get(appDir);
+  if (cached) {
+    if (cached.key === key) {
+      contextStats.rebuildCount++;
+      return cached.ctx;
+    }
+    // A resolution input changed (entry points or nodePaths) — dispose the
+    // stale context and build a fresh one so esbuild picks up the new paths.
+    appContexts.delete(appDir);
+    await cached.ctx.dispose();
+  }
+
+  const ctx = await esbuild.context({
+    entryPoints,
+    bundle: true,
+    minify: true,
+    outdir: distDir,
+    format: "esm",
+    target: "es2022",
+    jsx: "automatic",
+    jsxImportSource: "preact",
+    alias: { react: "preact/compat", "react-dom": "preact/compat" },
+    loader: {
+      ".tsx": "tsx",
+      ".ts": "ts",
+      ".jsx": "jsx",
+      ".js": "js",
+      ".css": "css",
+    },
+    nodePaths,
+    logLevel: "silent",
+    absWorkingDir: appDir,
+  });
+  contextStats.createCount++;
+  appContexts.set(appDir, { ctx, key });
+  return ctx;
+}
+
+/**
+ * Dispose every cached esbuild context and stop their child esbuild services.
+ * Called on daemon shutdown so no esbuild subprocesses are left running.
+ */
+export async function disposeAppCompilerContexts(): Promise<void> {
+  const contexts = [...appContexts.values()];
+  appContexts.clear();
+  await Promise.all(
+    contexts.map(({ ctx }) =>
+      ctx.dispose().catch((err) => {
+        log.warn({ err }, "Failed to dispose esbuild context");
+      }),
+    ),
+  );
+}
+
+/**
  * Compile a TSX app from appDir/src/ into appDir/dist/.
  *
  * Expects appDir/src/main.tsx as the entry point and appDir/src/index.html
@@ -400,54 +504,45 @@ async function runCompile(appDir: string): Promise<CompileResult> {
   // Scan source files for bare imports and JIT-install allowed packages
   await resolveAppImports(srcDir);
 
-  // Build NODE_PATH: preact parent dir + shared package cache
+  // Point esbuild's JS API at the on-disk binary. esbuild otherwise resolves
+  // it relative to its package, which doesn't exist inside bun --compile's
+  // /$bunfs/. esbuild caches the path on first build, so set it only once.
+  if (!esbuildBinaryConfigured) {
+    process.env.ESBUILD_BINARY_PATH = tools.esbuildBin;
+    esbuildBinaryConfigured = true;
+  }
+
+  // Resolution roots for bare imports: preact parent dir + shared package cache
   const preactParent = dirname(tools.preactDir);
   const cacheNodeModules = join(getCacheDir(), "node_modules");
-  const nodePath = [preactParent, cacheNodeModules]
-    .filter((p) => existsSync(p))
-    .join(":");
+  const nodePaths = [preactParent, cacheNodeModules].filter((p) =>
+    existsSync(p),
+  );
 
-  // Shell out to esbuild CLI
-  const args = [
-    entryPoint,
-    "--bundle",
-    "--minify",
-    `--outdir=${distDir}`,
-    "--format=esm",
-    "--target=es2022",
-    "--jsx=automatic",
-    "--jsx-import-source=preact",
-    "--alias:react=preact/compat",
-    "--alias:react-dom=preact/compat",
-    "--loader:.tsx=tsx",
-    "--loader:.ts=ts",
-    "--loader:.jsx=jsx",
-    "--loader:.js=js",
-    "--loader:.css=css",
-    "--log-level=warning",
-  ];
-
-  const proc = Bun.spawn({
-    cmd: [tools.esbuildBin, ...args],
-    cwd: appDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: { ...process.env, NODE_PATH: nodePath },
-  });
-
-  await proc.exited;
-  const stderr = await new Response(proc.stderr).text();
-
-  if (proc.exitCode !== 0) {
+  // esbuild's rebuild() resolves with an empty errors array on success and
+  // rejects with a BuildFailure carrying errors/warnings on failure.
+  let result: esbuild.BuildResult;
+  try {
+    const ctx = await getOrCreateContext(
+      appDir,
+      [entryPoint],
+      distDir,
+      nodePaths,
+    );
+    result = await ctx.rebuild();
+  } catch (err) {
     const durationMs = Math.round(performance.now() - start);
-    const { errors, warnings } = parseEsbuildStderr(stderr);
-    // If parsing found nothing, use raw stderr as the error
-    if (errors.length === 0 && stderr.trim()) {
-      errors.push({ text: stderr.trim() });
+    const failure = err as Partial<esbuild.BuildFailure>;
+    const errors = (failure.errors ?? []).map(toDiagnostic);
+    const warnings = (failure.warnings ?? []).map(toDiagnostic);
+    if (errors.length === 0) {
+      errors.push({ text: err instanceof Error ? err.message : String(err) });
     }
     log.info({ durationMs, errorCount: errors.length }, "Build failed");
     return { ok: false, errors, warnings, durationMs };
   }
+
+  const warnings = result.warnings.map(toDiagnostic);
 
   // Copy index.html and inject script/style tags
   const htmlSrc = join(srcDir, "index.html");
@@ -479,5 +574,5 @@ async function runCompile(appDir: string): Promise<CompileResult> {
 
   const durationMs = Math.round(performance.now() - start);
   log.info({ durationMs }, "Build succeeded");
-  return { ok: true, errors: [], warnings: [], durationMs };
+  return { ok: true, errors: [], warnings, durationMs };
 }

--- a/assistant/src/bundler/compiler-tools.ts
+++ b/assistant/src/bundler/compiler-tools.ts
@@ -24,8 +24,12 @@ import { PromiseGuard } from "../util/promise-guard.js";
 
 const log = getLogger("compiler-tools");
 
-// Pinned versions matching assistant/bun.lock
-const ESBUILD_VERSION = "0.24.2";
+// Pinned versions matching assistant/bun.lock.
+// ESBUILD_VERSION must match the esbuild JS API package version (see
+// node_modules/esbuild/package.json): app-compiler.ts drives the JS API and
+// points ESBUILD_BINARY_PATH at this on-disk binary, and esbuild refuses to
+// run a binary whose version differs from the host package.
+const ESBUILD_VERSION = "0.19.12";
 const PREACT_VERSION = "10.28.4";
 
 const TOOLS_VERSION = `esbuild-${ESBUILD_VERSION}_preact-${PREACT_VERSION}`;

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -72,10 +72,16 @@ export async function runAppLiveBuild(
   appDir: string,
   deps: AppLiveBuildDeps,
 ): Promise<void> {
-  // Snapshot the current generation for the non-bumping `building`/`error`
-  // outcomes (these never advance the counter, so they re-broadcast whatever
-  // generation a client already has).
-  const generationAtStart = appReloadGenerations.get(appId) ?? 0;
+  // The non-bumping `building`/`error` outcomes never advance the counter;
+  // they re-broadcast whatever generation a client already has. We read this
+  // CURRENT generation at settle time (not an invocation-time snapshot): when
+  // a source change queues behind an in-flight rebuild that later succeeds and
+  // bumps the generation, a subsequent error for the queued build must report
+  // the now-current (higher) generation. Reporting a stale pre-bump snapshot
+  // would put the error's `reloadGeneration` below the last applied `ok`, and
+  // the web store's stale-event guard drops such non-`ok` events — hiding the
+  // compile error while the preview looks healthy.
+  const currentGeneration = () => appReloadGenerations.get(appId) ?? 0;
 
   // Capture the last-good resolved html BEFORE compiling: compileApp begins
   // with `rm -rf dist/`, so on a failed compile the dist (and thus the
@@ -102,7 +108,7 @@ export async function runAppLiveBuild(
   broadcastUpdate({
     html: lastGoodHtml,
     compileStatus: "building",
-    reloadGeneration: generationAtStart,
+    reloadGeneration: currentGeneration(),
   });
 
   const settleError = (buildErrors: string[]) => {
@@ -113,11 +119,15 @@ export async function runAppLiveBuild(
       compileStatus: "error",
       buildErrors,
     });
+    // Report the CURRENT generation (read at settle time, after any
+    // interleaved successful build bumped it) so the web stale-guard does not
+    // drop this error. The error itself still does NOT bump the counter —
+    // this is keep-last-good, not a new good frame.
     broadcastUpdate({
       html: lastGoodHtml,
       compileStatus: "error",
       buildErrors,
-      reloadGeneration: generationAtStart,
+      reloadGeneration: currentGeneration(),
     });
   };
 

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -96,8 +96,9 @@ export async function runAppLiveBuild(
     if (update.compileStatus !== "building") deps.onSettled();
   };
 
-  // Show a building overlay immediately without blanking the preview. No
-  // surface refresh: a building status must not bump the reload generation.
+  // Signal that a rebuild is in flight while keeping the last-good preview
+  // visible. No surface refresh: a building status must not bump the reload
+  // generation.
   broadcastUpdate({
     html: lastGoodHtml,
     compileStatus: "building",

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -23,10 +23,13 @@ export interface AppLiveBuildDeps {
   /** Broadcast an app_preview_update event to all connected clients. */
   broadcast: (msg: AppPreviewUpdateEvent) => void;
   /**
-   * Refresh in-memory/persisted surfaces for the app. Returns the applied
-   * reload generation so this orchestrator can keep one source of truth shared
-   * with the broadcast event. When `reloadGeneration` is supplied the caller is
-   * expected to use it verbatim.
+   * Refresh in-memory/persisted surfaces for the app. The per-surface
+   * `reloadGeneration` is the single source of truth for the macOS reload, so
+   * this returns the highest generation actually applied across surfaces.
+   * `reloadGeneration` is a monotonic floor: each surface advances to at least
+   * `floor` but never below `currentGeneration + 1`, so the broadcast can adopt
+   * the returned value and stay in agreement with — and strictly ahead of —
+   * what clients last saw.
    */
   refreshSurfaces: (
     appId: string,
@@ -36,15 +39,21 @@ export interface AppLiveBuildDeps {
       buildErrors?: string[];
       reloadGeneration?: number;
     },
-  ) => void;
+  ) => number;
   /** Notify the app-list / publish pipeline (existing side effects). */
   onSettled: () => void;
 }
 
 /**
- * Per-app reload generation counter — the single source of truth for the
- * `reloadGeneration` field shared by the broadcast event and the refreshed
- * surfaces. Bumped only on a successful recompile.
+ * Per-app reload generation counter for the `app_preview_update` broadcast.
+ *
+ * The per-surface counter (see `refreshSurfacesForApp`) is the authoritative
+ * source of truth for the macOS change-detection reload; this map mirrors the
+ * highest generation applied to any surface so overlapping live builds keep
+ * issuing strictly increasing broadcast generations even when no surface is
+ * currently mounted. It is reconciled from `refreshSurfaces`' return value on
+ * every successful recompile, so it can never collide with or regress below
+ * what a client last saw.
  */
 const appReloadGenerations = new Map<string, number>();
 
@@ -64,9 +73,8 @@ export async function runAppLiveBuild(
   deps: AppLiveBuildDeps,
 ): Promise<void> {
   // Snapshot the current generation for the non-bumping `building`/`error`
-  // outcomes. The successful `ok` outcome instead reads-and-bumps the counter
-  // AFTER the (serialized) compile resolves, so two overlapping builds that
-  // both succeed produce two distinct, monotonically increasing generations.
+  // outcomes (these never advance the counter, so they re-broadcast whatever
+  // generation a client already has).
   const generationAtStart = appReloadGenerations.get(appId) ?? 0;
 
   // Capture the last-good resolved html BEFORE compiling: compileApp begins
@@ -74,55 +82,70 @@ export async function runAppLiveBuild(
   // resolvable html) would otherwise be wiped.
   const lastGoodHtml = deps.resolveEffectiveAppHtml(app);
 
-  // Settle a terminal outcome: refresh surfaces, broadcast the preview update,
-  // and run the existing app-list/publish side effects.
-  const emit = (
+  // Broadcast the preview update and run the existing app-list/publish side
+  // effects. Surface refresh (the source of the reload generation) happens in
+  // the caller for the `ok` path, since its applied generation feeds the
+  // broadcast; the non-bumping `error` path refreshes here.
+  const broadcastUpdate = (
     update: Pick<
       AppPreviewUpdateEvent,
       "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
     >,
   ) => {
-    if (update.compileStatus !== "building") {
-      deps.refreshSurfaces(appId, {
-        fileChange: true,
-        compileStatus: update.compileStatus,
-        buildErrors: update.buildErrors,
-        reloadGeneration: update.reloadGeneration,
-      });
-    }
     deps.broadcast({ type: "app_preview_update", appId, ...update });
     if (update.compileStatus !== "building") deps.onSettled();
   };
 
-  // Show a building overlay immediately without blanking the preview.
-  emit({
+  // Show a building overlay immediately without blanking the preview. No
+  // surface refresh: a building status must not bump the reload generation.
+  broadcastUpdate({
     html: lastGoodHtml,
     compileStatus: "building",
     reloadGeneration: generationAtStart,
   });
+
+  const settleError = (buildErrors: string[]) => {
+    // Failed compile: do NOT push broken/placeholder html and do NOT bump the
+    // reload generation. Re-broadcast the captured last-good html plus errors.
+    deps.refreshSurfaces(appId, {
+      fileChange: true,
+      compileStatus: "error",
+      buildErrors,
+    });
+    broadcastUpdate({
+      html: lastGoodHtml,
+      compileStatus: "error",
+      buildErrors,
+      reloadGeneration: generationAtStart,
+    });
+  };
 
   let result: CompileResult;
   try {
     result = await deps.compileApp(appDir);
   } catch {
     // Treat a thrown compile as a failed compile: keep the last-good preview.
-    emit({
-      html: lastGoodHtml,
-      compileStatus: "error",
-      buildErrors: ["Recompile failed"],
-      reloadGeneration: generationAtStart,
-    });
+    settleError(["Recompile failed"]);
     return;
   }
 
   if (result.ok) {
-    // Read-and-bump AFTER the compile resolves so overlapping successful
-    // builds each get a distinct, monotonically increasing generation. (Both
-    // the read and the write happen synchronously here with no intervening
-    // await, so they are atomic against other invocations.)
-    const nextGeneration = (appReloadGenerations.get(appId) ?? 0) + 1;
+    // Let the surface refresh advance the authoritative per-surface counter and
+    // tell us the generation it applied. We pass the module counter + 1 as a
+    // monotonic floor and adopt the returned value (which is also >= every
+    // surface's prior generation + 1), so the broadcast can never collide with
+    // or regress below what a client last saw, even across overlapping builds.
+    // The read-and-write of the module counter is synchronous (no intervening
+    // await), so it is atomic against other in-flight invocations.
+    const floor = (appReloadGenerations.get(appId) ?? 0) + 1;
+    const appliedGeneration = deps.refreshSurfaces(appId, {
+      fileChange: true,
+      compileStatus: "ok",
+      reloadGeneration: floor,
+    });
+    const nextGeneration = Math.max(floor, appliedGeneration);
     appReloadGenerations.set(appId, nextGeneration);
-    emit({
+    broadcastUpdate({
       html: deps.resolveEffectiveAppHtml(app),
       compileStatus: "ok",
       reloadGeneration: nextGeneration,
@@ -130,12 +153,5 @@ export async function runAppLiveBuild(
     return;
   }
 
-  // Failed compile: do NOT push broken/placeholder html and do NOT bump the
-  // reload generation. Re-broadcast the captured last-good html plus errors.
-  emit({
-    html: lastGoodHtml,
-    compileStatus: "error",
-    buildErrors: result.errors.map((e) => e.text),
-    reloadGeneration: generationAtStart,
-  });
+  settleError(result.errors.map((e) => e.text));
 }

--- a/assistant/src/daemon/app-live-build.ts
+++ b/assistant/src/daemon/app-live-build.ts
@@ -1,0 +1,141 @@
+/**
+ * Live-build orchestration for multifile app source changes.
+ *
+ * On every detected source-file change the daemon recompiles the app and
+ * refreshes connected surfaces. This module owns the `app_preview_update`
+ * broadcast contract that lets web hot-swap the preview iframe while the
+ * assistant is still writing, while keeping the last-good preview on a
+ * transient compile error.
+ *
+ * The orchestration is dependency-injected so it can be unit-tested without
+ * standing up the full daemon server.
+ */
+
+import type { AppPreviewUpdateEvent } from "../api/events/app-preview-update.js";
+import type { CompileResult } from "../bundler/app-compiler.js";
+import type { AppDefinition } from "../memory/app-store.js";
+
+export interface AppLiveBuildDeps {
+  /** Compile the multifile app at `appDir`. Begins with `rm -rf dist/`. */
+  compileApp: (appDir: string) => Promise<CompileResult>;
+  /** Resolve the effective (inlined) preview html for the app's current dist. */
+  resolveEffectiveAppHtml: (app: AppDefinition) => string;
+  /** Broadcast an app_preview_update event to all connected clients. */
+  broadcast: (msg: AppPreviewUpdateEvent) => void;
+  /**
+   * Refresh in-memory/persisted surfaces for the app. Returns the applied
+   * reload generation so this orchestrator can keep one source of truth shared
+   * with the broadcast event. When `reloadGeneration` is supplied the caller is
+   * expected to use it verbatim.
+   */
+  refreshSurfaces: (
+    appId: string,
+    opts: {
+      fileChange: true;
+      compileStatus: "ok" | "error";
+      buildErrors?: string[];
+      reloadGeneration?: number;
+    },
+  ) => void;
+  /** Notify the app-list / publish pipeline (existing side effects). */
+  onSettled: () => void;
+}
+
+/**
+ * Per-app reload generation counter — the single source of truth for the
+ * `reloadGeneration` field shared by the broadcast event and the refreshed
+ * surfaces. Bumped only on a successful recompile.
+ */
+const appReloadGenerations = new Map<string, number>();
+
+/** Test-only reset of the generation counters. */
+export function __resetAppReloadGenerations(): void {
+  appReloadGenerations.clear();
+}
+
+/**
+ * Recompile a multifile app on source change and broadcast its live-build
+ * status, keeping the last-good preview on compile failure.
+ */
+export async function runAppLiveBuild(
+  appId: string,
+  app: AppDefinition,
+  appDir: string,
+  deps: AppLiveBuildDeps,
+): Promise<void> {
+  // Snapshot the current generation for the non-bumping `building`/`error`
+  // outcomes. The successful `ok` outcome instead reads-and-bumps the counter
+  // AFTER the (serialized) compile resolves, so two overlapping builds that
+  // both succeed produce two distinct, monotonically increasing generations.
+  const generationAtStart = appReloadGenerations.get(appId) ?? 0;
+
+  // Capture the last-good resolved html BEFORE compiling: compileApp begins
+  // with `rm -rf dist/`, so on a failed compile the dist (and thus the
+  // resolvable html) would otherwise be wiped.
+  const lastGoodHtml = deps.resolveEffectiveAppHtml(app);
+
+  // Settle a terminal outcome: refresh surfaces, broadcast the preview update,
+  // and run the existing app-list/publish side effects.
+  const emit = (
+    update: Pick<
+      AppPreviewUpdateEvent,
+      "html" | "compileStatus" | "buildErrors" | "reloadGeneration"
+    >,
+  ) => {
+    if (update.compileStatus !== "building") {
+      deps.refreshSurfaces(appId, {
+        fileChange: true,
+        compileStatus: update.compileStatus,
+        buildErrors: update.buildErrors,
+        reloadGeneration: update.reloadGeneration,
+      });
+    }
+    deps.broadcast({ type: "app_preview_update", appId, ...update });
+    if (update.compileStatus !== "building") deps.onSettled();
+  };
+
+  // Show a building overlay immediately without blanking the preview.
+  emit({
+    html: lastGoodHtml,
+    compileStatus: "building",
+    reloadGeneration: generationAtStart,
+  });
+
+  let result: CompileResult;
+  try {
+    result = await deps.compileApp(appDir);
+  } catch {
+    // Treat a thrown compile as a failed compile: keep the last-good preview.
+    emit({
+      html: lastGoodHtml,
+      compileStatus: "error",
+      buildErrors: ["Recompile failed"],
+      reloadGeneration: generationAtStart,
+    });
+    return;
+  }
+
+  if (result.ok) {
+    // Read-and-bump AFTER the compile resolves so overlapping successful
+    // builds each get a distinct, monotonically increasing generation. (Both
+    // the read and the write happen synchronously here with no intervening
+    // await, so they are atomic against other invocations.)
+    const nextGeneration = (appReloadGenerations.get(appId) ?? 0) + 1;
+    appReloadGenerations.set(appId, nextGeneration);
+    emit({
+      html: deps.resolveEffectiveAppHtml(app),
+      compileStatus: "ok",
+      reloadGeneration: nextGeneration,
+    });
+    return;
+  }
+
+  // Failed compile: do NOT push broken/placeholder html and do NOT bump the
+  // reload generation. Re-broadcast the captured last-good html plus errors.
+  emit({
+    html: lastGoodHtml,
+    compileStatus: "error",
+    buildErrors: result.errors.map((e) => e.text),
+    reloadGeneration: generationAtStart,
+  });
+}

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1798,16 +1798,37 @@ export async function handleSurfaceAction(
 
 /**
  * After an app_refresh, refresh any active surface that displays the updated app.
+ *
+ * Returns whether any surface was refreshed plus the `reloadGeneration` that was
+ * applied, so live-build callers (the source-change recompile path) can emit a
+ * broadcast event whose generation counter agrees with the surface state.
+ *
+ * Additive live-build opts (do not affect the existing macOS path):
+ * - `compileStatus: "error"` keeps the last-good html and does NOT bump
+ *   `reloadGeneration` (the preview iframe is not swapped on a transient error).
+ * - `reloadGeneration` overrides the per-surface bump with an explicit value so
+ *   the server can keep one source of truth shared with the broadcast event.
  */
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
   appId: string,
-  opts?: { fileChange?: boolean; status?: string },
-): boolean {
+  opts?: {
+    fileChange?: boolean;
+    status?: string;
+    compileStatus?: "building" | "ok" | "error";
+    buildErrors?: string[];
+    reloadGeneration?: number;
+  },
+): { refreshed: boolean; reloadGeneration: number } {
   const app = getApp(appId);
-  if (!app) return false;
+  if (!app) return { refreshed: false, reloadGeneration: 0 };
+
+  // On a failed recompile, keep the last-good preview: do not swap html and do
+  // not bump the reload counter.
+  const isError = opts?.compileStatus === "error";
 
   let refreshed = false;
+  let appliedGeneration = opts?.reloadGeneration ?? 0;
   for (const [surfaceId, stored] of ctx.surfaceState.entries()) {
     if (stored.surfaceType !== "dynamic_page") continue;
     const data = stored.data as DynamicPageSurfaceData;
@@ -1816,14 +1837,23 @@ export function refreshSurfacesForApp(
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
+    // Compute the next reload generation. An explicit override (live-build
+    // path) wins so web and macOS agree; otherwise keep the existing
+    // per-surface bump on file change. A failed compile never bumps.
+    const nextGeneration = isError
+      ? (data.reloadGeneration ?? 0)
+      : (opts?.reloadGeneration ?? (data.reloadGeneration ?? 0) + 1);
+    appliedGeneration = nextGeneration;
+
     // Update in-memory surface state so the next refinement gets fresh HTML.
     // For multifile apps, resolve the compiled dist/index.html with inlined
     // assets rather than the empty root index.html (app.htmlDefinition).
+    // On a failed compile, retain the existing html (last-good preview).
     const updatedData: DynamicPageSurfaceData = {
       ...data,
-      html: resolveEffectiveAppHtml(app),
-      ...(opts?.fileChange
-        ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 }
+      ...(isError ? {} : { html: resolveEffectiveAppHtml(app) }),
+      ...(opts?.fileChange && !isError
+        ? { reloadGeneration: nextGeneration }
         : {}),
       ...(opts?.status !== undefined ? { status: opts.status } : {}),
     };
@@ -1851,7 +1881,7 @@ export function refreshSurfacesForApp(
       "Auto-refreshed surface after app_refresh",
     );
   }
-  return refreshed;
+  return { refreshed, reloadGeneration: appliedGeneration };
 }
 
 export function buildCompletionSummary(

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1799,15 +1799,20 @@ export async function handleSurfaceAction(
 /**
  * After an app_refresh, refresh any active surface that displays the updated app.
  *
- * Returns whether any surface was refreshed plus the `reloadGeneration` that was
- * applied, so live-build callers (the source-change recompile path) can emit a
- * broadcast event whose generation counter agrees with the surface state.
+ * The per-surface `reloadGeneration` is the single source of truth for the
+ * macOS change-detection reload. This function read-modify-writes it and
+ * returns the highest generation it applied so live-build callers (the
+ * source-change recompile path) can reconcile their per-app counter and emit a
+ * broadcast event whose `reloadGeneration` agrees with the surface state.
  *
  * Additive live-build opts (do not affect the existing macOS path):
  * - `compileStatus: "error"` keeps the last-good html and does NOT bump
  *   `reloadGeneration` (the preview iframe is not swapped on a transient error).
- * - `reloadGeneration` overrides the per-surface bump with an explicit value so
- *   the server can keep one source of truth shared with the broadcast event.
+ * - `reloadGeneration` is a monotonic floor from live-build's per-app counter:
+ *   each surface advances to `max(floor, currentGeneration + 1)`, so the value
+ *   is always strictly greater than what the client last saw (never a collision
+ *   that would suppress a reload) while still honoring the live-build counter
+ *   when it is already ahead.
  */
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
@@ -1837,13 +1842,15 @@ export function refreshSurfacesForApp(
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
-    // Compute the next reload generation. An explicit override (live-build
-    // path) wins so web and macOS agree; otherwise keep the existing
-    // per-surface bump on file change. A failed compile never bumps.
+    // Compute the next reload generation. A failed compile never bumps. On a
+    // bump, always go strictly above this surface's current generation so the
+    // macOS change-detection fires; an explicit floor from live-build's per-app
+    // counter raises it further so web and macOS stay in agreement.
+    const bumped = (data.reloadGeneration ?? 0) + 1;
     const nextGeneration = isError
       ? (data.reloadGeneration ?? 0)
-      : (opts?.reloadGeneration ?? (data.reloadGeneration ?? 0) + 1);
-    appliedGeneration = nextGeneration;
+      : Math.max(opts?.reloadGeneration ?? 0, bumped);
+    appliedGeneration = Math.max(appliedGeneration, nextGeneration);
 
     // Update in-memory surface state so the next refinement gets fresh HTML.
     // For multifile apps, resolve the compiled dist/index.html with inlined

--- a/assistant/src/daemon/message-types/apps.ts
+++ b/assistant/src/daemon/message-types/apps.ts
@@ -1,5 +1,6 @@
 // App management, gallery, publishing, and sharing types.
 
+import type { AppPreviewUpdateEvent } from "../../api/events/app-preview-update.js";
 import type { GalleryManifest } from "../../gallery/gallery-manifest.js";
 
 // === Client → Server ===
@@ -333,6 +334,10 @@ export interface AppFilesChanged {
   appId: string;
 }
 
+// `app_preview_update` (the live-build preview broadcast) is now canonical:
+// its wire contract lives in `../../api/events/app-preview-update.js`. Daemon
+// emitters/consumers import `AppPreviewUpdateEvent` directly from there.
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _AppsClientMessages =
@@ -381,4 +386,5 @@ export type _AppsServerMessages =
   | AppPreviewResponse
   | PublishPageResponse
   | UnpublishPageResponse
-  | AppFilesChanged;
+  | AppFilesChanged
+  | AppPreviewUpdateEvent;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -9,7 +9,12 @@ import type { CesClient } from "../credential-execution/client.js";
 import type { CesProcessManager } from "../credential-execution/process-manager.js";
 import { AssistantIpcServer } from "../ipc/assistant-server.js";
 import { SkillIpcServer } from "../ipc/skill-server.js";
-import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
+import {
+  getApp,
+  getAppDirPath,
+  isMultifileApp,
+  resolveEffectiveAppHtml,
+} from "../memory/app-store.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -26,6 +31,7 @@ import { updatePublishedAppDeployment } from "../services/published-app-updater.
 import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { runAppLiveBuild } from "./app-live-build.js";
 import {
   AppSourceWatcher,
   setEnsureAppSourceWatcher,
@@ -236,10 +242,9 @@ export class DaemonServer {
     const app = getApp(appId);
     if (!app) return;
 
-    const doRefresh = () => {
-      for (const conversation of allConversations()) {
-        refreshSurfacesForApp(conversation, appId, { fileChange: true });
-      }
+    // Notify the app-list / publish pipeline (fires regardless of compile
+    // outcome, matching the prior behavior).
+    const settle = () => {
       broadcastMessage({ type: "app_files_changed", appId });
       publishAppsChanged();
       void updatePublishedAppDeployment(appId);
@@ -247,24 +252,34 @@ export class DaemonServer {
 
     if (isMultifileApp(app)) {
       const appDir = getAppDirPath(appId);
-      void compileApp(appDir)
-        .then((result) => {
-          if (!result.ok) {
+      void runAppLiveBuild(appId, app, appDir, {
+        compileApp,
+        resolveEffectiveAppHtml,
+        broadcast: (msg) => broadcastMessage(msg),
+        refreshSurfaces: (id, opts) => {
+          if (opts.compileStatus === "error") {
             log.warn(
-              { appId, errors: result.errors },
-              "Recompile failed on app source change",
+              { appId: id, errors: opts.buildErrors },
+              "Recompile failed on app source change — keeping last-good preview",
             );
           }
-          doRefresh();
-        })
-        .catch((err) => {
-          log.warn({ appId, err }, "Recompile threw on app source change");
-          doRefresh();
-        });
+          for (const conversation of allConversations()) {
+            refreshSurfacesForApp(conversation, id, opts);
+          }
+        },
+        onSettled: settle,
+      }).catch((err) => {
+        log.warn({ appId, err }, "Live build threw on app source change");
+        settle();
+      });
       return;
     }
 
-    doRefresh();
+    // Single-file apps: no recompile, just refresh surfaces and settle.
+    for (const conversation of allConversations()) {
+      refreshSurfacesForApp(conversation, appId, { fileChange: true });
+    }
+    settle();
   }
 
   // ── Server lifecycle ────────────────────────────────────────────────

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { disposeAcpSessionManager } from "../acp/index.js";
-import { compileApp } from "../bundler/app-compiler.js";
+import {
+  compileApp,
+  disposeAppCompilerContexts,
+} from "../bundler/app-compiler.js";
 import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
 import type { CesClient } from "../credential-execution/client.js";
@@ -350,6 +353,7 @@ export class DaemonServer {
     this.evictor.stop();
     this.configWatcher.stop();
     this.appSourceWatcher.stop();
+    void disposeAppCompilerContexts();
     this.pluginSourceWatcher.stop();
     this.cliIpc.stop();
     this.skillIpc.stop();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -266,9 +266,19 @@ export class DaemonServer {
               "Recompile failed on app source change — keeping last-good preview",
             );
           }
+          // Return the highest generation applied across all conversations'
+          // surfaces so the live-build orchestrator can keep its broadcast
+          // generation in agreement with — and ahead of — every surface.
+          let maxGeneration = opts.reloadGeneration ?? 0;
           for (const conversation of allConversations()) {
-            refreshSurfacesForApp(conversation, id, opts);
+            const { reloadGeneration } = refreshSurfacesForApp(
+              conversation,
+              id,
+              opts,
+            );
+            maxGeneration = Math.max(maxGeneration, reloadGeneration);
           }
+          return maxGeneration;
         },
         onSettled: settle,
       }).catch((err) => {

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -470,12 +470,14 @@ BUN_BUNDLE_CACHE_DIR="$SCRIPT_DIR/.bun-bundle-cache/${BUN_VERSION}"
 # bundles and extracts it at runtime, but macOS rejects the dlopen because the
 # extracted binary's Team ID differs from the main process.  Externalising it
 # lets the lazy wrapper in avatar/resvg-lazy.ts handle the missing module.
-# esbuild's JS API resolves its native binary relative to its package at module
-# init; that path doesn't exist inside bun --compile's /$bunfs/. The daemon
-# lazy-imports esbuild (bundler/app-compiler.ts) and points ESBUILD_BINARY_PATH
-# at an on-disk binary, so the JS API + its @esbuild/* platform packages must
-# stay external rather than be bundled into /$bunfs/.
-BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*" --external "@resvg/resvg-js" --external "@resvg/resvg-js-darwin-arm64" --external "@resvg/resvg-js-darwin-x64" --external esbuild --external "@esbuild/*")
+# @esbuild/* are platform-specific native binary packages: bun --compile cannot
+# meaningfully bundle them, and ensureCompilerTools() stages the matching native
+# binary on disk (pointed to via ESBUILD_BINARY_PATH). Keep them external. The
+# esbuild JS API package is NOT externalised: where it resolves (e.g. cloud
+# `bun run`) the daemon uses its warm incremental context; where it does not
+# (this compiled binary, whose node_modules are stripped) the daemon falls back
+# to spawning the on-disk native binary (bundler/app-compiler.ts compileWithCli).
+BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*" --external "@resvg/resvg-js" --external "@resvg/resvg-js-darwin-arm64" --external "@resvg/resvg-js-darwin-x64" --external "@esbuild/*")
 
 # ---------------------------------------------------------------------------
 # build_bun_binary — compile a TypeScript project to a native binary via Bun.

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -470,7 +470,12 @@ BUN_BUNDLE_CACHE_DIR="$SCRIPT_DIR/.bun-bundle-cache/${BUN_VERSION}"
 # bundles and extracts it at runtime, but macOS rejects the dlopen because the
 # extracted binary's Team ID differs from the main process.  Externalising it
 # lets the lazy wrapper in avatar/resvg-lazy.ts handle the missing module.
-BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*" --external "@resvg/resvg-js" --external "@resvg/resvg-js-darwin-arm64" --external "@resvg/resvg-js-darwin-x64")
+# esbuild's JS API resolves its native binary relative to its package at module
+# init; that path doesn't exist inside bun --compile's /$bunfs/. The daemon
+# lazy-imports esbuild (bundler/app-compiler.ts) and points ESBUILD_BINARY_PATH
+# at an on-disk binary, so the JS API + its @esbuild/* platform packages must
+# stay external rather than be bundled into /$bunfs/.
+BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*" --external "@resvg/resvg-js" --external "@resvg/resvg-js-darwin-arm64" --external "@resvg/resvg-js-darwin-x64" --external esbuild --external "@esbuild/*")
 
 # ---------------------------------------------------------------------------
 # build_bun_binary — compile a TypeScript project to a native binary via Bun.


### PR DESCRIPTION
## Summary
Makes the web app-builder hot-reload the open app preview on every file change while the assistant is still writing — Lovable-style. The daemon already recompiled + refreshed on every source change; the web client now consumes that live-build signal, keeps the last-good preview on transient compile errors, shows a non-blocking build-error badge, and auto-opens a side-by-side preview panel the moment a build starts. Recompiles are made sub-second via a warm/incremental esbuild context. Web-first, hot-reload spike only — **no app-builder skill changes and no "building" overlay**, by design (see the attached plan's "Deliberately deferred" section).

## Self-review result
PASS after 3 remediation rounds (8 fix commits). The self-review caught — and fixed — a critical regression where the warm-esbuild change would have broken multifile app compilation in the packaged macOS daemon binary (`bun --compile`); resolved with a CLI-shellout fallback while keeping the warm JS-API context for the cloud/Docker daemon. Also fixed a reloadGeneration collision that could suppress a macOS reload, a stale-overlapping-build event that could regress the web preview, and CLI-fallback diagnostics that dropped source locations.

## Implementation PRs merged into this feature branch
- #33009: feat(daemon): emit app live-build status with keep-last-good preview on compile failure
- #33010: perf(daemon): reuse a warm esbuild context per app for fast hot-reload recompiles
- #33025: feat(web): hot-reload the open app preview on daemon app_preview_update events
- #33039: feat(web): auto-open the side-by-side app panel when an app build begins

### Fix PRs (self-review remediation)
- #33049 + #33063: esbuild safe under `bun --compile` (lazy import; CLI-shellout fallback for the compiled macOS binary; correct externalization)
- #33053: reloadGeneration monotonic vs the surface counter (no macOS-reload collision) + remove dead return
- #33051: drop stale build events, derive web types from the canonical event, reset build-error badge on new error
- #33074: preserve source location in esbuild CLI-fallback diagnostics

Part of plan: app-live-preview.md