### PR TITLE
feat(macos): add lazy CLI installer for packaged builds

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -141,7 +141,7 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(1);
     const [cmd, args, opts] = spawnCalls[0];
     expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`]);
+    expect(args).toEqual(["add", `@vellumai/cli@${PINNED_CLI_VERSION}`]);
     expect(opts).toEqual({
       cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
     });

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+// --- Mocks ---
+// Must be installed before the `await import` of the module under test so
+// the mocked module graph is in place when `cli-installer.ts` is evaluated.
+// See `commands.test.ts` for the ordering rationale.
+
+const userDataPath = "/mock/userData";
+const mockResourcesPath = "/mock/resources";
+
+// `process.resourcesPath` is only defined inside a packaged Electron app.
+// Set a known value so `path.join(process.resourcesPath, "bun")` works.
+Object.defineProperty(process, "resourcesPath", { value: mockResourcesPath, writable: true });
+
+mock.module("electron", () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === "userData") return userDataPath;
+      return "/tmp";
+    },
+    isPackaged: true,
+  },
+}));
+
+// Track fs calls so tests can assert on them.
+let existsSyncReturn = false;
+let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
+let readdirSyncError: Error | null = null;
+const mkdirSyncCalls: Array<[string, object]> = [];
+const rmSyncCalls: Array<[string, object]> = [];
+
+mock.module("node:fs", () => ({
+  existsSync: () => existsSyncReturn,
+  mkdirSync: (p: string, opts: object) => {
+    mkdirSyncCalls.push([p, opts]);
+  },
+  readdirSync: (_p: string, _opts?: object) => {
+    if (readdirSyncError) throw readdirSyncError;
+    return readdirSyncReturn;
+  },
+  rmSync: (p: string, opts: object) => {
+    rmSyncCalls.push([p, opts]);
+  },
+}));
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+let lastChild: FakeChild;
+const spawnCalls: Array<[string, string[], object]> = [];
+
+mock.module("node:child_process", () => ({
+  spawn: (cmd: string, args: string[], opts: object) => {
+    spawnCalls.push([cmd, args, opts]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+}));
+
+/** Helper to build fake Dirent entries for the readdirSync mock. */
+const dirEntry = (name: string) => ({ name, isDirectory: () => true });
+
+const {
+  PINNED_CLI_VERSION,
+  getCliInstallDir,
+  getCliBinPath,
+  getBundledBunPath,
+  isCliInstalled,
+  ensureCliInstalled,
+  cleanupOldVersions,
+} = await import("./cli-installer");
+
+afterEach(() => {
+  existsSyncReturn = false;
+  readdirSyncReturn.length = 0;
+  readdirSyncError = null;
+  mkdirSyncCalls.length = 0;
+  rmSyncCalls.length = 0;
+  spawnCalls.length = 0;
+});
+
+// --- Path helpers ---
+
+describe("getCliInstallDir", () => {
+  test("returns <userData>/cli/<version>", () => {
+    expect(getCliInstallDir()).toBe(
+      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
+    );
+  });
+});
+
+describe("getCliBinPath", () => {
+  test("returns <installDir>/node_modules/.bin/vellum", () => {
+    expect(getCliBinPath()).toBe(
+      `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum`,
+    );
+  });
+});
+
+describe("getBundledBunPath", () => {
+  test("returns <resourcesPath>/bun", () => {
+    expect(getBundledBunPath()).toBe(`${mockResourcesPath}/bun`);
+  });
+});
+
+// --- isCliInstalled ---
+
+describe("isCliInstalled", () => {
+  test("returns true when the bin path exists", () => {
+    existsSyncReturn = true;
+    expect(isCliInstalled()).toBe(true);
+  });
+
+  test("returns false when the bin path is missing", () => {
+    existsSyncReturn = false;
+    expect(isCliInstalled()).toBe(false);
+  });
+});
+
+// --- ensureCliInstalled ---
+
+describe("ensureCliInstalled", () => {
+  test("skips install when already installed", async () => {
+    existsSyncReturn = true;
+    await ensureCliInstalled();
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("spawns bun add with correct args and cwd", async () => {
+    existsSyncReturn = false;
+
+    const promise = ensureCliInstalled();
+
+    // Let the spawn resolve successfully.
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(spawnCalls).toHaveLength(1);
+    const [cmd, args, opts] = spawnCalls[0];
+    expect(cmd).toBe(`${mockResourcesPath}/bun`);
+    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`]);
+    expect(opts).toEqual({
+      cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
+    });
+  });
+
+  test("creates the install directory before spawning", async () => {
+    existsSyncReturn = false;
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(mkdirSyncCalls).toHaveLength(1);
+    const [dir, opts] = mkdirSyncCalls[0];
+    expect(dir).toBe(`${userDataPath}/cli/${PINNED_CLI_VERSION}`);
+    expect(opts).toEqual({ recursive: true });
+  });
+
+  test("throws on non-zero exit code", async () => {
+    existsSyncReturn = false;
+
+    const promise = ensureCliInstalled();
+    lastChild.stderr.emit("data", Buffer.from("install failed"));
+    lastChild.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(/CLI install failed/);
+    await expect(promise).rejects.toThrow(/exit code 1/);
+  });
+
+  test("throws on spawn error", async () => {
+    existsSyncReturn = false;
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("error", new Error("ENOENT"));
+
+    await expect(promise).rejects.toThrow(/Failed to spawn bun/);
+    await expect(promise).rejects.toThrow(/ENOENT/);
+  });
+
+  test("calls cleanupOldVersions after successful install", async () => {
+    existsSyncReturn = false;
+    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry(PINNED_CLI_VERSION)];
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    // cleanupOldVersions should have been called — verify it tried to
+    // remove 0.8.5 but not the pinned version.
+    expect(rmSyncCalls.length).toBeGreaterThanOrEqual(1);
+    const removedPaths = rmSyncCalls.map(([p]) => p);
+    expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
+    const pinnedPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}`;
+    expect(removedPaths).not.toContain(pinnedPath);
+  });
+});
+
+// --- cleanupOldVersions ---
+
+describe("cleanupOldVersions", () => {
+  test("deletes sibling directories that are not the pinned version", () => {
+    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry(PINNED_CLI_VERSION)];
+
+    cleanupOldVersions();
+
+    const removedPaths = rmSyncCalls.map(([p]) => p);
+    expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
+    expect(removedPaths).not.toContain(
+      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
+    );
+  });
+
+  test("passes recursive and force options to rmSync", () => {
+    readdirSyncReturn = [dirEntry("0.8.5")];
+
+    cleanupOldVersions();
+
+    expect(rmSyncCalls).toHaveLength(1);
+    expect(rmSyncCalls[0][1]).toEqual({ recursive: true, force: true });
+  });
+
+  test("tolerates a missing cli directory (ENOENT)", () => {
+    const enoent = new Error("ENOENT: no such file or directory");
+    (enoent as NodeJS.ErrnoException).code = "ENOENT";
+    readdirSyncError = enoent;
+
+    // Should not throw.
+    expect(() => cleanupOldVersions()).not.toThrow();
+  });
+
+  test("tolerates other read errors without propagating", () => {
+    readdirSyncError = new Error("EPERM: permission denied");
+
+    expect(() => cleanupOldVersions()).not.toThrow();
+  });
+});

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -11,9 +11,12 @@ import path from "node:path";
 /**
  * Pinned CLI version installed in packaged builds.
  *
- * This should be stamped by the release workflow using the same
- * `jq --arg v "$VERSION"` pattern used for CLI/meta packages in
- * `.github/workflows/release.yml`.
+ * TODO: Not yet stamped automatically. When the Electron app is added to
+ * the release pipeline in `.github/workflows/release.yml`, add a step to
+ * rewrite this value using the same `jq`/`sed` pattern that stamps
+ * `assistant/package.json` et al. (see the "Stamp release version into
+ * package.json" step in that workflow). Until then, bump manually when
+ * cutting a release that changes the CLI version in `cli/package.json`.
  */
 export const PINNED_CLI_VERSION = "0.8.6";
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -1,0 +1,120 @@
+import { app } from "electron";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import path from "node:path";
+
+/**
+ * Pinned CLI version installed in packaged builds.
+ *
+ * This should be stamped by the release workflow using the same
+ * `jq --arg v "$VERSION"` pattern used for CLI/meta packages in
+ * `.github/workflows/release.yml`.
+ */
+export const PINNED_CLI_VERSION = "0.8.6";
+
+/** Directory where the pinned CLI version is installed. */
+export function getCliInstallDir(): string {
+  return path.join(app.getPath("userData"), "cli", PINNED_CLI_VERSION);
+}
+
+/** Absolute path to the installed `vellum` binary. */
+export function getCliBinPath(): string {
+  return path.join(getCliInstallDir(), "node_modules", ".bin", "vellum");
+}
+
+/** Absolute path to the bun runtime bundled inside the app resources. */
+export function getBundledBunPath(): string {
+  return path.join(process.resourcesPath, "bun");
+}
+
+/** Whether the pinned CLI version is already installed on disk. */
+export function isCliInstalled(): boolean {
+  return existsSync(getCliBinPath());
+}
+
+/**
+ * Install the pinned CLI version if it isn't already present.
+ *
+ * Uses the bundled bun runtime to `bun add vellum@<version>` into the
+ * per-version install directory. After a successful install, stale
+ * versions are cleaned up.
+ */
+export async function ensureCliInstalled(): Promise<void> {
+  if (isCliInstalled()) return;
+
+  const installDir = getCliInstallDir();
+  mkdirSync(installDir, { recursive: true });
+
+  const bunPath = getBundledBunPath();
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(bunPath, ["add", `vellum@${PINNED_CLI_VERSION}`], {
+      cwd: installDir,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("error", (err: Error) => {
+      reject(
+        new Error(
+          `Failed to spawn bun for CLI install: ${err.message}`,
+        ),
+      );
+    });
+
+    child.on("close", (code: number | null) => {
+      if (code !== 0) {
+        const detail = (stderr || stdout).trim();
+        reject(
+          new Error(
+            `CLI install failed with exit code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`,
+          ),
+        );
+        return;
+      }
+      resolve();
+    });
+  });
+
+  cleanupOldVersions();
+}
+
+/**
+ * Remove CLI versions other than the currently pinned one.
+ *
+ * Non-fatal — cleanup errors are logged but never thrown so a stale
+ * directory doesn't block the app from starting.
+ */
+export function cleanupOldVersions(): void {
+  try {
+    const cliRoot = path.join(app.getPath("userData"), "cli");
+    const entries = readdirSync(cliRoot, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.name === PINNED_CLI_VERSION) continue;
+      if (!entry.isDirectory()) continue;
+
+      try {
+        rmSync(path.join(cliRoot, entry.name), { recursive: true, force: true });
+      } catch {
+        // Individual entry cleanup failure is non-fatal.
+      }
+    }
+  } catch {
+    // The cli directory may not exist yet — that's fine.
+  }
+}

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -43,7 +43,7 @@ export function isCliInstalled(): boolean {
 /**
  * Install the pinned CLI version if it isn't already present.
  *
- * Uses the bundled bun runtime to `bun add vellum@<version>` into the
+ * Uses the bundled bun runtime to `bun add @vellumai/cli@<version>` into the
  * per-version install directory. After a successful install, stale
  * versions are cleaned up.
  */
@@ -56,7 +56,7 @@ export async function ensureCliInstalled(): Promise<void> {
   const bunPath = getBundledBunPath();
 
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(bunPath, ["add", `vellum@${PINNED_CLI_VERSION}`], {
+    const child = spawn(bunPath, ["add", `@vellumai/cli@${PINNED_CLI_VERSION}`], {
       cwd: installDir,
     });
 


### PR DESCRIPTION
## Summary
- Add cli-installer module with lazy installation of vellum CLI from npm on first use
- Includes version pinning, old version cleanup, and bundled bun path resolution
- Comprehensive test coverage for all installer functions

Part of plan: packaged-cli-install.md (PR 2 of 4)