### PR TITLE
feat(subagent): per-subagent inference profile on spawn (JARVIS-1060)

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -33,6 +33,10 @@
             "type": "string",
             "enum": ["general", "researcher", "coder", "planner"],
             "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'general': full access (default). Ignored when fork: true (forks always use general)."
+          },
+          "override_profile": {
+            "type": "string",
+            "description": "Inference profile to run this subagent on, e.g. `quality-optimized` or `balanced`. Overrides the profile inherited from the parent. Use to route cheap, mechanical work (file-writing) to a faster tier while keeping judgment work on a strong model. Applies in both regular and fork modes."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/tools/subagent/spawn.test.ts
+++ b/assistant/src/tools/subagent/spawn.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock conversation-crud so getConversationOverrideProfile is deterministic.
+// By default the inherited profile is undefined; tests that exercise
+// inheritance supply context.overrideProfile, which spawn.ts prefers over
+// the row read.
+mock.module("../../memory/conversation-crud.js", () => ({
+  getConversationOverrideProfile: () => undefined,
+}));
+
+import { getSubagentManager } from "../../subagent/index.js";
+import type { ToolContext } from "../types.js";
+import { executeSubagentSpawn } from "./spawn.js";
+
+function makeContext(
+  conversationId: string,
+  extras: Record<string, unknown> = {},
+): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId,
+    trustClass: "guardian" as const,
+    sendToClient: () => {},
+    ...extras,
+  } as unknown as ToolContext;
+}
+
+/**
+ * Runs executeSubagentSpawn with manager.spawn stubbed and returns the
+ * captured config passed to the manager.
+ */
+async function spawnAndCapture(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<Record<string, unknown>> {
+  const manager = getSubagentManager();
+  const originalSpawn = manager.spawn.bind(manager);
+
+  let capturedConfig: Record<string, unknown> | undefined;
+  manager.spawn = async (config: Record<string, unknown>) => {
+    capturedConfig = config;
+    return "stub-subagent-id";
+  };
+
+  try {
+    const result = await executeSubagentSpawn(input, context);
+    expect(result.isError).toBe(false);
+    expect(capturedConfig).toBeDefined();
+    return capturedConfig as Record<string, unknown>;
+  } finally {
+    manager.spawn = originalSpawn;
+  }
+}
+
+describe("subagent_spawn override_profile", () => {
+  test("explicit override_profile is forwarded to manager.spawn", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+        override_profile: "balanced",
+      },
+      makeContext("conv-explicit"),
+    );
+
+    expect(config.overrideProfile).toBe("balanced");
+  });
+
+  test("omitted override_profile falls back to the inherited profile", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+      },
+      makeContext("conv-inherit", { overrideProfile: "quality-optimized" }),
+    );
+
+    expect(config.overrideProfile).toBe("quality-optimized");
+  });
+
+  test("omitted override_profile with no inheritance omits the field", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+      },
+      makeContext("conv-none"),
+    );
+
+    expect(config.overrideProfile).toBeUndefined();
+  });
+
+  test("explicit override_profile wins over a non-null inherited profile", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+        override_profile: "balanced",
+      },
+      makeContext("conv-override", {
+        overrideProfile: "quality-optimized",
+      }),
+    );
+
+    expect(config.overrideProfile).toBe("balanced");
+  });
+});

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -3,7 +3,10 @@ import { getConversationOverrideProfile } from "../../memory/conversation-crud.j
 import type { Message } from "../../providers/types.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
+import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("subagent-spawn");
 
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
@@ -14,6 +17,7 @@ export async function executeSubagentSpawn(
   const extraContext = input.context as string | undefined;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
+  const overrideProfile = input.override_profile as string | undefined;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -88,6 +92,18 @@ export async function executeSubagentSpawn(
     context.overrideProfile ??
     getConversationOverrideProfile(context.conversationId);
 
+  // An explicit `override_profile` from the caller wins over the inherited
+  // value; omitting it preserves the inherited-fallback behavior. Unknown
+  // profile names are tolerated — the provider resolver no-ops them.
+  const resolvedOverrideProfile = overrideProfile ?? inheritedOverrideProfile;
+
+  if (overrideProfile) {
+    log.debug(
+      { overrideProfile, label, fork },
+      "subagent_spawn override_profile set explicitly",
+    );
+  }
+
   try {
     const subagentId = await manager.spawn(
       {
@@ -99,12 +115,10 @@ export async function executeSubagentSpawn(
         // For fork mode, role is ignored by the manager (forced to general),
         // but we still omit it from the config to signal intent.
         ...(!fork && role ? { role: role as SubagentRole } : {}),
-        ...(inheritedOverrideProfile
-          ? { overrideProfile: inheritedOverrideProfile }
+        ...(resolvedOverrideProfile
+          ? { overrideProfile: resolvedOverrideProfile }
           : {}),
-        ...(context.toolUseId
-          ? { parentToolUseId: context.toolUseId }
-          : {}),
+        ...(context.toolUseId ? { parentToolUseId: context.toolUseId } : {}),
         ...forkFields,
       },
       sendToClient as (msg: unknown) => void,


### PR DESCRIPTION
## Summary
- Add model-settable `override_profile` to the subagent_spawn tool schema + executor
- Explicit value overrides the inherited parent profile; omission preserves current behavior
- Enables tiered planner/worker app-builder (planner@quality, workers@balanced)

Part of plan: ab-planner-worker.md (PR 1 of 9)
JARVIS-1060