### PR TITLE
fix(web): stop background userTimezone clobbering + serialize detectedTimezone PATCHes

### DIFF
--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,12 +1,12 @@
 /**
  * Tests for the headless `TimezoneSync` component.
  *
- * Strategy: mock the generated API client's `patch`, the browser-zone and
- * device-setting readers (separately), and the effective-timezone hook
- * (the reactivity trigger), drive the active assistant id through the real
- * selection store, and assert the PATCH writes both `detectedTimezone`
- * (browser zone) and `userTimezone` (override or "") and never persists a
- * stale zone when requests overlap.
+ * Strategy: mock the generated API client's `patch`, the browser-zone reader,
+ * and the effective-timezone hook (the reactivity trigger), drive the active
+ * assistant id through the real selection store, and assert the PATCH writes
+ * ONLY `detectedTimezone` (the live browser zone) and NEVER `userTimezone`,
+ * that writes are serialized (no two PATCHes in flight at once), and that the
+ * final write always reflects the newest zone when triggers overlap.
  */
 import {
   afterEach,
@@ -29,26 +29,19 @@ interface PatchArgs {
   body: { ui: Record<string, unknown> };
 }
 
-// Mutable separate readers; tests flip them then re-render. `browserTz`
-// is the live auto zone; `override` is the manual `device:timezone`.
+// Mutable browser zone; tests flip it then re-render.
 let browserTz = "America/New_York";
-let override = "";
 const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
 const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
 
-// The hook is just a reactivity trigger; it folds override over browser
-// zone (matching the real implementation) so a flip of either re-renders.
+// The hook is just a reactivity trigger; it tracks the browser zone so a flip
+// re-renders.
 mock.module("@/utils/use-effective-timezone", () => ({
-  useEffectiveTimezone: () => (override.trim() ? override.trim() : browserTz),
+  useEffectiveTimezone: () => browserTz,
 }));
 
 mock.module("@/utils/browser-timezone", () => ({
   getBrowserTimezone: () => browserTz,
-}));
-
-mock.module("@/utils/device-settings", () => ({
-  getDeviceSetting: (_name: string, fallback: string) =>
-    override === "" ? fallback : override,
 }));
 
 mock.module("@/generated/api/client.gen", () => ({
@@ -73,7 +66,6 @@ function renderSync() {
 
 beforeEach(() => {
   browserTz = "America/New_York";
-  override = "";
   patchMock.mockClear();
   captureErrorMock.mockClear();
   patchMock.mockImplementation(async () => ({ data: {} }));
@@ -90,36 +82,20 @@ function lastBody() {
 }
 
 describe("TimezoneSync", () => {
-  test("PATCHes both fields once on mount in auto mode (userTimezone cleared)", async () => {
+  test("PATCHes only detectedTimezone on mount; never sends userTimezone", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
     const call = patchMock.mock.calls[0]![0];
     expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
     expect(call.path).toEqual({ assistant_id: "asst-1" });
-    expect(call.body).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    // Explicitly assert userTimezone is never part of any PATCH body.
+    for (const c of patchMock.mock.calls) {
+      expect(c[0].body.ui).not.toHaveProperty("userTimezone");
+    }
   });
 
-  test("manual override is written to userTimezone; detectedTimezone carries the live browser zone", async () => {
-    override = "Asia/Tokyo";
-    renderSync();
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
-    });
-  });
-
-  test("trims the override before writing userTimezone", async () => {
-    override = "  Asia/Tokyo  ";
-    renderSync();
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
-    });
-  });
-
-  test("a browser-zone change triggers exactly one additional PATCH with the new zone", async () => {
+  test("a browser-zone change triggers exactly one additional PATCH with the new zone (no userTimezone)", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
@@ -127,9 +103,7 @@ describe("TimezoneSync", () => {
     rerender(<TimezoneSync />);
 
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "Europe/London", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
   });
 
   test("no additional PATCH when nothing changed across re-renders (redundant-key dedupe)", async () => {
@@ -174,9 +148,7 @@ describe("TimezoneSync", () => {
     browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("retries on app.resume with the same zone after a failed initial sync", async () => {
@@ -189,9 +161,7 @@ describe("TimezoneSync", () => {
 
     publish("app.resume", { signal: "visibility" });
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("retries on window focus with the same zone after a failed initial sync", async () => {
@@ -204,9 +174,7 @@ describe("TimezoneSync", () => {
 
     window.dispatchEvent(new Event("focus"));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
@@ -220,10 +188,12 @@ describe("TimezoneSync", () => {
     expect(patchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("last-writer-wins: a slow older PATCH cannot overwrite a newer zone", async () => {
-    // Two overlapping triggers; the FIRST (older zone) resolves AFTER the
-    // SECOND (newer zone). The final synced state must reflect the newer
-    // zone, and the stale older completion must not re-open it for resync.
+  test("serializes PATCHes (last-writer-wins): newer zone is the final write, no overlap", async () => {
+    // The first PATCH (older zone) is held pending while the zone flips. The
+    // serializer must NOT start a second PATCH while the first is in flight;
+    // the newer zone is queued and fired only after the first settles, so the
+    // FINAL server write reflects the newer zone — even if the first promise
+    // resolves after the newer target arrives.
     const resolvers: Array<() => void> = [];
     patchMock.mockImplementation(
       () =>
@@ -235,31 +205,37 @@ describe("TimezoneSync", () => {
     const { rerender } = renderSync();
     // First PATCH issued (mount) for America/New_York; still pending.
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
 
-    // Zone flips before the first request settles → second PATCH issued.
+    // Zone flips before the first request settles. NO second PATCH yet — the
+    // first is still in flight, so only ONE PATCH is ever in flight at once.
     browserTz = "Europe/London";
     rerender(<TimezoneSync />);
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(resolvers).toHaveLength(1);
 
-    expect(resolvers).toHaveLength(2);
-    // Newer request resolves first, then the stale older one resolves last.
-    resolvers[1]!();
+    // First (older) PATCH settles → queue drains and fires the newer zone.
     resolvers[0]!();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+    expect(resolvers).toHaveLength(2);
+
+    // Second (newer) PATCH settles → that is now the synced state.
+    resolvers[1]!();
     await new Promise((r) => setTimeout(r, 10));
 
-    // The newer zone is the synced state: re-rendering with Europe/London
-    // (the latest issued key) must NOT trigger a redundant PATCH...
+    // Re-rendering at the newer zone must NOT trigger a redundant PATCH...
     rerender(<TimezoneSync />);
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(2);
 
-    // ...and flipping back to the older zone DOES PATCH (so the stale
-    // completion never recorded America/New_York as the synced key).
+    // ...and flipping back to the older zone DOES PATCH (the older zone was
+    // never recorded as the synced key).
     browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    resolvers[2]!();
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 });

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,31 +1,29 @@
 /**
- * Headless background sync of the client's timezone into the assistant
- * daemon config, writing both cascade tiers separately:
+ * Headless background sync of the client's *auto* browser timezone into the
+ * assistant daemon config. It writes ONLY `ui.detectedTimezone` — the live
+ * auto browser zone, used for background grounding (memory retrospective,
+ * scheduling) that has no per-turn `clientTimezone`.
  *
- * - `ui.userTimezone`  ← the manual `device:timezone` override (trimmed),
- *   or `""` to CLEAR it when in auto mode. A deliberate override must
- *   live in this tier so it outranks another client's per-turn
- *   `clientTimezone`; storing it in `detectedTimezone` (the weakest
- *   relevant tier) would let a transient per-turn zone win.
- * - `ui.detectedTimezone` ← the live auto browser zone, used for
- *   background grounding (memory retrospective, scheduling) that has no
- *   per-turn `clientTimezone`.
+ * It deliberately NEVER writes `ui.userTimezone`. That tier is the
+ * authoritative manual override and may be set from the CLI, the assistant,
+ * or another client; a background auto-mode client clearing it would clobber
+ * a global override. The settings picker owns writing `ui.userTimezone` for
+ * explicit user actions.
  *
- * This is the single point that mirrors `device:timezone` into config;
- * the settings picker only writes localStorage. `useEffectiveTimezone()`
- * is used purely as a reactivity trigger (focus / app.resume / device
- * watcher) so the sync re-runs when either the browser zone or the
- * override changes.
+ * `useEffectiveTimezone()` is used purely as a reactivity trigger (focus /
+ * app.resume / device watcher) so the sync re-runs when the browser zone
+ * changes; the value persisted is always re-read from `getBrowserTimezone()`.
  *
- * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
- * failed sync (e.g. resumed-after-offline) leaves the key "unsynced" and
- * is retried on the next `app.resume` or focus — even when the values
- * are unchanged. A successful prior sync makes those triggers a no-op.
+ * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a failed
+ * sync (e.g. resumed-after-offline) leaves the zone "unsynced" and is retried
+ * on the next `app.resume` or focus. A successful prior sync makes those
+ * triggers a no-op.
  *
- * iOS fires `app.resume`+`focus` back-to-back, so PATCHes can overlap. A
- * monotonic request token guarantees last-writer-wins: a slow older
- * request's success is ignored once a newer request has been issued, so
- * a stale zone can never be persisted.
+ * Writes are truly serialized (last-writer-wins): at most one PATCH is in
+ * flight at a time. A trigger that fires while a PATCH is in flight only
+ * records the latest desired zone; when the in-flight PATCH settles, the
+ * queue drains to the latest target, so the final server write is always the
+ * newest zone and writes can never overlap or land out of order.
  *
  * Mounted once in `RootLayout` (behind `authMiddleware`). Renders `null`
  * and is silent on error — a failed background sync must never toast.
@@ -38,46 +36,37 @@ import { client } from "@/generated/api/client.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { captureError } from "@/lib/sentry/capture-error";
 import { getBrowserTimezone } from "@/utils/browser-timezone";
-import { getDeviceSetting } from "@/utils/device-settings";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function TimezoneSync(): null {
   // Reactivity trigger only: this value changes whenever the browser zone
-  // or the override changes, re-running the effect below. The actual
-  // detected/override values are re-read imperatively inside `trySync`.
+  // changes, re-running the effect below. The detected value is re-read
+  // imperatively inside `trySync` from `getBrowserTimezone()`.
   const effectiveTz = useEffectiveTimezone();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
 
   const { mutateAsync: patchTimezone } = useMutation({
-    mutationFn: async (vars: {
-      assistantId: string;
-      detectedTimezone: string;
-      userTimezone: string;
-    }) => {
+    mutationFn: async (vars: { assistantId: string; detectedTimezone: string }) => {
       const { data } = await client.patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: vars.assistantId },
-        body: {
-          ui: {
-            detectedTimezone: vars.detectedTimezone,
-            userTimezone: vars.userTimezone,
-          },
-        },
+        body: { ui: { detectedTimezone: vars.detectedTimezone } },
         throwOnError: true,
       });
       return data;
     },
   });
 
-  // Dedupe key of the last *successful* sync, covering both values plus
-  // the assistant (so switching assistants re-syncs even when unchanged).
-  // Only advanced on success, so a failed sync stays "unsynced".
+  // Dedupe key of the last *successful* sync (`${assistantId}:${detectedTimezone}`,
+  // so switching assistants re-syncs even when the zone is unchanged). Only
+  // advanced on success, so a failed sync stays "unsynced".
   const lastSyncedRef = useRef<string | null>(null);
 
-  // Monotonic token: incremented per issued PATCH. A request only records
-  // its key if it is still the latest issued, so a slow older completion
-  // cannot overwrite a newer zone (last-writer-wins).
-  const requestSeqRef = useRef(0);
+  // Write serialization: at most one PATCH in flight. `inFlightRef` guards
+  // overlap; `pendingKeyRef` holds the latest desired key while a PATCH is in
+  // flight so the queue can drain to it on settle.
+  const inFlightRef = useRef(false);
+  const pendingKeyRef = useRef<string | null>(null);
 
   // Hold the live assistant id so resume/focus handlers (which capture
   // `trySync` once) always target the current assistant.
@@ -87,33 +76,45 @@ export function TimezoneSync(): null {
   const trySync = useCallback(() => {
     const currentAssistantId = assistantIdRef.current;
     const detectedTimezone = getBrowserTimezone();
-    const userTimezone = getDeviceSetting("timezone", "").trim();
     if (!currentAssistantId || !detectedTimezone) return;
 
-    const key = `${currentAssistantId}:${detectedTimezone}:${userTimezone}`;
+    const key = `${currentAssistantId}:${detectedTimezone}`;
     if (lastSyncedRef.current === key) return;
 
-    const seq = ++requestSeqRef.current;
-    // Fire-and-forget: background sync, silent on error. Only record the
-    // key on success, and only if no newer request has since been issued.
-    patchTimezone({ assistantId: currentAssistantId, detectedTimezone, userTimezone })
+    // A PATCH is already running: just record the latest desired target so
+    // the in-flight PATCH drains to it on settle (no overlapping writes).
+    if (inFlightRef.current) {
+      pendingKeyRef.current = key;
+      return;
+    }
+
+    inFlightRef.current = true;
+    pendingKeyRef.current = null;
+
+    // Fire-and-forget background sync, silent on error. Record the key only
+    // on success; on settle, drain any newer target requested while in flight.
+    patchTimezone({ assistantId: currentAssistantId, detectedTimezone })
       .then(() => {
-        if (seq === requestSeqRef.current) {
-          lastSyncedRef.current = key;
-        }
+        lastSyncedRef.current = key;
       })
       .catch((error) => {
         captureError(error, { context: "timezone-sync" });
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+        const pending = pendingKeyRef.current;
+        pendingKeyRef.current = null;
+        if (pending && pending !== key) trySync();
       });
   }, [patchTimezone]);
 
-  // Reactive path: zone/override or assistant change.
+  // Reactive path: zone or assistant change.
   useEffect(() => {
     trySync();
   }, [effectiveTz, assistantId, trySync]);
 
-  // Resume/focus path: retry a previously failed sync even when the
-  // values are unchanged. A successful prior sync makes this a no-op.
+  // Resume/focus path: retry a previously failed sync even when the zone is
+  // unchanged. A successful prior sync makes this a no-op.
   useBusSubscription("app.resume", trySync);
   useEffect(() => {
     window.addEventListener("focus", trySync);


### PR DESCRIPTION
## Summary
- TimezoneSync no longer writes ui.userTimezone (was clearing a global override on auto-mode clients — P1). Writes only ui.detectedTimezone = live browser zone.
- Serializes PATCHes (single in-flight + queued latest) so the final server write is always the newest zone — true last-writer-wins.

Part of plan: fix-timezone-auto-update.md (review remediation round 2)