### PR TITLE
feat(web): add '*Credits not included' note to Pro plan card

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -653,6 +653,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                             features={plan.included_features}
                             variant="checklist"
                           />
+                          {isProCard && (
+                            <Typography
+                              as="p"
+                              variant="body-small-default"
+                              className="text-[var(--content-tertiary)]"
+                            >
+                              *Credits not included
+                            </Typography>
+                          )}
                         </div>
                         <div className="mt-4 flex flex-1 flex-col justify-end gap-4">
                           {!isCurrent && isProCard && (


### PR DESCRIPTION
## Summary
- Add a `*Credits not included` line below the features list on the Pro plan card in the adjust-plan modal (the modal shown after clicking "Upgrade to Pro" or "Manage Plan")
- The note is scoped to the Pro card only, rendered without a checkmark, using the same `content-tertiary` body-small styling as the card's other secondary text

## Original prompt
Add a line to the bottom of the Pro plan upgrade card in the modal that opens after clicking "Upgrade to Pro" or "Manage Plan". It should sit below the features list, render without the checkmark used by the feature items, and read "*Credits not included".