### PR TITLE
feat(web): add CreditsCard component matching iOS drawer mock

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for the presentational `CreditsCard`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the click handlers with `fireEvent`. No jest-dom matchers — we
+ * assert with plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { CreditsCard } from "./credits-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreditsCard", () => {
+  test("renders the balance, coins icon, and fires onAddCredits when Add is clicked", () => {
+    const onAddCredits = mock(() => {});
+    const onEarnCredits = mock(() => {});
+
+    const { getByText, getByRole, container } = render(
+      <CreditsCard
+        balance="60"
+        onAddCredits={onAddCredits}
+        onEarnCredits={onEarnCredits}
+      />,
+    );
+
+    expect(getByText("60 credits")).toBeTruthy();
+    // The Coins icon renders a lucide SVG; assert at least one is present.
+    expect(container.querySelector("svg.lucide-coins")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: /add/i }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(onEarnCredits).not.toHaveBeenCalled();
+  });
+
+  test("hides only the credits pill when balance is null but still renders Earn Credits", () => {
+    const { queryByText, getByText } = render(
+      <CreditsCard
+        balance={null}
+        onAddCredits={() => {}}
+        onEarnCredits={() => {}}
+      />,
+    );
+
+    expect(queryByText(/credits$/)).toBeNull();
+    expect(getByText("Earn Credits")).toBeTruthy();
+  });
+
+  test("fires onEarnCredits when the Earn Credits row is clicked", () => {
+    const onEarnCredits = mock(() => {});
+
+    const { getByText } = render(
+      <CreditsCard
+        balance="60"
+        onAddCredits={() => {}}
+        onEarnCredits={onEarnCredits}
+      />,
+    );
+
+    fireEvent.click(getByText("Earn Credits"));
+    expect(onEarnCredits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,0 +1,79 @@
+import { Button, cn } from "@vellum/design-library";
+import { Coins, Gift, Plus } from "lucide-react";
+
+interface CreditsCardProps {
+  /** Formatted whole-credits string, or null when unavailable. */
+  balance: string | null;
+  onAddCredits: () => void;
+  onEarnCredits: () => void;
+  className?: string;
+}
+
+/**
+ * Presentational credits card matching the iOS preferences-drawer mock:
+ * a bordered card containing a credits pill (coins icon + balance + a primary
+ * "Add" button) and an "Earn Credits" row beneath. Purely presentational — no
+ * data fetching; callers supply the formatted balance and handlers.
+ */
+export function CreditsCard({
+  balance,
+  onAddCredits,
+  onEarnCredits,
+  className,
+}: CreditsCardProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full",
+        className,
+      )}
+      style={{
+        borderColor: "var(--surface-base)",
+        background: "var(--surface-overlay)",
+      }}
+    >
+      {balance !== null && (
+        <div
+          className="flex items-center justify-between gap-2 rounded-[10px] py-2 pl-1.5 pr-2 w-full"
+          style={{ background: "var(--surface-base)" }}
+        >
+          <div className="flex items-center gap-2">
+            <Coins
+              className="h-3.5 w-3.5"
+              style={{ color: "var(--credits-accent)" }}
+              aria-hidden
+            />
+            <span
+              className="text-title-medium"
+              style={{ color: "var(--content-default)" }}
+            >
+              {balance} credits
+            </span>
+          </div>
+          <Button variant="primary" size="regular" onClick={onAddCredits}>
+            <Plus className="h-3 w-3" aria-hidden />
+            Add
+          </Button>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onEarnCredits}
+        className="flex items-center gap-2 pl-1.5 transition-colors hover:opacity-80"
+      >
+        <Gift
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--content-secondary)" }}
+          aria-hidden
+        />
+        <span
+          className="text-body-large-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          Earn Credits
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -248,6 +248,8 @@
   --feed-nudge-weak: #F0D9E0;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #C8E5E2;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #EFE8C4;
 
@@ -328,6 +330,8 @@
   --feed-nudge-weak: #432B33;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #293D3B;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #464125;
 
@@ -414,6 +418,8 @@
   --feed-nudge-weak: #432B33;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #293D3B;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #464125;
 


### PR DESCRIPTION
## Summary
- Add presentational CreditsCard (chat domain): bordered card with credits pill (coins icon + balance + primary Add button) and an Earn Credits row, matching the iOS mock
- Add --credits-accent design token for the teal coins icon
- Tests cover balance present/null and Add/Earn handlers

Part of plan: ios-theme-switcher-larger.md (PR 3 of 4)