### PR TITLE
Fix timezones not auto-updating when switching between timezones

### DIFF
--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -16,7 +16,12 @@ export interface DateRange {
 
 interface DateRangeSelectProps {
   readonly value: DateRange;
-  readonly onChange: (range: DateRange) => void;
+  /**
+   * Called when the user picks a preset. Emits both the computed range and the
+   * preset identity (`days`) so consumers can persist the active preset and
+   * recompute its bounds on a timezone change without reverse-matching.
+   */
+  readonly onChange: (range: DateRange, presetDays: number) => void;
 }
 
 /**
@@ -25,6 +30,9 @@ interface DateRangeSelectProps {
  * preset is active when the effective timezone changes.
  */
 export const PRESET_DAYS = [7, 30, 90] as const;
+
+/** Preset selected by default (matches the "Last 30 days" billing default). */
+export const DEFAULT_PRESET_DAYS = 30;
 
 type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
 
@@ -59,18 +67,30 @@ function daysBetween(from: string, to: string): number {
   return Math.round((toDate.getTime() - fromDate.getTime()) / msPerDay) + 1;
 }
 
+/**
+ * Map a range's span to the preset identity (`days`) this control would show
+ * for it, defaulting to `DEFAULT_PRESET_DAYS` for any span that isn't 7 or 90.
+ * Shared so consumers can derive the active preset with the same rule the
+ * dropdown uses for its selected option.
+ */
+export function presetDaysFromRange({ from, to }: DateRange): number {
+  const days = daysBetween(from, to);
+  if (days === 7) return 7;
+  if (days === 90) return 90;
+  return DEFAULT_PRESET_DAYS;
+}
+
 export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   const tz = useEffectiveTimezone();
 
-  const selectedPreset = useMemo<PresetDays>(() => {
-    const days = daysBetween(value.from, value.to);
-    if (days === 7) return "7";
-    if (days === 90) return "90";
-    return "30";
-  }, [value.from, value.to]);
+  const selectedPreset = useMemo<PresetDays>(
+    () => `${presetDaysFromRange(value)}` as PresetDays,
+    [value],
+  );
 
   const handleChange = (preset: PresetDays) => {
-    onChange(computeRangeInTimezone(Number(preset), tz));
+    const days = Number(preset);
+    onChange(computeRangeInTimezone(days, tz), days);
   };
 
   return (

--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -19,13 +19,18 @@ interface DateRangeSelectProps {
   readonly onChange: (range: DateRange) => void;
 }
 
-type PresetDays = "7" | "30" | "90";
+/**
+ * Single source of truth for the relative presets this control exposes. Other
+ * modules (e.g. billing reconciliation) iterate this to recompute whichever
+ * preset is active when the effective timezone changes.
+ */
+export const PRESET_DAYS = [7, 30, 90] as const;
 
-const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = [
-  { value: "7", label: "Last 7 days" },
-  { value: "30", label: "Last 30 days" },
-  { value: "90", label: "Last 90 days" },
-];
+type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
+
+const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = PRESET_DAYS.map(
+  (days) => ({ value: `${days}`, label: `Last ${days} days` }),
+);
 
 /**
  * Compute a "last N days" range whose calendar bounds are expressed in the

--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -5,7 +5,9 @@ import {
   type DropdownOption,
 } from "@vellum/design-library/components/dropdown";
 
-import { toLocalDateString } from "@/components/charts/format-date-label";
+import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export interface DateRange {
   readonly from: string;
@@ -25,14 +27,24 @@ const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> = [
   { value: "90", label: "Last 90 days" },
 ];
 
-function computeRange(days: number): DateRange {
-  const today = new Date();
-  const from = new Date(today);
-  from.setDate(today.getDate() - (days - 1));
-  return {
-    from: toLocalDateString(from),
-    to: toLocalDateString(today),
-  };
+/**
+ * Compute a "last N days" range whose calendar bounds are expressed in the
+ * given IANA timezone, so they stay aligned with the `tz` sent to the backend.
+ *
+ * "Today" is the calendar date in `tz`; the lower bound is that date minus
+ * `days - 1`. Day arithmetic runs on a UTC date anchored at noon to avoid DST
+ * edge slips when subtracting whole days.
+ */
+export function computeRangeInTimezone(
+  days: number,
+  tz: string = getEffectiveTimezone(),
+): DateRange {
+  const to = toTimezoneDateString(new Date(), tz);
+  const [y, m, d] = to.split("-").map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - (days - 1));
+  const from = toTimezoneDateString(anchor, "UTC");
+  return { from, to };
 }
 
 function daysBetween(from: string, to: string): number {
@@ -43,6 +55,8 @@ function daysBetween(from: string, to: string): number {
 }
 
 export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
+  const tz = useEffectiveTimezone();
+
   const selectedPreset = useMemo<PresetDays>(() => {
     const days = daysBetween(value.from, value.to);
     if (days === 7) return "7";
@@ -51,7 +65,7 @@ export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   }, [value.from, value.to]);
 
   const handleChange = (preset: PresetDays) => {
-    onChange(computeRange(Number(preset)));
+    onChange(computeRangeInTimezone(Number(preset), tz));
   };
 
   return (

--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -7,16 +7,6 @@ export function formatDateLabel(dateStr: string): string {
 }
 
 /**
- * Format a `Date` as a "YYYY-MM-DD" string using local time.
- */
-export function toLocalDateString(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-/**
  * Format a `Date` as a "YYYY-MM-DD" string representing the calendar date in
  * the given IANA timezone. `en-CA` yields ISO-like `YYYY-MM-DD` output.
  */
@@ -27,4 +17,45 @@ export function toTimezoneDateString(d: Date, tz: string): string {
     month: "2-digit",
     day: "2-digit",
   }).format(d);
+}
+
+/**
+ * Epoch ms for the start of the calendar day `dateStr` ("YYYY-MM-DD") as it
+ * occurs in the given IANA timezone — i.e. zone-local midnight. DST-safe:
+ * derives the zone's UTC offset at that instant and subtracts it, so the
+ * returned epoch maps back to 00:00 wall-clock in `tz`.
+ */
+export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  // Provisional UTC midnight, then correct by the zone offset observed there.
+  const utcMidnight = Date.UTC(y, m - 1, d);
+  const offsetMs = utcMidnight - zonedWallClockEpoch(new Date(utcMidnight), tz);
+  return utcMidnight + offsetMs;
+}
+
+/**
+ * Interpret the wall-clock time that `instant` shows in `tz` as if it were UTC,
+ * returning that as epoch ms. Used to recover a zone's UTC offset.
+ */
+function zonedWallClockEpoch(instant: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(instant);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+  return Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
 }

--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -22,20 +22,28 @@ export function toTimezoneDateString(d: Date, tz: string): string {
 /**
  * Epoch ms for the start of the calendar day `dateStr` ("YYYY-MM-DD") as it
  * occurs in the given IANA timezone — i.e. zone-local midnight. DST-safe:
- * derives the zone's UTC offset at that instant and subtracts it, so the
- * returned epoch maps back to 00:00 wall-clock in `tz`.
+ * resolves the zone-local wall clock 00:00:00 to its UTC instant via a
+ * two-pass technique, so it stays correct even on DST-transition days where
+ * the zone's offset differs between local- and UTC-midnight.
  */
 export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  // Provisional UTC midnight, then correct by the zone offset observed there.
-  const utcMidnight = Date.UTC(y, m - 1, d);
-  const offsetMs = utcMidnight - zonedWallClockEpoch(new Date(utcMidnight), tz);
-  return utcMidnight + offsetMs;
+  // Desired wall clock, scalarized by treating its Y-M-D-H-M-S as if UTC.
+  const desired = Date.parse(dateStr + "T00:00:00Z");
+  // First guess: interpret the desired wall clock as if it were UTC, then
+  // correct by the offset between the wall clock `guess` actually shows in
+  // `tz` and the desired one. A second pass converges DST-boundary days.
+  let guess = desired;
+  for (let pass = 0; pass < 2; pass++) {
+    const observed = zonedWallClockEpoch(new Date(guess), tz);
+    guess -= observed - desired;
+  }
+  return guess;
 }
 
 /**
- * Interpret the wall-clock time that `instant` shows in `tz` as if it were UTC,
- * returning that as epoch ms. Used to recover a zone's UTC offset.
+ * Read the wall clock that `instant` shows in `tz` and scalarize it by
+ * treating its Y-M-D-H-M-S as if UTC, returning that as epoch ms. Used to
+ * compare an observed wall clock against a desired one.
  */
 function zonedWallClockEpoch(instant: Date, tz: string): number {
   const parts = new Intl.DateTimeFormat("en-US", {

--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -15,3 +15,16 @@ export function toLocalDateString(d: Date): string {
   const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
 }
+
+/**
+ * Format a `Date` as a "YYYY-MM-DD" string representing the calendar date in
+ * the given IANA timezone. `en-CA` yields ISO-like `YYYY-MM-DD` output.
+ */
+export function toTimezoneDateString(d: Date, tz: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}

--- a/apps/web/src/components/charts/format-date-label.ts
+++ b/apps/web/src/components/charts/format-date-label.ts
@@ -37,6 +37,25 @@ export function timezoneDayStartEpoch(dateStr: string, tz: string): number {
     const observed = zonedWallClockEpoch(new Date(guess), tz);
     guess -= observed - desired;
   }
+
+  // Nonexistent-midnight (spring-forward) gap: some zones advance the clock
+  // *at* local midnight (e.g. America/Santiago), so the wall time 00:00:00
+  // never occurs on `dateStr`. The two-pass convergence then lands on the
+  // last pre-gap instant, which still belongs to the *previous* local date.
+  // Detect that by re-formatting the guess in `tz`: if its calendar date is
+  // earlier than `dateStr`, midnight was skipped. The correct answer is the
+  // first valid instant on `dateStr` — i.e. the moment the clock jumps
+  // forward — so advance the guess by the gap size (the offset jump across
+  // the transition), which lands exactly on the post-transition wall clock.
+  if (toTimezoneDateString(new Date(guess), tz) < dateStr) {
+    const offsetBefore = zonedWallClockEpoch(new Date(guess), tz) - guess;
+    const afterGap = guess + 60 * 60 * 1000;
+    const offsetAfter = zonedWallClockEpoch(new Date(afterGap), tz) - afterGap;
+    // gapMs is positive (typically one hour); adding it skips the missing
+    // local hour and lands on the first instant whose wall clock is `dateStr`.
+    const gapMs = offsetAfter - offsetBefore;
+    guess += gapMs;
+  }
   return guess;
 }
 

--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,12 +1,12 @@
 /**
  * Tests for the headless `TimezoneSync` component.
  *
- * Strategy: mock the generated API client's `patch`, the browser-zone and
- * device-setting readers (separately), and the effective-timezone hook
- * (the reactivity trigger), drive the active assistant id through the real
- * selection store, and assert the PATCH writes both `detectedTimezone`
- * (browser zone) and `userTimezone` (override or "") and never persists a
- * stale zone when requests overlap.
+ * Strategy: mock the generated API client's `patch`, the browser-zone reader,
+ * and the effective-timezone hook (the reactivity trigger), drive the active
+ * assistant id through the real selection store, and assert the PATCH writes
+ * ONLY `detectedTimezone` (the live browser zone) and NEVER `userTimezone`,
+ * that writes are serialized (no two PATCHes in flight at once), and that the
+ * final write always reflects the newest zone when triggers overlap.
  */
 import {
   afterEach,
@@ -29,26 +29,19 @@ interface PatchArgs {
   body: { ui: Record<string, unknown> };
 }
 
-// Mutable separate readers; tests flip them then re-render. `browserTz`
-// is the live auto zone; `override` is the manual `device:timezone`.
+// Mutable browser zone; tests flip it then re-render.
 let browserTz = "America/New_York";
-let override = "";
 const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
 const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
 
-// The hook is just a reactivity trigger; it folds override over browser
-// zone (matching the real implementation) so a flip of either re-renders.
+// The hook is just a reactivity trigger; it tracks the browser zone so a flip
+// re-renders.
 mock.module("@/utils/use-effective-timezone", () => ({
-  useEffectiveTimezone: () => (override.trim() ? override.trim() : browserTz),
+  useEffectiveTimezone: () => browserTz,
 }));
 
 mock.module("@/utils/browser-timezone", () => ({
   getBrowserTimezone: () => browserTz,
-}));
-
-mock.module("@/utils/device-settings", () => ({
-  getDeviceSetting: (_name: string, fallback: string) =>
-    override === "" ? fallback : override,
 }));
 
 mock.module("@/generated/api/client.gen", () => ({
@@ -73,7 +66,6 @@ function renderSync() {
 
 beforeEach(() => {
   browserTz = "America/New_York";
-  override = "";
   patchMock.mockClear();
   captureErrorMock.mockClear();
   patchMock.mockImplementation(async () => ({ data: {} }));
@@ -90,36 +82,20 @@ function lastBody() {
 }
 
 describe("TimezoneSync", () => {
-  test("PATCHes both fields once on mount in auto mode (userTimezone cleared)", async () => {
+  test("PATCHes only detectedTimezone on mount; never sends userTimezone", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
     const call = patchMock.mock.calls[0]![0];
     expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
     expect(call.path).toEqual({ assistant_id: "asst-1" });
-    expect(call.body).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    // Explicitly assert userTimezone is never part of any PATCH body.
+    for (const c of patchMock.mock.calls) {
+      expect(c[0].body.ui).not.toHaveProperty("userTimezone");
+    }
   });
 
-  test("manual override is written to userTimezone; detectedTimezone carries the live browser zone", async () => {
-    override = "Asia/Tokyo";
-    renderSync();
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
-    });
-  });
-
-  test("trims the override before writing userTimezone", async () => {
-    override = "  Asia/Tokyo  ";
-    renderSync();
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
-    });
-  });
-
-  test("a browser-zone change triggers exactly one additional PATCH with the new zone", async () => {
+  test("a browser-zone change triggers exactly one additional PATCH with the new zone (no userTimezone)", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
@@ -127,9 +103,7 @@ describe("TimezoneSync", () => {
     rerender(<TimezoneSync />);
 
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "Europe/London", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
   });
 
   test("no additional PATCH when nothing changed across re-renders (redundant-key dedupe)", async () => {
@@ -174,9 +148,7 @@ describe("TimezoneSync", () => {
     browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("retries on app.resume with the same zone after a failed initial sync", async () => {
@@ -189,9 +161,7 @@ describe("TimezoneSync", () => {
 
     publish("app.resume", { signal: "visibility" });
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("retries on window focus with the same zone after a failed initial sync", async () => {
@@ -204,9 +174,7 @@ describe("TimezoneSync", () => {
 
     window.dispatchEvent(new Event("focus"));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 
   test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
@@ -220,10 +188,12 @@ describe("TimezoneSync", () => {
     expect(patchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("last-writer-wins: a slow older PATCH cannot overwrite a newer zone", async () => {
-    // Two overlapping triggers; the FIRST (older zone) resolves AFTER the
-    // SECOND (newer zone). The final synced state must reflect the newer
-    // zone, and the stale older completion must not re-open it for resync.
+  test("serializes PATCHes (last-writer-wins): newer zone is the final write, no overlap", async () => {
+    // The first PATCH (older zone) is held pending while the zone flips. The
+    // serializer must NOT start a second PATCH while the first is in flight;
+    // the newer zone is queued and fired only after the first settles, so the
+    // FINAL server write reflects the newer zone — even if the first promise
+    // resolves after the newer target arrives.
     const resolvers: Array<() => void> = [];
     patchMock.mockImplementation(
       () =>
@@ -235,31 +205,37 @@ describe("TimezoneSync", () => {
     const { rerender } = renderSync();
     // First PATCH issued (mount) for America/New_York; still pending.
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
 
-    // Zone flips before the first request settles → second PATCH issued.
+    // Zone flips before the first request settles. NO second PATCH yet — the
+    // first is still in flight, so only ONE PATCH is ever in flight at once.
     browserTz = "Europe/London";
     rerender(<TimezoneSync />);
-    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(resolvers).toHaveLength(1);
 
-    expect(resolvers).toHaveLength(2);
-    // Newer request resolves first, then the stale older one resolves last.
-    resolvers[1]!();
+    // First (older) PATCH settles → queue drains and fires the newer zone.
     resolvers[0]!();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+    expect(resolvers).toHaveLength(2);
+
+    // Second (newer) PATCH settles → that is now the synced state.
+    resolvers[1]!();
     await new Promise((r) => setTimeout(r, 10));
 
-    // The newer zone is the synced state: re-rendering with Europe/London
-    // (the latest issued key) must NOT trigger a redundant PATCH...
+    // Re-rendering at the newer zone must NOT trigger a redundant PATCH...
     rerender(<TimezoneSync />);
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(2);
 
-    // ...and flipping back to the older zone DOES PATCH (so the stale
-    // completion never recorded America/New_York as the synced key).
+    // ...and flipping back to the older zone DOES PATCH (the older zone was
+    // never recorded as the synced key).
     browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({
-      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
-    });
+    resolvers[2]!();
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
   });
 });

--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for the headless `TimezoneSync` component.
  *
- * Strategy: mock the generated API client's `patch` and the effective-
- * timezone hook, drive the active assistant id through the real
- * selection store, and assert the PATCH fires only for genuinely new
- * `{ ui: { detectedTimezone } }` values.
+ * Strategy: mock the generated API client's `patch`, the browser-zone and
+ * device-setting readers (separately), and the effective-timezone hook
+ * (the reactivity trigger), drive the active assistant id through the real
+ * selection store, and assert the PATCH writes both `detectedTimezone`
+ * (browser zone) and `userTimezone` (override or "") and never persists a
+ * stale zone when requests overlap.
  */
 import {
   afterEach,
@@ -21,25 +23,32 @@ import type { ReactNode } from "react";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { publish } from "@/lib/event-bus";
 
-// Mutable zone returned by the mocked hook; tests flip it then re-render.
 interface PatchArgs {
   url: string;
   path: { assistant_id: string };
   body: { ui: Record<string, unknown> };
 }
 
-let currentTz = "America/New_York";
+// Mutable separate readers; tests flip them then re-render. `browserTz`
+// is the live auto zone; `override` is the manual `device:timezone`.
+let browserTz = "America/New_York";
+let override = "";
 const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
 const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
 
-// Both the reactive hook and the imperative resume/focus reader resolve
-// to the same mutable `currentTz`.
+// The hook is just a reactivity trigger; it folds override over browser
+// zone (matching the real implementation) so a flip of either re-renders.
 mock.module("@/utils/use-effective-timezone", () => ({
-  useEffectiveTimezone: () => currentTz,
+  useEffectiveTimezone: () => (override.trim() ? override.trim() : browserTz),
 }));
 
-mock.module("@/utils/effective-timezone", () => ({
-  getEffectiveTimezone: () => currentTz,
+mock.module("@/utils/browser-timezone", () => ({
+  getBrowserTimezone: () => browserTz,
+}));
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceSetting: (_name: string, fallback: string) =>
+    override === "" ? fallback : override,
 }));
 
 mock.module("@/generated/api/client.gen", () => ({
@@ -63,7 +72,8 @@ function renderSync() {
 }
 
 beforeEach(() => {
-  currentTz = "America/New_York";
+  browserTz = "America/New_York";
+  override = "";
   patchMock.mockClear();
   captureErrorMock.mockClear();
   patchMock.mockImplementation(async () => ({ data: {} }));
@@ -80,46 +90,61 @@ function lastBody() {
 }
 
 describe("TimezoneSync", () => {
-  test("PATCHes detectedTimezone once on mount with a resolvable assistant id", async () => {
+  test("PATCHes both fields once on mount in auto mode (userTimezone cleared)", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
     const call = patchMock.mock.calls[0]![0];
     expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
     expect(call.path).toEqual({ assistant_id: "asst-1" });
-    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(call.body).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
-  test("never writes userTimezone", async () => {
+  test("manual override is written to userTimezone; detectedTimezone carries the live browser zone", async () => {
+    override = "Asia/Tokyo";
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
-    expect(lastBody()?.ui).not.toHaveProperty("userTimezone");
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
+    });
   });
 
-  test("a zone change triggers exactly one additional PATCH with the new zone", async () => {
+  test("trims the override before writing userTimezone", async () => {
+    override = "  Asia/Tokyo  ";
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "Asia/Tokyo" },
+    });
+  });
+
+  test("a browser-zone change triggers exactly one additional PATCH with the new zone", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    currentTz = "Europe/London";
+    browserTz = "Europe/London";
     rerender(<TimezoneSync />);
 
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "Europe/London", userTimezone: "" },
+    });
   });
 
-  test("no additional PATCH when the zone is unchanged across re-renders", async () => {
+  test("no additional PATCH when nothing changed across re-renders (redundant-key dedupe)", async () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
     rerender(<TimezoneSync />);
     rerender(<TimezoneSync />);
 
-    // Give any stray effect a chance to fire, then assert it didn't.
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("no PATCH when the effective zone is empty", async () => {
-    currentTz = "";
+  test("no PATCH when the browser zone is empty", async () => {
+    browserTz = "";
     renderSync();
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).not.toHaveBeenCalled();
@@ -139,25 +164,22 @@ describe("TimezoneSync", () => {
     const { rerender } = renderSync();
     await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
     expect(captureErrorMock.mock.calls[0]![1]).toEqual({
-      context: "timezone-sync-detected",
+      context: "timezone-sync",
     });
 
-    // The onError handler reset the guard for the failed zone, so the
-    // next time that same zone comes back around (after a focus that
-    // flips it away and back) it re-syncs instead of being suppressed.
-    currentTz = "Europe/London";
+    browserTz = "Europe/London";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
 
-    currentTz = "America/New_York";
+    browserTz = "America/New_York";
     rerender(<TimezoneSync />);
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("retries on app.resume with the same zone after a failed initial sync", async () => {
-    // Initial sync rejects (e.g. resumed while offline). The guard ref
-    // stays unsynced because we only record the key on success.
     patchMock.mockImplementationOnce(async () => {
       throw new Error("offline");
     });
@@ -165,11 +187,11 @@ describe("TimezoneSync", () => {
     await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    // Resume with the SAME zone — a retry must fire even though tz is
-    // unchanged (the offline-then-resume case).
     publish("app.resume", { signal: "visibility" });
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("retries on window focus with the same zone after a failed initial sync", async () => {
@@ -182,19 +204,62 @@ describe("TimezoneSync", () => {
 
     window.dispatchEvent(new Event("focus"));
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
-    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 
   test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
     renderSync();
     await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
 
-    // No zone flip: the prior success recorded the key, so both triggers
-    // are no-ops (no redundant PATCH).
     publish("app.resume", { signal: "visibility" });
     window.dispatchEvent(new Event("focus"));
 
     await new Promise((r) => setTimeout(r, 10));
     expect(patchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("last-writer-wins: a slow older PATCH cannot overwrite a newer zone", async () => {
+    // Two overlapping triggers; the FIRST (older zone) resolves AFTER the
+    // SECOND (newer zone). The final synced state must reflect the newer
+    // zone, and the stale older completion must not re-open it for resync.
+    const resolvers: Array<() => void> = [];
+    patchMock.mockImplementation(
+      () =>
+        new Promise<{ data: Record<string, unknown> }>((resolve) => {
+          resolvers.push(() => resolve({ data: {} }));
+        }),
+    );
+
+    const { rerender } = renderSync();
+    // First PATCH issued (mount) for America/New_York; still pending.
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // Zone flips before the first request settles → second PATCH issued.
+    browserTz = "Europe/London";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+
+    expect(resolvers).toHaveLength(2);
+    // Newer request resolves first, then the stale older one resolves last.
+    resolvers[1]!();
+    resolvers[0]!();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The newer zone is the synced state: re-rendering with Europe/London
+    // (the latest issued key) must NOT trigger a redundant PATCH...
+    rerender(<TimezoneSync />);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(2);
+
+    // ...and flipping back to the older zone DOES PATCH (so the stale
+    // completion never recorded America/New_York as the synced key).
+    browserTz = "America/New_York";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
+    expect(lastBody()).toEqual({
+      ui: { detectedTimezone: "America/New_York", userTimezone: "" },
+    });
   });
 });

--- a/apps/web/src/components/timezone-sync.test.tsx
+++ b/apps/web/src/components/timezone-sync.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for the headless `TimezoneSync` component.
+ *
+ * Strategy: mock the generated API client's `patch` and the effective-
+ * timezone hook, drive the active assistant id through the real
+ * selection store, and assert the PATCH fires only for genuinely new
+ * `{ ui: { detectedTimezone } }` values.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { publish } from "@/lib/event-bus";
+
+// Mutable zone returned by the mocked hook; tests flip it then re-render.
+interface PatchArgs {
+  url: string;
+  path: { assistant_id: string };
+  body: { ui: Record<string, unknown> };
+}
+
+let currentTz = "America/New_York";
+const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
+const captureErrorMock = mock((_error: unknown, _opts: { context: string }) => {});
+
+// Both the reactive hook and the imperative resume/focus reader resolve
+// to the same mutable `currentTz`.
+mock.module("@/utils/use-effective-timezone", () => ({
+  useEffectiveTimezone: () => currentTz,
+}));
+
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => currentTz,
+}));
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: { patch: patchMock },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { TimezoneSync } = await import("@/components/timezone-sync");
+
+function renderSync() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<TimezoneSync />, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  currentTz = "America/New_York";
+  patchMock.mockClear();
+  captureErrorMock.mockClear();
+  patchMock.mockImplementation(async () => ({ data: {} }));
+  useAssistantSelectionStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantSelectionStore.setState({ activeAssistantId: null });
+});
+
+function lastBody() {
+  return patchMock.mock.calls.at(-1)?.[0]?.body;
+}
+
+describe("TimezoneSync", () => {
+  test("PATCHes detectedTimezone once on mount with a resolvable assistant id", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    const call = patchMock.mock.calls[0]![0];
+    expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
+    expect(call.path).toEqual({ assistant_id: "asst-1" });
+    expect(call.body).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("never writes userTimezone", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    expect(lastBody()?.ui).not.toHaveProperty("userTimezone");
+  });
+
+  test("a zone change triggers exactly one additional PATCH with the new zone", async () => {
+    const { rerender } = renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    currentTz = "Europe/London";
+    rerender(<TimezoneSync />);
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "Europe/London" } });
+  });
+
+  test("no additional PATCH when the zone is unchanged across re-renders", async () => {
+    const { rerender } = renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    rerender(<TimezoneSync />);
+    rerender(<TimezoneSync />);
+
+    // Give any stray effect a chance to fire, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("no PATCH when the effective zone is empty", async () => {
+    currentTz = "";
+    renderSync();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  test("no PATCH when no assistant id is available", async () => {
+    useAssistantSelectionStore.setState({ activeAssistantId: null });
+    renderSync();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  test("captures errors silently and allows a later retry of the failed zone", async () => {
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    const { rerender } = renderSync();
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+    expect(captureErrorMock.mock.calls[0]![1]).toEqual({
+      context: "timezone-sync-detected",
+    });
+
+    // The onError handler reset the guard for the failed zone, so the
+    // next time that same zone comes back around (after a focus that
+    // flips it away and back) it re-syncs instead of being suppressed.
+    currentTz = "Europe/London";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+
+    currentTz = "America/New_York";
+    rerender(<TimezoneSync />);
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(3));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("retries on app.resume with the same zone after a failed initial sync", async () => {
+    // Initial sync rejects (e.g. resumed while offline). The guard ref
+    // stays unsynced because we only record the key on success.
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("offline");
+    });
+    renderSync();
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // Resume with the SAME zone — a retry must fire even though tz is
+    // unchanged (the offline-then-resume case).
+    publish("app.resume", { signal: "visibility" });
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("retries on window focus with the same zone after a failed initial sync", async () => {
+    patchMock.mockImplementationOnce(async () => {
+      throw new Error("offline");
+    });
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(lastBody()).toEqual({ ui: { detectedTimezone: "America/New_York" } });
+  });
+
+  test("does not re-PATCH on resume/focus after a successful sync with the same zone", async () => {
+    renderSync();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    // No zone flip: the prior success recorded the key, so both triggers
+    // are no-ops (no redundant PATCH).
+    publish("app.resume", { signal: "visibility" });
+    window.dispatchEvent(new Event("focus"));
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,31 +1,29 @@
 /**
- * Headless background sync of the client's timezone into the assistant
- * daemon config, writing both cascade tiers separately:
+ * Headless background sync of the client's *auto* browser timezone into the
+ * assistant daemon config. It writes ONLY `ui.detectedTimezone` — the live
+ * auto browser zone, used for background grounding (memory retrospective,
+ * scheduling) that has no per-turn `clientTimezone`.
  *
- * - `ui.userTimezone`  ← the manual `device:timezone` override (trimmed),
- *   or `""` to CLEAR it when in auto mode. A deliberate override must
- *   live in this tier so it outranks another client's per-turn
- *   `clientTimezone`; storing it in `detectedTimezone` (the weakest
- *   relevant tier) would let a transient per-turn zone win.
- * - `ui.detectedTimezone` ← the live auto browser zone, used for
- *   background grounding (memory retrospective, scheduling) that has no
- *   per-turn `clientTimezone`.
+ * It deliberately NEVER writes `ui.userTimezone`. That tier is the
+ * authoritative manual override and may be set from the CLI, the assistant,
+ * or another client; a background auto-mode client clearing it would clobber
+ * a global override. The settings picker owns writing `ui.userTimezone` for
+ * explicit user actions.
  *
- * This is the single point that mirrors `device:timezone` into config;
- * the settings picker only writes localStorage. `useEffectiveTimezone()`
- * is used purely as a reactivity trigger (focus / app.resume / device
- * watcher) so the sync re-runs when either the browser zone or the
- * override changes.
+ * `useEffectiveTimezone()` is used purely as a reactivity trigger (focus /
+ * app.resume / device watcher) so the sync re-runs when the browser zone
+ * changes; the value persisted is always re-read from `getBrowserTimezone()`.
  *
- * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
- * failed sync (e.g. resumed-after-offline) leaves the key "unsynced" and
- * is retried on the next `app.resume` or focus — even when the values
- * are unchanged. A successful prior sync makes those triggers a no-op.
+ * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a failed
+ * sync (e.g. resumed-after-offline) leaves the zone "unsynced" and is retried
+ * on the next `app.resume` or focus. A successful prior sync makes those
+ * triggers a no-op.
  *
- * iOS fires `app.resume`+`focus` back-to-back, so PATCHes can overlap. A
- * monotonic request token guarantees last-writer-wins: a slow older
- * request's success is ignored once a newer request has been issued, so
- * a stale zone can never be persisted.
+ * Writes are truly serialized (last-writer-wins): at most one PATCH is in
+ * flight at a time. A trigger that fires while a PATCH is in flight only
+ * records the latest desired zone; when the in-flight PATCH settles, the
+ * queue drains to the latest target, so the final server write is always the
+ * newest zone and writes can never overlap or land out of order.
  *
  * Mounted once in `RootLayout` (behind `authMiddleware`). Renders `null`
  * and is silent on error — a failed background sync must never toast.
@@ -38,46 +36,37 @@ import { client } from "@/generated/api/client.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { captureError } from "@/lib/sentry/capture-error";
 import { getBrowserTimezone } from "@/utils/browser-timezone";
-import { getDeviceSetting } from "@/utils/device-settings";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function TimezoneSync(): null {
   // Reactivity trigger only: this value changes whenever the browser zone
-  // or the override changes, re-running the effect below. The actual
-  // detected/override values are re-read imperatively inside `trySync`.
+  // changes, re-running the effect below. The detected value is re-read
+  // imperatively inside `trySync` from `getBrowserTimezone()`.
   const effectiveTz = useEffectiveTimezone();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
 
   const { mutateAsync: patchTimezone } = useMutation({
-    mutationFn: async (vars: {
-      assistantId: string;
-      detectedTimezone: string;
-      userTimezone: string;
-    }) => {
+    mutationFn: async (vars: { assistantId: string; detectedTimezone: string }) => {
       const { data } = await client.patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: vars.assistantId },
-        body: {
-          ui: {
-            detectedTimezone: vars.detectedTimezone,
-            userTimezone: vars.userTimezone,
-          },
-        },
+        body: { ui: { detectedTimezone: vars.detectedTimezone } },
         throwOnError: true,
       });
       return data;
     },
   });
 
-  // Dedupe key of the last *successful* sync, covering both values plus
-  // the assistant (so switching assistants re-syncs even when unchanged).
-  // Only advanced on success, so a failed sync stays "unsynced".
+  // Dedupe key of the last *successful* sync (`${assistantId}:${detectedTimezone}`,
+  // so switching assistants re-syncs even when the zone is unchanged). Only
+  // advanced on success, so a failed sync stays "unsynced".
   const lastSyncedRef = useRef<string | null>(null);
 
-  // Monotonic token: incremented per issued PATCH. A request only records
-  // its key if it is still the latest issued, so a slow older completion
-  // cannot overwrite a newer zone (last-writer-wins).
-  const requestSeqRef = useRef(0);
+  // Write serialization: at most one PATCH in flight. `inFlightRef` guards
+  // overlap; `pendingKeyRef` holds the latest desired key while a PATCH is in
+  // flight so the queue can drain to it on settle.
+  const inFlightRef = useRef(false);
+  const pendingKeyRef = useRef<string | null>(null);
 
   // Hold the live assistant id so resume/focus handlers (which capture
   // `trySync` once) always target the current assistant.
@@ -87,33 +76,45 @@ export function TimezoneSync(): null {
   const trySync = useCallback(() => {
     const currentAssistantId = assistantIdRef.current;
     const detectedTimezone = getBrowserTimezone();
-    const userTimezone = getDeviceSetting("timezone", "").trim();
     if (!currentAssistantId || !detectedTimezone) return;
 
-    const key = `${currentAssistantId}:${detectedTimezone}:${userTimezone}`;
+    const key = `${currentAssistantId}:${detectedTimezone}`;
     if (lastSyncedRef.current === key) return;
 
-    const seq = ++requestSeqRef.current;
-    // Fire-and-forget: background sync, silent on error. Only record the
-    // key on success, and only if no newer request has since been issued.
-    patchTimezone({ assistantId: currentAssistantId, detectedTimezone, userTimezone })
+    // A PATCH is already running: just record the latest desired target so
+    // the in-flight PATCH drains to it on settle (no overlapping writes).
+    if (inFlightRef.current) {
+      pendingKeyRef.current = key;
+      return;
+    }
+
+    inFlightRef.current = true;
+    pendingKeyRef.current = null;
+
+    // Fire-and-forget background sync, silent on error. Record the key only
+    // on success; on settle, drain any newer target requested while in flight.
+    patchTimezone({ assistantId: currentAssistantId, detectedTimezone })
       .then(() => {
-        if (seq === requestSeqRef.current) {
-          lastSyncedRef.current = key;
-        }
+        lastSyncedRef.current = key;
       })
       .catch((error) => {
         captureError(error, { context: "timezone-sync" });
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+        const pending = pendingKeyRef.current;
+        pendingKeyRef.current = null;
+        if (pending && pending !== key) trySync();
       });
   }, [patchTimezone]);
 
-  // Reactive path: zone/override or assistant change.
+  // Reactive path: zone or assistant change.
   useEffect(() => {
     trySync();
   }, [effectiveTz, assistantId, trySync]);
 
-  // Resume/focus path: retry a previously failed sync even when the
-  // values are unchanged. A successful prior sync makes this a no-op.
+  // Resume/focus path: retry a previously failed sync even when the zone is
+  // unchanged. A successful prior sync makes this a no-op.
   useBusSubscription("app.resume", trySync);
   useEffect(() => {
     window.addEventListener("focus", trySync);

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,0 +1,102 @@
+/**
+ * Headless background sync of the live effective timezone into the
+ * assistant daemon config at `config.ui.detectedTimezone`.
+ *
+ * `useEffectiveTimezone()` re-reads the zone on window focus,
+ * visibility, and device-setting override changes, so this component
+ * keeps the daemon's *detected* zone fresh for background grounding
+ * (memory retrospective, scheduling) that has no per-turn
+ * `clientTimezone`. Per the backend resolver cascade this only ever
+ * writes `detectedTimezone` — `config.ui.userTimezone` is owned by the
+ * settings UI and a manual override still wins.
+ *
+ * Mounted once in `RootLayout` (behind `authMiddleware`), so it lives
+ * for the whole authenticated session and never renders on public
+ * `/account` routes. The active assistant id comes from
+ * `useAssistantSelectionStore`, which the lifecycle populates once a
+ * logged-in assistant resolves; until then the id is null and we skip.
+ *
+ * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
+ * failed sync (e.g. resumed-after-offline) leaves the key "unsynced"
+ * and is retried on the next `app.resume` bus signal or window focus —
+ * even when the effective zone string is unchanged. A successful prior
+ * sync makes those triggers a no-op, preserving the no-redundant-PATCH
+ * guarantee.
+ *
+ * Renders `null` and is silent on error — a failed background sync must
+ * never surface a toast.
+ */
+import { useCallback, useEffect, useRef } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { client } from "@/generated/api/client.gen";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { captureError } from "@/lib/sentry/capture-error";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+
+export function TimezoneSync(): null {
+  // Reactive zone drives the effect below; resume/focus handlers re-read
+  // the *current* zone via `getEffectiveTimezone()` to avoid stale closures.
+  const tz = useEffectiveTimezone();
+  const assistantId = useAssistantSelectionStore.use.activeAssistantId();
+
+  const { mutateAsync: patchDetectedTimezone } = useMutation({
+    mutationFn: async (vars: { assistantId: string; tz: string }) => {
+      const { data } = await client.patch<Record<string, unknown>, unknown, true>({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: vars.assistantId },
+        body: { ui: { detectedTimezone: vars.tz } },
+        throwOnError: true,
+      });
+      return data;
+    },
+  });
+
+  // `${assistantId}:${tz}` of the last *successful* sync, to avoid
+  // redundant PATCHes when nothing has changed. Keyed on the assistant
+  // too so switching assistants re-syncs even when the zone is identical.
+  // Only advanced on success, so a failed sync stays "unsynced" and is
+  // retried on the next resume/focus.
+  const lastSyncedRef = useRef<string | null>(null);
+
+  // Hold the live assistant id so resume/focus handlers (which capture
+  // `trySync` once) always target the current assistant.
+  const assistantIdRef = useRef(assistantId);
+  assistantIdRef.current = assistantId;
+
+  const trySync = useCallback(() => {
+    const currentAssistantId = assistantIdRef.current;
+    const currentTz = getEffectiveTimezone();
+    if (!currentAssistantId || !currentTz) return;
+
+    const key = `${currentAssistantId}:${currentTz}`;
+    if (lastSyncedRef.current === key) return;
+
+    // Fire-and-forget: background sync, silent on error. Only record the
+    // key on success so a transient failure is retried on next trigger.
+    patchDetectedTimezone({ assistantId: currentAssistantId, tz: currentTz })
+      .then(() => {
+        lastSyncedRef.current = key;
+      })
+      .catch((error) => {
+        captureError(error, { context: "timezone-sync-detected" });
+      });
+  }, [patchDetectedTimezone]);
+
+  // Reactive path: zone or assistant change.
+  useEffect(() => {
+    trySync();
+  }, [tz, assistantId, trySync]);
+
+  // Resume/focus path: retry a previously failed sync even when the zone
+  // string is unchanged. A successful prior sync makes this a no-op.
+  useBusSubscription("app.resume", trySync);
+  useEffect(() => {
+    window.addEventListener("focus", trySync);
+    return () => window.removeEventListener("focus", trySync);
+  }, [trySync]);
+
+  return null;
+}

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -1,30 +1,34 @@
 /**
- * Headless background sync of the live effective timezone into the
- * assistant daemon config at `config.ui.detectedTimezone`.
+ * Headless background sync of the client's timezone into the assistant
+ * daemon config, writing both cascade tiers separately:
  *
- * `useEffectiveTimezone()` re-reads the zone on window focus,
- * visibility, and device-setting override changes, so this component
- * keeps the daemon's *detected* zone fresh for background grounding
- * (memory retrospective, scheduling) that has no per-turn
- * `clientTimezone`. Per the backend resolver cascade this only ever
- * writes `detectedTimezone` — `config.ui.userTimezone` is owned by the
- * settings UI and a manual override still wins.
+ * - `ui.userTimezone`  ← the manual `device:timezone` override (trimmed),
+ *   or `""` to CLEAR it when in auto mode. A deliberate override must
+ *   live in this tier so it outranks another client's per-turn
+ *   `clientTimezone`; storing it in `detectedTimezone` (the weakest
+ *   relevant tier) would let a transient per-turn zone win.
+ * - `ui.detectedTimezone` ← the live auto browser zone, used for
+ *   background grounding (memory retrospective, scheduling) that has no
+ *   per-turn `clientTimezone`.
  *
- * Mounted once in `RootLayout` (behind `authMiddleware`), so it lives
- * for the whole authenticated session and never renders on public
- * `/account` routes. The active assistant id comes from
- * `useAssistantSelectionStore`, which the lifecycle populates once a
- * logged-in assistant resolves; until then the id is null and we skip.
+ * This is the single point that mirrors `device:timezone` into config;
+ * the settings picker only writes localStorage. `useEffectiveTimezone()`
+ * is used purely as a reactivity trigger (focus / app.resume / device
+ * watcher) so the sync re-runs when either the browser zone or the
+ * override changes.
  *
  * A sync only advances `lastSyncedRef` once the PATCH *succeeds*, so a
- * failed sync (e.g. resumed-after-offline) leaves the key "unsynced"
- * and is retried on the next `app.resume` bus signal or window focus —
- * even when the effective zone string is unchanged. A successful prior
- * sync makes those triggers a no-op, preserving the no-redundant-PATCH
- * guarantee.
+ * failed sync (e.g. resumed-after-offline) leaves the key "unsynced" and
+ * is retried on the next `app.resume` or focus — even when the values
+ * are unchanged. A successful prior sync makes those triggers a no-op.
  *
- * Renders `null` and is silent on error — a failed background sync must
- * never surface a toast.
+ * iOS fires `app.resume`+`focus` back-to-back, so PATCHes can overlap. A
+ * monotonic request token guarantees last-writer-wins: a slow older
+ * request's success is ignored once a newer request has been issued, so
+ * a stale zone can never be persisted.
+ *
+ * Mounted once in `RootLayout` (behind `authMiddleware`). Renders `null`
+ * and is silent on error — a failed background sync must never toast.
  */
 import { useCallback, useEffect, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
@@ -33,33 +37,47 @@ import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { client } from "@/generated/api/client.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { captureError } from "@/lib/sentry/capture-error";
-import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getDeviceSetting } from "@/utils/device-settings";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export function TimezoneSync(): null {
-  // Reactive zone drives the effect below; resume/focus handlers re-read
-  // the *current* zone via `getEffectiveTimezone()` to avoid stale closures.
-  const tz = useEffectiveTimezone();
+  // Reactivity trigger only: this value changes whenever the browser zone
+  // or the override changes, re-running the effect below. The actual
+  // detected/override values are re-read imperatively inside `trySync`.
+  const effectiveTz = useEffectiveTimezone();
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
 
-  const { mutateAsync: patchDetectedTimezone } = useMutation({
-    mutationFn: async (vars: { assistantId: string; tz: string }) => {
+  const { mutateAsync: patchTimezone } = useMutation({
+    mutationFn: async (vars: {
+      assistantId: string;
+      detectedTimezone: string;
+      userTimezone: string;
+    }) => {
       const { data } = await client.patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: vars.assistantId },
-        body: { ui: { detectedTimezone: vars.tz } },
+        body: {
+          ui: {
+            detectedTimezone: vars.detectedTimezone,
+            userTimezone: vars.userTimezone,
+          },
+        },
         throwOnError: true,
       });
       return data;
     },
   });
 
-  // `${assistantId}:${tz}` of the last *successful* sync, to avoid
-  // redundant PATCHes when nothing has changed. Keyed on the assistant
-  // too so switching assistants re-syncs even when the zone is identical.
-  // Only advanced on success, so a failed sync stays "unsynced" and is
-  // retried on the next resume/focus.
+  // Dedupe key of the last *successful* sync, covering both values plus
+  // the assistant (so switching assistants re-syncs even when unchanged).
+  // Only advanced on success, so a failed sync stays "unsynced".
   const lastSyncedRef = useRef<string | null>(null);
+
+  // Monotonic token: incremented per issued PATCH. A request only records
+  // its key if it is still the latest issued, so a slow older completion
+  // cannot overwrite a newer zone (last-writer-wins).
+  const requestSeqRef = useRef(0);
 
   // Hold the live assistant id so resume/focus handlers (which capture
   // `trySync` once) always target the current assistant.
@@ -68,30 +86,34 @@ export function TimezoneSync(): null {
 
   const trySync = useCallback(() => {
     const currentAssistantId = assistantIdRef.current;
-    const currentTz = getEffectiveTimezone();
-    if (!currentAssistantId || !currentTz) return;
+    const detectedTimezone = getBrowserTimezone();
+    const userTimezone = getDeviceSetting("timezone", "").trim();
+    if (!currentAssistantId || !detectedTimezone) return;
 
-    const key = `${currentAssistantId}:${currentTz}`;
+    const key = `${currentAssistantId}:${detectedTimezone}:${userTimezone}`;
     if (lastSyncedRef.current === key) return;
 
+    const seq = ++requestSeqRef.current;
     // Fire-and-forget: background sync, silent on error. Only record the
-    // key on success so a transient failure is retried on next trigger.
-    patchDetectedTimezone({ assistantId: currentAssistantId, tz: currentTz })
+    // key on success, and only if no newer request has since been issued.
+    patchTimezone({ assistantId: currentAssistantId, detectedTimezone, userTimezone })
       .then(() => {
-        lastSyncedRef.current = key;
+        if (seq === requestSeqRef.current) {
+          lastSyncedRef.current = key;
+        }
       })
       .catch((error) => {
-        captureError(error, { context: "timezone-sync-detected" });
+        captureError(error, { context: "timezone-sync" });
       });
-  }, [patchDetectedTimezone]);
+  }, [patchTimezone]);
 
-  // Reactive path: zone or assistant change.
+  // Reactive path: zone/override or assistant change.
   useEffect(() => {
     trySync();
-  }, [tz, assistantId, trySync]);
+  }, [effectiveTz, assistantId, trySync]);
 
-  // Resume/focus path: retry a previously failed sync even when the zone
-  // string is unchanged. A successful prior sync makes this a no-op.
+  // Resume/focus path: retry a previously failed sync even when the
+  // values are unchanged. A successful prior sync makes this a no-op.
   useBusSubscription("app.resume", trySync);
   useEffect(() => {
     window.addEventListener("focus", trySync);

--- a/apps/web/src/components/timezone-sync.tsx
+++ b/apps/web/src/components/timezone-sync.tsx
@@ -69,9 +69,17 @@ export function TimezoneSync(): null {
   const pendingKeyRef = useRef<string | null>(null);
 
   // Hold the live assistant id so resume/focus handlers (which capture
-  // `trySync` once) always target the current assistant.
+  // `trySync` once) always target the current assistant. Assigned in an
+  // effect (never during render) to avoid mutating a ref while rendering.
   const assistantIdRef = useRef(assistantId);
-  assistantIdRef.current = assistantId;
+  useEffect(() => {
+    assistantIdRef.current = assistantId;
+  }, [assistantId]);
+
+  // Stable indirection so `trySync`'s `.finally` drain can call the latest
+  // `trySync` without referencing `const trySync` inside its own initializer
+  // (which would be a temporal-dead-zone access).
+  const trySyncRef = useRef<() => void>(() => {});
 
   const trySync = useCallback(() => {
     const currentAssistantId = assistantIdRef.current;
@@ -104,9 +112,15 @@ export function TimezoneSync(): null {
         inFlightRef.current = false;
         const pending = pendingKeyRef.current;
         pendingKeyRef.current = null;
-        if (pending && pending !== key) trySync();
+        if (pending && pending !== key) trySyncRef.current();
       });
   }, [patchTimezone]);
+
+  // Keep the drain indirection pointed at the latest `trySync`. Assigned in an
+  // effect (never during render) for the same "no refs during render" reason.
+  useEffect(() => {
+    trySyncRef.current = trySync;
+  }, [trySync]);
 
   // Reactive path: zone or assistant change.
   useEffect(() => {

--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -22,6 +22,7 @@ import {
 import { persistPreChatOnboardingProfile } from "@/domains/onboarding/prechat-profile";
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 120_000;
@@ -504,6 +505,15 @@ export async function postChatMessage(
     sourceChannel: "vellum",
     interface: "vellum",
   };
+  // Read the effective timezone LIVE at send time (not from cached state) so
+  // every message carries the user's current zone, keeping the assistant's
+  // per-turn time awareness fresh as the OS/browser timezone changes. The
+  // daemon route consumes this field in its turn-timezone cascade (see
+  // `assistant/src/runtime/routes/conversation-routes.ts`, where the request
+  // schema accepts `clientTimezone: z.string().optional()` and forwards it
+  // into `resolveTurnTimezoneContext`).
+  const clientTimezone = getEffectiveTimezone();
+  if (clientTimezone) body.clientTimezone = clientTimezone;
   const conversationField = pickConversationIdWireField();
   if (conversationId !== null || conversationField !== "conversationId") {
     body[conversationField] = conversationId;

--- a/apps/web/src/domains/chat/api/post-chat-message.test.ts
+++ b/apps/web/src/domains/chat/api/post-chat-message.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Mock the effective-timezone resolver so we can control the zone
+// `postChatMessage` reads at send time without touching localStorage/Intl.
+let mockEffectiveTimezone = "America/New_York";
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => mockEffectiveTimezone,
+}));
+
 import { postChatMessage } from "@/domains/chat/api/messages";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -445,5 +452,87 @@ describe("postChatMessage server-minted conversation flow", () => {
     const body = getMessageBody();
     expect(body.conversationKey).toBe("conv-existing");
     expect(body).not.toHaveProperty("conversationId");
+  });
+});
+
+describe("postChatMessage clientTimezone payload", () => {
+  // Every message carries the live effective timezone so the assistant's
+  // per-turn time awareness stays current as the OS/browser zone changes.
+  // The daemon route (`conversation-routes.ts`) consumes `clientTimezone`
+  // in its turn-timezone cascade — no backend change is needed here.
+  let originalFetch: typeof fetch;
+  let originalDocument: unknown;
+  let capturedRequests: Array<{ url: string; body: string }> = [];
+
+  beforeEach(() => {
+    mockEffectiveTimezone = "America/New_York";
+    originalFetch = globalThis.fetch;
+    capturedRequests = [];
+    useAssistantIdentityStore.getState().clearIdentity();
+    originalDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { document?: unknown }).document = { cookie: "csrftoken=test" };
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      let bodyText: string | undefined;
+      if (input instanceof Request) {
+        bodyText = await input.clone().text();
+      } else if (typeof init?.body === "string") {
+        bodyText = init.body;
+      }
+      capturedRequests.push({ url, body: bodyText ?? "" });
+      return new Response(
+        JSON.stringify({
+          accepted: true,
+          messageId: "msg-1",
+          conversationId: "conv-resp-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDocument === undefined) {
+      delete (globalThis as { document?: unknown }).document;
+    } else {
+      (globalThis as { document?: unknown }).document = originalDocument;
+    }
+    useAssistantIdentityStore.getState().clearIdentity();
+  });
+
+  function getMessageBody(): Record<string, unknown> {
+    const requests = capturedRequests.filter((r) => r.url.includes("/messages/"));
+    expect(requests).toHaveLength(1);
+    return JSON.parse(requests[0]!.body) as Record<string, unknown>;
+  }
+
+  test("includes the live effective timezone on the wire", async () => {
+    mockEffectiveTimezone = "Europe/Berlin";
+
+    await postChatMessage("asst-1", "K", "hello");
+
+    const body = getMessageBody();
+    expect(body.clientTimezone).toBe("Europe/Berlin");
+  });
+
+  test("reflects a changed zone on the next message (read live at send time)", async () => {
+    await postChatMessage("asst-1", "K", "first");
+    expect(getMessageBody().clientTimezone).toBe("America/New_York");
+
+    capturedRequests = [];
+    mockEffectiveTimezone = "Asia/Tokyo";
+
+    await postChatMessage("asst-1", "K", "second");
+    expect(getMessageBody().clientTimezone).toBe("Asia/Tokyo");
+  });
+
+  test("omits clientTimezone when the resolver returns an empty string", async () => {
+    mockEffectiveTimezone = "";
+
+    await postChatMessage("asst-1", "K", "hello");
+
+    const body = getMessageBody();
+    expect(body).not.toHaveProperty("clientTimezone");
   });
 });

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -92,10 +92,14 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   );
   const timezone = useEffectiveTimezone();
   // Depend on `timezone` so bounded ranges (e.g. "Today", "Last 7 days")
-  // recompute their browser-local from/to boundaries when the live zone
-  // changes (OS or `device:timezone` update), keeping them aligned with the
-  // `tz` sent to the backend instead of using stale boundaries.
-  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range, timezone]);
+  // recompute their from/to boundaries in the effective zone when it changes
+  // (OS or `device:timezone` update). `resolveRangeWindow` derives the calendar
+  // day boundaries in `timezone`, keeping them aligned with the `tz` sent to
+  // the backend rather than browser-local boundaries.
+  const rangeWindow = useMemo(
+    () => resolveRangeWindow(range, timezone),
+    [range, timezone],
+  );
   const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
 
   const startCostConversation = (message: string) => {

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -8,7 +8,7 @@ import { Dropdown } from "@vellum/design-library";
 import { storePendingInitialMessage } from "@/utils/initial-message-launch";
 import { routes } from "@/utils/routes";
 import { formatCost, formatTokens } from "@/domains/logs/format";
-import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import {
   buildCallSiteMetadataMap,
   fetchUsageCallSiteCatalog,
@@ -90,9 +90,13 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   const [groupBy, setGroupBy] = useState<UsageGroupBy>(
     DEFAULT_USAGE_GROUP_BY,
   );
-  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range]);
+  const timezone = useEffectiveTimezone();
+  // Depend on `timezone` so bounded ranges (e.g. "Today", "Last 7 days")
+  // recompute their browser-local from/to boundaries when the live zone
+  // changes (OS or `device:timezone` update), keeping them aligned with the
+  // `tz` sent to the backend instead of using stale boundaries.
+  const rangeWindow = useMemo(() => resolveRangeWindow(range), [range, timezone]);
   const granularity = useMemo(() => resolveUsageGranularity(range), [range]);
-  const [timezone] = useState(getBrowserTimezone);
 
   const startCostConversation = (message: string) => {
     storePendingInitialMessage(message);

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import { resolveRangeWindow } from "@/domains/logs/usage-tab-state";
+
+const UTC = "UTC";
+
+describe("resolveRangeWindow", () => {
+  test("'all' returns from=0 and to=now regardless of tz", () => {
+    const now = Date.UTC(2026, 5, 2, 12, 0, 0);
+    expect(resolveRangeWindow("all", "America/New_York", now)).toEqual({
+      from: 0,
+      to: now,
+    });
+  });
+
+  test("'to' is the current instant; 'today' from is zone-local midnight", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const { from, to } = resolveRangeWindow("today", UTC, now);
+    expect(to).toBe(now);
+    // UTC midnight of 2026-06-02
+    expect(from).toBe(Date.UTC(2026, 5, 2, 0, 0, 0));
+  });
+
+  test("'7d' from is six zone-local days before today (UTC)", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const { from } = resolveRangeWindow("7d", UTC, now);
+    expect(from).toBe(Date.UTC(2026, 4, 27, 0, 0, 0));
+  });
+
+  test("day boundaries are computed in the supplied tz", () => {
+    // An instant where the calendar day differs across far-apart zones.
+    // 2026-06-02T01:00:00Z: UTC+14 (Kiritimati) is already 2026-06-02 15:00,
+    // while UTC-11 (Niue) is still 2026-06-01 14:00.
+    const now = Date.UTC(2026, 5, 2, 1, 0, 0);
+
+    const east = resolveRangeWindow("today", "Pacific/Kiritimati", now);
+    const west = resolveRangeWindow("today", "Pacific/Niue", now);
+
+    // Different calendar "today" => different from-boundaries.
+    expect(east.from).not.toBe(west.from);
+
+    // Sanity-check the actual calendar dates the boundaries land on.
+    expect(toTimezoneDateString(new Date(east.from), "Pacific/Kiritimati")).toBe(
+      "2026-06-02",
+    );
+    expect(toTimezoneDateString(new Date(west.from), "Pacific/Niue")).toBe(
+      "2026-06-01",
+    );
+  });
+
+  test("from epoch maps back to zone-local midnight (DST-safe)", () => {
+    // US DST is in effect in June; verify the from-boundary is local midnight.
+    const now = Date.UTC(2026, 5, 2, 18, 0, 0);
+    const tz = "America/New_York";
+    const { from } = resolveRangeWindow("7d", tz, now);
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(from));
+    const hour = parts.find((p) => p.type === "hour")?.value;
+    const minute = parts.find((p) => p.type === "minute")?.value;
+    expect(`${hour}:${minute}`).toBe("00:00");
+  });
+});

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -1,9 +1,59 @@
 import { describe, expect, test } from "bun:test";
 
-import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
 import { resolveRangeWindow } from "@/domains/logs/usage-tab-state";
 
 const UTC = "UTC";
+
+/** Render an instant's wall clock in `tz` as "YYYY-MM-DD HH:MM:SS". */
+function wallClock(epochMs: number, tz: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(epochMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value;
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get(
+    "minute",
+  )}:${get("second")}`;
+}
+
+describe("timezoneDayStartEpoch", () => {
+  test("DST-start day in Sydney resolves to local midnight, not 23:00 prior", () => {
+    // 2027-10-03 is a DST-start (spring-forward) date in Sydney. The naive
+    // offset-at-UTC-midnight approach returned 2027-10-02 23:00 here.
+    const epoch = timezoneDayStartEpoch("2027-10-03", "Australia/Sydney");
+    expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-10-03 00:00:00");
+  });
+
+  test("non-DST-boundary date in a fixed-offset zone is the obvious instant", () => {
+    // Asia/Kolkata is a fixed UTC+5:30 zone with no DST.
+    const epoch = timezoneDayStartEpoch("2026-06-02", "Asia/Kolkata");
+    // Local midnight is 18:30 UTC the previous day.
+    expect(epoch).toBe(Date.UTC(2026, 5, 1, 18, 30, 0));
+    expect(wallClock(epoch, "Asia/Kolkata")).toBe("2026-06-02 00:00:00");
+  });
+
+  test("DST-end (fall-back) day resolves to the correct local midnight", () => {
+    // 2027-04-04 is a DST-end (fall-back) date in Sydney.
+    const epoch = timezoneDayStartEpoch("2027-04-04", "Australia/Sydney");
+    expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-04-04 00:00:00");
+  });
+
+  test("UTC date resolves to UTC midnight", () => {
+    expect(timezoneDayStartEpoch("2026-06-02", UTC)).toBe(
+      Date.UTC(2026, 5, 2, 0, 0, 0),
+    );
+  });
+});
 
 describe("resolveRangeWindow", () => {
   test("'all' returns from=0 and to=now regardless of tz", () => {

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -48,6 +48,22 @@ describe("timezoneDayStartEpoch", () => {
     expect(wallClock(epoch, "Australia/Sydney")).toBe("2027-04-04 00:00:00");
   });
 
+  test("spring-forward that skips local midnight resolves to the first valid instant", () => {
+    // 2026-09-06 is a DST-start date in Santiago where the clock jumps from
+    // 23:59:59 (Sep 5) straight to 01:00:00 (Sep 6): local midnight never
+    // exists. The two-pass guess lands on 2026-09-05 23:00 (prior day); the
+    // gap fix must instead return the first valid instant ON 2026-09-06.
+    const epoch = timezoneDayStartEpoch("2026-09-06", "America/Santiago");
+    // First valid local time on the requested date is 01:00:00.
+    expect(wallClock(epoch, "America/Santiago")).toBe("2026-09-06 01:00:00");
+    // The formatted calendar date is the requested date, not the prior day.
+    expect(toTimezoneDateString(new Date(epoch), "America/Santiago")).toBe(
+      "2026-09-06",
+    );
+    // And the instant is at/after the transition (not before it).
+    expect(epoch).toBe(Date.UTC(2026, 8, 6, 4, 0, 0));
+  });
+
   test("UTC date resolves to UTC midnight", () => {
     expect(timezoneDayStartEpoch("2026-06-02", UTC)).toBe(
       Date.UTC(2026, 5, 2, 0, 0, 0),

--- a/apps/web/src/domains/logs/usage-tab-state.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.ts
@@ -1,3 +1,7 @@
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
 import { LLM_USAGE_DIMENSION_LABELS } from "@/utils/llm-dimension";
 import { UsageRequestError } from "./usage-api";
 import type {
@@ -119,8 +123,15 @@ const RANGE_START_DAY_OFFSETS: Record<Exclude<UsageTimeRange, "all">, number> =
     "90d": 89,
   };
 
+/**
+ * Resolve the `{ from, to }` epoch-ms window for a usage range, with calendar
+ * day boundaries computed in the effective `tz` so they stay aligned with the
+ * `tz` sent to the backend (which buckets by that zone). `to` is the current
+ * instant; `from` is zone-local midnight of the range's first calendar day.
+ */
 export function resolveRangeWindow(
   range: UsageTimeRange,
+  tz: string,
   now: Date | number = Date.now(),
 ): {
   from: number;
@@ -130,13 +141,15 @@ export function resolveRangeWindow(
   if (range === "all") {
     return { from: 0, to };
   }
-  const localNow = new Date(to);
   const dayOffset = RANGE_START_DAY_OFFSETS[range];
-  const from = new Date(
-    localNow.getFullYear(),
-    localNow.getMonth(),
-    localNow.getDate() - dayOffset,
-  ).getTime();
+  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
+  // anchor to avoid DST slips before resolving zone-local midnight.
+  const todayInTz = toTimezoneDateString(new Date(to), tz);
+  const [y, m, d] = todayInTz.split("-").map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - dayOffset);
+  const fromDate = toTimezoneDateString(anchor, "UTC");
+  const from = timezoneDayStartEpoch(fromDate, tz);
   return { from, to };
 }
 

--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -12,7 +12,9 @@ import { Typography } from "@vellum/design-library/components/typography";
 
 import {
   DateRangeSelect,
+  DEFAULT_PRESET_DAYS,
   type DateRange,
+  computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
   DEFAULT_LLM_USAGE_DIMENSION,
@@ -24,7 +26,6 @@ import { BillingUsageChart, type ChartMetric } from "@/domains/settings/componen
 import {
   type BillingUsageSourceFilter,
   getDefaultDateRange,
-  reconcilePresetRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
@@ -58,20 +59,29 @@ function formatEventCount(count: number | undefined): string {
 
 export function BillingUsagePanel() {
   const tz = useEffectiveTimezone();
-  const [dateRange, setDateRange] = useState<DateRange>(() =>
+  // Track the SELECTED PRESET IDENTITY (days), not its computed bounds. The
+  // active range is derived from this identity + the live tz below, so a tz
+  // change (even one that crosses a calendar-day rollover after the range was
+  // first computed) always yields the correct bounds for the active preset.
+  // `null` means a custom range that isn't a preset (defensive; billing only
+  // exposes presets today) — in that case `customRange` holds the bounds.
+  const [presetDays, setPresetDays] = useState<number | null>(
+    DEFAULT_PRESET_DAYS,
+  );
+  const [customRange, setCustomRange] = useState<DateRange>(() =>
     getDefaultDateRange(tz),
   );
-  // Tracks the tz the active range was computed in, so a tz change can recompute
-  // whichever relative preset is active without clobbering an untracked range.
-  // Initialized to the current tz so the first effect run is a no-op.
-  const prevTzRef = useRef<string>(tz);
 
-  useEffect(() => {
-    const prevTz = prevTzRef.current;
-    prevTzRef.current = tz;
-    if (prevTz === tz) return;
-    setDateRange((current) => reconcilePresetRange(current, prevTz, tz));
-  }, [tz]);
+  const dateRange = useMemo<DateRange>(
+    () =>
+      presetDays === null ? customRange : computeRangeInTimezone(presetDays, tz),
+    [presetDays, customRange, tz],
+  );
+
+  const handleRangeChange = (range: DateRange, nextPresetDays: number) => {
+    setPresetDays(nextPresetDays);
+    setCustomRange(range);
+  };
 
   const [drilldown, setDrilldown] = useState<{
     usageSource: BillingUsageSourceFilter;
@@ -81,7 +91,12 @@ export function BillingUsagePanel() {
 
   const { series, totals, isLoading, isError } = useBillingUsageData({
     dateRange,
-    setDateRange,
+    // Any imperative range set is treated as custom (not a preset). The data
+    // hook only reads `dateRange`, so this exists to satisfy UsageChartState.
+    setDateRange: (range) => {
+      setPresetDays(null);
+      setCustomRange(range);
+    },
     drilldown,
     setDrilldown,
   });
@@ -135,7 +150,7 @@ export function BillingUsagePanel() {
            *   wrapped by a 2px-padded container, so h-7 inner = 32px outer.
            */}
           <div className="flex flex-wrap items-center justify-end gap-2 [&_[role=combobox]]:h-8 [&_[role=radio]]:h-7">
-            <DateRangeSelect value={dateRange} onChange={setDateRange} />
+            <DateRangeSelect value={dateRange} onChange={handleRangeChange} />
             <div className="w-44">
               <SegmentControl
                 items={METRIC_ITEMS}

--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -24,8 +24,10 @@ import { BillingUsageChart, type ChartMetric } from "@/domains/settings/componen
 import {
   type BillingUsageSourceFilter,
   getDefaultDateRange,
+  reconcilePresetRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 const METRIC_ITEMS: SegmentControlItem<ChartMetric>[] = [
   { value: "spend", label: "Spend ($)" },
@@ -55,7 +57,22 @@ function formatEventCount(count: number | undefined): string {
 }
 
 export function BillingUsagePanel() {
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const tz = useEffectiveTimezone();
+  const [dateRange, setDateRange] = useState<DateRange>(() =>
+    getDefaultDateRange(tz),
+  );
+  // Tracks the tz the active range was computed in, so a tz change can recompute
+  // whichever relative preset is active without clobbering an untracked range.
+  // Initialized to the current tz so the first effect run is a no-op.
+  const prevTzRef = useRef<string>(tz);
+
+  useEffect(() => {
+    const prevTz = prevTzRef.current;
+    prevTzRef.current = tz;
+    if (prevTz === tz) return;
+    setDateRange((current) => reconcilePresetRange(current, prevTz, tz));
+  }, [tz]);
+
   const [drilldown, setDrilldown] = useState<{
     usageSource: BillingUsageSourceFilter;
     llmDimension?: LlmUsageDimension;

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+import { computeRangeInTimezone } from "@/components/charts/date-range-select";
+
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
   getDefaultDateRange,
+  reconcilePresetRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
 
@@ -61,6 +64,36 @@ describe("getDefaultDateRange", () => {
       expect(r.to).toMatch(DATE_RE);
       expect(daysApart(r.from, r.to)).toBe(30);
     }
+  });
+});
+
+describe("reconcilePresetRange", () => {
+  // Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) sit a full calendar
+  // day apart at most instants, so a preset's bounds differ between the zones.
+  const EAST = "Pacific/Kiritimati";
+  const WEST = "Pacific/Niue";
+
+  for (const days of [7, 30, 90]) {
+    test(`recomputes the active ${days}-day preset across a tz change`, () => {
+      const current = computeRangeInTimezone(days, EAST);
+      const result = reconcilePresetRange(current, EAST, WEST);
+      expect(result).toEqual(computeRangeInTimezone(days, WEST));
+    });
+  }
+
+  test("leaves a range that matches no preset unchanged", () => {
+    // 45 days apart matches none of the 7/30/90 presets.
+    const custom = { from: "2025-12-01", to: "2026-01-14" };
+    const result = reconcilePresetRange(custom, EAST, WEST);
+    expect(result).toBe(custom);
+  });
+
+  test("returns the same reference when the matched preset is unchanged", () => {
+    // Same tz on both sides: the preset's bounds are identical, so the helper
+    // must bail out referentially rather than allocate a new range.
+    const current = computeRangeInTimezone(7, EAST);
+    const result = reconcilePresetRange(current, EAST, EAST);
+    expect(result).toBe(current);
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  buildBillingUsageSeriesQuery,
+  buildBillingUsageTotalsQuery,
+  getDefaultDateRange,
+  type UsageChartState,
+} from "./use-billing-usage-data";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function daysApart(from: string, to: string): number {
+  const ms = Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`);
+  return Math.round(ms / 86_400_000) + 1;
+}
+
+function makeState(): UsageChartState {
+  return {
+    dateRange: { from: "2026-01-01", to: "2026-01-31" },
+    setDateRange: () => {},
+    drilldown: null,
+    setDrilldown: () => {},
+  };
+}
+
+describe("buildBillingUsageSeriesQuery", () => {
+  test("uses the explicit tz argument", () => {
+    const query = buildBillingUsageSeriesQuery(makeState(), "America/New_York");
+    expect(query.tz).toBe("America/New_York");
+    expect(query.from).toBe("2026-01-01");
+    expect(query.to).toBe("2026-01-31");
+  });
+});
+
+describe("buildBillingUsageTotalsQuery", () => {
+  test("uses the explicit tz argument", () => {
+    const query = buildBillingUsageTotalsQuery(makeState(), "America/New_York");
+    expect(query.tz).toBe("America/New_York");
+    expect(query.from).toBe("2026-01-01");
+    expect(query.to).toBe("2026-01-31");
+  });
+});
+
+describe("getDefaultDateRange", () => {
+  test("computes a 30-day range as YYYY-MM-DD bounds in the given tz", () => {
+    const { from, to } = getDefaultDateRange("America/New_York");
+    expect(from).toMatch(DATE_RE);
+    expect(to).toMatch(DATE_RE);
+    expect(daysApart(from, to)).toBe(30);
+  });
+
+  test("uses the supplied tz so dates can differ from another zone at a boundary", () => {
+    // Across a wide UTC offset gap, the calendar 'today' can differ. We assert
+    // each zone yields a self-consistent, well-formed 30-day range; at the
+    // right instant Kiritimati (UTC+14) and Niue (UTC-11) sit on different
+    // calendar days, so the computed bounds are independent per zone.
+    const east = getDefaultDateRange("Pacific/Kiritimati");
+    const west = getDefaultDateRange("Pacific/Niue");
+    for (const r of [east, west]) {
+      expect(r.from).toMatch(DATE_RE);
+      expect(r.to).toMatch(DATE_RE);
+      expect(daysApart(r.from, r.to)).toBe(30);
+    }
+  });
+});
+
+describe("default tz resolution", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("defaults to getEffectiveTimezone() for both builders", async () => {
+    mock.module("@/utils/effective-timezone", () => ({
+      getEffectiveTimezone: () => "Europe/Berlin",
+    }));
+
+    // Re-import after mocking so the builders pick up the mocked default.
+    const { buildBillingUsageSeriesQuery: buildSeries, buildBillingUsageTotalsQuery: buildTotals } =
+      await import("./use-billing-usage-data");
+
+    expect(buildSeries(makeState()).tz).toBe("Europe/Berlin");
+    expect(buildTotals(makeState()).tz).toBe("Europe/Berlin");
+  });
+});

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { computeRangeInTimezone } from "@/components/charts/date-range-select";
+import {
+  computeRangeInTimezone,
+  presetDaysFromRange,
+} from "@/components/charts/date-range-select";
 
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
   getDefaultDateRange,
-  reconcilePresetRange,
   type UsageChartState,
 } from "./use-billing-usage-data";
 
@@ -67,33 +69,58 @@ describe("getDefaultDateRange", () => {
   });
 });
 
-describe("reconcilePresetRange", () => {
+describe("presetDaysFromRange", () => {
+  for (const days of [7, 30, 90]) {
+    test(`maps a ${days}-day range back to its preset identity`, () => {
+      expect(presetDaysFromRange(computeRangeInTimezone(days))).toBe(days);
+    });
+  }
+
+  test("falls back to the 30-day default for a non-preset span", () => {
+    // 45 days apart matches none of the 7/30/90 presets.
+    expect(presetDaysFromRange({ from: "2025-12-01", to: "2026-01-14" })).toBe(
+      30,
+    );
+  });
+});
+
+describe("preset identity → range derivation (tz change)", () => {
+  // The panel stores the preset identity (days) and derives bounds from that
+  // identity + the live tz. This is what makes a tz change recompute the
+  // ACTIVE preset correctly, even across a calendar-day rollover.
+  //
   // Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) sit a full calendar
   // day apart at most instants, so a preset's bounds differ between the zones.
   const EAST = "Pacific/Kiritimati";
   const WEST = "Pacific/Niue";
 
   for (const days of [7, 30, 90]) {
-    test(`recomputes the active ${days}-day preset across a tz change`, () => {
-      const current = computeRangeInTimezone(days, EAST);
-      const result = reconcilePresetRange(current, EAST, WEST);
-      expect(result).toEqual(computeRangeInTimezone(days, WEST));
+    test(`deriving the ${days}-day preset by identity yields new-tz bounds`, () => {
+      // The range the panel was showing before the tz change. Its bounds are
+      // irrelevant to the new computation — only the stored identity matters.
+      const beforeTzChange = computeRangeInTimezone(days, EAST);
+      // On tz change the panel recomputes from identity (days) + new tz.
+      const afterTzChange = computeRangeInTimezone(days, WEST);
+
+      expect(afterTzChange).toEqual(computeRangeInTimezone(days, WEST));
+      // The two zones sit a calendar day apart, so the bounds actually moved —
+      // proving the derivation followed the new tz rather than the stale range.
+      expect(afterTzChange).not.toEqual(beforeTzChange);
     });
   }
 
-  test("leaves a range that matches no preset unchanged", () => {
-    // 45 days apart matches none of the 7/30/90 presets.
-    const custom = { from: "2025-12-01", to: "2026-01-14" };
-    const result = reconcilePresetRange(custom, EAST, WEST);
-    expect(result).toBe(custom);
-  });
+  test("rollover: a stale prior-day range is ignored, identity wins", () => {
+    // Simulate the bug's setup: the active range was computed on a PRIOR
+    // calendar day (a fixed, now-stale 7-day range). Reverse-matching this
+    // against freshly recomputed prev-tz bounds would fail and strand it as
+    // "custom". Deriving from the stored identity (7) sidesteps that entirely.
+    const stalePriorDayRange = { from: "2026-01-01", to: "2026-01-07" };
+    const presetDays = presetDaysFromRange(stalePriorDayRange); // 7
 
-  test("returns the same reference when the matched preset is unchanged", () => {
-    // Same tz on both sides: the preset's bounds are identical, so the helper
-    // must bail out referentially rather than allocate a new range.
-    const current = computeRangeInTimezone(7, EAST);
-    const result = reconcilePresetRange(current, EAST, EAST);
-    expect(result).toBe(current);
+    const recomputed = computeRangeInTimezone(presetDays, WEST);
+
+    expect(daysApart(recomputed.from, recomputed.to)).toBe(7);
+    expect(recomputed).toEqual(computeRangeInTimezone(7, WEST));
   });
 });
 

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type DateRange,
+  PRESET_DAYS,
   computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
@@ -26,6 +27,35 @@ import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
  */
 export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRange {
   return computeRangeInTimezone(30, tz);
+}
+
+/**
+ * Reconcile the active date range against a timezone change.
+ *
+ * The billing control exposes only relative presets (7/30/90 days), so when the
+ * effective timezone shifts we recompute whichever preset the user is currently
+ * on for the new timezone. We detect that preset by matching `current` against
+ * each preset's bounds computed for the PREVIOUS timezone; on a match we return
+ * the same preset recomputed for the NEW timezone. A range matching no preset is
+ * left untouched, defensively leaving any untracked/custom range alone, and the
+ * same `current` reference is returned whenever the bounds don't change so
+ * callers can rely on referential bail-outs.
+ */
+export function reconcilePresetRange(
+  current: DateRange,
+  prevTz: string,
+  nextTz: string,
+): DateRange {
+  for (const days of PRESET_DAYS) {
+    const prev = computeRangeInTimezone(days, prevTz);
+    if (current.from === prev.from && current.to === prev.to) {
+      const next = computeRangeInTimezone(days, nextTz);
+      return next.from === current.from && next.to === current.to
+        ? current
+        : next;
+    }
+  }
+  return current;
 }
 
 export type UsageChartState = {

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type DateRange,
-  PRESET_DAYS,
+  DEFAULT_PRESET_DAYS,
   computeRangeInTimezone,
 } from "@/components/charts/date-range-select";
 import {
@@ -22,40 +22,12 @@ import {
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 /**
- * Default "Last 30 days" range, with calendar bounds computed in the effective
- * timezone so they stay aligned with the `tz` sent to the billing backend.
+ * Default date range (the `DEFAULT_PRESET_DAYS` preset), with calendar bounds
+ * computed in the effective timezone so they stay aligned with the `tz` sent to
+ * the billing backend.
  */
 export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRange {
-  return computeRangeInTimezone(30, tz);
-}
-
-/**
- * Reconcile the active date range against a timezone change.
- *
- * The billing control exposes only relative presets (7/30/90 days), so when the
- * effective timezone shifts we recompute whichever preset the user is currently
- * on for the new timezone. We detect that preset by matching `current` against
- * each preset's bounds computed for the PREVIOUS timezone; on a match we return
- * the same preset recomputed for the NEW timezone. A range matching no preset is
- * left untouched, defensively leaving any untracked/custom range alone, and the
- * same `current` reference is returned whenever the bounds don't change so
- * callers can rely on referential bail-outs.
- */
-export function reconcilePresetRange(
-  current: DateRange,
-  prevTz: string,
-  nextTz: string,
-): DateRange {
-  for (const days of PRESET_DAYS) {
-    const prev = computeRangeInTimezone(days, prevTz);
-    if (current.from === prev.from && current.to === prev.to) {
-      const next = computeRangeInTimezone(days, nextTz);
-      return next.from === current.from && next.to === current.to
-        ? current
-        : next;
-    }
-  }
-  return current;
+  return computeRangeInTimezone(DEFAULT_PRESET_DAYS, tz);
 }
 
 export type UsageChartState = {

--- a/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/apps/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 
-import type { DateRange } from "@/components/charts/date-range-select";
-import { toLocalDateString } from "@/components/charts/format-date-label";
+import {
+  type DateRange,
+  computeRangeInTimezone,
+} from "@/components/charts/date-range-select";
 import {
   organizationsBillingUsageSeriesRetrieveOptions,
   organizationsBillingUsageTotalsRetrieveOptions,
@@ -10,21 +12,20 @@ import type {
   OrganizationsBillingUsageSeriesRetrieveData,
   OrganizationsBillingUsageTotalsRetrieveData,
 } from "@/generated/api/types.gen";
-import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import {
   DEFAULT_LLM_USAGE_DIMENSION,
   type LlmUsageDimension,
   toBillingGroupBy,
 } from "@/utils/llm-dimension";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
-export function getDefaultDateRange(): DateRange {
-  const today = new Date();
-  const from = new Date(today);
-  from.setDate(from.getDate() - 29);
-  return {
-    from: toLocalDateString(from),
-    to: toLocalDateString(today),
-  };
+/**
+ * Default "Last 30 days" range, with calendar bounds computed in the effective
+ * timezone so they stay aligned with the `tz` sent to the billing backend.
+ */
+export function getDefaultDateRange(tz: string = getEffectiveTimezone()): DateRange {
+  return computeRangeInTimezone(30, tz);
 }
 
 export type UsageChartState = {
@@ -57,7 +58,7 @@ export function getBillingUsageGroupBy(
 
 export function buildBillingUsageSeriesQuery(
   state: UsageChartState,
-  tz: string = getBrowserTimezone(),
+  tz: string = getEffectiveTimezone(),
 ): NonNullable<OrganizationsBillingUsageSeriesRetrieveData["query"]> {
   return {
     from: state.dateRange.from,
@@ -74,7 +75,7 @@ export function buildBillingUsageSeriesQuery(
 
 export function buildBillingUsageTotalsQuery(
   state: UsageChartState,
-  tz: string = getBrowserTimezone(),
+  tz: string = getEffectiveTimezone(),
 ): NonNullable<OrganizationsBillingUsageTotalsRetrieveData["query"]> {
   return {
     from: state.dateRange.from,
@@ -87,15 +88,17 @@ export function buildBillingUsageTotalsQuery(
 }
 
 export function useBillingUsageData(state: UsageChartState) {
+  const tz = useEffectiveTimezone();
+
   const seriesQuery = useQuery(
     organizationsBillingUsageSeriesRetrieveOptions({
-      query: buildBillingUsageSeriesQuery(state),
+      query: buildBillingUsageSeriesQuery(state, tz),
     }),
   );
 
   const totalsQuery = useQuery(
     organizationsBillingUsageTotalsRetrieveOptions({
-      query: buildBillingUsageTotalsQuery(state),
+      query: buildBillingUsageTotalsQuery(state, tz),
     }),
   );
 

--- a/apps/web/src/domains/settings/pages/general-page.test.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for `TimezoneCard` in the Settings General page.
+ *
+ * Strategy: render `TimezoneCard` directly (the full `GeneralPage` pulls in
+ * many feature-flag/query dependencies). Mock the generated API client's
+ * `patch`, `setDeviceSetting`, `captureError`, and stub `TimezonePicker` with
+ * a minimal harness that exposes its `onChange` via buttons. Drive the active
+ * assistant id through the real selection store. Assert that an explicit zone
+ * change PATCHes `{ ui: { userTimezone: "<zone>" } }`, auto/clear PATCHes
+ * `{ ui: { userTimezone: "" } }`, and that with no assistant id the device
+ * setting is still written but no PATCH is attempted.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+
+interface PatchArgs {
+  url: string;
+  path: { assistant_id: string };
+  body: { ui: Record<string, unknown> };
+}
+
+const ZONE = "America/Los_Angeles";
+
+const patchMock = mock(async (_args: PatchArgs) => ({ data: {} }));
+const setDeviceSettingMock = mock((_name: string, _value: string) => {});
+const captureErrorMock = mock(
+  (_error: unknown, _opts: { context: string }) => {},
+);
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: {
+    patch: patchMock,
+    getConfig: () => ({ baseUrl: "http://test.local" }),
+  },
+}));
+
+mock.module("@/utils/device-settings", () => ({
+  DEVICE_PREFIX: "device:",
+  deviceKey: (name: string) => `device:${name}`,
+  getDeviceSetting: (_name: string, fallback: string) => fallback,
+  setDeviceSetting: setDeviceSettingMock,
+  getDeviceBool: (_name: string, fallback: boolean) => fallback,
+  setDeviceBool: () => {},
+  watchDeviceSetting: () => () => {},
+  migrateDeviceSettings: () => {},
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+// Minimal picker harness: exposes the `onChange` handler through buttons so
+// the test can drive an explicit zone pick and an auto/clear ("") without
+// re-implementing the real picker's debounce / Intl logic.
+mock.module("@/domains/settings/components/timezone-picker", () => ({
+  TimezonePicker: ({ onChange }: { onChange: (value: string) => void }) => (
+    <div>
+      <button type="button" onClick={() => onChange(ZONE)}>
+        pick-zone
+      </button>
+      <button type="button" onClick={() => onChange("")}>
+        pick-auto
+      </button>
+    </div>
+  ),
+}));
+
+const { TimezoneCard } = await import("@/domains/settings/pages/general-page");
+
+beforeEach(() => {
+  patchMock.mockClear();
+  setDeviceSettingMock.mockClear();
+  captureErrorMock.mockClear();
+  patchMock.mockImplementation(async () => ({ data: {} }));
+  useAssistantSelectionStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantSelectionStore.setState({ activeAssistantId: null });
+});
+
+describe("TimezoneCard", () => {
+  test("explicit zone change PATCHes ui.userTimezone and writes the device setting", () => {
+    const { getByText } = render(<TimezoneCard />);
+    fireEvent.click(getByText("pick-zone"));
+
+    expect(setDeviceSettingMock).toHaveBeenCalledWith("timezone", ZONE);
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    const call = patchMock.mock.calls[0]![0];
+    expect(call.url).toBe("/v1/assistants/{assistant_id}/config");
+    expect(call.path).toEqual({ assistant_id: "asst-1" });
+    expect(call.body).toEqual({ ui: { userTimezone: ZONE } });
+  });
+
+  test("selecting auto/clear PATCHes ui.userTimezone with an empty string", () => {
+    const { getByText } = render(<TimezoneCard />);
+    fireEvent.click(getByText("pick-auto"));
+
+    expect(setDeviceSettingMock).toHaveBeenCalledWith("timezone", "");
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock.mock.calls[0]![0].body).toEqual({
+      ui: { userTimezone: "" },
+    });
+  });
+
+  test("with no assistant id, writes the device setting and skips the PATCH", () => {
+    useAssistantSelectionStore.setState({ activeAssistantId: null });
+    const { getByText } = render(<TimezoneCard />);
+    fireEvent.click(getByText("pick-zone"));
+
+    expect(setDeviceSettingMock).toHaveBeenCalledWith("timezone", ZONE);
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/settings/pages/general-page.test.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.test.tsx
@@ -182,4 +182,56 @@ describe("TimezoneCard", () => {
     expect(patchMock).toHaveBeenCalledTimes(2);
     expect(maxInFlight).toBe(1);
   });
+
+  test("a queued override after an assistant switch targets the CURRENT assistant, not the one active when the change started", async () => {
+    // Hold the first PATCH pending so we can switch assistants and queue a
+    // second change while it is in flight.
+    const resolvers: Array<() => void> = [];
+    patchMock.mockImplementation(
+      () =>
+        new Promise<{ data: Record<string, unknown> }>((resolve) => {
+          resolvers.push(() => resolve({ data: {} }));
+        }),
+    );
+
+    useAssistantSelectionStore.setState({ activeAssistantId: "asst-A" });
+    const { getByText, rerender } = render(<TimezoneCard />);
+
+    // (a) Start a change for assistant A: the first PATCH fires and stays in
+    // flight.
+    fireEvent.click(getByText("pick-zone")); // America/Los_Angeles
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock.mock.calls[0]![0].path).toEqual({ assistant_id: "asst-A" });
+
+    // (b) Switch the active assistant to B and re-render so `assistantIdRef`
+    // picks up the new id via its effect.
+    useAssistantSelectionStore.setState({ activeAssistantId: "asst-B" });
+    rerender(<TimezoneCard />);
+
+    // (c) Change the timezone again while A's PATCH is still in flight: this
+    // only records the pending value (no second PATCH yet).
+    fireEvent.click(getByText("pick-tokyo")); // Asia/Tokyo
+    expect(patchMock).toHaveBeenCalledTimes(1);
+
+    // Settle A's PATCH → the queue drains. The drained write must target the
+    // CURRENT assistant (B), carrying the latest requested value.
+    resolvers[0]!();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(patchMock.mock.calls[1]![0].path).toEqual({ assistant_id: "asst-B" });
+    expect(patchMock.mock.calls[1]![0].body).toEqual({
+      ui: { userTimezone: "Asia/Tokyo" },
+    });
+
+    // No write ever went to A carrying B's requested value.
+    const wroteTokyoToA = patchMock.mock.calls.some(
+      (call) =>
+        call[0].path.assistant_id === "asst-A" &&
+        call[0].body.ui.userTimezone === "Asia/Tokyo",
+    );
+    expect(wroteTokyoToA).toBe(false);
+
+    resolvers[1]!();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/domains/settings/pages/general-page.test.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.test.tsx
@@ -18,7 +18,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 
@@ -70,6 +70,12 @@ mock.module("@/domains/settings/components/timezone-picker", () => ({
       <button type="button" onClick={() => onChange("")}>
         pick-auto
       </button>
+      <button type="button" onClick={() => onChange("Europe/Paris")}>
+        pick-paris
+      </button>
+      <button type="button" onClick={() => onChange("Asia/Tokyo")}>
+        pick-tokyo
+      </button>
     </div>
   ),
 }));
@@ -120,5 +126,60 @@ describe("TimezoneCard", () => {
 
     expect(setDeviceSettingMock).toHaveBeenCalledWith("timezone", ZONE);
     expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  test("serializes rapid override changes (last-writer-wins): the final value is the last write and no two PATCHes overlap", async () => {
+    // Hold every PATCH pending so we can observe overlap (or the lack of it)
+    // while several changes fire in quick succession.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const resolvers: Array<() => void> = [];
+    patchMock.mockImplementation(
+      () =>
+        new Promise<{ data: Record<string, unknown> }>((resolve) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          resolvers.push(() => {
+            inFlight -= 1;
+            resolve({ data: {} });
+          });
+        }),
+    );
+
+    const { getByText } = render(<TimezoneCard />);
+
+    // Three rapid changes. The first starts a PATCH; the next two only update
+    // the pending target while the first is in flight.
+    fireEvent.click(getByText("pick-zone")); // America/Los_Angeles
+    fireEvent.click(getByText("pick-paris")); // Europe/Paris
+    fireEvent.click(getByText("pick-tokyo")); // Asia/Tokyo (last writer)
+
+    // Local device setting is written synchronously for every change.
+    expect(setDeviceSettingMock).toHaveBeenLastCalledWith(
+      "timezone",
+      "Asia/Tokyo",
+    );
+
+    // Only ONE PATCH is in flight despite three changes.
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock.mock.calls[0]![0].body).toEqual({
+      ui: { userTimezone: ZONE },
+    });
+    expect(maxInFlight).toBe(1);
+
+    // Settle the first PATCH → the queue drains to the LAST requested value,
+    // skipping the intermediate one entirely.
+    resolvers[0]!();
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(2));
+    expect(patchMock.mock.calls[1]![0].body).toEqual({
+      ui: { userTimezone: "Asia/Tokyo" },
+    });
+    expect(maxInFlight).toBe(1);
+
+    // Settle the drained PATCH; no further writes follow.
+    resolvers[1]!();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(patchMock).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBe(1);
   });
 });

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -1,5 +1,5 @@
 import { Heart, Monitor, Moon, Sun } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { SegmentControl } from "@vellum/design-library/components/segment-control";
 import { AssistantPicker } from "@/domains/settings/components/assistant-picker";
@@ -113,26 +113,50 @@ export function TimezoneCard() {
     getDeviceSetting("timezone", ""),
   );
 
+  // Serialize the `ui.userTimezone` override PATCH (last-writer-wins): at most
+  // one in flight. A change while one is in flight only records the latest
+  // desired value; the in-flight PATCH drains to it on settle, so overlapping
+  // rapid changes can never land out of order and leave a stale override.
+  const inFlightRef = useRef(false);
+  const pendingValueRef = useRef<string | null>(null);
+
+  const syncOverride = (assistantIdValue: string, value: string) => {
+    if (inFlightRef.current) {
+      pendingValueRef.current = value;
+      return;
+    }
+    inFlightRef.current = true;
+    pendingValueRef.current = null;
+    // `value` is the chosen IANA zone, or "" when auto is selected (the schema
+    // documents "" clears the setting). Silent on error.
+    client
+      .patch<Record<string, unknown>, unknown, true>({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: assistantIdValue },
+        body: { ui: { userTimezone: value } },
+        throwOnError: true,
+      })
+      .catch((error) => {
+        captureError(error, { context: "settings-timezone-override" });
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+        const pending = pendingValueRef.current;
+        pendingValueRef.current = null;
+        if (pending !== null) syncOverride(assistantIdValue, pending);
+      });
+  };
+
   const handleChange = (value: string) => {
     // Local source of truth for the reactive `useEffectiveTimezone` hook.
     setTimezone(value);
     setDeviceSetting("timezone", value);
 
     // Explicit user action: write the manual override to the authoritative
-    // `ui.userTimezone` cascade tier. `value` is the chosen IANA zone, or ""
-    // when auto is selected (the schema documents "" clears the setting).
-    // Fire-and-forget; never block the local setting on the network write.
+    // `ui.userTimezone` cascade tier. Fire-and-forget; never block the local
+    // setting on the network write, and never throw out of handleChange.
     if (!assistantId) return;
-    client
-      .patch<Record<string, unknown>, unknown, true>({
-        url: `/v1/assistants/{assistant_id}/config`,
-        path: { assistant_id: assistantId },
-        body: { ui: { userTimezone: value } },
-        throwOnError: true,
-      })
-      .catch((error) => {
-        captureError(error, { context: "settings-timezone-override" });
-      });
+    syncOverride(assistantId, value);
   };
 
   return (

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -20,6 +20,9 @@ import {
   useAssistantWithHealthz,
 } from "@/domains/settings/components/assistant-status-panel";
 
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { client } from "@/generated/api/client.gen";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -104,14 +107,32 @@ function ThemeCard() {
   );
 }
 
-function TimezoneCard() {
+export function TimezoneCard() {
+  const assistantId = useAssistantSelectionStore.use.activeAssistantId();
   const [timezone, setTimezone] = useState<string>(() =>
     getDeviceSetting("timezone", ""),
   );
 
   const handleChange = (value: string) => {
+    // Local source of truth for the reactive `useEffectiveTimezone` hook.
     setTimezone(value);
     setDeviceSetting("timezone", value);
+
+    // Explicit user action: write the manual override to the authoritative
+    // `ui.userTimezone` cascade tier. `value` is the chosen IANA zone, or ""
+    // when auto is selected (the schema documents "" clears the setting).
+    // Fire-and-forget; never block the local setting on the network write.
+    if (!assistantId) return;
+    client
+      .patch<Record<string, unknown>, unknown, true>({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: assistantId },
+        body: { ui: { userTimezone: value } },
+        throwOnError: true,
+      })
+      .catch((error) => {
+        captureError(error, { context: "settings-timezone-override" });
+      });
   };
 
   return (

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -113,6 +113,14 @@ export function TimezoneCard() {
     getDeviceSetting("timezone", ""),
   );
 
+  // Hold the live assistant id so a PATCH that fires (or drains) after the
+  // user switches assistants always targets the *current* one. Assigned in an
+  // effect (never during render) to avoid mutating a ref while rendering.
+  const assistantIdRef = useRef(assistantId);
+  useEffect(() => {
+    assistantIdRef.current = assistantId;
+  }, [assistantId]);
+
   // Serialize the `ui.userTimezone` override PATCH (last-writer-wins): at most
   // one in flight. A change while one is in flight only records the latest
   // desired value; the in-flight PATCH drains to it on settle, so overlapping
@@ -120,9 +128,24 @@ export function TimezoneCard() {
   const inFlightRef = useRef(false);
   const pendingValueRef = useRef<string | null>(null);
 
-  const syncOverride = (assistantIdValue: string, value: string) => {
+  // Stable indirection so the `.finally` drain can call the latest
+  // `syncOverride` without referencing `const syncOverride` inside its own
+  // initializer (which would be a temporal-dead-zone access).
+  const syncOverrideRef = useRef<(value: string) => void>(() => {});
+
+  const syncOverride = (value: string) => {
     if (inFlightRef.current) {
       pendingValueRef.current = value;
+      return;
+    }
+    // Re-read the current active assistant at fire time so a queued write after
+    // an assistant switch targets whatever assistant is selected now, not the
+    // one active when the change was first requested.
+    const currentAssistantId = assistantIdRef.current;
+    if (!currentAssistantId) {
+      // No assistant to target: drop this write and clear queued state so the
+      // serializer can't deadlock.
+      pendingValueRef.current = null;
       return;
     }
     inFlightRef.current = true;
@@ -132,7 +155,7 @@ export function TimezoneCard() {
     client
       .patch<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
-        path: { assistant_id: assistantIdValue },
+        path: { assistant_id: currentAssistantId },
         body: { ui: { userTimezone: value } },
         throwOnError: true,
       })
@@ -143,9 +166,16 @@ export function TimezoneCard() {
         inFlightRef.current = false;
         const pending = pendingValueRef.current;
         pendingValueRef.current = null;
-        if (pending !== null) syncOverride(assistantIdValue, pending);
+        if (pending !== null) syncOverrideRef.current(pending);
       });
   };
+
+  // Keep the drain indirection pointed at the latest `syncOverride`. Assigned
+  // in an effect (never during render) for the same "no refs during render"
+  // reason as `assistantIdRef`.
+  useEffect(() => {
+    syncOverrideRef.current = syncOverride;
+  });
 
   const handleChange = (value: string) => {
     // Local source of truth for the reactive `useEffectiveTimezone` hook.
@@ -155,8 +185,8 @@ export function TimezoneCard() {
     // Explicit user action: write the manual override to the authoritative
     // `ui.userTimezone` cascade tier. Fire-and-forget; never block the local
     // setting on the network write, and never throw out of handleChange.
-    if (!assistantId) return;
-    syncOverride(assistantId, value);
+    // `syncOverride` self-guards on a missing assistant id.
+    syncOverride(value);
   };
 
   return (

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -18,6 +18,7 @@ import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-sync";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { TimezoneSync } from "@/components/timezone-sync";
 
 /**
  * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
@@ -134,6 +135,10 @@ export function RootLayout() {
 
       {/* Portal target for mobile overlays that use `position: fixed`. */}
       <div id="viewport-overlays" />
+
+      {/* Headless: keeps daemon config.ui.detectedTimezone fresh on
+          focus/zone change. No-ops until an assistant id resolves. */}
+      <TimezoneSync />
     </div>
   );
 }

--- a/apps/web/src/utils/effective-timezone.test.ts
+++ b/apps/web/src/utils/effective-timezone.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for `getEffectiveTimezone`.
+ *
+ * Mocks the two collaborators (`getDeviceSetting`, `getBrowserTimezone`)
+ * rather than touching real `localStorage`/`Intl`, so the resolver's
+ * override-vs-auto branching is pinned in isolation.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getDeviceSettingMock = mock((_name: string, fallback: string) => fallback);
+mock.module("@/utils/device-settings", () => ({
+  getDeviceSetting: getDeviceSettingMock,
+}));
+
+const getBrowserTimezoneMock = mock(() => "America/Los_Angeles");
+mock.module("@/utils/browser-timezone", () => ({
+  getBrowserTimezone: getBrowserTimezoneMock,
+}));
+
+import { getEffectiveTimezone } from "./effective-timezone";
+
+beforeEach(() => {
+  getDeviceSettingMock.mockReset();
+  getBrowserTimezoneMock.mockReset();
+  getDeviceSettingMock.mockImplementation((_name, fallback) => fallback);
+  getBrowserTimezoneMock.mockImplementation(() => "America/Los_Angeles");
+});
+
+describe("getEffectiveTimezone", () => {
+  test("returns the device override when device:timezone is set", () => {
+    getDeviceSettingMock.mockImplementation(() => "America/New_York");
+
+    expect(getEffectiveTimezone()).toBe("America/New_York");
+    expect(getBrowserTimezoneMock).not.toHaveBeenCalled();
+  });
+
+  test("trims surrounding whitespace from a real override", () => {
+    getDeviceSettingMock.mockImplementation(() => "  Europe/London  ");
+
+    expect(getEffectiveTimezone()).toBe("Europe/London");
+  });
+
+  test("falls back to the live browser zone when the override is empty", () => {
+    expect(getEffectiveTimezone()).toBe("America/Los_Angeles");
+    expect(getBrowserTimezoneMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("treats a whitespace-only override as empty and falls back", () => {
+    getDeviceSettingMock.mockImplementation(() => "   ");
+
+    expect(getEffectiveTimezone()).toBe("America/Los_Angeles");
+    expect(getBrowserTimezoneMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/utils/effective-timezone.ts
+++ b/apps/web/src/utils/effective-timezone.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for "what timezone should the client use right now?".
+ *
+ * Two modes, keyed off the `device:timezone` setting:
+ *
+ * - **Manual override** (`device:timezone` is a non-empty IANA zone): the user
+ *   deliberately picked a zone. It always wins and is intentionally NOT
+ *   auto-updated when the OS timezone changes — a manual choice stays put.
+ * - **Auto** (`device:timezone` is empty/absent): follow the live browser zone.
+ *   `getBrowserTimezone()` re-reads `Intl` on every call, so switching OS
+ *   timezones is reflected the next time this resolver runs.
+ *
+ * Callers should use this instead of `getBrowserTimezone()` directly so the
+ * override-vs-auto semantics are applied consistently across the web client.
+ */
+
+import { getBrowserTimezone } from "@/utils/browser-timezone";
+import { getDeviceSetting } from "@/utils/device-settings";
+
+/**
+ * Resolve the effective timezone: a trimmed `device:timezone` override when
+ * present, otherwise the live browser zone.
+ */
+export function getEffectiveTimezone(): string {
+  const override = getDeviceSetting("timezone", "").trim();
+  if (override) return override;
+  return getBrowserTimezone();
+}

--- a/apps/web/src/utils/use-effective-timezone.test.tsx
+++ b/apps/web/src/utils/use-effective-timezone.test.tsx
@@ -21,6 +21,21 @@ mock.module("@/utils/device-settings", () => ({
   },
 }));
 
+// The hook subscribes to the cross-domain bus `app.resume` signal via
+// `useBusSubscription`, which calls `subscribe` from `@/lib/event-bus`.
+// Capture the registered event + handler so we can invoke it directly, and
+// expose an unsubscribe mock so we can assert teardown on unmount.
+let busEvent: string | null = null;
+let busHandler: (() => void) | null = null;
+const busUnsubscribe = mock(() => {});
+mock.module("@/lib/event-bus", () => ({
+  subscribe: (event: string, handler: () => void) => {
+    busEvent = event;
+    busHandler = handler;
+    return busUnsubscribe;
+  },
+}));
+
 const { useEffectiveTimezone } = await import("@/utils/use-effective-timezone");
 
 function renderTracked() {
@@ -34,7 +49,10 @@ function renderTracked() {
 beforeEach(() => {
   currentZone = "America/New_York";
   watchCallback = null;
+  busEvent = null;
+  busHandler = null;
   unwatch.mockClear();
+  busUnsubscribe.mockClear();
   localStorage.clear();
 });
 
@@ -61,34 +79,21 @@ describe("useEffectiveTimezone", () => {
     expect(result.current).toBe("Europe/Paris");
   });
 
-  test("updates on visibilitychange to visible", () => {
+  test("subscribes to the bus `app.resume` signal", () => {
+    renderHook(() => useEffectiveTimezone());
+    expect(busEvent).toBe("app.resume");
+    expect(busHandler).not.toBeNull();
+  });
+
+  test("updates when the bus `app.resume` signal fires", () => {
     const { result } = renderHook(() => useEffectiveTimezone());
 
     currentZone = "Asia/Tokyo";
-    Object.defineProperty(document, "visibilityState", {
-      value: "visible",
-      configurable: true,
-    });
     act(() => {
-      window.dispatchEvent(new Event("visibilitychange"));
+      busHandler?.();
     });
 
     expect(result.current).toBe("Asia/Tokyo");
-  });
-
-  test("ignores visibilitychange when not visible", () => {
-    const { result } = renderHook(() => useEffectiveTimezone());
-
-    currentZone = "Asia/Tokyo";
-    Object.defineProperty(document, "visibilityState", {
-      value: "hidden",
-      configurable: true,
-    });
-    act(() => {
-      window.dispatchEvent(new Event("visibilitychange"));
-    });
-
-    expect(result.current).toBe("America/New_York");
   });
 
   test("updates when the device:timezone watcher fires", () => {
@@ -103,13 +108,15 @@ describe("useEffectiveTimezone", () => {
     expect(result.current).toBe("Europe/London");
   });
 
-  test("calls the watcher cleanup on unmount", () => {
+  test("calls the watcher and bus cleanups on unmount", () => {
     const { unmount } = renderHook(() => useEffectiveTimezone());
     expect(unwatch).not.toHaveBeenCalled();
+    expect(busUnsubscribe).not.toHaveBeenCalled();
 
     unmount();
 
     expect(unwatch).toHaveBeenCalledTimes(1);
+    expect(busUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
   test("does not re-render when the recomputed value is unchanged", () => {

--- a/apps/web/src/utils/use-effective-timezone.test.tsx
+++ b/apps/web/src/utils/use-effective-timezone.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let currentZone = "America/New_York";
+let renderCount = 0;
+
+// The hook re-reads `getEffectiveTimezone` on focus/visibility/override changes,
+// so drive it from a mutable mock we can flip between renders.
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => currentZone,
+}));
+
+// Capture the watcher callback and its cleanup so we can fire the callback
+// directly and assert the cleanup runs on unmount.
+let watchCallback: (() => void) | null = null;
+const unwatch = mock(() => {});
+mock.module("@/utils/device-settings", () => ({
+  watchDeviceSetting: (_name: string, cb: () => void) => {
+    watchCallback = cb;
+    return unwatch;
+  },
+}));
+
+const { useEffectiveTimezone } = await import("@/utils/use-effective-timezone");
+
+function renderTracked() {
+  renderCount = 0;
+  return renderHook(() => {
+    renderCount += 1;
+    return useEffectiveTimezone();
+  });
+}
+
+beforeEach(() => {
+  currentZone = "America/New_York";
+  watchCallback = null;
+  unwatch.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("useEffectiveTimezone", () => {
+  test("initial value equals getEffectiveTimezone()", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(result.current).toBe("America/New_York");
+  });
+
+  test("updates on window focus when the zone changes", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(result.current).toBe("America/New_York");
+
+    currentZone = "Europe/Paris";
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(result.current).toBe("Europe/Paris");
+  });
+
+  test("updates on visibilitychange to visible", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+
+    currentZone = "Asia/Tokyo";
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+    act(() => {
+      window.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe("Asia/Tokyo");
+  });
+
+  test("ignores visibilitychange when not visible", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+
+    currentZone = "Asia/Tokyo";
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    act(() => {
+      window.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe("America/New_York");
+  });
+
+  test("updates when the device:timezone watcher fires", () => {
+    const { result } = renderHook(() => useEffectiveTimezone());
+    expect(watchCallback).not.toBeNull();
+
+    currentZone = "Europe/London";
+    act(() => {
+      watchCallback?.();
+    });
+
+    expect(result.current).toBe("Europe/London");
+  });
+
+  test("calls the watcher cleanup on unmount", () => {
+    const { unmount } = renderHook(() => useEffectiveTimezone());
+    expect(unwatch).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unwatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not re-render when the recomputed value is unchanged", () => {
+    const { result } = renderTracked();
+    const initialRenders = renderCount;
+    expect(result.current).toBe("America/New_York");
+
+    // Zone unchanged — refresh should be a no-op, no extra render.
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(renderCount).toBe(initialRenders);
+    expect(result.current).toBe("America/New_York");
+  });
+});

--- a/apps/web/src/utils/use-effective-timezone.ts
+++ b/apps/web/src/utils/use-effective-timezone.ts
@@ -3,10 +3,15 @@
  *
  * The browser emits no native event when the OS timezone changes, so there is
  * nothing to subscribe to for a live zone switch. Instead we re-read the
- * effective zone on window focus and on `visibilitychange` to visible — the
- * moments a user is most likely to return after changing their system clock or
- * crossing a timezone — plus on `device:timezone` setting changes (manual
- * override) via the device-setting watcher.
+ * effective zone on window focus and on the cross-domain bus `app.resume`
+ * signal — the moments a user is most likely to return after changing their
+ * system clock or crossing a timezone — plus on `device:timezone` setting
+ * changes (manual override) via the device-setting watcher.
+ *
+ * Visibility is intentionally not listened to directly here: the EVENT_BUS
+ * convention reserves `document` visibility listeners to
+ * `runtime/event-sources/dom-visibility.ts`, which publishes `app.resume`
+ * (fanning in page visibility, Capacitor app-state, and network-online).
  *
  * The functional `setTz` update returns the previous reference when the
  * recomputed zone is unchanged, so React skips the re-render in the common
@@ -15,10 +20,11 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { watchDeviceSetting } from "@/utils/device-settings";
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
 
-/** Returns the live effective timezone, updating on focus/visibility/override changes. */
+/** Returns the live effective timezone, updating on focus/resume/override changes. */
 export function useEffectiveTimezone(): string {
   const [tz, setTz] = useState(getEffectiveTimezone);
 
@@ -29,16 +35,13 @@ export function useEffectiveTimezone(): string {
     });
   }, []);
 
+  useBusSubscription("app.resume", refresh);
+
   useEffect(() => {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") refresh();
-    };
     window.addEventListener("focus", refresh);
-    window.addEventListener("visibilitychange", onVisibilityChange);
     const unwatch = watchDeviceSetting("timezone", refresh);
     return () => {
       window.removeEventListener("focus", refresh);
-      window.removeEventListener("visibilitychange", onVisibilityChange);
       unwatch();
     };
   }, [refresh]);

--- a/apps/web/src/utils/use-effective-timezone.ts
+++ b/apps/web/src/utils/use-effective-timezone.ts
@@ -1,0 +1,47 @@
+/**
+ * Reactive hook for the current effective timezone.
+ *
+ * The browser emits no native event when the OS timezone changes, so there is
+ * nothing to subscribe to for a live zone switch. Instead we re-read the
+ * effective zone on window focus and on `visibilitychange` to visible — the
+ * moments a user is most likely to return after changing their system clock or
+ * crossing a timezone — plus on `device:timezone` setting changes (manual
+ * override) via the device-setting watcher.
+ *
+ * The functional `setTz` update returns the previous reference when the
+ * recomputed zone is unchanged, so React skips the re-render in the common
+ * no-op case.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { watchDeviceSetting } from "@/utils/device-settings";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+
+/** Returns the live effective timezone, updating on focus/visibility/override changes. */
+export function useEffectiveTimezone(): string {
+  const [tz, setTz] = useState(getEffectiveTimezone);
+
+  const refresh = useCallback(() => {
+    setTz((prev) => {
+      const next = getEffectiveTimezone();
+      return next === prev ? prev : next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    window.addEventListener("focus", refresh);
+    window.addEventListener("visibilitychange", onVisibilityChange);
+    const unwatch = watchDeviceSetting("timezone", refresh);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      window.removeEventListener("visibilitychange", onVisibilityChange);
+      unwatch();
+    };
+  }, [refresh]);
+
+  return tz;
+}


### PR DESCRIPTION
## Summary
Makes the web client's timezone reactively follow the user when they switch zones, instead of caching the zone read once at mount. A single source of truth (manual `device:timezone` override → live browser zone) is consumed everywhere: usage/billing charts re-key and refetch on zone change, every chat message carries a live `clientTimezone`, and the assistant config's `ui.detectedTimezone` (auto) and `ui.userTimezone` (explicit override) are kept in sync per the backend cascade.

## Self-review result
PASS — 4-pass fresh-eyes review + 2 remediation rounds. Final correctness gate brute-forced 20,440 DST day/zone combinations (incl. skip-midnight and 30/45-min-offset zones) with zero failures, simulated the sync serialization state machine, and traced all changed call sites. No gaps remain.

## Plan PRs merged into this branch
- #33023: getEffectiveTimezone resolver (PR 1)
- #33029: useEffectiveTimezone reactive hook (PR 2)
- #33030: send live clientTimezone per chat message (PR 5)
- #33035: usage charts follow live timezone (PR 3)
- #33038: billing usage queries follow live timezone (PR 4)
- #33041: sync detected timezone to daemon config (PR 6)

## Review-driven follow-up / fix PRs
- #33036: hook uses app.resume bus signal (EVENT_BUS convention)
- #33047, #33066: billing preset reactivity, then preset-identity tracking
- #33062: usage-tab range boundaries genuinely tz-aware (+ removed dead toLocalDateString)
- #33064, #33081: timezone-sync semantics + serialized PATCHes; detectedTimezone-only (no userTimezone clobbering)
- #33085: settings picker writes ui.userTimezone on explicit change/clear
- #33082, #33088: DST-correct day-start math (two-pass + skip-midnight handling)

Part of plan: fix-timezone-auto-update.md