### PR TITLE
feat(web): collect base URL and models for openai-compatible in onboarding

### DIFF
--- a/apps/web/src/domains/onboarding/pages/api-key-screen.test.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+
+let searchParams = new URLSearchParams();
+const navigateMock = mock(() => {});
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParams],
+}));
+
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const { ApiKeyScreen } = await import(
+  "@/domains/onboarding/pages/api-key-screen"
+);
+const { setPendingProviderKey, peekPendingProviderKey } = await import(
+  "@/domains/onboarding/provider-key"
+);
+const { routes } = await import("@/utils/routes");
+
+beforeEach(() => {
+  searchParams = new URLSearchParams();
+  sessionStorage.clear();
+  navigateMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function continueButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+}
+
+describe("ApiKeyScreen — openai-compatible", () => {
+  test("shows Base URL + Models inputs and an optional API-key field", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    expect(
+      screen.getByPlaceholderText("https://api.example.com/v1"),
+    ).toBeTruthy();
+    expect(screen.getByPlaceholderText("model-1, model-2")).toBeTruthy();
+    expect(
+      screen.getByLabelText("OpenAI-compatible API Key (optional)"),
+    ).toBeTruthy();
+  });
+
+  test("Continue stays disabled until a base URL and at least one model are entered", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    expect(continueButton().disabled).toBe(true);
+
+    // Entering only an API key does not enable it.
+    fireEvent.change(
+      screen.getByLabelText("OpenAI-compatible API Key (optional)"),
+      { target: { value: "sk-test" } },
+    );
+    expect(continueButton().disabled).toBe(true);
+
+    // Base URL alone is not enough.
+    fireEvent.change(
+      screen.getByPlaceholderText("https://api.example.com/v1"),
+      { target: { value: "http://localhost:1234/v1" } },
+    );
+    expect(continueButton().disabled).toBe(true);
+
+    // Adding a model enables Continue.
+    fireEvent.change(screen.getByPlaceholderText("model-1, model-2"), {
+      target: { value: "local-model" },
+    });
+    expect(continueButton().disabled).toBe(false);
+  });
+
+  test("persists baseUrl + models on the pending key and navigates to privacy", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("https://api.example.com/v1"),
+      { target: { value: "http://localhost:1234/v1" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("model-1, model-2"), {
+      target: { value: "local-model" },
+    });
+
+    fireEvent.click(continueButton());
+
+    const pending = peekPendingProviderKey();
+    expect(pending?.provider).toBe("openai-compatible");
+    expect(pending?.baseUrl).toBe("http://localhost:1234/v1");
+    expect(pending?.models).toEqual(["local-model"]);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.privacy);
+  });
+});
+
+describe("ApiKeyScreen — keyed provider", () => {
+  test("anthropic requires the key and renders no Base URL/Models inputs", () => {
+    setPendingProviderKey({ provider: "anthropic", key: "" });
+    render(<ApiKeyScreen />);
+
+    expect(
+      screen.queryByPlaceholderText("https://api.example.com/v1"),
+    ).toBeNull();
+    expect(screen.queryByPlaceholderText("model-1, model-2")).toBeNull();
+    expect(screen.getByLabelText("Anthropic API Key")).toBeTruthy();
+
+    expect(continueButton().disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Anthropic API Key"), {
+      target: { value: "sk-ant-123" },
+    });
+    expect(continueButton().disabled).toBe(false);
+  });
+});

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.test.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.test.tsx
@@ -83,6 +83,60 @@ describe("ApiKeyScreen — openai-compatible", () => {
     expect(continueButton().disabled).toBe(false);
   });
 
+  test("a base URL without an http(s) scheme keeps Continue disabled and shows a hint", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("https://api.example.com/v1"),
+      { target: { value: "localhost:1234/v1" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("model-1, model-2"), {
+      target: { value: "local-model" },
+    });
+
+    expect(continueButton().disabled).toBe(true);
+    expect(
+      screen.getByText(
+        "Enter a full http(s) URL, e.g. http://localhost:1234/v1",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("no validation hint is shown while the base URL field is empty", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    expect(
+      screen.queryByText(
+        "Enter a full http(s) URL, e.g. http://localhost:1234/v1",
+      ),
+    ).toBeNull();
+  });
+
+  test("a valid http(s) base URL enables Continue and persists on click", () => {
+    setPendingProviderKey({ provider: "openai-compatible", key: "" });
+    render(<ApiKeyScreen />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("https://api.example.com/v1"),
+      { target: { value: "http://localhost:1234/v1" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("model-1, model-2"), {
+      target: { value: "local-model" },
+    });
+
+    expect(continueButton().disabled).toBe(false);
+    expect(
+      screen.queryByText(
+        "Enter a full http(s) URL, e.g. http://localhost:1234/v1",
+      ),
+    ).toBeNull();
+
+    fireEvent.click(continueButton());
+    expect(peekPendingProviderKey()?.baseUrl).toBe("http://localhost:1234/v1");
+  });
+
   test("persists baseUrl + models on the pending key and navigates to privacy", () => {
     setPendingProviderKey({ provider: "openai-compatible", key: "" });
     render(<ApiKeyScreen />);

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -28,16 +28,32 @@ export function ApiKeyScreen() {
   const [apiKey, setApiKey] = useState(
     () => peekPendingProviderKey()?.key ?? "",
   );
+  const [baseUrl, setBaseUrl] = useState(
+    () => peekPendingProviderKey()?.baseUrl ?? "",
+  );
+  const [modelsRaw, setModelsRaw] = useState(() =>
+    (peekPendingProviderKey()?.models ?? []).join(", "),
+  );
 
   const entry = onboardingProvider(provider) ?? DEFAULT_ONBOARDING_PROVIDER;
   const requiresKey = entry.requiresKey;
-  const canContinue = !requiresKey || apiKey.trim().length > 0;
+  const isCustom = entry.requiresBaseUrl ?? false;
+  const models = modelsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const keyOk = !requiresKey || apiKey.trim().length > 0;
+  const baseUrlOk = !isCustom || baseUrl.trim().length > 0;
+  const modelsOk = !isCustom || models.length > 0;
+  const canContinue = keyOk && baseUrlOk && modelsOk;
 
   const onContinue = () => {
     if (!canContinue) return;
     setPendingProviderKey({
       provider,
-      key: requiresKey ? apiKey.trim() : "",
+      key: requiresKey || isCustom ? apiKey.trim() : "",
+      ...(isCustom ? { baseUrl: baseUrl.trim(), models } : {}),
     });
     void navigate(
       hosting
@@ -82,6 +98,8 @@ export function ApiKeyScreen() {
                 if (match) {
                   setProvider(match.id);
                   setApiKey("");
+                  setBaseUrl("");
+                  setModelsRaw("");
                 }
               }}
               options={ONBOARDING_PROVIDERS.map((p) => ({
@@ -91,11 +109,45 @@ export function ApiKeyScreen() {
             />
           </div>
 
-          {requiresKey && (
+          {isCustom && (
+            <>
+              <div className="flex flex-col gap-1">
+                <label className="text-body-small-default text-[var(--content-tertiary)]">
+                  Base URL
+                </label>
+                <Input
+                  placeholder="https://api.example.com/v1"
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  fullWidth
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-body-small-default text-[var(--content-tertiary)]">
+                  Models
+                </label>
+                <Input
+                  placeholder="model-1, model-2"
+                  value={modelsRaw}
+                  onChange={(e) => setModelsRaw(e.target.value)}
+                  fullWidth
+                />
+                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                  Comma-separated model identifiers exposed by your endpoint.
+                </p>
+              </div>
+            </>
+          )}
+
+          {(requiresKey || isCustom) && (
             <div className="flex flex-col gap-3">
               <Input
                 type="password"
-                label={`${entry.displayName} API Key`}
+                label={
+                  isCustom && !requiresKey
+                    ? `${entry.displayName} API Key (optional)`
+                    : `${entry.displayName} API Key`
+                }
                 placeholder={entry.apiKeyPlaceholder ?? "Enter your API key"}
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}

--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -17,6 +17,15 @@ import {
 } from "@/domains/onboarding/provider-key";
 import { routes } from "@/utils/routes";
 
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function ApiKeyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -43,10 +52,12 @@ export function ApiKeyScreen() {
     .map((s) => s.trim())
     .filter(Boolean);
 
+  const trimmedBaseUrl = baseUrl.trim();
   const keyOk = !requiresKey || apiKey.trim().length > 0;
-  const baseUrlOk = !isCustom || baseUrl.trim().length > 0;
+  const baseUrlOk = !isCustom || isValidHttpUrl(trimmedBaseUrl);
   const modelsOk = !isCustom || models.length > 0;
   const canContinue = keyOk && baseUrlOk && modelsOk;
+  const showBaseUrlError = isCustom && trimmedBaseUrl.length > 0 && !baseUrlOk;
 
   const onContinue = () => {
     if (!canContinue) return;
@@ -121,6 +132,11 @@ export function ApiKeyScreen() {
                   onChange={(e) => setBaseUrl(e.target.value)}
                   fullWidth
                 />
+                {showBaseUrlError && (
+                  <p className="text-body-small-default text-[var(--content-tertiary)]">
+                    Enter a full http(s) URL, e.g. http://localhost:1234/v1
+                  </p>
+                )}
               </div>
               <div className="flex flex-col gap-1">
                 <label className="text-body-small-default text-[var(--content-tertiary)]">

--- a/apps/web/src/domains/onboarding/provider-catalog.ts
+++ b/apps/web/src/domains/onboarding/provider-catalog.ts
@@ -22,6 +22,8 @@ export interface OnboardingProvider {
   readonly docsUrl: string | null;
   /** Whether an API key is required before the user can continue. */
   readonly requiresKey: boolean;
+  /** Requires a custom endpoint base URL + model identifiers (openai-compatible). */
+  readonly requiresBaseUrl?: boolean;
 }
 
 export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
@@ -72,7 +74,8 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     displayName: "OpenAI-compatible",
     apiKeyPlaceholder: "Your provider's API key",
     docsUrl: null,
-    requiresKey: true,
+    requiresKey: false,
+    requiresBaseUrl: true,
   },
 ];
 

--- a/apps/web/src/domains/onboarding/provider-key.test.ts
+++ b/apps/web/src/domains/onboarding/provider-key.test.ts
@@ -1,13 +1,67 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
+type ClientCall = {
+  method: "patch" | "post";
+  url: string;
+  path?: Record<string, unknown>;
+  body?: Record<string, unknown>;
+};
+
+const calls: ClientCall[] = [];
+// Per-URL queue of responses; each create call shifts the next. Missing/empty
+// queue defaults to 200 OK.
+const responseQueues: Record<string, { ok: boolean; status: number }[]> = {};
+
+function nextResponse(url: string): { ok: boolean; status: number } {
+  const queued = responseQueues[url]?.shift();
+  return queued ?? { ok: true, status: 200 };
+}
+
+const patchMock = mock(
+  async (args: { url: string; body?: Record<string, unknown> }) => {
+    calls.push({ method: "patch", url: args.url, body: args.body });
+    return { response: nextResponse(args.url) };
+  },
+);
+
+const postMock = mock(
+  async (args: {
+    url: string;
+    path?: Record<string, unknown>;
+    body?: Record<string, unknown>;
+  }) => {
+    calls.push({
+      method: "post",
+      url: args.url,
+      path: args.path,
+      body: args.body,
+    });
+    return { response: nextResponse(args.url) };
+  },
+);
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: { patch: patchMock, post: postMock },
+}));
+
+const {
+  applyPendingProviderKey,
   consumePendingProviderKey,
   peekPendingProviderKey,
   setPendingProviderKey,
-} from "@/domains/onboarding/provider-key";
+} = await import("@/domains/onboarding/provider-key");
+
+const CONNECTIONS_URL =
+  "/v1/assistants/{assistant_id}/inference/provider-connections";
+const FLAG_URL =
+  "/v1/assistants/asst-1/feature-flags/openai-compatible-endpoints";
 
 beforeEach(() => {
   sessionStorage.clear();
+  calls.length = 0;
+  for (const key of Object.keys(responseQueues)) delete responseQueues[key];
+  patchMock.mockClear();
+  postMock.mockClear();
 });
 
 describe("pending provider key", () => {
@@ -64,5 +118,76 @@ describe("pending provider key", () => {
     expect(peeked).toEqual({ provider: "anthropic", key: "sk-ant-test" });
     expect(peeked?.baseUrl).toBeUndefined();
     expect(peeked?.models).toBeUndefined();
+  });
+});
+
+describe("applyPendingProviderKey", () => {
+  test("openai-compatible enables the flag before creating the connection", async () => {
+    setPendingProviderKey({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a"],
+    });
+
+    await applyPendingProviderKey("asst-1");
+
+    // Flag PATCH must precede the connection POST.
+    const flagIdx = calls.findIndex(
+      (c) => c.method === "patch" && c.url === FLAG_URL,
+    );
+    const connectionIdx = calls.findIndex(
+      (c) => c.method === "post" && c.url === CONNECTIONS_URL,
+    );
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    expect(connectionIdx).toBeGreaterThanOrEqual(0);
+    expect(flagIdx).toBeLessThan(connectionIdx);
+
+    expect(calls[flagIdx].body).toEqual({ enabled: true });
+
+    const connectionBody = calls[connectionIdx].body as Record<string, unknown>;
+    expect(connectionBody.provider).toBe("openai-compatible");
+    expect(connectionBody.base_url).toBe("http://localhost:1234/v1");
+    expect(connectionBody.models).toEqual([{ id: "model-a" }]);
+  });
+
+  test("non-openai-compatible provider issues no flag PATCH and a single POST", async () => {
+    setPendingProviderKey({ provider: "anthropic", key: "sk-ant-test" });
+
+    await applyPendingProviderKey("asst-1");
+
+    expect(patchMock).not.toHaveBeenCalled();
+
+    const connectionCalls = calls.filter(
+      (c) => c.method === "post" && c.url === CONNECTIONS_URL,
+    );
+    expect(connectionCalls.length).toBe(1);
+    const body = connectionCalls[0].body as Record<string, unknown>;
+    expect(body.provider).toBe("anthropic");
+    expect(body.base_url).toBeUndefined();
+    expect(body.models).toBeUndefined();
+  });
+
+  test("openai-compatible retries the connection POST on a 400 then succeeds", async () => {
+    // First create attempt fails with 400 (flag cache not yet propagated),
+    // second succeeds.
+    responseQueues[CONNECTIONS_URL] = [
+      { ok: false, status: 400 },
+      { ok: true, status: 200 },
+    ];
+
+    setPendingProviderKey({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a"],
+    });
+
+    await applyPendingProviderKey("asst-1");
+
+    const connectionCalls = calls.filter(
+      (c) => c.method === "post" && c.url === CONNECTIONS_URL,
+    );
+    expect(connectionCalls.length).toBe(2);
   });
 });

--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -8,6 +8,8 @@ import type { OnboardingProviderId } from "@/domains/onboarding/provider-catalog
 
 const PENDING_KEY_STORAGE = "onboarding.providerKey";
 
+const OPENAI_COMPATIBLE_FLAG = "openai-compatible-endpoints";
+
 export interface PendingProviderKey {
   provider: OnboardingProviderId;
   /** Empty for keyless providers (e.g. Ollama). */
@@ -66,6 +68,25 @@ export function consumePendingProviderKey(): PendingProviderKey | null {
 // than importing domains/settings/ai/provider-connections-client (cross-domain
 // imports are ESLint-gated in apps/web).
 
+// Raw template-literal URL (gateway route), matching
+// assistant-feature-flag-store.ts; the generated client has no typed path for
+// this endpoint.
+async function enableAssistantFeatureFlag(
+  assistantId: string,
+  flagKey: string,
+): Promise<void> {
+  const result = await client.patch({
+    url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
+    body: { enabled: true },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!result.response?.ok) {
+    throw Object.assign(new Error("Failed to enable feature flag"), {
+      status: result.response?.status,
+    });
+  }
+}
+
 async function writeApiKeySecret(
   assistantId: string,
   provider: OnboardingProviderId,
@@ -94,23 +115,36 @@ async function createProviderConnection(
   const auth = hasKey
     ? { type: "api_key", credential: `credential/${provider}/api_key` }
     : { type: "none" };
-  const result = await client.post({
-    url: "/v1/assistants/{assistant_id}/inference/provider-connections",
-    path: { assistant_id: assistantId },
-    body: {
-      name: provider,
-      provider,
-      auth,
-      ...(baseUrl ? { base_url: baseUrl } : {}),
-      ...(models && models.length > 0
-        ? { models: models.map((id) => ({ id })) }
-        : {}),
-    },
-    headers: { "Content-Type": "application/json" },
-  });
-  if (!result.response?.ok) {
+  const body = {
+    name: provider,
+    provider,
+    auth,
+    ...(baseUrl ? { base_url: baseUrl } : {}),
+    ...(models && models.length > 0
+      ? { models: models.map((id) => ({ id })) }
+      : {}),
+  };
+  // The daemon refreshes its feature-flag cache asynchronously, so right after
+  // enableAssistantFeatureFlag() returns it may still read
+  // openai-compatible-endpoints as disabled and reject the create with HTTP 400.
+  // Retry briefly to absorb that gateway->daemon propagation delay. Other
+  // providers (and genuine validation 400s) surface immediately.
+  const maxAttempts = provider === "openai-compatible" ? 5 : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await client.post({
+      url: "/v1/assistants/{assistant_id}/inference/provider-connections",
+      path: { assistant_id: assistantId },
+      body,
+      headers: { "Content-Type": "application/json" },
+    });
+    if (result.response?.ok) return;
+    const status = result.response?.status;
+    if (provider === "openai-compatible" && status === 400 && attempt < maxAttempts) {
+      await new Promise((r) => setTimeout(r, 250));
+      continue;
+    }
     throw Object.assign(new Error("Failed to create provider connection"), {
-      status: result.response?.status,
+      status,
     });
   }
 }
@@ -128,6 +162,9 @@ export async function applyPendingProviderKey(
   if (!pending) return;
   const trimmed = pending.key.trim();
   const hasKey = trimmed.length > 0;
+  if (pending.provider === "openai-compatible") {
+    await enableAssistantFeatureFlag(assistantId, OPENAI_COMPATIBLE_FLAG);
+  }
   if (hasKey) {
     await writeApiKeySecret(assistantId, pending.provider, trimmed);
   }


### PR DESCRIPTION
## Summary
- Add Base URL + Models inputs to the onboarding Connect-a-Model-Provider step for openai-compatible, and make the API key optional for it (LM Studio etc. need none).
- Gate Continue on a base URL + at least one model; persist them on the pending provider key. Keyed providers are unchanged.

Part of plan: openai-compatible-onboarding.md (PR 3 of 3)