### PR TITLE
[DO NOT MERGE] Add local nginx web interface spike

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { hostname } from "node:os";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 
 import {
@@ -74,6 +74,8 @@ interface ParsedArgs {
   bearerToken?: string;
   /** Interface identifier sent as X-Vellum-Interface-Id on all requests. */
   interfaceId: SupportedInterface;
+  /** Run the web interface through a local nginx edge instead of the built-in web server. */
+  nginx: boolean;
 }
 
 function readAssistantName(entry: AssistantEntry | null): string | undefined {
@@ -163,19 +165,17 @@ function parseArgs(): ParsedArgs {
       : (loadGuardianToken(entry?.assistantId ?? "")?.accessToken ?? undefined);
 
   let interfaceId: SupportedInterface = CLI_INTERFACE_ID;
+  let nginx = false;
 
-  for (let i = 0; i < flagArgs.length; i++) {
-    const flag = flagArgs[i];
-    if ((flag === "--url" || flag === "-u") && flagArgs[i + 1]) {
-      runtimeUrl = flagArgs[++i];
-    } else if (
-      (flag === "--assistant-id" || flag === "-a") &&
-      flagArgs[i + 1]
-    ) {
-      assistantId = flagArgs[++i];
+  for (let i = 0; i < args.length; i++) {
+    const flag = args[i];
+    if ((flag === "--url" || flag === "-u") && args[i + 1]) {
+      runtimeUrl = args[++i] ?? runtimeUrl;
+    } else if ((flag === "--assistant-id" || flag === "-a") && args[i + 1]) {
+      assistantId = args[++i] ?? assistantId;
       assistantName = undefined;
-    } else if ((flag === "--interface" || flag === "-i") && flagArgs[i + 1]) {
-      const value = flagArgs[++i];
+    } else if ((flag === "--interface" || flag === "-i") && args[i + 1]) {
+      const value = args[++i] ?? "";
       if (!(SUPPORTED_INTERFACES as readonly string[]).includes(value)) {
         console.error(
           `Unknown interface '${value}'. Supported: ${SUPPORTED_INTERFACES.join(", ")}.`,
@@ -183,6 +183,8 @@ function parseArgs(): ParsedArgs {
         process.exit(1);
       }
       interfaceId = value as SupportedInterface;
+    } else if (flag === "--nginx") {
+      nginx = true;
     }
   }
 
@@ -195,6 +197,7 @@ function parseArgs(): ParsedArgs {
     platformToken,
     bearerToken,
     interfaceId,
+    nginx,
   };
 }
 
@@ -250,6 +253,7 @@ ${ANSI.bold}OPTIONS:${ANSI.reset}
     -u, --url <url>            Runtime URL
     -a, --assistant-id <id>    Assistant ID
     -i, --interface <id>       Interface identifier: cli (default) or web
+        --nginx                With --interface web, serve the SPA through nginx on 127.0.0.1:3000
     -h, --help                 Show this help message
 
 ${ANSI.bold}DEFAULTS:${ANSI.reset}
@@ -259,6 +263,7 @@ ${ANSI.bold}DEFAULTS:${ANSI.reset}
 ${ANSI.bold}EXAMPLES:${ANSI.reset}
     vellum client
     vellum client vellum-assistant-foo
+    vellum client --interface web --nginx
     vellum client --url http://34.56.78.90:${GATEWAY_PORT}
     vellum client vellum-assistant-foo --url http://localhost:${GATEWAY_PORT}
 `);
@@ -298,6 +303,8 @@ async function maybeHydratePlatformAssistantName(
 }
 
 const SPA_BASE = "/assistant/";
+const DEFAULT_NGINX_PORT = 3000;
+const DEFAULT_NGINX_HELPER_PORT = 3010;
 
 /**
  * Locate the pre-built @vellumai/web dist directory.
@@ -328,6 +335,268 @@ function findWebDistDir(): string | null {
     dir = parent;
   }
   return null;
+}
+
+function parsePortEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    throw new Error(`${name} must be a valid TCP port`);
+  }
+  return value;
+}
+
+function nginxQuote(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function startNginxHelperServer(port: number): ReturnType<typeof Bun.serve> {
+  const platformUrl = getPlatformUrl();
+  const webUrl = getWebUrl();
+  const configJson = JSON.stringify({ webUrl, platformUrl });
+  const loopbackServerShim = {
+    requestIP: () => ({ address: "127.0.0.1" }),
+  };
+
+  return Bun.serve({
+    port,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      const { pathname } = url;
+
+      // Loopback auth: the platform redirects here after login with
+      // ?state=...&session_token=... — forward into the SPA.
+      if (pathname === "/callback") {
+        return Response.redirect(
+          `/account/platform-callback${url.search}`,
+          302,
+        );
+      }
+
+      if (pathname === "/assistant/__config" || pathname === "/__config") {
+        return new Response(configJson, {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const localResponse = await handleLocalEndpoints(
+        req,
+        url,
+        loopbackServerShim,
+      );
+      if (localResponse) return localResponse;
+
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+}
+
+function buildNginxConfig(opts: {
+  distDir: string;
+  helperPort: number;
+  listenPort: number;
+}): string {
+  const distDir = opts.distDir.replace(/\/+$/, "");
+  const distRoot = nginxQuote(distDir);
+  const assetsAlias = nginxQuote(`${distDir}/assets/`);
+  const helper = `http://127.0.0.1:${opts.helperPort}`;
+
+  return `
+worker_processes 1;
+error_log stderr;
+pid nginx.pid;
+
+events {}
+
+http {
+  access_log off;
+  default_type application/octet-stream;
+
+  types {
+    text/html html htm;
+    text/css css;
+    application/javascript js mjs;
+    application/json json;
+    application/wasm wasm;
+    image/svg+xml svg svgz;
+    image/png png;
+    image/jpeg jpg jpeg;
+    image/gif gif;
+    image/x-icon ico;
+    font/woff woff;
+    font/woff2 woff2;
+    font/ttf ttf;
+    text/plain txt;
+  }
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  server {
+    listen 127.0.0.1:${opts.listenPort};
+    server_name localhost 127.0.0.1;
+    client_max_body_size 512m;
+    add_header Cache-Control "no-store" always;
+    root ${distRoot};
+
+    location = / {
+      return 302 /assistant/;
+    }
+
+    location = /assistant {
+      return 301 /assistant/;
+    }
+
+    location = /callback {
+      proxy_pass ${helper};
+      proxy_set_header Host $host;
+    }
+
+    location = /assistant/__config {
+      proxy_pass ${helper};
+      proxy_set_header Host $host;
+    }
+
+    location /assistant/__local/ {
+      proxy_pass ${helper};
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_set_header Host $host;
+    }
+
+    location /assistant/__gateway/ {
+      proxy_pass ${helper};
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_read_timeout 1h;
+      proxy_set_header Host $host;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    }
+
+    location = /account {
+      try_files /index.html =404;
+    }
+
+    location /account/ {
+      try_files /index.html =404;
+    }
+
+    location = /assistant/ {
+      try_files /index.html =404;
+    }
+
+    location = /assistant/index.html {
+      try_files /index.html =404;
+    }
+
+    location = /assistant/favicon.svg {
+      try_files /favicon.svg =404;
+    }
+
+    location = /assistant/vellum-logo.svg {
+      try_files /vellum-logo.svg =404;
+    }
+
+    location = /assistant/vellum-logo-white.svg {
+      try_files /vellum-logo-white.svg =404;
+    }
+
+    location = /assistant/login-background-characters.svg {
+      try_files /login-background-characters.svg =404;
+    }
+
+    location /assistant/assets/ {
+      alias ${assetsAlias};
+    }
+
+    location /assistant/ {
+      try_files /index.html =404;
+    }
+  }
+}
+`;
+}
+
+async function runNginxWebInterface(): Promise<void> {
+  const distDir = findWebDistDir();
+  if (!distDir) {
+    console.error(
+      `${ANSI.bold}--interface web --nginx${ANSI.reset}: unable to locate ` +
+        `built @vellumai/web assets.\n\n` +
+        `  source checkout: cd apps/web && VITE_PLATFORM_MODE=false bun run build\n` +
+        `  npm/bunx install: install a package that includes @vellumai/web/dist`,
+    );
+    process.exit(1);
+  }
+
+  const listenPort = parsePortEnv("VELLUM_WEB_NGINX_PORT", DEFAULT_NGINX_PORT);
+  const helperPort = parsePortEnv(
+    "VELLUM_WEB_HELPER_PORT",
+    DEFAULT_NGINX_HELPER_PORT,
+  );
+  const nginxBin = process.env.NGINX_BIN || "nginx";
+
+  const helper = startNginxHelperServer(helperPort);
+  const prefix = mkdtempSync(path.join(tmpdir(), "vellum-web-nginx-"));
+  const confPath = path.join(prefix, "nginx.conf");
+  writeFileSync(
+    confPath,
+    buildNginxConfig({ distDir, helperPort, listenPort }),
+  );
+
+  const child = spawn(
+    nginxBin,
+    ["-p", prefix, "-c", confPath, "-g", "daemon off;"],
+    { stdio: "inherit" },
+  );
+
+  let childStarted = false;
+
+  const shutdown = (): void => {
+    helper.stop();
+    if (childStarted && child.exitCode === null) {
+      child.kill();
+    }
+    process.exit(0);
+  };
+
+  child.on("spawn", () => {
+    childStarted = true;
+    console.log(
+      `Vellum nginx web interface: http://127.0.0.1:${listenPort}${SPA_BASE}`,
+    );
+    console.log(`Local helper: http://127.0.0.1:${helperPort}`);
+  });
+
+  child.on("error", (err) => {
+    helper.stop();
+    console.error(
+      `${ANSI.bold}--interface web --nginx${ANSI.reset}: failed to start ${nginxBin}: ${err.message}`,
+    );
+    process.exit(1);
+  });
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("exit", (code) => {
+      helper.stop();
+      if (code !== 0) {
+        reject(new Error(`nginx exited with code ${code}`));
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 /**
@@ -790,9 +1059,14 @@ export async function client(): Promise<void> {
     platformToken,
     bearerToken,
     interfaceId,
+    nginx,
   } = parseArgs();
 
   if (interfaceId === WEB_INTERFACE_ID) {
+    if (nginx) {
+      await runNginxWebInterface();
+      return;
+    }
     await runWebInterface();
     return;
   }

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -304,7 +304,9 @@ async function maybeHydratePlatformAssistantName(
 
 const SPA_BASE = "/assistant/";
 const DEFAULT_NGINX_PORT = 3000;
-const DEFAULT_NGINX_HELPER_PORT = 3010;
+const NGINX_CACHE_NO_STORE = "no-store";
+const NGINX_CACHE_HASHED_ASSETS = "public, max-age=31536000, immutable";
+const NGINX_CACHE_PUBLIC_FILES = "public, max-age=3600";
 
 /**
  * Locate the pre-built @vellumai/web dist directory.
@@ -351,58 +353,33 @@ function nginxQuote(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function startNginxHelperServer(port: number): ReturnType<typeof Bun.serve> {
-  const platformUrl = getPlatformUrl();
-  const webUrl = getWebUrl();
-  const configJson = JSON.stringify({ webUrl, platformUrl });
-  const loopbackServerShim = {
-    requestIP: () => ({ address: "127.0.0.1" }),
-  };
+function normalizeGatewayUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`Invalid gateway URL: ${raw}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Gateway URL must use http or https, got ${parsed.protocol}`,
+    );
+  }
 
-  return Bun.serve({
-    port,
-    hostname: "127.0.0.1",
-    idleTimeout: 0,
-    fetch: async (req) => {
-      const url = new URL(req.url);
-      const { pathname } = url;
-
-      // Loopback auth: the platform redirects here after login with
-      // ?state=...&session_token=... — forward into the SPA.
-      if (pathname === "/callback") {
-        return Response.redirect(
-          `/account/platform-callback${url.search}`,
-          302,
-        );
-      }
-
-      if (pathname === "/assistant/__config" || pathname === "/__config") {
-        return new Response(configJson, {
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-
-      const localResponse = await handleLocalEndpoints(
-        req,
-        url,
-        loopbackServerShim,
-      );
-      if (localResponse) return localResponse;
-
-      return new Response("Not Found", { status: 404 });
-    },
-  });
+  // The self-hosted nginx edge proxies route namespaces to the gateway root.
+  // Runtime URLs are expected to be gateway origins, so discard path/query/hash
+  // here rather than creating surprising nginx proxy_pass URI rewriting.
+  return parsed.origin;
 }
 
 function buildNginxConfig(opts: {
   distDir: string;
-  helperPort: number;
+  gatewayUrl: string;
   listenPort: number;
 }): string {
   const distDir = opts.distDir.replace(/\/+$/, "");
   const distRoot = nginxQuote(distDir);
-  const assetsAlias = nginxQuote(`${distDir}/assets/`);
-  const helper = `http://127.0.0.1:${opts.helperPort}`;
+  const gateway = normalizeGatewayUrl(opts.gatewayUrl);
 
   return `
 worker_processes 1;
@@ -441,7 +418,6 @@ http {
     listen 127.0.0.1:${opts.listenPort};
     server_name localhost 127.0.0.1;
     client_max_body_size 512m;
-    add_header Cache-Control "no-store" always;
     root ${distRoot};
 
     location = / {
@@ -452,80 +428,80 @@ http {
       return 301 /assistant/;
     }
 
-    location = /callback {
-      proxy_pass ${helper};
-      proxy_set_header Host $host;
-    }
-
-    location = /assistant/__config {
-      proxy_pass ${helper};
-      proxy_set_header Host $host;
-    }
-
-    location /assistant/__local/ {
-      proxy_pass ${helper};
+    location = /healthz {
+      proxy_pass ${gateway};
       proxy_http_version 1.1;
-      proxy_request_buffering off;
-      proxy_buffering off;
-      proxy_set_header Host $host;
+      proxy_set_header Host $proxy_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /assistant/__gateway/ {
-      proxy_pass ${helper};
+    location /v1/ {
+      proxy_pass ${gateway};
       proxy_http_version 1.1;
       proxy_request_buffering off;
       proxy_buffering off;
       proxy_read_timeout 1h;
-      proxy_set_header Host $host;
+      proxy_set_header Host $proxy_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
 
     location = /account {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
       try_files /index.html =404;
     }
 
     location /account/ {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
+      try_files /index.html =404;
+    }
+
+    location = /logout {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
       try_files /index.html =404;
     }
 
     location = /assistant/ {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
       try_files /index.html =404;
     }
 
     location = /assistant/index.html {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
       try_files /index.html =404;
     }
 
-    location = /assistant/favicon.svg {
-      try_files /favicon.svg =404;
+    location ^~ /assistant/assets/ {
+      rewrite ^/assistant/(.*)$ /$1 break;
+      add_header Cache-Control "${NGINX_CACHE_HASHED_ASSETS}" always;
+      try_files $uri =404;
     }
 
-    location = /assistant/vellum-logo.svg {
-      try_files /vellum-logo.svg =404;
+    location ^~ /assistant/ {
+      rewrite ^/assistant/?(.*)$ /$1 break;
+      add_header Cache-Control "${NGINX_CACHE_PUBLIC_FILES}" always;
+      try_files $uri $uri/ @assistant_spa;
     }
 
-    location = /assistant/vellum-logo-white.svg {
-      try_files /vellum-logo-white.svg =404;
-    }
-
-    location = /assistant/login-background-characters.svg {
-      try_files /login-background-characters.svg =404;
-    }
-
-    location /assistant/assets/ {
-      alias ${assetsAlias};
-    }
-
-    location /assistant/ {
+    location @assistant_spa {
+      add_header Cache-Control "${NGINX_CACHE_NO_STORE}" always;
       try_files /index.html =404;
+    }
+
+    location / {
+      return 404;
     }
   }
 }
 `;
 }
 
-async function runNginxWebInterface(): Promise<void> {
+async function runNginxWebInterface(runtimeUrl: string): Promise<void> {
   const distDir = findWebDistDir();
   if (!distDir) {
     console.error(
@@ -538,18 +514,13 @@ async function runNginxWebInterface(): Promise<void> {
   }
 
   const listenPort = parsePortEnv("VELLUM_WEB_NGINX_PORT", DEFAULT_NGINX_PORT);
-  const helperPort = parsePortEnv(
-    "VELLUM_WEB_HELPER_PORT",
-    DEFAULT_NGINX_HELPER_PORT,
-  );
   const nginxBin = process.env.NGINX_BIN || "nginx";
 
-  const helper = startNginxHelperServer(helperPort);
   const prefix = mkdtempSync(path.join(tmpdir(), "vellum-web-nginx-"));
   const confPath = path.join(prefix, "nginx.conf");
   writeFileSync(
     confPath,
-    buildNginxConfig({ distDir, helperPort, listenPort }),
+    buildNginxConfig({ distDir, gatewayUrl: runtimeUrl, listenPort }),
   );
 
   const child = spawn(
@@ -561,7 +532,6 @@ async function runNginxWebInterface(): Promise<void> {
   let childStarted = false;
 
   const shutdown = (): void => {
-    helper.stop();
     if (childStarted && child.exitCode === null) {
       child.kill();
     }
@@ -573,11 +543,10 @@ async function runNginxWebInterface(): Promise<void> {
     console.log(
       `Vellum nginx web interface: http://127.0.0.1:${listenPort}${SPA_BASE}`,
     );
-    console.log(`Local helper: http://127.0.0.1:${helperPort}`);
+    console.log(`Gateway upstream: ${normalizeGatewayUrl(runtimeUrl)}`);
   });
 
   child.on("error", (err) => {
-    helper.stop();
     console.error(
       `${ANSI.bold}--interface web --nginx${ANSI.reset}: failed to start ${nginxBin}: ${err.message}`,
     );
@@ -589,7 +558,6 @@ async function runNginxWebInterface(): Promise<void> {
 
   await new Promise<void>((resolve, reject) => {
     child.on("exit", (code) => {
-      helper.stop();
       if (code !== 0) {
         reject(new Error(`nginx exited with code ${code}`));
         return;
@@ -1064,7 +1032,7 @@ export async function client(): Promise<void> {
 
   if (interfaceId === WEB_INTERFACE_ID) {
     if (nginx) {
-      await runNginxWebInterface();
+      await runNginxWebInterface(runtimeUrl);
       return;
     }
     await runWebInterface();


### PR DESCRIPTION
## Summary

Updates the local nginx-backed web client spike to match the self-hosted ingress shape:

- supports `vellum client --interface web --nginx`
- serves the built `@vellumai/web` SPA from the `dist` artifact root at `http://127.0.0.1:3000/assistant/`
- proxies `/v1/*` and `/healthz` directly to the resolved gateway runtime URL
- keeps platform-style cache policy split: `index.html` no-store, hashed `/assistant/assets/*` immutable, other public files short-lived
- removes the Bun helper from the nginx path
- removes nginx exposure of `/assistant/__local/*`, `/assistant/__gateway/*`, `/assistant/__config`, and `/callback`

## Why

This aligns the spike with the intended self-hosted production shape:

`Browser -> public/ngrok URL -> nginx -> gateway`

Nginx owns static SPA delivery and direct gateway proxying. The browser-facing nginx path no longer relies on a local Bun helper, loopback request-IP checks, guardian token helper routes, lockfile access, or dynamic gateway-port proxy routes.

## Notes

Auth between browser, nginx, and gateway still needs a dedicated design. This PR intentionally does not add a new loopback auth surface or reuse the helper token exchange path. The next design step is deciding how the browser obtains a gateway-authenticated session, likely cookie-backed, without depending on loopback.

The older non-nginx local/dev server path still has milestone-1 local-mode routes for development. This update only changes the `--interface web --nginx` ingress path.

## Validation

- `cd cli && bunx tsc --noEmit`
- `cd cli && bun run lint` passed with the existing unrelated warning in `cli/src/commands/roadmap.ts`
- commit hook passed secrets scan, generic example scan, formatting, and lint for `cli/src/commands/client.ts`
- pre-push hook passed lint for the changed CLI file
- smoke test: `vellum client --interface web --nginx` started nginx, `/assistant/` returned the SPA shell with `Cache-Control: no-store`, and `/healthz` proxied through to the gateway successfully
