### PR TITLE
build(macos): add electron-builder config with bundled bun runtime

### DIFF
--- a/apps/macos/.gitignore
+++ b/apps/macos/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 out/
 dist/
+resources/bun

--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -5,6 +5,10 @@ directories:
 extraResources:
   - from: resources/bun
     to: bun
+  # TODO: Stage the web renderer (apps/web/dist) here once the full
+  # packaging pipeline is built. The main process serves index.html from
+  # ../renderer/ in packaged mode; for now only the bun runtime is bundled
+  # and the renderer is loaded from the dev server during development.
 mac:
   category: public.app-category.productivity
   target:

--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -1,0 +1,13 @@
+appId: com.vellum.vellum-assistant-electron
+productName: Vellum
+directories:
+  output: dist
+extraResources:
+  - from: resources/bun
+    to: bun
+mac:
+  category: public.app-category.productivity
+  target:
+    - target: dmg
+      arch:
+        - arm64

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -15,7 +15,8 @@
     "build": "electron-vite build",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
-    "test:ci": "bun scripts/run-tests.ts"
+    "test:ci": "bun scripts/run-tests.ts",
+    "build:fetch-bun": "bash scripts/fetch-bun.sh"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/scripts/fetch-bun.sh
+++ b/apps/macos/scripts/fetch-bun.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# fetch-bun.sh — Download the bun binary pinned in .tool-versions into
+# apps/macos/resources/bun for bundling via electron-builder.
+#
+# Mirrors the pattern in clients/macos/build.sh (fetch_bundled_bun).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOURCES_DIR="$SCRIPT_DIR/../resources"
+
+# Parse bun version from the repo-root .tool-versions
+TOOL_VERSIONS="$SCRIPT_DIR/../../../.tool-versions"
+BUN_VERSION=$(awk '$1 == "bun" { print $2 }' "$TOOL_VERSIONS" 2>/dev/null)
+if [ -z "$BUN_VERSION" ]; then
+  echo "ERROR: could not read bun version from $TOOL_VERSIONS" >&2
+  exit 1
+fi
+
+# If the binary already exists and matches the expected version, skip download
+if [ -x "$RESOURCES_DIR/bun" ]; then
+  CURRENT_VERSION=$("$RESOURCES_DIR/bun" --version 2>/dev/null || echo "")
+  if [ "$CURRENT_VERSION" = "$BUN_VERSION" ]; then
+    echo "bun $BUN_VERSION already present at $RESOURCES_DIR/bun — skipping download."
+    exit 0
+  fi
+fi
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  aarch64|arm64)
+    PLATFORM="darwin-aarch64"
+    ;;
+  x86_64)
+    PLATFORM="darwin-x64"
+    ;;
+  *)
+    echo "ERROR: unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+echo "Downloading bun ${BUN_VERSION} (${PLATFORM})..."
+
+TMPDIR_DL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_DL"' EXIT
+
+ZIP_PATH="$TMPDIR_DL/bun.zip"
+if ! curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
+        --output "$ZIP_PATH" "$URL"; then
+  echo "ERROR: failed to download bun binary from $URL" >&2
+  exit 1
+fi
+
+if ! unzip -o -q "$ZIP_PATH" -d "$TMPDIR_DL"; then
+  echo "ERROR: failed to extract bun zip" >&2
+  exit 1
+fi
+
+EXTRACTED="$TMPDIR_DL/bun-${PLATFORM}/bun"
+if [ ! -f "$EXTRACTED" ]; then
+  echo "ERROR: bun binary missing after extraction at $EXTRACTED" >&2
+  exit 1
+fi
+
+mkdir -p "$RESOURCES_DIR"
+cp "$EXTRACTED" "$RESOURCES_DIR/bun"
+chmod +x "$RESOURCES_DIR/bun"
+
+echo "bun ${BUN_VERSION} installed to $RESOURCES_DIR/bun"

--- a/apps/macos/scripts/fetch-bun.sh
+++ b/apps/macos/scripts/fetch-bun.sh
@@ -25,7 +25,12 @@ if [ -x "$RESOURCES_DIR/bun" ]; then
   fi
 fi
 
-# Detect architecture
+# Detect architecture from the build host. This is intentional for local-dev
+# builds where host == target. For cross-compilation (e.g. building arm64 on
+# x64 CI), this must be replaced with an explicit target-arch parameter — the
+# full pattern lives in clients/macos/build.sh (fetch_bundled_bun), which
+# accepts aarch64|x64|universal. That will be wired up alongside universal
+# build and CI packaging support.
 ARCH=$(uname -m)
 case "$ARCH" in
   aarch64|arm64)


### PR DESCRIPTION
## Summary
- Add fetch-bun.sh script to download the correct bun binary for the current architecture
- Add electron-builder.yml config to bundle the bun binary as an extraResource
- Gitignore the fetched binary and add build:fetch-bun package.json script

Part of plan: packaged-cli-install.md (PR 4 of 4)