### PR TITLE
feat(subagent): bounded subagent concurrency cap (JARVIS-1060)

### DIFF
--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Concurrency-cap behavior for SubagentManager.
+ *
+ * Verifies that spawns beyond SUBAGENT_LIMITS.maxConcurrentRunning are accepted
+ * immediately but held in `pending`, and that queued subagents are started as
+ * running ones reach a terminal state — until all have run.
+ *
+ * Drives the manager via its private internals (matching the layout of
+ * subagent-disposal.test.ts) so the test never needs a real Conversation,
+ * provider, or daemon.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { SubagentManager } from "../subagent/manager.js";
+import { SUBAGENT_LIMITS, type SubagentState } from "../subagent/types.js";
+
+/** Minimal stand-in for the private ManagedSubagent the manager stores. */
+interface FakeManaged {
+  conversation: {
+    abort: () => void;
+    dispose: () => void;
+    persistUserMessage: () => { id: string; deduplicated: boolean };
+    runAgentLoop: () => Promise<void>;
+    usageStats: {
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCost: number;
+    };
+  } | null;
+  state: SubagentState;
+  parentSendToClient: (msg: ServerMessage) => void;
+  retainedUntil?: number;
+  hadEnqueuedMessages?: boolean;
+}
+
+interface ManagerInternals {
+  subagents: Map<string, FakeManaged>;
+  parentToChildren: Map<string, Set<string>>;
+  runQueue: string[];
+  runningCount: number;
+  startRun: (subagentId: string, objective: string) => void;
+  stopSweep: () => void;
+}
+
+function asInternals(manager: SubagentManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+function makeState(id: string): SubagentState {
+  return {
+    config: {
+      id,
+      parentConversationId: "parent-1",
+      label: id,
+      objective: `objective-${id}`,
+    },
+    status: "pending",
+    conversationId: `conv-${id}`,
+    isFork: false,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+/**
+ * Inject a fake subagent whose runAgentLoop blocks on a manually-resolved
+ * promise, letting the test control exactly when each "running" subagent
+ * completes. Returns a `release` fn that resolves the loop.
+ */
+function injectControllable(
+  manager: SubagentManager,
+  id: string,
+): { release: () => void } {
+  const internals = asInternals(manager);
+  let resolveLoop!: () => void;
+  const loopGate = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+
+  const managed: FakeManaged = {
+    conversation: {
+      abort: () => {},
+      dispose: () => {},
+      persistUserMessage: () => ({ id: "msg", deduplicated: false }),
+      runAgentLoop: () => loopGate,
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    },
+    state: makeState(id),
+    parentSendToClient: () => {},
+  };
+  internals.subagents.set(id, managed);
+
+  if (!internals.parentToChildren.has("parent-1")) {
+    internals.parentToChildren.set("parent-1", new Set());
+  }
+  internals.parentToChildren.get("parent-1")!.add(id);
+
+  return { release: resolveLoop };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("SubagentManager concurrency cap", () => {
+  test("spawns beyond the cap queue and drain as running ones complete", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+    const cap = SUBAGENT_LIMITS.maxConcurrentRunning;
+    const total = cap + 3;
+
+    const ids = Array.from({ length: total }, (_, i) => `sub-${i}`);
+    const gates = ids.map((id) => injectControllable(manager, id));
+
+    // Mimic spawn()'s cap-gating: start up to `cap`, queue the rest.
+    for (const id of ids) {
+      const objective = internals.subagents.get(id)!.state.config.objective;
+      if (internals.runningCount < cap) {
+        internals.startRun(id, objective);
+      } else {
+        internals.runQueue.push(id);
+      }
+    }
+    await flush();
+
+    // Exactly `cap` are running; the excess sit pending in the queue.
+    expect(internals.runningCount).toBe(cap);
+    expect(internals.runQueue.length).toBe(total - cap);
+    const running = ids.filter(
+      (id) => manager.getState(id)!.status === "running",
+    );
+    expect(running.length).toBe(cap);
+    for (const id of ids.slice(cap)) {
+      expect(manager.getState(id)!.status).toBe("pending");
+    }
+
+    // Complete running subagents one at a time; each completion should pull
+    // exactly one queued subagent into the running set.
+    for (let i = 0; i < total; i++) {
+      const runningNow = ids.filter(
+        (id) => manager.getState(id)!.status === "running",
+      );
+      expect(runningNow.length).toBeGreaterThan(0);
+      // Release the first currently-running subagent.
+      const idx = ids.indexOf(runningNow[0]!);
+      gates[idx]!.release();
+      await flush();
+      await flush();
+    }
+
+    // All eventually ran to completion; queue drained; no slots leaked.
+    for (const id of ids) {
+      expect(manager.getState(id)!.status).toBe("completed");
+    }
+    expect(internals.runQueue.length).toBe(0);
+    expect(internals.runningCount).toBe(0);
+
+    internals.stopSweep();
+  });
+
+  test("low-count spawns (under cap) all start immediately, none queued", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+
+    const ids = ["a", "b"]; // typical 1–2 subagent flow
+    for (const id of ids) injectControllable(manager, id);
+    for (const id of ids) {
+      internals.startRun(
+        id,
+        internals.subagents.get(id)!.state.config.objective,
+      );
+    }
+    await flush();
+
+    expect(internals.runQueue.length).toBe(0);
+    expect(internals.runningCount).toBe(ids.length);
+    for (const id of ids) {
+      expect(manager.getState(id)!.status).toBe("running");
+    }
+
+    internals.stopSweep();
+  });
+});

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -126,6 +126,20 @@ export class SubagentManager {
   private labelIndex = new Map<string, string>();
 
   /**
+   * FIFO queue of subagent IDs whose agent loop has NOT yet been kicked off
+   * because the concurrency cap (SUBAGENT_LIMITS.maxConcurrentRunning) was
+   * reached at spawn time. They remain in `pending` status until drained.
+   */
+  private runQueue: string[] = [];
+  /**
+   * Number of subagents whose agent loop has been kicked off and not yet
+   * reached a terminal state. Gated against SUBAGENT_LIMITS.maxConcurrentRunning.
+   * Tracked explicitly (rather than derived from status) so the cap counts only
+   * actually-started runs, never queued-but-pending ones.
+   */
+  private runningCount = 0;
+
+  /**
    * Shared rate-limit timestamps array from the daemon server.
    * Set by DaemonServer at startup so subagents share the global rate limit.
    */
@@ -374,12 +388,67 @@ export class SubagentManager {
       "Subagent spawned",
     );
 
-    // ── Kick off the agent loop (fire-and-forget) ───────────────────
-    this.runSubagent(subagentId, config.objective).catch((err) => {
-      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
-    });
+    // ── Kick off the agent loop (fire-and-forget), bounded by the cap ─
+    // If we're already at the concurrency cap, leave the subagent in `pending`
+    // and queue it; it will be started by drainRunQueue() as running subagents
+    // reach a terminal state. spawn() still returns the id immediately either
+    // way, preserving the fire-and-forget public contract.
+    if (this.runningCount < SUBAGENT_LIMITS.maxConcurrentRunning) {
+      this.startRun(subagentId, config.objective);
+    } else {
+      this.runQueue.push(subagentId);
+      log.info(
+        {
+          subagentId,
+          runningCount: this.runningCount,
+          queueDepth: this.runQueue.length,
+          cap: SUBAGENT_LIMITS.maxConcurrentRunning,
+        },
+        "Subagent queued — concurrency cap reached",
+      );
+    }
 
     return subagentId;
+  }
+
+  // ── Internal: concurrency-cap scheduling ──────────────────────────────
+
+  /**
+   * Account a started run against the cap and fire its agent loop
+   * (fire-and-forget). The matching decrement happens in runSubagent's
+   * `finally`, which also drains the queue.
+   */
+  private startRun(subagentId: string, objective: string): void {
+    this.runningCount++;
+    this.runSubagent(subagentId, objective).catch((err) => {
+      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
+    });
+  }
+
+  /**
+   * Release one slot held by a finished run and, if the cap now has headroom,
+   * start the next still-pending queued subagent. Called from runSubagent's
+   * `finally`, so exactly one slot frees per terminal subagent.
+   *
+   * Skips queued entries that are no longer startable (disposed, aborted, or
+   * already terminal — e.g. via abortAllForParent) so a cancelled queued
+   * subagent never consumes a slot, and keeps draining until a startable one is
+   * found or the queue empties.
+   */
+  private drainRunQueue(): void {
+    if (this.runningCount > 0) this.runningCount--;
+
+    while (
+      this.runningCount < SUBAGENT_LIMITS.maxConcurrentRunning &&
+      this.runQueue.length > 0
+    ) {
+      const nextId = this.runQueue.shift()!;
+      const managed = this.subagents.get(nextId);
+      if (!managed || TERMINAL_STATUSES.has(managed.state.status)) {
+        continue;
+      }
+      this.startRun(nextId, managed.state.config.objective);
+    }
   }
 
   // ── Internal: run the subagent ────────────────────────────────────────
@@ -493,6 +562,11 @@ export class SubagentManager {
       } else {
         this.releaseConversation(managed);
       }
+
+      // Free this run's slot and start the next queued subagent (if any).
+      // This subagent has reached a terminal state, so it no longer counts
+      // against the concurrency cap.
+      this.drainRunQueue();
     }
   }
 

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -101,6 +101,17 @@ export interface SubagentState {
 export const SUBAGENT_LIMITS = {
   /** Max nesting depth (1 = no nested subagents). */
   maxDepth: 1,
+  /**
+   * Max number of subagents allowed to be in the `running` state concurrently.
+   * Spawns beyond this cap are accepted immediately but held in `pending` and
+   * drained as running subagents reach a terminal state.
+   *
+   * Chosen at 8: high enough that existing single / low-count flows (which spawn
+   * 1–2 subagents) are never gated, while still bounding the burst of parallel
+   * `coder` workers app-builder v2 can fan out so they don't thrash provider
+   * rate limits.
+   */
+  maxConcurrentRunning: 8,
 } as const;
 
 // ── Roles ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add an enforced max-concurrent-running cap to the subagent manager; excess spawns queue and drain
- Preserves the fire-and-forget spawn() contract; existing low-count flows unaffected

Part of plan: ab-planner-worker.md (PR 9 of 9)
JARVIS-1060