### PR TITLE
fix(web): replace flat credits rows with CreditsCard in preferences menu

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -83,6 +83,10 @@ mock.module("@/components/theme-toggle", () => ({
   ThemeToggle: () => createElement("div", { "data-testid": "theme-toggle" }, "Theme"),
 }));
 
+mock.module("@/domains/chat/components/credits-card", () => ({
+  CreditsCard: () => createElement("div", { "data-testid": "credits-card" }, "Credits"),
+}));
+
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 
 beforeEach(() => {

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -186,7 +186,6 @@ function PreferencesMenuContent({
               onClose();
               onEarnCredits();
             }}
-            className="mx-2"
           />
           <MenuDivider />
         </>

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -3,7 +3,6 @@ import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
-  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -15,7 +14,6 @@ import { useNavigate } from "react-router";
 
 import {
   BottomSheet,
-  Button,
   PanelItem,
   Popover,
   SideMenu,
@@ -33,6 +31,8 @@ import {
 import { adminUrl, routes } from "@/utils/routes";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+
+import { CreditsCard } from "./credits-card";
 
 // Modal only opens when the user clicks "Share Feedback" — defer loading
 // until then to keep the modal's form deps (markdown editor, etc.) out of
@@ -172,37 +172,21 @@ function PreferencesMenuContent({
 
       {showBillingRows ? (
         <>
-          {effectiveBalance !== null ? (
-            <>
-              <div className="flex items-center justify-between gap-3 py-2 pl-[8px]">
-                <span
-                  className="text-body-medium-lighter"
-                  style={{ color: "var(--content-default)" }}
-                >
-                  {formatWholeCredits(effectiveBalance)} credits
-                </span>
-                <Button
-                  variant="ghost"
-                  size="compact"
-                  onClick={() => {
-                    onClose();
-                    navigate(routes.settings.billing);
-                  }}
-                >
-                  Add credits
-                </Button>
-              </div>
-              <MenuDivider />
-            </>
-          ) : null}
-
-          <PanelItem
-            icon={Gift}
-            label="Earn credits"
-            onSelect={() => {
+          <CreditsCard
+            balance={
+              effectiveBalance !== null
+                ? formatWholeCredits(effectiveBalance)
+                : null
+            }
+            onAddCredits={() => {
+              onClose();
+              navigate(routes.settings.billing);
+            }}
+            onEarnCredits={() => {
               onClose();
               onEarnCredits();
             }}
+            className="mx-2"
           />
           <MenuDivider />
         </>


### PR DESCRIPTION
## Summary
- Wire CreditsCard into the preferences drawer, replacing the flat credits rows + Earn credits PanelItem
- Preserves the billing gate, balance conditional, Add→billing navigation, and Earn Credits modal

Part of plan: ios-theme-switcher-larger.md (PR 4 of 4)