### PR TITLE
fix(web): return first valid instant when local midnight is skipped by DST (P1)

### DIFF
--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -37,6 +37,25 @@ export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
     const observed = zonedWallClockEpoch(new Date(guess), tz);
     guess -= observed - desired;
   }
+
+  // Nonexistent-midnight (spring-forward) gap: some zones advance the clock
+  // *at* local midnight (e.g. America/Santiago), so the wall time 00:00:00
+  // never occurs on `dateStr`. The two-pass convergence then lands on the
+  // last pre-gap instant, which still belongs to the *previous* local date.
+  // Detect that by re-formatting the guess in `tz`: if its calendar date is
+  // earlier than `dateStr`, midnight was skipped. The correct answer is the
+  // first valid instant on `dateStr` — i.e. the moment the clock jumps
+  // forward — so advance the guess by the gap size (the offset jump across
+  // the transition), which lands exactly on the post-transition wall clock.
+  if (toTimezoneDateString(new Date(guess), tz) < dateStr) {
+    const offsetBefore = zonedWallClockEpoch(new Date(guess), tz) - guess;
+    const afterGap = guess + 60 * 60 * 1000;
+    const offsetAfter = zonedWallClockEpoch(new Date(afterGap), tz) - afterGap;
+    // gapMs is positive (typically one hour); adding it skips the missing
+    // local hour and lands on the first instant whose wall clock is `dateStr`.
+    const gapMs = offsetAfter - offsetBefore;
+    guess += gapMs;
+  }
   return guess;
 }
 

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -48,6 +48,22 @@ describe("timezoneDayStartEpoch", () => {
     expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-04-04 00:00:00");
   });
 
+  test("spring-forward that skips local midnight resolves to the first valid instant", () => {
+    // 2026-09-06 is a DST-start date in Santiago where the clock jumps from
+    // 23:59:59 (Sep 5) straight to 01:00:00 (Sep 6): local midnight never
+    // exists. The two-pass guess lands on 2026-09-05 23:00 (prior day); the
+    // gap fix must instead return the first valid instant ON 2026-09-06.
+    const epoch = timezoneDayStartEpoch("2026-09-06", "America/Santiago");
+    // First valid local time on the requested date is 01:00:00.
+    expect(wallClock(epoch, "America/Santiago")).toBe("2026-09-06 01:00:00");
+    // The formatted calendar date is the requested date, not the prior day.
+    expect(toTimezoneDateString(new Date(epoch), "America/Santiago")).toBe(
+      "2026-09-06",
+    );
+    // And the instant is at/after the transition (not before it).
+    expect(epoch).toBe(Date.UTC(2026, 8, 6, 4, 0, 0));
+  });
+
   test("UTC date resolves to UTC midnight", () => {
     expect(timezoneDayStartEpoch("2026-06-02", UTC)).toBe(
       Date.UTC(2026, 5, 2, 0, 0, 0),


### PR DESCRIPTION
## Summary
- timezoneDayStartEpoch now detects nonexistent local midnight (spring-forward over 00:00, e.g. America/Santiago) and returns the first valid instant ON the requested date, instead of landing on the prior day's final hour.
- Preserves correct behavior for normal and fall-back days.

Part of plan: fix-timezone-auto-update.md (review remediation round 3)