### PR TITLE
test(app-builder): golden-set eval harness (JARVIS-1060)

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -5,7 +5,8 @@
     "scripts/**/*.ts",
     "src/daemon/main.ts!",
     "src/plugin-api/index.ts!",
-    "src/api/index.ts!"
+    "src/api/index.ts!",
+    "src/config/bundled-skills/app-builder/__evals__/index.ts!"
   ],
   "project": ["src/**/*.ts!", "src/**/*.tsx!", "scripts/**/*.ts"],
   "ignoreDependencies": [

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/README.md
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/README.md
@@ -1,0 +1,76 @@
+# app-builder eval / golden-set harness
+
+A standalone harness for measuring whether a change to the app-builder flow
+improves taste and latency, instead of guessing. It runs a fixed set of prompts
+through one or more **build variants** and emits an A/B-comparable **scorecard**.
+
+The immediate motivation is app-builder v2 (a tiered planner/worker flow). This
+harness lets us baseline the current **single-model** skill now, then A/B it
+against the **planner/worker** flow once that lands.
+
+> This is **not** wired into the default test / CI gate. It is meant to be run
+> by hand when evaluating a change.
+
+## What it measures
+
+Per build (one prompt under one variant), three independent dimensions:
+
+| Dimension          | What it checks                                                               | Where               |
+| ------------------ | ---------------------------------------------------------------------------- | ------------------- |
+| **compile**        | Did the produced source compile?                                             | `runner.ts`         |
+| **plan-adherence** | Did the output use the expected design tokens / files? (static, best-effort) | `plan-adherence.ts` |
+| **design rubric**  | LLM-scored aesthetic/quality judgment                                        | `rubric.ts`         |
+
+These roll up into a `Scorecard` (`types.ts`) with one column per variant and
+columns reserved for **latency** and **cost** — to be filled in by PR 7
+telemetry.
+
+## Run it
+
+```bash
+cd assistant
+bun run src/config/bundled-skills/app-builder/__evals__/index.ts
+```
+
+Prints a scorecard table. Out of the box both columns use a deterministic
+**stub** build driver and a **stub** design judge, so the numbers are
+placeholders that prove the pipeline runs end-to-end.
+
+Run the smoke test:
+
+```bash
+cd assistant
+bun test src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
+```
+
+## Files
+
+- `prompts.ts` — the fixed golden prompt set (habit tracker, finance dashboard,
+  slide deck, calculator). **Append-only** — editing existing prompts breaks
+  comparability across runs.
+- `types.ts` — shared types and the two key interfaces: `AppBuildDriver` and
+  `DesignJudge`.
+- `build-driver.ts` — `AppBuildDriver` impls. Ships `StubBuildDriver`; real
+  single-model and planner/worker drivers slot in here.
+- `rubric.ts` — the design rubric, the LLM-judge interface (`LLMDesignJudge`),
+  and `StubDesignJudge`.
+- `plan-adherence.ts` — best-effort static token/file checks.
+- `runner.ts` — drives builds, scores them, aggregates the scorecard. Compile
+  and judge steps are injectable.
+- `index.ts` — CLI entry + scorecard formatter.
+
+## Wiring real signal (later)
+
+The harness depends only on the `AppBuildDriver` and `DesignJudge` interfaces,
+so making it real is a matter of swapping stubs for live impls:
+
+1. **Live build driver** — implement `AppBuildDriver.build()` to run the actual
+   app-builder skill (single-model) and the planner/worker flow, returning the
+   real source files (and the planner/worker's committed plan).
+2. **Live design judge** — implement `DesignJudge.score()` to render the built
+   app, send `buildJudgePrompt()` + a screenshot to a model, and parse the
+   rubric scores (`scoreToOverall()` does the weighting).
+3. **Real compile** — pass `compile` to `runEvals` backed by the esbuild
+   `compileApp` from `assistant/src/bundler/app-compiler.ts`.
+4. **Telemetry** — populate `BuildResult.telemetry` (latency/cost) once PR 7
+   lands; the scorecard already has the columns.

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { StubBuildDriver } from "../build-driver.js";
+import { checkPlanAdherence } from "../plan-adherence.js";
+import { GOLDEN_PROMPTS } from "../prompts.js";
+import { DESIGN_RUBRIC, scoreToOverall, StubDesignJudge } from "../rubric.js";
+import { runEvals } from "../runner.js";
+import type { BuildArtifact } from "../types.js";
+
+describe("app-builder eval harness", () => {
+  test("ships a non-empty fixed prompt set with unique ids", () => {
+    expect(GOLDEN_PROMPTS.length).toBeGreaterThan(0);
+    const ids = GOLDEN_PROMPTS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("scoreToOverall maps a perfect rubric to 1 and a floor to 0", () => {
+    const perfect = DESIGN_RUBRIC.map((c) => ({
+      criterionId: c.id,
+      score: 5,
+      rationale: "",
+    }));
+    const floor = DESIGN_RUBRIC.map((c) => ({
+      criterionId: c.id,
+      score: 1,
+      rationale: "",
+    }));
+    expect(scoreToOverall(perfect)).toBeCloseTo(1);
+    expect(scoreToOverall(floor)).toBeCloseTo(0);
+  });
+
+  test("plan-adherence rewards expected tokens/files and flags misses", async () => {
+    const prompt = GOLDEN_PROMPTS[0];
+    const good = await new StubBuildDriver("single-model").build(prompt);
+    const goodResult = checkPlanAdherence(good, prompt);
+    expect(goodResult.fileCoverage).toBe(1);
+    expect(goodResult.tokenCoverage).toBeGreaterThan(0);
+
+    const empty: BuildArtifact = { sourceFiles: {} };
+    const emptyResult = checkPlanAdherence(empty, prompt);
+    expect(emptyResult.fileCoverage).toBe(0);
+    expect(emptyResult.missingFiles.length).toBeGreaterThan(0);
+  });
+
+  test("stub design judge returns one score per rubric criterion", async () => {
+    const prompt = GOLDEN_PROMPTS[0];
+    const artifact = await new StubBuildDriver("single-model").build(prompt);
+    const result = await new StubDesignJudge().score(artifact, prompt);
+    expect(result.scores.length).toBe(DESIGN_RUBRIC.length);
+    expect(result.overall).toBeGreaterThanOrEqual(0);
+    expect(result.overall).toBeLessThanOrEqual(1);
+  });
+
+  test("runEvals produces an A/B scorecard with one column per driver", async () => {
+    const card = await runEvals({
+      prompts: GOLDEN_PROMPTS,
+      drivers: [
+        new StubBuildDriver("single-model"),
+        new StubBuildDriver("planner-worker"),
+      ],
+    });
+
+    expect(card.promptSetSize).toBe(GOLDEN_PROMPTS.length);
+    expect(card.columns.map((c) => c.variant)).toEqual([
+      "single-model",
+      "planner-worker",
+    ]);
+    for (const col of card.columns) {
+      expect(col.rows.length).toBe(GOLDEN_PROMPTS.length);
+      expect(col.compileRate).toBe(1); // stub scaffold always compiles
+      // Telemetry columns are present but empty until PR 7 wires them.
+      expect(col.meanLatencyMs).toBeUndefined();
+      expect(col.meanCostUsd).toBeUndefined();
+    }
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/build-driver.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/build-driver.ts
@@ -1,0 +1,47 @@
+/**
+ * Build drivers: the seam between the harness and an actual app-build flow.
+ *
+ * A driver takes a golden prompt and returns the source files (and optional
+ * plan) the flow produced. Two real drivers are expected to land:
+ *
+ *  - single-model (baseline) — runs the current app-builder skill once.
+ *  - planner-worker (v2)      — runs the tiered flow from this plan.
+ *
+ * Actually invoking the skill end-to-end (spinning up a conversation, calling
+ * the model, executing app-create) is heavier than this scaffolding PR. So we
+ * ship {@link StubBuildDriver}: it returns a representative scaffold so the
+ * harness produces a scorecard today. Replace with a live driver that wires the
+ * real flow — the harness only depends on the {@link AppBuildDriver} interface.
+ */
+
+import type {
+  AppBuildDriver,
+  BuildArtifact,
+  GoldenPrompt,
+  Variant,
+} from "./types.js";
+
+/**
+ * Deterministic placeholder driver. Emits the standard formatVersion-2
+ * scaffold using a handful of design tokens so compile + plan-adherence checks
+ * have something real to run against. It does NOT call a model.
+ */
+export class StubBuildDriver implements AppBuildDriver {
+  constructor(readonly variant: Variant) {}
+
+  async build(prompt: GoldenPrompt): Promise<BuildArtifact> {
+    const main = [
+      `// stub build for "${prompt.label}" (${this.variant})`,
+      "export default function App() {",
+      "  return (",
+      '    <main style={{ background: "var(--v-bg)", color: "var(--v-text)" }}>',
+      `      <h1 style={{ color: "var(--v-accent)" }}>${prompt.label}</h1>`,
+      "    </main>",
+      "  );",
+      "}",
+      "",
+    ].join("\n");
+
+    return { sourceFiles: { "src/main.tsx": main } };
+  }
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
@@ -62,7 +62,6 @@ export async function main(): Promise<void> {
       new StubBuildDriver("planner-worker"),
     ],
   });
-  // eslint-disable-next-line no-console -- standalone CLI output
   console.log(formatScorecard(card));
 }
 

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
@@ -1,0 +1,71 @@
+/**
+ * Standalone CLI entry for the app-builder eval harness.
+ *
+ *   bun run assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
+ *
+ * Runs the golden prompt set through the registered build drivers and prints an
+ * A/B scorecard. This is intentionally NOT wired into the default test/CI gate.
+ *
+ * Today both columns use the stub driver + stub judge (see build-driver.ts /
+ * rubric.ts), so the numbers are placeholders that prove the pipeline works.
+ * Swap in a live single-model driver and the planner/worker driver to get real
+ * A/B signal once PR 7 (telemetry) and the v2 flow land.
+ */
+
+import { StubBuildDriver } from "./build-driver.js";
+import { GOLDEN_PROMPTS } from "./prompts.js";
+import { runEvals } from "./runner.js";
+import type { Scorecard } from "./types.js";
+
+function fmt(n: number | undefined): string {
+  return n === undefined ? "—" : n.toFixed(2);
+}
+
+export function formatScorecard(card: Scorecard): string {
+  const lines: string[] = [];
+  lines.push(`app-builder eval scorecard — ${card.generatedAt}`);
+  lines.push(`prompts: ${card.promptSetSize}`);
+  lines.push("");
+  lines.push(
+    [
+      "variant".padEnd(16),
+      "compile",
+      "tokens",
+      "files",
+      "design",
+      "lat(ms)",
+      "cost($)",
+    ].join("  "),
+  );
+  for (const col of card.columns) {
+    lines.push(
+      [
+        col.variant.padEnd(16),
+        fmt(col.compileRate).padStart(7),
+        fmt(col.meanTokenCoverage).padStart(6),
+        fmt(col.meanFileCoverage).padStart(5),
+        fmt(col.meanDesignScore).padStart(6),
+        fmt(col.meanLatencyMs).padStart(7),
+        fmt(col.meanCostUsd).padStart(7),
+      ].join("  "),
+    );
+  }
+  return lines.join("\n");
+}
+
+export async function main(): Promise<void> {
+  const card = await runEvals({
+    prompts: GOLDEN_PROMPTS,
+    // Two columns wired for A/B; both stubbed until the live flows land.
+    drivers: [
+      new StubBuildDriver("single-model"),
+      new StubBuildDriver("planner-worker"),
+    ],
+  });
+  // eslint-disable-next-line no-console -- standalone CLI output
+  console.log(formatScorecard(card));
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/plan-adherence.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/plan-adherence.ts
@@ -1,0 +1,91 @@
+/**
+ * Best-effort static plan-adherence checks.
+ *
+ * "Plan adherence" asks: did the build actually use the design tokens and
+ * files it was supposed to? We can't run the app here, so we do cheap static
+ * checks over the produced source — token presence and file presence.
+ *
+ * Expectations come from the build's own plan when available (planner/worker
+ * emits one), otherwise from {@link DEFAULT_EXPECTATIONS} keyed by prompt, then
+ * a generic baseline. This keeps the check meaningful for the single-model
+ * variant (which has no explicit plan) while letting the v2 flow be graded
+ * against what it claimed it would do.
+ */
+
+import type {
+  BuildArtifact,
+  GoldenPrompt,
+  PlanAdherenceResult,
+  PlanExpectations,
+} from "./types.js";
+
+/** Tokens every well-formed app should lean on (design-system surface). */
+const BASELINE_TOKENS = ["--v-bg", "--v-text", "--v-accent"];
+
+/** The multi-file (formatVersion 2) scaffold every app should produce. */
+const BASELINE_FILES = ["src/main.tsx"];
+
+/**
+ * Per-prompt expectations layered on top of the baseline. Best-effort — these
+ * encode "a faithful X build tends to use Y", not a hard spec.
+ */
+export const DEFAULT_EXPECTATIONS: Record<string, PlanExpectations> = {
+  "habit-tracker": {
+    designTokens: [...BASELINE_TOKENS, "--v-success"],
+    files: BASELINE_FILES,
+  },
+  "finance-dashboard": {
+    designTokens: [...BASELINE_TOKENS, "--v-surface"],
+    files: BASELINE_FILES,
+  },
+  "slide-deck": {
+    designTokens: [...BASELINE_TOKENS],
+    files: BASELINE_FILES,
+  },
+  calculator: {
+    designTokens: [...BASELINE_TOKENS, "--v-font-mono"],
+    files: BASELINE_FILES,
+  },
+};
+
+function resolveExpectations(
+  artifact: BuildArtifact,
+  prompt: GoldenPrompt,
+): PlanExpectations {
+  return (
+    artifact.plan ??
+    prompt.expects ??
+    DEFAULT_EXPECTATIONS[prompt.id] ?? {
+      designTokens: BASELINE_TOKENS,
+      files: BASELINE_FILES,
+    }
+  );
+}
+
+function coverage<T>(expected: T[], isPresent: (item: T) => boolean) {
+  if (expected.length === 0) return { fraction: 1, missing: [] as T[] };
+  const missing = expected.filter((item) => !isPresent(item));
+  return {
+    fraction: (expected.length - missing.length) / expected.length,
+    missing,
+  };
+}
+
+export function checkPlanAdherence(
+  artifact: BuildArtifact,
+  prompt: GoldenPrompt,
+): PlanAdherenceResult {
+  const expected = resolveExpectations(artifact, prompt);
+  const allSource = Object.values(artifact.sourceFiles).join("\n");
+  const presentFiles = new Set(Object.keys(artifact.sourceFiles));
+
+  const tokens = coverage(expected.designTokens, (t) => allSource.includes(t));
+  const files = coverage(expected.files, (f) => presentFiles.has(f));
+
+  return {
+    tokenCoverage: tokens.fraction,
+    fileCoverage: files.fraction,
+    missingTokens: tokens.missing,
+    missingFiles: files.missing,
+  };
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/prompts.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/prompts.ts
@@ -1,0 +1,33 @@
+/**
+ * The fixed golden prompt set. Keep this stable — changing prompts breaks
+ * comparability across runs. Add new prompts; don't edit existing ones.
+ */
+
+import type { GoldenPrompt } from "./types.js";
+
+export const GOLDEN_PROMPTS: readonly GoldenPrompt[] = [
+  {
+    id: "habit-tracker",
+    label: "Habit tracker",
+    prompt:
+      "Build me a habit tracker where I can add daily habits and check them off, with a streak counter.",
+  },
+  {
+    id: "finance-dashboard",
+    label: "Finance dashboard",
+    prompt:
+      "Build a personal finance dashboard showing spending by category with a chart and a recent-transactions list.",
+  },
+  {
+    id: "slide-deck",
+    label: "Slide deck",
+    prompt:
+      "Build a 5-slide deck pitching a coffee subscription startup, with a title slide and presenter navigation.",
+  },
+  {
+    id: "calculator",
+    label: "Calculator",
+    prompt:
+      "Build a calculator with the standard arithmetic operations and a clean keypad layout.",
+  },
+] as const;

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/rubric.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/rubric.ts
@@ -1,0 +1,121 @@
+/**
+ * Design rubric definition + the LLM-judge interface.
+ *
+ * The rubric is the spec we hand an LLM (alongside a render of the built app)
+ * to score design quality. The criteria mirror the aesthetic principles the
+ * `frontend-design` skill enforces — these are what "whoa, this looks
+ * designed" decomposes into.
+ *
+ * `LLMDesignJudge` is the real interface a live judge implements. Wiring an
+ * actual model (screenshot the built app, send rubric + image, parse scores)
+ * is out of scope for this scaffolding PR, so we also ship
+ * {@link StubDesignJudge}: a deterministic placeholder that lets the full
+ * pipeline run and produce a scorecard today. Swap it for a live judge when
+ * available — the harness depends only on the {@link DesignJudge} interface.
+ */
+
+import type {
+  BuildArtifact,
+  DesignJudge,
+  GoldenPrompt,
+  RubricCriterion,
+  RubricResult,
+  RubricScore,
+} from "./types.js";
+
+/** The scored dimensions. Weights need not sum to 1; we normalize. */
+export const DESIGN_RUBRIC: readonly RubricCriterion[] = [
+  {
+    id: "visual-identity",
+    label: "Visual identity",
+    description:
+      "Does the app have a distinctive, domain-matched look (palette, atmosphere) rather than a generic branded template?",
+    weight: 2,
+  },
+  {
+    id: "typography",
+    label: "Typography & hierarchy",
+    description:
+      "Clear type scale, readable body, intentional emphasis. Nothing cramped or default-looking.",
+    weight: 1,
+  },
+  {
+    id: "layout",
+    label: "Layout & composition",
+    description:
+      "Balanced spacing, aligned grids, sensible density. Looks composed, not auto-generated.",
+    weight: 1,
+  },
+  {
+    id: "polish",
+    label: "Polish & micro-interactions",
+    description:
+      "Empty states, hover/focus states, motion, and finishing touches that make it feel crafted.",
+    weight: 1,
+  },
+  {
+    id: "prompt-fit",
+    label: "Prompt fit",
+    description:
+      "Does the result actually satisfy what the user asked for, including implied features?",
+    weight: 2,
+  },
+] as const;
+
+/** Build the prompt text a live judge would send to the model. */
+export function buildJudgePrompt(prompt: GoldenPrompt): string {
+  const criteria = DESIGN_RUBRIC.map(
+    (c) => `- ${c.label} (id: ${c.id}): ${c.description}`,
+  ).join("\n");
+  return [
+    "You are a senior product designer scoring a generated app.",
+    `The user asked: "${prompt.prompt}"`,
+    "Score each criterion 1-5 (5 = excellent) and give a one-line rationale.",
+    "Criteria:",
+    criteria,
+    'Respond as JSON: {"scores":[{"criterionId","score","rationale"}]}.',
+  ].join("\n");
+}
+
+/** Normalize per-criterion scores (1..5) into a weighted 0..1 overall. */
+export function scoreToOverall(scores: RubricScore[]): number {
+  const byId = new Map(scores.map((s) => [s.criterionId, s.score]));
+  let weighted = 0;
+  let totalWeight = 0;
+  for (const c of DESIGN_RUBRIC) {
+    const raw = byId.get(c.id);
+    if (raw === undefined) continue;
+    // map 1..5 -> 0..1
+    weighted += ((raw - 1) / 4) * c.weight;
+    totalWeight += c.weight;
+  }
+  return totalWeight === 0 ? 0 : weighted / totalWeight;
+}
+
+/**
+ * The interface a live LLM judge implements. Documented seam: an implementation
+ * renders `artifact` to an image, sends {@link buildJudgePrompt} + the image to
+ * a model, parses the JSON scores, and calls {@link scoreToOverall}.
+ */
+export type LLMDesignJudge = DesignJudge;
+
+/**
+ * Deterministic stand-in so the pipeline runs without a live model. It does NOT
+ * judge design — it derives a stable pseudo-score from the artifact so runs are
+ * reproducible. Replace with a live judge to get real design signal.
+ */
+export class StubDesignJudge implements DesignJudge {
+  async score(
+    artifact: BuildArtifact,
+    _prompt: GoldenPrompt,
+  ): Promise<RubricResult> {
+    const sourceLen = Object.values(artifact.sourceFiles).join("").length;
+    const scores: RubricScore[] = DESIGN_RUBRIC.map((c, i) => ({
+      criterionId: c.id,
+      // Stable, content-derived placeholder in the 3-5 band.
+      score: 3 + ((sourceLen + i) % 3),
+      rationale: "stub judge — no live model wired",
+    }));
+    return { scores, overall: scoreToOverall(scores) };
+  }
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/runner.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/runner.ts
@@ -1,0 +1,102 @@
+/**
+ * The eval runner: drives each (variant, prompt) build, scores it on the three
+ * dimensions, and rolls the results up into an A/B-comparable {@link Scorecard}.
+ */
+
+import { checkPlanAdherence } from "./plan-adherence.js";
+import { StubDesignJudge } from "./rubric.js";
+import type {
+  AppBuildDriver,
+  BuildArtifact,
+  BuildResult,
+  CompileResult,
+  DesignJudge,
+  GoldenPrompt,
+  Scorecard,
+  ScorecardColumn,
+} from "./types.js";
+
+/**
+ * Compiles a build's source. The default is a lightweight static sanity check
+ * so the harness runs anywhere; a live runner can pass the real esbuild-backed
+ * `compileApp` (write files to a temp dir, call it, map the result).
+ */
+export type CompileFn = (artifact: BuildArtifact) => Promise<CompileResult>;
+
+const defaultCompile: CompileFn = async (artifact) => {
+  const errors: string[] = [];
+  const files = Object.entries(artifact.sourceFiles);
+  if (files.length === 0) errors.push("no source files produced");
+  for (const [path, contents] of files) {
+    if (!contents.trim()) errors.push(`${path}: empty file`);
+    // Cheap balance check — catches the most common truncation failures.
+    const open = (contents.match(/[({[]/g) ?? []).length;
+    const close = (contents.match(/[)}\]]/g) ?? []).length;
+    if (open !== close) errors.push(`${path}: unbalanced brackets`);
+  }
+  return { ok: errors.length === 0, errors };
+};
+
+export interface RunnerOptions {
+  prompts: readonly GoldenPrompt[];
+  drivers: readonly AppBuildDriver[];
+  /** Design judge; defaults to the deterministic stub. */
+  judge?: DesignJudge;
+  /** Compile check; defaults to a lightweight static check. */
+  compile?: CompileFn;
+}
+
+function mean(xs: number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function defined(xs: (number | undefined)[]): number[] {
+  return xs.filter((x): x is number => x !== undefined);
+}
+
+function summarize(
+  variant: AppBuildDriver["variant"],
+  rows: BuildResult[],
+): ScorecardColumn {
+  const latencies = defined(rows.map((r) => r.telemetry.latencyMs));
+  const costs = defined(rows.map((r) => r.telemetry.costUsd));
+  return {
+    variant,
+    rows,
+    compileRate: mean(rows.map((r) => (r.compile.ok ? 1 : 0))),
+    meanTokenCoverage: mean(rows.map((r) => r.planAdherence.tokenCoverage)),
+    meanFileCoverage: mean(rows.map((r) => r.planAdherence.fileCoverage)),
+    meanDesignScore: mean(rows.map((r) => r.rubric.overall)),
+    meanLatencyMs: latencies.length ? mean(latencies) : undefined,
+    meanCostUsd: costs.length ? mean(costs) : undefined,
+  };
+}
+
+export async function runEvals(options: RunnerOptions): Promise<Scorecard> {
+  const judge = options.judge ?? new StubDesignJudge();
+  const compile = options.compile ?? defaultCompile;
+
+  const columns: ScorecardColumn[] = [];
+  for (const driver of options.drivers) {
+    const rows: BuildResult[] = [];
+    for (const prompt of options.prompts) {
+      const artifact = await driver.build(prompt);
+      rows.push({
+        variant: driver.variant,
+        promptId: prompt.id,
+        compile: await compile(artifact),
+        planAdherence: checkPlanAdherence(artifact, prompt),
+        rubric: await judge.score(artifact, prompt),
+        // Latency/cost left empty — populated once PR 7 telemetry lands.
+        telemetry: {},
+      });
+    }
+    columns.push(summarize(driver.variant, rows));
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    promptSetSize: options.prompts.length,
+    columns,
+  };
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/types.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared types for the app-builder golden-set eval harness.
+ *
+ * The harness measures whether a given build *variant* (the current
+ * single-model skill, or the future tiered planner/worker flow) produces
+ * good apps. It scores three independent dimensions per build:
+ *
+ *  1. compile — did the produced source actually compile?
+ *  2. plan-adherence — did the output use the design tokens / files the
+ *     variant said it would? (best-effort static checks)
+ *  3. design rubric — an LLM-scored aesthetic/quality judgment.
+ *
+ * Results roll up into a {@link Scorecard} that is shaped for A/B comparison
+ * between variants, with latency/cost columns left ready for PR 7 telemetry.
+ */
+
+/** A single fixed prompt in the golden set. */
+export interface GoldenPrompt {
+  /** Stable id, used as a column key in the scorecard. */
+  id: string;
+  /** Human-readable label, e.g. "Habit tracker". */
+  label: string;
+  /** The user request fed to the build variant verbatim. */
+  prompt: string;
+  /**
+   * Design tokens / file paths we expect a faithful build to use. Drives the
+   * best-effort plan-adherence static checks. Optional per-prompt overrides;
+   * defaults live in {@link plan-adherence.ts}.
+   */
+  expects?: PlanExpectations;
+}
+
+/** What a faithful build is expected to contain (static, best-effort). */
+export interface PlanExpectations {
+  /** Design-system CSS variables expected to appear, e.g. "--v-accent". */
+  designTokens: string[];
+  /** Source file paths expected to exist, e.g. "src/main.tsx". */
+  files: string[];
+}
+
+/** The artifact a build variant produces for a prompt. */
+export interface BuildArtifact {
+  /** Map of file path -> file contents (the TSX/CSS the variant wrote). */
+  sourceFiles: Record<string, string>;
+  /**
+   * The plan the variant committed to, if any. The planner/worker flow emits
+   * one; the single-model baseline may leave this undefined. When present, it
+   * lets plan-adherence check intent vs. output rather than a fixed default.
+   */
+  plan?: PlanExpectations;
+}
+
+/** Identifies which build flow produced a result. */
+export type Variant = "single-model" | "planner-worker";
+
+/** Compile-check outcome for one build. */
+export interface CompileResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Plan-adherence outcome for one build (best-effort static analysis). */
+export interface PlanAdherenceResult {
+  /** 0..1 fraction of expected design tokens found in the output. */
+  tokenCoverage: number;
+  /** 0..1 fraction of expected files present in the output. */
+  fileCoverage: number;
+  /** Tokens/files that were expected but missing (for debugging). */
+  missingTokens: string[];
+  missingFiles: string[];
+}
+
+/** A single rubric dimension's definition. */
+export interface RubricCriterion {
+  id: string;
+  label: string;
+  description: string;
+  /** Relative weight when computing the overall design score. */
+  weight: number;
+}
+
+/** An LLM's score for one rubric criterion. */
+export interface RubricScore {
+  criterionId: string;
+  /** 1..5, where 5 is excellent. */
+  score: number;
+  rationale: string;
+}
+
+/** Full design-rubric judgment for one build. */
+export interface RubricResult {
+  scores: RubricScore[];
+  /** Weighted overall, normalized to 0..1. */
+  overall: number;
+}
+
+/** Telemetry placeholders, to be populated by PR 7. */
+export interface BuildTelemetry {
+  latencyMs?: number;
+  costUsd?: number;
+}
+
+/** Everything we learned about one (variant, prompt) build. */
+export interface BuildResult {
+  variant: Variant;
+  promptId: string;
+  compile: CompileResult;
+  planAdherence: PlanAdherenceResult;
+  rubric: RubricResult;
+  telemetry: BuildTelemetry;
+}
+
+/** One column of the scorecard: a single variant's aggregate + per-prompt rows. */
+export interface ScorecardColumn {
+  variant: Variant;
+  rows: BuildResult[];
+  /** Fraction of builds that compiled. */
+  compileRate: number;
+  /** Mean token coverage across builds. */
+  meanTokenCoverage: number;
+  /** Mean file coverage across builds. */
+  meanFileCoverage: number;
+  /** Mean design rubric overall across builds. */
+  meanDesignScore: number;
+  /** Mean latency, when telemetry is present. */
+  meanLatencyMs?: number;
+  /** Mean cost, when telemetry is present. */
+  meanCostUsd?: number;
+}
+
+/** The A/B-comparable result of an eval run. */
+export interface Scorecard {
+  generatedAt: string;
+  promptSetSize: number;
+  columns: ScorecardColumn[];
+}
+
+/**
+ * Drives a single app build end-to-end for one prompt under one variant.
+ *
+ * This is the real seam between the harness and a build flow. The current
+ * single-model skill and the future planner/worker flow each implement this.
+ * See {@link build-driver.ts} for the baseline stub.
+ */
+export interface AppBuildDriver {
+  readonly variant: Variant;
+  build(prompt: GoldenPrompt): Promise<BuildArtifact>;
+}
+
+/**
+ * Scores a build's design quality. The real implementation calls an LLM with
+ * the rubric and a render/screenshot of the app; the harness ships a
+ * deterministic stub so the pipeline runs without a live model. See
+ * {@link rubric.ts}.
+ */
+export interface DesignJudge {
+  score(artifact: BuildArtifact, prompt: GoldenPrompt): Promise<RubricResult>;
+}


### PR DESCRIPTION
## Summary
- Add __evals__ scaffolding: fixed prompt set, runner, design rubric, scorecard
- Standalone-runnable; ready to A/B single-model vs planner/worker builds

Part of plan: ab-planner-worker.md (PR 8 of 9)
JARVIS-1060