### PR TITLE
feat(assistant): include incognito fields in conversation API payloads

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6028,6 +6028,10 @@ paths:
                           type: number
                         inferenceProfile:
                           type: string
+                        incognito:
+                          type: boolean
+                        factorInMemories:
+                          type: boolean
                         isProcessing:
                           type: boolean
                       required:
@@ -6389,6 +6393,10 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      incognito:
+                        type: boolean
+                      factorInMemories:
+                        type: boolean
                       isProcessing:
                         type: boolean
                     required:
@@ -6587,6 +6595,10 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      incognito:
+                        type: boolean
+                      factorInMemories:
+                        type: boolean
                       isProcessing:
                         type: boolean
                     required:
@@ -7550,6 +7562,10 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      incognito:
+                        type: boolean
+                      factorInMemories:
+                        type: boolean
                       isProcessing:
                         type: boolean
                     required:

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -134,6 +134,8 @@ export const conversationSummarySchema = z.object({
   forkParent: forkParentSchema.optional(),
   archivedAt: z.number().optional(),
   inferenceProfile: z.string().optional(),
+  incognito: z.boolean().optional(),
+  factorInMemories: z.boolean().optional(),
   /**
    * True when the agent loop is currently mid-turn for this conversation.
    * Mirrors the in-memory `Conversation.isProcessing()` flag on the daemon

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -221,6 +221,9 @@ export function serializeConversationSummary(params: {
     ...(conversation.inferenceProfile != null
       ? { inferenceProfile: conversation.inferenceProfile }
       : {}),
+    ...(conversation.incognito
+      ? { incognito: true, factorInMemories: conversation.factorInMemories !== 0 }
+      : {}),
     isProcessing,
   };
 }


### PR DESCRIPTION
## Summary
- Add optional `incognito`/`factorInMemories` to the conversation summary schema + serializer (only emitted for incognito conversations)

Part of plan: incognito-conversations.md (PR 10 of 16)