### PR TITLE
Rework iOS theme switcher + credits section to match Figma mock

### DIFF
--- a/apps/web/src/components/theme-toggle.test.tsx
+++ b/apps/web/src/components/theme-toggle.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for `ThemeToggle`.
+ *
+ * The component is a thin wrapper over the design-library `SegmentControl`
+ * (icon-only mode). We mount it via `@testing-library/react` (backed by
+ * happy-dom — see `apps/web/test-setup.ts`) and assert the user-facing
+ * contract: the three base segments render as labelled radios, each glyph
+ * carries the mock's 14px (`h-3.5 w-3.5`) sizing, and selecting a segment
+ * persists + applies the chosen preference.
+ *
+ * Theme state internals (`readStoredThemePreference` /
+ * `writeStoredThemePreference` / `applyThemePreference`) and device-setting
+ * watching are mocked — they're owned/tested elsewhere.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// --- Mocks ----------------------------------------------------------------
+
+const velvetRef = { value: false };
+
+mock.module("@/stores/client-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    velvet: () => velvetRef.value,
+  };
+  return { useClientFeatureFlagStore: store };
+});
+
+// `watchDeviceSetting(name, cb)` returns an unsubscribe function. The toggle
+// only registers it in an effect; we never fire it here.
+mock.module("@/utils/device-settings", () => ({
+  watchDeviceSetting: () => () => {},
+}));
+
+const writeStoredThemePreference = mock(() => {});
+const applyThemePreference = mock(() => {});
+const readStoredThemePreference = mock(() => "system" as const);
+
+mock.module("@/domains/settings/utils/theme-preferences", () => ({
+  readStoredThemePreference,
+  writeStoredThemePreference,
+  applyThemePreference,
+}));
+
+import { ThemeToggle } from "@/components/theme-toggle";
+
+beforeEach(() => {
+  velvetRef.value = false;
+  writeStoredThemePreference.mockClear();
+  applyThemePreference.mockClear();
+  readStoredThemePreference.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function getRadios(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[role="radio"]'));
+}
+
+function getRadio(label: string): HTMLElement {
+  const match = getRadios().find(
+    (el) => el.getAttribute("aria-label") === label,
+  );
+  if (!match) {
+    throw new Error(
+      `expected a radio with aria-label "${label}" — saw: ${getRadios()
+        .map((el) => `"${el.getAttribute("aria-label")}"`)
+        .join(", ")}`,
+    );
+  }
+  return match;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("ThemeToggle rendering", () => {
+  test("renders the three base options as labelled radios", () => {
+    render(<ThemeToggle />);
+    const labels = getRadios().map((el) => el.getAttribute("aria-label"));
+    expect(labels).toEqual(["System", "Light", "Dark"]);
+  });
+
+  test("each glyph carries the mock's h-3.5 w-3.5 sizing", () => {
+    render(<ThemeToggle />);
+    for (const label of ["System", "Light", "Dark"]) {
+      const glyph = getRadio(label).querySelector("svg");
+      expect(glyph).not.toBeNull();
+      expect(glyph?.getAttribute("class") ?? "").toContain("h-3.5");
+      expect(glyph?.getAttribute("class") ?? "").toContain("w-3.5");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe("ThemeToggle selection", () => {
+  test("selecting a non-active segment persists and applies it", () => {
+    readStoredThemePreference.mockReturnValue("system");
+    render(<ThemeToggle />);
+
+    fireEvent.click(getRadio("Dark"));
+
+    expect(writeStoredThemePreference).toHaveBeenCalledTimes(1);
+    expect(writeStoredThemePreference).toHaveBeenCalledWith("dark");
+    expect(applyThemePreference).toHaveBeenCalledTimes(1);
+    expect(applyThemePreference).toHaveBeenCalledWith("dark");
+  });
+
+  test("clicking the already-active segment is a no-op", () => {
+    readStoredThemePreference.mockReturnValue("system");
+    render(<ThemeToggle />);
+
+    fireEvent.click(getRadio("System"));
+
+    expect(writeStoredThemePreference).not.toHaveBeenCalled();
+    expect(applyThemePreference).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -79,6 +79,7 @@ export function ThemeToggle({ className }: { className?: string } = {}) {
         items={themeOptions.map(({ value, label, Icon }) => ({
           value,
           label,
+          // Mock glyph is ~14px (h-3.5 w-3.5 == 14px); bump to 16px on mobile.
           icon: <Icon className="h-3.5 w-3.5 max-md:h-4 max-md:w-4" />,
         }))}
       />

--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for the presentational `CreditsCard`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the click handlers with `fireEvent`. No jest-dom matchers — we
+ * assert with plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { CreditsCard } from "./credits-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreditsCard", () => {
+  test("renders the balance, coins icon, and fires onAddCredits when Add is clicked", () => {
+    const onAddCredits = mock(() => {});
+    const onEarnCredits = mock(() => {});
+
+    const { getByText, getByRole, container } = render(
+      <CreditsCard
+        balance="60"
+        onAddCredits={onAddCredits}
+        onEarnCredits={onEarnCredits}
+      />,
+    );
+
+    expect(getByText("60 credits")).toBeTruthy();
+    // The Coins icon renders a lucide SVG; assert at least one is present.
+    expect(container.querySelector("svg.lucide-coins")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: /add/i }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(onEarnCredits).not.toHaveBeenCalled();
+  });
+
+  test("hides only the credits pill when balance is null but still renders Earn Credits", () => {
+    const { queryByText, getByText } = render(
+      <CreditsCard
+        balance={null}
+        onAddCredits={() => {}}
+        onEarnCredits={() => {}}
+      />,
+    );
+
+    expect(queryByText(/credits$/)).toBeNull();
+    expect(getByText("Earn Credits")).toBeTruthy();
+  });
+
+  test("fires onEarnCredits when the Earn Credits row is clicked", () => {
+    const onEarnCredits = mock(() => {});
+
+    const { getByText } = render(
+      <CreditsCard
+        balance="60"
+        onAddCredits={() => {}}
+        onEarnCredits={onEarnCredits}
+      />,
+    );
+
+    fireEvent.click(getByText("Earn Credits"));
+    expect(onEarnCredits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,4 +1,4 @@
-import { Button, cn } from "@vellum/design-library";
+import { Button } from "@vellum/design-library";
 import { Coins, Gift, Plus } from "lucide-react";
 
 interface CreditsCardProps {
@@ -6,7 +6,6 @@ interface CreditsCardProps {
   balance: string | null;
   onAddCredits: () => void;
   onEarnCredits: () => void;
-  className?: string;
 }
 
 /**
@@ -19,14 +18,10 @@ export function CreditsCard({
   balance,
   onAddCredits,
   onEarnCredits,
-  className,
 }: CreditsCardProps) {
   return (
     <div
-      className={cn(
-        "flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full",
-        className,
-      )}
+      className="flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full"
       style={{
         borderColor: "var(--surface-base)",
         background: "var(--surface-overlay)",

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,0 +1,79 @@
+import { Button, cn } from "@vellum/design-library";
+import { Coins, Gift, Plus } from "lucide-react";
+
+interface CreditsCardProps {
+  /** Formatted whole-credits string, or null when unavailable. */
+  balance: string | null;
+  onAddCredits: () => void;
+  onEarnCredits: () => void;
+  className?: string;
+}
+
+/**
+ * Presentational credits card matching the iOS preferences-drawer mock:
+ * a bordered card containing a credits pill (coins icon + balance + a primary
+ * "Add" button) and an "Earn Credits" row beneath. Purely presentational — no
+ * data fetching; callers supply the formatted balance and handlers.
+ */
+export function CreditsCard({
+  balance,
+  onAddCredits,
+  onEarnCredits,
+  className,
+}: CreditsCardProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-lg border px-3 pt-3 pb-4 w-full",
+        className,
+      )}
+      style={{
+        borderColor: "var(--surface-base)",
+        background: "var(--surface-overlay)",
+      }}
+    >
+      {balance !== null && (
+        <div
+          className="flex items-center justify-between gap-2 rounded-[10px] py-2 pl-1.5 pr-2 w-full"
+          style={{ background: "var(--surface-base)" }}
+        >
+          <div className="flex items-center gap-2">
+            <Coins
+              className="h-3.5 w-3.5"
+              style={{ color: "var(--credits-accent)" }}
+              aria-hidden
+            />
+            <span
+              className="text-title-medium"
+              style={{ color: "var(--content-default)" }}
+            >
+              {balance} credits
+            </span>
+          </div>
+          <Button variant="primary" size="regular" onClick={onAddCredits}>
+            <Plus className="h-3 w-3" aria-hidden />
+            Add
+          </Button>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onEarnCredits}
+        className="flex items-center gap-2 pl-1.5 transition-colors hover:opacity-80"
+      >
+        <Gift
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--content-secondary)" }}
+          aria-hidden
+        />
+        <span
+          className="text-body-large-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          Earn Credits
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -83,6 +83,10 @@ mock.module("@/components/theme-toggle", () => ({
   ThemeToggle: () => createElement("div", { "data-testid": "theme-toggle" }, "Theme"),
 }));
 
+mock.module("@/domains/chat/components/credits-card", () => ({
+  CreditsCard: () => createElement("div", { "data-testid": "credits-card" }, "Credits"),
+}));
+
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 
 beforeEach(() => {

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -3,7 +3,6 @@ import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
-  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -15,7 +14,6 @@ import { useNavigate } from "react-router";
 
 import {
   BottomSheet,
-  Button,
   PanelItem,
   Popover,
   SideMenu,
@@ -33,6 +31,8 @@ import {
 import { adminUrl, routes } from "@/utils/routes";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+
+import { CreditsCard } from "./credits-card";
 
 // Modal only opens when the user clicks "Share Feedback" — defer loading
 // until then to keep the modal's form deps (markdown editor, etc.) out of
@@ -172,34 +172,17 @@ function PreferencesMenuContent({
 
       {showBillingRows ? (
         <>
-          {effectiveBalance !== null ? (
-            <>
-              <div className="flex items-center justify-between gap-3 py-2 pl-[8px]">
-                <span
-                  className="text-body-medium-lighter"
-                  style={{ color: "var(--content-default)" }}
-                >
-                  {formatWholeCredits(effectiveBalance)} credits
-                </span>
-                <Button
-                  variant="ghost"
-                  size="compact"
-                  onClick={() => {
-                    onClose();
-                    navigate(routes.settings.billing);
-                  }}
-                >
-                  Add credits
-                </Button>
-              </div>
-              <MenuDivider />
-            </>
-          ) : null}
-
-          <PanelItem
-            icon={Gift}
-            label="Earn credits"
-            onSelect={() => {
+          <CreditsCard
+            balance={
+              effectiveBalance !== null
+                ? formatWholeCredits(effectiveBalance)
+                : null
+            }
+            onAddCredits={() => {
+              onClose();
+              navigate(routes.settings.billing);
+            }}
+            onEarnCredits={() => {
               onClose();
               onEarnCredits();
             }}

--- a/packages/design-library/src/components/segment-control.test.tsx
+++ b/packages/design-library/src/components/segment-control.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for the SegmentControl primitive.
+ *
+ * No DOM environment — mirroring `button.test.tsx`, we verify behavior through
+ * two angles:
+ *   1. `renderToStaticMarkup` — asserts the HTML the component emits, including
+ *      the icon-only geometry that PR 1 enlarges to match the iOS mock.
+ *   2. The pure `resolveSegmentSelection` helper that each segment's onClick
+ *      delegates to — asserts the click→onChange decision without a renderer.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  SegmentControl,
+  type SegmentControlItem,
+  resolveSegmentSelection,
+} from "./segment-control";
+
+type ThemeValue = "light" | "dark" | "system";
+
+const iconItems: SegmentControlItem<ThemeValue>[] = [
+  { value: "light", label: "Light", icon: <svg data-testid="icon-light" /> },
+  { value: "dark", label: "Dark", icon: <svg data-testid="icon-dark" /> },
+  { value: "system", label: "System", icon: <svg data-testid="icon-system" /> },
+];
+
+const textItems: SegmentControlItem<ThemeValue>[] = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+/** Extracts the `class` value of every `role="radio"` button in the markup. */
+function radioClassNames(html: string): string[] {
+  const matches = html.matchAll(/<button[^>]*role="radio"[^>]*>/g);
+  return [...matches].map((match) => {
+    const classMatch = match[0].match(/class="([^"]*)"/);
+    return classMatch?.[1] ?? "";
+  });
+}
+
+/** Extracts the `class` value of the `data-slot="segment-control"` container. */
+function containerClassName(html: string): string {
+  const match = html.match(
+    /<div[^>]*data-slot="segment-control"[^>]*>/,
+  )?.[0];
+  return match?.match(/class="([^"]*)"/)?.[1] ?? "";
+}
+
+describe("SegmentControl icon-only geometry", () => {
+  test("container uses the enlarged 10px radius", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={iconItems}
+        value="light"
+        onChange={() => {}}
+        iconOnly
+        ariaLabel="Theme"
+      />,
+    );
+    expect(containerClassName(html)).toContain("rounded-[10px]");
+  });
+
+  test("each segment uses the enlarged radius (rounded-lg) and padding (px-2)", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={iconItems}
+        value="light"
+        onChange={() => {}}
+        iconOnly
+        ariaLabel="Theme"
+      />,
+    );
+    const classes = radioClassNames(html);
+    expect(classes).toHaveLength(iconItems.length);
+    for (const cls of classes) {
+      expect(cls).toContain("rounded-lg");
+      expect(cls).toContain("px-2");
+    }
+  });
+});
+
+describe("SegmentControl text-mode (non-icon-only) geometry is unchanged", () => {
+  test("container stays rounded-lg and does NOT gain the 10px radius", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={textItems}
+        value="light"
+        onChange={() => {}}
+        ariaLabel="Theme"
+      />,
+    );
+    const container = containerClassName(html);
+    expect(container).toContain("rounded-lg");
+    expect(container).not.toContain("rounded-[10px]");
+  });
+
+  test("each segment keeps flex-1, px-3 and py-1.5", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={textItems}
+        value="light"
+        onChange={() => {}}
+        ariaLabel="Theme"
+      />,
+    );
+    const classes = radioClassNames(html);
+    expect(classes).toHaveLength(textItems.length);
+    for (const cls of classes) {
+      expect(cls).toContain("flex-1");
+      expect(cls).toContain("px-3");
+      expect(cls).toContain("py-1.5");
+    }
+  });
+});
+
+describe("SegmentControl selection behavior", () => {
+  test("clicking a non-active segment resolves to the new value", () => {
+    expect(resolveSegmentSelection(iconItems, "light", "dark")).toBe("dark");
+  });
+
+  test("clicking the active segment is a no-op", () => {
+    expect(resolveSegmentSelection(iconItems, "light", "light")).toBeNull();
+  });
+
+  test("clicking a disabled segment is a no-op", () => {
+    const items: SegmentControlItem<ThemeValue>[] = [
+      { value: "light", label: "Light" },
+      { value: "dark", label: "Dark", disabled: true },
+      { value: "system", label: "System" },
+    ];
+    expect(resolveSegmentSelection(items, "light", "dark")).toBeNull();
+  });
+});

--- a/packages/design-library/src/components/segment-control.tsx
+++ b/packages/design-library/src/components/segment-control.tsx
@@ -120,6 +120,7 @@ export function SegmentControl<T extends string>({
       className={cn(
         "inline-flex rounded-lg bg-[var(--surface-active)] p-0.5",
         !iconOnly && "w-full",
+        iconOnly && "rounded-[10px]",
         className,
       )}
     >
@@ -144,7 +145,7 @@ export function SegmentControl<T extends string>({
             className={cn(
               "min-w-[30px] cursor-pointer justify-center gap-1.5 rounded-md border-0 text-body-medium-default",
               iconOnly
-                ? "h-7 px-[5px] py-1 max-md:h-9 max-md:min-w-9 max-md:px-2"
+                ? "h-7 rounded-lg px-2 py-1 max-md:h-9 max-md:min-w-9 max-md:px-2"
                 : "h-auto flex-1 px-3 py-1.5",
               isActive
                 ? "bg-[var(--surface-overlay)] text-[var(--content-emphasised)] shadow-sm hover:bg-[var(--surface-overlay)]"

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -248,6 +248,8 @@
   --feed-nudge-weak: #F0D9E0;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #C8E5E2;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #EFE8C4;
 
@@ -328,6 +330,8 @@
   --feed-nudge-weak: #432B33;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #293D3B;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #464125;
 
@@ -414,6 +418,8 @@
   --feed-nudge-weak: #432B33;
   --feed-digest-strong: #0E9B8B;
   --feed-digest-weak: #293D3B;
+  /* credits/coins accent (teal) */
+  --credits-accent: #0E9B8B;
   --feed-thread-strong: #E9C91A;
   --feed-thread-weak: #464125;
 


### PR DESCRIPTION
## Summary
Reworks the iOS (Capacitor web app, `apps/web`) preferences drawer to match the Figma mock (node 4502-120273): the theme switcher is slightly larger/rounder, and the credits + earn-credits area becomes a single bordered card (coins pill + balance + primary "Add" button, with an "Earn Credits" row).

## Self-review result
PASS — 1 minor gap fixed across 1 fix PR (removed an unused `className` prop). Other advisory findings (semantic `--credits-accent` token, harmless `tailwind-merge` class overlap) were reviewed and intentionally kept.

## PRs merged into feature branch
- #33116: fix(design-library): enlarge icon-only SegmentControl to match iOS mock
- #33117: fix(web): align theme switcher glyph/label sizing with iOS mock
- #33118: feat(web): add CreditsCard component matching iOS drawer mock
- #33124: fix(web): replace flat credits rows with CreditsCard in preferences menu

### Fix PRs
- #33131: refactor(web): drop unused className prop from CreditsCard

## Notes
- The shared `SegmentControl` change is gated to `iconOnly` mode (sole consumer is the theme switcher); the 6 text-mode usages are unaffected.
- `theme-toggle.tsx` mobile glyph/height were intentionally left as-is (only corners rounded) — see the plan's documented open decision about the `max-md` breakpoint on iOS.

Part of plan: ios-theme-switcher-larger.md