### PR TITLE
feat(assistant): endpoint to update incognito conversation memory opt-in

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6770,6 +6770,50 @@ paths:
           schema:
             type: string
           description: ID of the selected LLM call from the rail. Defines the chronological cutoff for the trail.
+  /v1/conversations/{id}/incognito:
+    put:
+      operationId: conversations_by_id_incognito_put
+      summary: Set incognito conversation memory opt-in
+      description:
+        Toggle whether an incognito conversation factors in existing memories. Returns 404 if the conversation does
+        not exist and 409 if it is not incognito.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  incognito:
+                    type: boolean
+                    const: true
+                  factorInMemories:
+                    type: boolean
+                required:
+                  - incognito
+                  - factorInMemories
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                factorInMemories:
+                  type: boolean
+              required:
+                - factorInMemories
+              additionalProperties: false
   /v1/conversations/{id}/inference-profile:
     put:
       operationId: conversations_by_id_inferenceprofile_put

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1803,6 +1803,24 @@ export function setConversationInferenceProfile(
 }
 
 /**
+ * Set whether an incognito conversation should factor in existing memories.
+ * Stored as 1/0 in the `factor_in_memories` column. Bumps `updatedAt`.
+ */
+export function setConversationFactorInMemories(
+  id: string,
+  factorInMemories: boolean,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      factorInMemories: factorInMemories ? 1 : 0,
+      updatedAt: Date.now(),
+    })
+    .where(eq(conversations.id, id))
+    .run();
+}
+
+/**
  * Atomically set the inference profile, session id, and expiry timestamp for
  * a conversation. Pass `null` for all three to clear the session-backed
  * override and fall back to the workspace `llm.activeProfile` resolution.

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -26,8 +26,8 @@ mock.module("../../assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
-import { getDb } from "../../../memory/db-connection.js";
 import { getConversation } from "../../../memory/conversation-crud.js";
+import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { conversations } from "../../../memory/schema.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -27,6 +27,7 @@ mock.module("../../assistant-event-hub.js", () => ({
 }));
 
 import { getDb } from "../../../memory/db-connection.js";
+import { getConversation } from "../../../memory/conversation-crud.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { conversations } from "../../../memory/schema.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
@@ -75,6 +76,10 @@ const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "setConversationInferenceProfile",
 );
+const incognitoHandler = findHandler(
+  CONVERSATION_MANAGEMENT_ROUTES,
+  "setConversationIncognitoFactorInMemories",
+);
 const openHandler = findHandler(
   INFERENCE_PROFILE_SESSION_ROUTES,
   "inference_profile_open",
@@ -92,7 +97,10 @@ function clearConversations(): void {
   getDb().delete(conversations).run();
 }
 
-function seedConversation(id: string): void {
+function seedConversation(
+  id: string,
+  opts: { incognito?: boolean } = {},
+): void {
   const now = Date.now();
   getDb()
     .insert(conversations)
@@ -104,6 +112,7 @@ function seedConversation(id: string): void {
       source: "test",
       conversationType: "standard",
       memoryScopeId: "default",
+      incognito: opts.incognito ? 1 : 0,
     })
     .run();
 }
@@ -315,5 +324,70 @@ describe("POST /v1/conversations/inference-profile-session/close (inference_prof
 
     expect(result.noop).toBe(true);
     expect(result.closed).toBeNull();
+  });
+});
+
+describe("PUT /v1/conversations/:id/incognito", () => {
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  test("updates factor_in_memories on an incognito conversation", async () => {
+    const convId = crypto.randomUUID();
+    seedConversation(convId, { incognito: true });
+
+    // Default seed leaves factor_in_memories = 1; turn it off.
+    const off = (await incognitoHandler({
+      pathParams: { id: convId },
+      body: { factorInMemories: false },
+    })) as { incognito: boolean; factorInMemories: boolean };
+
+    expect(off.incognito).toBe(true);
+    expect(off.factorInMemories).toBe(false);
+    expect(getConversation(convId)!.factorInMemories).toBe(0);
+
+    // And back on.
+    const on = (await incognitoHandler({
+      pathParams: { id: convId },
+      body: { factorInMemories: true },
+    })) as { incognito: boolean; factorInMemories: boolean };
+
+    expect(on.factorInMemories).toBe(true);
+    expect(getConversation(convId)!.factorInMemories).toBe(1);
+  });
+
+  test("rejects a non-incognito conversation with 409", async () => {
+    const convId = crypto.randomUUID();
+    seedConversation(convId, { incognito: false });
+
+    await expect(
+      incognitoHandler({
+        pathParams: { id: convId },
+        body: { factorInMemories: false },
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    // Unchanged.
+    expect(getConversation(convId)!.factorInMemories).toBe(1);
+  });
+
+  test("returns 404 for an unknown conversation", async () => {
+    await expect(
+      incognitoHandler({
+        pathParams: { id: crypto.randomUUID() },
+        body: { factorInMemories: true },
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  test("rejects a non-boolean factorInMemories with 400", async () => {
+    const convId = crypto.randomUUID();
+    seedConversation(convId, { incognito: true });
+
+    await expect(
+      incognitoHandler({
+        pathParams: { id: convId },
+        body: { factorInMemories: "yes" },
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
   });
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -5,6 +5,7 @@
  * POST   /v1/conversations/switch         — switch to an existing conversation
  * POST   /v1/conversations/fork           — fork an existing conversation
  * PUT    /v1/conversations/:id/inference-profile — set per-conversation inference profile
+ * PUT    /v1/conversations/:id/incognito  — set incognito conversation memory opt-in
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
  * POST   /v1/conversations/:id/wipe       — wipe conversation and revert memory
@@ -36,6 +37,7 @@ import {
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
+  setConversationFactorInMemories,
   unarchiveConversation,
   updateConversationTitle,
   wipeConversation,
@@ -57,7 +59,12 @@ import {
   publishConversationTitleChanged,
 } from "../sync/resource-sync-events.js";
 import { conversationSummarySchema } from "./conversation-list-routes.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  InternalError,
+  NotFoundError,
+} from "./errors.js";
 import { setInferenceProfileSession } from "./inference-profile-session-handler.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -203,6 +210,30 @@ async function handleSetInferenceProfile({
   });
 
   return result;
+}
+
+async function handleSetIncognitoFactorInMemories({
+  pathParams = {},
+  body = {},
+}: RouteHandlerArgs) {
+  if (typeof body.factorInMemories !== "boolean") {
+    throw new BadRequestError("factorInMemories must be a boolean");
+  }
+  const factorInMemories = body.factorInMemories as boolean;
+
+  const conversation = getConversation(pathParams.id!);
+  if (!conversation) {
+    throw new NotFoundError(`Conversation ${pathParams.id} not found`);
+  }
+  if (!conversation.incognito) {
+    throw new ConflictError(
+      `Conversation ${pathParams.id} is not incognito; factorInMemories can only be set on incognito conversations`,
+    );
+  }
+
+  setConversationFactorInMemories(pathParams.id!, factorInMemories);
+
+  return { incognito: true, factorInMemories };
 }
 
 function handleRenameConversation({
@@ -550,6 +581,29 @@ export const ROUTES: RouteDefinition[] = [
         .nullable(),
     }),
     handler: handleSetInferenceProfile,
+  },
+  {
+    operationId: "setConversationIncognitoFactorInMemories",
+    endpoint: "conversations/:id/incognito",
+    method: "PUT",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Set incognito conversation memory opt-in",
+    description:
+      "Toggle whether an incognito conversation factors in existing memories. " +
+      "Returns 404 if the conversation does not exist and 409 if it is not incognito.",
+    tags: ["conversations"],
+    pathParams: [{ name: "id", type: "uuid" }],
+    requestBody: z.object({
+      factorInMemories: z.boolean(),
+    }),
+    responseBody: z.object({
+      incognito: z.literal(true),
+      factorInMemories: z.boolean(),
+    }),
+    handler: handleSetIncognitoFactorInMemories,
   },
   {
     operationId: "renameConversation",


### PR DESCRIPTION
## Summary
- Add setConversationFactorInMemories CRUD updater + PUT /conversations/{id}/incognito route to toggle factor-in-memories on incognito conversations (404 unknown, 409 non-incognito)

Part of plan: incognito-conversations.md (PR 16 of 16)