### PR TITLE
fix(web): correct timezoneDayStartEpoch DST math (two-pass zone-midnight resolution)

### DIFF
--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -22,20 +22,28 @@ export function toTimezoneDateString(d: Date, tz: string): string {
 /**
  * Epoch ms for the start of the calendar day `dateStr` ("YYYY-MM-DD") as it
  * occurs in the given IANA timezone — i.e. zone-local midnight. DST-safe:
- * derives the zone's UTC offset at that instant and subtracts it, so the
- * returned epoch maps back to 00:00 wall-clock in `tz`.
+ * resolves the zone-local wall clock 00:00:00 to its UTC instant via a
+ * two-pass technique, so it stays correct even on DST-transition days where
+ * the zone's offset differs between local- and UTC-midnight.
  */
 export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  // Provisional UTC midnight, then correct by the zone offset observed there.
-  const utcMidnight = Date.UTC(y, m - 1, d);
-  const offsetMs = utcMidnight - zonedWallClockEpoch(new Date(utcMidnight), tz);
-  return utcMidnight + offsetMs;
+  // Desired wall clock, scalarized by treating its Y-M-D-H-M-S as if UTC.
+  const desired = Date.parse(dateStr + "T00:00:00Z");
+  // First guess: interpret the desired wall clock as if it were UTC, then
+  // correct by the offset between the wall clock `guess` actually shows in
+  // `tz` and the desired one. A second pass converges DST-boundary days.
+  let guess = desired;
+  for (let pass = 0; pass < 2; pass++) {
+    const observed = zonedWallClockEpoch(new Date(guess), tz);
+    guess -= observed - desired;
+  }
+  return guess;
 }
 
 /**
- * Interpret the wall-clock time that `instant` shows in `tz` as if it were UTC,
- * returning that as epoch ms. Used to recover a zone's UTC offset.
+ * Read the wall clock that `instant` shows in `tz` and scalarize it by
+ * treating its Y-M-D-H-M-S as if UTC, returning that as epoch ms. Used to
+ * compare an observed wall clock against a desired one.
  */
 function zonedWallClockEpoch(instant: Date, tz: string): number {
   const parts = new Intl.DateTimeFormat("en-US", {

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -1,9 +1,59 @@
 import { describe, expect, test } from "bun:test";
 
-import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
 import { resolveRangeWindow } from "@/domains/logs/usage-tab-state";
 
 const UTC = "UTC";
+
+/** Render an instant's wall clock in `tz` as "YYYY-MM-DD HH:MM:SS". */
+function wallClock(epochMs: number, tz: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(epochMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value;
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get(
+    "minute",
+  )}:${get("second")}`;
+}
+
+describe("timezoneDayStartEpoch", () => {
+  test("DST-start day in Sydney resolves to local midnight, not 23:00 prior", () => {
+    // 2027-10-03 is a DST-start (spring-forward) date in Sydney. The naive
+    // offset-at-UTC-midnight approach returned 2027-10-02 23:00 here.
+    const epoch = timezoneDayStartEpoch("2027-10-03", "Australia/Sydney");
+    expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-10-03 00:00:00");
+  });
+
+  test("non-DST-boundary date in a fixed-offset zone is the obvious instant", () => {
+    // Asia/Kolkata is a fixed UTC+5:30 zone with no DST.
+    const epoch = timezoneDayStartEpoch("2026-06-02", "Asia/Kolkata");
+    // Local midnight is 18:30 UTC the previous day.
+    expect(epoch).toBe(Date.UTC(2026, 5, 1, 18, 30, 0));
+    expect(wallClock(epoch, "Asia/Kolkata")).toBe("2026-06-02 00:00:00");
+  });
+
+  test("DST-end (fall-back) day resolves to the correct local midnight", () => {
+    // 2027-04-04 is a DST-end (fall-back) date in Sydney.
+    const epoch = timezoneDayStartEpoch("2027-04-04", "Australia/Sydney");
+    expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-04-04 00:00:00");
+  });
+
+  test("UTC date resolves to UTC midnight", () => {
+    expect(timezoneDayStartEpoch("2026-06-02", UTC)).toBe(
+      Date.UTC(2026, 5, 2, 0, 0, 0),
+    );
+  });
+});
 
 describe("resolveRangeWindow", () => {
   test("'all' returns from=0 and to=now regardless of tz", () => {


### PR DESCRIPTION
## Summary
- timezoneDayStartEpoch now resolves zone-local midnight with a two-pass technique, correct for zones whose offset differs between local- and UTC-midnight (e.g. Sydney/Auckland on DST-start dates).
- Fixes usage range buckets that previously included the prior day's final hour on DST-transition start dates.

Part of plan: fix-timezone-auto-update.md (review remediation round 2)