### PR TITLE
fix(app-builder): per-app-slug write/compile serialization (JARVIS-1060)

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -14,8 +14,18 @@ let compileResultOverride: CompileResult = {
   durationMs: 0,
 };
 
+/**
+ * Optional hook letting a test observe and gate each compileApp invocation.
+ * When set, compileApp awaits whatever it returns before resolving, so a test
+ * can assert serialization by counting concurrently-running compiles.
+ */
+let compileGate: ((appDir: string) => Promise<void>) | undefined;
+
 mock.module("../bundler/app-compiler.js", () => ({
-  compileApp: async () => compileResultOverride,
+  compileApp: async (appDir: string) => {
+    if (compileGate) await compileGate(appDir);
+    return compileResultOverride;
+  },
 }));
 
 beforeEach(() => {
@@ -25,6 +35,7 @@ beforeEach(() => {
     warnings: [],
     durationMs: 0,
   };
+  compileGate = undefined;
 });
 
 import type { AppDefinition } from "../memory/app-store.js";
@@ -406,5 +417,81 @@ describe("executeAppRefresh", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-app-slug write/compile serialization
+//
+// getAppDirPath(id) is deterministic per id (falls back to <appsDir>/<id> when
+// no on-disk definition exists), so distinct ids map to distinct lock keys and
+// the same id always maps to the same key — exactly the slug-keying contract.
+// ---------------------------------------------------------------------------
+
+describe("app-slug compile serialization", () => {
+  /** A deferred promise plus its resolver. */
+  function defer(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  test("serializes concurrent refreshes for the SAME app", async () => {
+    let running = 0;
+    let maxConcurrent = 0;
+    const release = defer();
+    compileGate = async () => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await release.promise;
+      running--;
+    };
+
+    const app = makeMultifileApp({ id: "same-slug-app" });
+    const store = mockStore(app);
+
+    const first = executeAppRefresh({ app_id: app.id }, store);
+    const second = executeAppRefresh({ app_id: app.id }, store);
+
+    // Let both kick off. Only the first compile may be running; the second is
+    // queued behind the per-slug lock.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(maxConcurrent).toBe(1);
+
+    release.resolve();
+    await Promise.all([first, second]);
+    // Never more than one compile in flight for this slug.
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test("runs refreshes for DIFFERENT apps concurrently", async () => {
+    let running = 0;
+    let maxConcurrent = 0;
+    const release = defer();
+    compileGate = async () => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await release.promise;
+      running--;
+    };
+
+    const appA = makeMultifileApp({ id: "slug-a" });
+    const appB = makeMultifileApp({ id: "slug-b" });
+    const storeA = mockStore(appA);
+    const storeB = mockStore(appB);
+
+    const first = executeAppRefresh({ app_id: appA.id }, storeA);
+    const second = executeAppRefresh({ app_id: appB.id }, storeB);
+
+    // Different slugs must not block each other — both compiles run at once.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(maxConcurrent).toBe(2);
+
+    release.resolve();
+    await Promise.all([first, second]);
   });
 });

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -12,6 +12,25 @@ import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
+import { createKeyedMutex } from "../../util/keyed-mutex.js";
+
+// ---------------------------------------------------------------------------
+// Per-app-slug write/compile serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Defense-in-depth lock keyed by an app's on-disk dir (its frozen slug).
+ *
+ * app-builder v2 runs multiple `coder` workers that write DISJOINT files into
+ * one app dir in parallel, and only the parent compiles — a layout that already
+ * avoids most races. This guards the residual ones: a write landing during the
+ * compile's `rm -rf dist/` + esbuild window, or two same-slug write/compile
+ * batches overlapping. Operations on the SAME slug serialize; DIFFERENT slugs
+ * stay fully concurrent, honoring the per-resource serialization rule in
+ * CLAUDE.md. Disjoint writes within one batch share a single acquisition, so
+ * workers never deadlock or queue beyond the compile boundary.
+ */
+const appSlugMutex = createKeyedMutex();
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -198,19 +217,27 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-  if (input.source_files) {
-    for (const [filePath, content] of Object.entries(input.source_files)) {
-      store.writeAppFile(app.id, filePath, content);
-    }
-  }
+  // Serialize the source-file writes + compile for this slug so a concurrent
+  // operation on the SAME app (e.g. another worker's app_refresh) can't
+  // interleave with these writes or the dist/ rebuild below.
+  const appDir = getAppDirPath(app.id);
 
-  const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
-  if (!store.appFileExists(app.id, "src/index.html")) {
-    store.writeAppFile(app.id, "src/index.html", indexHtml);
-  }
-  if (mainTsxScaffolded) {
-    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-  }
+  const mainTsxScaffolded = await appSlugMutex(appDir, () => {
+    if (input.source_files) {
+      for (const [filePath, content] of Object.entries(input.source_files)) {
+        store.writeAppFile(app.id, filePath, content);
+      }
+    }
+
+    const scaffolded = !store.appFileExists(app.id, "src/main.tsx");
+    if (!store.appFileExists(app.id, "src/index.html")) {
+      store.writeAppFile(app.id, "src/index.html", indexHtml);
+    }
+    if (scaffolded) {
+      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+    }
+    return scaffolded;
+  });
 
   // When the placeholder main.tsx was actually scaffolded, the tool result
   // must steer the agent toward writing the real source files instead of
@@ -224,9 +251,9 @@ render(<App />, document.getElementById('app')!);
       }
     : {};
 
-  // Compile src/ → dist/
-  const appDir = getAppDirPath(app.id);
-  const compileResult = await compileApp(appDir);
+  // Compile src/ → dist/, serialized per slug so the dist/ rebuild can't race
+  // a concurrent same-slug write/compile.
+  const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
   if (!compileResult.ok) {
     return {
       content: JSON.stringify({
@@ -345,7 +372,9 @@ export async function executeAppRefresh(
   // stale scaffold placeholder from the initial app_create.
   if (app.formatVersion === 2) {
     const appDir = getAppDirPath(input.app_id);
-    const compileResult = await compileApp(appDir);
+    // Serialize the dist/ rebuild per slug so a concurrent same-slug
+    // operation (e.g. another worker's app_create) can't race this compile.
+    const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
     return {
       content: JSON.stringify({
         refreshed: true,

--- a/assistant/src/util/__tests__/keyed-mutex.test.ts
+++ b/assistant/src/util/__tests__/keyed-mutex.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import { createKeyedMutex } from "../keyed-mutex.js";
+
+/** A deferred promise plus its resolver, for hand-controlling op timing. */
+function defer(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("createKeyedMutex", () => {
+  test("serializes operations sharing a key (no interleaving)", async () => {
+    const mutex = createKeyedMutex();
+    const events: string[] = [];
+
+    const a = defer();
+    const b = defer();
+
+    const opA = mutex("slug", async () => {
+      events.push("A:start");
+      await a.promise;
+      events.push("A:end");
+    });
+    const opB = mutex("slug", async () => {
+      events.push("B:start");
+      await b.promise;
+      events.push("B:end");
+    });
+
+    // B must NOT start until A has fully settled, even though both were
+    // submitted synchronously and A is still awaiting.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start"]);
+
+    a.resolve();
+    await opA;
+    // Now A is done; B should have begun.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start", "A:end", "B:start"]);
+
+    b.resolve();
+    await opB;
+    expect(events).toEqual(["A:start", "A:end", "B:start", "B:end"]);
+  });
+
+  test("runs operations on different keys concurrently", async () => {
+    const mutex = createKeyedMutex();
+    const events: string[] = [];
+
+    const a = defer();
+    const b = defer();
+
+    const opA = mutex("slug-a", async () => {
+      events.push("A:start");
+      await a.promise;
+      events.push("A:end");
+    });
+    const opB = mutex("slug-b", async () => {
+      events.push("B:start");
+      await b.promise;
+      events.push("B:end");
+    });
+
+    // Both should have started without waiting on each other.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start", "B:start"]);
+
+    b.resolve();
+    await opB;
+    a.resolve();
+    await opA;
+    expect(events).toEqual(["A:start", "B:start", "B:end", "A:end"]);
+  });
+
+  test("a rejected operation does not poison the queue for its key", async () => {
+    const mutex = createKeyedMutex();
+
+    const failed = mutex("slug", async () => {
+      throw new Error("boom");
+    });
+    await expect(failed).rejects.toThrow("boom");
+
+    const ok = await mutex("slug", async () => 42);
+    expect(ok).toBe(42);
+  });
+
+  test("preserves submission order under a same-key burst", async () => {
+    const mutex = createKeyedMutex();
+    const order: number[] = [];
+
+    const ops = [0, 1, 2, 3, 4].map((i) =>
+      mutex("slug", async () => {
+        // Yield to prove ordering comes from the mutex, not sync execution.
+        await Promise.resolve();
+        order.push(i);
+      }),
+    );
+
+    await Promise.all(ops);
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("drops map entries once a key's queue drains", async () => {
+    const mutex = createKeyedMutex();
+    expect(mutex.size).toBe(0);
+
+    await mutex("slug", async () => {});
+    // Allow the cleanup microtask to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mutex.size).toBe(0);
+  });
+});

--- a/assistant/src/util/keyed-mutex.ts
+++ b/assistant/src/util/keyed-mutex.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-key async mutex built on Promise chaining.
+ *
+ * Operations submitted for the SAME key run strictly one-at-a-time in
+ * submission order; operations for DIFFERENT keys proceed concurrently. This
+ * is the lightweight in-process serialization primitive used to guard shared
+ * mutable resources (e.g. an app's source dir + its dist/ rebuild) against
+ * concurrent callers racing on `rm -rf` + write sequences, per the
+ * "serialise per-resource" rule in CLAUDE.md.
+ *
+ * The same pattern already backs `createSurfaceMutex`; this generalises it as a
+ * standalone utility so other per-resource critical sections can reuse it.
+ */
+export type KeyedMutex = {
+  /**
+   * Run `fn` exclusively with respect to other `run` calls sharing `key`.
+   * Returns whatever `fn` resolves to (or rejects with `fn`'s error). A
+   * rejection does not poison the queue — subsequent operations still run.
+   */
+  <T>(key: string, fn: () => T | Promise<T>): Promise<T>;
+  /** Number of keys with an in-flight or queued operation (for tests). */
+  readonly size: number;
+};
+
+export function createKeyedMutex(): KeyedMutex {
+  const chains = new Map<string, Promise<unknown>>();
+
+  const mutex = <T>(key: string, fn: () => T | Promise<T>): Promise<T> => {
+    const prev = chains.get(key) ?? Promise.resolve();
+    // Chain off the prior op regardless of its outcome so a failure doesn't
+    // block the queue, but only start `fn` after the prior op fully settles.
+    const next = prev.then(fn, fn);
+    // The tail keeps the chain alive and swallows errors so the map entry
+    // stays a clean "previous settled" anchor for the next submission.
+    const tail = next.then(
+      () => {},
+      () => {},
+    );
+    chains.set(key, tail);
+    // Drop the entry once the queue drains to keep the map bounded.
+    tail.then(() => {
+      if (chains.get(key) === tail) {
+        chains.delete(key);
+      }
+    });
+    return next;
+  };
+
+  Object.defineProperty(mutex, "size", { get: () => chains.size });
+  return mutex as KeyedMutex;
+}


### PR DESCRIPTION
## Summary
- Add a per-app-slug async lock around file writes + compileApp/dist for an app
- Same-slug ops serialize; different slugs stay concurrent (defense-in-depth for parallel workers)

Part of plan: ab-planner-worker.md (PR 4 of 9)
JARVIS-1060