### PR TITLE
refactor: extract shared FakeChild test utility

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
+
+import { FakeChild } from "./test-helpers";
 
 // --- Mocks ---
 // Must be installed before the `await import` of the module under test so
@@ -43,11 +44,6 @@ mock.module("node:fs", () => ({
     rmSyncCalls.push([p, opts]);
   },
 }));
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-}
 
 let lastChild: FakeChild;
 const spawnCalls: Array<[string, string[], object]> = [];

--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -30,11 +29,7 @@ mock.module("electron", () => ({
   },
 }));
 
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild } from "./test-helpers";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[]]> = [];

--- a/apps/macos/src/main/test-helpers.ts
+++ b/apps/macos/src/main/test-helpers.ts
@@ -1,0 +1,9 @@
+import { mock } from "bun:test";
+import { EventEmitter } from "node:events";
+
+/** Fake ChildProcess for spawn-based tests. */
+export class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}


### PR DESCRIPTION
## Summary
Extract duplicate FakeChild class from cli-installer.test.ts and local-mode.test.ts into a shared test utility file.

Fixes gap identified during plan review for packaged-cli-install.md.

**Gap:** Duplicate FakeChild class
**What was expected:** Shared test utilities
**What was found:** Near-identical FakeChild in two test files