### PR TITLE
fix: upload skill assets to dev, staging, and production

### DIFF
--- a/.github/workflows/upload-skill-assets.yaml
+++ b/.github/workflows/upload-skill-assets.yaml
@@ -9,9 +9,13 @@ on:
 
 jobs:
   upload:
-    name: Upload skill assets
+    name: Upload skill assets (${{ matrix.environment }})
     runs-on: ubuntu-latest
-    environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, staging, production]
+    environment: ${{ matrix.environment }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Adds a matrix strategy to the upload-skill-assets workflow so icons are uploaded to all three GCS buckets (dev, staging, production) instead of only production

🤖 Generated with [Claude Code](https://claude.com/claude-code)