### PR TITLE
refactor(web): drop unused className prop from CreditsCard

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,4 +1,4 @@
-import { Button, cn } from "@vellum/design-library";
+import { Button } from "@vellum/design-library";
 import { Coins, Gift, Plus } from "lucide-react";
 
 interface CreditsCardProps {
@@ -6,7 +6,6 @@ interface CreditsCardProps {
   balance: string | null;
   onAddCredits: () => void;
   onEarnCredits: () => void;
-  className?: string;
 }
 
 /**
@@ -19,14 +18,10 @@ export function CreditsCard({
   balance,
   onAddCredits,
   onEarnCredits,
-  className,
 }: CreditsCardProps) {
   return (
     <div
-      className={cn(
-        "flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full",
-        className,
-      )}
+      className="flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full"
       style={{
         borderColor: "var(--surface-base)",
         background: "var(--surface-overlay)",


### PR DESCRIPTION
## Summary
Fixes slop gap from plan self-review for ios-theme-switcher-larger.md.

**Gap:** CreditsCard declared an optional `className` prop threaded through `cn()`, but no caller passes it (the planned `mx-2` was removed to fix a Codex overflow finding). Removed the dead prop and the now-unused `cn` import; the root uses a static class string.