### PR TITLE
feat(assistant): skip memory retrospective for incognito conversations

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -12,6 +12,7 @@ mock.module("../../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 let sourceTag: string | null = null;
+let incognitoFlag = 0;
 const upsertCalls: Array<{
   payload: { conversationId: string };
   runAfter: number;
@@ -19,6 +20,7 @@ const upsertCalls: Array<{
 
 mock.module("../conversation-crud.js", () => ({
   getConversationSource: (_id: string) => sourceTag,
+  getConversation: (_id: string) => ({ incognito: incognitoFlag }),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
@@ -47,6 +49,7 @@ import {
 describe("enqueueMemoryRetrospectiveIfEnabled", () => {
   beforeEach(() => {
     sourceTag = null;
+    incognitoFlag = 0;
     upsertCalls.length = 0;
   });
 
@@ -85,6 +88,28 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     });
     expect(upsertCalls).toHaveLength(0);
   });
+
+  test("incognito conversation skips enqueue across triggers", () => {
+    incognitoFlag = 1;
+    for (const trigger of [
+      "interval",
+      "message_count",
+      "compaction",
+      "lifecycle",
+    ] as const) {
+      enqueueMemoryRetrospectiveIfEnabled({ conversationId: "c1", trigger });
+    }
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("non-incognito conversation still enqueues", () => {
+    incognitoFlag = 0;
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+    expect(upsertCalls).toHaveLength(1);
+  });
 });
 
 describe("isMemoryRetrospectiveConversation", () => {
@@ -111,6 +136,7 @@ describe("isMemoryRetrospectiveConversation", () => {
 describe("enqueueMemoryRetrospectiveOnCompaction", () => {
   beforeEach(() => {
     sourceTag = null;
+    incognitoFlag = 0;
     upsertCalls.length = 0;
   });
 

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -18,7 +18,7 @@ import {
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
-import { getConversationSource } from "./conversation-crud.js";
+import { getConversation, getConversationSource } from "./conversation-crud.js";
 import {
   isMemoryEnabled,
   upsertMemoryRetrospectiveJob,
@@ -49,6 +49,15 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     log.debug(
       { conversationId, trigger },
       "Skipping memory-retrospective enqueue: source is a memory-retrospective conversation",
+    );
+    return;
+  }
+
+  const conversation = getConversation(conversationId);
+  if (conversation?.incognito) {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping memory-retrospective enqueue: conversation is incognito",
     );
     return;
   }

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -18,7 +18,11 @@ import {
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
-import { getConversation, getConversationSource } from "./conversation-crud.js";
+// Namespace import + optional call: Bun `mock.module` global-leak means many
+// test files mock conversation-crud with only a partial export set. A named
+// `getConversation` import would fail at link time under those mocks; the
+// namespace access degrades to undefined (treated as non-incognito) instead.
+import * as conversationCrud from "./conversation-crud.js";
 import {
   isMemoryEnabled,
   upsertMemoryRetrospectiveJob,
@@ -53,7 +57,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     return;
   }
 
-  const conversation = getConversation(conversationId);
+  const conversation = conversationCrud.getConversation?.(conversationId);
   if (conversation?.incognito) {
     log.debug(
       { conversationId, trigger },
@@ -83,7 +87,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
 export function isMemoryRetrospectiveConversation(
   conversationId: string,
 ): boolean {
-  const source = getConversationSource(conversationId);
+  const source = conversationCrud.getConversationSource(conversationId);
   return source !== null && MEMORY_RETROSPECTIVE_SOURCES.includes(source);
 }
 


### PR DESCRIPTION
## Summary
- Early-return in enqueueMemoryRetrospectiveIfEnabled when the conversation is incognito so it never produces memories

Part of plan: incognito-conversations.md (PR 7 of 16)