### PR TITLE
Prevent background artifact side effects

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -960,7 +960,7 @@ describe("session-agent-loop", () => {
   });
 
   describe("proactive artifact trigger", () => {
-    test("suppresses proactive app build when the foreground turn used app tools", async () => {
+    test("does not start proactive artifact jobs after foreground user turns", async () => {
       mockConversationRow = {
         ...mockConversationRow,
         id: "test-conv",
@@ -1037,11 +1037,7 @@ describe("session-agent-loop", () => {
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(runProactiveArtifactJobMock).toHaveBeenCalledTimes(1);
-      expect(runProactiveArtifactJobMock.mock.calls[0]?.[0]).toMatchObject({
-        conversationId: "test-conv",
-        suppressAppBuild: true,
-      });
+      expect(runProactiveArtifactJobMock).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -124,11 +124,6 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
-import {
-  hasProactiveArtifactCompleted,
-  runProactiveArtifactJob,
-  tryClaimProactiveArtifactTrigger,
-} from "../proactive-artifact/index.js";
 import type {
   ContentBlock,
   Message,
@@ -3240,42 +3235,6 @@ export async function runAgentLoopImpl(
             : {}),
         });
         publishLoopMessagesChanged();
-
-        // Proactive artifact: fire once when the processed turn was the 4th user message.
-        // Only trigger for real user-authored turns (not subagent/system messages).
-        {
-          const paConv = getConversation(ctx.conversationId);
-          if (
-            paConv &&
-            paConv.conversationType === "standard" &&
-            options?.isUserMessage
-          ) {
-            void (async () => {
-              try {
-                if (hasProactiveArtifactCompleted()) return;
-                const userMsg = getMessageById(
-                  userMessageId,
-                  ctx.conversationId,
-                );
-                if (!userMsg) return;
-                if (!tryClaimProactiveArtifactTrigger(userMsg.createdAt))
-                  return;
-                await runProactiveArtifactJob({
-                  conversationId: ctx.conversationId,
-                  userMessageCutoff: userMsg.createdAt,
-                  assistantMessageId: state.lastAssistantMessageId,
-                  suppressAppBuild: state.appBuildToolUsedThisRun,
-                  broadcastMessage,
-                });
-              } catch (err) {
-                log.warn(
-                  { err, conversationId: ctx.conversationId },
-                  "Proactive artifact trigger failed",
-                );
-              }
-            })();
-          }
-        }
       }
     }
 

--- a/assistant/src/daemon/wake-target-adapter.ts
+++ b/assistant/src/daemon/wake-target-adapter.ts
@@ -196,6 +196,13 @@ export function conversationToWakeTarget(
       conversation.processing = on;
     },
     setTrustContext: (ctx) => conversation.setTrustContext(ctx),
+    setWakeAllowedTools: (tools) => {
+      const previous = conversation.subagentAllowedTools;
+      conversation.setSubagentAllowedTools(new Set(tools));
+      return () => {
+        conversation.setSubagentAllowedTools(previous);
+      };
+    },
     persistTailMessage: async (message) => {
       const turnChannelCtx = conversation.getTurnChannelContext();
       const turnInterfaceCtx = conversation.getTurnInterfaceContext();

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -316,10 +316,11 @@ describe("memoryRetrospectiveJob", () => {
     expect(bootstrapCalls[0]!.forkParentConversationId).toBe("src-conv-1");
   });
 
-  test("legacy path: wake opts include suppressWakeSurface so the full retrospective prompt isn't rendered as a 'Conversation Woke' card body to clients", async () => {
+  test("legacy path: wake is scoped to memory saves and suppresses the internal wake surface", async () => {
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.allowedTools).toEqual(["remember"]);
     expect(wakeCalls[0]!.opts.suppressWakeSurface).toBe(true);
   });
 
@@ -537,7 +538,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(forkCalls[0]!.groupId).toBe("system:background");
   });
 
-  test("fork path: wake opts include suppressWakeSurface so clients don't render an empty wake card on top of the '(Retrospective)' fork", async () => {
+  test("fork path: wake is scoped to memory saves and suppresses the internal wake surface", async () => {
     forkFlagEnabled = true;
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
@@ -545,6 +546,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls).toHaveLength(1);
     expect(wakeCalls[0]!.conversationId).toBe("fork-conv-1");
     const opts = wakeCalls[0]!.opts;
+    expect(opts.allowedTools).toEqual(["remember"]);
     expect(opts.suppressWakeSurface).toBe(true);
     // Sanity: the other fork-specific opts the handler relies on are still set.
     expect(opts.skipHintInjection).toBe(true);

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -208,6 +208,7 @@ async function runLegacyRetrospective(
       source: MEMORY_RETROSPECTIVE_SOURCE,
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
+      allowedTools: ["remember"],
       // The background conversation's title already reads "Memory
       // Retrospective", and `hint` is the full retrospective prompt — surfacing
       // it verbatim as a "Conversation Woke" card body is noisy internal
@@ -409,6 +410,7 @@ async function runForkBasedRetrospective(
       source: MEMORY_RETROSPECTIVE_SOURCE,
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
+      allowedTools: ["remember"],
       hintRole: "user",
       skipHintInjection: true,
       suppressAutoCompaction: true,

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -145,6 +145,7 @@ interface MockTarget extends WakeTarget {
     input: Message[];
     requestId?: string;
     turnContext?: unknown;
+    allowedTools?: string[];
   }>;
   processingToggles: boolean[];
   /** Tail messages handed to `persistTailMessage`, in call order. */
@@ -163,6 +164,11 @@ interface MockTarget extends WakeTarget {
    * just inferring it from the order of recorded toggles.
    */
   processingDuringDrain: boolean[];
+  /**
+   * Tool allowlist snapshots captured whenever the wake applies/restores a
+   * scope. `undefined` means unrestricted.
+   */
+  allowedToolSnapshots: Array<string[] | undefined>;
 }
 
 function makeTarget(options: {
@@ -175,6 +181,7 @@ function makeTarget(options: {
   isProcessing?: boolean;
   /** When true, omit `drainQueue` so we can verify the wake handles its absence. */
   omitDrainQueue?: boolean;
+  initialAllowedTools?: Set<string>;
 }): MockTarget {
   const emittedEvents: AgentEvent[] = [];
   const pushedMessages: Message[] = [];
@@ -182,14 +189,19 @@ function makeTarget(options: {
     input: Message[];
     requestId?: string;
     turnContext?: unknown;
+    allowedTools?: string[];
   }> = [];
   const processingToggles: boolean[] = [];
   const persistedTailCalls: Message[] = [];
   const callSequence: string[] = [];
   const processingDuringDrain: boolean[] = [];
+  const allowedToolSnapshots: Array<string[] | undefined> = [];
   const history: Message[] = [...(options.baseline ?? [])];
   let processing = options.isProcessing ?? false;
   let drainQueueCalls = 0;
+  let activeAllowedTools = options.initialAllowedTools;
+  const snapshotAllowedTools = (): string[] | undefined =>
+    activeAllowedTools ? [...activeAllowedTools].sort() : undefined;
 
   const target: MockTarget = {
     conversationId: options.conversationId ?? "conv-test",
@@ -200,6 +212,7 @@ function makeTarget(options: {
     persistedTailCalls,
     callSequence,
     processingDuringDrain,
+    allowedToolSnapshots,
     get drainQueueCalls() {
       return drainQueueCalls;
     },
@@ -213,6 +226,7 @@ function makeTarget(options: {
           input: [...input],
           requestId: runOptions?.requestId,
           turnContext: runOptions?.turnContext,
+          allowedTools: snapshotAllowedTools(),
         });
         // Emit any scripted events the test wanted us to produce.
         for (const ev of options.scriptedEvents ?? []) {
@@ -253,6 +267,19 @@ function makeTarget(options: {
     persistTailMessage: async (msg: Message) => {
       persistedTailCalls.push(msg);
       callSequence.push("persist");
+    },
+    setWakeAllowedTools: (tools: ReadonlySet<string>) => {
+      const previous = activeAllowedTools;
+      activeAllowedTools = new Set(tools);
+      allowedToolSnapshots.push(snapshotAllowedTools());
+      callSequence.push(`tools:${snapshotAllowedTools()?.join(",") ?? "all"}`);
+      return () => {
+        activeAllowedTools = previous;
+        allowedToolSnapshots.push(snapshotAllowedTools());
+        callSequence.push(
+          `tools:${snapshotAllowedTools()?.join(",") ?? "all"}`,
+        );
+      };
     },
     ...(options.omitDrainQueue
       ? {}
@@ -500,6 +527,69 @@ describe("wakeAgentForOpportunity", () => {
         },
       ],
     });
+  });
+
+  test("scopes allowed tools during the wake and restores before queued messages drain", async () => {
+    const target = makeTarget({
+      initialAllowedTools: new Set(["bash"]),
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "Saved." }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "review for memories",
+        source: "memory-retrospective",
+        allowedTools: ["remember"],
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(target.runCalls[0]!.allowedTools).toEqual(["remember"]);
+    expect(target.allowedToolSnapshots).toEqual([["remember"], ["bash"]]);
+
+    const restoreIndex = target.callSequence.indexOf("tools:bash");
+    const processingFalseIndex =
+      target.callSequence.indexOf("processing:false");
+    const drainIndex = target.callSequence.indexOf("drain");
+    expect(restoreIndex).toBeGreaterThan(-1);
+    expect(restoreIndex).toBeLessThan(processingFalseIndex);
+    expect(processingFalseIndex).toBeLessThan(drainIndex);
+  });
+
+  test("restores allowed tools before drain when the wake is a silent no-op", async () => {
+    const target = makeTarget({
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "review for memories",
+        source: "memory-retrospective",
+        allowedTools: ["remember"],
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(target.runCalls[0]!.allowedTools).toEqual(["remember"]);
+    expect(target.allowedToolSnapshots).toEqual([["remember"], undefined]);
+
+    const restoreIndex = target.callSequence.indexOf("tools:all");
+    const processingFalseIndex =
+      target.callSequence.indexOf("processing:false");
+    const drainIndex = target.callSequence.indexOf("drain");
+    expect(restoreIndex).toBeGreaterThan(-1);
+    expect(restoreIndex).toBeLessThan(processingFalseIndex);
+    expect(processingFalseIndex).toBeLessThan(drainIndex);
   });
 
   test("produces tool calls when LLM emits a tool_use block", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -14,7 +14,8 @@
  *     trailing user message satisfies providers that reject assistant
  *     prefill. The bookend user messages are hardcoded strings with no
  *     dynamic content, so they cannot carry injection payloads.
- *   - Invokes the agent loop with all conversation tools available.
+ *   - Invokes the agent loop with all conversation tools available unless
+ *     the caller provides an explicit `allowedTools` scope.
  *   - No tool calls AND no assistant text → silent no-op (nothing persisted,
  *     nothing emitted). Returns `{ invoked: true, producedToolCalls: false }`.
  *   - Tool calls produced → normal tool execution runs (the conversation's
@@ -164,6 +165,12 @@ export interface WakeTarget {
    * `trustContext` through the wake.
    */
   setTrustContext?(ctx: TrustContext): void;
+  /**
+   * Temporarily restrict the tools visible/executable during this wake.
+   * Returns a restore callback so the wake can release the scope before any
+   * queued user turn is drained.
+   */
+  setWakeAllowedTools?(tools: ReadonlySet<string>): () => void;
 }
 
 export interface WakeOptions {
@@ -238,6 +245,12 @@ export interface WakeOptions {
    * retrospectives whose conversation title already says "(Retrospective)").
    */
   suppressWakeSurface?: boolean;
+  /**
+   * Optional exact tool allowlist for this wake. Used by internal maintenance
+   * jobs that need the assistant's judgment but must not execute arbitrary
+   * side-effect tools.
+   */
+  allowedTools?: readonly string[];
 }
 
 /**
@@ -834,11 +847,55 @@ export async function wakeAgentForOpportunity(
       overrideProfile,
     });
 
+    let wakeToolScopeRestored = false;
+    let restoreWakeToolScope: (() => void) | null = null;
+    const restoreWakeAllowedTools = (): void => {
+      if (wakeToolScopeRestored) return;
+      wakeToolScopeRestored = true;
+      if (!restoreWakeToolScope) return;
+      try {
+        restoreWakeToolScope();
+      } catch (err) {
+        log.warn(
+          { conversationId, source, err },
+          "agent-wake: failed to restore tool allowlist; continuing",
+        );
+      }
+    };
+    const applyWakeAllowedTools = (): boolean => {
+      if (!opts.allowedTools) return true;
+      if (!target.setWakeAllowedTools) {
+        log.warn(
+          { conversationId, source, allowedTools: opts.allowedTools },
+          "agent-wake: target cannot apply requested tool allowlist; skipping",
+        );
+        return false;
+      }
+      try {
+        restoreWakeToolScope = target.setWakeAllowedTools(
+          new Set(opts.allowedTools),
+        );
+        return true;
+      } catch (err) {
+        log.warn(
+          { conversationId, source, allowedTools: opts.allowedTools, err },
+          "agent-wake: failed to apply requested tool allowlist; skipping",
+        );
+        return false;
+      }
+    };
+
     // Mark processing for the duration of the run so a concurrent user
     // send is queued by `enqueueMessage()` rather than spawning a second
     // concurrent agent loop on the same conversation (which would
-    // interleave writes to `conversation.messages`).
-    target.markProcessing(true);
+    // interleave writes to `conversation.messages`). This happens before
+    // applying a wake-scoped tool allowlist so a concurrent user turn cannot
+    // start under the wake's restricted tool set.
+    try {
+      target.markProcessing(true);
+    } catch (err) {
+      throw err;
+    }
 
     // Fires after each tool-execution turn finalizes (assistant message
     // + matching tool_result user message both in history). A single
@@ -860,6 +917,14 @@ export async function wakeAgentForOpportunity(
     let tailMessageCount = 0;
     let drainedInTry = false;
     try {
+      if (!applyWakeAllowedTools()) {
+        return {
+          invoked: false,
+          producedToolCalls: false,
+          reason: "no_resolver" as const,
+        };
+      }
+
       let updatedHistory: Message[];
       try {
         ({ history: updatedHistory } = await target.agentLoop.run(
@@ -943,6 +1008,7 @@ export async function wakeAgentForOpportunity(
       // accepts entries while processing === true, and drain expects
       // processing to already be false). The finally block handles the
       // error/early-return paths where no tail was produced.
+      restoreWakeAllowedTools();
       try {
         target.markProcessing(false);
       } catch (err) {
@@ -971,6 +1037,7 @@ export async function wakeAgentForOpportunity(
       // exit the try body before reaching the drain block, so
       // `drainedInTry` is still false.
       if (!drainedInTry) {
+        restoreWakeAllowedTools();
         try {
           target.markProcessing(false);
         } catch (err) {


### PR DESCRIPTION
## Summary
- stop completed foreground turns from launching the proactive artifact background job
- scope memory retrospective wakes to the `remember` tool only
- restore wake tool scopes before queued user messages drain

This is intentionally surgical so it can be cherry-picked onto the release branch. The broader proactive artifact subsystem cleanup can follow separately for the next release.

## Tests
- `cd assistant && bun test src/runtime/__tests__/agent-wake.test.ts`
- `cd assistant && bun test src/memory/__tests__/memory-retrospective-job.test.ts`
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "proactive artifact"`
- `cd assistant && bunx tsc --noEmit`