### PR TITLE
refactor(web): share model-id parsing and narrow openai-compatible create retry

### DIFF
--- a/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -15,6 +15,7 @@ import {
   peekPendingProviderKey,
   setPendingProviderKey,
 } from "@/domains/onboarding/provider-key";
+import { parseModelIds } from "@/utils/parse-model-ids";
 import { routes } from "@/utils/routes";
 
 function isValidHttpUrl(value: string): boolean {
@@ -47,10 +48,7 @@ export function ApiKeyScreen() {
   const entry = onboardingProvider(provider) ?? DEFAULT_ONBOARDING_PROVIDER;
   const requiresKey = entry.requiresKey;
   const isCustom = entry.requiresBaseUrl ?? false;
-  const models = modelsRaw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const models = parseModelIds(modelsRaw);
 
   const trimmedBaseUrl = baseUrl.trim();
   const keyOk = !requiresKey || apiKey.trim().length > 0;

--- a/apps/web/src/domains/onboarding/provider-key.test.ts
+++ b/apps/web/src/domains/onboarding/provider-key.test.ts
@@ -7,12 +7,30 @@ type ClientCall = {
   body?: Record<string, unknown>;
 };
 
+type QueuedResponse = {
+  ok: boolean;
+  status: number;
+  /** Daemon error envelope surfaced by the generated client on `result.error`. */
+  error?: unknown;
+};
+
 const calls: ClientCall[] = [];
 // Per-URL queue of responses; each create call shifts the next. Missing/empty
 // queue defaults to 200 OK.
-const responseQueues: Record<string, { ok: boolean; status: number }[]> = {};
+const responseQueues: Record<string, QueuedResponse[]> = {};
 
-function nextResponse(url: string): { ok: boolean; status: number } {
+// The daemon's flag-disabled rejection message
+// (assistant inference-provider-connection-routes.ts) wrapped in the standard
+// error envelope (`{ error: { code, message } }`).
+const FLAG_DISABLED_BODY = {
+  error: {
+    code: "BAD_REQUEST",
+    message:
+      "OpenAI-compatible endpoints are disabled. Enable the openai-compatible-endpoints feature flag to configure this provider.",
+  },
+};
+
+function nextResponse(url: string): QueuedResponse {
   const queued = responseQueues[url]?.shift();
   return queued ?? { ok: true, status: 200 };
 }
@@ -20,7 +38,8 @@ function nextResponse(url: string): { ok: boolean; status: number } {
 const patchMock = mock(
   async (args: { url: string; body?: Record<string, unknown> }) => {
     calls.push({ method: "patch", url: args.url, body: args.body });
-    return { response: nextResponse(args.url) };
+    const { ok, status, error } = nextResponse(args.url);
+    return { response: { ok, status }, error };
   },
 );
 
@@ -36,7 +55,8 @@ const postMock = mock(
       path: args.path,
       body: args.body,
     });
-    return { response: nextResponse(args.url) };
+    const { ok, status, error } = nextResponse(args.url);
+    return { response: { ok, status }, error };
   },
 );
 
@@ -168,11 +188,11 @@ describe("applyPendingProviderKey", () => {
     expect(body.models).toBeUndefined();
   });
 
-  test("openai-compatible retries the connection POST on a 400 then succeeds", async () => {
-    // First create attempt fails with 400 (flag cache not yet propagated),
-    // second succeeds.
+  test("openai-compatible retries the connection POST on the flag-disabled 400 then succeeds", async () => {
+    // First create attempt fails with the flag-disabled 400 (flag cache not
+    // yet propagated), second succeeds.
     responseQueues[CONNECTIONS_URL] = [
-      { ok: false, status: 400 },
+      { ok: false, status: 400, error: FLAG_DISABLED_BODY },
       { ok: true, status: 200 },
     ];
 
@@ -189,5 +209,39 @@ describe("applyPendingProviderKey", () => {
       (c) => c.method === "post" && c.url === CONNECTIONS_URL,
     );
     expect(connectionCalls.length).toBe(2);
+  });
+
+  test("openai-compatible does NOT retry a genuine validation 400 — throws on first attempt", async () => {
+    // A real validation rejection (e.g. base_url_required) must surface
+    // immediately rather than being retried as a flag-propagation delay.
+    responseQueues[CONNECTIONS_URL] = [
+      {
+        ok: false,
+        status: 400,
+        error: {
+          error: { code: "BAD_REQUEST", message: "base_url is required." },
+        },
+      },
+      // Sentinel: a second attempt (if it wrongly retried) would succeed —
+      // so a passing assertion of a single attempt proves no retry happened.
+      { ok: true, status: 200 },
+    ];
+
+    setPendingProviderKey({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a"],
+    });
+
+    await expect(applyPendingProviderKey("asst-1")).rejects.toMatchObject({
+      message: "Failed to create provider connection",
+      status: 400,
+    });
+
+    const connectionCalls = calls.filter(
+      (c) => c.method === "post" && c.url === CONNECTIONS_URL,
+    );
+    expect(connectionCalls.length).toBe(1);
   });
 });

--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -1,5 +1,6 @@
 import { client } from "@/generated/api/client.gen";
 import type { OnboardingProviderId } from "@/domains/onboarding/provider-catalog";
+import { extractErrorMessage } from "@/utils/api-errors";
 
 // Model-provider API key collected during onboarding. Held in sessionStorage
 // (consume-once) between the API-key step and the post-hatch application, then
@@ -105,6 +106,25 @@ async function writeApiKeySecret(
   }
 }
 
+/**
+ * True when a non-ok create result is the daemon's "feature flag still
+ * disabled" rejection (HTTP 400 carrying the openai-compatible-endpoints
+ * disabled message). The daemon shapes errors as `{ error: { code, message } }`
+ * (assistant http-errors.ts), surfaced by the generated client on
+ * `result.error`. Matched on a stable substring of
+ * `rejectDisabledOpenAICompatibleProvider`'s message
+ * (inference-provider-connection-routes.ts) so it's robust to minor wording
+ * changes while excluding genuine validation 400s (base_url_required,
+ * models_required, SSRF/metadata rejection, malformed base_url).
+ */
+function isFlagDisabledError(result: {
+  response?: { status?: number };
+  error?: unknown;
+}): boolean {
+  if (result.response?.status !== 400) return false;
+  return extractErrorMessage(result.error).toLowerCase().includes("feature flag");
+}
+
 async function createProviderConnection(
   assistantId: string,
   provider: OnboardingProviderId,
@@ -126,9 +146,11 @@ async function createProviderConnection(
   };
   // The daemon refreshes its feature-flag cache asynchronously, so right after
   // enableAssistantFeatureFlag() returns it may still read
-  // openai-compatible-endpoints as disabled and reject the create with HTTP 400.
-  // Retry briefly to absorb that gateway->daemon propagation delay. Other
-  // providers (and genuine validation 400s) surface immediately.
+  // openai-compatible-endpoints as disabled and reject the create with the
+  // flag-disabled 400. Retry briefly to absorb that gateway->daemon
+  // propagation delay, but ONLY for that specific 400 — genuine validation
+  // 400s (base_url_required, models_required, SSRF rejection, malformed
+  // base_url) and all non-openai-compatible providers surface immediately.
   const maxAttempts = provider === "openai-compatible" ? 5 : 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = await client.post({
@@ -138,13 +160,12 @@ async function createProviderConnection(
       headers: { "Content-Type": "application/json" },
     });
     if (result.response?.ok) return;
-    const status = result.response?.status;
-    if (provider === "openai-compatible" && status === 400 && attempt < maxAttempts) {
+    if (isFlagDisabledError(result) && attempt < maxAttempts) {
       await new Promise((r) => setTimeout(r, 250));
       continue;
     }
     throw Object.assign(new Error("Failed to create provider connection"), {
-      status,
+      status: result.response?.status,
     });
   }
 }

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -31,6 +31,7 @@ import {
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { toKebabCase } from "@/domains/settings/ai/slugify";
 import { providerSupportsPlatformAuth } from "@/assistant/llm-model-catalog";
+import { parseModelIds } from "@/utils/parse-model-ids";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -511,6 +512,18 @@ export function ProviderEditorContent({
 
       const labelValue = label.trim() || null;
 
+      // openai-compatible carries base_url + models on both create and update.
+      // Hoisted so the create and update inputs share one source of truth
+      // (empty object for other providers leaves both fields off the payload).
+      const openAICompatibleFields = isOpenAICompatible
+        ? {
+            base_url: baseUrl.trim() || null,
+            models: connectionModels.trim()
+              ? parseModelIds(connectionModels).map((id) => ({ id }))
+              : null,
+          }
+        : {};
+
       let saved: ProviderConnection;
       if (effectiveMode === "create") {
         // Create path — used by genuine create-mode opens AND by the
@@ -522,15 +535,7 @@ export function ProviderEditorContent({
           provider,
           auth,
           ...(labelValue !== null && { label: labelValue }),
-          ...(isOpenAICompatible && {
-            base_url: baseUrl.trim() || null,
-            models: connectionModels.trim()
-              ? connectionModels
-                  .split(",")
-                  .map((id) => ({ id: id.trim() }))
-                  .filter((m) => m.id)
-              : null,
-          }),
+          ...openAICompatibleFields,
         };
         const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
           path: { assistant_id: assistantId },
@@ -545,15 +550,7 @@ export function ProviderEditorContent({
         const input: UpdateConnectionInput = {
           auth,
           label: labelValue,
-          ...(isOpenAICompatible && {
-            base_url: baseUrl.trim() || null,
-            models: connectionModels.trim()
-              ? connectionModels
-                  .split(",")
-                  .map((id) => ({ id: id.trim() }))
-                  .filter((m) => m.id)
-              : null,
-          }),
+          ...openAICompatibleFields,
         };
         const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
           path: { assistant_id: assistantId, name: connection!.name },

--- a/apps/web/src/utils/parse-model-ids.test.ts
+++ b/apps/web/src/utils/parse-model-ids.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseModelIds } from "@/utils/parse-model-ids";
+
+describe("parseModelIds", () => {
+  test("splits, trims, and preserves order", () => {
+    expect(parseModelIds("a, b ,c")).toEqual(["a", "b", "c"]);
+  });
+
+  test("drops empty and whitespace-only entries", () => {
+    expect(parseModelIds("a,,  ,b")).toEqual(["a", "b"]);
+  });
+
+  test("returns an empty array for an empty string", () => {
+    expect(parseModelIds("")).toEqual([]);
+  });
+});

--- a/apps/web/src/utils/parse-model-ids.ts
+++ b/apps/web/src/utils/parse-model-ids.ts
@@ -1,0 +1,11 @@
+/**
+ * Parse a comma-separated list of model identifiers into trimmed, non-empty
+ * ids. Shared by the onboarding API-key screen and the settings provider
+ * editor so the "split → trim → drop empties" parse can't drift between them.
+ */
+export function parseModelIds(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}


### PR DESCRIPTION
## Summary
- Extract parseModelIds to apps/web/src/utils and reuse in onboarding + settings (removes 3x duplication; collapses the modal's intra-file copy-paste).
- Narrow the openai-compatible provider-connection create retry to only the feature-flag-propagation 400, so genuine validation errors surface immediately.

Fixes gaps identified during plan review for openai-compatible-onboarding.md.