### PR TITLE
fix(memory): bump conversation-title sidechain timeout to 15s

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -89,7 +89,7 @@ describe("conversation-title-service", () => {
         systemPrompt: expect.stringContaining("conversation titles"),
         tools: [],
         callSite: "conversationTitle",
-        timeoutMs: 10_000,
+        timeoutMs: 15_000,
       }),
     );
     expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
@@ -207,7 +207,7 @@ describe("conversation-title-service", () => {
         systemPrompt: expect.stringContaining("conversation titles"),
         tools: [],
         callSite: "conversationTitle",
-        timeoutMs: 10_000,
+        timeoutMs: 15_000,
       }),
     );
     expect(mockUpdateConversationTitle).toHaveBeenCalledWith(

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -140,7 +140,7 @@ export async function generateAndPersistConversationTitle(
     tools: [],
     callSite: "conversationTitle",
     signal,
-    timeoutMs: 10_000,
+    timeoutMs: 15_000,
   });
   const title = normalizeTitle(result.text);
   if (title) {
@@ -275,7 +275,7 @@ export async function regenerateConversationTitle(
     tools: [],
     callSite: "conversationTitle",
     signal,
-    timeoutMs: 10_000,
+    timeoutMs: 15_000,
   });
   const title = normalizeTitle(result.text);
   if (title) {


### PR DESCRIPTION
## Summary
- Bump the hardcoded `timeoutMs` on the conversation-title generation sidechain from `10_000` to `15_000` in both the first-pass and second-pass (regeneration) call sites in `conversation-title-service.ts`.
- Gives slower title generations more headroom before the caller-side deadline fires.

## Original prompt
While investigating ATL-737 (Anthropic transport aborts at exactly elapsedMs=10000 for a Pro user), we traced the exact-10000ms caller abort to the hardcoded 10s timeout on the conversation-title sidechain in `assistant/src/memory/conversation-title-service.ts`. As an immediate mitigation, bump that timeout to 15s.