### PR TITLE
fix(app-builder): remove redundant compile serialization; consolidate mutex

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -14,18 +14,8 @@ let compileResultOverride: CompileResult = {
   durationMs: 0,
 };
 
-/**
- * Optional hook letting a test observe and gate each compileApp invocation.
- * When set, compileApp awaits whatever it returns before resolving, so a test
- * can assert serialization by counting concurrently-running compiles.
- */
-let compileGate: ((appDir: string) => Promise<void>) | undefined;
-
 mock.module("../bundler/app-compiler.js", () => ({
-  compileApp: async (appDir: string) => {
-    if (compileGate) await compileGate(appDir);
-    return compileResultOverride;
-  },
+  compileApp: async () => compileResultOverride,
 }));
 
 beforeEach(() => {
@@ -35,7 +25,6 @@ beforeEach(() => {
     warnings: [],
     durationMs: 0,
   };
-  compileGate = undefined;
 });
 
 import type { AppDefinition } from "../memory/app-store.js";
@@ -417,81 +406,5 @@ describe("executeAppRefresh", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("not found");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Per-app-slug write/compile serialization
-//
-// getAppDirPath(id) is deterministic per id (falls back to <appsDir>/<id> when
-// no on-disk definition exists), so distinct ids map to distinct lock keys and
-// the same id always maps to the same key — exactly the slug-keying contract.
-// ---------------------------------------------------------------------------
-
-describe("app-slug compile serialization", () => {
-  /** A deferred promise plus its resolver. */
-  function defer(): { promise: Promise<void>; resolve: () => void } {
-    let resolve!: () => void;
-    const promise = new Promise<void>((r) => {
-      resolve = r;
-    });
-    return { promise, resolve };
-  }
-
-  test("serializes concurrent refreshes for the SAME app", async () => {
-    let running = 0;
-    let maxConcurrent = 0;
-    const release = defer();
-    compileGate = async () => {
-      running++;
-      maxConcurrent = Math.max(maxConcurrent, running);
-      await release.promise;
-      running--;
-    };
-
-    const app = makeMultifileApp({ id: "same-slug-app" });
-    const store = mockStore(app);
-
-    const first = executeAppRefresh({ app_id: app.id }, store);
-    const second = executeAppRefresh({ app_id: app.id }, store);
-
-    // Let both kick off. Only the first compile may be running; the second is
-    // queued behind the per-slug lock.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(maxConcurrent).toBe(1);
-
-    release.resolve();
-    await Promise.all([first, second]);
-    // Never more than one compile in flight for this slug.
-    expect(maxConcurrent).toBe(1);
-  });
-
-  test("runs refreshes for DIFFERENT apps concurrently", async () => {
-    let running = 0;
-    let maxConcurrent = 0;
-    const release = defer();
-    compileGate = async () => {
-      running++;
-      maxConcurrent = Math.max(maxConcurrent, running);
-      await release.promise;
-      running--;
-    };
-
-    const appA = makeMultifileApp({ id: "slug-a" });
-    const appB = makeMultifileApp({ id: "slug-b" });
-    const storeA = mockStore(appA);
-    const storeB = mockStore(appB);
-
-    const first = executeAppRefresh({ app_id: appA.id }, storeA);
-    const second = executeAppRefresh({ app_id: appB.id }, storeB);
-
-    // Different slugs must not block each other — both compiles run at once.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(maxConcurrent).toBe(2);
-
-    release.resolve();
-    await Promise.all([first, second]);
   });
 });

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -28,6 +28,7 @@ import type {
   InteractiveUiResult,
 } from "../runtime/interactive-ui-types.js";
 import type { ToolExecutionResult } from "../tools/types.js";
+import { createKeyedMutex } from "../util/keyed-mutex.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
@@ -544,33 +545,12 @@ export type SurfaceMutex = {
 /**
  * Per-surface async mutex using Promise chaining.
  * Operations on the same surfaceId are serialized; different surfaces run concurrently.
+ *
+ * Thin wrapper over the generic {@link createKeyedMutex} primitive, keyed by
+ * surfaceId.
  */
 export function createSurfaceMutex(): SurfaceMutex {
-  const chains = new Map<string, Promise<void>>();
-
-  const mutex = <T>(
-    surfaceId: string,
-    fn: () => T | Promise<T>,
-  ): Promise<T> => {
-    const prev = chains.get(surfaceId) ?? Promise.resolve();
-    const next = prev.then(fn, fn);
-    // Keep the chain alive but swallow errors so one failure doesn't block subsequent ops
-    const tail = next.then(
-      () => {},
-      () => {},
-    );
-    chains.set(surfaceId, tail);
-    // Clean up the map entry once the queue settles to prevent unbounded growth
-    tail.then(() => {
-      if (chains.get(surfaceId) === tail) {
-        chains.delete(surfaceId);
-      }
-    });
-    return next;
-  };
-
-  Object.defineProperty(mutex, "size", { get: () => chains.size });
-  return mutex as SurfaceMutex;
+  return createKeyedMutex() as SurfaceMutex;
 }
 
 // ── Standalone surface lifecycle ────────────────────────────────────

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -12,25 +12,6 @@ import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
-import { createKeyedMutex } from "../../util/keyed-mutex.js";
-
-// ---------------------------------------------------------------------------
-// Per-app-slug write/compile serialization
-// ---------------------------------------------------------------------------
-
-/**
- * Defense-in-depth lock keyed by an app's on-disk dir (its frozen slug).
- *
- * app-builder v2 runs multiple `coder` workers that write DISJOINT files into
- * one app dir in parallel, and only the parent compiles — a layout that already
- * avoids most races. This guards the residual ones: a write landing during the
- * compile's `rm -rf dist/` + esbuild window, or two same-slug write/compile
- * batches overlapping. Operations on the SAME slug serialize; DIFFERENT slugs
- * stay fully concurrent, honoring the per-resource serialization rule in
- * CLAUDE.md. Disjoint writes within one batch share a single acquisition, so
- * workers never deadlock or queue beyond the compile boundary.
- */
-const appSlugMutex = createKeyedMutex();
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -217,27 +198,21 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-  // Serialize the source-file writes + compile for this slug so a concurrent
-  // operation on the SAME app (e.g. another worker's app_refresh) can't
-  // interleave with these writes or the dist/ rebuild below.
   const appDir = getAppDirPath(app.id);
 
-  const mainTsxScaffolded = await appSlugMutex(appDir, () => {
-    if (input.source_files) {
-      for (const [filePath, content] of Object.entries(input.source_files)) {
-        store.writeAppFile(app.id, filePath, content);
-      }
+  if (input.source_files) {
+    for (const [filePath, content] of Object.entries(input.source_files)) {
+      store.writeAppFile(app.id, filePath, content);
     }
+  }
 
-    const scaffolded = !store.appFileExists(app.id, "src/main.tsx");
-    if (!store.appFileExists(app.id, "src/index.html")) {
-      store.writeAppFile(app.id, "src/index.html", indexHtml);
-    }
-    if (scaffolded) {
-      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-    }
-    return scaffolded;
-  });
+  const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
+  if (!store.appFileExists(app.id, "src/index.html")) {
+    store.writeAppFile(app.id, "src/index.html", indexHtml);
+  }
+  if (mainTsxScaffolded) {
+    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+  }
 
   // When the placeholder main.tsx was actually scaffolded, the tool result
   // must steer the agent toward writing the real source files instead of
@@ -251,9 +226,10 @@ render(<App />, document.getElementById('app')!);
       }
     : {};
 
-  // Compile src/ → dist/, serialized per slug so the dist/ rebuild can't race
-  // a concurrent same-slug write/compile.
-  const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
+  // Compile src/ → dist/. compileApp serialises concurrent same-appDir
+  // compiles internally (latest-wins coalescing) so the dist/ rebuild can't
+  // race another caller's compile.
+  const compileResult = await compileApp(appDir);
   if (!compileResult.ok) {
     return {
       content: JSON.stringify({
@@ -372,9 +348,10 @@ export async function executeAppRefresh(
   // stale scaffold placeholder from the initial app_create.
   if (app.formatVersion === 2) {
     const appDir = getAppDirPath(input.app_id);
-    // Serialize the dist/ rebuild per slug so a concurrent same-slug
-    // operation (e.g. another worker's app_create) can't race this compile.
-    const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
+    // compileApp serialises concurrent same-appDir compiles internally, so a
+    // concurrent operation (e.g. another worker's app_create) can't race this
+    // dist/ rebuild.
+    const compileResult = await compileApp(appDir);
     return {
       content: JSON.stringify({
         refreshed: true,

--- a/assistant/src/util/keyed-mutex.ts
+++ b/assistant/src/util/keyed-mutex.ts
@@ -3,13 +3,12 @@
  *
  * Operations submitted for the SAME key run strictly one-at-a-time in
  * submission order; operations for DIFFERENT keys proceed concurrently. This
- * is the lightweight in-process serialization primitive used to guard shared
- * mutable resources (e.g. an app's source dir + its dist/ rebuild) against
- * concurrent callers racing on `rm -rf` + write sequences, per the
- * "serialise per-resource" rule in CLAUDE.md.
+ * is the lightweight in-process serialization primitive used to guard
+ * per-resource critical sections, per the "serialise per-resource" rule in
+ * CLAUDE.md.
  *
- * The same pattern already backs `createSurfaceMutex`; this generalises it as a
- * standalone utility so other per-resource critical sections can reuse it.
+ * `createSurfaceMutex` (in conversation-surfaces.ts) is a thin wrapper over
+ * this primitive, keyed by surfaceId.
  */
 export type KeyedMutex = {
   /**


### PR DESCRIPTION
## Summary
- Remove appSlugMutex around compileApp() — compileApp already serializes per-appDir via compileSlots (latest-wins coalescing); the extra lock degraded it to strict FIFO
- Remove the executors.ts write-side lock (false safety: workers use file_write which bypassed it; orchestration compiles once after all workers anyway) and correct the overstated comments
- Consolidate createSurfaceMutex to delegate to the generic createKeyedMutex (one implementation)

Addresses self-review findings on plan ab-planner-worker.md (PR 4).