### PR TITLE
fix(assistant): drop unused idx_conversations_incognito index

### DIFF
--- a/assistant/src/memory/migrations/271-conversations-incognito-flags.ts
+++ b/assistant/src/memory/migrations/271-conversations-incognito-flags.ts
@@ -9,13 +9,9 @@ import { getSqliteFrom } from "../db-connection.js";
  * - `factor_in_memories` (default 1) — controls whether existing memories are
  *   recalled into the conversation.
  *
- * An index on `incognito` supports filtering incognito conversations out of
- * memory-producing queries.
- *
  * Idempotent — the `ADD COLUMN` statements are wrapped in try/catch (mirroring
  * the surrounding additive-column migrations, e.g.
- * 253-conversation-last-notified-profile and 221-conversations-archived-at),
- * and `CREATE INDEX IF NOT EXISTS` is a no-op once the index exists.
+ * 253-conversation-last-notified-profile and 221-conversations-archived-at).
  */
 export function migrateConversationsIncognitoFlags(database: DrizzleDb): void {
   const raw = getSqliteFrom(database);
@@ -33,7 +29,4 @@ export function migrateConversationsIncognitoFlags(database: DrizzleDb): void {
   } catch {
     // Column already exists — nothing to do.
   }
-  raw.exec(
-    `CREATE INDEX IF NOT EXISTS idx_conversations_incognito ON conversations(incognito)`,
-  );
 }

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -56,7 +56,6 @@ export const conversations = sqliteTable(
     index("idx_conversations_fork_parent_conversation_id").on(
       table.forkParentConversationId,
     ),
-    index("idx_conversations_incognito").on(table.incognito),
   ],
 );
 


### PR DESCRIPTION
## Summary
Fixes gap from plan review for incognito-conversations.md.

The incognito gates all look up conversations by primary key; nothing filters by the incognito column, so idx_conversations_incognito was pure write-amplification. Drop the index from the schema and migration 271; keep both columns.