### PR TITLE
Fix macOS composer Auto profile gating (#33096)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -57,23 +57,41 @@ struct ChatProfilePicker: View {
     @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
 
     /// Pill label: the override profile's display name when set, otherwise
-    /// "Auto" when auto-routing is enabled or "Default (`<activeProfile>`)"
-    /// when it is not.
+    /// "Default (`<activeProfile>`)". The seeded auto profile is surfaced as
+    /// "Auto" when it is the effective profile.
     static func label(current: String?, profiles: [InferenceProfile], activeProfile: String, autoRouting: Bool = false) -> String {
+        if current == InferenceProfile.autoProfileName {
+            return "Auto"
+        }
         if let current {
             return profiles.first(where: { $0.name == current })?.displayName ?? current
         }
-        if autoRouting {
+        if autoRouting && activeProfile == InferenceProfile.autoProfileName {
             return "Auto"
         }
         let activeDisplay = profiles.first(where: { $0.name == activeProfile })?.displayName ?? activeProfile
         return "Default (\(activeDisplay))"
     }
 
+    /// Chat pickers render "Auto" as a dedicated nil-selection row, so the
+    /// seeded meta-profile should never appear in the regular profile list.
+    /// Disabled profiles stay hidden unless they are the selected value.
+    static func visibleProfilesForPicker(
+        _ profiles: [InferenceProfile],
+        selectedNames: [String?] = []
+    ) -> [InferenceProfile] {
+        let selected = Set(selectedNames.compactMap { $0 }.filter { !$0.isEmpty })
+        return profiles.filter { profile in
+            guard profile.name != InferenceProfile.autoProfileName else { return false }
+            return !profile.isDisabled || selected.contains(profile.name)
+        }
+    }
+
     var body: some View {
-        let activeProfiles = profiles.filter { !$0.isDisabled }
         let autoRoutingEnabled = assistantFeatureFlagStore.isEnabled("query-complexity-routing")
-        let isAutoActive = autoRoutingEnabled && current == nil
+        let effectiveProfile = current ?? activeProfile
+        let activeProfiles = Self.visibleProfilesForPicker(profiles, selectedNames: [effectiveProfile])
+        let isAutoActive = autoRoutingEnabled && effectiveProfile == InferenceProfile.autoProfileName
         let pillLabel = Self.label(current: current, profiles: activeProfiles, activeProfile: activeProfile, autoRouting: autoRoutingEnabled)
         #if os(macOS)
         ComposerPillMenu(
@@ -96,7 +114,7 @@ struct ChatProfilePicker: View {
                     isActive: isAutoActive,
                     size: .regular
                 ) {
-                    onSelect(nil)
+                    onSelect(InferenceProfile.autoProfileName)
                 } trailing: {
                     VStack(alignment: .trailing, spacing: 2) {
                         if isAutoActive {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -153,40 +153,45 @@ struct ComposerSettingsMenu: View {
 
                 if let config, !config.profiles.isEmpty {
                     let autoRoutingEnabled = assistantFeatureFlagStore.isEnabled("query-complexity-routing")
-                    let hasOverride = config.current != nil
-                    let isAutoActive = autoRoutingEnabled && !hasOverride
                     let effectiveProfile = config.current ?? config.activeProfile
+                    let isAutoActive = autoRoutingEnabled && effectiveProfile == InferenceProfile.autoProfileName
+                    let visibleProfiles = ChatProfilePicker.visibleProfilesForPicker(
+                        config.profiles,
+                        selectedNames: [effectiveProfile]
+                    )
 
-                    sectionHeader("Model Profile")
+                    if autoRoutingEnabled || !visibleProfiles.isEmpty {
+                        sectionHeader("Model Profile")
 
-                    if autoRoutingEnabled {
-                        VMenuItem(
-                            icon: VIcon.wand.rawValue,
-                            label: "Auto",
-                            isActive: isAutoActive,
-                            size: .regular
-                        ) {
-                            config.onSelect(nil)
-                        } trailing: {
-                            if isAutoActive {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
+                        if autoRoutingEnabled {
+                            VMenuItem(
+                                icon: VIcon.wand.rawValue,
+                                label: "Auto",
+                                isActive: isAutoActive,
+                                size: .regular
+                            ) {
+                                config.onSelect(InferenceProfile.autoProfileName)
+                            } trailing: {
+                                if isAutoActive {
+                                    VIconView(.check, size: 12)
+                                        .foregroundStyle(VColor.primaryBase)
+                                }
                             }
                         }
-                    }
 
-                    ForEach(config.profiles) { profile in
-                        VMenuItem(
-                            icon: VIcon.sparkles.rawValue,
-                            label: profile.displayName,
-                            isActive: !isAutoActive && effectiveProfile == profile.name,
-                            size: .regular
-                        ) {
-                            config.onSelect(profile.name)
-                        } trailing: {
-                            if !isAutoActive && effectiveProfile == profile.name {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
+                        ForEach(visibleProfiles) { profile in
+                            VMenuItem(
+                                icon: VIcon.sparkles.rawValue,
+                                label: profile.displayName,
+                                isActive: !isAutoActive && effectiveProfile == profile.name,
+                                size: .regular
+                            ) {
+                                config.onSelect(profile.name)
+                            } trailing: {
+                                if !isAutoActive && effectiveProfile == profile.name {
+                                    VIconView(.check, size: 12)
+                                        .foregroundStyle(VColor.primaryBase)
+                                }
                             }
                         }
                     }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -50,6 +50,45 @@ final class ChatProfilePickerTests: XCTestCase {
         )
     }
 
+    func testLabelShowsAutoForExplicitAutoProfile() {
+        let profiles = [InferenceProfile(name: "balanced", label: "Balanced")]
+        XCTAssertEqual(
+            ChatProfilePicker.label(
+                current: InferenceProfile.autoProfileName,
+                profiles: profiles,
+                activeProfile: "balanced",
+                autoRouting: true
+            ),
+            "Auto"
+        )
+    }
+
+    func testLabelShowsDefaultWhenRoutingEnabledButActiveProfileIsNotAuto() {
+        let profiles = [InferenceProfile(name: "balanced", label: "Balanced")]
+        XCTAssertEqual(
+            ChatProfilePicker.label(
+                current: nil,
+                profiles: profiles,
+                activeProfile: "balanced",
+                autoRouting: true
+            ),
+            "Default (Balanced)"
+        )
+    }
+
+    func testLabelShowsAutoWhenActiveProfileIsAuto() {
+        let profiles = [InferenceProfile(name: "balanced", label: "Balanced")]
+        XCTAssertEqual(
+            ChatProfilePicker.label(
+                current: nil,
+                profiles: profiles,
+                activeProfile: InferenceProfile.autoProfileName,
+                autoRouting: true
+            ),
+            "Auto"
+        )
+    }
+
     // MARK: - Disabled profiles are filtered from the picker
 
     func testDisabledProfilesAreFilteredFromLabel() {
@@ -65,15 +104,55 @@ final class ChatProfilePickerTests: XCTestCase {
     }
 
     func testPickerBodyFiltersDisabledProfiles() {
-        // Verify that the filtered activeProfiles excludes disabled ones.
         let profiles: [InferenceProfile] = [
             InferenceProfile(name: "active-one"),
             InferenceProfile(name: "disabled-one", status: "disabled"),
             InferenceProfile(name: "active-two"),
         ]
-        let active = profiles.filter { !$0.isDisabled }
+        let active = ChatProfilePicker.visibleProfilesForPicker(profiles)
         XCTAssertEqual(active.count, 2)
         XCTAssertEqual(active.map(\.name), ["active-one", "active-two"])
+    }
+
+    func testVisibleProfilesKeepSelectedDisabledProfile() {
+        let profiles: [InferenceProfile] = [
+            InferenceProfile(name: "balanced", label: "Balanced"),
+            InferenceProfile(name: "legacy-quality", status: "disabled", label: "Legacy Quality"),
+            InferenceProfile(name: "quality-optimized", label: "Quality"),
+        ]
+
+        let visible = ChatProfilePicker.visibleProfilesForPicker(
+            profiles,
+            selectedNames: ["legacy-quality"]
+        )
+
+        XCTAssertEqual(visible.map(\.name), ["balanced", "legacy-quality", "quality-optimized"])
+    }
+
+    func testVisibleProfilesHideAutoProfile() {
+        let profiles: [InferenceProfile] = [
+            InferenceProfile(name: InferenceProfile.autoProfileName, label: "Auto"),
+            InferenceProfile(name: "balanced", label: "Balanced"),
+            InferenceProfile(name: "quality-optimized", label: "Quality"),
+        ]
+
+        let visible = ChatProfilePicker.visibleProfilesForPicker(profiles)
+
+        XCTAssertEqual(visible.map(\.name), ["balanced", "quality-optimized"])
+    }
+
+    func testVisibleProfilesHideAutoEvenWhenSelected() {
+        let profiles: [InferenceProfile] = [
+            InferenceProfile(name: InferenceProfile.autoProfileName, label: "Auto"),
+            InferenceProfile(name: "balanced", label: "Balanced"),
+        ]
+
+        let visible = ChatProfilePicker.visibleProfilesForPicker(
+            profiles,
+            selectedNames: [InferenceProfile.autoProfileName]
+        )
+
+        XCTAssertEqual(visible.map(\.name), ["balanced"])
     }
 
     // MARK: - Selection callback wiring (covers ComposerView → ChatProfilePicker → ConversationManager)


### PR DESCRIPTION
already reviewed etc. from https://github.com/vellum-ai/vellum-assistant/pull/33096 (meant to merge that onto main, not the release branch)

## Summary
- Reuse the existing inference-profile gate in native chat profile pickers so the seeded `auto` profile is hidden when query-complexity-routing is disabled.
- Apply the filtered profile list to the combined composer settings menu.
- Add macOS regression coverage for hiding and showing `auto` based on the routing flag.

## Original prompt
Debug a staging macOS report where Model Profile still showed Auto even though Query Complexity Routing was disabled, then put up a PR for the fix.