### PR TITLE
fix(assistant): support keyless openai-compatible connections

### DIFF
--- a/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
@@ -46,13 +46,13 @@ describe("openai-compatible adapter factory", () => {
     expect(adapter).not.toBeNull();
   });
 
-  test("createAdapterFromConnection rejects 'none' auth for openai-compatible", () => {
+  test("createAdapterFromConnection allows keyless 'none' auth for openai-compatible", () => {
     const connection: ProviderConnection = {
-      name: "my-vllm",
+      name: "my-lmstudio",
       provider: "openai-compatible",
       auth: { type: "none" },
       label: null,
-      baseUrl: "http://localhost:8080/v1",
+      baseUrl: "http://localhost:1234/v1",
       models: [{ id: "my-model" }],
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -61,12 +61,36 @@ describe("openai-compatible adapter factory", () => {
 
     const resolvedAuth: ResolvedAuth = { kind: "none" };
 
+    // Keyless local endpoints (LM Studio, etc.) need no key — the factory must
+    // build an adapter without throwing despite the empty credential.
     const adapter = createAdapterFromConnection(connection, resolvedAuth, {
       model: "my-model",
     });
 
-    // openai-compatible is setupMode: "api-key", not keyless, so none auth
-    // should be rejected.
+    expect(adapter).not.toBeNull();
+  });
+
+  test("createAdapterFromConnection rejects 'none' auth for a keyed non-openai-compatible provider", () => {
+    const connection: ProviderConnection = {
+      name: "my-anthropic",
+      provider: "anthropic",
+      auth: { type: "none" },
+      label: null,
+      baseUrl: null,
+      models: [{ id: "claude-sonnet" }],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: false,
+    };
+
+    const resolvedAuth: ResolvedAuth = { kind: "none" };
+
+    const adapter = createAdapterFromConnection(connection, resolvedAuth, {
+      model: "claude-sonnet",
+    });
+
+    // anthropic is setupMode: "api-key" and not openai-compatible, so the
+    // relaxed keyless guard must NOT apply — none auth stays rejected.
     expect(adapter).toBeNull();
   });
 });

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -105,8 +105,10 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       useNativeWebSearch,
       streamTimeoutMs,
     }),
+  // Keyless openai-compatible endpoints (e.g. LM Studio) ignore the key; the
+  // placeholder satisfies the OpenAI SDK, which requires a non-empty key.
   "openai-compatible": ({ apiKey, model, streamTimeoutMs, baseURL }) =>
-    new OpenAIChatCompletionsProvider(apiKey, model, {
+    new OpenAIChatCompletionsProvider(apiKey || "not-needed", model, {
       providerName: "openai-compatible",
       providerLabel: "OpenAI-compatible",
       streamTimeoutMs,
@@ -162,8 +164,10 @@ export function buildProviderAdapter(
  * Build a Provider instance for a given connection + resolved auth.
  *
  * Returns null when the provider/auth combination is not usable
- * (e.g. `none` auth on a keyed provider). The caller decides whether to
- * log a warning or fall back to the global registry.
+ * (e.g. `none` auth on a keyed provider). `openai-compatible` is exempt:
+ * it may be keyless to support local endpoints (LM Studio, vLLM, Ollama's
+ * OpenAI API) that need no key. The caller decides whether to log a
+ * warning or fall back to the global registry.
  */
 export function createAdapterFromConnection(
   connection: ProviderConnection,
@@ -178,16 +182,26 @@ export function createAdapterFromConnection(
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);
   if (!entry) return null;
   const isKeyless = entry.setupMode === "keyless";
+  const isOpenAICompatible = provider === "openai-compatible";
 
-  // Keyed providers can't operate without a credential.
-  if (!isKeyless && resolvedAuth.kind === "none") return null;
+  // Keyed providers can't operate without a credential. openai-compatible is
+  // exempt because local endpoints (LM Studio, etc.) commonly need no key.
+  if (!isKeyless && !isOpenAICompatible && resolvedAuth.kind === "none") {
+    return null;
+  }
 
   const apiKey =
     resolvedAuth.kind === "header"
       ? (resolvedAuth.headers["Authorization"] ?? "").replace(/^Bearer /, "")
       : "";
+  // For non-header auth, `resolveAuth` drops the base URL, so pull it from the
+  // connection for openai-compatible (keyless endpoints still need their URL).
   const baseURL =
-    resolvedAuth.kind === "header" ? resolvedAuth.baseUrl : undefined;
+    resolvedAuth.kind === "header"
+      ? resolvedAuth.baseUrl
+      : isOpenAICompatible
+        ? (connection.baseUrl ?? undefined)
+        : undefined;
 
   const codexSubscription =
     connection.auth.type === "oauth_subscription" && provider === "openai";


### PR DESCRIPTION
## Summary
- Allow none-auth openai-compatible connections at the adapter layer (LM Studio and other local endpoints need no key); pull the base URL from the connection and pass a placeholder key to the OpenAI SDK.
- Keyed openai-compatible and all other providers are unchanged; non-openai-compatible providers still reject none auth.

Addresses Codex P1 on the openai-compatible onboarding feature branch.