### PR TITLE
fix: add concurrency guard to ensureCliInstalled

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -71,6 +71,7 @@ const {
   isCliInstalled,
   ensureCliInstalled,
   cleanupOldVersions,
+  _resetInstallLock,
 } = await import("./cli-installer");
 
 afterEach(() => {
@@ -80,6 +81,7 @@ afterEach(() => {
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   spawnCalls.length = 0;
+  _resetInstallLock();
 });
 
 // --- Path helpers ---
@@ -196,6 +198,35 @@ describe("ensureCliInstalled", () => {
     expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
     const pinnedPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}`;
     expect(removedPaths).not.toContain(pinnedPath);
+  });
+
+  test("concurrent calls share a single install", async () => {
+    existsSyncReturn = false;
+
+    const p1 = ensureCliInstalled();
+    const p2 = ensureCliInstalled();
+
+    // Only one spawn should have occurred.
+    expect(spawnCalls).toHaveLength(1);
+
+    lastChild.emit("close", 0);
+    await Promise.all([p1, p2]);
+  });
+
+  test("failed install resets the lock so retries are possible", async () => {
+    existsSyncReturn = false;
+
+    const p1 = ensureCliInstalled();
+    lastChild.stderr.emit("data", Buffer.from("disk full"));
+    lastChild.emit("close", 1);
+
+    await expect(p1).rejects.toThrow(/CLI install failed/);
+
+    // Second attempt should spawn a new process.
+    const p2 = ensureCliInstalled();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.emit("close", 0);
+    await p2;
   });
 });
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -40,6 +40,14 @@ export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
 }
 
+// Singleton promise prevents concurrent installs from corrupting node_modules.
+let installPromise: Promise<void> | null = null;
+
+/** Reset the install lock. Exposed for testing only. */
+export function _resetInstallLock(): void {
+  installPromise = null;
+}
+
 /**
  * Install the pinned CLI version if it isn't already present.
  *
@@ -50,50 +58,61 @@ export function isCliInstalled(): boolean {
 export async function ensureCliInstalled(): Promise<void> {
   if (isCliInstalled()) return;
 
-  const installDir = getCliInstallDir();
-  mkdirSync(installDir, { recursive: true });
+  if (installPromise) return installPromise;
 
-  const bunPath = getBundledBunPath();
+  installPromise = (async () => {
+    const installDir = getCliInstallDir();
+    mkdirSync(installDir, { recursive: true });
 
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(bunPath, ["add", `@vellumai/cli@${PINNED_CLI_VERSION}`], {
-      cwd: installDir,
-    });
+    const bunPath = getBundledBunPath();
 
-    let stdout = "";
-    let stderr = "";
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(bunPath, ["add", `@vellumai/cli@${PINNED_CLI_VERSION}`], {
+        cwd: installDir,
+      });
 
-    child.stdout.on("data", (data: Buffer) => {
-      stdout += data.toString();
-    });
+      let stdout = "";
+      let stderr = "";
 
-    child.stderr.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
+      child.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
 
-    child.on("error", (err: Error) => {
-      reject(
-        new Error(
-          `Failed to spawn bun for CLI install: ${err.message}`,
-        ),
-      );
-    });
+      child.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
 
-    child.on("close", (code: number | null) => {
-      if (code !== 0) {
-        const detail = (stderr || stdout).trim();
+      child.on("error", (err: Error) => {
         reject(
           new Error(
-            `CLI install failed with exit code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`,
+            `Failed to spawn bun for CLI install: ${err.message}`,
           ),
         );
-        return;
-      }
-      resolve();
-    });
-  });
+      });
 
-  cleanupOldVersions();
+      child.on("close", (code: number | null) => {
+        if (code !== 0) {
+          const detail = (stderr || stdout).trim();
+          reject(
+            new Error(
+              `CLI install failed with exit code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`,
+            ),
+          );
+          return;
+        }
+        resolve();
+      });
+    });
+
+    cleanupOldVersions();
+  })();
+
+  try {
+    await installPromise;
+  } catch (err) {
+    installPromise = null;
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes race condition during first app launch where concurrent IPC calls could spawn parallel bun add operations in the same install directory.

Fixes gap identified during plan review for packaged-cli-install.md.

**Gap:** Concurrency guard on ensureCliInstalled
**What was expected:** Safe concurrent calls
**What was found:** No locking; parallel installs could corrupt node_modules