### PR TITLE
fix(web): surface server-backed incognito state in Conversation mapper

### DIFF
--- a/apps/web/src/utils/conversation-transforms-list.test.ts
+++ b/apps/web/src/utils/conversation-transforms-list.test.ts
@@ -96,6 +96,26 @@ describe("toConversation — field mapping", () => {
     expect(result.scheduleJobId).toBe("job-1");
     expect(result.displayOrder).toBe(3);
   });
+
+  test("maps incognito state with factorInMemories", () => {
+    const recalled = toConversation(
+      makeRaw({ id: "c", incognito: true, factorInMemories: true }),
+    );
+    expect(recalled.incognito).toBe(true);
+    expect(recalled.factorInMemories).toBe(true);
+
+    const isolated = toConversation(
+      makeRaw({ id: "c", incognito: true, factorInMemories: false }),
+    );
+    expect(isolated.incognito).toBe(true);
+    expect(isolated.factorInMemories).toBe(false);
+  });
+
+  test("omits incognito fields for a normal conversation", () => {
+    const result = toConversation(makeRaw({ id: "c" }));
+    expect(result.incognito).toBeUndefined();
+    expect(result.factorInMemories).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/utils/conversation-transforms.ts
+++ b/apps/web/src/utils/conversation-transforms.ts
@@ -108,6 +108,9 @@ export function toConversation(raw: RawConversationSummary): Conversation {
     channelBinding: mapChannelBinding(raw.channelBinding),
     originChannel,
     isProcessing: raw.isProcessing,
+    ...(raw.incognito
+      ? { incognito: true, factorInMemories: raw.factorInMemories }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes gap from plan review for incognito-conversations.md.

- toConversation dropped incognito/factorInMemories from server responses, so the badge/toggle broke after reload for persisted incognito conversations. Map them through.
- Regenerate stale committed daemon types so the raw summary type carries the fields.