### PR TITLE
feat(web): add factor-in-memories toggle for incognito conversations

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -30,6 +30,7 @@ import {
   type ThresholdPreset,
 } from "@/utils/threshold-presets";
 import { activeProfileModelQueryKey } from "@/domains/chat/hooks/use-active-profile-model";
+import { IncognitoMemoryToggle } from "@/domains/chat/components/incognito-memory-toggle";
 
 interface Props {
   assistantId: string;
@@ -371,6 +372,9 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
                 })}
               </>
             )}
+            <div className="px-[8px] pt-1 empty:hidden">
+              <IncognitoMemoryToggle assistantId={assistantId} conversationId={conversationId} />
+            </div>
           </BottomSheet.Body>
         </BottomSheet.Content>
       </BottomSheet.Root>
@@ -428,6 +432,16 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
             })}
           </>
         )}
+        {/* Wrapped so toggling the switch doesn't bubble to Radix and close
+            the menu. `empty:hidden` collapses the padding when the toggle
+            self-gates to null (flag off / non-incognito conversation). */}
+        <div
+          className="px-2 py-1.5 empty:hidden"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <IncognitoMemoryToggle assistantId={assistantId} conversationId={conversationId} />
+        </div>
       </Menu.Content>
     </Menu.Root>
   );

--- a/apps/web/src/domains/chat/components/incognito-memory-toggle.tsx
+++ b/apps/web/src/domains/chat/components/incognito-memory-toggle.tsx
@@ -1,0 +1,119 @@
+/**
+ * "Factor in memories" toggle for incognito conversations.
+ *
+ * Incognito conversations never produce memories, but can optionally recall
+ * existing ones. This toggle controls that opt-in. It is rendered only when
+ * the `incognito-conversations` flag is on AND the active conversation is
+ * incognito.
+ *
+ * State sources, in precedence order:
+ * - The server-backed `Conversation` row (conversation list query) supplies
+ *   `incognito` / `factorInMemories` once a conversation is persisted.
+ * - The client store (`getConversationSettings`) holds the draft intent for a
+ *   not-yet-persisted conversation.
+ *
+ * Write paths mirror the per-conversation override pattern in
+ * `composer-settings-menu.tsx`:
+ * - Draft (only in the client store): update the store, no network call.
+ * - Persisted (present in the server list): PUT
+ *   `/v1/conversations/{id}/incognito`, optimistically reflect the value,
+ *   invalidate the conversation list on success, roll back on failure.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { Toggle } from "@vellum/design-library";
+import { client } from "@/generated/api/client.gen";
+import { useConversationListQuery } from "@/hooks/conversation-queries";
+import { conversationsQueryKey } from "@/lib/sync/query-tags";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+interface Props {
+  assistantId: string;
+  conversationId: string | undefined;
+}
+
+export function IncognitoMemoryToggle({ assistantId, conversationId }: Props) {
+  const queryClient = useQueryClient();
+  const flagEnabled = useAssistantFeatureFlagStore.use.incognitoConversations();
+
+  // Server-backed conversation row (foreground list). Present once the
+  // conversation is persisted; absent for not-yet-sent drafts.
+  const { conversations } = useConversationListQuery(assistantId);
+  const serverConversation = conversationId
+    ? conversations.find((c) => c.conversationId === conversationId)
+    : undefined;
+
+  // Client-store draft settings — reactive so the toggle reflects draft
+  // incognito intent before the server assigns a real id.
+  const conversationSettings = useConversationStore.use.conversationSettings();
+  const storeSettings = conversationId
+    ? conversationSettings.get(conversationId)
+    : undefined;
+
+  // A conversation is persisted when the server list holds a non-draft row.
+  // Anything else (only in the client store, or flagged `draft`) updates the
+  // store without a network call.
+  const isPersisted = Boolean(serverConversation) && serverConversation?.draft !== true;
+
+  const isIncognito =
+    serverConversation?.incognito ?? storeSettings?.incognito ?? false;
+
+  const initialFactorInMemories =
+    serverConversation?.factorInMemories ?? storeSettings?.factorInMemories ?? false;
+
+  const [checked, setChecked] = useState(initialFactorInMemories);
+
+  // Keep local state in sync when the resolved source value changes (e.g. the
+  // active conversation switches, or the server row loads/updates).
+  useEffect(() => {
+    setChecked(initialFactorInMemories);
+  }, [initialFactorInMemories]);
+
+  const handleChange = useCallback(
+    async (next: boolean) => {
+      if (!conversationId) return;
+
+      if (!isPersisted) {
+        // Draft: client-store only, no network.
+        setChecked(next);
+        useConversationStore
+          .getState()
+          .updateConversationSettings(conversationId, { factorInMemories: next });
+        return;
+      }
+
+      // Persisted: optimistic update + PUT, rollback on failure.
+      const previous = checked;
+      setChecked(next);
+      try {
+        await client.put({
+          url: `/v1/conversations/{conversation_id}/incognito`,
+          path: { conversation_id: conversationId },
+          body: { factorInMemories: next },
+          headers: { "Content-Type": "application/json" },
+          throwOnError: true,
+        });
+        void queryClient.invalidateQueries({
+          queryKey: conversationsQueryKey(assistantId),
+        });
+      } catch {
+        setChecked(previous);
+      }
+    },
+    [assistantId, conversationId, isPersisted, checked, queryClient],
+  );
+
+  if (!flagEnabled || !isIncognito) return null;
+
+  return (
+    <Toggle
+      checked={checked}
+      onChange={(next) => void handleChange(next)}
+      label="Factor in memories"
+      helperText="Incognito conversations never create memories, but can optionally read your existing ones."
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add a flag-gated 'Factor in memories' toggle for incognito conversations: draft updates client store; persisted conversations PUT /v1/conversations/{id}/incognito and invalidate the conversation list

Part of plan: incognito-conversations.md (PR 14 of 16)