### PR TITLE
feat(subagent): per-phase build telemetry

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1878,6 +1878,7 @@ function makeSubagentState(
     },
     status: overrides.status ?? "running",
     conversationId: `conv-${overrides.id}`,
+    resolvedRole: overrides.resolvedRole ?? "general",
     isFork: overrides.isFork ?? false,
     createdAt: overrides.createdAt ?? Date.now() - 60_000,
     startedAt: overrides.startedAt ?? Date.now() - 55_000,

--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -58,6 +58,7 @@ function makeState(id: string): SubagentState {
     },
     status: "pending",
     conversationId: `conv-${id}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -90,6 +90,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -114,6 +114,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -102,6 +102,7 @@ function makeState(
     config: makeConfig({ id: subagentId, ...configOverrides }),
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -118,6 +118,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -95,6 +95,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-telemetry.test.ts
+++ b/assistant/src/__tests__/subagent-telemetry.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Per-phase build telemetry for subagents.
+ *
+ * Two layers under test:
+ *  1. The pure event builders (`buildSubagentSpawnEvent` /
+ *     `buildSubagentTerminalEvent`) — assert the structured event shape,
+ *     that the tier (overrideProfile) is recorded per subagent, that role →
+ *     build-phase mapping is correct, and the silent-context-starvation signal.
+ *  2. The manager integration — drive a controllable fake subagent through
+ *     spawn → completion and assert the established telemetry sink
+ *     (`recordLifecycleEvent`) is hit with the per-subagent tier, with no
+ *     regression to spawn/concurrency accounting.
+ *
+ * Note: this file mocks `../memory/lifecycle-events-store.js`. Per the repo's
+ * bun-mock isolation gotcha, run it on its own (single-file `bun test`).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// Capture every lifecycle event name the manager records, before importing the
+// modules under test so the mock is in place at import time.
+const recordedLifecycleEvents: string[] = [];
+mock.module("../memory/lifecycle-events-store.js", () => ({
+  recordLifecycleEvent: (eventName: string) => {
+    recordedLifecycleEvents.push(eventName);
+    return { id: "evt", eventName, createdAt: Date.now() };
+  },
+}));
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { SubagentManager } from "../subagent/manager.js";
+import {
+  buildSubagentSpawnEvent,
+  buildSubagentTerminalEvent,
+} from "../subagent/telemetry.js";
+import type { SubagentState } from "../subagent/types.js";
+
+// ── Pure builders ───────────────────────────────────────────────────────
+
+describe("subagent telemetry — event builders", () => {
+  test("spawn event records role, phase, and tier (overrideProfile)", () => {
+    const evt = buildSubagentSpawnEvent({
+      subagentId: "sub-1",
+      label: "Build the worker",
+      role: "coder",
+      overrideProfile: "worker-cheap",
+      isFork: false,
+    });
+
+    expect(evt).toMatchObject({
+      event: "subagent_build_spawned",
+      subagentId: "sub-1",
+      label: "Build the worker",
+      role: "coder",
+      phase: "worker", // coder → worker phase
+      overrideProfile: "worker-cheap",
+      isFork: false,
+    });
+    // Lifecycle name encodes phase + tier so platform aggregation can group.
+    expect(evt.lifecycleEventName).toBe(
+      "subagent_build:worker:worker-cheap:spawned",
+    );
+  });
+
+  test("planner maps to the plan phase; missing tier becomes 'default'", () => {
+    const evt = buildSubagentSpawnEvent({
+      subagentId: "sub-2",
+      label: "Plan",
+      role: "planner",
+      isFork: false,
+    });
+    expect(evt.phase).toBe("plan");
+    expect(evt.overrideProfile).toBeNull();
+    expect(evt.lifecycleEventName).toBe("subagent_build:plan:default:spawned");
+  });
+
+  test("terminal event carries tier, duration, tokens, and outcome", () => {
+    const evt = buildSubagentTerminalEvent({
+      subagentId: "sub-3",
+      label: "Worker",
+      role: "coder",
+      overrideProfile: "tier-a",
+      isFork: false,
+      outcome: "completed",
+      durationMs: 4200,
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.012,
+    });
+
+    expect(evt).toMatchObject({
+      event: "subagent_build_terminal",
+      outcome: "completed",
+      overrideProfile: "tier-a",
+      durationMs: 4200,
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.012,
+      suspiciousZeroOutput: false,
+    });
+    expect(evt.lifecycleEventName).toBe(
+      "subagent_build:worker:tier-a:completed",
+    );
+    expect(evt.zeroOutputLifecycleEventName).toBeUndefined();
+  });
+
+  test("overrideProfile (tier) is recorded distinctly per subagent", () => {
+    const cheap = buildSubagentTerminalEvent({
+      subagentId: "a",
+      label: "a",
+      role: "coder",
+      overrideProfile: "cheap",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 1,
+      estimatedCost: 0,
+    });
+    const premium = buildSubagentTerminalEvent({
+      subagentId: "b",
+      label: "b",
+      role: "coder",
+      overrideProfile: "premium",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 1,
+      estimatedCost: 0,
+    });
+    expect(cheap.overrideProfile).toBe("cheap");
+    expect(premium.overrideProfile).toBe("premium");
+    expect(cheap.lifecycleEventName).not.toBe(premium.lifecycleEventName);
+  });
+
+  test("silent-context-starvation: completed coder with zero output is flagged", () => {
+    const starved = buildSubagentTerminalEvent({
+      subagentId: "sub-x",
+      label: "Worker",
+      role: "coder",
+      overrideProfile: "tier-a",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 5000,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(starved.suspiciousZeroOutput).toBe(true);
+    expect(starved.zeroOutputLifecycleEventName).toBe(
+      "subagent_build:worker:tier-a:zero_output",
+    );
+
+    // Non-coder roles, failures, and non-zero output do NOT trip the signal.
+    const planner = buildSubagentTerminalEvent({
+      subagentId: "sub-y",
+      label: "Plan",
+      role: "planner",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(planner.suspiciousZeroOutput).toBe(false);
+
+    const failed = buildSubagentTerminalEvent({
+      subagentId: "sub-z",
+      label: "Worker",
+      role: "coder",
+      isFork: false,
+      outcome: "failed",
+      inputTokens: 1,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(failed.suspiciousZeroOutput).toBe(false);
+  });
+});
+
+// ── Manager integration ─────────────────────────────────────────────────
+
+interface FakeManaged {
+  conversation: {
+    abort: () => void;
+    dispose: () => void;
+    persistUserMessage: () => { id: string; deduplicated: boolean };
+    runAgentLoop: () => Promise<void>;
+    usageStats: {
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCost: number;
+    };
+  } | null;
+  state: SubagentState;
+  parentSendToClient: (msg: ServerMessage) => void;
+  retainedUntil?: number;
+  hadEnqueuedMessages?: boolean;
+}
+
+interface ManagerInternals {
+  subagents: Map<string, FakeManaged>;
+  parentToChildren: Map<string, Set<string>>;
+  runQueue: string[];
+  runningCount: number;
+  startRun: (subagentId: string, objective: string) => void;
+  stopSweep: () => void;
+}
+
+function asInternals(manager: SubagentManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+function makeState(id: string, overrideProfile?: string): SubagentState {
+  return {
+    config: {
+      id,
+      parentConversationId: "parent-1",
+      label: id,
+      objective: `objective-${id}`,
+      role: "coder",
+      ...(overrideProfile ? { overrideProfile } : {}),
+    },
+    status: "pending",
+    conversationId: `conv-${id}`,
+    resolvedRole: "coder",
+    isFork: false,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+function injectControllable(
+  manager: SubagentManager,
+  id: string,
+  overrideProfile?: string,
+): { release: () => void } {
+  const internals = asInternals(manager);
+  let resolveLoop!: () => void;
+  const loopGate = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+  const managed: FakeManaged = {
+    conversation: {
+      abort: () => {},
+      dispose: () => {},
+      persistUserMessage: () => ({ id: "msg", deduplicated: false }),
+      runAgentLoop: () => loopGate,
+      usageStats: { inputTokens: 10, outputTokens: 20, estimatedCost: 0.01 },
+    },
+    state: makeState(id, overrideProfile),
+    parentSendToClient: () => {},
+  };
+  internals.subagents.set(id, managed);
+  if (!internals.parentToChildren.has("parent-1")) {
+    internals.parentToChildren.set("parent-1", new Set());
+  }
+  internals.parentToChildren.get("parent-1")!.add(id);
+  return { release: resolveLoop };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("subagent telemetry — manager integration", () => {
+  test("completion records a per-tier terminal lifecycle event", async () => {
+    recordedLifecycleEvents.length = 0;
+
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+
+    const gate = injectControllable(manager, "sub-int-1", "tier-fast");
+    internals.startRun(
+      "sub-int-1",
+      internals.subagents.get("sub-int-1")!.state.config.objective,
+    );
+    await flush();
+
+    gate.release();
+    await flush();
+    await flush();
+
+    // The completed coder ran on tier-fast → its terminal event is recorded
+    // with the worker phase + tier encoded.
+    expect(recordedLifecycleEvents).toContain(
+      "subagent_build:worker:tier-fast:completed",
+    );
+    // Concurrency accounting did not leak.
+    expect(internals.runningCount).toBe(0);
+    expect(internals.runQueue.length).toBe(0);
+
+    internals.stopSweep();
+  });
+});

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -86,6 +86,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-types.test.ts
+++ b/assistant/src/__tests__/subagent-types.test.ts
@@ -68,6 +68,7 @@ describe("SubagentState type shape", () => {
       },
       status: "pending" as SubagentStatus,
       conversationId: "conv-id",
+      resolvedRole: "general",
       isFork: false,
       createdAt: Date.now(),
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -25,6 +25,11 @@ import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
+  emitSubagentSpawnTelemetry,
+  emitSubagentTerminalTelemetry,
+  type SubagentBuildOutcome,
+} from "./telemetry.js";
+import {
   SUBAGENT_LIMITS,
   SUBAGENT_ROLE_REGISTRY,
   type SubagentConfig,
@@ -269,6 +274,7 @@ export class SubagentManager {
       },
       status: "pending",
       conversationId: conversationRecord.id,
+      resolvedRole: role,
       isFork,
       createdAt: now,
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
@@ -387,6 +393,16 @@ export class SubagentManager {
       },
       "Subagent spawned",
     );
+
+    // Per-phase telemetry: record the spawn with its tier (overrideProfile) so
+    // the tiered app-builder flow's fan-out is measurable per tier/phase.
+    emitSubagentSpawnTelemetry({
+      subagentId,
+      label: config.label,
+      role,
+      overrideProfile: config.overrideProfile,
+      isFork,
+    });
 
     // ── Kick off the agent loop (fire-and-forget), bounded by the cap ─
     // If we're already at the concurrency cap, leave the subagent in `pending`
@@ -522,6 +538,8 @@ export class SubagentManager {
 
         log.info({ subagentId }, "Subagent completed");
 
+        this.emitTerminalTelemetry(managed, "completed");
+
         // Notify the parent conversation so the LLM can call subagent_read.
         this.notifyParentTerminal(managed, "completed");
       }
@@ -536,6 +554,7 @@ export class SubagentManager {
       // Only update status if not already terminal (e.g. aborted).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
         this.setStatus(subagentId, "failed", getSender(), errorMsg);
+        this.emitTerminalTelemetry(managed, "failed");
         this.notifyParentTerminal(managed, "failed");
       }
 
@@ -636,6 +655,11 @@ export class SubagentManager {
     } else {
       managed.state.status = "aborted";
     }
+
+    // Per-phase telemetry. Usage may be partial here (the agent loop's usage
+    // copy races the abort), but tier/phase/duration/outcome are accurate —
+    // which is what tiering + failure-rate analysis needs.
+    this.emitTerminalTelemetry(managed, "aborted");
 
     log.info({ subagentId }, "Subagent aborted");
     return true;
@@ -920,6 +944,36 @@ export class SubagentManager {
       error,
       usage: managed.state.usage,
     } as ServerMessage);
+  }
+
+  /**
+   * Emit per-phase build telemetry for a subagent that has reached a terminal
+   * state. Pulls timing/tokens off the subagent's state (already populated by
+   * the caller) and tags the event with the resolved role (build phase) and
+   * overrideProfile (tier).
+   */
+  private emitTerminalTelemetry(
+    managed: ManagedSubagent,
+    outcome: SubagentBuildOutcome,
+  ): void {
+    const { state } = managed;
+    const durationMs =
+      state.startedAt !== undefined && state.completedAt !== undefined
+        ? state.completedAt - state.startedAt
+        : undefined;
+    emitSubagentTerminalTelemetry({
+      subagentId: state.config.id,
+      label: state.config.label,
+      role: state.resolvedRole,
+      overrideProfile: state.config.overrideProfile,
+      isFork: state.isFork,
+      outcome,
+      durationMs,
+      inputTokens: state.usage.inputTokens,
+      outputTokens: state.usage.outputTokens,
+      estimatedCost: state.usage.estimatedCost,
+      ...(state.error ? { error: state.error } : {}),
+    });
   }
 
   // ── Child → Parent notification ────────────────────────────────────

--- a/assistant/src/subagent/telemetry.ts
+++ b/assistant/src/subagent/telemetry.ts
@@ -1,0 +1,219 @@
+/**
+ * Per-phase telemetry for subagent builds.
+ *
+ * Instruments the subagent lifecycle so the tiered app-builder flow's savings
+ * (which tier/profile each phase ran on) and failure rates are measurable.
+ *
+ * This deliberately reuses the two telemetry surfaces already established in
+ * the daemon rather than inventing a parallel system:
+ *
+ *  1. {@link recordLifecycleEvent} — the DB-backed, flush-to-platform sink used
+ *     by tool-permission telemetry (`events/tool-permission-telemetry-listener.ts`).
+ *     Lifecycle events only carry a string `eventName`, so we encode the
+ *     coarse, queryable dimensions (phase / role / tier / outcome) into a
+ *     stable, colon-delimited name. This is what makes cross-build aggregation
+ *     (tiering savings, failure rates) possible from the platform side.
+ *  2. The structured {@link getLogger} pino logger already used throughout
+ *     `manager.ts`. The full structured payload (ids, duration, tokens, etc.)
+ *     rides on the log record where local/aggregated log tooling can read it —
+ *     lifecycle rows are intentionally low-cardinality.
+ */
+
+import { recordLifecycleEvent } from "../memory/lifecycle-events-store.js";
+import { getLogger } from "../util/logger.js";
+import type { SubagentRole } from "./types.js";
+
+const log = getLogger("subagent-telemetry");
+
+/** Lifecycle event-name prefix for every subagent build-phase event. */
+const EVENT_PREFIX = "subagent_build";
+
+/** Terminal outcome of a subagent run, as seen by the telemetry layer. */
+export type SubagentBuildOutcome = "completed" | "failed" | "aborted";
+
+/**
+ * Map a subagent role to its app-builder build *phase* so plan / worker /
+ * repair phases are distinguishable in aggregate. Roles that don't map to a
+ * build phase fall through to the role name itself, keeping the event useful
+ * for non-app-builder subagents too.
+ *
+ *  - planner  → plan
+ *  - coder    → worker
+ *  - general  → general (e.g. forks / ad-hoc delegation)
+ */
+function phaseForRole(role: SubagentRole): string {
+  switch (role) {
+    case "planner":
+      return "plan";
+    case "coder":
+      return "worker";
+    default:
+      return role;
+  }
+}
+
+/** Sanitize a free-form label into a low-cardinality, name-safe token. */
+function safeProfileTag(overrideProfile: string | undefined): string {
+  if (!overrideProfile) return "default";
+  // Lifecycle event names are colon-delimited; keep the segment well-formed.
+  return overrideProfile.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+export interface SubagentSpawnTelemetry {
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  /** The ad-hoc inference-profile override — i.e. the *tier* the phase runs on. */
+  overrideProfile?: string;
+  isFork: boolean;
+}
+
+export interface SubagentTerminalTelemetry extends SubagentSpawnTelemetry {
+  outcome: SubagentBuildOutcome;
+  /** Wall-clock duration from run start to terminal, when start was recorded. */
+  durationMs?: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  /** Failure message, when the outcome is `failed`. */
+  error?: string;
+}
+
+/** Structured spawn event — the payload that rides the structured logger. */
+export interface SubagentSpawnEvent {
+  event: "subagent_build_spawned";
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  /** App-builder build phase derived from the role (plan / worker / …). */
+  phase: string;
+  /** The tier the phase runs on (overrideProfile), or null for the default. */
+  overrideProfile: string | null;
+  isFork: boolean;
+  /** Stable, low-cardinality lifecycle event name for platform aggregation. */
+  lifecycleEventName: string;
+}
+
+/** Structured terminal event — the payload that rides the structured logger. */
+export interface SubagentTerminalEvent {
+  event: "subagent_build_terminal";
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  phase: string;
+  overrideProfile: string | null;
+  isFork: boolean;
+  outcome: SubagentBuildOutcome;
+  durationMs: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  /**
+   * Silent-context-starvation signal: a `coder` (worker) that *completes*
+   * having produced zero output tokens — the closest observable proxy, at this
+   * layer, for "reported success but did nothing useful". See note below.
+   */
+  suspiciousZeroOutput: boolean;
+  error?: string;
+  /** Stable lifecycle event name for the outcome (platform aggregation). */
+  lifecycleEventName: string;
+  /** Extra lifecycle name emitted when {@link suspiciousZeroOutput} is set. */
+  zeroOutputLifecycleEventName?: string;
+}
+
+/** Pure builder for the spawn event — no side effects, for unit testing. */
+export function buildSubagentSpawnEvent(
+  info: SubagentSpawnTelemetry,
+): SubagentSpawnEvent {
+  const phase = phaseForRole(info.role);
+  const tier = safeProfileTag(info.overrideProfile);
+  return {
+    event: "subagent_build_spawned",
+    subagentId: info.subagentId,
+    label: info.label,
+    role: info.role,
+    phase,
+    overrideProfile: info.overrideProfile ?? null,
+    isFork: info.isFork,
+    lifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:spawned`,
+  };
+}
+
+/**
+ * Pure builder for the terminal event — no side effects, for unit testing.
+ *
+ * Silent-context-starvation signal: the manager does not have access to a
+ * per-subagent file-write count (the Conversation does not expose one), so we
+ * cannot assert "zero file writes" directly. We approximate with zero output
+ * tokens on a completed `coder` and surface a dedicated flag/lifecycle name for
+ * follow-up rather than over-reaching.
+ */
+export function buildSubagentTerminalEvent(
+  info: SubagentTerminalTelemetry,
+): SubagentTerminalEvent {
+  const phase = phaseForRole(info.role);
+  const tier = safeProfileTag(info.overrideProfile);
+  const suspiciousZeroOutput =
+    info.outcome === "completed" &&
+    info.role === "coder" &&
+    info.outputTokens === 0;
+  return {
+    event: "subagent_build_terminal",
+    subagentId: info.subagentId,
+    label: info.label,
+    role: info.role,
+    phase,
+    overrideProfile: info.overrideProfile ?? null,
+    isFork: info.isFork,
+    outcome: info.outcome,
+    durationMs: info.durationMs ?? null,
+    inputTokens: info.inputTokens,
+    outputTokens: info.outputTokens,
+    estimatedCost: info.estimatedCost,
+    suspiciousZeroOutput,
+    ...(info.error ? { error: info.error } : {}),
+    lifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:${info.outcome}`,
+    ...(suspiciousZeroOutput
+      ? {
+          zeroOutputLifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:zero_output`,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Emit telemetry when a subagent's run is kicked off. The lifecycle event keys
+ * on phase + tier so spawn volume per tier is queryable; full detail rides the
+ * structured log.
+ */
+export function emitSubagentSpawnTelemetry(info: SubagentSpawnTelemetry): void {
+  try {
+    const evt = buildSubagentSpawnEvent(info);
+    recordLifecycleEvent(evt.lifecycleEventName);
+    log.info(evt, "Subagent build phase spawned");
+  } catch (err) {
+    // Telemetry must never break the spawn path.
+    log.warn({ err }, "Failed to emit subagent spawn telemetry");
+  }
+}
+
+/**
+ * Emit telemetry when a subagent reaches a terminal state, carrying the tier,
+ * timing, token usage, and outcome so tiering savings and failure rates are
+ * measurable.
+ */
+export function emitSubagentTerminalTelemetry(
+  info: SubagentTerminalTelemetry,
+): void {
+  try {
+    const evt = buildSubagentTerminalEvent(info);
+    recordLifecycleEvent(evt.lifecycleEventName);
+    if (evt.zeroOutputLifecycleEventName) {
+      recordLifecycleEvent(evt.zeroOutputLifecycleEventName);
+    }
+    log.info(evt, "Subagent build phase terminal");
+  } catch (err) {
+    // Telemetry must never break the run path.
+    log.warn({ err }, "Failed to emit subagent terminal telemetry");
+  }
+}

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -84,6 +84,12 @@ export interface SubagentState {
   status: SubagentStatus;
   /** The subagent's own conversationId (different from parentConversationId). */
   conversationId: string;
+  /**
+   * The role the manager actually resolved at spawn time (after fork→general
+   * coercion). Distinct from `config.role`, which is the *requested* role.
+   * Used by build-phase telemetry so plan/worker phases are distinguishable.
+   */
+  resolvedRole: SubagentRole;
   /** Whether this sub-agent is a fork (inherits parent context). Defaults to `false`. */
   isFork: boolean;
   /** Error message if status is 'failed'. */


### PR DESCRIPTION
## Summary
- Emit structured telemetry on subagent spawn + terminal: role, override_profile (tier), duration, tokens, outcome
- Makes app-builder tiering savings + failure rates measurable; feeds the eval harness

Part of plan: ab-planner-worker.md (PR 7 of 9)