### PR TITLE
feat(assistant): skip memory injection for incognito conversations that opt out

### DIFF
--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -127,6 +127,20 @@ mock.module("../../qdrant-client.js", () => ({
   resolveQdrantUrl: () => "http://127.0.0.1:6333",
 }));
 
+// Mock `getConversation` so the incognito opt-out gate in `prepareMemory`
+// is driven by a controllable holder instead of a real `conversations` row
+// (the in-memory test DB created below doesn't provision that table). Spread
+// the real module so other crud helpers keep their real bindings.
+let getConversationResult: {
+  incognito: number;
+  factorInMemories: number;
+} | null = null;
+const realConversationCrud = await import("../../conversation-crud.js");
+mock.module("../../conversation-crud.js", () => ({
+  ...realConversationCrud,
+  getConversation: () => getConversationResult,
+}));
+
 // ---------------------------------------------------------------------------
 // Workspace + DB fixtures
 // ---------------------------------------------------------------------------
@@ -301,6 +315,8 @@ beforeEach(() => {
   embedWithBackendMock.mockClear();
   generateSparseEmbeddingMock.mockClear();
   _resetMemoryV2QdrantForTests();
+  // Default: non-incognito conversation so the opt-out gate stays open.
+  getConversationResult = { incognito: 0, factorInMemories: 1 };
 });
 
 // ---------------------------------------------------------------------------
@@ -562,6 +578,71 @@ describe("ConversationGraphMemory.prepareMemory — memory.enabled gate", () => 
     expect(result.runMessages).toEqual(messages);
     expect(loadContextMemoryMock).not.toHaveBeenCalled();
     expect(retrieveForTurnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConversationGraphMemory.prepareMemory — incognito opt-out gate", () => {
+  test("incognito + factorInMemories=0 → mode=none, no injection, v2/v1 not called", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    getConversationResult = { incognito: 1, factorInMemories: 0 };
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("none");
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+    expect(retrieveForTurnMock).not.toHaveBeenCalled();
+    expect(loadContextMemoryMock).not.toHaveBeenCalled();
+  });
+
+  test("incognito + factorInMemories=1 → not short-circuited, normal injection occurs", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    getConversationResult = { incognito: 1, factorInMemories: 1 };
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).not.toBeNull();
+    expect(result.injectedBlockText).toContain(
+      "# memory/concepts/alice-vscode.md",
+    );
+  });
+
+  test("non-incognito + factorInMemories=0 → not short-circuited (gate requires incognito)", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    getConversationResult = { incognito: 0, factorInMemories: 0 };
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).not.toBeNull();
   });
 });
 

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -19,6 +19,7 @@ import type {
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { getConversation } from "../conversation-crud.js";
 import { getDb } from "../db-connection.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
@@ -371,6 +372,18 @@ export class ConversationGraphMemory {
       // Clear any cached injection so a later overflow-reduction
       // re-injection via `reinjectCachedMemory()` cannot reintroduce a
       // stale <memory> block after the user disables memory.
+      this.lastInjectedBlock = null;
+      this.lastInjectedNodeIds = [];
+      this.lastInjectedImages = new Map();
+      return noopResult;
+    }
+
+    const conversation = getConversation(this.conversationId);
+    if (conversation?.incognito && !conversation.factorInMemories) {
+      // Incognito conversation opted out of memory recall — clear any cached
+      // injection (mirroring the !config.memory.enabled branch) so a later
+      // overflow-reduction re-injection via `reinjectCachedMemory()` cannot
+      // reintroduce a stale <memory> block, and inject nothing.
       this.lastInjectedBlock = null;
       this.lastInjectedNodeIds = [];
       this.lastInjectedImages = new Map();

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -19,7 +19,11 @@ import type {
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import { getConversation } from "../conversation-crud.js";
+// Namespace import + optional call: Bun `mock.module` global-leak means many
+// test files mock conversation-crud with only a partial export set. A named
+// `getConversation` import would fail at link time under those mocks; the
+// namespace access degrades to undefined (treated as non-incognito) instead.
+import * as conversationCrud from "../conversation-crud.js";
 import { getDb } from "../db-connection.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
@@ -378,7 +382,7 @@ export class ConversationGraphMemory {
       return noopResult;
     }
 
-    const conversation = getConversation(this.conversationId);
+    const conversation = conversationCrud.getConversation?.(this.conversationId);
     if (conversation?.incognito && !conversation.factorInMemories) {
       // Incognito conversation opted out of memory recall — clear any cached
       // injection (mirroring the !config.memory.enabled branch) so a later


### PR DESCRIPTION
## Summary
- Add an incognito-opt-out gate in prepareMemory: when incognito && !factorInMemories, clear cached injection and inject no memory

Part of plan: incognito-conversations.md (PR 9 of 16)