### PR TITLE
chore: condense PINNED_CLI_VERSION comment

### DIFF
--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -8,16 +8,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-/**
- * Pinned CLI version installed in packaged builds.
- *
- * TODO: Not yet stamped automatically. When the Electron app is added to
- * the release pipeline in `.github/workflows/release.yml`, add a step to
- * rewrite this value using the same `jq`/`sed` pattern that stamps
- * `assistant/package.json` et al. (see the "Stamp release version into
- * package.json" step in that workflow). Until then, bump manually when
- * cutting a release that changes the CLI version in `cli/package.json`.
- */
+// TODO: auto-stamp in release workflow; bump manually until then.
 export const PINNED_CLI_VERSION = "0.8.6";
 
 /** Directory where the pinned CLI version is installed. */


### PR DESCRIPTION
## Summary
Condense verbose 8-line JSDoc on PINNED_CLI_VERSION to a terse TODO comment per project conventions.

Fixes gap identified during plan review for packaged-cli-install.md.

**Gap:** Verbose PINNED_CLI_VERSION JSDoc
**What was expected:** Terse comments per convention
**What was found:** 8-line JSDoc block